### PR TITLE
Fix two NPEs when decoding Drawables/Bitmaps

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -39,7 +39,7 @@ public class ShadowBitmapFactory {
         InputStream.class, Rect.class, BitmapFactory.Options.class)
         .invoke(res, value, is, pad, opts);
 
-    if (value.string != null && value.string.toString().contains(".9.")) {
+    if (value != null && value.string != null && value.string.toString().contains(".9.")) {
       // todo: better support for nine-patches
       method("setNinePatchChunk").withParameterTypes(byte[].class).in(bitmap).invoke(new byte[0]);
     }

--- a/src/main/java/org/robolectric/shadows/ShadowDrawable.java
+++ b/src/main/java/org/robolectric/shadows/ShadowDrawable.java
@@ -63,7 +63,7 @@ public class ShadowDrawable {
 
     Bitmap  bm = BitmapFactory.decodeResourceStream(res, value, is, pad, opts);
     if (bm != null) {
-      boolean isNinePatch = srcName.contains(".9.");
+      boolean isNinePatch = srcName != null && srcName.contains(".9.");
       if (isNinePatch) {
         method("setNinePatchChunk").withParameterTypes(byte[].class).in(bm).invoke(new byte[0]);
       }

--- a/src/test/java/org/robolectric/shadows/BitmapFactoryTest.java
+++ b/src/test/java/org/robolectric/shadows/BitmapFactoryTest.java
@@ -88,6 +88,15 @@ public class BitmapFactoryTest {
   }
 
   @Test
+  public void decodeResourceStream_canTakeOptions() throws Exception {
+    BitmapFactory.Options options = new BitmapFactory.Options();
+    InputStream inputStream = Robolectric.application.getContentResolver().openInputStream(Uri.parse("content:/path"));
+    options.inSampleSize = 100;
+    Bitmap bitmap = BitmapFactory.decodeResourceStream(Robolectric.application.getResources(), null, inputStream, null, options);
+    assertEquals(true, shadowOf(bitmap).getDescription().contains("inSampleSize=100"));
+  }
+
+  @Test
   public void decodeFile_shouldGetWidthAndHeightFromHints() throws Exception {
     ShadowBitmapFactory.provideWidthAndHeightHints("/some/file.jpg", 123, 456);
 

--- a/src/test/java/org/robolectric/shadows/DrawableTest.java
+++ b/src/test/java/org/robolectric/shadows/DrawableTest.java
@@ -1,5 +1,6 @@
 package org.robolectric.shadows;
 
+import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.ColorFilter;
 import android.graphics.Rect;
@@ -25,6 +26,13 @@ public class DrawableTest {
     String corruptedStreamSource = "http://foo.com/image.jpg";
     ShadowDrawable.addCorruptStreamSource(corruptedStreamSource);
     assertNull(ShadowDrawable.createFromStream(new ByteArrayInputStream(new byte[0]), corruptedStreamSource));
+  }
+
+  @Test
+  public void createFromResourceStream_shouldWorkWithoutSourceName() {
+    Drawable drawable = Drawable.createFromResourceStream(Robolectric.application.getResources(),
+        null, new ByteArrayInputStream(new byte[0]), null, new BitmapFactory.Options());
+    assertNotNull(drawable);
   }
 
   @Test


### PR DESCRIPTION
These arguments are not required in the real android implementations. Adding null checks and a test to ensure this behavior is preserved in Robolectric.
