### PR TITLE
Create SearchManager shadow.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowSearchManager.java
+++ b/src/main/java/org/robolectric/shadows/ShadowSearchManager.java
@@ -1,0 +1,17 @@
+package org.robolectric.shadows;
+
+import android.app.SearchManager;
+import android.app.SearchableInfo;
+import android.content.ComponentName;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Implementation;
+
+@Implements(SearchManager.class)
+public class ShadowSearchManager {
+
+  @Implementation
+  public SearchableInfo getSearchableInfo(ComponentName componentName) {
+    // Prevent Robolectric from calling through
+    return null;
+  }
+}


### PR DESCRIPTION
Prevent an NPE when Robolectric tries to call into getSearchableInfo.
