### PR TITLE
Added static method appendEscapedSQLString() support to DatabaseUtils

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowDatabaseUtils.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowDatabaseUtils.java
@@ -2,6 +2,7 @@ package com.xtremelabs.robolectric.shadows;
 
 import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteProgram;
+
 import com.xtremelabs.robolectric.internal.Implementation;
 import com.xtremelabs.robolectric.internal.Implements;
 
@@ -40,5 +41,22 @@ public class ShadowDatabaseUtils {
 		builder.append( "'" ).append( value ).append( "'" );	
 		
 		return builder.toString();
+	}
+    
+    @Implementation
+	public static void appendEscapedSQLString(StringBuilder sb, String sqlString){
+		sb.append('\'');
+        if (sqlString.indexOf('\'') != -1) {
+            int length = sqlString.length();
+            for (int i = 0; i < length; i++) {
+                char c = sqlString.charAt(i);
+                if (c == '\'') {
+                    sb.append('\'');
+                }
+                sb.append(c);
+            }
+        } else
+            sb.append(sqlString);
+        sb.append('\'');
 	}
 }

--- a/src/test/java/com/xtremelabs/robolectric/shadows/DatabaseUtilsTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/DatabaseUtilsTest.java
@@ -3,10 +3,10 @@ package com.xtremelabs.robolectric.shadows;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import com.xtremelabs.robolectric.WithTestDefaultsRunner;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import com.xtremelabs.robolectric.WithTestDefaultsRunner;
 
 @RunWith(WithTestDefaultsRunner.class)
 public class DatabaseUtilsTest {
@@ -15,5 +15,16 @@ public class DatabaseUtilsTest {
 	public void testQuote() {
 		assertThat( ShadowDatabaseUtils.sqlEscapeString( "foobar" ), equalTo( "'foobar'" ) );
 		assertThat( ShadowDatabaseUtils.sqlEscapeString( "Rich's" ), equalTo( "'Rich''s'" ) );
+	}
+	
+	@Test
+	public void testQuoteWithBuilder() {
+		StringBuilder builder = new StringBuilder();
+		ShadowDatabaseUtils.appendEscapedSQLString( builder , "foobar" );
+		assertThat( builder.toString(), equalTo( "'foobar'" ) );
+		
+		builder = new StringBuilder();
+		ShadowDatabaseUtils.appendEscapedSQLString( builder, "Blundell's" );
+		assertThat( builder.toString(), equalTo( "'Blundell''s'" ) );
 	}
 }


### PR DESCRIPTION
StringBuilder builder = new StringBuilder();
        ShadowDatabaseUtils.appendEscapedSQLString( builder , "foobar" );
        assertThat( builder.toString(), equalTo( "'foobar'" ) );
