### PR TITLE
Support for SQLiteDatabase insertOrThrow, replaceOrThrow

### DIFF
--- a/src/test/java/com/xtremelabs/robolectric/shadows/DatabaseTestBase.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/DatabaseTestBase.java
@@ -126,8 +126,11 @@ public abstract class DatabaseTestBase {
     
     @Test(expected = android.database.SQLException.class)
     public void testInsertOrThrowWithSQLException() {
-        shDatabase.setThrowOnInsert(true);
-        database.insertOrThrow("table_name", null, new ContentValues());
+        ContentValues values = new ContentValues();
+        values.put("id", 1);
+
+        database.insertOrThrow("table_name", null, values);
+        database.insertOrThrow("table_name", null, values);
     }
     
     @Test
@@ -431,7 +434,7 @@ public abstract class DatabaseTestBase {
         int firstIndex = cursor.getColumnIndex("first_column");
         int nameIndex = cursor.getColumnIndex("name");
         assertThat(cursor.getString(nameIndex), equalTo(name));
-        assertThat(cursor.getString(firstIndex), equalTo(null));
+        assertThat(cursor.getString(firstIndex), equalTo((String)null));
 
     }
 

--- a/src/test/java/com/xtremelabs/robolectric/shadows/SQLiteDatabaseTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/SQLiteDatabaseTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 
 import static com.xtremelabs.robolectric.Robolectric.shadowOf;
@@ -37,10 +38,43 @@ public class SQLiteDatabaseTest extends DatabaseTestBase {
         long replaceId = database.replace("table_name", null, values);
         assertThat(replaceId, equalTo(id));
 
-        Statement statement = shadowOf(database).getConnection().createStatement();
-        ResultSet resultSet = statement.executeQuery("SELECT name FROM table_name where id = "+id);
+        String query = "SELECT name FROM table_name where id = " + id;
+        ResultSet resultSet = executeQuery(query);
 
         assertThat(resultSet.next(), equalTo(true));
         assertThat(resultSet.getString(1), equalTo("Norris"));
+    }
+
+    @Test
+    public void testReplaceIsReplacing() throws SQLException {
+        final String query = "SELECT first_column FROM table_name WHERE id = ";
+        String stringValueA = "column_valueA";
+        String stringValueB = "column_valueB";
+        long id = 1;
+
+        ContentValues valuesA = new ContentValues();
+        valuesA.put("id", id);
+        valuesA.put("first_column", stringValueA);
+
+        ContentValues valuesB = new ContentValues();
+        valuesB.put("id", id);
+        valuesB.put("first_column", stringValueB);
+
+        long firstId = database.replaceOrThrow("table_name", null, valuesA);
+        ResultSet firstResultSet = executeQuery(query + firstId);
+        firstResultSet.next();
+        long secondId = database.replaceOrThrow("table_name", null, valuesB);
+        ResultSet secondResultSet = executeQuery(query + secondId);
+        secondResultSet.next();
+
+        assertThat(firstId, equalTo(id));
+        assertThat(secondId, equalTo(id));
+        assertThat(firstResultSet.getString(1), equalTo(stringValueA));
+        assertThat(secondResultSet.getString(1), equalTo(stringValueB));
+    }
+
+    private ResultSet executeQuery(String query) throws SQLException {
+        Statement statement = shadowOf(database).getConnection().createStatement();
+        return statement.executeQuery(query);
     }
 }


### PR DESCRIPTION
`insert` returns now new id or -1 on exception.
`insertOrThrow` returns inserted id or throws exception.
Similar with `replace` and `replaceOrThrow`. Now they're working as supposed.

I removed `setThrowOnInsert` which was used to emulate `insertOrThrow`. I think it's useless in this case.
