### PR TITLE
Consider android maps and play services classes to be part of the Android SDK, but other classes under com.google.android to not be.

### DIFF
--- a/src/main/java/org/robolectric/bytecode/Setup.java
+++ b/src/main/java/org/robolectric/bytecode/Setup.java
@@ -95,7 +95,8 @@ public class Setup {
     return className.startsWith("android.")
         || className.startsWith("libcore.")
         || className.startsWith("com.android.internal.")
-        || className.startsWith("com.google.android.")
+        || className.startsWith("com.google.android.maps.")
+        || className.startsWith("com.google.android.gms.")
         || className.startsWith("org.apache.http.impl.client.DefaultRequestDirector");
   }
 

--- a/src/test/java/org/robolectric/bytecode/SetupTest.java
+++ b/src/test/java/org/robolectric/bytecode/SetupTest.java
@@ -27,6 +27,16 @@ public class SetupTest {
   }
 
   @Test
+  public void shouldInstrumentGooglePlayServicesClasses() throws Exception {
+    assertTrue(setup.shouldInstrument(wrap("com.google.android.gms.auth.GoogleAuthUtil")));
+  }
+
+  @Test
+  public void shouldNotInstrumentAndroidAppClasses() throws Exception {
+    assertFalse(setup.shouldInstrument(wrap("com.google.android.apps.Foo")));
+  }
+
+  @Test
   public void shouldNotInstrumentCoreJdkClasses() throws Exception {
     assertFalse(setup.shouldInstrument(wrap("java.lang.Object")));
     assertFalse(setup.shouldInstrument(wrap("java.lang.String")));


### PR DESCRIPTION
If your code under test happens to live under com.google.android, tests will fail with an obscure exception that looks like: "VerifyError: Expecting a stackmap frame at branch target...".

This fixes that by making only com.google.android.maps and com.google.android.gms classes be considered to be part the android SDK.
