### PR TITLE
MediaPlayer error handling 

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
+++ b/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
@@ -28,6 +28,7 @@ public class ShadowMediaPlayer {
 	private int sourceResId;
 	private MediaPlayer.OnCompletionListener completionListener;
 	private MediaPlayer.OnPreparedListener preparedListener;
+	private MediaPlayer.OnErrorListener errorListener;
 	
 	@Implementation
 	public static MediaPlayer create(Context context, int resId) {
@@ -69,6 +70,13 @@ public class ShadowMediaPlayer {
 	public void setOnPreparedListener(MediaPlayer.OnPreparedListener listener) {
 		preparedListener = listener;
 	}
+	
+	@Implementation
+	public void setOnErrorListener(MediaPlayer.OnErrorListener listener) {
+		errorListener = listener;
+	}
+	
+	
 	
 	@Implementation
 	public boolean isPlaying() {
@@ -180,5 +188,17 @@ public class ShadowMediaPlayer {
     public void invokeCompletionListener() {
     	if (completionListener == null) return;
     	completionListener.onCompletion( player );
-    }    
+    }
+    
+    
+    public void invokeErrorListener(int what,int extra){
+		playing = false;
+		prepared = false;
+    	if (errorListener == null) return;
+    	boolean handled = errorListener.onError(player,what,extra);
+    	if (!handled){
+    		invokeCompletionListener();
+    	}
+    		    
+    }
 }

--- a/src/test/java/org/robolectric/shadows/MediaPlayerTest.java
+++ b/src/test/java/org/robolectric/shadows/MediaPlayerTest.java
@@ -1,9 +1,12 @@
 package org.robolectric.shadows;
 
 import android.media.MediaPlayer;
+
+import org.apache.tools.ant.taskdefs.Length.When;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.robolectric.Robolectric;
 import org.robolectric.TestRunners;
 
@@ -30,4 +33,49 @@ public class MediaPlayerTest {
             assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(position);
         }
     }
+    
+    
+    @Test
+    public void testErrorListenerCalled() {
+		MediaPlayer.OnErrorListener err = Mockito.mock(MediaPlayer.OnErrorListener.class);
+		shadowMediaPlayer.setOnErrorListener(err);
+		shadowMediaPlayer.invokeErrorListener(0,0);
+		Mockito.verify(err).onError(mediaPlayer,0,0);
+    }
+    
+    
+    @Test
+    public void testErrorListenerCalledNoOnCompleteCalledWhenReturnTrue() {
+		MediaPlayer.OnErrorListener err = Mockito.mock(MediaPlayer.OnErrorListener.class);
+		MediaPlayer.OnCompletionListener complete =  Mockito.mock(MediaPlayer.OnCompletionListener.class);
+		Mockito.when(err.onError(mediaPlayer,0,0)).thenReturn(true);
+		shadowMediaPlayer.setOnErrorListener(err);
+		shadowMediaPlayer.setOnCompletionListener(complete);
+		
+		shadowMediaPlayer.invokeErrorListener(0, 0);
+		
+		Mockito.verify(err).onError(mediaPlayer,0,0);
+		Mockito.verifyZeroInteractions(complete);
+		
+    }
+    
+    
+    @Test
+    public void testErrorListenerCalledOnCompleteCalledWhenReturnFalse() {
+		MediaPlayer.OnErrorListener err = Mockito.mock(MediaPlayer.OnErrorListener.class);
+		MediaPlayer.OnCompletionListener complete =  Mockito.mock(MediaPlayer.OnCompletionListener.class);
+		Mockito.when(err.onError(mediaPlayer,0,0)).thenReturn(false);
+		shadowMediaPlayer.setOnErrorListener(err);
+		shadowMediaPlayer.setOnCompletionListener(complete);
+		
+		shadowMediaPlayer.invokeErrorListener(0, 0);
+		
+		Mockito.verify(err).onError(mediaPlayer,0,0);
+		Mockito.verify(complete).onCompletion(mediaPlayer);
+		
+    }
+    
+    
+    
+    
 }


### PR DESCRIPTION
Added error invocation methods on mediaplayer to enable to emulate errors while testing classes that uses android media player
