### PR TITLE
Add implementations for BluetoothAdapter#enable and #disable

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
+++ b/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
@@ -59,9 +59,18 @@ public class ShadowBluetoothAdapter {
     return enabled;
   }
 
-  public void setEnabled(boolean enabled) {
-    this.enabled = enabled;
+  @Implementation
+  public boolean enable() {
+    enabled = true;
+    return true;
   }
+
+  @Implementation
+  public boolean disable() {
+    enabled = false;
+    return true;
+  }
+
   @Implementation
   public String getAddress() {
     return this.address;
@@ -112,5 +121,9 @@ public class ShadowBluetoothAdapter {
 
   public void setState(int state) {
     this.state = state;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
   }
 }

--- a/src/test/java/org/robolectric/shadows/BluetoothAdapterTest.java
+++ b/src/test/java/org/robolectric/shadows/BluetoothAdapterTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.TestRunners;
 
-import static org.junit.Assert.*;
+import static org.fest.assertions.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.shadowOf;
 
 @RunWith(TestRunners.WithDefaults.class)
@@ -24,19 +24,32 @@ public class BluetoothAdapterTest {
 
   @Test
   public void testAdapterDefaultsDisabled() {
-    assertFalse(bluetoothAdapter.isEnabled());
+    assertThat(bluetoothAdapter.isEnabled()).isFalse();
   }
 
   @Test
-  public void testAdapterCanBeEnabled() {
+  public void testAdapterCanBeEnabled_forTesting() {
     shadowBluetoothAdapter.setEnabled(true);
-    assertTrue(bluetoothAdapter.isEnabled());
+    assertThat(bluetoothAdapter.isEnabled()).isTrue();
   }
 
   @Test
   public void canGetAndSetAddress() throws Exception {
     BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
     shadowOf(adapter).setAddress("expected");
-    assertEquals("expected", adapter.getAddress());
+    assertThat(adapter.getAddress()).isEqualTo("expected");
+  }
+
+  @Test
+  public void canEnable_withAndroidApi() throws Exception {
+    bluetoothAdapter.enable();
+    assertThat(bluetoothAdapter.isEnabled()).isTrue();
+  }
+
+  @Test
+  public void canDisable_withAndroidApi() throws Exception {
+    shadowBluetoothAdapter.setEnabled(true);
+    bluetoothAdapter.disable();
+    assertThat(bluetoothAdapter.isEnabled()).isFalse();
   }
 }


### PR DESCRIPTION
Fixes #590

ShadowBluetoothAdapter#setEnabled is still available for testing
purposes; enable and disable are intended for apps with the bluetooth
admin permission.
