### PR TITLE
Add support for android:contentDescription in ShadowView

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowView.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowView.java
@@ -74,6 +74,7 @@ public class ShadowView {
     private ViewTreeObserver viewTreeObserver;
     private MotionEvent lastTouchEvent;
     private int nextFocusDownId = View.NO_ID;
+    private CharSequence contentDescription = null;
 
     public void __constructor__(Context context) {
         __constructor__(context, null);
@@ -99,6 +100,7 @@ public class ShadowView {
         applyBackgroundAttribute();
         applyTagAttribute();
         applyOnClickAttribute();
+        applyContentDescriptionAttribute();
     }
 
     @Implementation
@@ -142,6 +144,11 @@ public class ShadowView {
         }
     }
 
+    @Implementation(i18nSafe = false)
+    public void setContentDescription(CharSequence contentDescription) {
+        this.contentDescription = contentDescription;
+    }
+
     @Implementation
     public boolean isFocusable() {
         return focusable;
@@ -150,6 +157,11 @@ public class ShadowView {
     @Implementation
     public int getId() {
         return id;
+    }
+
+    @Implementation
+    public CharSequence getContentDescription() {
+        return contentDescription;
     }
 
     /**
@@ -777,6 +789,17 @@ public class ShadowView {
                 }
             }
         });
+    }
+
+    private void applyContentDescriptionAttribute() {
+        String contentDescription = attributeSet.getAttributeValue("android", "contentDescription");
+        if (contentDescription != null) {
+            if (contentDescription.startsWith("@string/")) {
+                int resId = attributeSet.getAttributeResourceValue("android", "contentDescription", 0);
+                contentDescription = context.getResources().getString(resId);
+            }
+            setContentDescription(contentDescription);
+        }
     }
 
     private boolean noParentHasFocus(View view) {

--- a/src/test/java/com/xtremelabs/robolectric/res/ViewLoaderTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/res/ViewLoaderTest.java
@@ -268,6 +268,12 @@ public class ViewLoaderTest {
     }
 
     @Test
+    public void testContentDescriptionIsSet() throws Exception {
+        View mediaView = viewLoader.inflateView(context, "layout/main");
+        assertThat(mediaView.findViewById(R.id.time).getContentDescription().toString(), equalTo("Howdy"));
+    }
+
+    @Test
     public void testViewBackgroundIdIsSet() throws Exception {
         View mediaView = viewLoader.inflateView(context, "layout/main");
         ImageView imageView = (ImageView) mediaView.findViewById(R.id.image);

--- a/src/test/resources/res/layout/main.xml
+++ b/src/test/resources/res/layout/main.xml
@@ -22,6 +22,7 @@
             android:textSize="14dip"
             android:textColor="#fff"
             android:enabled="false"
+            android:contentDescription="@string/howdy"
             />
 
     <TextView


### PR DESCRIPTION
ShadowView lacks support for applying `android:contentDescription` after a view is inflated from XML.

This commit adds support for inflating said attribute from XML, all related accessors in `ShadowView` and a simple test to `ShadowViewTest` to ensure that the attribute is applied correctly after loading.
