### PR TITLE
Support library included

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/bytecode/AndroidTranslator.java
+++ b/src/main/java/com/xtremelabs/robolectric/bytecode/AndroidTranslator.java
@@ -34,7 +34,7 @@ public class AndroidTranslator implements Translator {
         instrumentingList.add("org.apache.http.impl.client.DefaultRequestDirector");
 
         instrumentingExcludeList.add("android.support.v4.app.NotificationCompat");
-        instrumentingExcludeList.add("android.support.v4.content.");
+//        instrumentingExcludeList.add("android.support.v4.content.");
         instrumentingExcludeList.add("android.support.v4.util.LruCache");
     }
 


### PR DESCRIPTION
Somebody added "android.support.v4.content." to the instumentation exclude list. Now everything in this package is not working (like ShadowCursorLoader). I commented this line out.
