### PR TITLE
ShadowHtml should throw a NullPointerException when a null String is passed to fromHtml()

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowHtml.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowHtml.java
@@ -11,6 +11,14 @@ public class ShadowHtml {
 
     @Implementation
     public static Spanned fromHtml(String source) {
+		if (source == null) {
+			/*
+			 * Mimic the behavior of the real fromHtml() method. It uses a
+			 * StringReader that throws a NullPointerException when a null
+			 * string is passed in.
+			 */
+			throw new NullPointerException();
+		}
         return new SpannedThatActsLikeString(source);
     }
 

--- a/src/test/java/com/xtremelabs/robolectric/shadows/HtmlTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/HtmlTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 @RunWith(WithTestDefaultsRunner.class)
@@ -36,4 +37,16 @@ public class HtmlTest {
         editText.setText(Html.fromHtml("<b>some</b> html text"));
         assertThat(editText.getText().toString(), equalTo("<b>some</b> html text"));
     }
+    
+    @Test
+    public void shouldThrowNullPointerExceptionWhenNullStringEncountered() throws Exception {
+    	NullPointerException npe = null;
+    	try {
+    		Html.fromHtml(null);
+    	} catch (NullPointerException e) {
+    		npe = e;
+    	}
+    	assertThat(npe, notNullValue());
+    }
+
 }


### PR DESCRIPTION
The Html class uses a StringReader which throws a NullPointerException when it encounters a null String. This change makes ShadowHtml behave similarly.
