### PR TITLE
Fix PopupWindow.isShowing()

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowPopupWindow.java
+++ b/src/main/java/org/robolectric/shadows/ShadowPopupWindow.java
@@ -105,15 +105,6 @@ public class ShadowPopupWindow {
     return outSideTouchable;
   }
 
-  /**
-   * non-android setter for testing
-   *
-   * @param showing true if popup window is showing
-   */
-  public void setShowing(boolean showing) {
-    this.showing = showing;
-  }
-
   @Implementation
   public boolean isShowing() {
     return showing;
@@ -148,6 +139,7 @@ public class ShadowPopupWindow {
     containerView.addView(contentView);
     containerView.setBackgroundDrawable(background);
     getWindowManager().addView(containerView, new WindowManager.LayoutParams());
+    showing = true;
   }
 
   @Implementation

--- a/src/test/java/org/robolectric/shadows/PopupWindowTest.java
+++ b/src/test/java/org/robolectric/shadows/PopupWindowTest.java
@@ -82,24 +82,6 @@ public class PopupWindowTest {
       assertTrue(popupWindow.isOutsideTouchable());
     }
 
-    @Test
-    public void testShowing() {
-      shadowOf(popupWindow).setShowing(true);
-
-      assertTrue(popupWindow.isShowing());
-    }
-
-    @Test
-    public void testDismiss() {
-      shadowOf(popupWindow).setShowing(true);
-
-      assertTrue(popupWindow.isShowing());
-
-      popupWindow.dismiss();
-
-      assertFalse(popupWindow.isShowing());
-    }
-
     @SuppressWarnings("RedundantCast") //For some reason this is needed because of a compile error without it
     @Test
     public void testBackgroundDrawable() {
@@ -138,6 +120,26 @@ public class PopupWindowTest {
       anchor = new View(Robolectric.application);
 
       shadowWindowManager = (ShadowWindowManagerImpl) shadowOf(windowManager);
+    }
+
+    @Test
+    public void testShowing() {
+      PopupWindow popupWindow = new PopupWindow(contentView, 0, 0, true);
+      popupWindow.showAsDropDown(anchor);
+
+      assertTrue(popupWindow.isShowing());
+    }
+
+    @Test
+    public void testDismiss() {
+      PopupWindow popupWindow = new PopupWindow(contentView, 0, 0, true);
+      popupWindow.showAsDropDown(anchor);
+
+      assertTrue(popupWindow.isShowing());
+
+      popupWindow.dismiss();
+
+      assertFalse(popupWindow.isShowing());
     }
 
     @Test


### PR DESCRIPTION
I tried to remove the ShadowPopupWindow altogether, as I understand this to be the current mantra. However I ran into several other breakages when doing this. Specifically: a test broke around touch events, and the view didn't appear to be getting added correctly to the WindowManager.
