### PR TITLE
Added support for non-android shadows.

### DIFF
--- a/src/main/java/org/robolectric/bytecode/Setup.java
+++ b/src/main/java/org/robolectric/bytecode/Setup.java
@@ -25,6 +25,7 @@ import org.robolectric.util.DatabaseConfig;
 import org.robolectric.util.I18nException;
 import org.robolectric.util.Transcript;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -88,8 +89,48 @@ public class Setup {
       return false;
     }
 
-    // allow explicit control with @Instrument, mostly for tests
-    return classInfo.hasAnnotation(Instrument.class) || isFromAndroidSdk(classInfo);
+    if (isFromAndroidSdk(classInfo)) {
+      return true;
+    }
+
+    // Avoid infinite loop caused by trying to load the
+    // RobolectricInternals class below.
+    if (classInfo.getName().equals(RobolectricInternals.class.getName())) {
+      return false;
+    }
+
+    // Check the current ShadowMap to see if a custom shadow has been
+    // configured.
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+    if (classLoader != null) {
+      ShadowWrangler shadowWrangler;
+
+      try {
+        String className = RobolectricInternals.class.getName();
+        Class<?> robolectricInternalsClass = classLoader.loadClass(className);
+        Field field = robolectricInternalsClass.getDeclaredField("classHandler");
+        field.setAccessible(true);
+        shadowWrangler = (ShadowWrangler) field.get(null);
+
+        if ((shadowWrangler != null) &&
+            (shadowWrangler.shadowMap != null) &&
+            shadowWrangler.shadowMap.containsKey(classInfo.getName())) {
+          return true;
+        }
+      } catch (NoSuchFieldException e) {
+          throw new RuntimeException(e);
+      } catch (IllegalAccessException e) {
+          throw new RuntimeException(e);
+      } catch (ClassNotFoundException e) {
+          throw new RuntimeException(e);
+      }
+    }
+
+    // Allow tests with @Instrument to be instrumented.  During normal
+    // conditions, classes being shadowed will never have
+    // @Instrument annotations.
+    return classInfo.hasAnnotation(Instrument.class);
   }
 
   public boolean isFromAndroidSdk(ClassInfo classInfo) {

--- a/src/main/java/org/robolectric/bytecode/ShadowMap.java
+++ b/src/main/java/org/robolectric/bytecode/ShadowMap.java
@@ -76,6 +76,10 @@ public class ShadowMap {
     return false;
   }
 
+  public boolean containsKey(String className) {
+    return map.containsKey(className);
+  }
+
   public ShadowConfig get(Class<?> clazz) {
     String className = clazz.getName();
     ShadowConfig shadowConfig = map.get(className);

--- a/src/main/java/org/robolectric/bytecode/ShadowWrangler.java
+++ b/src/main/java/org/robolectric/bytecode/ShadowWrangler.java
@@ -39,7 +39,7 @@ public class ShadowWrangler implements ClassHandler {
   private static final ShadowConfig NO_SHADOW_CONFIG = new ShadowConfig(Object.class.getName(), true, false, false);
   public boolean debug = false;
 
-  private final ShadowMap shadowMap;
+  final ShadowMap shadowMap;
   private final Map<Class, MetaShadow> metaShadowMap = new HashMap<Class, MetaShadow>();
   private final Map<String, Plan> planCache = new LinkedHashMap<String, Plan>() {
     @Override protected boolean removeEldestEntry(Map.Entry<String, Plan> eldest) {

--- a/src/test/java/org/robolectric/bytecode/AndroidTranslatorClassInstrumentedTest.java
+++ b/src/test/java/org/robolectric/bytecode/AndroidTranslatorClassInstrumentedTest.java
@@ -38,8 +38,7 @@ public class AndroidTranslatorClassInstrumentedTest {
   }
 
   /*
-   * Test "foreign class" getting its methods shadowed whe it's
-   * in the InstrumentingClassLoader CustomClassNames arrayList
+   * Test "android class" getting its methods shadowed
    */
   @Test
   @Config(shadows = {ShadowCustomPaint.class, ShadowPaintForTests.class})
@@ -50,15 +49,14 @@ public class AndroidTranslatorClassInstrumentedTest {
   }
 
   /*
-   * Test "foreign class" not getting its methods shadowed when it's
-   * not in the InstrumentingClassLoader CustomClassNames arrayList
+   * Test "foreign class" getting its methods shadowed
    */
   @Test
   @Config(shadows = {ShadowCustomXmasPaint.class, ShadowPaintForTests.class})
   public void testCustomMethodNotShadowed() throws Exception {
     CustomXmasPaint customXmasPaint = new CustomXmasPaint();
-    assertThat(customXmasPaint.getColor()).isEqualTo(999);
-    assertThat(customXmasPaint.getColorName()).isEqualTo("XMAS");
+    assertThat(customXmasPaint.getColor()).isEqualTo(-999);
+    assertThat(customXmasPaint.getColorName()).isEqualTo("XMAS Color Test");
   }
 
   public static class ClassWithPrivateConstructor {


### PR DESCRIPTION
src/main/java/org/robolectric/bytecode/Setup.java
- Modified shouldInstrument() to quickly short circuit for Android
  classes and then check the current ShadowMap for custom shadows.

src/main/java/org/robolectric/bytecode/ShadowMap.java
- Added constainsKey() for use by Setup.shouldInstrument().

src/main/java/org/robolectric/bytecode/ShadowWrangler.java
- Made shadowMap "package private", so Setup can access it.

src/test/java/org/robolectric/bytecode/AndroidTranslatorClassInstrumentedTest.java
- Renamed testCustomMethodShadowed() to testAndroidMethodShadowed()
  and testCustomMethodNotShadowed() to testCustomMethodShadowed().
