### PR TITLE
Add implementation for AccountManager.removeAccount() method

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
+++ b/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
@@ -2,18 +2,25 @@ package org.robolectric.shadows;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
+import android.accounts.AccountManagerCallback;
+import android.accounts.AccountManagerFuture;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
 import android.content.Context;
 import android.content.pm.PermissionGroupInfo;
 import android.os.Bundle;
+import android.os.Handler;
 
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Shadow implementation for the Android {@code AccountManager } class.
@@ -110,6 +117,45 @@ public class ShadowAccountManager {
       return null;
     }
     return tokensForAccount.get(authTokenType);
+  }
+
+  @Implementation
+  public AccountManagerFuture<Boolean> removeAccount (final Account account,
+                                                      AccountManagerCallback<Boolean> callback,
+                                                      Handler handler) {
+
+    if (account == null) throw new IllegalArgumentException("account is null");
+
+    final boolean accountRemoved = accounts.remove(account);
+
+    return new AccountManagerFuture<Boolean>() {
+      @Override
+      public boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+      }
+
+      @Override
+      public boolean isCancelled() {
+        return false;
+      }
+
+      @Override
+      public boolean isDone() {
+        return false;
+      }
+
+      @Override
+      public Boolean getResult() throws OperationCanceledException, IOException,
+              AuthenticatorException {
+        return accountRemoved;
+      }
+
+      @Override
+      public Boolean getResult(long timeout, TimeUnit unit) throws OperationCanceledException,
+              IOException, AuthenticatorException {
+        return accountRemoved;
+      }
+    };
   }
 
   /**

--- a/src/test/java/org/robolectric/shadows/AccountManagerTest.java
+++ b/src/test/java/org/robolectric/shadows/AccountManagerTest.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
+import android.accounts.AccountManagerFuture;
 import android.accounts.AuthenticatorException;
 import android.accounts.OperationCanceledException;
 import android.app.Activity;
@@ -153,16 +154,36 @@ public class AccountManagerTest {
       am.blockingGetAuthToken(null, "token_type_1", false);
       fail("blockingGetAuthToken() should throw an illegal argument exception if the account is null");
     } catch (IllegalArgumentException iae) {
-      // NOP
+      // Expected
     }
     try {
       am.blockingGetAuthToken(account, null, false);
       fail("blockingGetAuthToken() should throw an illegal argument exception if the auth token type is null");
     } catch (IllegalArgumentException iae) {
-      // NOP
+      // Expected
     }
 
     Account account1 = new Account("unknown", "type");
     assertThat(am.blockingGetAuthToken(account1, "token_type_1", false)).isNull();
+  }
+
+  @Test
+  public void testRemoveAccount() {
+    AccountManager am = AccountManager.get(app);
+    Account account = new Account("name", "type");
+    Robolectric.shadowOf(am).addAccount(account);
+
+    try {
+      am.removeAccount(null, null, null);
+    } catch (IllegalArgumentException iae) {
+      // Expected
+    }
+
+    Account wrongAccount = new Account("wrong_name", "type");
+    am.removeAccount(wrongAccount, null, null);
+    assertThat(am.getAccountsByType("type")).isNotEmpty();
+
+    am.removeAccount(account, null, null);
+    assertThat(am.getAccountsByType("type")).isEmpty();
   }
 }


### PR DESCRIPTION
It's just a simple implementation that removes the account if it was previously added. Anything the AccountManager does asynchronously isn't supported.
