### PR TITLE
fix broken link to javadocs for @Config

### DIFF
--- a/user-guide.md
+++ b/user-guide.md
@@ -49,7 +49,7 @@ public class HomeActivityTest {
 }
 {% endhighlight %}
 
-See the javadocs for [org.robolectric.annotation.Config](/javadoc/org/robolectric/annotation/Config.html) for details.
+See the javadocs for [org.robolectric.annotation.Config](/robolectric/javadoc/org/robolectric/annotation/Config.html) for details.
 
 ##  `Robolectric.shadowOf()`
 Sometimes Android classes don't provide methods to access the state of the Android objects under test. The


### PR DESCRIPTION
I noticed the link to `org.robolectric.annotation.Config` javadocs on the [User Guide](http://pivotal.github.io/robolectric/user-guide.html) is currently returning a 404. Adding the project name to the url makes it resolve.
