### PR TITLE
Changed the way SDK version is processed

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/RobolectricTestRunner.java
+++ b/src/main/java/com/xtremelabs/robolectric/RobolectricTestRunner.java
@@ -1,14 +1,16 @@
 package com.xtremelabs.robolectric;
 
-import android.app.Application;
-import android.net.Uri__FromAndroid;
-import com.xtremelabs.robolectric.bytecode.ClassHandler;
-import com.xtremelabs.robolectric.bytecode.RobolectricClassLoader;
-import com.xtremelabs.robolectric.bytecode.ShadowWrangler;
-import com.xtremelabs.robolectric.internal.RealObject;
-import com.xtremelabs.robolectric.internal.RobolectricTestRunnerInterface;
-import com.xtremelabs.robolectric.res.ResourceLoader;
-import com.xtremelabs.robolectric.shadows.ShadowApplication;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
@@ -16,15 +18,16 @@ import org.junit.runners.model.Statement;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
+import android.app.Application;
+import android.net.Uri__FromAndroid;
+
+import com.xtremelabs.robolectric.bytecode.ClassHandler;
+import com.xtremelabs.robolectric.bytecode.RobolectricClassLoader;
+import com.xtremelabs.robolectric.bytecode.ShadowWrangler;
+import com.xtremelabs.robolectric.internal.RealObject;
+import com.xtremelabs.robolectric.internal.RobolectricTestRunnerInterface;
+import com.xtremelabs.robolectric.res.ResourceLoader;
+import com.xtremelabs.robolectric.shadows.ShadowApplication;
 
 /**
  * Installs a {@link RobolectricClassLoader} and {@link com.xtremelabs.robolectric.res.ResourceLoader} in order to
@@ -56,7 +59,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
      * @param testClass the test class to be run
      * @throws InitializationError if junit says so
      */
-    public RobolectricTestRunner(Class<?> testClass) throws InitializationError {
+    public RobolectricTestRunner(final Class<?> testClass) throws InitializationError {
         this(testClass, new RobolectricConfig(new File(".")));
     }
 
@@ -68,7 +71,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
      * @param robolectricConfig the configuration data
      * @throws InitializationError if junit says so
      */
-    protected RobolectricTestRunner(Class<?> testClass, RobolectricConfig robolectricConfig)
+    protected RobolectricTestRunner(final Class<?> testClass, final RobolectricConfig robolectricConfig)
             throws InitializationError {
         this(testClass,
                 isInstrumented() ? null : ShadowWrangler.getInstance(),
@@ -83,7 +86,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
      * @param androidProjectRoot the directory containing your AndroidManifest.xml file and res dir
      * @throws InitializationError if the test class is malformed
      */
-    public RobolectricTestRunner(Class<?> testClass, File androidProjectRoot) throws InitializationError {
+    public RobolectricTestRunner(final Class<?> testClass, final File androidProjectRoot) throws InitializationError {
         this(testClass, new RobolectricConfig(androidProjectRoot));
     }
 
@@ -95,7 +98,8 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
      * @throws InitializationError if junit says so
      * @deprecated Use {@link #RobolectricTestRunner(Class, File)} instead.
      */
-    public RobolectricTestRunner(Class<?> testClass, String androidProjectRoot) throws InitializationError {
+    @Deprecated
+    public RobolectricTestRunner(final Class<?> testClass, final String androidProjectRoot) throws InitializationError {
         this(testClass, new RobolectricConfig(new File(androidProjectRoot)));
     }
 
@@ -110,7 +114,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
      * @param resourceDirectory   the directory containing the project's resources
      * @throws InitializationError if junit says so
      */
-    protected RobolectricTestRunner(Class<?> testClass, File androidManifestPath, File resourceDirectory)
+    protected RobolectricTestRunner(final Class<?> testClass, final File androidManifestPath, final File resourceDirectory)
             throws InitializationError {
         this(testClass, new RobolectricConfig(androidManifestPath, resourceDirectory));
     }
@@ -127,7 +131,8 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
      * @throws InitializationError if junit says so
      * @deprecated Use {@link #RobolectricTestRunner(Class, File, File)} instead.
      */
-    protected RobolectricTestRunner(Class<?> testClass, String androidManifestPath, String resourceDirectory)
+    @Deprecated
+    protected RobolectricTestRunner(final Class<?> testClass, final String androidManifestPath, final String resourceDirectory)
             throws InitializationError {
         this(testClass, new RobolectricConfig(new File(androidManifestPath), new File(resourceDirectory)));
     }
@@ -148,7 +153,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
      * @param robolectricConfig the configuration
      * @throws InitializationError if junit says so
      */
-    protected RobolectricTestRunner(Class<?> testClass, ClassHandler classHandler, RobolectricClassLoader classLoader, RobolectricConfig robolectricConfig) throws InitializationError {
+    protected RobolectricTestRunner(final Class<?> testClass, final ClassHandler classHandler, final RobolectricClassLoader classLoader, final RobolectricConfig robolectricConfig) throws InitializationError {
         super(isInstrumented() ? testClass : classLoader.bootstrap(testClass));
 
         if (!isInstrumented()) {
@@ -186,18 +191,20 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
      * This is not the constructor you are looking for.
      */
     @SuppressWarnings({"UnusedDeclaration", "JavaDoc"})
-    protected RobolectricTestRunner(Class<?> testClass, ClassHandler classHandler, RobolectricConfig robolectricConfig) throws InitializationError {
+    protected RobolectricTestRunner(final Class<?> testClass, final ClassHandler classHandler, final RobolectricConfig robolectricConfig) throws InitializationError {
         super(testClass);
         this.classHandler = classHandler;
         this.robolectricConfig = robolectricConfig;
     }
 
-    protected void delegateLoadingOf(String className) {
+    protected void delegateLoadingOf(final String className) {
         classLoader.delegateLoadingOf(className);
     }
 
     @Override protected Statement methodBlock(final FrameworkMethod method) {
-        if (classHandler != null) classHandler.beforeTest();
+        if (classHandler != null) {
+            classHandler.beforeTest();
+        }
         delegate.internalBeforeTest(method.getMethod());
 
         final Statement statement = super.methodBlock(method);
@@ -208,7 +215,9 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
                     statement.evaluate();
                 } finally {
                     delegate.internalAfterTest(method.getMethod());
-                    if (classHandler != null) classHandler.afterTest();
+                    if (classHandler != null) {
+                        classHandler.afterTest();
+                    }
                 }
             }
         };
@@ -217,17 +226,17 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
     /*
      * Called before each test method is run. Sets up the simulation of the Android runtime environment.
      */
-    @Override public void internalBeforeTest(Method method) {
+    @Override public void internalBeforeTest(final Method method) {
         setupApplicationState(robolectricConfig);
 
         beforeTest(method);
     }
 
-    @Override public void internalAfterTest(Method method) {
+    @Override public void internalAfterTest(final Method method) {
         afterTest(method);
     }
 
-    @Override public void setRobolectricConfig(RobolectricConfig robolectricConfig) {
+    @Override public void setRobolectricConfig(final RobolectricConfig robolectricConfig) {
         this.robolectricConfig = robolectricConfig;
     }
 
@@ -236,7 +245,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
      *
      * @param method the test method about to be run
      */
-    public void beforeTest(Method method) {
+    public void beforeTest(final Method method) {
     }
 
     /**
@@ -244,7 +253,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
      *
      * @param method the test method that just ran.
      */
-    public void afterTest(Method method) {
+    public void afterTest(final Method method) {
     }
 
     /**
@@ -263,10 +272,10 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
         }
     }
 
-    public void prepareTest(Object test) {
+    public void prepareTest(final Object test) {
     }
 
-    public void setupApplicationState(RobolectricConfig robolectricConfig) {
+    public void setupApplicationState(final RobolectricConfig robolectricConfig) {
         ResourceLoader resourceLoader = createResourceLoader(robolectricConfig);
 
         Robolectric.bindDefaultShadowClasses();
@@ -302,7 +311,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
         return new ApplicationResolver(robolectricConfig).resolveApplication();
     }
 
-    private ResourceLoader createResourceLoader(RobolectricConfig robolectricConfig) {
+    private ResourceLoader createResourceLoader(final RobolectricConfig robolectricConfig) {
         ResourceLoader resourceLoader = resourceLoaderForRootAndDirectory.get(robolectricConfig);
         if (resourceLoader == null) {
             try {
@@ -310,7 +319,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
 
                 String rClassName = robolectricConfig.getRClassName();
                 Class rClass = Class.forName(rClassName);
-                resourceLoader = new ResourceLoader(robolectricConfig.getSdkVersion(), rClass, robolectricConfig.getResourceDirectory(), robolectricConfig.getAssetsDirectory());
+                resourceLoader = new ResourceLoader(robolectricConfig.getRealSdkVersion(), rClass, robolectricConfig.getResourceDirectory(), robolectricConfig.getAssetsDirectory());
                 resourceLoaderForRootAndDirectory.put(robolectricConfig, resourceLoader);
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -319,7 +328,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
         return resourceLoader;
     }
 
-    private String findResourcePackageName(File projectManifestFile) throws ParserConfigurationException, IOException, SAXException {
+    private String findResourcePackageName(final File projectManifestFile) throws ParserConfigurationException, IOException, SAXException {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         DocumentBuilder db = dbf.newDocumentBuilder();
         Document doc = db.parse(projectManifestFile);

--- a/src/test/java/com/xtremelabs/robolectric/RobolectricConfigTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/RobolectricConfigTest.java
@@ -1,18 +1,30 @@
 package com.xtremelabs.robolectric;
 
-import android.content.BroadcastReceiver;
-import android.content.Context;
-import android.content.Intent;
-import com.xtremelabs.robolectric.util.TestUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import java.util.List;
-
+import static android.content.pm.ApplicationInfo.FLAG_ALLOW_BACKUP;
+import static android.content.pm.ApplicationInfo.FLAG_ALLOW_CLEAR_USER_DATA;
+import static android.content.pm.ApplicationInfo.FLAG_ALLOW_TASK_REPARENTING;
+import static android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE;
+import static android.content.pm.ApplicationInfo.FLAG_HAS_CODE;
+import static android.content.pm.ApplicationInfo.FLAG_KILL_AFTER_RESTORE;
+import static android.content.pm.ApplicationInfo.FLAG_PERSISTENT;
+import static android.content.pm.ApplicationInfo.FLAG_RESIZEABLE_FOR_SCREENS;
+import static android.content.pm.ApplicationInfo.FLAG_RESTORE_ANY_VERSION;
+import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_LARGE_SCREENS;
+import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_NORMAL_SCREENS;
+import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_SCREEN_DENSITIES;
+import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_SMALL_SCREENS;
+import static android.content.pm.ApplicationInfo.FLAG_TEST_ONLY;
+import static android.content.pm.ApplicationInfo.FLAG_VM_SAFE_MODE;
 import static com.xtremelabs.robolectric.util.TestUtil.newConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static android.content.pm.ApplicationInfo.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
 
 @RunWith(WithTestDefaultsRunner.class)
 public class RobolectricConfigTest {
@@ -31,13 +43,19 @@ public class RobolectricConfigTest {
 
     public static class ConfigTestReceiver extends BroadcastReceiver {
         @Override
-        public void onReceive(Context context, Intent intent) { }
+        public void onReceive(final Context context, final Intent intent) { }
     }
 
     @Test
     public void shouldReadSdkVersionFromAndroidManifest() throws Exception {
         assertEquals(42, newConfig("TestAndroidManifestWithSdkVersion.xml").getSdkVersion());
         assertEquals(3, newConfig("TestAndroidManifestWithSdkVersion.xml").getMinSdkVersion());
+    }
+    
+    @Test
+    public void shouldRessolveSdkVersionForResources() throws Exception {
+        assertEquals(3, newConfig("TestAndroidManifestWithMinSdkVersionOnly.xml").getRealSdkVersion());
+        assertEquals(42, newConfig("TestAndroidManifestWithSdkVersion.xml").getRealSdkVersion());
     }
     
     @Test
@@ -70,7 +88,7 @@ public class RobolectricConfigTest {
         assertTrue(hasFlag(config.getApplicationFlags(), FLAG_VM_SAFE_MODE));
     }
     
-    private boolean hasFlag(int flags, int flag) {
+    private boolean hasFlag(final int flags, final int flag) {
     	return (flags & flag) != 0;
     }
 }

--- a/src/test/resources/TestAndroidManifestWithMinSdkVersionOnly.xml
+++ b/src/test/resources/TestAndroidManifestWithMinSdkVersionOnly.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-sdk android:minSdkVersion="3"/>
+</manifest>


### PR DESCRIPTION
Right now only targetSdkVersion was processed in order to load resources.
That's not always true. If targetSdkVersion is not present, it should process minSdkVersion. For example I have min SDK for 8 and don't have platform-10 downloaded so Robolectric was failling. With this change, everything works ok.
