### PR TITLE
Add shadow support for registerReceiver with permission

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -13,6 +13,7 @@ import android.content.ServiceConnection;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
 import android.os.PowerManager;
@@ -60,6 +61,7 @@ public class ShadowApplication extends ShadowContextWrapper {
   private Map<String, Intent> stickyIntents = new HashMap<String, Intent>();
   private FakeHttpLayer fakeHttpLayer = new FakeHttpLayer();
   private Looper mainLooper = ShadowLooper.myLooper();
+  private Handler mainHandler = new Handler(mainLooper);
   private Scheduler backgroundScheduler = new Scheduler();
   private Map<String, Map<String, Object>> sharedPreferenceMap = new HashMap<String, Map<String, Object>>();
   private ArrayList<Toast> shownToasts = new ArrayList<Toast>();
@@ -324,23 +326,43 @@ public class ShadowApplication extends ShadowContextWrapper {
     return resourceLoader;
   }
 
+  @Override
+  @Implementation
+  public void sendBroadcast(Intent intent) {
+    sendBroadcastWithPermission(intent, null);
+  }
+
+  @Override
+  @Implementation
+  public void sendBroadcast(Intent intent, String receiverPermission) {
+    sendBroadcastWithPermission(intent, receiverPermission);
+  }
+
   /**
-   * Broadcasts the {@code Intent} by iterating through the registered receivers, invoking their filters, and calling
-   * {@code onRecieve(Application, Intent)} as appropriate. Does not enqueue the {@code Intent} for later inspection.
+   * Broadcasts the {@code Intent} by iterating through the registered receivers, invoking their filters including
+   * permissions, and calling {@code onReceive(Application, Intent)} as appropriate. Does not enqueue the
+   * {@code Intent} for later inspection.
    *
    * @param intent the {@code Intent} to broadcast
    *               todo: enqueue the Intent for later inspection
    */
-  @Override
-  @Implementation
-  public void sendBroadcast(Intent intent) {
+  private void sendBroadcastWithPermission(Intent intent, String receiverPermission) {
     broadcastIntents.add(intent);
 
     List<Wrapper> copy = new ArrayList<Wrapper>();
     copy.addAll(registeredReceivers);
     for (Wrapper wrapper : copy) {
-      if (wrapper.intentFilter.matchAction(intent.getAction())) {
-        wrapper.broadcastReceiver.onReceive(realApplication, intent);
+      if (hasMatchingPermission(wrapper.broadcastPermission, receiverPermission)
+          && wrapper.intentFilter.matchAction(intent.getAction())) {
+        final Handler scheduler = (wrapper.scheduler != null) ? wrapper.scheduler : this.mainHandler;
+        final BroadcastReceiver receiver = wrapper.broadcastReceiver;
+        final Intent broadcastIntent = intent;
+        scheduler.post(new Runnable() {
+          @Override
+          public void run() {
+            receiver.onReceive(realApplication, broadcastIntent);
+          }
+        });
       }
     }
   }
@@ -363,12 +385,18 @@ public class ShadowApplication extends ShadowContextWrapper {
   @Override
   @Implementation
   public Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter) {
-    return registerReceiverWithContext(receiver, filter, realApplication);
+    return registerReceiverWithContext(receiver, filter, null, null, realApplication);
   }
 
-  Intent registerReceiverWithContext(BroadcastReceiver receiver, IntentFilter filter, Context context) {
+  @Override
+  @Implementation
+  public Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter, String broadcastPermission, Handler scheduler) {
+    return registerReceiverWithContext(receiver, filter, broadcastPermission, scheduler, realApplication);
+  }
+
+  Intent registerReceiverWithContext(BroadcastReceiver receiver, IntentFilter filter, String broadcastPermission, Handler scheduler, Context context) {
     if (receiver != null) {
-      registeredReceivers.add(new Wrapper(receiver, filter, context));
+      registeredReceivers.add(new Wrapper(receiver, filter, context, broadcastPermission, scheduler));
     }
     return getStickyIntent(filter);
   }
@@ -583,11 +611,15 @@ public class ShadowApplication extends ShadowContextWrapper {
     public IntentFilter intentFilter;
     public Context context;
     public Throwable exception;
+    public String broadcastPermission;
+    public Handler scheduler;
 
-    public Wrapper(BroadcastReceiver broadcastReceiver, IntentFilter intentFilter, Context context) {
+    public Wrapper(BroadcastReceiver broadcastReceiver, IntentFilter intentFilter, Context context, String broadcastPermission, Handler scheduler) {
       this.broadcastReceiver = broadcastReceiver;
       this.intentFilter = intentFilter;
       this.context = context;
+      this.broadcastPermission = broadcastPermission;
+      this.scheduler = scheduler;
       exception = new Throwable();
     }
 
@@ -619,5 +651,9 @@ public class ShadowApplication extends ShadowContextWrapper {
     for (String permissionName : permissionNames) {
       grantedPermissions.remove(permissionName);
     }
+  }
+
+  private boolean hasMatchingPermission(String permission1, String permission2) {
+    return permission1 == null ? permission2 == null : permission1.equals(permission2);
   }
 }

--- a/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
+++ b/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
@@ -13,6 +13,7 @@ import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
 import android.database.sqlite.SQLiteDatabase;
+import android.os.Handler;
 import android.os.Looper;
 import java.io.File;
 import java.io.FileInputStream;
@@ -141,6 +142,11 @@ public class ShadowContextWrapper extends ShadowContext {
     getApplicationContext().sendBroadcast(intent);
   }
 
+  @Implementation
+  public void sendBroadcast(Intent intent, String receiverPermission) {
+    getApplicationContext().sendBroadcast(intent, receiverPermission);
+  }
+
   public List<Intent> getBroadcastIntents() {
     return ((ShadowApplication) shadowOf(getApplicationContext())).getBroadcastIntents();
   }
@@ -152,7 +158,12 @@ public class ShadowContextWrapper extends ShadowContext {
 
   @Implementation
   public Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter) {
-    return ((ShadowApplication) shadowOf(getApplicationContext())).registerReceiverWithContext(receiver, filter, realContextWrapper);
+    return ((ShadowApplication) shadowOf(getApplicationContext())).registerReceiverWithContext(receiver, filter, null, null, realContextWrapper);
+  }
+
+  @Implementation
+  public Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter, String broadcastPermission, Handler scheduler) {
+    return ((ShadowApplication) shadowOf(getApplicationContext())).registerReceiverWithContext(receiver, filter, broadcastPermission, scheduler, realContextWrapper);
   }
 
   @Implementation


### PR DESCRIPTION
Permission restriction has been added to registerReceiver / sendBroadcast.
Intents will only be broadcasted to receivers that has matching
permission. If null is provided then it will simply mean no permission
is required.

Posting the BroadcastReceiver on a provided Handler has also been
added.  If you provide a Handler when registering your receiver that
receiver will be notified from that Handler.  Otherwise the main
application Handler will be used.

Added necessary tests to exercise this new support.

This was an old pull request that I had done about 9 months ago which was originally differed because of Robolectric 2.0 was support to bring this support.  Unfortunately currently Robolectric 2.+ doesn't support it.

I'm simply doing this pull request in case it would be wanted in now.  I know it would be better to fix this without shadowing but my time was very limited on this so I thought it might be worth it regardless.
