### PR TITLE
Properties file for a custom path to cached-robolectric-classes.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,12 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+            <version>1.6</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.0.3</version>

--- a/src/main/java/com/xtremelabs/robolectric/bytecode/RobolectricClassLoader.java
+++ b/src/main/java/com/xtremelabs/robolectric/bytecode/RobolectricClassLoader.java
@@ -1,10 +1,16 @@
 package com.xtremelabs.robolectric.bytecode;
 
+import java.io.File;
 import java.util.ArrayList;
 import javassist.CannotCompileException;
 import javassist.ClassPool;
 import javassist.LoaderClassPath;
 import javassist.NotFoundException;
+
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
 
 public class RobolectricClassLoader extends javassist.Loader {
     private ClassCache classCache;
@@ -19,7 +25,16 @@ public class RobolectricClassLoader extends javassist.Loader {
         delegateLoadingOf(AndroidTranslator.class.getName());
         delegateLoadingOf(ClassHandler.class.getName());
 
-        classCache = new ClassCache("tmp/cached-robolectric-classes.jar", AndroidTranslator.CACHE_VERSION);
+        File classCacheTmpDirectory = new File("tmp");
+        try {
+            final Configuration config = new PropertiesConfiguration("roboelectric.properties");
+            classCacheTmpDirectory = new File(config.getString("cached.roboelectric.classes.path"));
+        } catch (ConfigurationException e) {
+            // ignore and fallback to default configuration
+        }
+
+        classCache = new ClassCache(new File(classCacheTmpDirectory, "cached-robolectric-classes.jar").getAbsolutePath(), 
+                AndroidTranslator.CACHE_VERSION);
         try {
             ClassPool classPool = new ClassPool();
             classPool.appendClassPath(new LoaderClassPath(RobolectricClassLoader.class.getClassLoader()));


### PR DESCRIPTION
Use commons-configuration to load a "robolectric.properties" file with
a property cached.robolectric.classes.path to configure the directory where
cached-robolectric-classes.jar is written.

This is usefull to get a better integration with maven.
