### PR TITLE
fix test for windows compatibility

### DIFF
--- a/src/test/java/com/xtremelabs/robolectric/shadows/ContextTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/ContextTest.java
@@ -93,6 +93,6 @@ public class ContextTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void openFileOutput_shouldNotAcceptPathsWithSeparatorCharacters() throws Exception {
-        context.openFileOutput("/data/test/hi", 0);
+        context.openFileOutput(File.separator + "data" + File.separator + "test" + File.separator + "hi", 0);
     }
 }


### PR DESCRIPTION
the test openFileOutput_shouldNotAcceptPathsWithSeparatorCharacters() fails on windows because the rest of the code is written with "File.separator" and this single test is written with '/'.  on windows '/' is not equivalent to File.separator so the test fails.
