### PR TITLE
`ShadowAsyncTask#executeOnExecutor` runs on the passed `Executor`.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowAsyncTask.java
+++ b/src/main/java/org/robolectric/shadows/ShadowAsyncTask.java
@@ -101,17 +101,18 @@ public class ShadowAsyncTask<Params, Progress, Result> {
 
   @Implementation
   public AsyncTask<Params, Progress, Result> executeOnExecutor(Executor executor, Params... params) {
-      status = AsyncTask.Status.RUNNING;
-      getBridge().onPreExecute();
+    status = AsyncTask.Status.RUNNING;
+    getBridge().onPreExecute();
 
-      worker.params = params;
-      executor.execute(new Runnable() {
-          @Override public void run() {
-              future.run();
-          }
-      });
+    worker.params = params;
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        future.run();
+      }
+    });
 
-      return realAsyncTask;
+    return realAsyncTask;
   }
 
   @Implementation

--- a/src/test/java/org/robolectric/shadows/AsyncTaskTest.java
+++ b/src/test/java/org/robolectric/shadows/AsyncTaskTest.java
@@ -22,7 +22,8 @@ import static org.junit.Assert.assertTrue;
 public class AsyncTaskTest {
   private Transcript transcript;
 
-  @Before public void setUp() throws Exception {
+  @Before
+  public void setUp() throws Exception {
     transcript = new Transcript();
     Robolectric.getBackgroundScheduler().pause();
     Robolectric.getUiThreadScheduler().pause();
@@ -81,7 +82,8 @@ public class AsyncTaskTest {
   @Test
   public void progressUpdatesAreQueuedUntilBackgroundThreadFinishes() throws Exception {
     AsyncTask<String, String, String> asyncTask = new MyAsyncTask() {
-      @Override protected String doInBackground(String... strings) {
+      @Override
+      protected String doInBackground(String... strings) {
         publishProgress("33%");
         publishProgress("66%");
         publishProgress("99%");
@@ -148,47 +150,52 @@ public class AsyncTaskTest {
 
   @Test
   public void executeOnExecutor_usesPassedExecutor() throws Exception {
-      AsyncTask<String, String, String> asyncTask = new MyAsyncTask();
+    AsyncTask<String, String, String> asyncTask = new MyAsyncTask();
 
-      assertThat(asyncTask.getStatus()).isEqualTo(AsyncTask.Status.PENDING);
+    assertThat(asyncTask.getStatus()).isEqualTo(AsyncTask.Status.PENDING);
 
-      asyncTask.executeOnExecutor(new ImmediateExecutor(), "a", "b");
+    asyncTask.executeOnExecutor(new ImmediateExecutor(), "a", "b");
 
-      assertThat(asyncTask.getStatus()).isEqualTo(AsyncTask.Status.FINISHED);
-      transcript.assertEventsSoFar("onPreExecute", "doInBackground a, b");
-      assertEquals("Result should get stored in the AsyncTask", "c", asyncTask.get());
+    assertThat(asyncTask.getStatus()).isEqualTo(AsyncTask.Status.FINISHED);
+    transcript.assertEventsSoFar("onPreExecute", "doInBackground a, b");
+    assertEquals("Result should get stored in the AsyncTask", "c", asyncTask.get());
 
-      Robolectric.runUiThreadTasks();
-      transcript.assertEventsSoFar("onPostExecute c");
+    Robolectric.runUiThreadTasks();
+    transcript.assertEventsSoFar("onPostExecute c");
   }
 
   private class MyAsyncTask extends AsyncTask<String, String, String> {
-    @Override protected void onPreExecute() {
+    @Override
+    protected void onPreExecute() {
       transcript.add("onPreExecute");
     }
 
-    @Override protected String doInBackground(String... strings) {
+    @Override
+    protected String doInBackground(String... strings) {
       transcript.add("doInBackground " + Join.join(", ", (Object[]) strings));
       return "c";
     }
 
-    @Override protected void onProgressUpdate(String... values) {
+    @Override
+    protected void onProgressUpdate(String... values) {
       transcript.add("onProgressUpdate " + Join.join(", ", (Object[]) values));
     }
 
-    @Override protected void onPostExecute(String s) {
+    @Override
+    protected void onPostExecute(String s) {
       transcript.add("onPostExecute " + s);
     }
 
-    @Override protected void onCancelled() {
+    @Override
+    protected void onCancelled() {
       transcript.add("onCancelled");
     }
   }
 
   public class ImmediateExecutor implements Executor {
-      @Override
-      public void execute(Runnable command) {
-          command.run();
-      }
+    @Override
+    public void execute(Runnable command) {
+      command.run();
+    }
   }
 }


### PR DESCRIPTION
Noticed that this didn't work when investigating #686. All this changes is that `AsyncTask#executeOnExecutor` will actually run the background task using the passed in `Executor` instead of calling through to the default `execute` implementation.
