### PR TITLE
Fix to allow Robolectric to run with mixed Scala\Java and so that tests run with Maven

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/RobolectricTestRunner.java
+++ b/src/main/java/com/xtremelabs/robolectric/RobolectricTestRunner.java
@@ -61,6 +61,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner implements Rob
         return defaultLoader;
     }
     public static void setDefaultLoader(Loader robolectricClassLoader) {
+    	//used by the RoboSpecs project to allow for mixed scala\java tests to be run with Maven Surefire (see the RoboSpecs project on github)
         if (defaultLoader == null) {
             defaultLoader = (RobolectricClassLoader)robolectricClassLoader;
         } else throw new RuntimeException("You may not set the default robolectricClassLoader unless it is null!");

--- a/src/main/java/com/xtremelabs/robolectric/bytecode/RobolectricClassLoader.java
+++ b/src/main/java/com/xtremelabs/robolectric/bytecode/RobolectricClassLoader.java
@@ -35,7 +35,8 @@ public class RobolectricClassLoader extends javassist.Loader {
     
     @Override
     public Class loadClass(String name) throws ClassNotFoundException {
-        boolean shouldComeFromThisClassLoader = !(name.startsWith("org.junit") || name.startsWith("org.hamcrest")  || name.startsWith("org.specs2") || name.startsWith("scala."));
+        boolean shouldComeFromThisClassLoader = !(name.startsWith("org.junit") || name.startsWith("org.hamcrest")  
+        		|| name.startsWith("org.specs2") || name.startsWith("scala.")); //org.specs2 and scala. allows for android projects with mixed scala\java tests to be run with Maven Surefire (see the RoboSpecs project on github)
 
         Class<?> theClass;
         if (shouldComeFromThisClassLoader) {


### PR DESCRIPTION
Some small edits to let the RoboSpecs project (Scala\Robolectric) run a mixed set of scala\java tests in maven surefire. (I still need to send RoboSpecs a pull request with changes for that project too...)

This allows Java and Scala Robolectric tests to share the same classloader when run under maven. Otherwise they clash and crash.
