### PR TITLE
Null AttributeSet causing NullPointerException

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowView.java
+++ b/src/main/java/org/robolectric/shadows/ShadowView.java
@@ -295,7 +295,7 @@ public class ShadowView {
   }
 
   public void applyFocus() {
-    if (noParentHasFocus(realView)) {
+    if (noParentHasFocus(realView) && attributeSet != null) {
       Boolean focusRequested = attributeSet.getAttributeBooleanValue(ANDROID_NS, "focus", false);
       if (focusRequested || realView.isFocusableInTouchMode()) {
         realView.requestFocus();


### PR DESCRIPTION
I'm still not 100% certain why the attributeSet is null at this point.  The code is coming from a ViewStub in ActionBarSherlock that has attributes, but not a shadow class (doesn't seem to be a ShadowViewStub class).  When the ViewStub is casted to a ShadowView, the attributes don't come over.  This check at least lets my tests continue to run and pass.
