### PR TITLE
Add support for AlarmManager.setExact()

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowAlarmManager.java
+++ b/src/main/java/org/robolectric/shadows/ShadowAlarmManager.java
@@ -24,6 +24,11 @@ public class ShadowAlarmManager {
   public void set(int type, long triggerAtTime, PendingIntent operation) {
     internalSet(type, triggerAtTime, 0L, operation);
   }
+  
+  @Implementation
+  public void setExact(int type, long triggerAtTime, PendingIntent operation) {
+    internalSet(type, triggerAtTime, 0L, operation);
+  }
 
   @Implementation
   public void setRepeating(int type, long triggerAtTime, long interval, PendingIntent operation) {

--- a/src/test/java/org/robolectric/shadows/AlarmManagerTest.java
+++ b/src/test/java/org/robolectric/shadows/AlarmManagerTest.java
@@ -45,6 +45,15 @@ public class AlarmManagerTest {
     assertThat(scheduledAlarm).isNotNull();
   }
 
+  @Test @Config(emulateSdk = Build.VERSION_CODES.KITKAT)
+  public void shouldSupportSetExact_forApiLevel19() throws Exception {
+	  assertThat(shadowAlarmManager.getNextScheduledAlarm()).isNull();
+	  alarmManager.setExact(AlarmManager.ELAPSED_REALTIME, 0, PendingIntent.getActivity(activity, 0, new Intent(activity, activity.getClass()), 0));
+	  
+	  ShadowAlarmManager.ScheduledAlarm scheduledAlarm = shadowAlarmManager.getNextScheduledAlarm();
+	  assertThat(scheduledAlarm).isNotNull();
+  }
+
   @Test
   public void shouldSupportSetRepeating() throws Exception {
     assertThat(shadowAlarmManager.getNextScheduledAlarm()).isNull();
@@ -54,12 +63,14 @@ public class AlarmManagerTest {
     ShadowAlarmManager.ScheduledAlarm scheduledAlarm = shadowAlarmManager.getNextScheduledAlarm();
     assertThat(scheduledAlarm).isNotNull();
   }
+  
   @Test
   public void setShouldReplaceDuplicates() {
     alarmManager.set(AlarmManager.ELAPSED_REALTIME, 0, PendingIntent.getActivity(activity, 0, new Intent(activity, activity.getClass()), 0));
     alarmManager.set(AlarmManager.ELAPSED_REALTIME, 0, PendingIntent.getActivity(activity, 0, new Intent(activity, activity.getClass()), 0));
     assertEquals(1, shadowAlarmManager.getScheduledAlarms().size());
   }
+  
   @Test
   public void setRepeatingShouldReplaceDuplicates() {
     alarmManager.setRepeating(AlarmManager.ELAPSED_REALTIME, 0, AlarmManager.INTERVAL_HOUR, PendingIntent.getActivity(activity, 0, new Intent(activity, activity.getClass()), 0));


### PR DESCRIPTION
Beginning with API Level 19 (KITKAT) alarm delivery is inexact.

A new method has been added to the **AlarmManager**:
[setExact(int, long, PendingIntent)](http://developer.android.com/reference/android/app/AlarmManager.html#setExact(int, long, android.app.PendingIntent))
