### PR TITLE
Initialize ShadowSystemClock.bootedAt to 0.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
+++ b/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
@@ -8,7 +8,7 @@ import org.robolectric.internal.HiddenApi;
 
 @Implements(value = SystemClock.class, callThroughByDefault = true)
 public class ShadowSystemClock {
-  private static long bootedAt = now();
+  private static long bootedAt = 0;
   private static long nanoTime = 0;
 
   private static long now() {


### PR DESCRIPTION
Initialize ShadowSystemClock.bootedAt to 0 rather than Robolectric.getUiThreadScheduler().getCurrentTime(). Otherwise, the value assigned to bootedAt will depend on when ShadowSystemClock happens to get loaded by the classloader, which may be at a time when getUiThreadScheduler().getCurrentTime() has already been advanced, which causes SystemClock.uptimeMillis() to report a time less than getuiThreadScheduler().getCurrentTime().
