### PR TITLE
Dialogs have cancelable set to true by default in the Android SDK.

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowDialog.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowDialog.java
@@ -36,7 +36,7 @@ public class ShadowDialog {
     private DialogInterface.OnCancelListener onCancelListener;
     private Window window;
     private Activity ownerActivity;
-    private boolean isCancelable;
+    private boolean isCancelable = true;
     private boolean hasShownBefore;
     
     public static void reset() {

--- a/src/test/java/com/xtremelabs/robolectric/shadows/DialogTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/DialogTest.java
@@ -57,13 +57,16 @@ public class DialogTest {
         Dialog dialog = new Dialog(null);
         ShadowDialog shadow = Robolectric.shadowOf(dialog);
 
-        assertThat(shadow.isCancelable(), equalTo(false));
-
-        dialog.setCancelable(true);
-        assertThat(shadow.isCancelable(), equalTo(true));
-
         dialog.setCancelable(false);
         assertThat(shadow.isCancelable(), equalTo(false));
+    }
+
+    @Test
+    public void shouldDefaultCancelableToTrueAsTheSDKDoes() throws Exception {
+        Dialog dialog = new Dialog(null);
+        ShadowDialog shadow = Robolectric.shadowOf(dialog);
+
+        assertThat(shadow.isCancelable(), equalTo(true));
     }
 
     @Test


### PR DESCRIPTION
The current default value in Robolectric doesn't match the one in Android SDK.
