### PR TITLE
Parse android:versionCode and android:versionName 

### DIFF
--- a/src/main/java/org/robolectric/AndroidManifest.java
+++ b/src/main/java/org/robolectric/AndroidManifest.java
@@ -29,6 +29,8 @@ public class AndroidManifest {
     private boolean manifestIsParsed = false;
     private Integer targetSdkVersion;
     private Integer minSdkVersion;
+    private int versionCode;
+    private String versionName;
     private int applicationFlags;
     private final List<ReceiverAndIntentFilter> receivers = new ArrayList<ReceiverAndIntentFilter>();
     private List<AndroidManifest> libraryManifests;
@@ -91,6 +93,8 @@ public class AndroidManifest {
             Document manifestDocument = db.parse(androidManifestFile);
 
             packageName = getTagAttributeText(manifestDocument, "manifest", "package");
+            versionCode = getTagAttributeIntValue(manifestDocument, "manifest", "android:versionCode");
+            versionName = getTagAttributeText(manifestDocument, "manifest", "android:versionName");
             rClassName = packageName + ".R";
             applicationName = getTagAttributeText(manifestDocument, "application", "android:name");
             minSdkVersion = getTagAttributeIntValue(manifestDocument, "uses-sdk", "android:minSdkVersion");
@@ -189,6 +193,14 @@ public class AndroidManifest {
     public String getPackageName() {
         parseAndroidManifest();
         return packageName;
+    }
+
+    public int getVersionCode() {
+        return versionCode;
+    }
+
+    public String getVersionName() {
+        return versionName;
     }
 
     public int getMinSdkVersion() {

--- a/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
+++ b/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
@@ -247,7 +247,8 @@ public class RobolectricPackageManager extends StubPackageManager {
 
         PackageInfo packageInfo = new PackageInfo();
         packageInfo.packageName = contextWrapper.getPackageName();
-        packageInfo.versionName = "1.0";
+        packageInfo.versionName = androidManifest.getVersionName();
+        packageInfo.versionCode = androidManifest.getVersionCode();
 
         packageList = new HashMap<String, PackageInfo>();
         addPackage(packageInfo);


### PR DESCRIPTION
Some applications may rely on PackageInfo.versionCode or PackageInfo.versionName.
Robolectric didn't try to parse it from manifest and just left versionCode as 0 and versionName as "1.0".

The patch fixes this issue.
