### PR TITLE
Fixed ShadowContentValues to fix a bug with the equals implementation.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowContentValues.java
+++ b/src/main/java/org/robolectric/shadows/ShadowContentValues.java
@@ -18,6 +18,7 @@ package org.robolectric.shadows;
 
 import android.content.ContentValues;
 import android.util.Log;
+import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
@@ -287,15 +288,16 @@ public final class ShadowContentValues {
     @Override @Implementation
     public boolean equals(Object object) {
         if (object == null) return false;
-        Object o = shadowOf_(object);
-        if (o == null) return false;
-        if (this == o) return true;
-        if (getClass() != o.getClass()) return false;
-
-        if (!(o instanceof ContentValues)) {
+        final ShadowContentValues shadowObject;
+        if (object instanceof ShadowContentValues) {
+            shadowObject = (ShadowContentValues) object;
+        } else if (object instanceof ContentValues) {
+            shadowObject = Robolectric.shadowOf((ContentValues) object);
+        } else {
             return false;
         }
-        return values.equals(shadowOf((ContentValues) o).values);
+        if (this == shadowObject) return true;
+        return values.equals(shadowObject.values);
     }
 
     @Override @Implementation

--- a/src/test/java/org/robolectric/shadows/ContentValuesTest.java
+++ b/src/test/java/org/robolectric/shadows/ContentValuesTest.java
@@ -1,0 +1,46 @@
+package org.robolectric.shadows;
+
+import android.content.ContentValues;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.TestRunners;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class ContentValuesTest {
+
+    @Test
+    public void shouldBeEqualIfContentValuesAreEquivalent() {
+        ContentValues valuesA = new ContentValues();
+        assertThat(valuesA).isEqualTo(valuesA);
+    }
+
+    @Test
+    public void shouldBeEqualIfBothContentValuesAreEmpty() {
+        ContentValues valuesA = new ContentValues();
+        ContentValues valuesB = new ContentValues();
+        assertThat(valuesA).isEqualTo(valuesB);
+    }
+
+    @Test
+    public void shouldBeEqualIfBothContentValuesHaveSameValues() {
+        ContentValues valuesA = new ContentValues();
+        valuesA.put("String", "A");
+        valuesA.put("Integer", 23);
+        valuesA.put("Boolean", false);
+        ContentValues valuesB = new ContentValues();
+        valuesB.putAll(valuesA);
+        assertThat(valuesA).isEqualTo(valuesB);
+    }
+
+    @Test
+    public void shouldNotBeEqualIfContentValuesHaveDifferentValue() {
+        ContentValues valuesA = new ContentValues();
+        valuesA.put("String", "A");
+        ContentValues valuesB = new ContentValues();
+        assertThat(valuesA).isNotEqualTo(valuesB);
+        valuesB.put("String", "B");
+        assertThat(valuesA).isNotEqualTo(valuesB);
+    }
+}


### PR DESCRIPTION
Previously, it would always return false on equality because the object passed in was converted to a ShadowContentValues and then tested to be an instance of ContentValues.

Added tests for ContentValues equality.
