### PR TITLE
Allow setting display dimensions via @Config

### DIFF
--- a/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -42,6 +42,7 @@ import org.robolectric.res.PackageResourceLoader;
 import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.ResourcePath;
 import org.robolectric.res.RoutingResourceLoader;
+import org.robolectric.shadows.ShadowDisplay;
 import org.robolectric.util.AnnotationUtil;
 import org.robolectric.util.DatabaseConfig.DatabaseMap;
 import org.robolectric.util.DatabaseConfig.UsingDatabaseMap;
@@ -216,6 +217,13 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
           staticField("SDK_INT").ofType(int.class).in(versionClass).set(sdkVersion);
 
           ResourceLoader systemResourceLoader = sdkEnvironment.getSystemResourceLoader(MAVEN_CENTRAL, RobolectricTestRunner.this);
+
+          Class<?> displayShadowClass = sdkEnvironment.bootstrappedClass(ShadowDisplay.class);
+          int screenWidth = pickScreenWidth(config);
+          staticField("initialWidth").ofType(int.class).in(displayShadowClass).set(screenWidth);
+          int screenHeight = pickScreenHeight(config);
+          staticField("initialHeight").ofType(int.class).in(displayShadowClass).set(screenHeight);
+
           setUpApplicationState(bootstrappedMethod, parallelUniverseInterface, strictI18n, systemResourceLoader, appManifest, config);
           testLifecycle.beforeTest(bootstrappedMethod);
         } catch (Exception e) {
@@ -295,6 +303,21 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
     }
   }
 
+  protected int pickScreenWidth(Config config) {
+    if (config.screenWidth()!=-1) {
+      return config.screenWidth(); 
+    } else {
+      return ShadowDisplay.DEFAULT_WIDTH;
+    }
+  }
+
+  protected int pickScreenHeight(Config config) {
+    if (config.screenHeight()!=-1) {
+      return config.screenHeight(); 
+    } else {
+      return ShadowDisplay.DEFAULT_HEIGHT;
+    }
+  }
   protected AndroidManifest getAppManifest(Config config) {
     if (config.manifest().equals(Config.NONE)) {
       return null;

--- a/src/main/java/org/robolectric/annotation/Config.java
+++ b/src/main/java/org/robolectric/annotation/Config.java
@@ -53,6 +53,9 @@ public @interface Config {
    */
   int reportSdk() default -1;
 
+  int screenWidth() default -1;
+  int screenHeight() default -1;
+  
   /**
    * A list of shadow classes to enable, in addition to those that are already present.
    */
@@ -63,6 +66,8 @@ public @interface Config {
     private final String manifest;
     private final String qualifiers;
     private final int reportSdk;
+    private final int screenWidth;
+    private final int screenHeight;
     private final Class<?>[] shadows;
 
     public static Config fromProperties(Properties configProperties) {
@@ -72,6 +77,8 @@ public @interface Config {
           configProperties.getProperty("manifest", DEFAULT),
           configProperties.getProperty("qualifiers", ""),
           Integer.parseInt(configProperties.getProperty("reportSdk", "-1")),
+          Integer.parseInt(configProperties.getProperty("screenWidth", "-1")),
+          Integer.parseInt(configProperties.getProperty("screenHeight", "-1")),
           parseClasses(configProperties.getProperty("shadows", ""))
       );
     }
@@ -90,11 +97,14 @@ public @interface Config {
       return classes;
     }
 
-    public Implementation(int emulateSdk, String manifest, String qualifiers, int reportSdk, Class<?>[] shadows) {
+    public Implementation(int emulateSdk, String manifest, String qualifiers, int reportSdk, 
+        int screenWidth, int screenHeight, Class<?>[] shadows) {
       this.emulateSdk = emulateSdk;
       this.manifest = manifest;
       this.qualifiers = qualifiers;
       this.reportSdk = reportSdk;
+      this.screenWidth = screenWidth;
+      this.screenHeight = screenHeight;
       this.shadows = shadows;
     }
 
@@ -103,6 +113,8 @@ public @interface Config {
       this.manifest = pick(baseConfig.manifest(), overlayConfig.manifest(), DEFAULT);
       this.qualifiers = pick(baseConfig.qualifiers(), overlayConfig.qualifiers(), "");
       this.reportSdk = pick(baseConfig.reportSdk(), overlayConfig.reportSdk(), -1);
+      this.screenWidth = pick(baseConfig.screenWidth(), overlayConfig.screenWidth(), -1);
+      this.screenHeight = pick(baseConfig.screenHeight(), overlayConfig.screenHeight(), -1);
       ArrayList<Class<?>> shadows = new ArrayList<Class<?>>();
       shadows.addAll(Arrays.asList(baseConfig.shadows()));
       shadows.addAll(Arrays.asList(overlayConfig.shadows()));
@@ -128,7 +140,12 @@ public @interface Config {
     @Override public int reportSdk() {
       return reportSdk;
     }
-
+    @Override public int screenWidth() {
+      return screenWidth;
+    }
+    @Override public int screenHeight() {
+      return screenHeight;
+    }
     @Override public Class<?>[] shadows() {
       return shadows;
     }
@@ -146,6 +163,8 @@ public @interface Config {
 
       if (emulateSdk != other.emulateSdk) return false;
       if (reportSdk != other.reportSdk) return false;
+      if (screenWidth != other.screenWidth) return false;
+      if (screenHeight != other.screenHeight) return false;
       if (!qualifiers.equals(other.qualifiers)) return false;
       if (!Arrays.equals(shadows, other.shadows)) return false;
 
@@ -157,6 +176,8 @@ public @interface Config {
       int result = emulateSdk;
       result = 31 * result + qualifiers.hashCode();
       result = 31 * result + reportSdk;
+      result = 31 * result + screenWidth;
+      result = 31 * result + screenHeight;
       result = 31 * result + Arrays.hashCode(shadows);
       return result;
     }

--- a/src/main/java/org/robolectric/shadows/ShadowDisplay.java
+++ b/src/main/java/org/robolectric/shadows/ShadowDisplay.java
@@ -15,9 +15,15 @@ import org.robolectric.annotation.Implements;
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Display.class)
 public class ShadowDisplay {
+  public static final int DEFAULT_WIDTH = 480;
+  public static final int DEFAULT_HEIGHT = 800;
+  
+  public static int initialWidth = DEFAULT_WIDTH; 
+  public static int initialHeight = DEFAULT_HEIGHT; 
+
   private int displayId;
-  private int width = 480;
-  private int height = 800;
+  private int width = initialWidth;
+  private int height = initialHeight;
   private float density = 1.5f;
   private int densityDpi = DisplayMetrics.DENSITY_HIGH;
   private float xdpi = 240.0f;

--- a/src/test/java/org/robolectric/shadows/DisplayTest.java
+++ b/src/test/java/org/robolectric/shadows/DisplayTest.java
@@ -1,12 +1,15 @@
 package org.robolectric.shadows;
 
+import android.app.Activity;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.util.DisplayMetrics;
 import android.view.Display;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.robolectric.Robolectric.newInstanceOf;
@@ -80,5 +83,30 @@ public class DisplayTest {
     shadowOf(display).setRotation(testValue);
     assertEquals(testValue, display.getOrientation());
   }
+  
+  @Test
+  public void defaultDisplaySize() {
+    Display display = newInstanceOf(Display.class);
+    assertEquals(480,display.getWidth());  
+    assertEquals(800,display.getHeight());  
+  }
 
+  @Test
+  @Config(screenWidth=1280,screenHeight=800)
+  public void setDefaultDisplaySizeUsingAnnotations() {
+    Display display = newInstanceOf(Display.class);
+    assertEquals(1280,display.getWidth());  
+    assertEquals(800,display.getHeight());  
+  }
+
+  @Test
+  @Config(screenWidth=1280,screenHeight=800)
+  public void activityGetsAnnotatedDisplaySize() {
+    Activity dummyActivity = Robolectric.buildActivity(Activity.class)
+      .create()
+      .get();
+    Display display = dummyActivity.getWindowManager().getDefaultDisplay();
+    assertEquals(1280,display.getWidth());  
+    assertEquals(800,display.getHeight());  
+  }
 }


### PR DESCRIPTION
It's useful to be able to set the screen size that is returned to activities via WindowManager.getDefaultDisplay for testing screen-size dependent code.  As per issue #605 this isn't possible using Robolectric.setDefaultDisplay because that method doesn't pass the provided display to WindowManager.getDefaultDisplay.  

Instead this adds two options to @Config: screenWidth and screenHeight.  

I'm not sure if this is a good overall approach, since there are other screen parameters that you might conceivably want to set (density, dpi, etc), and adding all of them as separate config keywords might make things cluttered?  

Also the way I've implemented it means that RobolectricTestRunner has a dependency on ShadowDisplay, not sure if that is a good idea.
