### PR TITLE
Make SQLiteQueryBuilder work

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowSQLiteDatabase.java
+++ b/src/main/java/org/robolectric/shadows/ShadowSQLiteDatabase.java
@@ -11,6 +11,7 @@ import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteQuery;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.database.sqlite.SQLiteStatement;
+import android.os.CancellationSignal;
 import android.text.TextUtils;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implementation;
@@ -302,6 +303,13 @@ public class ShadowSQLiteDatabase extends ShadowSQLiteClosable {
     shadowOf(cursor).setResultSet(resultSet, sqlBody);
     cursors.add(cursor);
     return cursor;
+  }
+
+  @Implementation
+  public Cursor rawQueryWithFactory(
+      CursorFactory cursorFactory, String sql, String[] selectionArgs,
+      String editTable, CancellationSignal cancellationSignal) {
+    return rawQueryWithFactory(cursorFactory, sql, selectionArgs, editTable);
   }
 
   @Implementation

--- a/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
+++ b/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
@@ -893,4 +893,12 @@ public class SQLiteDatabaseTest extends DatabaseTestBase {
     shadowDB.unlock();
     assertThat(database.isDbLockedByCurrentThread()).isFalse();
   }
+
+  @Test
+  public void testRawQueryWithFactoryAndCancellationSignal() throws Exception {
+    Cursor cursor = database.rawQueryWithFactory(null, "select * from table_name", null, null, null);
+    assertThat(cursor).isNotNull();
+    assertThat(cursor.getColumnCount()).isEqualTo(5);
+    assertThat(cursor.isClosed()).isFalse();
+  }
 }


### PR DESCRIPTION
Currently, the usage of SQLiteQueryBuilder causes an InstantationException because it calls `SQLiteDatabase#rawQueryWithFactory(CursorFactory, String, String[], String, CancellationSignal)` which is currently not implemented in ShadowSQLiteDatabase. This pull requests adds the missing implementation.
