### PR TITLE
Ensure that Robolectric defaults to the targetSdkVersion specified in the manifest.

### DIFF
--- a/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -284,7 +284,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
   }
 
   protected SdkConfig pickSdkVersion(AndroidManifest appManifest, Config config) {
-    if (config != null) {
+    if (config != null && config.emulateSdk() > 0) {
       return new SdkConfig(config.emulateSdk());
     } else {
       if (appManifest != null) {

--- a/src/main/java/org/robolectric/SdkConfig.java
+++ b/src/main/java/org/robolectric/SdkConfig.java
@@ -2,8 +2,6 @@ package org.robolectric;
 
 import android.os.Build;
 import org.apache.maven.model.Dependency;
-import org.robolectric.annotation.Config;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,12 +34,8 @@ public class SdkConfig {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-
     SdkConfig sdkConfig = (SdkConfig) o;
-
-    if (!artifactVersionString.equals(sdkConfig.artifactVersionString)) return false;
-
-    return true;
+    return artifactVersionString.equals(sdkConfig.artifactVersionString);
   }
 
   @Override
@@ -81,7 +75,7 @@ public class SdkConfig {
   }
 
   public static SdkConfig getDefaultSdk() {
-    return new SdkConfig(Config.DEFAULT_SDK_LEVEL);
+    return new SdkConfig(Build.VERSION_CODES.JELLY_BEAN);
   }
 
   public int getApiLevel() {

--- a/src/main/java/org/robolectric/annotation/Config.java
+++ b/src/main/java/org/robolectric/annotation/Config.java
@@ -23,12 +23,11 @@ public @interface Config {
   @SuppressWarnings("UnusedDeclaration")
   public static final String NONE = "--none";
   public static final String DEFAULT = "--default";
-  public static final int DEFAULT_SDK_LEVEL = Build.VERSION_CODES.JELLY_BEAN;
 
   /**
    * The Android SDK level to emulate. If not specified, Robolectric defaults to API 16.
    */
-  int emulateSdk() default DEFAULT_SDK_LEVEL;
+  int emulateSdk() default -1;
 
   /**
    * The Android manifest file to load; Robolectric will look relative to the current directory.
@@ -100,7 +99,7 @@ public @interface Config {
     }
 
     public Implementation(Config baseConfig, Config overlayConfig) {
-      this.emulateSdk = pick(baseConfig.emulateSdk(), overlayConfig.emulateSdk(), DEFAULT_SDK_LEVEL);
+      this.emulateSdk = pick(baseConfig.emulateSdk(), overlayConfig.emulateSdk(), -1);
       this.manifest = pick(baseConfig.manifest(), overlayConfig.manifest(), DEFAULT);
       this.qualifiers = pick(baseConfig.qualifiers(), overlayConfig.qualifiers(), "");
       this.reportSdk = pick(baseConfig.reportSdk(), overlayConfig.reportSdk(), -1);

--- a/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -32,10 +32,10 @@ public class RobolectricTestRunnerTest {
 
   @Test public void whenClassDoesntHaveConfigAnnotation_getConfig_shouldUseMethodConfig() throws Exception {
     assertConfig(configFor(Test2.class, "withoutAnnotation"),
-        Config.DEFAULT_SDK_LEVEL, "--default", "", -1, new Class[]{});
+        -1, "--default", "", -1, new Class[]{});
 
     assertConfig(configFor(Test2.class, "withDefaultsAnnotation"),
-        Config.DEFAULT_SDK_LEVEL, "--default", "", -1, new Class[]{});
+        -1, "--default", "", -1, new Class[]{});
 
     assertConfig(configFor(Test2.class, "withOverrideAnnotation"),
         9, "furf", "from-method", 8, new Class[]{Test1.class});


### PR DESCRIPTION
Since the @Config annotation had a default value for emulateSdk, the test runner would always pick this version if no annotations were found.  It should still default to API 16 if no @Config annotations are present and a targetSdkVersion is not specified.
