### PR TITLE
Only load libraries from project.properties if they exist

### DIFF
--- a/src/main/java/org/robolectric/AndroidManifest.java
+++ b/src/main/java/org/robolectric/AndroidManifest.java
@@ -1,7 +1,6 @@
 package org.robolectric;
 
 import android.app.Activity;
-
 import org.robolectric.res.ActivityData;
 import org.robolectric.res.Fs;
 import org.robolectric.res.FsFile;
@@ -23,7 +22,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static android.content.pm.ApplicationInfo.*;
+import static android.content.pm.ApplicationInfo.FLAG_ALLOW_BACKUP;
+import static android.content.pm.ApplicationInfo.FLAG_ALLOW_CLEAR_USER_DATA;
+import static android.content.pm.ApplicationInfo.FLAG_ALLOW_TASK_REPARENTING;
+import static android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE;
+import static android.content.pm.ApplicationInfo.FLAG_HAS_CODE;
+import static android.content.pm.ApplicationInfo.FLAG_KILL_AFTER_RESTORE;
+import static android.content.pm.ApplicationInfo.FLAG_PERSISTENT;
+import static android.content.pm.ApplicationInfo.FLAG_RESIZEABLE_FOR_SCREENS;
+import static android.content.pm.ApplicationInfo.FLAG_RESTORE_ANY_VERSION;
+import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_LARGE_SCREENS;
+import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_NORMAL_SCREENS;
+import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_SCREEN_DENSITIES;
+import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_SMALL_SCREENS;
+import static android.content.pm.ApplicationInfo.FLAG_TEST_ONLY;
+import static android.content.pm.ApplicationInfo.FLAG_VM_SAFE_MODE;
 
 public class AndroidManifest {
   private final FsFile androidManifestFile;
@@ -330,7 +343,10 @@ public class AndroidManifest {
       String lib;
       while ((lib = properties.getProperty("android.library.reference." + libRef)) != null) {
         FsFile libraryBaseDir = baseDir.join(lib);
-        libraryBaseDirs.add(libraryBaseDir);
+        if (libraryBaseDir.exists()) {
+          libraryBaseDirs.add(libraryBaseDir);
+        }
+
         libRef++;
       }
     }

--- a/src/test/java/org/robolectric/AndroidManifestTest.java
+++ b/src/test/java/org/robolectric/AndroidManifestTest.java
@@ -16,12 +16,28 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static android.content.pm.ApplicationInfo.*;
+import static android.content.pm.ApplicationInfo.FLAG_ALLOW_BACKUP;
+import static android.content.pm.ApplicationInfo.FLAG_ALLOW_CLEAR_USER_DATA;
+import static android.content.pm.ApplicationInfo.FLAG_ALLOW_TASK_REPARENTING;
+import static android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE;
+import static android.content.pm.ApplicationInfo.FLAG_HAS_CODE;
+import static android.content.pm.ApplicationInfo.FLAG_KILL_AFTER_RESTORE;
+import static android.content.pm.ApplicationInfo.FLAG_PERSISTENT;
+import static android.content.pm.ApplicationInfo.FLAG_RESIZEABLE_FOR_SCREENS;
+import static android.content.pm.ApplicationInfo.FLAG_RESTORE_ANY_VERSION;
+import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_LARGE_SCREENS;
+import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_NORMAL_SCREENS;
+import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_SCREEN_DENSITIES;
+import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_SMALL_SCREENS;
+import static android.content.pm.ApplicationInfo.FLAG_TEST_ONLY;
+import static android.content.pm.ApplicationInfo.FLAG_VM_SAFE_MODE;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.robolectric.util.TestUtil.*;
+import static org.robolectric.util.TestUtil.joinPath;
+import static org.robolectric.util.TestUtil.newConfig;
+import static org.robolectric.util.TestUtil.resourceFile;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class AndroidManifestTest {
@@ -85,7 +101,7 @@ public class AndroidManifestTest {
     assertEquals("metaValue2", meta.get("org.robolectric.metaName2"));
   }
   
-  @Test public void shouldLoadAllResourcesForLibraries() {
+  @Test public void shouldLoadAllResourcesForExistingLibraries() {
     AndroidManifest appManifest = new AndroidManifest(resourceFile("TestAndroidManifest.xml"), resourceFile("res"));
 
     // This intentionally loads from the non standard resources/project.properties

--- a/src/test/resources/project.properties
+++ b/src/test/resources/project.properties
@@ -5,3 +5,4 @@
 target=android-42
 android.library.reference.1=lib1
 android.library.reference.2=lib2
+android.library.reference.3=lib4


### PR DESCRIPTION
This fixes #713. Before, references in `project.properties` that did not exist would cause Robolectric to explode. This is problematic if you use different build systems for dev and CI as they will need to reference the library in both places.
