### PR TITLE
Reimplement ShadowCookieManager with org.apache.http.client.CookieStore

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowCookieManager.java
+++ b/src/main/java/org/robolectric/shadows/ShadowCookieManager.java
@@ -1,22 +1,38 @@
 package org.robolectric.shadows;
 
-import android.webkit.CookieManager;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.http.client.CookieStore;
+import org.apache.http.cookie.Cookie;
+import org.apache.http.cookie.CookieOrigin;
+import org.apache.http.cookie.CookieSpec;
+import org.apache.http.cookie.MalformedCookieException;
+import org.apache.http.cookie.SM;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.cookie.BestMatchSpec;
+import org.apache.http.message.BasicHeader;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
-import java.util.HashMap;
-import java.util.Map;
+import android.webkit.CookieManager;
 
 /**
  * Shadows the {@code android.webkit.CookieManager} class.
  */
-@SuppressWarnings({"UnusedDeclaration"})
 @Implements(CookieManager.class)
 public class ShadowCookieManager {
+  private static final String HTTP = "http://";
+  private static final String HTTPS = "https://";
+  private static final String[] COOKIE_ATTRS_NOT_STRICT = {"Expires", "expires"};
   private static CookieManager sRef;
-  private Map<String,String> cookies = new HashMap<String, String>();
+  private CookieStore store = new BasicCookieStore();
   private boolean accept;
+  private static final List<Cookie> emtpyCookieList = new ArrayList<Cookie>();
 
   @Implementation
   public static CookieManager getInstance() {
@@ -28,12 +44,50 @@ public class ShadowCookieManager {
 
   @Implementation
   public void setCookie(String url, String value) {
-    cookies.put(url, value);
+    List<Cookie> cookies = parseCookies(url, value);
+    for(Cookie cookie : cookies) {
+      store.addCookie(cookie);
+    }
   }
 
   @Implementation
   public String getCookie(String url) {
-    return cookies.get(url);
+    CookieOrigin origin = getOrigin(url);
+    List<Cookie> matchedCookies = filter(origin);
+    if (matchedCookies.isEmpty()) {
+      return null;
+    }
+
+    StringBuffer cookieHeaderValue = new StringBuffer();
+    for (int i=0, n= matchedCookies.size(); i<n ; i++) {
+      Cookie cookie = matchedCookies.get(i);
+
+      if (i > 0) {
+        cookieHeaderValue.append("; ");
+      }
+      cookieHeaderValue.append(cookie.getName());
+      String value = cookie.getValue();
+      if (value != null) {
+        cookieHeaderValue.append("=");
+        cookieHeaderValue.append(value);
+      }
+    }
+
+    return cookieHeaderValue.toString();
+  }
+
+  private List<Cookie> filter(CookieOrigin origin) {
+    List<Cookie> matchedCookies = new ArrayList<Cookie>();
+    Date now = new Date();
+    CookieSpec cookieSpec = createSpec();
+    for (Cookie cookie : store.getCookies()) {
+        if (!cookie.isExpired(now)) {
+            if (cookieSpec.match(cookie, origin)) {
+                matchedCookies.add(cookie);
+            }
+        }
+    }
+    return matchedCookies;
   }
 
   @Implementation
@@ -48,6 +102,74 @@ public class ShadowCookieManager {
 
   @Implementation
   public void removeAllCookie() {
-    cookies.clear();
+    store.clear();
+  }
+  
+  @Implementation
+  public void removeExpiredCookie() {
+    store.clearExpired(new Date());
+  }
+
+  @Implementation
+  public boolean hasCookies() {
+    return !store.getCookies().isEmpty();
+  }
+
+  @Implementation
+  public void removeSessionCookie() {
+    synchronized(store){
+      clearAndAddPersistentCookies();
+    }
+  }
+
+  private void clearAndAddPersistentCookies() {
+    List<Cookie> cookies = new ArrayList<Cookie>(store.getCookies());
+    store.clear();
+    for(Cookie cookie : cookies) {
+      if(cookie.isPersistent()){
+        store.addCookie(cookie);
+      }
+    }
+  }
+
+  private List<Cookie> parseCookies(String url, String cookieHeader) {
+      CookieOrigin origin = getOrigin(url);
+      BasicHeader header = new BasicHeader(SM.SET_COOKIE, cookieHeader);
+      int attrIndex = 0;
+      do {
+        try {
+          CookieSpec cookieSpec = createSpec();
+          return cookieSpec.parse(header, origin);
+        } catch (MalformedCookieException e) {
+          int indexOfAttrTitle = cookieHeader.indexOf(COOKIE_ATTRS_NOT_STRICT[attrIndex]);
+          if (indexOfAttrTitle != -1) {
+            cookieHeader = cookieHeader.substring(0,indexOfAttrTitle);
+            header = new BasicHeader(SM.SET_COOKIE, cookieHeader);
+          }
+          attrIndex++;
+        }
+      } while (attrIndex <= COOKIE_ATTRS_NOT_STRICT.length);
+      return emtpyCookieList;
+  }
+
+  private CookieSpec createSpec() {
+    return new BestMatchSpec();
+  }
+
+  private CookieOrigin getOrigin(String url) {
+    if ( !(url.startsWith(HTTP) || url.startsWith(HTTPS)) ) {
+      url = HTTP + url;
+    }
+    URI uri = null;
+    try {
+      uri = new URI(url);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("wrong URL :" + url, e);
+    }
+
+    int port = (uri.getPort() < 0) ? 80 : uri.getPort();
+    boolean secure = "https".equals(uri.getScheme());
+    CookieOrigin origin = new CookieOrigin(uri.getHost(), port, uri.getPath(),  secure);
+    return origin;
   }
 }

--- a/src/test/java/org/robolectric/shadows/CookieManagerTest.java
+++ b/src/test/java/org/robolectric/shadows/CookieManagerTest.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import android.webkit.CookieManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.TestRunners;
 
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -11,7 +12,11 @@ import static org.junit.Assert.assertNull;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class CookieManagerTest {
-
+  String url = "robolectric.org/";
+  String httpUrl = "http://robolectric.org/";
+  String httpsUrl = "https://robolectric.org/";
+  CookieManager cookieManager = Robolectric.newInstanceOf(CookieManager.class);;
+  
   @Test
   public void shouldGetASingletonInstance() {
     assertNotNull(CookieManager.getInstance());
@@ -51,6 +56,103 @@ public class CookieManagerTest {
     cookieManager.removeAllCookie();
     assertNull(cookieManager.getCookie("foo"));
     assertNull(cookieManager.getCookie("baz"));
+  }
+  
+  @Test
+  public void shouldHaveCookieWhenCookieIsSet() {
+    cookieManager.setCookie(url, "name=value; Expires=Wed, 09 Jun 2021 10:18:14 GMT");
+    assertThat(cookieManager.hasCookies()).isEqualTo(true);
+  }
+
+  @Test
+  public void shouldNotHaveCookieWhenCookieIsNotSet() {
+    assertThat(cookieManager.hasCookies()).isEqualTo(false);
+  }
+
+  @Test
+  public void shouldGetNullWhenCookieIsNotPresent() {
+    assertThat(cookieManager.getCookie(url)).isNull();
+  }
+
+  @Test
+  public void shouldGetNullWhenCookieIsNotPresentInUrl() {
+    cookieManager.setCookie(httpUrl, "name=value; Expires=Wed, 11 Jul 2035 08:12:26 GMT");
+    assertThat(cookieManager.getCookie("http://google.com")).isNull();
+  }
+ 
+  @Test
+  public void shouldSetAndGetOneCookie() {
+    cookieManager.setCookie(httpUrl, "name=value; Expires=Wed, 11 Jul 2035 08:12:26 GMT");
+    assertThat(cookieManager.getCookie(httpUrl)).isEqualTo("name=value");
+  }
+
+  @Test
+  public void shouldSetWithHttpAndGetWithoutHttp() {
+    cookieManager.setCookie(httpUrl, "name=value; Expires=Wed, 11 Jul 2035 08:12:26 GMT");
+    assertThat(cookieManager.getCookie(url)).isEqualTo("name=value");
+  }
+
+  @Test
+  public void shouldSetWithHttpAndGetWithHttps() {
+    cookieManager.setCookie(httpUrl, "name=value; Expires=Wed, 11 Jul 2035 08:12:26 GMT");
+    assertThat(cookieManager.getCookie(httpsUrl)).isEqualTo("name=value");
+  }
+
+  @Test
+  public void shouldSetTwoCookies() {
+    cookieManager.setCookie(url, "name=value; Expires=Wed, 09 Jun 2021 10:18:14 GMT");
+    cookieManager.setCookie(url, "name2=value2; Expires=Wed, 09 Jun 2021 10:18:14 GMT");
+    assertThat(cookieManager.getCookie(url)).isEqualTo("name=value; name2=value2");
+  }
+
+  @Test
+  public void shouldSetCookieWithInvalidExpiesValue() {
+    cookieManager.setCookie(httpUrl, "name=value; Expires=3234asdfasdf10:18:14 GMT");
+    assertThat(cookieManager.getCookie(url)).isEqualTo("name=value");
+  }
+
+  @Test
+  public void shouldSetCookieWithoutValue() {
+    cookieManager.setCookie(httpUrl, "name=");
+    assertThat(cookieManager.getCookie(url)).isEqualTo("name=");
+  }
+  
+  @Test
+  public void shouldSetCookieWithNameOnly() {
+    cookieManager.setCookie(httpUrl, "name");
+    assertThat(cookieManager.getCookie(url)).isEqualTo("name");
+  }
+
+  @Test
+  public void testSetAndGetCookieWhenAcceptCookieIsFalse() {
+    cookieManager.setAcceptCookie(false);
+    cookieManager.setCookie(httpUrl, "name=value; Expires=3234asdfasdf10:18:14 GMT");
+    assertThat(cookieManager.getCookie(url)).isEqualTo("name=value");
+    assertThat(cookieManager.acceptCookie()).isEqualTo(false);
+  }
+
+  @Test
+  public void shouldRemoveAllCookie() {
+    cookieManager.setCookie(url, "name=value; Expires=Wed, 09 Jun 2021 10:18:14 GMT");
+    cookieManager.setCookie(url, "name2=value2;");
+    cookieManager.removeAllCookie();
+    assertThat(cookieManager.getCookie(url)).isNull();
+  }
+
+  @Test
+  public void shouldRemoveExpiredCookie() {
+    cookieManager.setCookie(url, "name=value; Expires=Wed, 11 Jul 2035 10:18:14 GMT");
+    cookieManager.setCookie(url, "name2=value2; Expires=Wed, 13 Jul 2011 10:18:14 GMT");
+    cookieManager.removeExpiredCookie();
+    assertThat(cookieManager.getCookie(url)).isEqualTo("name=value");
+  }
+
+  @Test
+  public void shouldRemoveSessionCookie() {
+    cookieManager.setCookie(url, "name=value; Expires=Wed, 09 Jun 2021 10:18:14 GMT");
+    cookieManager.setCookie(url, "name2=value2;");
+    cookieManager.removeSessionCookie();
+    assertThat(cookieManager.getCookie(url)).isEqualTo("name=value");
   }
 }
 


### PR DESCRIPTION
The ShadowCookieManager of ver 2.2 cannot support original behavior of android.webkit.CookieManager with attributes like 'Expires', 'Domain' and so on.

For example, a following test fails.

```
cookieManager.setCookie(httpUrl, "name=value; Expires=Wed, 11 Jul 2035 08:12:26 GMT");
assertThat(cookieManager.getCookie(httpUrl)).isEqualTo("name=value");
```

It can be a solution to use org.apache.http.client.CookieStore in the implementation.

I tested android.webkit.CookieManager with AndroidTestCase ( https://gist.github.com/benelog/7655764 ) , and ported the tests to 'CookieManagerTest'. Then I made new implementation of ShawdowCookieManager passing that tests.
