### PR TITLE
Fixed Resources#getQuantityString with Qualifiers

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -358,7 +358,7 @@ public class ShadowResources {
   }
 
   private String getQualifiers() {
-    return shadowOf(realResources.getConfiguration()).getQualifiers();
+    return shadowOf(realResources.getAssets()).getQualifiers();
   }
 
   @Implementation
@@ -374,7 +374,7 @@ public class ShadowResources {
     String string = plural.getString();
     ShadowAssetManager shadowAssetManager = shadowOf(realResources.getAssets());
     TypedResource typedResource = shadowAssetManager.resolve(
-        new TypedResource(string, ResType.CHAR_SEQUENCE), getQualifiers(),
+        new TypedResource<String>(string, ResType.CHAR_SEQUENCE), getQualifiers(),
         new ResName(resName.packageName, "string", resName.name));
     return typedResource == null ? null : typedResource.asString();
   }

--- a/src/test/java/org/robolectric/QualifiersTest.java
+++ b/src/test/java/org/robolectric/QualifiersTest.java
@@ -19,4 +19,9 @@ public class QualifiersTest {
   @Test public void shouldGetFromMethod() throws Exception {
     assertThat(shadowOf(application.getAssets()).getQualifiers()).isEqualTo("fr");
   }
+
+  @Config(qualifiers = "de")
+  @Test public void getQuantityString() throws Exception {
+    assertThat(application.getResources().getQuantityString(R.plurals.minute, 2)).isEqualTo(application.getResources().getString(R.string.minute_plural));
+  }
 }

--- a/src/test/java/org/robolectric/R.java
+++ b/src/test/java/org/robolectric/R.java
@@ -120,10 +120,13 @@ public final class R {
     public static final int interpolate = 0x1010f;
     public static final int app_name = 0x10110;
     public static final int activity_name = 0x10111;
+    public static final int minute_singular = 0x10112;
+    public static final int minute_plural = 0x10113;
   }
 
   public static final class plurals {
     public static final int beer = 0x10200;
+    public static final int minute = 0x10201;
   }
 
   public static final class array {

--- a/src/test/java/org/robolectric/res/DrawableResourceLoaderTest.java
+++ b/src/test/java/org/robolectric/res/DrawableResourceLoaderTest.java
@@ -35,7 +35,6 @@ import static org.robolectric.util.TestUtil.testResources;
 public class DrawableResourceLoaderTest {
   protected DrawableResourceLoader drawableResourceLoader;
   private ResBundle<DrawableNode> drawableNodes;
-  private ResourceIndex resourceIndex;
   private Resources resources;
 
   @Before
@@ -46,9 +45,6 @@ public class DrawableResourceLoaderTest {
     new DocumentLoader(testResources()).load("anim", drawableResourceLoader);
     new DocumentLoader(systemResources()).load("drawable", drawableResourceLoader);
 
-    resourceIndex = new MergedResourceIndex(
-        new ResourceExtractor(testResources()),
-        new ResourceExtractor(getClass().getClassLoader()));
     drawableResourceLoader.findDrawableResources(testResources());
     drawableResourceLoader.findDrawableResources(systemResources());
     resources = Robolectric.application.getResources();
@@ -63,7 +59,7 @@ public class DrawableResourceLoaderTest {
     drawableResourceLoader.findDrawableResources(testResources());
 
     assertNotNull(drawableNodes.get(new ResName(TEST_PACKAGE, "drawable", "rainbow"), ""));
-    assertEquals(28, drawableNodes.size());
+    assertEquals(29, drawableNodes.size());
   }
 
   @Test

--- a/src/test/resources/res/values-de/strings.xml
+++ b/src/test/resources/res/values-de/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="minute_singular">Minute</string>
+  <string name="minute_plural">Minuten</string>
+</resources>

--- a/src/test/resources/res/values/plurals.xml
+++ b/src/test/resources/res/values/plurals.xml
@@ -6,4 +6,8 @@
     <item quantity="two">Two beers</item>
     <item quantity="other">%d beers, yay!</item>
   </plurals>
+  <plurals name="minute">
+    <item quantity="one">@string/minute_singular</item>
+    <item quantity="other">@string/minute_plural</item>
+  </plurals>
 </resources>

--- a/src/test/resources/res/values/strings.xml
+++ b/src/test/resources/res/values/strings.xml
@@ -17,4 +17,6 @@
   <string name="interpolate">Here's a %s!</string>
   <string name="app_name">Testing App</string>
   <string name="activity_name">Testing App Activity</string>
+  <string name="minute_singular">minute</string>
+  <string name="minute_plural">minutes</string>
 </resources>


### PR DESCRIPTION
Use `Resources#getAssets` (`ShadowAssetManager`) instead of `Resources#getConfiguration` (`ShadowConfiguration`) for getting the current qualifiers. Fixes #779
