### PR TITLE
In-memory databases are now retained during testing.

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowSQLiteDatabase.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowSQLiteDatabase.java
@@ -306,8 +306,26 @@ public class ShadowSQLiteDatabase  {
 		// This method is usually called after a single DB operation and can
 		// validly be called multiple times in a single test case with the
 		// expectation that data will be retained.
-		closedConnection = connection;
-		connection = null;
+		if (connection != null) {
+			closedConnection = connection;
+			connection = null;
+		}
+	}
+
+	boolean closedForReal() {
+		return connection == null && closedConnection == null;
+	}
+
+	void closeForReal() {
+		close();
+		if (closedConnection != null) {
+			try {
+				closedConnection.close();
+			} catch (SQLException e) {
+				e.printStackTrace();
+			}
+			closedConnection = null;
+		}
 	}
 
 	@Implementation

--- a/src/test/java/com/xtremelabs/robolectric/shadows/SQLiteOpenHelperTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/SQLiteOpenHelperTest.java
@@ -135,7 +135,7 @@ public class SQLiteOpenHelperTest {
     
     @Test
     public void testDataRetained() throws Exception {
-		final String createTableSql = "create table x(id int primary key)";
+		final String createTableSql = "create table datarentiontest(id int primary key)";
 
 		// Create table the first time - no worries
 		SQLiteDatabase db = helper.getWritableDatabase();
@@ -150,4 +150,21 @@ public class SQLiteOpenHelperTest {
 		} catch (SQLException e) {
 		}
     }
+
+	@Test
+	public void testReset() throws Exception {
+		final String createTableSql = "create table resettest(id int primary key)";
+
+		// Create a table
+		SQLiteDatabase db = helper.getWritableDatabase();
+		db.execSQL(createTableSql);
+		db.close();
+
+		ShadowSQLiteDatabase.resetInMemoryDatabases();
+
+		// Create table second time - should work if wiped properly
+		db = helper.getWritableDatabase();
+		db.execSQL(createTableSql);
+		db.close();
+	}
 }


### PR DESCRIPTION
- ShadowSQLiteOpenHelper and ShadowSQLiteDatabase no longer use static
  connection state.
- InMemory database connections are not actually closed, they just act
  like it now.
- In-memory databases scoped by name, just as filename-based ones are.
- ShadowSQLiteDatabase.resetInMemoryDatabases() can be used to reset
  test databases.
- Existing tests pass without change. Added test for new functionality.

Solves the same problem as #190 but in a different way.
