### PR TITLE
Add android:label support

### DIFF
--- a/src/main/java/org/robolectric/AndroidManifest.java
+++ b/src/main/java/org/robolectric/AndroidManifest.java
@@ -45,6 +45,7 @@ public class AndroidManifest {
   private boolean manifestIsParsed;
 
   private String applicationName;
+  private String applicationLabel;
   private String rClassName;
   private String packageName;
   private String processName;
@@ -142,6 +143,7 @@ public class AndroidManifest {
       versionName = getTagAttributeText(manifestDocument, "manifest", "android:versionName");
       rClassName = packageName + ".R";
       applicationName = getTagAttributeText(manifestDocument, "application", "android:name");
+      applicationLabel = getTagAttributeText(manifestDocument, "application", "android:label");
       minSdkVersion = getTagAttributeIntValue(manifestDocument, "uses-sdk", "android:minSdkVersion");
       targetSdkVersion = getTagAttributeIntValue(manifestDocument, "uses-sdk", "android:targetSdkVersion");
       processName = getTagAttributeText(manifestDocument, "application", "android:process");
@@ -191,10 +193,14 @@ public class AndroidManifest {
       NamedNodeMap attributes = activityNode.getAttributes();
       Node nameAttr = attributes.getNamedItem("android:name");
       Node themeAttr = attributes.getNamedItem("android:theme");
+      Node labelAttr = attributes.getNamedItem("android:label");
       if (nameAttr == null) continue;
       String activityName = nameAttr.getNodeValue();
+      if(activityName.startsWith(".")) activityName = packageName + activityName;
+
       activityDatas.put(activityName,
           new ActivityData(activityName,
+              labelAttr == null ? null : labelAttr.getNodeValue(),
               themeAttr == null ? null : resolveClassRef(themeAttr.getNodeValue())
           ));
     }
@@ -267,6 +273,12 @@ public class AndroidManifest {
   public String getApplicationName() {
     parseAndroidManifest();
     return applicationName;
+  }
+
+  public String getActivityLabel(Class<? extends Activity> activity) {
+    parseAndroidManifest();
+    ActivityData data = getActivityData(activity.getName());
+    return (data != null && data.getLabel() != null) ? data.getLabel() : applicationLabel;
   }
 
   public void setPackageName(String packageName) {

--- a/src/main/java/org/robolectric/res/ActivityData.java
+++ b/src/main/java/org/robolectric/res/ActivityData.java
@@ -2,15 +2,21 @@ package org.robolectric.res;
 
 public class ActivityData {
   private final String name;
+  private final String label;
   private final String themeRef;
 
-  public ActivityData(String name, String themeRef) {
+  public ActivityData(String name, String label, String themeRef) {
     this.name = name;
+    this.label = label;
     this.themeRef = themeRef;
   }
 
   public String getName() {
     return name;
+  }
+
+  public String getLabel() {
+    return label;
   }
 
   public String getThemeRef() {

--- a/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -63,7 +63,6 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   private int pendingTransitionExitAnimResId = -1;
   private Object lastNonConfigurationInstance;
   private Map<Integer, Dialog> dialogForId = new HashMap<Integer, Dialog>();
-  private CharSequence title;
   private boolean onKeyUpWasCalled;
   private ArrayList<Cursor> managedCusors = new ArrayList<Cursor>();
 
@@ -226,21 +225,6 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
 
   public int getDefaultKeymode() {
     return mDefaultKeyMode;
-  }
-
-  @Implementation(i18nSafe = false)
-  public void setTitle(CharSequence title) {
-    this.title = title;
-  }
-
-  @Implementation
-  public void setTitle(int titleId) {
-    this.title = this.getResources().getString(titleId);
-  }
-
-  @Implementation
-  public CharSequence getTitle() {
-    return title;
   }
 
   @Implementation

--- a/src/test/java/org/robolectric/R.java
+++ b/src/test/java/org/robolectric/R.java
@@ -118,6 +118,8 @@ public final class R {
     public static final int in_lib1_and_lib3 = 0x1010d;
     public static final int in_main_and_lib1 = 0x1010e;
     public static final int interpolate = 0x1010f;
+    public static final int app_name = 0x10110;
+    public static final int activity_name = 0x10111;
   }
 
   public static final class plurals {

--- a/src/test/java/org/robolectric/shadows/ActivityTest.java
+++ b/src/test/java/org/robolectric/shadows/ActivityTest.java
@@ -30,7 +30,7 @@ import org.robolectric.AndroidManifest;
 import org.robolectric.DefaultTestLifecycle;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
-import org.robolectric.TestRunners;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.res.Fs;
 import org.robolectric.shadows.testing.OnMethodTestActivity;
@@ -56,10 +56,39 @@ import static org.robolectric.Robolectric.application;
 import static org.robolectric.Robolectric.buildActivity;
 import static org.robolectric.Robolectric.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = "src/test/resources/TestAndroidManifest.xml")
 public class ActivityTest {
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private Activity activity;
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithLabels.xml")
+  public void shouldUseApplicationLabelFromManifestAsTitleForActivity() throws Exception {
+    activity = create(LabelTestActivity1.class);
+    assertThat(activity.getTitle()).isNotNull();
+    assertThat(activity.getTitle().toString()).isEqualTo(activity.getString(R.string.app_name));
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithLabels.xml")
+  public void shouldUseActivityLabelFromManifestAsTitleForActivity() throws Exception {
+    activity = create(LabelTestActivity2.class);
+    assertThat(activity.getTitle()).isNotNull();
+    assertThat(activity.getTitle().toString()).isEqualTo(activity.getString(R.string.activity_name));
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithLabels.xml")
+  public void shouldUseActivityLabelFromManifestAsTitleForActivityWithShortName() throws Exception {
+    activity = create(LabelTestActivity3.class);
+    assertThat(activity.getTitle()).isNotNull();
+    assertThat(activity.getTitle().toString()).isEqualTo(activity.getString(R.string.activity_name));
+  }
+
+  public static final class LabelTestActivity1 extends Activity {}
+  public static final class LabelTestActivity2 extends Activity {}
+  public static final class LabelTestActivity3 extends Activity {}
 
   @Test(expected = IllegalStateException.class)
   public void shouldComplainIfActivityIsDestroyedWithRegisteredBroadcastReceivers() throws Exception {

--- a/src/test/resources/TestAndroidManifestWithLabels.xml
+++ b/src/test/resources/TestAndroidManifestWithLabels.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="org.robolectric">
+    <uses-sdk android:targetSdkVersion="18"/>
+
+    <application android:label="@string/app_name">
+        <activity android:name="org.robolectric.shadows.ActivityTest$LabelTestActivity1" />
+        <activity android:name="org.robolectric.shadows.ActivityTest$LabelTestActivity2"
+                  android:label="@string/activity_name"/>
+        <activity android:name=".shadows.ActivityTest$LabelTestActivity3"
+                  android:label="@string/activity_name"/>
+    </application>
+</manifest>

--- a/src/test/resources/res/values/strings.xml
+++ b/src/test/resources/res/values/strings.xml
@@ -15,4 +15,6 @@
   <string name="ok">@string/ok2</string>
   <string name="ok2">ok yup!</string>
   <string name="interpolate">Here's a %s!</string>
+  <string name="app_name">Testing App</string>
+  <string name="activity_name">Testing App Activity</string>
 </resources>


### PR DESCRIPTION
`android:label` attribute wasn't being respected. Removed `ShadowActivity`'s unnecessary implementations of methods `getTitle()` and `setTitle(String)`. Added setting of an activity's title based on the activity's `android:label` attribute if it has one, or the application's `android:label` attribute if it has one. If neither are present, then the title will be set to null.

Also added support for short class names, i.e. starting with '.' to represent that the name starts with the package name set by the manifest element's `package` attribute.
