### PR TITLE
Patched a StackOverflowError when a ValueAnimator is animating

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowValueAnimator.java
+++ b/src/main/java/org/robolectric/shadows/ShadowValueAnimator.java
@@ -5,10 +5,13 @@ import android.animation.ValueAnimator;
 import android.view.animation.LinearInterpolator;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
 
 @Implements(ValueAnimator.class)
 public class ShadowValueAnimator extends ShadowAnimator {
   private TimeInterpolator interpolator;
+  @RealObject
+  private ValueAnimator realObject;
 
   @Implementation
   public void setInterpolator(TimeInterpolator value) {
@@ -37,5 +40,10 @@ public class ShadowValueAnimator extends ShadowAnimator {
   @Implementation @Override
   public long getDuration() {
     return super.getDuration();
+  }
+
+  @Implementation
+  public void start() {
+    realObject.end();
   }
 }


### PR DESCRIPTION
Since Robolectric doesn't actually have a Looper queue the per-frame Runnables
from ValueAnimator run in a single stack which overflows very easily.
