### PR TITLE
Setter and test for setting actvity parent on ShadowActivity

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowActivity.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowActivity.java
@@ -278,6 +278,11 @@ public class ShadowActivity extends ShadowContextWrapper {
         return parent;
     }
 
+	public void setParent(Activity parent)
+	{
+		this.parent = parent;
+	}
+
     @Implementation
     public void onBackPressed() {
         finish();
@@ -468,7 +473,7 @@ public class ShadowActivity extends ShadowContextWrapper {
         onKeyUpWasCalled = false;
     }
 
-    /**
+	/**
      * Container object to hold an Intent, together with the requestCode used
      * in a call to {@code Activity#startActivityForResult(Intent, int)}
      */

--- a/src/test/java/com/xtremelabs/robolectric/shadows/ActivityTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/ActivityTest.java
@@ -631,6 +631,15 @@ public class ActivityTest {
         shadowOf(activity).callOnStart();
     }
 
+	@Test
+	public void allowsAParentToBeSetThroughShadow()
+	{
+		final Activity activity = new Activity();
+		final Activity parentActivity = new Activity();
+		shadowOf(activity).setParent(parentActivity);
+		assertThat(activity.getParent(), is(sameInstance(parentActivity)));
+	}
+
     private static class MyActivity extends Activity {
         @Override protected void onDestroy() {
             super.onDestroy();


### PR DESCRIPTION
Needed to test behaviour of an activity normally within a TabActivity, which involved mocking its parent. Can't see why you shouldn't be able to set it on the shadow. It has a field for it but there was no way it could be set to anything, so would always be null.

Added a setter and a test that the Activity will then return what you set on the shadow.
