### PR TITLE
Delete ShadowActivity#create, which is obsoleted by ActivityController

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -646,16 +646,6 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
     return dialogForId.get(dialogId);
   }
 
-  public void create() {
-    final ActivityInvoker invoker = new ActivityInvoker();
-
-    final Bundle noInstanceState = null;
-    invoker.call("onCreate", Bundle.class).with(noInstanceState);
-    invoker.call("onStart").withNothing();
-    invoker.call("onPostCreate", Bundle.class).with(noInstanceState);
-    invoker.call("onResume").withNothing();
-  }
-
   @Implementation
   public void recreate() {
     Bundle outState = new Bundle();

--- a/src/test/java/org/robolectric/shadows/ActivityTest.java
+++ b/src/test/java/org/robolectric/shadows/ActivityTest.java
@@ -469,21 +469,6 @@ public class ActivityTest {
   }
 
   @Test
-  public void createGoesThroughFullLifeCycle() throws Exception {
-    TestActivity activity = new TestActivity();
-
-    shadowOf(activity).create();
-
-    activity.transcript.assertEventsSoFar(
-        "onCreate",
-        "onStart",
-        "onPostCreate",
-        "onResume"
-    );
-  }
-
-
-  @Test
   public void recreateGoesThroughFullLifeCycle() throws Exception {
     TestActivity activity = new TestActivity();
 


### PR DESCRIPTION
We were trying to merge the mainline robolectric master into the PhoneWindow pull request branch (see #659), and found that the ShadowActivity#create method's test was failing. We realized that method is obsoleted by the ActivityController API, so we deleted it (and its test).

There's more cleanup to be done here, as there is other lifecycle-related code in ShadowActivity still. However, this was the only bit that won't play well with PhoneWindow, so we only dealt with this for now.
