### PR TITLE
ShadowApplication.sendBroadcast does not log sent broadcasts

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowApplication.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowApplication.java
@@ -63,6 +63,7 @@ public class ShadowApplication extends ShadowContextWrapper {
     private List<Intent> startedActivities = new ArrayList<Intent>();
     private List<Intent> startedServices = new ArrayList<Intent>();
     private List<Intent> stoppedServies = new ArrayList<Intent>();
+    private List<Intent> broadcastIntents = new ArrayList<Intent>();
     private List<ServiceConnection> unboundServiceConnections = new ArrayList<ServiceConnection>();
     private List<Wrapper> registeredReceivers = new ArrayList<Wrapper>();
     private Map<String, Intent> stickyIntents = new HashMap<String, Intent>();
@@ -308,6 +309,8 @@ public class ShadowApplication extends ShadowContextWrapper {
     @Override
     @Implementation
     public void sendBroadcast(Intent intent) {
+        broadcastIntents.add(intent);
+		
         List<Wrapper> copy = new ArrayList<Wrapper>();
         copy.addAll(registeredReceivers);
         for (Wrapper wrapper : copy) {
@@ -315,6 +318,10 @@ public class ShadowApplication extends ShadowContextWrapper {
                 wrapper.broadcastReceiver.onReceive(realApplication, intent);
             }
         }
+    }
+	
+    public List<Intent> getBroadcastIntents() {
+        return broadcastIntents;
     }
 
     @Implementation

--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowContextWrapper.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowContextWrapper.java
@@ -38,7 +38,6 @@ public class ShadowContextWrapper extends ShadowContext {
 
     private String appName;
     private String packageName;
-    private ArrayList<Intent> broadcastIntents = new ArrayList<Intent>();
     private Set<String> grantedPermissions = new HashSet<String>();
 
     public void __constructor__(Context baseContext) {
@@ -73,11 +72,10 @@ public class ShadowContextWrapper extends ShadowContext {
     @Implementation
     public void sendBroadcast(Intent intent) {
         getApplicationContext().sendBroadcast(intent);
-        broadcastIntents.add(intent);
     }
 
     public List<Intent> getBroadcastIntents() {
-        return broadcastIntents;
+        return ((ShadowApplication) shadowOf(getApplicationContext())).getBroadcastIntents();
     }
 
     @Implementation

--- a/src/test/java/com/xtremelabs/robolectric/shadows/ApplicationTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/ApplicationTest.java
@@ -23,9 +23,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.FileDescriptor;
+import java.util.List;
 
 import static com.xtremelabs.robolectric.Robolectric.shadowOf;
 import static com.xtremelabs.robolectric.util.TestUtil.newConfig;
+import static junit.framework.Assert.assertEquals;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.*;
@@ -220,6 +222,17 @@ public class ApplicationTest {
 
         shadowOf(Robolectric.application).assertNoBroadcastListenersOfActionRegistered(activity, "Bar");
     }
+    
+    @Test
+	public void broadcasts_shouldBeLogged()
+	{
+		Intent broadcastIntent = new Intent("foo");
+		Robolectric.application.sendBroadcast(broadcastIntent);
+		
+		List<Intent> broadcastIntents = shadowOf(Robolectric.application).getBroadcastIntents();
+		assertTrue(broadcastIntents.size() == 1);
+		assertEquals(broadcastIntent, broadcastIntents.get(0));
+	}
 
     private static class NullBinder implements IBinder {
         @Override

--- a/src/test/java/com/xtremelabs/robolectric/shadows/ContextWrapperTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/ContextWrapperTest.java
@@ -1,5 +1,7 @@
 package com.xtremelabs.robolectric.shadows;
 
+import java.util.List;
+
 import android.app.Activity;
 import android.appwidget.AppWidgetProvider;
 import android.content.BroadcastReceiver;
@@ -22,6 +24,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
 
 @RunWith(WithTestDefaultsRunner.class)
@@ -94,6 +97,18 @@ public class ContextWrapperTest {
 
         new ContextWrapper(Robolectric.application).unregisterReceiver(receiver);
     }
+	
+	@Test
+	public void broadcasts_shouldBeLogged()
+	{
+		Intent broadcastIntent = new Intent("foo");
+		contextWrapper.sendBroadcast(broadcastIntent);
+		
+		List<Intent> broadcastIntents = shadowOf(contextWrapper).getBroadcastIntents();
+		assertTrue(broadcastIntents.size() == 1);
+		assertEquals(broadcastIntent, broadcastIntents.get(0));
+	}
+	
 
     @Test
     public void shouldReturnSameApplicationEveryTime() throws Exception {


### PR DESCRIPTION
ShadowApplication.sendBroadcast and ShadowContextWrapper.sendBroadcast behave differently. ShadowApplication.sendBroadcast does not add the intent to the list of sent broadcasts which you can get with getBroadcastIntents()
