### PR TITLE
MatrixCursor.getBlob and Number casting

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowMatrixCursor.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowMatrixCursor.java
@@ -28,32 +28,32 @@ public class ShadowMatrixCursor extends ShadowAbstractCursor {
 
     @Implementation
     public String getString(int column) {
-        return (String) get(column);
+        return get(column).toString();
     }
 
     @Implementation
     public long getLong(int column) {
-        return (Long) get(column);
+        return ((Number) get(column)).longValue();
     }
 
     @Implementation
     public short getShort(int column) {
-        return (Short) get(column);
+        return ((Number) get(column)).shortValue();
     }
 
     @Implementation
     public int getInt(int column) {
-        return (Integer) get(column);
+        return ((Number) get(column)).intValue();
     }
 
     @Implementation
     public float getFloat(int column) {
-        return (Float) get(column);
+        return ((Number) get(column)).floatValue();
     }
 
     @Implementation
     public double getDouble(int column) {
-        return (Double) get(column);
+        return ((Number) get(column)).doubleValue();
     }
 
     @Implementation

--- a/src/test/java/com/xtremelabs/robolectric/shadows/MatrixCursorTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/MatrixCursorTest.java
@@ -62,6 +62,27 @@ public class MatrixCursorTest {
         assertThat(cursor.getBlob(0), equalTo(blob));
     }
 
+    @Test
+    public void shouldAllowTypeFlexibility() throws Exception {
+        MatrixCursor cursor = new MatrixCursor(new String[] { "a", "b", "c" });
+        cursor.addRow(new Object[] { 42, 3.3 });
+        assertTrue(cursor.moveToFirst());
+
+        assertThat(cursor.getString(0), equalTo("42"));
+        assertThat(cursor.getShort(0), equalTo((short) 42));
+        assertThat(cursor.getInt(0), equalTo(42));
+        assertThat(cursor.getLong(0), equalTo(42L));
+        assertThat(cursor.getFloat(0), equalTo(42.0F));
+        assertThat(cursor.getDouble(0), equalTo(42.0));
+
+        assertThat(cursor.getString(1), equalTo("3.3"));
+        assertThat(cursor.getShort(1), equalTo((short) 3));
+        assertThat(cursor.getInt(1), equalTo(3));
+        assertThat(cursor.getLong(1), equalTo(3L));
+        assertThat(cursor.getFloat(1), equalTo(3.3F));
+        assertThat(cursor.getDouble(1), equalTo(3.3));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void shouldDefineGetColumnNameOrThrow() throws Exception {
         MatrixCursor cursor = new MatrixCursor(new String[] { "a", "b", "c"});


### PR DESCRIPTION
Implements getBlob() on ShadowMatrixCursor.  Also, number getters (e.g. getInt, getFloat) now first to Number and then call the appropriate value method (e.g. intValue, floatValue).  This allows for a bit more flexibility when setting the cursor rows.  Finally, getString calls toString on whatever is on the column.

This is closer to the real MatrixCursor behavior, which in addition to all this does null checks and returns sensible values.
