### PR TITLE
Added getter for TabHost.tabSpecs

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowTabHost.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowTabHost.java
@@ -119,4 +119,8 @@ public class ShadowTabHost extends ShadowFrameLayout {
         }
         return null;
     }
+
+	public List<TabHost.TabSpec> getTabSpecs() {
+		return new ArrayList<TabHost.TabSpec>(tabSpecs);
+	}
 }


### PR DESCRIPTION
ShadowTabHost has an array of tab specs but no getter.

Calling `getTabCount()` and `getChildCount()` on both TabHost and TabWidget return 0 at test runtime. This patch allows me to do this:

``` java
assertThat(shadowOf(subject.tabHost).getTabSpecs().size()).isEqualTo(3);
```
