### PR TITLE
added stripSeparators shadow method to PhoneNumberUtils

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowPhoneNumberUtils.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowPhoneNumberUtils.java
@@ -11,4 +11,9 @@ public class ShadowPhoneNumberUtils {
     public static java.lang.String formatNumber(java.lang.String source) {
         return source + "-formatted";
     }
+
+    @Implementation
+    public static java.lang.String stripSeparators(java.lang.String source) {
+        return source + "-stripped";
+    }
 }

--- a/src/test/java/com/xtremelabs/robolectric/shadows/PhoneNumberUtilTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/PhoneNumberUtilTest.java
@@ -14,4 +14,10 @@ public class PhoneNumberUtilTest {
     public void testFormatNumber() {
         assertThat(PhoneNumberUtils.formatNumber("12345678901"), equalTo("12345678901-formatted"));
     }
+
+    @Test
+    public void testStripSeparators() {
+        assertThat(PhoneNumberUtils.stripSeparators("12345678901"), equalTo("12345678901-stripped"));
+    }
+        
 }


### PR DESCRIPTION
stripSeparators method follows the same format as formatNumber in PhoneNumberUtils.
