### PR TITLE
System property for a custom path to cached-robolectric-classes.jar

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/bytecode/RobolectricClassLoader.java
+++ b/src/main/java/com/xtremelabs/robolectric/bytecode/RobolectricClassLoader.java
@@ -5,6 +5,8 @@ import javassist.ClassPool;
 import javassist.LoaderClassPath;
 import javassist.NotFoundException;
 
+import java.io.File;
+import java.lang.System;
 import java.util.List;
 
 public class RobolectricClassLoader extends javassist.Loader {
@@ -21,7 +23,15 @@ public class RobolectricClassLoader extends javassist.Loader {
         delegateLoadingOf(AndroidTranslator.class.getName());
         delegateLoadingOf(ClassHandler.class.getName());
 
-        classCache = new ClassCache("tmp/cached-robolectric-classes.jar", AndroidTranslator.CACHE_VERSION);
+        final String classCachePath = System.getProperty("cached.roboelectric.classes.path");
+        final File classCacheDirectory;
+        if (null == classCachePath || "".equals(classCachePath.trim())) {
+            classCacheDirectory = new File("./tmp");
+        } else {
+            classCacheDirectory = new File(classCachePath);
+        }
+
+        classCache = new ClassCache(new File(classCacheDirectory, "cached-robolectric-classes.jar").getAbsolutePath(), AndroidTranslator.CACHE_VERSION);
         try {
             ClassPool classPool = new ClassPool();
             classPool.appendClassPath(new LoaderClassPath(RobolectricClassLoader.class.getClassLoader()));


### PR DESCRIPTION
Initialize classCachePath from a system property named cached.robolectric.classes.path or fallback to default value.

To set a system property we can configure the maven-surefire-plugin: http://maven.apache.org/plugins/maven-surefire-plugin/examples/system-properties.html

Hoping this is better :) 

Regards, 
Jeremie
