### PR TITLE
Add support for action providers in a menu item.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowMenuInflater.java
+++ b/src/main/java/org/robolectric/shadows/ShadowMenuInflater.java
@@ -3,11 +3,12 @@ package org.robolectric.shadows;
 import android.content.Context;
 import android.view.Menu;
 import android.view.MenuInflater;
-import android.view.SubMenu;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.res.MenuNode;
 import org.robolectric.res.ResourceLoader;
+import org.robolectric.tester.android.view.TestMenu;
+import org.robolectric.tester.android.view.TestSubMenu;
 import org.robolectric.util.I18nException;
 
 import static org.robolectric.Robolectric.shadowOf;
@@ -36,7 +37,7 @@ public class ShadowMenuInflater {
     MenuNode menuNode = resourceLoader.getMenuNode(resourceLoader.getResourceIndex().getResName(resource), qualifiers);
 
     try {
-      addChildrenInGroup(menuNode, 0, root);
+      addChildrenInGroup(menuNode, 0, (TestMenu) root);
     } catch (I18nException e) {
       throw e;
     } catch (Exception e) {
@@ -44,7 +45,7 @@ public class ShadowMenuInflater {
     }
   }
 
-  private void addChildrenInGroup(MenuNode source, int groupId, Menu root) {
+  private void addChildrenInGroup(MenuNode source, int groupId, TestMenu testMenu) {
     for (MenuNode child : source.getChildren()) {
       String name = child.getName();
       RoboAttributeSet attributes = shadowOf(context).createAttributeSet(child.getAttributes(), null);
@@ -53,19 +54,17 @@ public class ShadowMenuInflater {
       }
       if (name.equals("item")) {
         if (child.isSubMenuItem()) {
-          SubMenu sub = root.addSubMenu(groupId,
+          TestSubMenu sub = (TestSubMenu) testMenu.addSubMenu(groupId,
               attributes.getAttributeResourceValue(ANDROID_NS, "id", 0),
               0, attributes.getAttributeValue(ANDROID_NS, "title"));
           MenuNode subMenuNode = child.getChildren().get(0);
           addChildrenInGroup(subMenuNode, groupId, sub);
         } else {
-          root.add(groupId,
-              attributes.getAttributeResourceValue(ANDROID_NS, "id", 0),
-              0, attributes.getAttributeValue(ANDROID_NS, "title"));
+          testMenu.add(attributes);
         }
       } else if (name.equals("group")) {
         int newGroupId = attributes.getAttributeResourceValue(ANDROID_NS, "id", 0);
-        addChildrenInGroup(child, newGroupId, root);
+        addChildrenInGroup(child, newGroupId, testMenu);
       }
     }
   }

--- a/src/main/java/org/robolectric/tester/android/view/TestMenu.java
+++ b/src/main/java/org/robolectric/tester/android/view/TestMenu.java
@@ -3,11 +3,11 @@ package org.robolectric.tester.android.view;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.view.KeyEvent;
-import android.view.Menu;
-import android.view.MenuItem;
-import android.view.SubMenu;
+import android.view.*;
+import org.robolectric.Robolectric;
+import org.robolectric.shadows.RoboAttributeSet;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -188,5 +188,27 @@ public class TestMenu implements Menu {
       }
     }
     return null;
+  }
+
+  public MenuItem add(RoboAttributeSet attributes) {
+    TestMenuItem menuItem = new TestMenuItem();
+    menuItems.add(menuItem);
+    menuItem.setItemId(attributes.getAttributeResourceValue("android", "id", 0));
+    menuItem.setTitle(attributes.getAttributeValue("android", "title"));
+    createActionProviderInstance(menuItem, attributes.getAttributeValue("android", "actionProviderClass"));
+    return menuItem;
+  }
+
+  private void createActionProviderInstance(TestMenuItem menuItem, String actionProviderClass) {
+    if (actionProviderClass != null) {
+      try {
+        Class<ActionProvider> apc = (Class<ActionProvider>) Class.forName(actionProviderClass);
+        Constructor constructor = apc.getConstructor(Context.class);
+        ActionProvider actionProvider = (ActionProvider) constructor.newInstance(Robolectric.application);
+        menuItem.setActionProvider(actionProvider);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 }

--- a/src/main/java/org/robolectric/tester/android/view/TestMenuItem.java
+++ b/src/main/java/org/robolectric/tester/android/view/TestMenuItem.java
@@ -18,6 +18,7 @@ public class TestMenuItem implements MenuItem {
   public int iconRes;
   private Intent intent;
   private SubMenu subMenu;
+  private ActionProvider actionProvider;
 
   public TestMenuItem() {
     super();
@@ -225,12 +226,13 @@ public class TestMenuItem implements MenuItem {
 
   @Override
   public MenuItem setActionProvider(ActionProvider actionProvider) {
-    return null;
+    this.actionProvider = actionProvider;
+    return this;
   }
 
   @Override
   public ActionProvider getActionProvider() {
-    return null;
+    return actionProvider;
   }
 
   @Override

--- a/src/test/java/org/robolectric/R.java
+++ b/src/test/java/org/robolectric/R.java
@@ -215,6 +215,7 @@ public final class R {
   public static final class menu {
     public static final int test = 0x10a00;
     public static final int test_withchilds = 0x10a01;
+    public static final int test_with_action_provider = 0x10a02;
   }
 
   public static final class xml {

--- a/src/test/java/org/robolectric/shadows/MenuInflaterTest.java
+++ b/src/test/java/org/robolectric/shadows/MenuInflaterTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
 import org.robolectric.TestRunners;
+import org.robolectric.shadows.testing.FakeActionProvider;
 import org.robolectric.tester.android.view.TestMenu;
 import org.robolectric.tester.android.view.TestMenuItem;
 import org.robolectric.util.I18nException;
@@ -63,5 +64,13 @@ public class MenuInflaterTest {
   public void shouldThrowExceptionOnI18nStrictModeInflateMenu() throws Exception {
     shadowOf(context).setStrictI18n(true);
     new MenuInflater(context).inflate(R.menu.test, new TestMenu());
+  }
+  
+  @Test
+  public void shouldParseActionProvider() throws Exception {
+    TestMenu menu = new TestMenu();
+    new MenuInflater(context).inflate(R.menu.test_with_action_provider, menu);
+    MenuItem item = menu.findItem(R.id.test_menu_1);
+    assertThat(item.getActionProvider()).isInstanceOfAny(FakeActionProvider.class);
   }
 }

--- a/src/test/java/org/robolectric/shadows/testing/FakeActionProvider.java
+++ b/src/test/java/org/robolectric/shadows/testing/FakeActionProvider.java
@@ -1,0 +1,16 @@
+package org.robolectric.shadows.testing;
+
+import android.content.Context;
+import android.view.ActionProvider;
+import android.view.View;
+
+public class FakeActionProvider extends ActionProvider {
+  public FakeActionProvider(Context context) {
+    super(context);
+  }
+
+  @Override
+  public View onCreateActionView() {
+    return null;
+  }
+}

--- a/src/test/resources/res/menu/test_with_action_provider.xml
+++ b/src/test/resources/res/menu/test_with_action_provider.xml
@@ -1,0 +1,5 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:id="@id/test_menu_1"
+        android:title="Test menu item 1"
+        android:actionProviderClass="org.robolectric.shadows.testing.FakeActionProvider"/>
+</menu>


### PR DESCRIPTION
In lieu of having real MenuInflater support, this allows you to inflate an action provider from a menu item.  This may go away when menus are real, but it helps us now.
