### PR TITLE
Modify startService to return ComponentName of given intent

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -206,6 +206,9 @@ public class ShadowApplication extends ShadowContextWrapper {
     @Override
     public ComponentName startService(Intent intent) {
         startedServices.add(intent);
+        if (intent.getComponent() != null) {
+            return intent.getComponent();
+        }
         return new ComponentName("some.service.package", "SomeServiceName-FIXME");
     }
 

--- a/src/test/java/org/robolectric/shadows/ApplicationTest.java
+++ b/src/test/java/org/robolectric/shadows/ApplicationTest.java
@@ -207,6 +207,24 @@ public class ApplicationTest {
     }
 
     @Test
+    public void shouldHaveStoppedServiceByStartedComponent() {
+        ShadowApplication shadowApplication = shadowOf(Robolectric.application);
+
+        Activity activity = new Activity();
+
+        ComponentName componentName = new ComponentName("package.test", "package.test.TestClass");
+        Intent startServiceIntent = new Intent().setComponent(componentName);
+
+        ComponentName startedComponent = activity.startService(startServiceIntent);
+
+        Intent stopServiceIntent = new Intent().setComponent(startedComponent);
+        boolean wasRunning = activity.stopService(stopServiceIntent);
+
+        assertTrue(wasRunning);
+        assertEquals(startServiceIntent, shadowApplication.getNextStoppedService());
+    }
+
+    @Test
     public void shouldClearStartedServiceIntents() {
         ShadowApplication shadowApplication = shadowOf(Robolectric.application);
         shadowApplication.startService(getSomeActionIntent("some.action"));


### PR DESCRIPTION
Currently, ShadowApplication#startService(Intent) returns a fake componentName regardless of what Intent is passed to the method. In android platform, Context#startService(Intent) returns ComponentName of started service, so I think ShadowApplication#startService at least return Intent.getComponentName() if Intent contains concrete ComponentName.
