### PR TITLE
New Matrix implementation and Bitmap creation metadata.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowBitmap.java
+++ b/src/main/java/org/robolectric/shadows/ShadowBitmap.java
@@ -1,13 +1,14 @@
 package org.robolectric.shadows;
 
 import android.graphics.Bitmap;
+import android.graphics.Matrix;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import org.robolectric.Robolectric;
 import org.robolectric.internal.Implementation;
 import org.robolectric.internal.Implements;
 import org.robolectric.internal.RealObject;
-
-import java.io.IOException;
-import java.io.OutputStream;
 
 import static org.robolectric.Robolectric.shadowOf;
 
@@ -16,13 +17,99 @@ import static org.robolectric.Robolectric.shadowOf;
 public class ShadowBitmap {
     @RealObject private Bitmap realBitmap;
 
+    int createdFromResId;
+    String createdFromPath;
+    InputStream createdFromStream;
+    byte[] createdFromBytes;
+    private Bitmap createdFromBitmap;
+    private int createdFromX = -1;
+    private int createdFromY = -1;
+    private int createdFromWidth = -1;
+    private int createdFromHeight = -1;
+    private Matrix createdFromMatrix;
+    private boolean createdFromFilter;
+
     private int width;
     private int height;
     private Bitmap.Config config;
     private boolean mutable;
     private String description = "";
-    private int loadedFromResourceId = -1;
     private boolean recycled = false;
+
+    /**
+     * Reference to original Bitmap from which this Bitmap was created. {@code null} if this Bitmap
+     * was not copied from another instance.
+     */
+    public Bitmap getCreatedFromBitmap() {
+        return createdFromBitmap;
+    }
+
+    /**
+     * Resource ID from which this Bitmap was created. {@code 0} if this Bitmap was not created
+     * from a resource.
+     */
+    public int getCreatedFromResId() {
+        return createdFromResId;
+    }
+
+    /**
+     * Path from which this Bitmap was created. {@code null} if this Bitmap was not create from a
+     * path.
+     */
+    public String getCreatedFromPath() {
+        return createdFromPath;
+    }
+
+    /**
+     * {@link InputStream} from which this Bitmap was created. {@code null} if this Bitmap was not
+     * created from a stream.
+     */
+    public InputStream getCreatedFromStream() {
+        return createdFromStream;
+    }
+
+    /**
+     * Bytes from which this Bitmap was created. {@code null} if this Bitmap was not created from
+     * bytes.
+     */
+    public byte[] getCreatedFromBytes() {
+        return createdFromBytes;
+    }
+
+    /** Horizontal offset within {@link #getCreatedFromBitmap()} of this Bitmap's content, or -1. */
+    public int getCreatedFromX() {
+        return createdFromX;
+    }
+    /** Vertical offset within {@link #getCreatedFromBitmap()} of this Bitmap's content, or -1. */
+    public int getCreatedFromY() {
+        return createdFromY;
+    }
+
+    /**
+     * Width from {@link #getCreatedFromX()} within {@link #getCreatedFromBitmap()} of this Bitmap's
+     * content, or -1.
+     */
+    public int getCreatedFromWidth() {
+        return createdFromWidth;
+    }
+
+    /**
+     * Height from {@link #getCreatedFromX()} within {@link #getCreatedFromBitmap()} of this Bitmap's
+     * content, or -1.
+     */
+    public int getCreatedFromHeight() {
+        return createdFromHeight;
+    }
+
+    /** Matrix from which this Bitmap's content was transformed, or {@code null}. */
+    public Matrix getCreateFromMatrix() {
+        return createdFromMatrix;
+    }
+
+    /** {@code true} if this Bitmap was created with filtering. */
+    public boolean getCreatedFromFilter() {
+        return createdFromFilter;
+    }
 
     @Implementation
     public boolean compress(Bitmap.CompressFormat format, int quality, OutputStream stream) {
@@ -39,32 +126,84 @@ public class ShadowBitmap {
     public static Bitmap createBitmap(int width, int height, Bitmap.Config config) {
         Bitmap scaledBitmap = Robolectric.newInstanceOf(Bitmap.class);
         ShadowBitmap shadowBitmap = shadowOf(scaledBitmap);
-        shadowBitmap.appendDescription("Bitmap (" + width + " x " + height + ")");
-        shadowBitmap.setWidth(width);
-        shadowBitmap.setHeight(height);
-        shadowBitmap.setConfig(config);
+
+        shadowBitmap.setDescription("Bitmap (" + width + " x " + height + ")");
+
+        shadowBitmap.width = width;
+        shadowBitmap.height = height;
+        shadowBitmap.config = config;
         return scaledBitmap;
     }
 
     @Implementation
-    public static Bitmap createBitmap(Bitmap bitmap) {
-        ShadowBitmap shadowBitmap = shadowOf(bitmap);
+    public static Bitmap createBitmap(Bitmap src) {
+        ShadowBitmap shadowBitmap = shadowOf(src);
         shadowBitmap.appendDescription(" created from Bitmap object");
-        return bitmap;
+        return src;
     }
 
     @Implementation
     public static Bitmap createScaledBitmap(Bitmap src, int dstWidth, int dstHeight, boolean filter) {
         Bitmap scaledBitmap = Robolectric.newInstanceOf(Bitmap.class);
         ShadowBitmap shadowBitmap = shadowOf(scaledBitmap);
+
         shadowBitmap.appendDescription(shadowOf(src).getDescription());
         shadowBitmap.appendDescription(" scaled to " + dstWidth + " x " + dstHeight);
         if (filter) {
             shadowBitmap.appendDescription(" with filter " + filter);
         }
-        shadowBitmap.setWidth(dstWidth);
-        shadowBitmap.setHeight(dstHeight);
+
+        shadowBitmap.createdFromBitmap = src;
+        shadowBitmap.createdFromFilter = filter;
+        shadowBitmap.width = dstWidth;
+        shadowBitmap.height = dstHeight;
         return scaledBitmap;
+    }
+
+    @Implementation
+    public static Bitmap createBitmap(Bitmap src, int x, int y, int width, int height) {
+        Bitmap newBitmap = Robolectric.newInstanceOf(Bitmap.class);
+        ShadowBitmap shadowBitmap = shadowOf(newBitmap);
+
+        shadowBitmap.appendDescription(shadowOf(src).getDescription());
+        shadowBitmap.appendDescription(" at (" + x + "," + y);
+        shadowBitmap.appendDescription(" with width " + width + " and height " + height);
+
+        shadowBitmap.createdFromBitmap = src;
+        shadowBitmap.createdFromX = x;
+        shadowBitmap.createdFromY = y;
+        shadowBitmap.createdFromWidth = width;
+        shadowBitmap.createdFromHeight = height;
+        shadowBitmap.width = width;
+        shadowBitmap.height = height;
+        return newBitmap;
+    }
+
+    @Implementation
+    public static Bitmap createBitmap(Bitmap src, int x, int y, int width, int height, Matrix matrix, boolean filter) {
+        Bitmap newBitmap = Robolectric.newInstanceOf(Bitmap.class);
+        ShadowBitmap shadowBitmap = shadowOf(newBitmap);
+
+        shadowBitmap.appendDescription(shadowOf(src).getDescription());
+        shadowBitmap.appendDescription(" at (" + x + "," + y);
+        shadowBitmap.appendDescription(" with width " + width + " and height " + height);
+        if (matrix != null) {
+            shadowBitmap.appendDescription(" using matrix " + matrix);
+        }
+        if (filter) {
+            shadowBitmap.appendDescription(" with filter " + filter);
+        }
+
+        shadowBitmap.createdFromBitmap = src;
+        shadowBitmap.createdFromX = x;
+        shadowBitmap.createdFromY = y;
+        shadowBitmap.createdFromWidth = width;
+        shadowBitmap.createdFromHeight = height;
+        shadowBitmap.createdFromMatrix = matrix;
+        shadowBitmap.createdFromFilter = filter;
+        shadowBitmap.width = width;
+        shadowBitmap.height = height;
+        return newBitmap;
     }
 
     @Implementation
@@ -79,10 +218,12 @@ public class ShadowBitmap {
 
     @Implementation
     public Bitmap copy(Bitmap.Config config, boolean isMutable) {
-        ShadowBitmap shadowBitmap = shadowOf(realBitmap);
-        shadowBitmap.setConfig(config);
-        shadowBitmap.setMutable(isMutable);
-        return realBitmap;
+        Bitmap newBitmap = Robolectric.newInstanceOf(Bitmap.class);
+        ShadowBitmap shadowBitmap = shadowOf(newBitmap);
+        shadowBitmap.createdFromBitmap = realBitmap;
+        shadowBitmap.config = config;
+        shadowBitmap.mutable = isMutable;
+        return newBitmap;
     }
 
     @Implementation
@@ -113,23 +254,6 @@ public class ShadowBitmap {
 
     public String getDescription() {
         return description;
-    }
-
-    public static Bitmap create(String name) {
-        Bitmap bitmap = Robolectric.newInstanceOf(Bitmap.class);
-        shadowOf(bitmap).appendDescription(name);
-        return bitmap;
-    }
-
-    public void setLoadedFromResourceId(int loadedFromResourceId) {
-        this.loadedFromResourceId = loadedFromResourceId;
-    }
-
-    public int getLoadedFromResourceId() {
-        if (loadedFromResourceId == -1) {
-            throw new IllegalStateException("not loaded from a resource");
-        }
-        return loadedFromResourceId;
     }
 
     public void setWidth(int width) {

--- a/src/main/java/org/robolectric/shadows/ShadowBitmapDrawable.java
+++ b/src/main/java/org/robolectric/shadows/ShadowBitmapDrawable.java
@@ -80,11 +80,11 @@ public class ShadowBitmapDrawable extends ShadowDrawable {
      * your tests assert that the bitmap is correct without having to actually load the bitmap.
      *
      * @return resource id from which this {@code BitmapDrawable} was loaded
-     * @deprecated use org.robolectric.shadows.ShadowBitmap#getLoadedFromResourceId() instead.
+     * @deprecated use org.robolectric.shadows.ShadowBitmap#getCreatedFromResId() instead.
      */
     @Override
     public int getLoadedFromResourceId() {
-        return shadowOf(bitmap).getLoadedFromResourceId();
+        return shadowOf(bitmap).getCreatedFromResId();
     }
 
     // Used by ShadowDrawable.createFromStream()

--- a/src/main/java/org/robolectric/shadows/ShadowDrawable.java
+++ b/src/main/java/org/robolectric/shadows/ShadowDrawable.java
@@ -54,7 +54,7 @@ public class ShadowDrawable {
 
     public static Drawable createFromResourceId(int resourceId) {
         Bitmap bitmap = Robolectric.newInstanceOf(Bitmap.class);
-        shadowOf(bitmap).setLoadedFromResourceId(resourceId);
+        shadowOf(bitmap).createdFromResId = resourceId;
         BitmapDrawable drawable = new BitmapDrawable(bitmap);
         shadowOf(drawable).validate(); // start off not invalidated
         return drawable;

--- a/src/main/java/org/robolectric/shadows/ShadowImageView.java
+++ b/src/main/java/org/robolectric/shadows/ShadowImageView.java
@@ -9,8 +9,6 @@ import android.widget.ImageView;
 import org.robolectric.internal.Implementation;
 import org.robolectric.internal.Implements;
 
-import static org.robolectric.Robolectric.shadowOf;
-
 @Implements(value = ImageView.class, inheritImplementationMethods = true)
 public class ShadowImageView extends ShadowView {
     private Drawable imageDrawable;
@@ -83,13 +81,12 @@ public class ShadowImageView extends ShadowView {
     }
 
     @Implementation
+    public Matrix getImageMatrix() {
+        return matrix;
+    }
+
+    @Implementation
     public void draw(Canvas canvas) {
-        if (matrix != null) {
-            canvas.translate(shadowOf(matrix).getTransX(), shadowOf(matrix)
-                    .getTransY());
-            canvas.scale(shadowOf(matrix).getScaleX(), shadowOf(matrix)
-                    .getScaleY());
-        }
         if (imageDrawable != null) {
             imageDrawable.draw(canvas);
         }

--- a/src/main/java/org/robolectric/shadows/ShadowMatrix.java
+++ b/src/main/java/org/robolectric/shadows/ShadowMatrix.java
@@ -1,6 +1,13 @@
 package org.robolectric.shadows;
 
 import android.graphics.Matrix;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.robolectric.internal.Implementation;
 import org.robolectric.internal.Implements;
 
@@ -9,66 +16,191 @@ import static org.robolectric.Robolectric.shadowOf;
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Matrix.class)
 public class ShadowMatrix {
-    private float scaleX = 1;
-    private float transX;
+    public static final String TRANSLATE = "translate";
+    public static final String SCALE = "scale";
+    public static final String ROTATE = "rotate";
+    public static final String SINCOS = "sincos";
+    public static final String SKEW = "skew";
+    public static final String MATRIX = "matrix";
 
-    private float scaleY = 1;
-    private float transY;
-
-    // scaleX=0, skewX=1,  transX=2
-    // skewY=3,  scaleY=4, transY=5
-    // persp0=6, persp1=7, persp2=8
-
-    // identity: Matrix{[1.0, 0.0, 0.0][0.0, 1.0, 0.0][0.0, 0.0, 1.0]}
-
-    // drag down: Matrix{[1.0, 0.0, -1.3872986][0.0, 1.0, 0.37722778][0.0, 0.0, 1.0]}
-
+    private final Deque<String> preOps = new ArrayDeque<String>();
+    private final Deque<String> postOps = new ArrayDeque<String>();
+    private final Map<String, String> setOps = new LinkedHashMap<String, String>();
 
     public void __constructor__(Matrix src) {
         set(src);
     }
 
+    /**
+     * A list of all 'pre' operations performed on this Matrix. The last operation performed will
+     * be first in the list.
+     */
+    public List<String> getPreOperations() {
+        return Collections.unmodifiableList(new ArrayList<String>(preOps));
+    }
+
+    /**
+     * A list of all 'post' operations performed on this Matrix. The last operation performed will
+     * be last in the list.
+     */
+    public List<String> getPostOperations() {
+        return Collections.unmodifiableList(new ArrayList<String>(postOps));
+    }
+
+    /** A map of all 'set' operations performed on this Matrix. */
+    public Map<String, String> getSetOperations() {
+        return Collections.unmodifiableMap(new LinkedHashMap<String, String>(setOps));
+    }
+
+    @Implementation
+    public boolean isIdentity() {
+      return preOps.isEmpty() && postOps.isEmpty() && setOps.isEmpty();
+    }
+
     @Implementation
     public void set(Matrix src) {
-        transX = shadowOf(src).transX;
-        scaleX = shadowOf(src).scaleX;
+        reset();
 
-        transY = shadowOf(src).transY;
-        scaleY = shadowOf(src).scaleY;
+        ShadowMatrix shadowMatrix = shadowOf(src);
+        preOps.addAll(shadowMatrix.preOps);
+        postOps.addAll(shadowMatrix.postOps);
+        setOps.putAll(shadowMatrix.setOps);
+    }
+
+    @Implementation
+    public void reset() {
+        preOps.clear();
+        postOps.clear();
+        setOps.clear();
     }
 
     @Implementation
     public void setTranslate(float dx, float dy) {
-        transX = dx;
-        transY = dy;
+        setOps.put(TRANSLATE, dx + " " + dy);
+    }
+
+    @Implementation
+    public void setScale(float sx, float sy, float px, float py) {
+        setOps.put(SCALE, sx + " " + sy + " " + py + " " + py);
+    }
+
+    @Implementation
+    public void setScale(float sx, float sy) {
+        setOps.put(SCALE, sx + " " + sy);
+    }
+
+    @Implementation
+    public void setRotate(float degrees, float px, float py) {
+        setOps.put(ROTATE, degrees + " " + px + " " + py);
+    }
+
+    @Implementation
+    public void setRotate(float degrees) {
+        setOps.put(ROTATE, Float.toString(degrees));
+    }
+
+    @Implementation
+    public void setSinCos(float sinValue, float cosValue, float px, float py) {
+        setOps.put(SINCOS, sinValue + " " + cosValue + " " + px + " " + py);
+    }
+
+    @Implementation
+    public void setSinCos(float sinValue, float cosValue) {
+        setOps.put(SINCOS, sinValue + " " + cosValue);
+    }
+
+    @Implementation
+    public void setSkew(float kx, float ky, float px, float py) {
+        setOps.put(SKEW, kx + " " + ky + " " + px + " " + py);
+    }
+
+    @Implementation
+    public void setSkew(float kx, float ky) {
+        setOps.put(SKEW, kx + " " + ky);
+    }
+
+    @Implementation
+    public void preTranslate(float dx, float dy) {
+        preOps.addFirst(TRANSLATE + " " + dx + " " + dy);
+    }
+
+    @Implementation
+    public void preScale(float sx, float sy, float px, float py) {
+        preOps.addFirst(SCALE + " " + sx + " " + sy + " " + px + " " + py);
+    }
+
+    @Implementation
+    public void preScale(float sx, float sy) {
+        preOps.addFirst(SCALE + " " + sx + " " + sy);
+    }
+
+    @Implementation
+    public void preRotate(float degrees, float px, float py) {
+        preOps.addFirst(ROTATE + " " + degrees + " " + px + " " + py);
+    }
+
+    @Implementation
+    public void preRotate(float degrees) {
+        preOps.addFirst(ROTATE + " " + Float.toString(degrees));
+    }
+
+    @Implementation
+    public void preSkew(float kx, float ky, float px, float py) {
+        preOps.addFirst(SKEW + " " + kx + " " + ky + " " + px + " " + py);
+    }
+
+    @Implementation
+    public void preSkew(float kx, float ky) {
+        preOps.addFirst(SKEW + " " + kx + " " + ky);
+    }
+
+    @Implementation
+    public void preConcat(Matrix other) {
+        preOps.addFirst(MATRIX + " " + other);
     }
 
     @Implementation
     public void postTranslate(float dx, float dy) {
-        transX += dx;
-        transY += dy;
-    }
-
-    public float getTransX() {
-        return transX;
-    }
-
-    public float getTransY() {
-        return transY;
+        postOps.addLast(TRANSLATE + " " + dx + " " + dy);
     }
 
     @Implementation
-    public boolean postScale(float sx, float sy, float px, float py) {
-        scaleX *= sx;
-        scaleY *= sy;
-        return true;
+    public void postScale(float sx, float sy, float px, float py) {
+        postOps.addLast(SCALE + " " + sx + " " + sy + " " + px + " " + py);
     }
 
-    public float getScaleX() {
-        return scaleX;
+    @Implementation
+    public void postScale(float sx, float sy) {
+        postOps.addLast(SCALE + " " + sx + " " + sy);
     }
 
-    public float getScaleY() {
-        return scaleY;
+    @Implementation
+    public void postRotate(float degrees, float px, float py) {
+        postOps.addLast(ROTATE + " " + degrees + " " + px + " " + py);
+    }
+
+    @Implementation
+    public void postRotate(float degrees) {
+        postOps.addLast(ROTATE + " " + Float.toString(degrees));
+    }
+
+    @Implementation
+    public void postSkew(float kx, float ky, float px, float py) {
+        postOps.addLast(SKEW + " " + kx + " " + ky + " " + px + " " + py);
+    }
+
+    @Implementation
+    public void postSkew(float kx, float ky) {
+        postOps.addLast(SKEW + " " + kx + " " + ky);
+    }
+
+    @Implementation
+    public void postConcat(Matrix other) {
+        postOps.addLast(MATRIX + " " + other);
+    }
+
+    @Implementation
+    public String toString() {
+        return "Matrix[pre=" + preOps + ", set=" + setOps + ", post=" + postOps + "]";
     }
 }

--- a/src/test/java/org/robolectric/shadows/BitmapFactoryTest.java
+++ b/src/test/java/org/robolectric/shadows/BitmapFactoryTest.java
@@ -19,26 +19,43 @@ import static org.robolectric.Robolectric.shadowOf;
 @RunWith(TestRunners.WithDefaults.class)
 public class BitmapFactoryTest {
     @Test
-    public void decodeResource_shouldSetDescription() throws Exception {
+    public void decodeResource_shouldSetDescriptionAndCreatedFrom() throws Exception {
         Bitmap bitmap = BitmapFactory.decodeResource(Robolectric.application.getResources(), R.drawable.an_image);
-        assertEquals("Bitmap for resource:org.robolectric:drawable/an_image", shadowOf(bitmap).getDescription());
+        ShadowBitmap shadowBitmap = shadowOf(bitmap);
+        assertEquals("Bitmap for resource:org.robolectric:drawable/an_image", shadowBitmap.getDescription());
+        assertEquals(R.drawable.an_image, shadowBitmap.getCreatedFromResId());
         assertEquals(100, bitmap.getWidth());
         assertEquals(100, bitmap.getHeight());
     }
 
     @Test
-    public void decodeFile_shouldSetDescription() throws Exception {
+    public void decodeFile_shouldSetDescriptionAndCreatedFrom() throws Exception {
         Bitmap bitmap = BitmapFactory.decodeFile("/some/file.jpg");
-        assertEquals("Bitmap for file:/some/file.jpg", shadowOf(bitmap).getDescription());
+        ShadowBitmap shadowBitmap = shadowOf(bitmap);
+        assertEquals("Bitmap for file:/some/file.jpg", shadowBitmap.getDescription());
+        assertEquals("/some/file.jpg", shadowBitmap.getCreatedFromPath());
         assertEquals(100, bitmap.getWidth());
         assertEquals(100, bitmap.getHeight());
     }
 
     @Test
-    public void decodeStream_shouldSetDescription() throws Exception {
+    public void decodeStream_shouldSetDescriptionAndCreatedFrom() throws Exception {
         InputStream inputStream = Robolectric.application.getContentResolver().openInputStream(Uri.parse("content:/path"));
         Bitmap bitmap = BitmapFactory.decodeStream(inputStream);
-        assertEquals("Bitmap for content:/path", shadowOf(bitmap).getDescription());
+        ShadowBitmap shadowBitmap = shadowOf(bitmap);
+        assertEquals("Bitmap for content:/path", shadowBitmap.getDescription());
+        assertEquals(inputStream, shadowBitmap.getCreatedFromStream());
+        assertEquals(100, bitmap.getWidth());
+        assertEquals(100, bitmap.getHeight());
+    }
+
+    @Test
+    public void decodeBytes_shouldSetDescriptionAndCreatedFrom() throws Exception {
+        byte[] yummyBites = "Hi!".getBytes("UTF-8");
+        Bitmap bitmap = BitmapFactory.decodeByteArray(yummyBites, 100, 100);
+        ShadowBitmap shadowBitmap = shadowOf(bitmap);
+        assertEquals("Bitmap for Hi! bytes 100..100", shadowBitmap.getDescription());
+        assertEquals(yummyBites, shadowBitmap.getCreatedFromBytes());
         assertEquals(100, bitmap.getWidth());
         assertEquals(100, bitmap.getHeight());
     }
@@ -142,7 +159,6 @@ public class BitmapFactoryTest {
         assertThat(shadowOf(bitmap).getDescription()).isEqualTo("Bitmap for byte array, checksum: 3693078531");
         assertThat(bitmap.getWidth()).isEqualTo(100);
         assertThat(bitmap.getHeight()).isEqualTo(100);
-
     }
 
     @Test

--- a/src/test/java/org/robolectric/shadows/BitmapTest.java
+++ b/src/test/java/org/robolectric/shadows/BitmapTest.java
@@ -19,8 +19,7 @@ import static org.robolectric.Robolectric.shadowOf;
 public class BitmapTest {
     @Test
     public void shouldCreateScaledBitmap() throws Exception {
-        Bitmap originalBitmap = Robolectric.newInstanceOf(Bitmap.class);
-        shadowOf(originalBitmap).appendDescription("Original bitmap");
+        Bitmap originalBitmap = create("Original bitmap");
         Bitmap scaledBitmap = Bitmap.createScaledBitmap(originalBitmap, 100, 200, false);
         assertEquals("Original bitmap scaled to 100 x 200", shadowOf(scaledBitmap).getDescription());
         assertEquals(100, scaledBitmap.getWidth());
@@ -32,43 +31,40 @@ public class BitmapTest {
         Bitmap bitmap = Bitmap.createBitmap(100, 200, Config.ARGB_8888);
         assertFalse(bitmap.isRecycled());
     }
-    
+
     @Test
     public void shouldCreateBitmapWithCorrectConfig() throws Exception {
         Bitmap bitmap = Bitmap.createBitmap(100, 200, Config.ARGB_8888);
         assertEquals(bitmap.getConfig(), Config.ARGB_8888);
     }
-    
+
     @Test
     public void shouldCreateBitmapFromAnotherBitmap() {
-    	Bitmap originalBitmap = Robolectric.newInstanceOf(Bitmap.class);
-        shadowOf(originalBitmap).appendDescription("Original bitmap");
+    	Bitmap originalBitmap = create("Original bitmap");
         Bitmap newBitmap = Bitmap.createBitmap(originalBitmap);
         assertEquals("Original bitmap created from Bitmap object", shadowOf(newBitmap).getDescription());
     }
-    
-    
+
     @Test
     public void shouldRecycleBitmap() throws Exception {
         Bitmap bitmap = Bitmap.createBitmap(100, 200, Config.ARGB_8888);
         bitmap.recycle();
-        assertTrue( bitmap.isRecycled() );    	
+        assertTrue(bitmap.isRecycled());
     }
 
     @Test
     public void equals_shouldCompareDescriptions() throws Exception {
-        assertFalse(ShadowBitmap.create("bitmap A").equals(ShadowBitmap.create("bitmap B")));
-
-        assertTrue(ShadowBitmap.create("bitmap A").equals(ShadowBitmap.create("bitmap A")));
+        assertFalse(create("bitmap A").equals(create("bitmap B")));
+        assertTrue(create("bitmap A").equals(create("bitmap A")));
     }
 
     @Test
     public void equals_shouldCompareWidthAndHeight() throws Exception {
-        Bitmap bitmapA1 = ShadowBitmap.create("bitmap A");
+        Bitmap bitmapA1 = create("bitmap A");
         shadowOf(bitmapA1).setWidth(100);
         shadowOf(bitmapA1).setHeight(100);
 
-        Bitmap bitmapA2 = ShadowBitmap.create("bitmap A");
+        Bitmap bitmapA2 = create("bitmap A");
         shadowOf(bitmapA2).setWidth(101);
         shadowOf(bitmapA2).setHeight(101);
 
@@ -77,11 +73,8 @@ public class BitmapTest {
 
     @Test
     public void shouldReceiveDescriptionWhenDrawingToCanvas() throws Exception {
-        Bitmap bitmap1 = Robolectric.newInstanceOf(Bitmap.class);
-        shadowOf(bitmap1).appendDescription("Bitmap One");
-
-        Bitmap bitmap2 = Robolectric.newInstanceOf(Bitmap.class);
-        shadowOf(bitmap2).appendDescription("Bitmap Two");
+        Bitmap bitmap1 = create("Bitmap One");
+        Bitmap bitmap2 = create("Bitmap Two");
 
         Canvas canvas = new Canvas(bitmap1);
         canvas.drawBitmap(bitmap2, 0, 0, null);
@@ -91,11 +84,8 @@ public class BitmapTest {
 
     @Test
     public void shouldReceiveDescriptionWhenDrawingToCanvasWithBitmapAndMatrixAndPaint() throws Exception {
-        Bitmap bitmap1 = Robolectric.newInstanceOf(Bitmap.class);
-        shadowOf(bitmap1).appendDescription("Bitmap One");
-
-        Bitmap bitmap2 = Robolectric.newInstanceOf(Bitmap.class);
-        shadowOf(bitmap2).appendDescription("Bitmap Two");
+        Bitmap bitmap1 = create("Bitmap One");
+        Bitmap bitmap2 = create("Bitmap Two");
 
         Canvas canvas = new Canvas(bitmap1);
         canvas.drawBitmap(bitmap2, new Matrix(), null);
@@ -105,11 +95,8 @@ public class BitmapTest {
 
     @Test
     public void shouldReceiveDescriptionWhenDrawABitmapToCanvasWithAPaintEffect() throws Exception {
-        Bitmap bitmap1 = Robolectric.newInstanceOf(Bitmap.class);
-        shadowOf(bitmap1).appendDescription("Bitmap One");
-
-        Bitmap bitmap2 = Robolectric.newInstanceOf(Bitmap.class);
-        shadowOf(bitmap2).appendDescription("Bitmap Two");
+        Bitmap bitmap1 = create("Bitmap One");
+        Bitmap bitmap2 = create("Bitmap Two");
 
         Canvas canvas = new Canvas(bitmap1);
         Paint paint = new Paint();
@@ -121,18 +108,21 @@ public class BitmapTest {
 
     @Test
     public void visualize_shouldReturnDescription() throws Exception {
-        Bitmap bitmap = Robolectric.newInstanceOf(Bitmap.class);
-        shadowOf(bitmap).appendDescription("Bitmap One");
-
+        Bitmap bitmap = create("Bitmap One");
         assertEquals("Bitmap One", Robolectric.visualize(bitmap));
-
     }
-    
+
     @Test
     public void shouldCopyBitmap() {
-    	Bitmap bitmap = Robolectric.newInstanceOf(Bitmap.class);
-    	Bitmap bitmapCopy = bitmap.copy(Config.ARGB_8888, true);
-    	assertEquals(shadowOf(bitmapCopy).getConfig(), Config.ARGB_8888);
-    	assertTrue(shadowOf(bitmapCopy).isMutable());
+        Bitmap bitmap = Robolectric.newInstanceOf(Bitmap.class);
+        Bitmap bitmapCopy = bitmap.copy(Config.ARGB_8888, true);
+        assertEquals(shadowOf(bitmapCopy).getConfig(), Config.ARGB_8888);
+        assertTrue(shadowOf(bitmapCopy).isMutable());
+    }
+
+    private static Bitmap create(String name) {
+      Bitmap bitmap = Robolectric.newInstanceOf(Bitmap.class);
+      shadowOf(bitmap).appendDescription(name);
+      return bitmap;
     }
 }

--- a/src/test/java/org/robolectric/shadows/ImageViewTest.java
+++ b/src/test/java/org/robolectric/shadows/ImageViewTest.java
@@ -16,8 +16,12 @@ import org.robolectric.Robolectric;
 import org.robolectric.TestRunners;
 
 import static org.fest.assertions.api.Assertions.assertThat;
-import static org.junit.Assert.*;
-import static org.robolectric.Robolectric.*;
+import static org.fest.assertions.data.MapEntry.entry;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Robolectric.application;
+import static org.robolectric.Robolectric.shadowOf;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ImageViewTest {
@@ -33,33 +37,20 @@ public class ImageViewTest {
     }
 
     @Test
-    public void shouldDrawWithImageMatrix() throws Exception {
-        imageView.setImageMatrix(new Matrix());
-        assertEquals("Bitmap for resource:org.robolectric:drawable/an_image",
-                visualize(imageView));
-
-        Matrix matrix = new Matrix();
-        matrix.setTranslate(15, 20);
-        imageView.setImageMatrix(matrix);
-        assertEquals("Bitmap for resource:org.robolectric:drawable/an_image at (15,20)",
-                visualize(imageView));
-    }
-
-    @Test
     public void shouldCopyMatrixSetup() throws Exception {
         Matrix matrix = new Matrix();
         matrix.setTranslate(15, 20);
         imageView.setImageMatrix(matrix);
-        assertEquals("Bitmap for resource:org.robolectric:drawable/an_image at (15,20)",
-                visualize(imageView));
+        ShadowMatrix m1 = shadowOf(imageView.getImageMatrix());
+        assertThat(m1.getSetOperations()).contains(entry("translate", "15.0 20.0"));
 
         matrix.setTranslate(30, 40);
-        assertEquals("Bitmap for resource:org.robolectric:drawable/an_image at (15,20)",
-                visualize(imageView));
+        ShadowMatrix m2 = shadowOf(imageView.getImageMatrix());
+        assertThat(m2.getSetOperations()).contains(entry("translate", "15.0 20.0"));
 
         imageView.setImageMatrix(matrix);
-        assertEquals("Bitmap for resource:org.robolectric:drawable/an_image at (30,40)",
-                visualize(imageView));
+        ShadowMatrix m3 = shadowOf(imageView.getImageMatrix());
+        assertThat(m3.getSetOperations()).contains(entry("translate", "30.0 40.0"));
     }
 
     @Test
@@ -91,7 +82,7 @@ public class ImageViewTest {
         assertEquals(400, animation.getDuration(0));
         assertEquals(300, animation.getDuration(2));
     }
-    
+
     @Test
     public void testSetImageResource_layerDrawable() {
         imageView.setImageResource(R.drawable.rainbow);

--- a/src/test/java/org/robolectric/shadows/MatrixTest.java
+++ b/src/test/java/org/robolectric/shadows/MatrixTest.java
@@ -1,0 +1,55 @@
+package org.robolectric.shadows;
+
+import android.graphics.Matrix;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.TestRunners;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.data.MapEntry.entry;
+import static org.robolectric.Robolectric.shadowOf;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class MatrixTest {
+    @Test
+    public void preOperationsAreStacked() {
+        Matrix m = new Matrix();
+        m.preRotate(4, 8, 15);
+        m.preTranslate(16, 23);
+        m.preSkew(42, 108);
+
+        assertThat(shadowOf(m).getPreOperations()).containsExactly(
+                "skew 42.0 108.0",
+                "translate 16.0 23.0",
+                "rotate 4.0 8.0 15.0"
+        );
+    }
+
+    @Test
+    public void postOperationsAreQueued() {
+        Matrix m = new Matrix();
+        m.postRotate(4, 8, 15);
+        m.postTranslate(16, 23);
+        m.postSkew(42, 108);
+
+        assertThat(shadowOf(m).getPostOperations()).containsExactly(
+                "rotate 4.0 8.0 15.0",
+                "translate 16.0 23.0",
+                "skew 42.0 108.0"
+        );
+    }
+
+    @Test
+    public void setOperationsOverride() {
+        Matrix m = new Matrix();
+        m.setRotate(4);
+        m.setRotate(8);
+        m.setRotate(15);
+        m.setRotate(16);
+        m.setRotate(23);
+        m.setRotate(42);
+        m.setRotate(108);
+
+        assertThat(shadowOf(m).getSetOperations()).contains(entry("rotate", "108.0"));
+    }
+}


### PR DESCRIPTION
This pull adds a fresh implementation of how operations on Matrix instances are recorded. Normal operations (`setRotate`, `setSkew`, etc.) are kept in a map of operation key to a string representation of the operation's data. Operations that are 'pre' or 'post' are kept in a stack and queue, respectively, using the concatenation of transformation key and value representations.

Bitmaps also now record metadata about their creation. The use of a source Bitmap, stream, file path, resource, or byte array is kept in the shadow, along with information about filtering, a matrix transformation, or cropping. This allows for verifying the operations taken in complex creation or a chain of transformations.
