### PR TITLE
Add additional support for unregistering listeners in ShadowSensorManager

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
+++ b/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
@@ -53,6 +53,11 @@ public class ShadowSensorManager {
     listeners.remove(listener);
   }
 
+  @Implementation
+  public void unregisterListener(SensorEventListener listener) {
+    listeners.remove(listener);
+  }
+
   public boolean hasListener(SensorEventListener listener) {
     return listeners.contains(listener);
   }

--- a/src/test/java/org/robolectric/shadows/SensorManagerTest.java
+++ b/src/test/java/org/robolectric/shadows/SensorManagerTest.java
@@ -57,6 +57,14 @@ public class SensorManagerTest {
   }
 
   @Test
+  public void shouldReturnHasNoListenerAfterUnregisterListenerWithoutSpecificSensor() {
+    SensorEventListener listener = registerListener();
+    sensorManager.unregisterListener(listener);
+
+    assertThat(shadow.hasListener(listener)).isFalse();
+  }
+
+  @Test
   public void shouldReturnHasNoListenerByDefault() {
     SensorEventListener listener = new TestSensorEventListener();
 


### PR DESCRIPTION
As it currently does not handle the case when there's no Sensor to give as parameter.
