### PR TITLE
Views inflated from Robolectric.application have correct getContext().getApplicationContext()

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
+++ b/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
@@ -15,17 +15,18 @@ import android.content.res.Resources;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Handler;
 import android.os.Looper;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.util.List;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.res.ResourceLoader;
 import org.robolectric.tester.android.content.TestSharedPreferences;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.util.List;
 
 import static android.database.sqlite.SQLiteDatabase.CursorFactory;
 import static org.robolectric.Robolectric.shadowOf;
@@ -50,7 +51,8 @@ public class ShadowContextWrapper extends ShadowContext {
 
   @Implementation
   public Context getApplicationContext() {
-    return realContextWrapper.getBaseContext().getApplicationContext();
+    Context applicationContext = realContextWrapper.getBaseContext().getApplicationContext();
+    return applicationContext == null ? Robolectric.application : applicationContext;
   }
 
   @Implementation

--- a/src/test/java/org/robolectric/shadows/ContextWrapperTest.java
+++ b/src/test/java/org/robolectric/shadows/ContextWrapperTest.java
@@ -11,10 +11,12 @@ import android.content.IntentFilter;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
-
+import android.view.LayoutInflater;
+import android.view.View;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.R;
 import org.robolectric.Robolectric;
 import org.robolectric.TestRunners;
 import org.robolectric.util.Transcript;
@@ -167,6 +169,13 @@ public class ContextWrapperTest {
     assertThat(activity.getApplicationContext()).isSameAs(activity.getApplicationContext());
 
     assertThat(activity.getApplicationContext()).isSameAs(new Activity().getApplicationContext());
+  }
+
+  @Test
+  public void shouldReturnApplicationContext_forViewContextInflatedWithApplicationContext() throws Exception {
+    View view = LayoutInflater.from(Robolectric.application).inflate(R.layout.custom_layout, null);
+    Context viewContext = new ContextWrapper(view.getContext());
+    assertThat(viewContext.getApplicationContext()).isEqualTo(Robolectric.application);
   }
 
   @Test


### PR DESCRIPTION
Fixes #757.
