### PR TITLE
Fixed a failure caused by the size of Integer in h2 being different than in SQLite

### DIFF
--- a/src/com/xtremelabs/robolectric/shadows/ShadowSQLiteDatabase.java
+++ b/src/com/xtremelabs/robolectric/shadows/ShadowSQLiteDatabase.java
@@ -135,6 +135,8 @@ public class ShadowSQLiteDatabase {
 
         // Map 'autoincrement' (sqlite) to 'auto_increment' (h2).
         String scrubbedSQL = sql.replaceAll("(?i:autoincrement)", "auto_increment");
+        // Map 'integer' (sqlite) to 'bigint(19)' (h2).
+        scrubbedSQL = scrubbedSQL.replaceAll("(?i:integer)", "bigint(19)");
 
         try {
             connection.createStatement().execute(scrubbedSQL);


### PR DESCRIPTION
When you create a table column using the keyword INTEGER, this is interpreted by h2 as an INTEGER(10), however SQLite dynamically changes the size of the INTEGER to fit the data from 1 to 8 bytes in size.  This is a LONG or BIGINT(19) in h2.

I fixed this by creating a mapping in the execSQL statement that maps INTEGER to BIGINT(19) (case-insensitively, of course.)
