### PR TITLE
Add basic implementation of ShadowProcess

### DIFF
--- a/src/main/java/org/robolectric/Robolectric.java
+++ b/src/main/java/org/robolectric/Robolectric.java
@@ -311,6 +311,7 @@ import org.robolectric.shadows.ShadowWifiManager;
 import org.robolectric.shadows.ShadowWindow;
 import org.robolectric.shadows.ShadowWindowManager;
 import org.robolectric.shadows.ShadowZoomButtonsController;
+import org.robolectric.shadows.ShadowProcess;
 import org.robolectric.tester.org.apache.http.FakeHttpLayer;
 import org.robolectric.tester.org.apache.http.HttpRequestInfo;
 import org.robolectric.tester.org.apache.http.RequestMatcher;
@@ -1322,6 +1323,7 @@ public class Robolectric {
     ShadowPowerManager.reset();
     ShadowStatFs.reset();
     ShadowTypeface.reset();
+    ShadowProcess.reset();
   }
 
   public static <T extends Activity> ActivityController<T> buildActivity(Class<T> activityClass) {

--- a/src/main/java/org/robolectric/RobolectricBase.java
+++ b/src/main/java/org/robolectric/RobolectricBase.java
@@ -212,6 +212,7 @@ import org.robolectric.shadows.ShadowWindow;
 import org.robolectric.shadows.ShadowWindowManager;
 import org.robolectric.shadows.ShadowWindowManagerImpl;
 import org.robolectric.shadows.ShadowZoomButtonsController;
+import org.robolectric.shadows.ShadowProcess;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -450,6 +451,7 @@ public class RobolectricBase {
       ShadowWindow.class,
       ShadowWindowManager.class,
       ShadowWindowManagerImpl.class,
-      ShadowZoomButtonsController.class
+      ShadowZoomButtonsController.class,
+      ShadowProcess.class
   ));
 }

--- a/src/main/java/org/robolectric/shadows/ShadowProcess.java
+++ b/src/main/java/org/robolectric/shadows/ShadowProcess.java
@@ -1,0 +1,25 @@
+package org.robolectric.shadows;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Shadows the {@code android.os.Process} class.
+ */
+@Implements(android.os.Process.class)
+public class ShadowProcess {
+  private static int pid;
+
+  @Implementation
+  public static final int myPid() {
+    return pid;
+  }
+  
+  public static void setPid(int pid) {
+    ShadowProcess.pid = pid;
+  }
+  
+  public static void reset() {
+    ShadowProcess.pid = 0;
+  }
+}

--- a/src/test/java/org/robolectric/shadows/ProcessTest.java
+++ b/src/test/java/org/robolectric/shadows/ProcessTest.java
@@ -1,0 +1,22 @@
+package org.robolectric.shadows;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.TestRunners;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class ProcessTest {
+  @Test
+  public void shouldBeZeroWhenNotSet() {
+    assertThat(android.os.Process.myPid()).isEqualTo(0);
+  }
+  
+  @Test
+  public void shouldGetMyPidAsSet() {
+    ShadowProcess.setPid(3);
+    assertThat(android.os.Process.myPid()).isEqualTo(3);
+  }
+}
+


### PR DESCRIPTION
ShadowProcess can be used when mocking android.os.Process.myPid().

I found a identical class from the android git repository.

https://android.googlesource.com/platform/external/robolectric/+/df5951775e9c13526de56166ccdb841aa910a674%5E/src/main/java/com/xtremelabs/robolectric/shadows/ShadowProcess.java
