### PR TITLE
Allow testing of Notifications

### DIFF
--- a/.pairs
+++ b/.pairs
@@ -31,6 +31,8 @@ pairs:
   at: Amrit Thakur
   cs: Callum Stott; callum
   cd: Corey Downing; cdowning
+  ms: Mike Stallard; mstallard
+  ca: Chris Adams; cadams   
 email:
   prefix: pair
   domain: pivotallabs.com

--- a/src/main/java/org/robolectric/RobolectricBase.java
+++ b/src/main/java/org/robolectric/RobolectricBase.java
@@ -419,6 +419,7 @@ public class RobolectricBase {
       ShadowNdefMessage.class,
       ShadowNdefRecord.class,
       ShadowNfcAdapter.class,
+      ShadowNotification.ShadowBuilder.class,
       ShadowNotificationManager.class,
       ShadowNetworkInfo.class,
       ShadowNinePatch.class,

--- a/src/main/java/org/robolectric/shadows/ShadowNotification.java
+++ b/src/main/java/org/robolectric/shadows/ShadowNotification.java
@@ -3,13 +3,20 @@ package org.robolectric.shadows;
 import android.app.Notification;
 import android.app.PendingIntent;
 import android.content.Context;
+import android.view.View;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
+import static org.robolectric.Robolectric.directlyOn;
+import static org.robolectric.Robolectric.shadowOf;
+
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Notification.class)
 public class ShadowNotification {
+  private CharSequence contentTitle;
+  private CharSequence contentText;
+  private int smallIcon;
 
   public Notification getRealNotification() {
     return realNotification;
@@ -24,6 +31,30 @@ public class ShadowNotification {
     realNotification.icon = icon;
     realNotification.tickerText = tickerText;
     realNotification.when = when;
+  }
+
+  public CharSequence getContentTitle() {
+    return contentTitle;
+  }
+
+  public CharSequence getContentText() {
+    return contentText;
+  }
+
+  public int getSmallIcon() {
+    return smallIcon;
+  }
+
+  public void setContentTitle(CharSequence contentTitle) {
+    this.contentTitle = contentTitle;
+  }
+
+  public void setContentText(CharSequence contentText) {
+    this.contentText = contentText;
+  }
+
+  public void setSmallIcon(int icon) {
+    this.smallIcon = icon;
   }
 
   @Implementation
@@ -58,6 +89,49 @@ public class ShadowNotification {
 
     public PendingIntent getContentIntent() {
       return contentIntent;
+    }
+  }
+
+  @Implements(Notification.Builder.class)
+  public static class ShadowBuilder {
+
+    @RealObject private Notification.Builder realBuilder;
+    private String contentTitle;
+    private String contentText;
+    private int icon;
+
+    @Implementation
+    public Notification build() {
+      Notification result = (Notification)directlyOn(realBuilder, Notification.Builder.class, "build").invoke();
+      ShadowNotification shadowResult = shadowOf(result);
+      shadowResult.setContentTitle(contentTitle);
+      shadowResult.setContentText(contentText);
+      shadowResult.setSmallIcon(icon);
+      return result;
+    }
+
+    @Implementation
+    public Notification.Builder setContentTitle(CharSequence title) {
+      contentTitle = title.toString();
+      directlyOn(realBuilder, Notification.Builder.class, "setContentTitle", CharSequence.class).invoke(title);
+
+      return realBuilder;
+    }
+
+    @Implementation
+    public Notification.Builder setContentText(CharSequence text) {
+      contentText = text.toString();
+      directlyOn(realBuilder, Notification.Builder.class, "setContentText", CharSequence.class).invoke(text);
+
+      return realBuilder;
+    }
+
+    @Implementation
+    public Notification.Builder setSmallIcon(int smallIcon) {
+      this.icon = smallIcon;
+      directlyOn(realBuilder, Notification.Builder.class, "setSmallIcon", int.class).invoke(smallIcon);
+
+      return realBuilder;
     }
   }
 }

--- a/src/test/java/org/robolectric/shadows/NotificationBuilderTest.java
+++ b/src/test/java/org/robolectric/shadows/NotificationBuilderTest.java
@@ -1,0 +1,46 @@
+package org.robolectric.shadows;
+
+import android.app.Activity;
+import android.app.Notification;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.TestRunners;
+
+import static org.junit.Assert.assertEquals;
+import static org.robolectric.Robolectric.shadowOf;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class NotificationBuilderTest {
+  Notification.Builder builder;
+
+  @Before
+  public void setup() {
+    builder = new Notification.Builder(Robolectric.buildActivity(Activity.class).get());
+  }
+
+  @Test
+  public void build_setsContentTitleOnNotification() throws Exception {
+    builder.setContentTitle("Hello");
+    builder.build();
+    Notification notification = builder.build();
+    assertEquals("Hello", shadowOf(notification).getContentTitle());
+  }
+
+  @Test
+  public void build_setsContentTextOnNotification() throws Exception {
+    builder.setContentText("Hello Text");
+    builder.build();
+    Notification notification = builder.build();
+    assertEquals("Hello Text", shadowOf(notification).getContentText());
+  }
+
+  @Test
+  public void build_setsIconOnNotification() throws Exception {
+    builder.setSmallIcon(9001);
+    builder.build();
+    Notification notification = builder.build();;
+    assertEquals(9001, shadowOf(notification).getSmallIcon());
+  }
+}


### PR DESCRIPTION
This just piggybacks a notification's data (for the moment just title, content and icon) on the `ShadowNotification`. This allows the data on the last sent Notification to be tested  by grabbing it from `ShadowNotificationManager.getNotification`.

Before this could only be tested if you were using the deprecated `Notification` constructor and then grabbed the data via `getLastEventInfo` which should no longer be used.
