### PR TITLE
Quick code to support default Gradle build configuration.

### DIFF
--- a/src/main/java/org/robolectric/AndroidManifest.java
+++ b/src/main/java/org/robolectric/AndroidManifest.java
@@ -340,8 +340,10 @@ public class AndroidManifest {
       
       // get the project.properties overrides and apply them (if any)
       Properties overrideProperties = getProperties(baseDir.join("test-project.properties"));
-      if (overrideProperties!=null) { properties.putAll(overrideProperties); }
-      
+      if (overrideProperties != null) {
+        properties.putAll(overrideProperties);
+      }
+
       int libRef = 1;
       String lib;
       while ((lib = properties.getProperty("android.library.reference." + libRef)) != null) {
@@ -365,7 +367,9 @@ public class AndroidManifest {
 
   protected void locateLibrariesInGradleOut(List<FsFile> libraryBaseDirs) {
     FsFile baseDir = findGradleExplodedBundlesDir();
-    if (baseDir == null) { return; }
+    if (baseDir == null) {
+      return;
+    }
     for (FsFile bundleDir : baseDir.listFiles()) {
       libraryBaseDirs.add(bundleDir);
     }
@@ -374,17 +378,20 @@ public class AndroidManifest {
   protected FsFile findGradleExplodedBundlesDir() {
     final String explodedBundledDirName = "exploded-bundles";
     FsFile dir = getBaseDir();
-    if (explodedBundledDirName.equals(dir.getParent().getName())) { return null; } // skip for libraries
+    if (explodedBundledDirName.equals(dir.getParent().getName())) {
+      // skip for libraries
+      return null;
+    }
     
     final int maxUpTo = 4;
-    int level = maxUpTo;
-    while (level > 0) {
+    for (int level = maxUpTo; level > 0 && dir != null; level--) {
       if (dir.join("build.gradle").exists()) {
         FsFile result = dir.join("build", explodedBundledDirName);
-        if (result.exists()) { return result; }
+        if (result.exists()) {
+          return result;
+        }
       }
       dir = dir.getParent();
-      level--;
     }
     return null;
   }

--- a/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -319,10 +319,10 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
       assetsDir = Fs.fileFromPath(assetsProperty);
     } else {
       String manifestStr = defaultManifest ? "AndroidManifest.xml" : config.manifest();
-      if (!fsFile.join(manifestStr).exists() && defaultManifest) {
-        manifestStr = "src/main/" + manifestStr;
-      }
       manifestFile = fsFile.join(manifestStr);
+      if (!manifestFile.exists() && defaultManifest) {
+        manifestFile = fsFile.join("src", "main", manifestStr);
+      }
       resDir = manifestFile.getParent().join("res");
       assetsDir = manifestFile.getParent().join("assets");
     }


### PR DESCRIPTION
It resolves base directories for libraries packaged as aar when tests a launched from Gradle.
