### PR TITLE
Some corrections to ShadowMessage (new branch)

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowMessage.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowMessage.java
@@ -52,7 +52,6 @@ public class ShadowMessage {
         message.obj = m.obj;
         message.what = m.what;
         message.setData(m.getData());
-        message.setTarget(m.getTarget());
     }
 
     @Implementation
@@ -93,6 +92,14 @@ public class ShadowMessage {
     public static Message obtain(Handler h, int what, int arg1, int arg2, Object obj) {
         Message m = obtain(h, what, arg1, arg2);
         m.obj = obj;
+        return m;
+    }
+
+    @Implementation
+    public static Message obtain(Message msg) {
+        Message m = new Message();
+        m.copyFrom(msg);
+        m.setTarget(msg.getTarget());
         return m;
     }
 

--- a/src/test/java/com/xtremelabs/robolectric/shadows/MessageTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/MessageTest.java
@@ -64,7 +64,7 @@ public class MessageTest {
         assertThat(m2.obj, equalTo(m.obj));
         assertThat(m2.what, equalTo(m.what));
         assertThat(m2.getData(), equalTo(m.getData()));
-        assertThat(m2.getTarget(), equalTo(m.getTarget()));
+        assertNull(m2.getTarget());
     }
 
     @Test
@@ -132,6 +132,26 @@ public class MessageTest {
         assertThat(m.arg1, equalTo(arg1));
         assertThat(m.arg2, equalTo(arg2));
         assertThat(m.obj, equalTo(obj));
+    }
+
+    @Test
+    public void testObtainWithMessage() throws Exception {
+        Bundle b = new Bundle();
+        Message m = new Message();
+        m.arg1 = 10;
+        m.arg2 = 42;
+        m.obj = "obj";
+        m.what = 24;
+        m.setData(b);
+        m.setTarget(new Handler());
+        Message m2 = Message.obtain(m);
+
+        assertThat(m2.arg1, equalTo(m.arg1));
+        assertThat(m2.arg2, equalTo(m.arg2));
+        assertThat(m2.obj, equalTo(m.obj));
+        assertThat(m2.what, equalTo(m.what));
+        assertThat(m2.getData(), equalTo(m.getData()));
+        assertThat(m2.getTarget(), equalTo(m.getTarget()));
     }
 
     @Test


### PR DESCRIPTION
Updated ShadowMessage.copyFrom to not copy the target as Android does and to properly copy the what field.

Added an implementation for ShadowMessage.obtain(msg) which does copy the target as the Android documentation states.
