### PR TITLE
Fix SQLiteLibraryLoader tests

### DIFF
--- a/src/test/java/org/robolectric/util/SQLiteLibraryLoaderTest.java
+++ b/src/test/java/org/robolectric/util/SQLiteLibraryLoaderTest.java
@@ -135,7 +135,6 @@ public class SQLiteLibraryLoaderTest {
 
   private String loadLibrary(SQLiteLibraryLoader loader, String name, String arch) throws IOException {
     setNameAndArch(name, arch);
-    loader.doLoad();
     return loader.getLibClasspathResourceName();
   }
 


### PR DESCRIPTION
Fixes build failure: https://travis-ci.org/robolectric/robolectric/builds/15288333.

Don't invoke real loading for fake environments, just check paths used for picking a library.

Seems like tests did not fail before due to a bit of luck with tests execution order: real loading test (`shouldExtractNativeLibrary` e.g.) was invoked first, so that calls to `doLoad()` in tests with fake environments were ignored since the library had already been loaded.
