### PR TITLE
SQLite native libs are packaged as .jnilib (on OSX).

### DIFF
--- a/src/main/java/org/robolectric/util/SQLiteLibraryLoader.java
+++ b/src/main/java/org/robolectric/util/SQLiteLibraryLoader.java
@@ -158,7 +158,7 @@ public class SQLiteLibraryLoader {
   }
 
   private String getNativesResourcesFilePart() {
-    return libraryNameMapper.mapLibraryName(SQLITE4JAVA).replace(".dylib", ".jnilib");
+    return getLibName().replace(".dylib", ".jnilib");
   }
 
   private String getOsPrefix() {


### PR DESCRIPTION
All of the SQLite tests were failing on my machine because System.mapLibraryName was returning .dylib as the extension while the native libs are packaged as .jnilib (I'm on OSX with Java 7).  I changed the loader code to look for a .jnilib, but still unpack the file with the correct extension (.dylib in the case of Java 7).

Would @roman-mazur or @jberkel mind taking a look at this?
