### PR TITLE
Enable Shadow for Settings.Global

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowSettings.java
+++ b/src/main/java/org/robolectric/shadows/ShadowSettings.java
@@ -127,6 +127,10 @@ public class ShadowSettings {
   public static class ShadowSecure extends SettingsImpl {
   }
 
+  @Implements(value = Settings.Global.class, inheritImplementationMethods = true)
+  public static class ShadowGlobal extends SettingsImpl {
+  }
+
   /**
    * Non-Android accessor that allows the value of the AIRPLANE_MODE_ON setting to be set.
    *

--- a/src/test/java/org/robolectric/shadows/SettingsTest.java
+++ b/src/test/java/org/robolectric/shadows/SettingsTest.java
@@ -40,6 +40,15 @@ public class SettingsTest {
   }
 
   @Test
+  public void testGlobalGetInt() throws Exception {
+    assertThat(Settings.Global.getInt(contentResolver, "property", 0)).isEqualTo(0);
+    assertThat(Settings.Global.getInt(contentResolver, "property", 2)).isEqualTo(2);
+
+    Settings.Global.putInt(contentResolver, "property", 1);
+    assertThat(Settings.Global.getInt(contentResolver, "property", 0)).isEqualTo(1);
+  }
+
+  @Test
   public void testSystemGetString() throws Exception {
     assertThat(Settings.System.getString(contentResolver, "property")).isNull();
 


### PR DESCRIPTION
I know the team's focus has been on removing shadows, but removing ShadowContentResolver and others seemed non-trivial for me. So I figured adding Settings.Global would help others in the shorter term.
