### PR TITLE
Add support for setting the system clock time.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
+++ b/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
@@ -8,6 +8,8 @@ import org.robolectric.annotation.Implements;
 @Implements(value = SystemClock.class, callThroughByDefault = true)
 public class ShadowSystemClock {
   private static long bootedAt = now();
+  private static long fakeTime;
+  private static boolean timeFaked;
 
   private static long now() {
     return System.currentTimeMillis();
@@ -20,7 +22,11 @@ public class ShadowSystemClock {
 
   @Implementation
   public static long uptimeMillis() {
-    return now() - bootedAt;
+    if (timeFaked) {
+      return fakeTime;
+    } else {
+      return now() - bootedAt;
+    }
   }
 
   @Implementation
@@ -41,5 +47,14 @@ public class ShadowSystemClock {
   @HiddenApi @Implementation
   public static long currentTimeMicro() {
     return now() * 1000;
+  }
+
+  public static void setFakeUptimeMillis(long millis) {
+    fakeTime = millis;
+    timeFaked = true;
+  }
+
+  public static void unfakeUptimeMillis() {
+    timeFaked = false;
   }
 }

--- a/src/test/java/org/robolectric/shadows/SystemClockTest.java
+++ b/src/test/java/org/robolectric/shadows/SystemClockTest.java
@@ -1,0 +1,25 @@
+package org.robolectric.shadows;
+
+import android.os.SystemClock;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.TestRunners;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class SystemClockTest {
+
+  @Test
+  public void shouldAllowForFakingOfTime() throws Exception {
+    ShadowSystemClock.setFakeUptimeMillis(500);
+    assertThat(SystemClock.uptimeMillis()).isEqualTo(500);
+  }
+
+  @Test
+  public void shouldAllowUnfakingofTime() throws Exception {
+    ShadowSystemClock.setFakeUptimeMillis(576726726L);
+    ShadowSystemClock.unfakeUptimeMillis();
+    assertThat(SystemClock.uptimeMillis()).isNotEqualTo(576726726L);
+  }
+}


### PR DESCRIPTION
This helps with testing animations that use SystemClock for
determining when the animation is complete.
