### PR TITLE
project.properties lookup improvements.

### DIFF
--- a/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -120,14 +120,14 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
     return new ShadowWrangler(shadowMap, sdkConfig);
   }
 
-  protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetsDir) {
+  protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetsDir, FsFile projectPropertiesFile) {
     if (!manifestFile.exists()) {
-      System.out.print("WARNING: No manifest file found at " + manifestFile.getPath() + ".");
+      System.out.print("WARNING: No manifest file found at " + manifestFile.getPath() + ". ");
       System.out.println("Falling back to the Android OS resources only.");
       System.out.println("To remove this warning, annotate your test class with @Config(manifest=Config.NONE).");
       return null;
     }
-    AndroidManifest manifest = new AndroidManifest(manifestFile, resDir, assetsDir);
+    AndroidManifest manifest = new AndroidManifest(manifestFile, resDir, assetsDir, projectPropertiesFile);
     String packageName = System.getProperty("android.package");
     manifest.setPackageName(packageName);
     return manifest;
@@ -311,16 +311,20 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
     FsFile manifestFile;
     FsFile resDir;
     FsFile assetsDir;
+    FsFile projectProperties;
 
     boolean defaultManifest = config.manifest().equals(Config.DEFAULT);
     if (defaultManifest && manifestProperty != null) {
       manifestFile = Fs.fileFromPath(manifestProperty);
       resDir = Fs.fileFromPath(resourcesProperty);
       assetsDir = Fs.fileFromPath(assetsProperty);
+      String projectPropertiesProperty = System.getProperty("android.project.properties");
+      projectProperties = projectPropertiesProperty == null ? manifestFile.getParent().join("project.properties") : Fs.fileFromPath(projectPropertiesProperty);
     } else {
       manifestFile = fsFile.join(defaultManifest ? "AndroidManifest.xml" : config.manifest());
       resDir = manifestFile.getParent().join("res");
       assetsDir = manifestFile.getParent().join("assets");
+      projectProperties = manifestFile.getParent().join("project.properties");
     }
 
     synchronized (envHolder) {
@@ -328,7 +332,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
       appManifest = envHolder.appManifestsByFile.get(manifestFile);
       if (appManifest == null) {
         long startTime = System.currentTimeMillis();
-        appManifest = createAppManifest(manifestFile, resDir, assetsDir);
+        appManifest = createAppManifest(manifestFile, resDir, assetsDir, projectProperties);
         if (DocumentLoader.DEBUG_PERF)
           System.out.println(String.format("%4dms spent in %s", System.currentTimeMillis() - startTime, manifestFile));
 

--- a/src/test/java/org/robolectric/AndroidManifestTest.java
+++ b/src/test/java/org/robolectric/AndroidManifestTest.java
@@ -7,12 +7,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.res.Fs;
-import org.robolectric.res.ResourcePath;
 import org.robolectric.test.TemporaryFolder;
+import org.robolectric.util.TestUtil;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -105,7 +104,7 @@ public class AndroidManifestTest {
     AndroidManifest appManifest = new AndroidManifest(resourceFile("TestAndroidManifest.xml"), resourceFile("res"));
 
     // This intentionally loads from the non standard resources/project.properties
-    List<String> resourcePaths = stringify(appManifest.getIncludedResourcePaths());
+    List<String> resourcePaths = TestUtil.stringify(appManifest.getIncludedResourcePaths());
     assertEquals(asList(
         joinPath(".", "src", "test", "resources", "res"),
         joinPath(".", "src", "test", "resources", "lib1", "res"),
@@ -113,6 +112,23 @@ public class AndroidManifestTest {
         joinPath(".", "src", "test", "resources", "lib2", "res")),
         resourcePaths);
   }
+
+    @Test public void shouldLoadAllResourcesForExisingLibrariesWithGivenCustomProjectProperties() {
+      AndroidManifest appManifest = new AndroidManifest(
+          resourceFile("mavenapp/AndroidManifest.xml"),
+          resourceFile("mavenapp/src/main/resources"),
+          resourceFile("mavenapp/src/main/assets"),
+          resourceFile("mavenapp/project.properties")
+      );
+
+      // This intentionally loads from the non standard resources/project.properties
+      List<String> resourcePaths = TestUtil.stringify(appManifest.getIncludedResourcePaths());
+      assertEquals(asList(
+          joinPath("./src/test/resources/mavenapp/src/main/resources"),
+          joinPath("./src/test/resources/mavenapp/../lib1/res"),
+          joinPath("./src/test/resources/mavenapp/../lib1/../lib3/res")),
+          resourcePaths);
+    }
 
   @Test
   public void shouldTolerateMissingRFile() throws Exception {
@@ -132,14 +148,6 @@ public class AndroidManifestTest {
             "    <uses-sdk " + usesSdkAttrs + "/>\n" +
             "</manifest>\n");
     return new AndroidManifest(Fs.newFile(f), null, null);
-  }
-
-  private List<String> stringify(List<ResourcePath> resourcePaths) {
-    List<String> resourcePathBases = new ArrayList<String>();
-    for (ResourcePath resourcePath : resourcePaths) {
-      resourcePathBases.add(resourcePath.resourceBase.toString());
-    }
-    return resourcePathBases;
   }
 
   @Test

--- a/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -17,6 +17,8 @@ import java.util.Properties;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.reflect.core.Reflection.method;
+import static org.robolectric.util.TestUtil.resourceFile;
+
 
 public class RobolectricTestRunnerTest {
   @Test public void whenClassHasConfigAnnotation_getConfig_shouldMergeClassAndMethodConfig() throws Exception {

--- a/src/test/java/org/robolectric/RobolectricTestRunnerWithSystemPropertiesTest.java
+++ b/src/test/java/org/robolectric/RobolectricTestRunnerWithSystemPropertiesTest.java
@@ -1,0 +1,92 @@
+package org.robolectric;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.model.InitializationError;
+import org.robolectric.annotation.Config;
+import org.robolectric.res.FsFile;
+import org.robolectric.util.TestUtil;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.fest.reflect.core.Reflection.method;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeNotNull;
+import static org.robolectric.util.TestUtil.joinPath;
+import static org.robolectric.util.TestUtil.resourceFile;
+
+@RunWith(Parameterized.class)
+public class RobolectricTestRunnerWithSystemPropertiesTest {
+  private final Class<?> testClass;
+  private final String testMethod;
+  private final boolean expectValuesFromProperties;
+
+  private final static FsFile manifestFile = resourceFile("mavenapp/AndroidManifest.xml");
+  private final static FsFile resDir = resourceFile("mavenapp/src/main/resources");
+  private final static FsFile assetsDir = resourceFile("mavenapp/src/main/assets");
+  private final static FsFile projectPropertiesFile = resourceFile("mavenapp/project.properties");
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        {RobolectricTestRunnerTest.Test1.class, "withoutAnnotation", true},
+        {RobolectricTestRunnerTest.Test1.class, "withDefaultsAnnotation", true},
+        {RobolectricTestRunnerTest.Test1.class, "withOverrideAnnotation", false},
+        {RobolectricTestRunnerTest.Test2.class, "withoutAnnotation", true},
+        {RobolectricTestRunnerTest.Test2.class, "withDefaultsAnnotation", true},
+        {RobolectricTestRunnerTest.Test2.class, "withOverrideAnnotation", false},
+    });
+  }
+
+  public RobolectricTestRunnerWithSystemPropertiesTest(Class<?> testClass, String testMethod, boolean propValues) {
+    this.testClass = testClass;
+    this.testMethod = testMethod;
+    this.expectValuesFromProperties = propValues;
+  }
+
+  @Before
+  public void setUp() {
+    System.setProperty("android.manifest", manifestFile.getPath());
+    System.setProperty("android.resources", resDir.getPath());
+    System.setProperty("android.assets", assetsDir.getPath());
+    System.setProperty("android.project.properties", projectPropertiesFile.getPath());
+  }
+
+  @After
+  public void tearDown() {
+    System.clearProperty("android.manifest");
+    System.clearProperty("android.resources");
+    System.clearProperty("android.assets");
+    System.clearProperty("android.project.properties");
+  }
+
+  @Test
+  public void shouldReadManifestPropertiesFromSystemPropertiesIfTheyAreSet() throws InitializationError {
+    RobolectricTestRunner testRunner = new RobolectricTestRunner(testClass);
+    Config config = testRunner.getConfig(method(testMethod).withParameterTypes().in(testClass).info());
+    AndroidManifest manifest = testRunner.getAppManifest(config);
+
+    // skip test if there is no manifest beneath
+    assumeNotNull(manifest);
+
+    assertEquals(expectValuesFromProperties, manifest.getResDirectory().equals(resDir));
+    assertEquals(expectValuesFromProperties, manifest.getAssetsDirectory().equals(assetsDir));
+    assertEquals(expectValuesFromProperties, manifest.getApplicationName().equals("MavenApp"));
+    if (expectValuesFromProperties) {
+      TestUtil.assertEquals(
+          asList(
+              joinPath("./src/test/resources/mavenapp/src/main/resources"),
+              joinPath("./src/test/resources/mavenapp/../lib1/res"),
+              joinPath("./src/test/resources/mavenapp/../lib1/../lib3/res")
+          ),
+          TestUtil.stringify(manifest.getIncludedResourcePaths())
+      );
+    }
+  }
+}

--- a/src/test/java/org/robolectric/TestRunnerSequenceTest.java
+++ b/src/test/java/org/robolectric/TestRunnerSequenceTest.java
@@ -45,7 +45,7 @@ public class TestRunnerSequenceTest {
   @Test public void whenNoAppManifest_shouldRunThingsInTheRightOrder() throws Exception {
     StateHolder.transcript = new Transcript();
     assertNoFailures(run(new Runner(SimpleTest.class) {
-      @Override protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetsDir) {
+      @Override protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetsDir, FsFile projectPropertiesFile) {
         return null;
       }
     }));
@@ -107,8 +107,8 @@ public class TestRunnerSequenceTest {
     }
 
     @Override
-    protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetsDir) {
-      return new AndroidManifest(resourceFile("TestAndroidManifest.xml"), resourceFile("res"), resourceFile("assets"));
+    protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetsDir, FsFile projectPropertiesFile) {
+      return new AndroidManifest(resourceFile("TestAndroidManifest.xml"), resourceFile("res"), resourceFile("assets"), resourceFile("project.properties"));
     }
 
     @Override protected Class<? extends TestLifecycle> getTestLifecycleClass() {

--- a/src/test/java/org/robolectric/TestRunners.java
+++ b/src/test/java/org/robolectric/TestRunners.java
@@ -25,8 +25,8 @@ public class TestRunners {
     }
 
     @Override
-    protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetsDir) {
-      return new AndroidManifest(resourceFile("TestAndroidManifest.xml"), resourceFile("res"), resourceFile("assets"));
+    protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetsDir, FsFile projectPropertiesFile) {
+      return new AndroidManifest(resourceFile("TestAndroidManifest.xml"), resourceFile("res"), resourceFile("assets"), resourceFile("project.properties"));
     }
 
     @Override
@@ -57,7 +57,7 @@ public class TestRunners {
           .build();
     }
 
-    @Override protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetsDir) {
+    @Override protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetsDir, FsFile projectPropertiesFile) {
       return null;
     }
 
@@ -84,8 +84,8 @@ public class TestRunners {
     }
 
     @Override
-    protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetsDir) {
-      return new AndroidManifest(resourceFile("TestAndroidManifest.xml"), resourceFile("res"), resourceFile("assets"));
+    protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetsDir, FsFile projectPropertiesFile) {
+      return new AndroidManifest(resourceFile("TestAndroidManifest.xml"), resourceFile("res"), resourceFile("assets"), resourceFile("project.properties"));
     }
   }
 

--- a/src/test/java/org/robolectric/util/TestUtil.java
+++ b/src/test/java/org/robolectric/util/TestUtil.java
@@ -22,7 +22,9 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 
@@ -150,5 +152,13 @@ public abstract class TestUtil {
 
   public static Resources emptyResources() {
     return ShadowResources.createFor(new EmptyResourceLoader());
+  }
+
+  public static List<String> stringify(List<ResourcePath> resourcePaths) {
+    List<String> resourcePathBases = new ArrayList<String>();
+    for (ResourcePath resourcePath : resourcePaths) {
+      resourcePathBases.add(resourcePath.resourceBase.toString());
+    }
+    return resourcePathBases;
   }
 }

--- a/src/test/resources/mavenapp/AndroidManifest.xml
+++ b/src/test/resources/mavenapp/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      package="org.robolectric.mavenapp">
+  <uses-sdk android:targetSdkVersion="16"/>
+
+    <application android:name="MavenApp">
+        <activity android:name="org.robolectric.shadows.TestActivity"/>
+
+        <activity android:name=".shadows.TestActivity2"/>
+    </application>
+</manifest>

--- a/src/test/resources/mavenapp/project.properties
+++ b/src/test/resources/mavenapp/project.properties
@@ -1,0 +1,6 @@
+# This is for RoboelectricTestRunnerTest to ensure that we parse and include
+# library references in project with mavenized layout
+
+# Project target.
+target=android-16
+android.library.reference.1=../lib1

--- a/src/test/resources/mavenapp/src/main/resources/raw/raw_resource.txt
+++ b/src/test/resources/mavenapp/src/main/resources/raw/raw_resource.txt
@@ -1,0 +1,1 @@
+raw txt file contents


### PR DESCRIPTION
Uses android.project.properties property to find file, or falls backs to use manifest path.

This change is to fix #820. I tested it with my project, and it works well if I'm supplying android.project.properties value as well as if I'm don't supplying it, but have AndroidManifest.xml in project root which usually default location for both AndroidManifest.xml and project.properties.
