### PR TITLE
Make DefaultRequestDirectorTest.shouldSupportRealHttpRequests work on systems using OpenDNS

### DIFF
--- a/src/test/java/com/xtremelabs/robolectric/shadows/DefaultRequestDirectorTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/DefaultRequestDirectorTest.java
@@ -344,6 +344,6 @@ public class DefaultRequestDirectorTest {
     public void shouldSupportRealHttpRequests() throws Exception {
         Robolectric.getFakeHttpLayer().interceptHttpRequests(false);
         DefaultHttpClient client = new DefaultHttpClient();
-        client.execute(new HttpGet("http://www.this-host-should-not-exist-123456790.org"));
+        client.execute(new HttpGet("http://www.this-host-should-not-exist-123456790.org:999"));
     }
 }


### PR DESCRIPTION
OpenDNS will redirect invalid hostnames to OpenDNS' troubleshooting
page, which causes HTTP requests to any hostname to successfully
complete.  We add a port number so that this test will generate the
expected IOException even if OpenDNS (or any other sort of captive
portal) is in use.
