### PR TITLE
Override project.properies (library locations)

### DIFF
--- a/src/main/java/org/robolectric/AndroidManifest.java
+++ b/src/main/java/org/robolectric/AndroidManifest.java
@@ -300,6 +300,9 @@ public class AndroidManifest {
     List<FsFile> libraryBaseDirs = new ArrayList<FsFile>();
 
     Properties properties = getProperties(baseDir.join("project.properties"));
+    // get the project.properties overrides and apply them (if any)
+    Properties overrideProperties = getProperties(baseDir.join("robo-project.properties"));
+    if (overrideProperties!=null) properties.putAll(overrideProperties);
     if (properties != null) {
       int libRef = 1;
       String lib;


### PR DESCRIPTION
Override project.properties with those from robo-project.properties if it exists.

I'm using roboletric from maven and have encountered an issue when attempting to perform a maven release. The release tests fail because robolectric cannot find the libraries at the location specified in the project.properties file.
The project.properties file has something like:
../../locale-parent/locale-api
However when performing a maven release the actual location is:
target/unpack/apklibs/com.twoforutyfouram_locale-api_apklib_0.0.7
I couldn't find a mechanism to override the library location that roboletric will use so I've created a simple pull request. The idea being if robolectric finds a ‘robo-project.properties file next to the project.properties file the properties in the former will take precedence. This will enable build systems maven, ivy, Jenkins etc to manipulate the library path as required.
