### PR TITLE
Fix the issue that custom attribute value is used for android:xxx attribute

### DIFF
--- a/src/main/java/org/robolectric/res/StyleData.java
+++ b/src/main/java/org/robolectric/res/StyleData.java
@@ -33,7 +33,7 @@ public class StyleData implements Style {
     Attribute attribute = items.get(resName);
 
     // yuck. hack to work around library package remapping
-    if (attribute == null) {
+    if (attribute == null && !"android".equals(resName.packageName)) {
       attribute = items.get(resName.withPackageName(packageName));
       if (attribute != null && (!"android".equals(attribute.contextPackageName))) {
         attribute = new Attribute(resName, attribute.value, resName.packageName);

--- a/src/test/resources/res/values/attrs.xml
+++ b/src/test/resources/res/values/attrs.xml
@@ -26,6 +26,9 @@
     <attr name="aspectRatio" format="float" />
     <attr name="aspectRatioEnabled" format="boolean" />
     <attr name="animalStyle" format="reference" />
+
+    <!-- Test the same attr name as android namespace with different format -->
+    <attr name="typeface" format="string" />
   </declare-styleable>
 
   <attr name="gravity">

--- a/src/test/resources/res/values/themes.xml
+++ b/src/test/resources/res/values/themes.xml
@@ -10,6 +10,7 @@
     <item name="logoHeight">?android:attr/listItemPreferredHeight</item>
     <item name="averageSheepWidth">42px</item>
     <item name="animalStyle">@style/Gastropod</item>
+    <item name="typeface">custom_font</item>
   </style>
 
   <style name="Theme.ThirdTheme" parent="@style/Theme.Robolectric">


### PR DESCRIPTION
This should fix the issue reported in [Google Group](https://groups.google.com/d/topic/robolectric/p-s0Qc8ZA-A/discussion).

The root cause of this issue is that when a custom attribute is defined with the same name as android namespace, but with different format, Robolectric mixes up them. For example, if custom attribute "typeface" is defined as string format which is originally defined as enum in android name space, it causes exception when android:typeface is accessed, because Robolectric tries to search string value of custom typeface attribute in android:typeface enum values.
