### PR TITLE
Fixing the ShadowBundle to work with RoboGuice InjectExtras

### DIFF
--- a/src/com/xtremelabs/robolectric/shadows/ShadowBundle.java
+++ b/src/com/xtremelabs/robolectric/shadows/ShadowBundle.java
@@ -62,6 +62,11 @@ public class ShadowBundle {
         return (Parcelable) map.get(key);
     }
 
+    @Implementation
+    public boolean containsKey(String key) {
+        return map.containsKey(key);
+    }
+
     @Override @Implementation
     public boolean equals(Object o) {
         if (o == null) return false;


### PR DESCRIPTION
In roboguice.inject.ExtrasListener:87 it asks if a Bundle contains a key and without this method on ShadowBundle it always fails.
