### PR TITLE
Add support for inch(in) and millimeter(mm) dimensions in dimens.xml

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/res/DimenResourceLoader.java
+++ b/src/main/java/com/xtremelabs/robolectric/res/DimenResourceLoader.java
@@ -3,9 +3,9 @@ package com.xtremelabs.robolectric.res;
 import org.w3c.dom.Node;
 public class DimenResourceLoader extends XpathResourceXmlLoader implements ResourceValueConverter {
 
-    private static final String[] UNITS = { "dp", "dip", "pt", "px", "sp" };
+	private static final String[] UNITS = { "dp", "dip", "in", "mm", "pt", "px", "sp" };
 	
-    private ResourceReferenceResolver<Float> dimenResolver = new ResourceReferenceResolver<Float>("dimen");
+    private final ResourceReferenceResolver<Float> dimenResolver = new ResourceReferenceResolver<Float>("dimen");
 
     public DimenResourceLoader(ResourceExtractor resourceExtractor) {
         super(resourceExtractor, "/resources/dimen");

--- a/src/test/java/com/xtremelabs/robolectric/R.java
+++ b/src/test/java/com/xtremelabs/robolectric/R.java
@@ -150,6 +150,8 @@ public final class R {
     public static final class dimen {
         public static final int test_dp_dimen = nextId++;
         public static final int test_dip_dimen = nextId++;
+        public static final int test_in_dimen = nextId++;
+        public static final int test_mm_dimen = nextId++;
         public static final int test_pt_dimen = nextId++;
         public static final int test_px_dimen = nextId++;
         public static final int test_sp_dimen = nextId++;

--- a/src/test/java/com/xtremelabs/robolectric/res/DimenResourceLoaderTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/res/DimenResourceLoaderTest.java
@@ -4,10 +4,10 @@ import static com.xtremelabs.robolectric.util.TestUtil.resourceFile;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import com.xtremelabs.robolectric.R;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import com.xtremelabs.robolectric.R;
 
 public class DimenResourceLoaderTest {
 
@@ -28,6 +28,10 @@ public class DimenResourceLoaderTest {
 				equalTo(8.0f));
 		assertThat(dimenResourceLoader.getValue(R.dimen.test_dip_dimen),
 				equalTo(20.0f));
+		assertThat(dimenResourceLoader.getValue(R.dimen.test_in_dimen),
+		        equalTo(19.0f));
+	    assertThat(dimenResourceLoader.getValue(R.dimen.test_mm_dimen),
+		        equalTo(86.0f));
 		assertThat(dimenResourceLoader.getValue(R.dimen.test_pt_dimen),
 				equalTo(12.0f));
 		assertThat(dimenResourceLoader.getValue(R.dimen.test_px_dimen),

--- a/src/test/resources/res/values/dimens.xml
+++ b/src/test/resources/res/values/dimens.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<dimen name="test_dp_dimen">8dp</dimen>
-	<dimen name="test_dip_dimen">20dip</dimen>
-	<dimen name="test_pt_dimen">12pt</dimen>
-	<dimen name="test_px_dimen">15px</dimen>
-	<dimen name="test_sp_dimen">5sp</dimen>
+
+  <dimen name="test_dp_dimen">8dp</dimen>
+  <dimen name="test_dip_dimen">20dip</dimen>
+  <dimen name="test_in_dimen">19in</dimen>
+  <dimen name="test_mm_dimen">86mm</dimen>
+  <dimen name="test_pt_dimen">12pt</dimen>
+  <dimen name="test_px_dimen">15px</dimen>
+  <dimen name="test_sp_dimen">5sp</dimen>
+
 </resources>


### PR DESCRIPTION
Moved the changes off my master branch so had to resubmit the pull!

When <code>com.xtremelabs.robolectric.res.ResourceLoader</code> encounters a dimens.xml such as the following:

<code>
&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
&lt;resources&gt;
    &lt;dimen name=&quot;text_size&quot;&gt;19in&lt;/dimen&gt;
&lt;/resources&gt;
</code>

<code>java.lang.RuntimeException: java.lang.NumberFormatException: For input string: "19in"
at com.xtremelabs.robolectric.res.ResourceLoader.init(ResourceLoader.java:148)</code>

<code>
&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;
&lt;resources&gt;
    &lt;dimen name=&quot;text_size&quot;&gt;86mm&lt;/dimen&gt;
&lt;/resources&gt;
</code>

an exception is thrown:

<code>java.lang.RuntimeException: java.lang.NumberFormatException: For input string: "86mm"
at com.xtremelabs.robolectric.res.ResourceLoader.init(ResourceLoader.java:148)</code>

This pull request adds support for the Inch ("in") and Millimeter ("mm") dimension unit of measure:

http://developer.android.com/guide/topics/resources/more-resources.html#Dimension

Mirroring this request that added point("pt")

https://github.com/pivotal/robolectric/pull/321

(deprecated pull https://github.com/pivotal/robolectric/pull/364)
