### PR TITLE
Added header related methods to TestHttpResponse

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/Robolectric.java
+++ b/src/main/java/com/xtremelabs/robolectric/Robolectric.java
@@ -845,9 +845,10 @@ public class Robolectric {
      *
      * @param statusCode   the status code of the response
      * @param responseBody the body of the response
+     * @param headers      optional headers for the request
      */
-    public static void addPendingHttpResponse(int statusCode, String responseBody) {
-        getFakeHttpLayer().addPendingHttpResponse(statusCode, responseBody);
+    public static void addPendingHttpResponse(int statusCode, String responseBody, Header... headers) {
+        getFakeHttpLayer().addPendingHttpResponse(statusCode, responseBody, headers);
     }
 
     /**
@@ -856,9 +857,10 @@ public class Robolectric {
      * @param statusCode   the status code of the response
      * @param responseBody the body of the response
      * @param contentType  the contentType of the response
+     * @deprecated         use {@link #addPendingHttpResponse(int, String, Header...)} instead
      */
     public static void addPendingHttpResponseWithContentType(int statusCode, String responseBody, Header contentType) {
-        getFakeHttpLayer().addPendingHttpResponseWithContentType(statusCode, responseBody, contentType);
+        getFakeHttpLayer().addPendingHttpResponse(statusCode, responseBody, contentType);
     }
 
     /**

--- a/src/main/java/com/xtremelabs/robolectric/tester/org/apache/http/FakeHttpLayer.java
+++ b/src/main/java/com/xtremelabs/robolectric/tester/org/apache/http/FakeHttpLayer.java
@@ -37,12 +37,8 @@ public class FakeHttpLayer {
         return requestInfos.get(requestInfos.size() - 1);
     }
 
-    public void addPendingHttpResponse(int statusCode, String responseBody) {
-        addPendingHttpResponse(new TestHttpResponse(statusCode, responseBody));
-    }
-
-    public void addPendingHttpResponseWithContentType(int statusCode, String responseBody, Header contentType) {
-        addPendingHttpResponse(new TestHttpResponse(statusCode, responseBody, new Header[]{contentType}));
+    public void addPendingHttpResponse(int statusCode, String responseBody, Header... headers) {
+        addPendingHttpResponse(new TestHttpResponse(statusCode, responseBody, headers));
     }
 
     public void addPendingHttpResponse(HttpResponse httpResponse) {

--- a/src/test/java/com/xtremelabs/robolectric/shadows/DefaultRequestDirectorTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/DefaultRequestDirectorTest.java
@@ -268,7 +268,7 @@ public class DefaultRequestDirectorTest {
     
     @Test
     public void shouldSupportBasicResponseHandlerHandleResponse() throws Exception {
-        Robolectric.addPendingHttpResponseWithContentType(200, "OK", new BasicHeader("Content-Type", "text/plain"));
+        Robolectric.addPendingHttpResponse(200, "OK", new BasicHeader("Content-Type", "text/plain"));
 
         DefaultHttpClient client = new DefaultHttpClient();
         HttpResponse response = client.execute(new HttpGet("http://www.nowhere.org"));

--- a/src/test/java/com/xtremelabs/robolectric/tester/org/apache/http/TestHttpResponseTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/tester/org/apache/http/TestHttpResponseTest.java
@@ -1,0 +1,103 @@
+package com.xtremelabs.robolectric.tester.org.apache.http;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.http.Header;
+import org.apache.http.HeaderIterator;
+import org.apache.http.HttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+public class TestHttpResponseTest {
+
+    @Test
+    public void shouldSupportGetFirstHeader() throws Exception {
+        HttpResponse resp =
+                new TestHttpResponse(304, "REDIRECTED",
+                        new BasicHeader("Location", "http://bar.com"));
+
+        assertThat(resp.getFirstHeader("None"), nullValue());
+        assertThat(new TestHttpResponse(200, "OK").getFirstHeader("Foo"), nullValue());
+
+        for (String l : new String[] { "location", "Location" }) {
+            assertThat(resp.getFirstHeader(l).getValue(), equalTo("http://bar.com"));
+        }
+    }
+
+    @Test
+    public void shouldSupportGetLastHeader() throws Exception {
+        HttpResponse resp =
+                new TestHttpResponse(304, "REDIRECTED",
+                        new BasicHeader("Location", "http://bar.com"),
+                        new BasicHeader("Location", "http://zombo.com"));
+
+        assertThat(resp.getLastHeader("None"), nullValue());
+
+        for (String l : new String[] { "location", "Location" }) {
+            assertThat(resp.getLastHeader(l).getValue(), equalTo("http://zombo.com"));
+        }
+    }
+
+    @Test
+    public void shouldSupportContainsHeader() throws Exception {
+        HttpResponse resp =
+                new TestHttpResponse(304, "ZOMBO",
+                        new BasicHeader("X-Zombo-Com", "Welcome"));
+
+        assertThat(resp.containsHeader("X-Zombo-Com"), is(true));
+        assertThat(resp.containsHeader("Location"), is(false));
+    }
+
+    @Test
+    public void shouldSupportHeaderIterator() throws Exception {
+        HttpResponse resp =
+                new TestHttpResponse(304, "REDIRECTED",
+                        new BasicHeader("Location", "http://bar.com"),
+                        new BasicHeader("Location", "http://zombo.com"));
+
+        HeaderIterator it = resp.headerIterator();
+
+        assertThat(it.hasNext(), is(true));
+        assertThat(it.nextHeader().getValue(), equalTo("http://bar.com"));
+        assertThat(it.nextHeader().getValue(), equalTo("http://zombo.com"));
+        assertThat(it.hasNext(), is(false));
+    }
+
+    @Test
+    public void shouldSupportHeaderIteratorWithArg() throws Exception {
+        HttpResponse resp =
+                new TestHttpResponse(304, "REDIRECTED",
+                        new BasicHeader("Location", "http://bar.com"),
+                        new BasicHeader("X-Zombo-Com", "http://zombo.com"),
+                        new BasicHeader("Location", "http://foo.com"));
+
+        HeaderIterator it = resp.headerIterator("Location");
+
+        assertThat(it.hasNext(), is(true));
+        assertThat(it.nextHeader().getValue(), equalTo("http://bar.com"));
+        assertThat(it.hasNext(), is(true));
+        assertThat(it.nextHeader().getValue(), equalTo("http://foo.com"));
+        assertThat(it.hasNext(), is(false));
+    }
+
+
+    @Test
+    public void shouldSupportGetHeadersWithArg() throws Exception {
+        HttpResponse resp =
+                new TestHttpResponse(304, "REDIRECTED",
+                        new BasicHeader("Location", "http://bar.com"),
+                        new BasicHeader("X-Zombo-Com", "http://zombo.com"),
+                        new BasicHeader("Location", "http://foo.com"));
+
+
+        Header[] headers = resp.getHeaders("Location");
+        assertThat(headers.length, is(2));
+        assertThat(headers[0].getValue(), CoreMatchers.equalTo("http://bar.com"));
+        assertThat(headers[1].getValue(), CoreMatchers.equalTo("http://foo.com"));
+    }
+}


### PR DESCRIPTION
 Also changed `Robolectric#addPendingHttpResponse(int, String)` to
 `Robolectric#addPendingHttpResponse(int, String, Header...)` so that
 addPendingHttpResponseWithContentType() is no longer needed.
