### PR TITLE
Add shadow constructor for Intent

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowIntent.java
+++ b/src/main/java/org/robolectric/shadows/ShadowIntent.java
@@ -45,6 +45,12 @@ public class ShadowIntent {
   private String packageName;
   private final Set<String> categories = new HashSet<String>();
 
+  public void __constructor__(String action, Uri uri, Context packageContext, Class cls) {
+    componentName = new ComponentName(packageContext, cls);
+    intentClass = cls;
+    RobolectricInternals.getConstructor(Intent.class, realIntent, String.class, Uri.class, Context.class, Class.class).invoke(action, uri, packageContext, cls);
+  }
+
   public void __constructor__(Context packageContext, Class cls) {
     componentName = new ComponentName(packageContext, cls);
     intentClass = cls;

--- a/src/test/java/org/robolectric/shadows/IntentTest.java
+++ b/src/test/java/org/robolectric/shadows/IntentTest.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.TestRunners;
 
 import static junit.framework.Assert.assertEquals;
@@ -21,6 +22,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.robolectric.Robolectric.shadowOf;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class IntentTest {
@@ -472,6 +474,13 @@ public class IntentTest {
     intent.putIntegerArrayListExtra("KEY", integers);
     assertThat(intent.getIntegerArrayListExtra("KEY")).isEqualTo(integers);
     assertThat(intent.getExtras().getIntegerArrayList("KEY")).isEqualTo(integers);
+  }
+
+  @Test
+  public void constructor_shouldSetComponentAndAction() {
+    Intent intent = new Intent("roboaction", null, Robolectric.application, Activity.class);
+    assertThat(shadowOf(intent).getComponent()).isEqualTo(new ComponentName("org.robolectric", "android.app.Activity"));
+    assertThat(shadowOf(intent).getAction()).isEqualTo("roboaction");
   }
 
   private static class TestSerializable implements Serializable {


### PR DESCRIPTION
None of the arguments to the Intent(String action, Uri uri, Context packageContext, Class<?> cls) constructor were getting captured by the shadow.  I added support for this constructor.
