### PR TITLE
Fix jar file separator handling on Windows.

### DIFF
--- a/src/main/java/org/robolectric/res/DirectoryMatchingFilter.java
+++ b/src/main/java/org/robolectric/res/DirectoryMatchingFilter.java
@@ -4,6 +4,7 @@ import java.io.File;
 
 public class DirectoryMatchingFilter implements FsFile.Filter {
     private final String folderBaseName;
+    private static final String JAR_SEPARATOR = "/";
 
     public DirectoryMatchingFilter(String folderBaseName) {
         this.folderBaseName = folderBaseName;
@@ -11,6 +12,13 @@ public class DirectoryMatchingFilter implements FsFile.Filter {
 
     @Override
     public boolean accept(FsFile file) {
-        return file.getPath().contains(File.separator + folderBaseName);
+        boolean isAccepted = file.getPath().contains(File.separator + folderBaseName);
+
+        // The file separator is always '/' in jar file, even on Windows.
+        if (file instanceof Fs.JarFs.JarFsFile && !isAccepted) {
+            isAccepted = file.getPath().contains(JAR_SEPARATOR + folderBaseName);
+        }
+
+        return isAccepted;
     }
 }

--- a/src/main/java/org/robolectric/res/Fs.java
+++ b/src/main/java/org/robolectric/res/Fs.java
@@ -48,7 +48,7 @@ abstract public class Fs {
         return newFile(new File("."));
     }
 
-    private static class JarFs extends Fs {
+    static class JarFs extends Fs {
         private final JarFile jarFile;
         private final NavigableMap<String, JarEntry> jarEntryMap = new TreeMap<String, JarEntry>();
 
@@ -69,7 +69,7 @@ abstract public class Fs {
             return new JarFsFile(folderBaseName);
         }
 
-        private class JarFsFile implements FsFile {
+        class JarFsFile implements FsFile {
             private final String path;
 
             public JarFsFile(String path) {

--- a/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -653,6 +653,7 @@ public class ShadowApplication extends ShadowContextWrapper {
         }
     }
 
+    @Implementation
     public int checkPermission(String permission, int pid, int uid) {
         return grantedPermissions.contains(permission) ? PERMISSION_GRANTED : PERMISSION_DENIED;
     }


### PR DESCRIPTION
On windows, File.separator is "\", but the separator in jar file is always '/'.
Thus Robolectric can't load android res files from android-res-4.1.2_r1_rc-real.jar.

This patch fix it by add special handling for JarFsFile in DirectoryMatchingFilter#accept.

Some tests get error because of this. After this fix there is no error. (but some failures still remain.)

This patch could be related to the issue #490.
