### PR TITLE
Fix NPE when using ActivityController.withIntent()

### DIFF
--- a/src/main/java/org/robolectric/util/ActivityController.java
+++ b/src/main/java/org/robolectric/util/ActivityController.java
@@ -80,6 +80,9 @@ public class ActivityController<T extends Activity> {
     Application application = this.application == null ? Robolectric.application : this.application;
     Context baseContext = this.baseContext == null ? application : this.baseContext;
     Intent intent = this.intent == null ? new Intent(application, activity.getClass()) : this.intent;
+    if (intent.getComponent() == null) {
+      intent.setClass(application, activity.getClass());
+    }
     ActivityInfo activityInfo = new ActivityInfo();
 
     ClassLoader cl = baseContext.getClassLoader();

--- a/src/test/java/org/robolectric/util/ActivityControllerTest.java
+++ b/src/test/java/org/robolectric/util/ActivityControllerTest.java
@@ -2,6 +2,7 @@ package org.robolectric.util;
 
 import android.app.Activity;
 import android.content.ComponentName;
+import android.content.Intent;
 import android.os.Bundle;
 import android.os.Looper;
 import org.junit.Before;
@@ -28,6 +29,15 @@ public class ActivityControllerTest {
     assertThat(myActivity.getIntent()).isNotNull();
     assertThat(myActivity.getIntent().getComponent())
         .isEqualTo(new ComponentName("org.robolectric", MyActivity.class.getName()));
+  }
+
+  @Test public void shouldSetIntentComponentWithCustomIntentWithoutComponentSet() throws Exception {
+    MyActivity myActivity = Robolectric.buildActivity(MyActivity.class)
+        .withIntent(new Intent("some action")).create().get();
+    assertThat(myActivity.getIntent().getComponent())
+        .isEqualTo(new ComponentName("org.robolectric", MyActivity.class.getName()));
+    assertThat(myActivity.getIntent().getAction())
+        .isEqualTo("some action");
   }
 
   @Test public void whenLooperIsNotPaused_shouldCreateTestsWithMainLooperPaused() throws Exception {


### PR DESCRIPTION
Calling attach with a custom intent from ActivityController
seems to crash unless an explicit component name is set. Android
framework allows intents with as little as an action and Robolectric
should too.
