### PR TITLE
Fix `Animation.hasEnded()` so it is true after `invokeEnd()`/`cancel()`

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowAnimation.java
+++ b/src/main/java/org/robolectric/shadows/ShadowAnimation.java
@@ -45,9 +45,7 @@ public class ShadowAnimation {
   @Implementation
   public void cancel() {
     startFlag = false;
-    if (listener != null) {
-      listener.onAnimationEnd(realAnimation);
-    }
+    endAnimation();
   }
 
   @Implementation
@@ -142,12 +140,8 @@ public class ShadowAnimation {
    * Non-Android accessor.  Use to simulate end of animation.
    */
   public void invokeEnd() {
-    if (listener != null) {
-      listener.onAnimationEnd(realAnimation);
-    }
+    endAnimation();
     new ShadowAnimationBridge(realAnimation).applyTransformation(1.0f, new Transformation());
-
-    endFlag = true;
   }
 
   public void setLoadedFromResourceId(int loadedFromResourceId) {
@@ -159,6 +153,14 @@ public class ShadowAnimation {
       throw new IllegalStateException("not loaded from a resource");
     }
     return loadedFromResourceId;
+  }
+
+  private void endAnimation() {
+    if (listener != null) {
+      listener.onAnimationEnd(realAnimation);
+    }
+
+    endFlag = true;
   }
 
 }

--- a/src/test/java/org/robolectric/shadows/AnimationTest.java
+++ b/src/test/java/org/robolectric/shadows/AnimationTest.java
@@ -71,6 +71,12 @@ public class AnimationTest {
   }
 
   @Test
+  public void cancel_endsTheAnimation() throws Exception {
+    animation.cancel();
+    assertThat(animation.hasEnded()).isTrue();
+  }
+
+  @Test
   public void simulateAnimationEndShouldInvokeApplyTransformationWith1() throws Exception {
     assertThat(animation.interpolatedTime).isEqualTo(0f);
     shadow.invokeEnd();


### PR DESCRIPTION
This just adds a flag to `ShadowAnimation` so `invokeEnd()` and `cancel()` correctly update the result of `hasEnded`. 

Fixes #381. 
