### PR TITLE
getCause() doesn't always return an Exception

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/bytecode/ClassHandler.java
+++ b/src/main/java/com/xtremelabs/robolectric/bytecode/ClassHandler.java
@@ -9,5 +9,5 @@ public interface ClassHandler {
 
     void afterTest();
 
-    Object methodInvoked(Class clazz, String methodName, Object instance, String[] paramTypes, Object[] params) throws Exception;
+    Object methodInvoked(Class clazz, String methodName, Object instance, String[] paramTypes, Object[] params) throws Throwable;
 }

--- a/src/main/java/com/xtremelabs/robolectric/bytecode/RobolectricInternals.java
+++ b/src/main/java/com/xtremelabs/robolectric/bytecode/RobolectricInternals.java
@@ -106,8 +106,12 @@ public class RobolectricInternals {
     }
 
     @SuppressWarnings({"UnusedDeclaration"})
-    public static Object methodInvoked(Class clazz, String methodName, Object instance, String[] paramTypes, Object[] params) throws Exception {
-        return classHandler.methodInvoked(clazz, methodName, instance, paramTypes, params);
+    public static Object methodInvoked(Class clazz, String methodName, Object instance, String[] paramTypes, Object[] params) throws Throwable {
+        try {
+          return classHandler.methodInvoked(clazz, methodName, instance, paramTypes, params);
+        } catch(java.lang.LinkageError e) {
+          throw new Exception(e);
+        }
     }
 
     @SuppressWarnings({"UnusedDeclaration"})

--- a/src/main/java/com/xtremelabs/robolectric/bytecode/ShadowWrangler.java
+++ b/src/main/java/com/xtremelabs/robolectric/bytecode/ShadowWrangler.java
@@ -76,7 +76,7 @@ public class ShadowWrangler implements ClassHandler {
     }
 
     @Override
-    public Object methodInvoked(Class clazz, String methodName, Object instance, String[] paramTypes, Object[] params) throws Exception {
+    public Object methodInvoked(Class clazz, String methodName, Object instance, String[] paramTypes, Object[] params) throws Throwable {
         InvocationPlan invocationPlan = new InvocationPlan(clazz, methodName, instance, paramTypes);
         if (!invocationPlan.prepare()) {
             reportNoShadowMethodFound(clazz, methodName, paramTypes);
@@ -89,7 +89,7 @@ public class ShadowWrangler implements ClassHandler {
             throw new RuntimeException(invocationPlan.getShadow().getClass().getName() + " is not assignable from " +
                     invocationPlan.getDeclaredShadowClass().getName(), e);
         } catch (InvocationTargetException e) {
-            throw stripStackTrace((Exception) e.getCause());
+            throw stripStackTrace(e.getCause());
         }
     }
 


### PR DESCRIPTION
In methodInvoked on ShadowWrangler doing a cast to Exception on e.getCause() is problematic when the cause is not an exception.  

Specifically, I ran into a case where the cause was a LinkageError.  The cast to Exception caused the LinkageError itself to be lost and all I got was an InvalidCastException when trying to cast LinkageError to Exception.  

It seems OK to catch Throwable here since we're just munging it's stack trace and rethrowing it anyways.

If you really don't like the idea of ever catching Throwable then an alternative to my approach would be to just detect when the cause is an Error and rethrow it without stripping the stack trace.
