### PR TITLE
ShadowBitmapFactory/ShadowBitmapDrawable: Support the non-deprecated Bit...

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowBitmapDrawable.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowBitmapDrawable.java
@@ -1,16 +1,18 @@
 package com.xtremelabs.robolectric.shadows;
 
+import static com.xtremelabs.robolectric.Robolectric.shadowOf;
+
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.ColorFilter;
 import android.graphics.Paint;
+import android.graphics.Shader.TileMode;
 import android.graphics.drawable.BitmapDrawable;
+
 import com.xtremelabs.robolectric.internal.Implementation;
 import com.xtremelabs.robolectric.internal.Implements;
 import com.xtremelabs.robolectric.internal.RealObject;
-
-import static android.graphics.Shader.TileMode;
-import static com.xtremelabs.robolectric.Robolectric.shadowOf;
 
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(BitmapDrawable.class)
@@ -25,6 +27,10 @@ public class ShadowBitmapDrawable extends ShadowDrawable {
     private TileMode tileModeY;
 
     public void __constructor__(Bitmap bitmap) {
+        this.bitmap = bitmap;
+    }
+
+    public void __constructor__(Resources resources, Bitmap bitmap) {
         this.bitmap = bitmap;
     }
 
@@ -57,6 +63,7 @@ public class ShadowBitmapDrawable extends ShadowDrawable {
      * @return resource id from which this {@code BitmapDrawable} was loaded
      * @deprecated use com.xtremelabs.robolectric.shadows.ShadowBitmap#getLoadedFromResourceId() instead.
      */
+    @Deprecated
     @Override
     public int getLoadedFromResourceId() {
         return shadowOf(bitmap).getLoadedFromResourceId();
@@ -99,7 +106,7 @@ public class ShadowBitmapDrawable extends ShadowDrawable {
     public TileMode getTileModeY() {
         return tileModeY;
     }
-    
+
     @Implementation
     public void setTileModeXY(TileMode modeX, TileMode modeY) {
         setTileModeX(modeX);

--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowResources.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowResources.java
@@ -123,7 +123,7 @@ public class ShadowResources {
     public CharSequence getText(int id) throws Resources.NotFoundException {
         return getString(id);
     }
-    
+
     public void setDensity(float density) {
         this.density = density;
     }
@@ -166,12 +166,12 @@ public class ShadowResources {
         if (colorDrawable != null) {
             return colorDrawable;
         }
-        
+
         if (resLoader.isNinePatchDrawable(drawableResourceId)) {
         	return new NinePatchDrawable(realResources, null);
         }
 
-        return new BitmapDrawable(BitmapFactory.decodeResource(realResources, drawableResourceId));
+        return new BitmapDrawable(realResources, BitmapFactory.decodeResource(realResources, drawableResourceId));
     }
 
     @Implementation
@@ -183,7 +183,7 @@ public class ShadowResources {
     public int getInteger(int id) throws Resources.NotFoundException {
     	return resourceLoader.getIntegerValue( id );
     }
-    
+
     @Implementation
     public int getDimensionPixelSize(int id) throws Resources.NotFoundException {
         // The int value returned from here is probably going to be handed to TextView.setTextSize(),

--- a/src/test/java/com/xtremelabs/robolectric/shadows/BitmapFactoryTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/BitmapFactoryTest.java
@@ -26,6 +26,17 @@ public class BitmapFactoryTest {
     }
 
     @Test
+    public void decodeResourceWithOpts_shouldSetDescription() throws Exception {
+        BitmapFactory.Options opts = new BitmapFactory.Options();
+        Bitmap bitmap = BitmapFactory.decodeResource(Robolectric.application.getResources(), R.drawable.an_image, opts);
+        assertEquals("Bitmap for resource:drawable/an_image", shadowOf(bitmap).getDescription());
+        assertEquals(100, bitmap.getWidth());
+        assertEquals(100, bitmap.getHeight());
+        assertEquals(100, opts.outWidth);
+        assertEquals(100, opts.outHeight);
+    }
+
+    @Test
     public void decodeFile_shouldSetDescription() throws Exception {
         Bitmap bitmap = BitmapFactory.decodeFile("/some/file.jpg");
         assertEquals("Bitmap for file:/some/file.jpg", shadowOf(bitmap).getDescription());


### PR DESCRIPTION
...mapDrawable(Resources, Bitmap) constructor and use it be default.

Note: Most of these changes are obsolete due to a previous pull request that was recently pulled in. The only main change is to use the new decodeResource method by default from ShadowResources.
