### PR TITLE
NonApkTestRunner

### DIFF
--- a/src/main/java/org/robolectric/NonApkTestRunner.java
+++ b/src/main/java/org/robolectric/NonApkTestRunner.java
@@ -15,63 +15,66 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 /**
- * A {@link RobolectricTestRunner} that will run test cases for non apk projects.  This is useful in situations where
- * A simple jar library project uses some android code and needs non stubbed or shadow classes from Robolectric
+ * A {@link RobolectricTestRunner} that will run test cases for non apk
+ * projects. This is useful in situations where A simple jar library project
+ * uses some android code and needs non stubbed or shadow classes from
+ * Robolectric
  * 
  * @author mriley
  */
 public class NonApkTestRunner extends RobolectricTestRunner {
-	
-	// ===========================================================
-	// Constants
-	// ===========================================================
-	
-	private static final Log log = LogFactory.getLog(NonApkTestRunner.class);
-	
-	/**
-	 * Root dir for the fake apk directory
-	 */
-	public static final String BASE_FAKEAPK_DIR = System.getProperty("java.io.tmpdir");
-	/**
-	 * Directories required by Robolectric
-	 */
-	public static final String[] REQUIRED_APK_DIRS = {File.separator + "res"+File.separator+"values"+File.separator, File.separator+"assets"+File.separator};
 
-	
-	// ===========================================================
-	// Inner classes
-	// ===========================================================
-	
-	/**
-	 * Allows test cases to define some info that should be in the generated
-	 * AndroidManifest.xml  
-	 * 
-	 * @author mriley
-	 */
-	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
-	public static @interface Manifest {
-		/**
-		 * @return The packageName that should be in the android manifest.  If not
-		 * provided, the package name for the test class will be used.
-		 */
-		String packageName() default "";
-		
-		/**
-		 * @return The minSdkVersion that should be in the android manifest
-		 */
-		int minSdkVersion() default 1;
-		
-		/**
-		 * @return The targetSdkVersion that should be in the android manifest
-		 */
-		int targetSdkVersion() default 1;
-	}
-	
     // ===========================================================
-	// Static methods
-	// ===========================================================
-    
+    // Constants
+    // ===========================================================
+
+    private static final Log log = LogFactory.getLog(NonApkTestRunner.class);
+
+    /**
+     * Root dir for the fake apk directory
+     */
+    public static final String BASE_FAKEAPK_DIR = System.getProperty("java.io.tmpdir");
+    /**
+     * Directories required by Robolectric
+     */
+    public static final String[] REQUIRED_APK_DIRS = { File.separator + "res" + File.separator + "values" + File.separator,
+            File.separator + "assets" + File.separator };
+
+    // ===========================================================
+    // Inner classes
+    // ===========================================================
+
+    /**
+     * Allows test cases to define some info that should be in the generated
+     * AndroidManifest.xml
+     * 
+     * @author mriley
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public static @interface Manifest {
+        /**
+         * @return The packageName that should be in the android manifest. If
+         *         not provided, the package name for the test class will be
+         *         used.
+         */
+        String packageName() default "";
+
+        /**
+         * @return The minSdkVersion that should be in the android manifest
+         */
+        int minSdkVersion() default 1;
+
+        /**
+         * @return The targetSdkVersion that should be in the android manifest
+         */
+        int targetSdkVersion() default 1;
+    }
+
+    // ===========================================================
+    // Static methods
+    // ===========================================================
+
     /**
      * Builds a fake apk dir complete with generated AndroidManifest.xml
      * 
@@ -79,32 +82,32 @@ public class NonApkTestRunner extends RobolectricTestRunner {
      * @return
      */
     private static File buildFakeApkDir(Class<?> testClass) {
-    	
-    	// guess the manifest things
-    	Manifest annotation = testClass.getAnnotation(Manifest.class);
-    	int target = 1;
-    	int min = 1;
-    	String pkg = "";
-    	if( annotation != null ) {
-    		target = annotation.targetSdkVersion();
-    		min = annotation.minSdkVersion();
-    		pkg = annotation.packageName();
-    	}
-		if( "".equals(pkg.trim()) ) {
-			pkg = testClass.getPackage().getName();
-		}
-    	
-		// do some validation
-		try {
-			testClass.getClassLoader().loadClass(pkg + ".R");
-		} catch (ClassNotFoundException e) {
-			log.warn("Robolectric wants a(n) " + pkg + ".R.class.  Please add an empty R.java.");
-		}
-		
-		// make the dir structure
+
+        // guess the manifest things
+        Manifest annotation = testClass.getAnnotation(Manifest.class);
+        int target = 1;
+        int min = 1;
+        String pkg = "";
+        if (annotation != null) {
+            target = annotation.targetSdkVersion();
+            min = annotation.minSdkVersion();
+            pkg = annotation.packageName();
+        }
+        if ("".equals(pkg.trim())) {
+            pkg = testClass.getPackage().getName();
+        }
+
+        // do some validation
+        try {
+            testClass.getClassLoader().loadClass(pkg + ".R");
+        } catch (ClassNotFoundException e) {
+            log.warn("Robolectric wants a(n) " + pkg + ".R.class.  Please add an empty R.java.");
+        }
+
+        // make the dir structure
         File tmpDir = mkDir(mkBaseDir(pkg));
-        for( String s : REQUIRED_APK_DIRS ) {
-        	mkDir(new File(tmpDir + s));
+        for (String s : REQUIRED_APK_DIRS) {
+            mkDir(new File(tmpDir + s));
         }
 
         // generate the AndroidManifest.xml
@@ -112,65 +115,69 @@ public class NonApkTestRunner extends RobolectricTestRunner {
         FileWriter writer = null;
         try {
             writer = new FileWriter(manifest);
-            writer.write("<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" package=\""+
-            		pkg+"\" android:versionCode=\"1\" android:versionName=\"TEST\"> <uses-sdk android:minSdkVersion=\""+
-            		min+"\" android:targetSdkVersion=\""+target+"\"/></manifest>");
-        } catch ( Exception e ) {
+            writer.write("<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" package=\"" + pkg
+                    + "\" android:versionCode=\"1\" android:versionName=\"TEST\"> <uses-sdk android:minSdkVersion=\"" + min + "\" android:targetSdkVersion=\""
+                    + target + "\"/></manifest>");
+        } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {
-            if( writer != null ) try {writer.close();} catch ( Exception ignored ) {}
+            if (writer != null)
+                try {
+                    writer.close();
+                } catch (Exception ignored) {
+                }
         }
         return tmpDir;
     }
 
-	private static File mkBaseDir(String pkg) {
-		File baseDir = new File(BASE_FAKEAPK_DIR + "/" + pkg +"/");
-		deepClean(baseDir);
-		return baseDir;
-	}
+    private static File mkBaseDir(String pkg) {
+        File baseDir = new File(BASE_FAKEAPK_DIR + "/" + pkg + "/");
+        deepClean(baseDir);
+        return baseDir;
+    }
 
-	private static File mkDir(File tmpDir) {
-		if( !tmpDir.exists() && !tmpDir.mkdirs() ) {
+    private static File mkDir(File tmpDir) {
+        if (!tmpDir.exists() && !tmpDir.mkdirs()) {
             throw new RuntimeException("Failed to find or create app dir " + tmpDir);
         }
-		return tmpDir;
-	}
-	
-	private static void deepClean( File file ) {
-		if( file.exists() ) {
-			if( file.isDirectory() ) {
-				File[] children = file.listFiles();
-				if( children != null ) {
-					for( File child : children ) {
-						deepClean(child);
-					}
-				}
-			}
-			if( !file.delete() ) {
-				throw new RuntimeException("Failed to clean fake apk dir.  Failed to delete " + file);
-			}
-		}
-	}
-	
-	// ===========================================================
-	// Member vars
-	// ===========================================================
-	
-	private final Class<?> testClass;
-	
-	// ===========================================================
-	// CTORs
-	// ===========================================================
-	
+        return tmpDir;
+    }
+
+    private static void deepClean(File file) {
+        if (file.exists()) {
+            if (file.isDirectory()) {
+                File[] children = file.listFiles();
+                if (children != null) {
+                    for (File child : children) {
+                        deepClean(child);
+                    }
+                }
+            }
+            if (!file.delete()) {
+                throw new RuntimeException("Failed to clean fake apk dir.  Failed to delete " + file);
+            }
+        }
+    }
+
+    // ===========================================================
+    // Member vars
+    // ===========================================================
+
+    private final Class<?> testClass;
+
+    // ===========================================================
+    // CTORs
+    // ===========================================================
+
     public NonApkTestRunner(final Class<?> testClass) throws InitializationError {
         super(testClass);
         this.testClass = testClass;
     }
-    
+
     @Override
     protected AndroidManifest getAppManifest(Config config) {
         File appManifestBaseDir = buildFakeApkDir(testClass);
-        EnvHolder envHolder = getEnvHolder();        
+        EnvHolder envHolder = getEnvHolder();
         synchronized (envHolder) {
             AndroidManifest appManifest;
             appManifest = envHolder.appManifestsByFile.get(appManifestBaseDir);
@@ -181,9 +188,9 @@ public class NonApkTestRunner extends RobolectricTestRunner {
             return appManifest;
         }
     }
-    
+
     @Override
     protected AndroidManifest createAppManifest(File baseDir) {
-    	return super.createAppManifest(baseDir);
+        return super.createAppManifest(baseDir);
     }
 }

--- a/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -103,8 +103,8 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
     }
     
     public EnvHolder getEnvHolder() {
-		return envHolder;
-	}
+        return envHolder;
+    }
 
     private void assureTestLifecycle(SdkEnvironment sdkEnvironment) {
         try {

--- a/src/test/java/org/robolectric/NonApkTestRunnerTest.java
+++ b/src/test/java/org/robolectric/NonApkTestRunnerTest.java
@@ -9,36 +9,38 @@ import org.robolectric.annotation.Config;
 
 public class NonApkTestRunnerTest {
 
-	public static final class FakeTestCase1 {
-		@Test
-		public void fakeTest() {}
-	}
-	
-	@NonApkTestRunner.Manifest(packageName="org.robolectric.test",minSdkVersion=11,targetSdkVersion=14)
-	public static final class FakeTestCase2 {
-		@Test
-		public void fakeTest() {}
-	}
-	
-	@Test
-	public void testGenApkDir1() throws InitializationError {
-		NonApkTestRunner runner = new NonApkTestRunner(FakeTestCase1.class);
-		AndroidManifest appManifest = runner.getAppManifest(new Config.Implementation(1,null,1,null));
-		Assert.assertEquals(FakeTestCase1.class.getPackage().getName(), appManifest.getPackageName());
-		Assert.assertEquals(1, appManifest.getMinSdkVersion());
-		Assert.assertEquals(1, appManifest.getTargetSdkVersion());
-		Assert.assertEquals(appManifest.getPackageName(), appManifest.getBaseDir().getName());
-		runner.run(new RunNotifier());
-	}
-	
-	@Test
-	public void testGenApkDir2() throws InitializationError {
-		NonApkTestRunner runner = new NonApkTestRunner(FakeTestCase2.class);
-		AndroidManifest appManifest = runner.getAppManifest(new Config.Implementation(1,null,1,null));
-		Assert.assertEquals(11, appManifest.getMinSdkVersion());
-		Assert.assertEquals(14, appManifest.getTargetSdkVersion());
-		Assert.assertEquals("org.robolectric.test", appManifest.getPackageName());
-		Assert.assertEquals(appManifest.getPackageName(), appManifest.getBaseDir().getName());
-		runner.run(new RunNotifier());
-	}
+    public static final class FakeTestCase1 {
+        @Test
+        public void fakeTest() {
+        }
+    }
+
+    @NonApkTestRunner.Manifest(packageName = "org.robolectric.test", minSdkVersion = 11, targetSdkVersion = 14)
+    public static final class FakeTestCase2 {
+        @Test
+        public void fakeTest() {
+        }
+    }
+
+    @Test
+    public void testGenApkDir1() throws InitializationError {
+        NonApkTestRunner runner = new NonApkTestRunner(FakeTestCase1.class);
+        AndroidManifest appManifest = runner.getAppManifest(new Config.Implementation(1, null, 1, null));
+        Assert.assertEquals(FakeTestCase1.class.getPackage().getName(), appManifest.getPackageName());
+        Assert.assertEquals(1, appManifest.getMinSdkVersion());
+        Assert.assertEquals(1, appManifest.getTargetSdkVersion());
+        Assert.assertEquals(appManifest.getPackageName(), appManifest.getBaseDir().getName());
+        runner.run(new RunNotifier());
+    }
+
+    @Test
+    public void testGenApkDir2() throws InitializationError {
+        NonApkTestRunner runner = new NonApkTestRunner(FakeTestCase2.class);
+        AndroidManifest appManifest = runner.getAppManifest(new Config.Implementation(1, null, 1, null));
+        Assert.assertEquals(11, appManifest.getMinSdkVersion());
+        Assert.assertEquals(14, appManifest.getTargetSdkVersion());
+        Assert.assertEquals("org.robolectric.test", appManifest.getPackageName());
+        Assert.assertEquals(appManifest.getPackageName(), appManifest.getBaseDir().getName());
+        runner.run(new RunNotifier());
+    }
 }


### PR DESCRIPTION
I have a set of jar library (not android projects) projects that have some dependencies on non stubbed android framework code.  To make my tests work using robolectric shadows, I extended the standard test running with a test runner that generates an apk project directory.  Let me know if this is a dumb idea or there is a better way to do this.  Otherwise, heres a patch.

This commit includes a test runner for non apk projects that would like to use the shadows provided by robolectric. 
