### PR TITLE
Extends FragmentTestUtil to work with non-support Fragment

### DIFF
--- a/src/main/java/org/robolectric/util/FragmentTestUtil.java
+++ b/src/main/java/org/robolectric/util/FragmentTestUtil.java
@@ -1,25 +1,42 @@
 package org.robolectric.util;
 
-import android.support.v4.app.Fragment;
+import android.app.Activity;
+import android.app.Fragment;
 import android.support.v4.app.FragmentActivity;
-import android.support.v4.app.FragmentManager;
+import android.app.FragmentManager;
 import org.robolectric.Robolectric;
 
-import static org.robolectric.Robolectric.shadowOf;
-
-public class FragmentTestUtil {
+public final class FragmentTestUtil {
+  
   public static void startFragment(Fragment fragment) {
-    FragmentActivity activity = createActivity();
+    Activity activity = createActivity();
+    
+    FragmentManager fragmentManager = activity.getFragmentManager();
+    fragmentManager.beginTransaction()
+        .add(fragment, null)
+        .commit();
+  }
+  
+  public static void startFragment(android.support.v4.app.Fragment fragment) {
+    FragmentActivity activity = createSupportActivity();
 
-    FragmentManager fragmentManager = activity.getSupportFragmentManager();
+    android.support.v4.app.FragmentManager fragmentManager = activity.getSupportFragmentManager();
     fragmentManager.beginTransaction()
         .add(fragment, null)
         .commit();
   }
 
-  private static FragmentActivity createActivity() {
-    ActivityController<FragmentActivity> controller = Robolectric.buildActivity(FragmentActivity.class);
+  private static Activity createActivity() {
+    return createActivity(Activity.class);  
+  }
+  
+  private static FragmentActivity createFragmentActivity() {
+    return createActivity(FragmentActivity.class);
+  }
+  
+  private static <T extends Activity> T createActivity(Class<T> clz) {
+    ActivityController<T> controller = Robolectric.buildActivity(clz);
     controller.create().start().resume();
-    return controller.get();
+    return controller.get();  
   }
 }


### PR DESCRIPTION
Since support Fragment and framework Fragment are separate classes, method overloading should allow switching to support or framework Fragment management.
