### PR TITLE
Fixed LayoutInflater.inflate() result when attachToRoot is on.

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowLayoutInflater.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowLayoutInflater.java
@@ -40,7 +40,8 @@ public class ShadowLayoutInflater {
 
     @Implementation
     public View inflate(int resource, ViewGroup root, boolean attachToRoot) {
-        return getResourceLoader().inflateView(context, resource, attachToRoot ? root : null);
+        View inflated = getResourceLoader().inflateView(context, resource, attachToRoot ? root : null);
+        return attachToRoot ? root : inflated;
     }
 
     @Implementation


### PR DESCRIPTION
inflate() should always return the root view. When attachToRoot is
enabled, this means that the result should be the root view rather than
the inflated view.
