### PR TITLE
Fix a typo in javadoc for ShadowCookieManager

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowCookieManager.java
+++ b/src/main/java/org/robolectric/shadows/ShadowCookieManager.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Shadows the {@code android.telephony.TelephonyManager} class.
+ * Shadows the {@code android.webkit.CookieManager} class.
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(CookieManager.class)


### PR DESCRIPTION
The JavaDoc for the ShadowCookieManager has a typo. This class shadows CookieManager, but the javadoc refers TelephonyManager.
