### PR TITLE
Fix NullPointerException in ShadowHandler

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowHandler.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowHandler.java
@@ -84,6 +84,7 @@ public class ShadowHandler {
         message.arg1 = arg1;
         message.arg2 = arg2;
         message.obj = obj;
+        message.setTarget(realHandler);
         return message;
     }
 
@@ -129,7 +130,7 @@ public class ShadowHandler {
 
     @Implementation
     public final Looper getLooper() {
-    	return looper;
+        return looper;
     }
 
     @Implementation

--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowMessage.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowMessage.java
@@ -21,7 +21,7 @@ public class ShadowMessage {
     public void setData(Bundle data) {
         this.data = data;
     }
-    
+
     @Implementation
     public void setTarget(Handler target) {
         this.target = target;
@@ -39,7 +39,7 @@ public class ShadowMessage {
         }
         return data;
     }
-    
+
     @Implementation
     public Handler getTarget() {
         return target;
@@ -51,6 +51,7 @@ public class ShadowMessage {
         message.arg2 = m.arg2;
         message.obj = m.obj;
         message.setData(m.getData());
+        message.setTarget(m.getTarget());
     }
 
     @Implementation

--- a/src/test/java/com/xtremelabs/robolectric/shadows/HandlerTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/HandlerTest.java
@@ -261,6 +261,20 @@ public class HandlerTest {
     }
 
     @Test
+    public void testSendToTarget() {
+        Robolectric.pauseMainLooper();
+        Object testObject = new Object();
+        Handler handler = new Handler();
+        Message message = handler.obtainMessage(123, testObject);
+
+        assertThat(handler, equalTo(message.getTarget()));
+
+        message.sendToTarget();
+
+        assertTrue(handler.hasMessages(123, testObject));
+    }
+
+    @Test
     public void removeMessages_removesFromLooperQueueAsWell() {
         final boolean[] wasRun = new boolean[1];
         Robolectric.pauseMainLooper();


### PR DESCRIPTION
The following code causes a NPE while working in standard android framework.

new Handler().obtainMessage().sendToTarget();

This pull request fixes this. Ran all tests successfully and added one for this case.
