### PR TITLE
Adding support for missing registerReceiver

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowApplication.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowApplication.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
 import android.content.res.Resources;
+import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
 import android.os.PowerManager;
@@ -81,6 +82,7 @@ public class ShadowApplication extends ShadowContextWrapper {
     private Map<String, Intent> stickyIntents = new HashMap<String, Intent>();
     private FakeHttpLayer fakeHttpLayer = new FakeHttpLayer();
     private Looper mainLooper = ShadowLooper.myLooper();
+    private Handler mainHandler = new Handler(mainLooper);
     private Scheduler backgroundScheduler = new Scheduler();
     private Map<String, Map<String, Object>> sharedPreferenceMap = new HashMap<String, Map<String, Object>>();
     private ArrayList<Toast> shownToasts = new ArrayList<Toast>();
@@ -312,6 +314,18 @@ public class ShadowApplication extends ShadowContextWrapper {
         return resourceLoader;
     }
 
+    @Override
+    @Implementation
+    public void sendBroadcast(Intent intent) {
+        sendBroadcastWithPermission(intent, null);
+    }
+
+    @Override
+    @Implementation
+    public void sendBroadcast(Intent intent, String receiverPermission) {
+        sendBroadcastWithPermission(intent, receiverPermission);
+    }
+
     /**
      * Broadcasts the {@code Intent} by iterating through the registered receivers, invoking their filters, and calling
      * {@code onRecieve(Application, Intent)} as appropriate. Does not enqueue the {@code Intent} for later inspection.
@@ -319,16 +333,23 @@ public class ShadowApplication extends ShadowContextWrapper {
      * @param intent the {@code Intent} to broadcast
      *               todo: enqueue the Intent for later inspection
      */
-    @Override
-    @Implementation
-    public void sendBroadcast(Intent intent) {
+    private void sendBroadcastWithPermission(Intent intent, String receiverPermission) {
         broadcastIntents.add(intent);
-		
+
         List<Wrapper> copy = new ArrayList<Wrapper>();
         copy.addAll(registeredReceivers);
         for (Wrapper wrapper : copy) {
-            if (wrapper.intentFilter.matchAction(intent.getAction())) {
-                wrapper.broadcastReceiver.onReceive(realApplication, intent);
+            if (hasMatchingPermission(wrapper.broadcastPermission, receiverPermission)
+                    && wrapper.intentFilter.matchAction(intent.getAction())) {
+                final Handler scheduler = (wrapper.scheduler != null) ? wrapper.scheduler : this.mainHandler;
+                final BroadcastReceiver receiver = wrapper.broadcastReceiver;
+                final Intent broadcastIntent = intent;
+                scheduler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        receiver.onReceive(realApplication, broadcastIntent);
+                    }
+                });
             }
         }
     }
@@ -351,12 +372,18 @@ public class ShadowApplication extends ShadowContextWrapper {
     @Override
     @Implementation
     public Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter) {
-        return registerReceiverWithContext(receiver, filter, realApplication);
+        return registerReceiverWithContext(receiver, filter, null, null, realApplication);
     }
 
-    Intent registerReceiverWithContext(BroadcastReceiver receiver, IntentFilter filter, Context context) {
+    @Override
+    @Implementation
+    public Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter, String broadcastPermission, Handler scheduler) {
+        return registerReceiverWithContext(receiver, filter, broadcastPermission, scheduler, realApplication);
+    }
+
+    Intent registerReceiverWithContext(BroadcastReceiver receiver, IntentFilter filter, String broadcastPermission, Handler scheduler, Context context) {
         if (receiver != null) {
-            registeredReceivers.add(new Wrapper(receiver, filter, context));
+            registeredReceivers.add(new Wrapper(receiver, filter, context, broadcastPermission, scheduler));
         }
         return getStickyIntent(filter);
     }
@@ -534,11 +561,15 @@ public class ShadowApplication extends ShadowContextWrapper {
         public IntentFilter intentFilter;
         public Context context;
         public Throwable exception;
+        public String broadcastPermission;
+        public Handler scheduler;
 
-        public Wrapper(BroadcastReceiver broadcastReceiver, IntentFilter intentFilter, Context context) {
+        public Wrapper(BroadcastReceiver broadcastReceiver, IntentFilter intentFilter, Context context, String broadcastPermission, Handler scheduler) {
             this.broadcastReceiver = broadcastReceiver;
             this.intentFilter = intentFilter;
             this.context = context;
+            this.broadcastPermission = broadcastPermission;
+            this.scheduler = scheduler;
             exception = new Throwable();
         }
 
@@ -553,5 +584,17 @@ public class ShadowApplication extends ShadowContextWrapper {
         public Context getContext() {
             return context;
         }
+    }
+
+    private boolean hasMatchingPermission(String permission1, String permission2) {
+        boolean match = false;
+        if (permission1 == null && permission2 == null) {
+            match = true;
+        } else if (permission1 != null && permission1.equals(permission2)) {
+            match = true;
+        } else if (permission2 != null && permission2.equals(permission1)) {
+            match = true;
+        }
+        return match;
     }
 }

--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowContextWrapper.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowContextWrapper.java
@@ -13,6 +13,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
+import android.os.Handler;
 import android.os.Looper;
 import com.xtremelabs.robolectric.internal.Implementation;
 import com.xtremelabs.robolectric.internal.Implements;
@@ -73,6 +74,11 @@ public class ShadowContextWrapper extends ShadowContext {
         getApplicationContext().sendBroadcast(intent);
     }
 
+    @Implementation
+    public void sendBroadcast(Intent intent, String receiverPermission) {
+        getApplicationContext().sendBroadcast(intent, receiverPermission);
+    }
+
     public List<Intent> getBroadcastIntents() {
         return ((ShadowApplication) shadowOf(getApplicationContext())).getBroadcastIntents();
     }
@@ -84,7 +90,12 @@ public class ShadowContextWrapper extends ShadowContext {
 
     @Implementation
     public Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter) {
-        return ((ShadowApplication) shadowOf(getApplicationContext())).registerReceiverWithContext(receiver, filter, realContextWrapper);
+        return ((ShadowApplication) shadowOf(getApplicationContext())).registerReceiverWithContext(receiver, filter, null, null, realContextWrapper);
+    }
+
+    @Implementation
+    public Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter, String broadcastPermission, Handler scheduler) {
+        return ((ShadowApplication) shadowOf(getApplicationContext())).registerReceiverWithContext(receiver, filter, broadcastPermission, scheduler, realContextWrapper);
     }
 
     @Implementation


### PR DESCRIPTION
Permission restriction has been added to registerReceiver / sendBroadcast.
Intents will only be broadcasted to receivers that has matching
permission. If null is provided then it will simply mean no permission
is required.

Posting the BroadcastReceiver on a provided Handler has also been added.
If you provide a Handler when registering your receiver that receiver
will be notified from that Handler.  Otherwise the main application
Handler will be used.

Added necessary tests to exercise this new support.
