### PR TITLE
Added DROPBOX_SERVICE to SYSTEM_SERVICE_MAP

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
+++ b/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
@@ -53,6 +53,7 @@ public class ShadowContextImpl extends ShadowContext {
     SYSTEM_SERVICE_MAP.put(Context.DOWNLOAD_SERVICE, "android.app.DownloadManager");
     SYSTEM_SERVICE_MAP.put(Context.TEXT_SERVICES_MANAGER_SERVICE, "android.view.textservice.TextServicesManager");
     SYSTEM_SERVICE_MAP.put(Context.DEVICE_POLICY_SERVICE, "android.app.admin.DevicePolicyManager");
+    SYSTEM_SERVICE_MAP.put(Context.DROPBOX_SERVICE, "android.os.DropBoxManager");
   }
 
   @RealObject private Context realContextImpl;

--- a/src/test/java/org/robolectric/shadows/ApplicationTest.java
+++ b/src/test/java/org/robolectric/shadows/ApplicationTest.java
@@ -109,6 +109,7 @@ public class ApplicationTest {
     checkSystemService(Context.UI_MODE_SERVICE, android.app.UiModeManager.class);
     checkSystemService(Context.DOWNLOAD_SERVICE, android.app.DownloadManager.class);
     checkSystemService(Context.DEVICE_POLICY_SERVICE, android.app.admin.DevicePolicyManager.class);
+    checkSystemService(Context.DROPBOX_SERVICE, android.os.DropBoxManager.class);
   }
 
   @Test public void shouldProvideLayoutInflater() throws Exception {


### PR DESCRIPTION
The DropBoxManager was not in the SYSTEM_SERVICE_MAP, preventing applications from grabbing a reference to it via getSystemService.
