### PR TITLE
Add ValueResourceLoader that has <item ... type="layout"> to PackageResourceLoader

### DIFF
--- a/src/main/java/org/robolectric/res/PackageResourceLoader.java
+++ b/src/main/java/org/robolectric/res/PackageResourceLoader.java
@@ -35,6 +35,7 @@ public class PackageResourceLoader extends XResourceLoader {
         new ValueResourceLoader(data, "/resources/dimen", "dimen", ResType.DIMEN),
         new ValueResourceLoader(data, "/resources/integer", "integer", ResType.INTEGER),
         new ValueResourceLoader(data, "/resources/integer-array", "array", ResType.INTEGER_ARRAY),
+        new ValueResourceLoader(data, "/resources/item", "layout", ResType.LAYOUT),
         new PluralResourceLoader(pluralsData),
         new ValueResourceLoader(data, "/resources/string", "string", ResType.CHAR_SEQUENCE),
         new ValueResourceLoader(data, "/resources/string-array", "array", ResType.CHAR_SEQUENCE_ARRAY),


### PR DESCRIPTION
For multi pane layout, I used layout.xml
### res/values/layout.xml

```
<?xml version="1.0" encoding="utf-8"?>
<resources>
    <item name="main_layout" type="layout">@layout/activity_main</item>
    <bool name="has_two_panes">false</bool>
</resources>
```
### res/values/layout.xml

```
<?xml version="1.0" encoding="utf-8"?>
<resources>
    <item name="main_layout" type="layout">@layout/activity_main_land</item>
    <bool name="has_two_panes">true</bool>
</resources>
```
### MainActivity.java

```
@Override
protected void onCreate(Bundle savedInstanceState) {
    super.onCreate(savedInstanceState);
    setContentView(R.layout.main_layout);

    initView();
    initMainFragment();
}
```

Robolectric could not parse &lt;item type="layout"&gt; of &lt;resources&gt;.
