### PR TITLE
Add getters for pending transition animation resource IDs.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -539,6 +539,14 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
     shadowOf(getWindow()).performLayout();
   }
 
+  public int getPendingTransitionEnterAnimationResourceId() {
+    return pendingTransitionEnterAnimResId;
+  }
+
+  public int getPendingTransitionExitAnimationResourceId() {
+    return pendingTransitionExitAnimResId;
+  }
+
   /**
    * Container object to hold an Intent, together with the requestCode used
    * in a call to {@code Activity#startActivityForResult(Intent, int)}

--- a/src/test/java/org/robolectric/shadows/ActivityTest.java
+++ b/src/test/java/org/robolectric/shadows/ActivityTest.java
@@ -728,6 +728,20 @@ public class ActivityTest {
     assertFalse(activity.isTaskRoot());
   }
 
+  @Test
+  public void getPendingTransitionEnterAnimationResourceId_should() throws Exception {
+    Activity activity = new Activity();
+    activity.overridePendingTransition(15, 2);
+    assertThat(shadowOf(activity).getPendingTransitionEnterAnimationResourceId()).isEqualTo(15);
+  }
+
+  @Test
+  public void getPendingTransitionExitAnimationResourceId_should() throws Exception {
+    Activity activity = new Activity();
+    activity.overridePendingTransition(15, 2);
+    assertThat(shadowOf(activity).getPendingTransitionExitAnimationResourceId()).isEqualTo(2);
+  }
+
   /////////////////////////////
 
   private void destroy(Activity activity) {


### PR DESCRIPTION
Exposed getters for pending transition resource IDs so we can property test that activity transitions have the correct animations.
