### PR TITLE
BugFix for ShadowArrayAdapter. This bug was unmasked by the changes to Sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ local.properties
 *.iws
 *.iml
 *.ipr
+*.orig
 *~
 \#*\#

--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowArrayAdapter.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowArrayAdapter.java
@@ -1,21 +1,22 @@
 package com.xtremelabs.robolectric.shadows;
 
+import static com.xtremelabs.robolectric.Robolectric.shadowOf;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Filter;
 import android.widget.TextView;
+
 import com.xtremelabs.robolectric.Robolectric;
 import com.xtremelabs.robolectric.internal.Implementation;
 import com.xtremelabs.robolectric.internal.Implements;
 import com.xtremelabs.robolectric.res.ResourceLoader;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static com.xtremelabs.robolectric.Robolectric.shadowOf;
 
 @SuppressWarnings( { "UnusedDeclaration" })
 @Implements(ArrayAdapter.class)
@@ -38,8 +39,16 @@ public class ShadowArrayAdapter<T> extends ShadowBaseAdapter {
     private int textViewResourceId;
     private Filter filter;
 
+    public int getTextViewResourceId() {
+        return textViewResourceId;
+    }
+    
+    public int getResourceId() {
+        return resource;
+    }
+    
     public void __constructor__(Context context, int textViewResourceId) {
-        init(context, 0, textViewResourceId, new ArrayList<T>());
+        init(context, textViewResourceId, 0, new ArrayList<T>());
     }
 
     public void __constructor__(Context context, int resource, int textViewResourceId) {
@@ -47,7 +56,7 @@ public class ShadowArrayAdapter<T> extends ShadowBaseAdapter {
     }
 
     public void __constructor__(Context context, int textViewResourceId, T[] objects) {
-        init(context, 0, textViewResourceId, Arrays.asList(objects));
+        init(context, textViewResourceId, 0, Arrays.asList(objects));
     }
 
     public void __constructor__(Context context, int resource, int textViewResourceId, T[] objects) {
@@ -55,7 +64,7 @@ public class ShadowArrayAdapter<T> extends ShadowBaseAdapter {
     }
 
     public void __constructor__(Context context, int textViewResourceId, List<T> objects) {
-        init(context, 0, textViewResourceId, objects);
+        init(context, textViewResourceId, 0, objects);
     }
 
     public void __constructor__(Context context, int resource, int textViewResourceId, List<T> objects) {
@@ -103,6 +112,12 @@ public class ShadowArrayAdapter<T> extends ShadowBaseAdapter {
     public View getView(int position, View convertView, ViewGroup parent) {
         T item = list.get(position);
         View view = getResourceLoader().inflateView(context, resource, parent);
+
+        if (convertView == null) {
+            view = getResourceLoader().inflateView(context,resource, parent);
+        } else {
+            view = convertView;
+        }
 
         TextView text;
         if (textViewResourceId == 0) {

--- a/src/test/java/com/xtremelabs/robolectric/shadows/ArrayAdapterTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/ArrayAdapterTest.java
@@ -2,6 +2,7 @@
 
 package com.xtremelabs.robolectric.shadows;
 
+import android.content.Context;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
@@ -9,11 +10,14 @@ import android.widget.TextView;
 import com.xtremelabs.robolectric.R;
 import com.xtremelabs.robolectric.Robolectric;
 import com.xtremelabs.robolectric.WithTestDefaultsRunner;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -51,5 +55,32 @@ public class ArrayAdapterTest {
         View listItemView = arrayAdapter.getView(0, null, parent);
         TextView titleTextView = (TextView) listItemView.findViewById(R.id.title);
         assertEquals("first value", titleTextView.getText().toString());
+    }
+    
+    @Test
+    public void hasTheCorrectConstructorResourceIDs() {
+        ArrayAdapter<String> arrayAdapter = new ArrayAdapter<String>(Robolectric.application, R.id.title, new String[] { "first value" });
+        
+        //this assertion may look a little backwards since R.id.title is labeled
+        //textViewResourceId in the constructor parameter list, but the output is correct.
+        Assert.assertTrue(Robolectric.shadowOf(arrayAdapter).getResourceId()==R.id.title);
+        Assert.assertTrue(Robolectric.shadowOf(arrayAdapter).getTextViewResourceId()!=R.id.title);
+        Assert.assertTrue(Robolectric.shadowOf(arrayAdapter).getTextViewResourceId()==0);
+        
+        ArrayAdapter<String> arrayAdapter2 = new ArrayAdapter<String>(Robolectric.application, R.id.title);
+        
+        //this assertion may look a little backwards since R.id.title is labeled
+        //textViewResourceId in the constructor parameter list, but the output is correct.
+        Assert.assertTrue(Robolectric.shadowOf(arrayAdapter2).getResourceId()==R.id.title);
+        Assert.assertTrue(Robolectric.shadowOf(arrayAdapter2).getTextViewResourceId()!=R.id.title);
+        Assert.assertTrue(Robolectric.shadowOf(arrayAdapter2).getTextViewResourceId()==0);
+        
+        ArrayAdapter<String> arrayAdapter3 = new ArrayAdapter<String>(Robolectric.application, R.id.title, Arrays.asList(new String[] { "first value" }));
+        
+        //this assertion may look a little backwards since R.id.title is labeled
+        //textViewResourceId in the constructor parameter list, but the output is correct.
+        Assert.assertTrue(Robolectric.shadowOf(arrayAdapter3).getResourceId()==R.id.title);
+        Assert.assertTrue(Robolectric.shadowOf(arrayAdapter3).getTextViewResourceId()!=R.id.title);
+        Assert.assertTrue(Robolectric.shadowOf(arrayAdapter3).getTextViewResourceId()==0);
     }
 }


### PR DESCRIPTION
BugFix for ShadowArrayAdapter. This bug was unmasked by the changes to ShadowArrayAdapter committed to pivotal/master on 7/1/11, previously the code in ShadowArrayAdapter's getview() just went along with this bug's idea of proper resourceIds.  I know this change may look odd given the names of variables in ShadowArrayAdapter's source code. But looking at the source of the android ArrayAdapter you will see that this change is correct.

```
modified:   .gitignore
modified:   src/main/java/com/xtremelabs/robolectric/shadows/ShadowArrayAdapter.java
modified:   src/test/java/com/xtremelabs/robolectric/shadows/ArrayAdapterTest.java
```
