### PR TITLE
Add a script to install support library from android's m2 repository.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
     - tar xzf android-sdk_r22.3-linux.tgz
     - export ANDROID_HOME=$PWD/android-sdk-linux
     - export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
-    - echo y | android update sdk --filter platform-tools,android-18,addon-google_apis-google-18,extra-android-support --no-ui --force
+    - echo y | android update sdk --filter platform-tools,android-18,addon-google_apis-google-18,extra-android-m2repository --no-ui --force
     - ./scripts/install-maps-jar.sh
     - ./scripts/install-support-jar.sh
 

--- a/scripts/install-support-jar.sh
+++ b/scripts/install-support-jar.sh
@@ -10,8 +10,17 @@
 #  2. Your ANDROID_HOME environment variable points to the Android SDK install dir.
 #  3. You have installed the Android Support (compatibility) libraries from the SDK installer.
 
-echo "Installing com.android.support:support-v4 from $ANDROID_HOME/extras"
-mvn -q install:install-file -DgroupId=com.android.support -DartifactId=support-v4 \
-  -Dversion=19.0.0 -Dpackaging=jar -Dfile="$ANDROID_HOME/extras/android/support/v4/android-support-v4.jar"
+jarLocation="$ANDROID_HOME/extras/android/m2repository/com/android/support/support-v4/19.0.0/support-v4-19.0.0.jar"  
+if [ ! -f "$jarLocation" ]; then
+  jarLocation="$ANDROID_HOME/extras/android/support/v4/android-support-v4.jar"
+  if [ ! -f "$jarLocation" ]; then
+    echo "support-v4 artifact not found!";
+    exit 1;
+  fi
+fi
 
+echo "Installing com.android.support:support-v4 from $jarLocation"
+mvn -q install:install-file -DgroupId=com.android.support -DartifactId=support-v4 \
+  -Dversion=19.0.0 -Dpackaging=jar -Dfile="$jarLocation"
+    
 echo "Done!"


### PR DESCRIPTION
Since gradle users don't use the directory `extras/android/support/v4/android-support-v4.jar` (they use `extras/android/m2repository/com/android/support/support-v4/19.0.0/support-v4-19.0.0.jar` instead) the `install-support-jar` script will fail. I just duplicated it and changed the path to the other location.
