### PR TITLE
Added support for parsing ApplicationInfo from the manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>com.google.android.maps</groupId>
             <artifactId>maps</artifactId>
-            <version>9_r1</version>
+            <version>9_r2</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/com/xtremelabs/robolectric/Robolectric.java
+++ b/src/main/java/com/xtremelabs/robolectric/Robolectric.java
@@ -1,5 +1,12 @@
 package com.xtremelabs.robolectric;
 
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.impl.client.DefaultRequestDirector;
+
 import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.AlertDialog;
@@ -15,6 +22,8 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageItemInfo;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -56,6 +65,7 @@ import android.widget.RemoteViews;
 import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.ZoomButtonsController;
+
 import com.xtremelabs.robolectric.bytecode.RobolectricInternals;
 import com.xtremelabs.robolectric.bytecode.ShadowWrangler;
 import com.xtremelabs.robolectric.shadows.*;
@@ -63,12 +73,6 @@ import com.xtremelabs.robolectric.tester.org.apache.http.FakeHttpLayer;
 import com.xtremelabs.robolectric.tester.org.apache.http.HttpRequestInfo;
 import com.xtremelabs.robolectric.tester.org.apache.http.RequestMatcher;
 import com.xtremelabs.robolectric.util.Scheduler;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
-import org.apache.http.impl.client.DefaultRequestDirector;
-
-import java.util.Arrays;
-import java.util.List;
 
 @SuppressWarnings({"UnusedDeclaration"})
 public class Robolectric {
@@ -125,6 +129,7 @@ public class Robolectric {
                 ShadowAlertDialog.class,
                 ShadowAlertDialog.ShadowBuilder.class,
                 ShadowApplication.class,
+                ShadowApplicationInfo.class,
                 ShadowAppWidgetManager.class,
                 ShadowArrayAdapter.class,
                 ShadowAssetManager.class,
@@ -188,6 +193,7 @@ public class Robolectric {
                 ShadowNotificationManager.class,
                 ShadowNetworkInfo.class,
                 ShadowOverlayItem.class,
+                ShadowPackageItemInfo.class,
                 ShadowPaint.class,
                 ShadowPath.class,
                 ShadowPendingIntent.class,
@@ -279,7 +285,15 @@ public class Robolectric {
     public static ShadowApplication shadowOf(Application instance) {
         return (ShadowApplication) shadowOf_(instance);
     }
+    
+    public static ShadowApplicationInfo shadowOf(ApplicationInfo instance) {
+        return (ShadowApplicationInfo) shadowOf_(instance);
+    }
 
+    public static ShadowPackageItemInfo shadowOf(PackageItemInfo instance) {
+        return (ShadowPackageItemInfo) shadowOf_(instance);
+    }
+    
     public static ShadowContext shadowOf(Context instance) {
         return (ShadowContext) shadowOf_(instance);
     }

--- a/src/main/java/com/xtremelabs/robolectric/res/RobolectricPackageManager.java
+++ b/src/main/java/com/xtremelabs/robolectric/res/RobolectricPackageManager.java
@@ -1,19 +1,24 @@
 package com.xtremelabs.robolectric.res;
 
-import android.content.ContextWrapper;
-import android.content.pm.PackageInfo;
-import com.xtremelabs.robolectric.tester.android.content.pm.StubPackageManager;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import android.content.ContextWrapper;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+
+import com.xtremelabs.robolectric.RobolectricConfig;
+import com.xtremelabs.robolectric.tester.android.content.pm.StubPackageManager;
 
 public class RobolectricPackageManager extends StubPackageManager {
     public PackageInfo packageInfo;
     public ArrayList<PackageInfo> packageList;
     private ContextWrapper contextWrapper;
-
-    public RobolectricPackageManager(ContextWrapper contextWrapper) {
+    private RobolectricConfig config;
+    
+    public RobolectricPackageManager(ContextWrapper contextWrapper, RobolectricConfig config) {
         this.contextWrapper = contextWrapper;
+        this.config = config;
     }
 
     @Override
@@ -23,6 +28,21 @@ public class RobolectricPackageManager extends StubPackageManager {
     }
 
     @Override
+    public ApplicationInfo getApplicationInfo(String packageName, int flags) throws NameNotFoundException {
+    	if (config.getPackageName().equals(packageName))
+    	{
+    		ApplicationInfo applicationInfo = new ApplicationInfo();
+        	applicationInfo.flags = config.getApplicationFlags();
+        	applicationInfo.targetSdkVersion = config.getSdkVersion();
+    		applicationInfo.packageName = config.getPackageName();
+    		applicationInfo.processName = config.getProcessName();
+    		return applicationInfo;
+    	}
+    	
+    	throw new NameNotFoundException();
+    }
+
+	@Override
     public List<PackageInfo> getInstalledPackages(int flags) {
         ensurePackageInfo();
         if (packageList == null) {
@@ -39,5 +59,4 @@ public class RobolectricPackageManager extends StubPackageManager {
             packageInfo.versionName = "1.0";
         }
     }
-
 }

--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowApplicationInfo.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowApplicationInfo.java
@@ -1,0 +1,18 @@
+package com.xtremelabs.robolectric.shadows;
+
+import android.content.pm.ApplicationInfo;
+
+import com.xtremelabs.robolectric.internal.Implements;
+
+/**
+ * Shadows the {@code android.content.pm.ApplicationInfo} class. 
+ */
+@Implements(ApplicationInfo.class)
+public class ShadowApplicationInfo extends ShadowPackageItemInfo {
+
+	public String flags;
+	
+	public void __constructor__() {
+	}
+	
+}

--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowContextWrapper.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowContextWrapper.java
@@ -1,5 +1,9 @@
 package com.xtremelabs.robolectric.shadows;
 
+import static com.xtremelabs.robolectric.Robolectric.shadowOf;
+
+import java.io.File;
+
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.ContentResolver;
@@ -12,13 +16,13 @@ import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
 import android.os.Looper;
-import com.xtremelabs.robolectric.tester.android.content.TestSharedPreferences;
+
+import com.xtremelabs.robolectric.RobolectricConfig;
 import com.xtremelabs.robolectric.internal.Implementation;
 import com.xtremelabs.robolectric.internal.Implements;
 import com.xtremelabs.robolectric.internal.RealObject;
 import com.xtremelabs.robolectric.res.RobolectricPackageManager;
-
-import static com.xtremelabs.robolectric.Robolectric.shadowOf;
+import com.xtremelabs.robolectric.tester.android.content.TestSharedPreferences;
 
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(ContextWrapper.class)
@@ -87,7 +91,7 @@ public class ShadowContextWrapper extends ShadowContext {
     @Implementation
     public PackageManager getPackageManager() {
         if (packageManager == null) {
-            packageManager = new RobolectricPackageManager(realContextWrapper);
+            packageManager = new RobolectricPackageManager(realContextWrapper, new RobolectricConfig(new File(".")));
         }
         return packageManager;
     }

--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowPackageItemInfo.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowPackageItemInfo.java
@@ -1,0 +1,19 @@
+package com.xtremelabs.robolectric.shadows;
+
+import android.content.pm.PackageItemInfo;
+
+import com.xtremelabs.robolectric.internal.Implements;
+
+/**
+ * Shadows the {@code android.content.pm.PackageItemInfo} class.
+ */
+@Implements(PackageItemInfo.class)
+public class ShadowPackageItemInfo {
+
+	public String packageName;
+	
+	public void __constructor__() {
+		packageName = "";
+	}
+	
+}

--- a/src/test/java/com/xtremelabs/robolectric/RobolectricConfigTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/RobolectricConfigTest.java
@@ -5,11 +5,45 @@ import org.junit.runner.RunWith;
 
 import static com.xtremelabs.robolectric.util.TestUtil.newConfig;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static android.content.pm.ApplicationInfo.*;
 
 @RunWith(WithTestDefaultsRunner.class)
 public class RobolectricConfigTest {
     @Test
     public void shouldReadSdkVersionFromAndroidManifest() throws Exception {
         assertEquals(42, newConfig("TestAndroidManifestWithSdkVersion.xml").getSdkVersion());
+        assertEquals(3, newConfig("TestAndroidManifestWithSdkVersion.xml").getMinSdkVersion());
+    }
+    
+    @Test
+    public void shouldReadProcessFromAndroidManifest() throws Exception {
+    	assertEquals("robolectricprocess", newConfig("TestAndroidManifestWithProcess.xml").getProcessName());
+    	// expect process to equal package name when no process is specified
+    	assertEquals("com.xtremelabs.robolectric", newConfig("TestAndroidManifestWithNoProcess.xml").getProcessName());
+    }
+    
+    @Test
+    public void shouldReadFlagsFromAndroidManifest() throws Exception {
+        RobolectricConfig config = newConfig("TestAndroidManifestWithFlags.xml");
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_ALLOW_BACKUP));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_ALLOW_CLEAR_USER_DATA));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_ALLOW_TASK_REPARENTING));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_DEBUGGABLE));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_HAS_CODE));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_KILL_AFTER_RESTORE));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_PERSISTENT));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_RESIZEABLE_FOR_SCREENS));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_RESTORE_ANY_VERSION));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_SUPPORTS_LARGE_SCREENS));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_SUPPORTS_NORMAL_SCREENS));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_SUPPORTS_SCREEN_DENSITIES));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_SUPPORTS_SMALL_SCREENS));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_TEST_ONLY));
+        assertTrue(hasFlag(config.getApplicationFlags(), FLAG_VM_SAFE_MODE));
+    }
+    
+    private boolean hasFlag(int flags, int flag) {
+    	return (flags & flag) != 0;
     }
 }

--- a/src/test/resources/TestAndroidManifestWithFlags.xml
+++ b/src/test/resources/TestAndroidManifestWithFlags.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.xtremelabs.robolectric">
+    <application android:name="com.xtremelabs.robolectric.TestApplication"
+    	android:allowBackup="true"
+    	android:allowClearUserData="true"
+    	android:allowTaskReparenting="true"
+    	android:debuggable="true"
+    	android:hasCode="true"
+    	android:killAfterRestore="true"
+    	android:persistent="true"
+    	android:resizeable="true"
+    	android:restoreAnyVersion="true"
+    	android:largeScreens="true"
+    	android:normalScreens="true"
+    	android:smallScreens="true"
+    	android:anyDensity="true"
+    	android:testOnly="true"
+    	android:vmSafeMode="true" />
+</manifest>

--- a/src/test/resources/TestAndroidManifestWithNoProcess.xml
+++ b/src/test/resources/TestAndroidManifestWithNoProcess.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+           package="com.xtremelabs.robolectric">
+    <application android:name="com.xtremelabs.robolectric.TestApplication"/>
+</manifest>

--- a/src/test/resources/TestAndroidManifestWithProcess.xml
+++ b/src/test/resources/TestAndroidManifestWithProcess.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+           package="com.xtremelabs.robolectric">
+    <application android:name="com.xtremelabs.robolectric.TestApplication"
+    		android:process="robolectricprocess"/>
+</manifest>


### PR DESCRIPTION
As a response to missing ApplicationInfo support, and problems running Roboguice 1.1 with Robolectric (as reported here: http://groups.google.com/group/robolectric/browse_thread/thread/3e92bc828455d6e2, here: https://github.com/pivotal/robolectric/issues#issue/45 and here: http://groups.google.com/group/robolectric/browse_thread/thread/3d03a56bb595b7cc) I've updated the RobolectricPackageManager, added a couple of Shadow classes, modified RobolectricConfig to do the necessary manifest parsing and updated the tests accordingly.

In order for the RobolectricPackageManager to have access to the necessary manifest properties, I injected a new instance of the RobolectricConfig through the RPM constructor. As I'm new to the codebase, I'm not sure if this is the best way to do this... 

This is my first time using Git/GitHub, and so I wasn't sure how to exclude changes I made to the pom from the pull request (which you can safely ignore).

Anyway, love the framework.

Rob
