### PR TITLE
I have a fix for ShadowViewPager which I needed in order to prevent a StackOverflowError.

### DIFF
--- a/src/main/java/com/xtremelabs/robolectric/shadows/ShadowViewPager.java
+++ b/src/main/java/com/xtremelabs/robolectric/shadows/ShadowViewPager.java
@@ -37,10 +37,12 @@ public class ShadowViewPager extends ShadowViewGroup {
 
     @Implementation
     public void setCurrentItem(int position) {
-        if (onPageChangeListener != null) {
-            onPageChangeListener.onPageSelected(position);
+        if (currentItem != position) {
+            currentItem = position;
+            if (onPageChangeListener != null) {
+                onPageChangeListener.onPageSelected(position);
+            }
         }
-        currentItem = position;
     }
     
     @Implementation

--- a/src/test/java/com/xtremelabs/robolectric/shadows/ViewPagerTest.java
+++ b/src/test/java/com/xtremelabs/robolectric/shadows/ViewPagerTest.java
@@ -46,6 +46,15 @@ public class ViewPagerTest {
         assertTrue(listener.onPageSelectedCalled);
     }
 
+    @Test
+    public void setCurrentItem_shouldntInvokeListenerWhenSettingRedundantly() throws Exception {
+        TestOnPageChangeListener listener = new TestOnPageChangeListener();
+        pager.setOnPageChangeListener(listener);
+        assertFalse(listener.onPageSelectedCalled);
+        pager.setCurrentItem(pager.getCurrentItem());
+        assertFalse(listener.onPageSelectedCalled);
+    }
+
     private static class TestPagerAdapter extends PagerAdapter {
         @Override
         public int getCount() {


### PR DESCRIPTION
I had come across an issue where my listener was calling back to setCurrentItem(), causing a cyclical recursion and eventual stack overflow. With this fix, the second call to setCurrentItem in the recursion will result in a no-op, allowing the original call to complete.  This matches the logic in the real ViewPager class.
