### PR TITLE
Issue 617: Reset index back to zero if indexOfSlash is less than zero.

### DIFF
--- a/src/main/java/org/robolectric/res/ResName.java
+++ b/src/main/java/org/robolectric/res/ResName.java
@@ -46,8 +46,8 @@ public class ResName {
   public static @NotNull ResName qualifyResName(@NotNull String possiblyQualifiedResourceName, String defaultPackageName, String defaultType) {
     int indexOfColon = possiblyQualifiedResourceName.indexOf(':');
     int indexOfSlash = possiblyQualifiedResourceName.indexOf('/');
-    String packageName = indexOfColon == -1 ? null : possiblyQualifiedResourceName.substring(0, indexOfColon);
-    String type = indexOfSlash == -1 ? null : possiblyQualifiedResourceName.substring(indexOfColon == -1 ? 0 : indexOfColon + 1, indexOfSlash);
+    String packageName = indexOfColon < 0 ? null : possiblyQualifiedResourceName.substring(0, indexOfColon); 
+    String type = indexOfSlash < 0 ? null : possiblyQualifiedResourceName.substring(indexOfColon < 0 ? 0 : indexOfColon + 1, indexOfSlash);
     int indexBeforeName = indexOfColon > indexOfSlash ? indexOfColon : indexOfSlash;
 
     return new ResName(packageName == null ? defaultPackageName : packageName,

--- a/src/test/java/org/robolectric/res/ResNameTest.java
+++ b/src/test/java/org/robolectric/res/ResNameTest.java
@@ -11,5 +11,6 @@ public class ResNameTest {
     assertThat(ResName.qualifyResourceName("some.package:name", "default.package", "deftype")).isEqualTo("some.package:deftype/name");
     assertThat(ResName.qualifyResourceName("type/name", "default.package", "deftype")).isEqualTo("default.package:type/name");
     assertThat(ResName.qualifyResourceName("name", "default.package", "deftype")).isEqualTo("default.package:deftype/name");
+    assertThat(ResName.qualifyResourceName("", "", "")).isEqualTo(":/");
   }
 }


### PR DESCRIPTION
Should solve the issue when indexOfSlash is less than zero causing layouts not to inflate.   This was reported in issue  617.
