### PR TITLE
Implementation of getAllProviders() method in ShadowLocationManager

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowLocationManager.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowLocationManager.java
@@ -1,5 +1,7 @@
 package com.xtremelabs.robolectric.shadows;
 
+import java.util.LinkedHashSet;
+import java.util.Set;
 import android.location.Criteria;
 import android.location.GpsStatus.Listener;
 import android.location.Location;
@@ -34,6 +36,16 @@ public class ShadowLocationManager {
     public boolean isProviderEnabled(String provider) {
         Boolean isEnabled = providersEnabled.get(provider);
         return isEnabled == null ? true : isEnabled;
+    }
+
+    @Implementation
+    public List<String> getAllProviders() {
+        Set<String> allKnownProviders = new LinkedHashSet<String>(providersEnabled.keySet());
+        allKnownProviders.add(LocationManager.GPS_PROVIDER);
+        allKnownProviders.add(LocationManager.NETWORK_PROVIDER);
+        allKnownProviders.add(LocationManager.PASSIVE_PROVIDER);
+
+        return new ArrayList<String>(allKnownProviders);
     }
 
     /**

--- a/src/test/java/com/xtremelabs/robolectric/shadows/LocationManagerTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/LocationManagerTest.java
@@ -98,6 +98,14 @@ public class LocationManagerTest {
     }
 
     @Test
+    public void shouldReturnAllProviders() throws Exception {
+        assertThat(locationManager.getAllProviders().size(), equalTo(3));
+
+        shadowLocationManager.setProviderEnabled("MY_PROVIDER", false);
+        assertThat(locationManager.getAllProviders().size(), equalTo(4));
+    }
+
+    @Test
     public void shouldReturnLastKnownLocationForAProvider() throws Exception {
         assertNull(locationManager.getLastKnownLocation(NETWORK_PROVIDER));
 


### PR DESCRIPTION
Returns all currently available Location Providers and all Providers added by using setProviderEnabled(). Location Providers provided by the framework are added by default.
