### PR TITLE
Add system property to specify package name

### DIFF
--- a/src/main/java/org/robolectric/AndroidManifest.java
+++ b/src/main/java/org/robolectric/AndroidManifest.java
@@ -42,7 +42,7 @@ public class AndroidManifest {
   private final FsFile androidManifestFile;
   private final FsFile resDirectory;
   private final FsFile assetsDirectory;
-  private boolean manifestIsParsed = false;
+  private boolean manifestIsParsed;
 
   private String applicationName;
   private String rClassName;
@@ -135,7 +135,9 @@ public class AndroidManifest {
       Document manifestDocument = db.parse(inputStream);
       inputStream.close();
 
-      packageName = getTagAttributeText(manifestDocument, "manifest", "package");
+      if (packageName == null) {
+        packageName = getTagAttributeText(manifestDocument, "manifest", "package");
+      }
       versionCode = getTagAttributeIntValue(manifestDocument, "manifest", "android:versionCode", 0);
       versionName = getTagAttributeText(manifestDocument, "manifest", "android:versionName");
       rClassName = packageName + ".R";
@@ -201,7 +203,7 @@ public class AndroidManifest {
   private void parseApplicationMetaData(final Document manifestDocument) {
     Node application = manifestDocument.getElementsByTagName("application").item(0);
     if (application == null) return;
-    
+
     for (Node metaNode : getChildrenTags(application, "meta-data")) {
       NamedNodeMap attributes = metaNode.getAttributes();
       Node nameAttr = attributes.getNamedItem("android:name");
@@ -211,7 +213,7 @@ public class AndroidManifest {
       applicationMetaData.put(nameAttr.getNodeValue(), valueAttr.getNodeValue());
     }
   }
-  
+
   private String resolveClassRef(String maybePartialClassName) {
     return (maybePartialClassName.startsWith(".")) ? packageName + maybePartialClassName : maybePartialClassName;
   }
@@ -267,6 +269,10 @@ public class AndroidManifest {
     return applicationName;
   }
 
+  public void setPackageName(String packageName) {
+    this.packageName = packageName;
+  }
+
   public String getPackageName() {
     parseAndroidManifest();
     return packageName;
@@ -304,7 +310,7 @@ public class AndroidManifest {
     parseAndroidManifest();
     return applicationMetaData;
   }
-  
+
   public ResourcePath getResourcePath() {
     validate();
     return new ResourcePath(getRClass(), getPackageName(), resDirectory, assetsDirectory);

--- a/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -128,7 +128,10 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
       System.out.println("To remove this warning, annotate your test class with @Config(manifest=Config.NONE).");
       return null;
     }
-    return new AndroidManifest(manifestFile, resDir, assetsDir);
+    AndroidManifest manifest = new AndroidManifest(manifestFile, resDir, assetsDir);
+    String packageName = System.getProperty("android.package");
+    manifest.setPackageName(packageName);
+    return manifest;
   }
 
   public Setup createSetup() {


### PR DESCRIPTION
- This is to help gradle builds which flavors declare a package name different from the one R.class is located in.
