### PR TITLE
Add support for TestMenuItem isCheckable, isChecked, and isVisible.

### DIFF
--- a/src/main/java/org/robolectric/tester/android/view/TestMenuItem.java
+++ b/src/main/java/org/robolectric/tester/android/view/TestMenuItem.java
@@ -14,6 +14,9 @@ public class TestMenuItem implements MenuItem {
   private int itemId;
   private CharSequence title;
   private boolean enabled = true;
+  private boolean checked = false;
+  private boolean checkable = false;
+  private boolean visible = true;
   private OnMenuItemClickListener menuItemClickListener;
   public int iconRes;
   private Intent intent;
@@ -127,32 +130,35 @@ public class TestMenuItem implements MenuItem {
 
   @Override
   public MenuItem setCheckable(boolean checkable) {
-    return null;
+    this.checkable = checkable;
+    return this;
   }
 
   @Override
   public boolean isCheckable() {
-    return false;
+    return checkable;
   }
 
   @Override
   public MenuItem setChecked(boolean checked) {
-    return null;
+    this.checked = checked;
+    return this;
   }
 
   @Override
   public boolean isChecked() {
-    return false;
+    return checked;
   }
 
   @Override
   public MenuItem setVisible(boolean visible) {
-    return null;
+    this.visible = visible;
+    return this;
   }
 
   @Override
   public boolean isVisible() {
-    return false;
+    return visible;
   }
 
   @Override

--- a/src/test/java/org/robolectric/tester/android/view/TestMenuItemTest.java
+++ b/src/test/java/org/robolectric/tester/android/view/TestMenuItemTest.java
@@ -1,0 +1,30 @@
+package org.robolectric.tester.android.view;
+
+import org.junit.Test;
+import android.view.MenuItem;
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class TestMenuItemTest {
+  private MenuItem item = new TestMenuItem();
+
+  @Test
+  public void shouldCheckTheMenuItem() throws Exception {
+    assertThat(item.isChecked()).isFalse();
+    item.setChecked(true);
+    assertThat(item.isChecked()).isTrue();
+  }
+
+  @Test
+  public void shouldAllowSettingCheckable() throws Exception {
+    assertThat(item.isCheckable()).isFalse();
+    item.setCheckable(true);
+    assertThat(item.isCheckable()).isTrue();
+  }
+
+  @Test
+  public void shouldAllowSettingVisible() throws Exception {
+    assertThat(item.isVisible()).isTrue();
+    item.setVisible(false);
+    assertThat(item.isVisible()).isFalse();
+  }
+}


### PR DESCRIPTION
Since these "shadows" are still around, we needed a way to check if the items were checked, checkable, and visible.
