### PR TITLE
Add `setupActivity` helper

### DIFF
--- a/src/main/java/org/robolectric/Robolectric.java
+++ b/src/main/java/org/robolectric/Robolectric.java
@@ -1350,6 +1350,10 @@ public class Robolectric {
     return new ActivityController<T>(activityClass);
   }
 
+  public static <T extends Activity> T setupActivity(Class<T> activityClass) {
+    return new ActivityController<T>(activityClass).create().start().resume().visible().get();
+  }
+
   /**
    * Set to true if you'd like Robolectric to strictly simulate the real Android behavior when
    * calling {@link Context#startActivity(android.content.Intent)}. Real Android throws a

--- a/src/test/java/org/robolectric/RobolectricTest.java
+++ b/src/test/java/org/robolectric/RobolectricTest.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 import android.os.Handler;
 import android.view.Display;
 import android.view.View;
@@ -154,6 +155,16 @@ public class RobolectricTest {
     Robolectric.application.startActivity(new Intent("i.dont.exist.activity"));
   }
 
+  @Test
+  public void setupActivity_returnsAVisibleActivity() throws Exception {
+    LifeCycleActivity activity = Robolectric.setupActivity(LifeCycleActivity.class);
+
+    assertThat(activity.isCreated()).isTrue();
+    assertThat(activity.isStarted()).isTrue();
+    assertThat(activity.isResumed()).isTrue();
+    assertThat(activity.isVisible()).isTrue();
+  }
+
   @Implements(View.class)
   public static class TestShadowView {
     @SuppressWarnings({"UnusedDeclaration"})
@@ -176,5 +187,34 @@ public class RobolectricTest {
     DefaultRequestDirector requestDirector = new DefaultRequestDirector(null, null, null, connectionKeepAliveStrategy, null, null, null, null, null, null, null, null);
 
     requestDirector.execute(null, new HttpGet(uri), null);
+  }
+
+  private static class LifeCycleActivity extends Activity {
+    private boolean created;
+    private boolean started;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      created = true;
+    }
+
+    @Override
+    protected void onStart() {
+      super.onStart();
+      started = true;
+    }
+
+    public boolean isStarted() {
+      return started;
+    }
+
+    public boolean isCreated() {
+      return created;
+    }
+
+    public boolean isVisible() {
+      return getWindow().getDecorView().getWindowToken() != null;
+    }
   }
 }


### PR DESCRIPTION
This runs through the whole creation lifecycle for the Activity of the passed class and then returns it. Makes the simplest tests (where you just test interaction) less verbose. Might also make documentation and basic Robolectric examples a little less daunting.

I think one drawback might be that it hides the `ActivityController` which might be something we want to expose as much as possible :confused:.
