### PR TITLE
Set default locale for Robolectric's test runner

### DIFF
--- a/src/test/java/org/robolectric/TestRunners.java
+++ b/src/test/java/org/robolectric/TestRunners.java
@@ -1,6 +1,8 @@
 package org.robolectric;
 
+import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
 import org.robolectric.annotation.Config;
 import org.robolectric.bytecode.AndroidTranslatorClassInstrumentedTest;
 import org.robolectric.bytecode.ClassInfo;
@@ -12,6 +14,7 @@ import org.robolectric.res.ResourceLoader;
 import org.robolectric.shadows.ShadowSystemProperties;
 
 import java.lang.reflect.Method;
+import java.util.Locale;
 
 import static org.robolectric.util.TestUtil.resourceFile;
 
@@ -67,6 +70,7 @@ public class TestRunners {
   public static class WithDefaults extends RobolectricTestRunner {
     public WithDefaults(Class<?> testClass) throws InitializationError {
       super(testClass);
+      Locale.setDefault(Locale.ENGLISH);
     }
 
     @Override public Setup createSetup() {


### PR DESCRIPTION
 Set default locale to English for the internal Robolectric TestRunner to avoid number localization issues. Fixes #737
