### PR TITLE
Remove `ShadowActivity#onCreate`

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -342,10 +342,6 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
     Robolectric.getUiThreadScheduler().post(action);
   }
 
-  @Implementation
-  public void onCreate(Bundle savedInstanceState) {
-  }
-
   /**
    * Checks to see if {@code BroadcastListener}s are still registered.
    *

--- a/src/test/java/org/robolectric/shadows/ActivityTest.java
+++ b/src/test/java/org/robolectric/shadows/ActivityTest.java
@@ -470,10 +470,8 @@ public class ActivityTest {
 
   @Test
   public void recreateGoesThroughFullLifeCycle() throws Exception {
-    TestActivity activity = new TestActivity();
-
-    ShadowActivity shadow = shadowOf(activity);
-    shadow.recreate();
+    TestActivity activity = buildActivity(TestActivity.class).attach().get();
+    activity.recreate();
 
     activity.transcript.assertEventsSoFar(
         "onSaveInstanceState",


### PR DESCRIPTION
Was investigating issue #677 and noticed that the `FragmentManager` was not getting properly initialized. Traced it back to the `ShadowActivity` overriding `onCreate` to be a no-op. `onCreate` is where the `Activity` normally initializes the `FragmentManager`.

Then fixed the `recreateGoesThroughFullLifeCycle` test to use the `ActivityController` because `recreate` no longer worked with an unattached `Activity`.

Now `Activity` layouts can contain `<fragment>` tags without using the support library :smile: 
