### PR TITLE
Store Toast duration in ShadowToast

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowToast.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowToast.java
@@ -20,6 +20,7 @@ import static com.xtremelabs.robolectric.Robolectric.shadowOf;
 @Implements(Toast.class)
 public class ShadowToast {
     private String text;
+    private int duration;
     private int gravity;
     private View view;
 
@@ -33,6 +34,7 @@ public class ShadowToast {
     @Implementation(i18nSafe=false)
     public static Toast makeText(Context context, CharSequence text, int duration) {
         Toast toast = new Toast(null);
+        toast.setDuration(duration);
         shadowOf(toast).text = text.toString();
         return toast;
     }
@@ -60,6 +62,16 @@ public class ShadowToast {
     @Implementation
     public int getGravity() {
         return gravity;
+    }
+
+    @Implementation
+    public void setDuration(int duration) {
+        this.duration = duration;
+    }
+
+    @Implementation
+    public int getDuration() {
+        return duration;
     }
 
     /**

--- a/src/test/java/com/xtremelabs/robolectric/shadows/ToastTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/ToastTest.java
@@ -1,0 +1,31 @@
+package com.xtremelabs.robolectric.shadows;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import android.app.Activity;
+import android.widget.Toast;
+
+import com.xtremelabs.robolectric.WithTestDefaultsRunner;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(WithTestDefaultsRunner.class)
+public class ToastTest {
+
+    @Test
+    public void shouldHaveShortDuration() throws Exception {
+        Toast toast = Toast.makeText(new Activity(), "short toast",
+                Toast.LENGTH_SHORT);
+        assertNotNull(toast);
+        assertEquals(Toast.LENGTH_SHORT, toast.getDuration());
+    }
+
+    @Test
+    public void shouldHaveLongDuration() throws Exception {
+        Toast toast = Toast.makeText(new Activity(), "long toast",
+                Toast.LENGTH_LONG);
+        assertNotNull(toast);
+        assertEquals(Toast.LENGTH_LONG, toast.getDuration());
+    }
+}


### PR DESCRIPTION
`Toast` objects returned from `ShadowToast.getLatestToast()` were previously always returning a `getDuration()` value of zero even when created with a non-zero value such as  `Toast.LENGTH_LONG`.

This change stores the duration that `Toast.makeText` was called with in the `ShadowToast` instance.
