### PR TITLE
Fixed activity theme handling in RobolectricPackageManager

### DIFF
--- a/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
+++ b/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
@@ -72,8 +72,7 @@ public class RobolectricPackageManager extends StubPackageManager {
       // Based on ShadowActivity
       if (activityData.getThemeRef() != null) {
         themeRef = activityData.getThemeRef();
-      }
-      else {
+      } else {
         themeRef = androidManifest.getThemeRef();
       }
       if (themeRef != null) {


### PR DESCRIPTION
It was giving an IllegalStateException for the style not being fully qualified. Fix is based on similar code on org.robolectric.shadows.ShadowActivity.
