### PR TITLE
extended Setup to allow instrumentation of classes located in the dalvik package

### DIFF
--- a/src/main/java/org/robolectric/bytecode/Setup.java
+++ b/src/main/java/org/robolectric/bytecode/Setup.java
@@ -94,6 +94,7 @@ public class Setup {
     String className = classInfo.getName();
     return className.startsWith("android.")
         || className.startsWith("libcore.")
+        || className.startsWith("dalvik.")
         || className.startsWith("com.android.internal.")
         || className.startsWith("com.google.android.maps.")
         || className.startsWith("com.google.android.gms.")

--- a/src/test/java/org/robolectric/bytecode/SetupTest.java
+++ b/src/test/java/org/robolectric/bytecode/SetupTest.java
@@ -37,6 +37,11 @@ public class SetupTest {
   }
 
   @Test
+  public void shouldInstrumentDalvikClasses() {
+    assertTrue(setup.shouldInstrument(wrap("dalvik.system.DexFile")));
+  }
+
+  @Test
   public void shouldNotInstrumentCoreJdkClasses() throws Exception {
     assertFalse(setup.shouldInstrument(wrap("java.lang.Object")));
     assertFalse(setup.shouldInstrument(wrap("java.lang.String")));


### PR DESCRIPTION
In order to use robolectric for testing the [CucumberInstrumentation](https://github.com/cucumber/cucumber-jvm/blob/master/android/src/main/java/cucumber/api/android/CucumberInstrumentation.java) of the [cucumber-android](https://github.com/cucumber/cucumber-jvm/tree/master/android) project I would like to allow instrumentation of classes located in the dalvik package.
