### PR TITLE
Fix incorrect ids returned from ShadowSQLiteDatabase.insert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.7.2</version>
+      <version>3.7.15-M1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
I have encountered weird issue related to triggers and fts3 virtual tables. The ids returned by `insert()` method were incorrect. Using latest sqlite-jdbc solves the issue.
