### PR TITLE
Allow shadows for Google Play Services classes.

### DIFF
--- a/src/main/java/org/robolectric/bytecode/Setup.java
+++ b/src/main/java/org/robolectric/bytecode/Setup.java
@@ -95,7 +95,7 @@ public class Setup {
     return className.startsWith("android.")
         || className.startsWith("libcore.")
         || className.startsWith("com.android.internal.")
-        || className.startsWith("com.google.android.maps.")
+        || className.startsWith("com.google.android.")
         || className.startsWith("org.apache.http.impl.client.DefaultRequestDirector");
   }
 


### PR DESCRIPTION
We want to create shadows for some of the classes in the Google Play Services package, and to do this we needed to expand the notion of what classes are in the Android SDK.
