### PR TITLE
Do not instrument android.support.v4.content package

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/bytecode/AndroidTranslator.java
+++ b/src/main/java/com/xtremelabs/robolectric/bytecode/AndroidTranslator.java
@@ -33,7 +33,7 @@ public class AndroidTranslator implements Translator {
         instrumentingList.add("com.google.android.maps");
         instrumentingList.add("org.apache.http.impl.client.DefaultRequestDirector");
 
-        instrumentingExcludeList.add("android.support.v4.content.LocalBroadcastManager");
+        instrumentingExcludeList.add("android.support.v4.content.");
         instrumentingExcludeList.add("android.support.v4.util.LruCache");
     }
 


### PR DESCRIPTION
This package should not be instrumented since all the java code is available (not noly LocalBroadcastManager class). It's crucial for testing loaders.
