### PR TITLE
Added missing android-test dependency to pom.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,10 @@
     <description>An alternative Android testing framework.</description>
     <url>http://pivotal.github.com/robolectric/</url>
 
+    <properties>
+        <android.sdk.version>2.3.3</android.sdk.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -71,8 +75,15 @@
         <dependency>
             <groupId>com.google.android</groupId>
             <artifactId>android</artifactId>
-            <version>2.3.3</version>
+            <version>${android.sdk.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.android</groupId>
+            <artifactId>android-test</artifactId>
+            <version>${android.sdk.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Hey guys, build is broken since the following commit:

2b68d9981b16b9d721448c63e7912796d1ff40bf is the first bad commit
commit 2b68d9981b16b9d721448c63e7912796d1ff40bf
Author: David Farber & Joe Moore <pair+dfarber+joe@pivotallabs.com>
Date:   Tue Jul 19 13:55:40 2011 -0700

```
require ShadowContentResolver to use TestCursor so they can track the params from the query() method;
TestCursor can track params matching ContentResolver.query();
RequestMatcherBuilder tracks and matches on HttpRequest headers;
ParamsParser parses HttpPost data
```

Please pull to add android-test as a project dependency.
