### PR TITLE
Fixed UriMatcher to match root paths.

### DIFF
--- a/src/test/java/com/xtremelabs/robolectric/shadows/UriMatcherTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/UriMatcherTest.java
@@ -1,87 +1,70 @@
 package com.xtremelabs.robolectric.shadows;
 
-import android.content.UriMatcher;
-import android.net.Uri;
-import com.xtremelabs.robolectric.Robolectric;
-import com.xtremelabs.robolectric.WithTestDefaultsRunner;
-import com.xtremelabs.robolectric.shadows.ShadowUriMatcher.MatchNode;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.matchers.JUnitMatchers.hasItem;
+import android.content.UriMatcher;
+import android.net.Uri;
+
+import com.xtremelabs.robolectric.Robolectric;
+import com.xtremelabs.robolectric.WithTestDefaultsRunner;
+import com.xtremelabs.robolectric.shadows.ShadowUriMatcher.MatchNode;
 
 @RunWith(WithTestDefaultsRunner.class)
 public class UriMatcherTest {
-	static final String AUTH = "com.foo";
-	static final int NO_MATCH = -2;
+  static final String AUTH = "com.foo";
 
-	UriMatcher matcher;
-	MatchNode root;
-    Uri URI;
-    
-	@Before public void getMatcher() {
-        URI = Uri.parse("content://" + AUTH);
-		matcher = new UriMatcher(NO_MATCH);
-		root = Robolectric.shadowOf(matcher).rootNode;
-	}
+  UriMatcher matcher;
+  MatchNode root;
+  Uri URI;
 
-	@Test public void canInstantiate() {
-		assertThat(root.code, is(NO_MATCH));
-		assertThat(root.map.isEmpty(), is(true));
-		assertThat(root.number, is(nullValue()));
-		assertThat(root.text, is(nullValue()));
-	}
+  @Before
+  public void getMatcher() {
+    URI = Uri.parse("content://" + AUTH);
+    matcher = new UriMatcher(UriMatcher.NO_MATCH);
+    root = Robolectric.shadowOf(matcher).rootNode;
+  }
 
-	@Test public void canAddBasicMatch() {
-		MatchNode node = root;
-		String path = "bar/cat";
+  @Test
+  public void canMatch() {
+    matcher.addURI(AUTH, "bar", 1);
+    assertThat(matcher.match(Uri.withAppendedPath(URI, "bar")), is(1));
 
-		matcher.addURI(AUTH, path, 1);
-		assertThat(node.map.keySet(), hasItem(AUTH));
+    matcher.addURI(AUTH, "bar/#", 2);
+    assertThat(matcher.match(Uri.withAppendedPath(URI, "bar/1")), is(2));
 
-		node = node.map.get(AUTH);
-		assertThat(node.map.keySet(), hasItem("bar"));
+    matcher.addURI(AUTH, "/", 3);
+    assertThat(matcher.match(Uri.withAppendedPath(URI, "/")), is(3));
 
-		node = node.map.get("bar");
-		assertThat(node.map.keySet(), hasItem("cat"));
+    matcher.addURI(AUTH, "transport/*/#/type", 4);
+    assertThat(matcher.match(Uri.withAppendedPath(URI, "transport/land/45/type")), is(4));
 
-		node = node.map.get("cat");
-		assertThat(node.code, is(1));
-	}
+    matcher.addURI(AUTH, "*", 5);  
+    assertThat(matcher.match(Uri.withAppendedPath(URI, "bar")), is(1));
+    assertThat(matcher.match(Uri.withAppendedPath(URI, "cat")), is(5));
+  }
 
-	@Test public void canAddWildcardMatches() {
-		matcher.addURI(AUTH, "#", 1);
-		matcher.addURI(AUTH, "*", 2);
-		MatchNode node = root.map.get(AUTH);
+  @Test
+  public void orderOfWildcardAdditionAffectsMatching() {
+    matcher.addURI(AUTH, "foo", 1);
+    assertThat(matcher.match(Uri.withAppendedPath(URI, "foo")), is(1));
 
-		assertThat(node.number.code, is(1));
-		assertThat(node.text.code, is(2));
-	}
+    matcher.addURI(AUTH, "*", 2);
+    assertThat(matcher.match(Uri.withAppendedPath(URI, "foo")), is(1));
 
-	@Test public void canMatch() {
-		matcher.addURI(AUTH, "bar", 1);
-		assertThat(matcher.match(Uri.withAppendedPath(URI, "bar")), is(1));
+    matcher.addURI(AUTH, "bar", 3);
+    assertThat(matcher.match(Uri.withAppendedPath(URI, "bar")), is(2));
+  }
 
-		matcher.addURI(AUTH, "bar/#", 2);
-		assertThat(matcher.match(Uri.withAppendedPath(URI, "bar/1")), is(2));
-
-		matcher.addURI(AUTH, "*", 3);
-		assertThat(matcher.match(Uri.withAppendedPath(URI, "bar")), is(1));
-		assertThat(matcher.match(Uri.withAppendedPath(URI, "cat")), is(3));
-
-		matcher.addURI(AUTH, "transport/*/#/type", 4);
-		assertThat(matcher.match(Uri.withAppendedPath(URI, "transport/land/45/type")), is(4));
-	}
-
-	@Test public void returnsRootCodeForIfNoMatch() {
-		matcher.addURI(AUTH, "bar/#", 1);
-		assertThat(matcher.match(Uri.withAppendedPath(URI, "cat")), is(NO_MATCH));
-		assertThat(matcher.match(Uri.withAppendedPath(URI, "bar")), is(NO_MATCH));
-		assertThat(matcher.match(Uri.withAppendedPath(URI, "bar/cat")), is(NO_MATCH));
-	}
-
+  @Test
+  public void returnsRootCodeForIfNoMatch() {
+    matcher.addURI(AUTH, "bar/#", 1);
+    assertThat(matcher.match(Uri.withAppendedPath(URI, "cat")), is(UriMatcher.NO_MATCH));
+    assertThat(matcher.match(Uri.withAppendedPath(URI, "bar")), is(UriMatcher.NO_MATCH));
+    assertThat(matcher.match(Uri.withAppendedPath(URI, "bar/cat")), is(UriMatcher.NO_MATCH));
+  }
 }


### PR DESCRIPTION
1.  Existing ShadowUriMatcher does not match root paths, as the Android UriMatcher can.
2.  Existing ShadowUriMatcher does not match Uris as the Android UriMatcher with respect to the order in which addUri with wildcards is called.

The Android UriMatcher class is fairly small.  I just adapted the Android API 16 code and adapted the existing tests.  

I also removed a couple of existing tests that were testing the existing shadow implementation, and not it's interface.  Obviously, these tests no longer passed with a different implementation.
