### PR TITLE
Fix ShadowParcel.writeString(), add ShadowParcel.writeByteArray() and ShadowParcel.createByteArray().

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowParcel.java
+++ b/src/main/java/org/robolectric/shadows/ShadowParcel.java
@@ -31,9 +31,6 @@ public class ShadowParcel {
 
   @Implementation
   public void writeString(String str) {
-    if (str == null) {
-      return;
-    }
     parcelData.add(str);
   }
 
@@ -335,6 +332,26 @@ public class ShadowParcel {
         writeInt(0);
       }
       i++;
+    }
+  }
+
+  @Implementation
+  public void writeByteArray(byte[] val) {
+    writeInt(val.length);
+    for (byte b : val) writeByte(b);
+  }
+
+  @Implementation
+  public byte[] createByteArray() {
+    int n = readInt();
+    if (n >= 0) {
+      byte[] val = new byte[n];
+      for (int i = 0; i < n; i++) {
+        val[i] = readByte();
+      }
+      return val;
+    } else {
+      return null;
     }
   }
 

--- a/src/test/java/org/robolectric/shadows/ParcelTest.java
+++ b/src/test/java/org/robolectric/shadows/ParcelTest.java
@@ -69,8 +69,8 @@ public class ParcelTest {
   public void testWriteNullString() {
     parcel.writeString(null);
     assertThat(parcel.readString()).isNull();
-    assertThat(shadowParcel.getIndex()).isEqualTo(0);
-    assertThat(shadowParcel.getParcelData().size()).isEqualTo(0);
+    assertThat(shadowParcel.getIndex()).isEqualTo(1);
+    assertThat(shadowParcel.getParcelData().size()).isEqualTo(1);
   }
 
   @Test
@@ -142,6 +142,22 @@ public class ParcelTest {
     final String[] strings2 = new String[strings.length];
     parcel.readStringArray(strings2);
     assertTrue(Arrays.equals(strings, strings2));
+  }
+
+  @Test
+  public void testWriteAndCreateByteArray() {
+    byte[] bytes = new byte[] { -1, 2, 3, 127 };
+    parcel.writeByteArray(bytes);
+    byte[] actualBytes = parcel.createByteArray();
+    assertTrue(Arrays.equals(bytes, actualBytes));
+  }
+
+  @Test
+  public void testWriteAndCreateByteArray_lengthZero() {
+    byte[] bytes = new byte[] { };
+    parcel.writeByteArray(bytes);
+    byte[] actualBytes = parcel.createByteArray();
+    assertTrue(Arrays.equals(bytes, actualBytes));
   }
 
   @Test


### PR DESCRIPTION
Fix ShadowParcel.writeString() to accept null as a valid value instead of ignoring it. I verified on Gingerbread and ICS that this is how Android behaves.

Add ShadowParcel.writeByteArray() and ShadowParcel.createByteArray().
