### PR TITLE
TestHttpResponse

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/tester/org/apache/http/TestHttpResponse.java
+++ b/src/main/java/com/xtremelabs/robolectric/tester/org/apache/http/TestHttpResponse.java
@@ -38,6 +38,10 @@ public class TestHttpResponse extends HttpResponseStub {
         return httpEntity;
     }
 
+    @Override public Header[] getAllHeaders() {
+        return new Header[] { contentType };
+    }
+
     public class TestHttpEntity extends HttpEntityStub {
         @Override public long getContentLength() {
             return responseBody.length();


### PR DESCRIPTION
I'm trying to use Robolectric.addPendingHttpResponse with Springs RestTemplate. Unfortunately, it calls getAllHeaders to get the ContentType. The current implementation just throws an UnsupportedOperationException.

Currently, I extended TestHttpResponse and overrode that method. But it would be nice if this wasn't necessary.
