### PR TITLE
Fixes NullPointerException when using @Config manifest NONE

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
+++ b/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
@@ -285,9 +285,11 @@ public class ShadowContentResolver {
 
     if (!providers.containsKey(uri.getAuthority())) {
       AndroidManifest manifest = Robolectric.getShadowApplication().getAppManifest();
-      for (ContentProviderData providerData : manifest.getContentProviders()) {
-        if (providerData.getAuthority().equals(uri.getAuthority())) {
-          providers.put(providerData.getAuthority(), createAndInitialize(providerData));
+      if (manifest != null) {
+        for (ContentProviderData providerData : manifest.getContentProviders()) {
+          if (providerData.getAuthority().equals(uri.getAuthority())) {
+            providers.put(providerData.getAuthority(), createAndInitialize(providerData));
+          }
         }
       }
     }

--- a/src/test/java/org/robolectric/shadows/ContentResolverTest.java
+++ b/src/test/java/org/robolectric/shadows/ContentResolverTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.AndroidManifest;
+import org.robolectric.DefaultTestLifecycle;
 import org.robolectric.Robolectric;
 import org.robolectric.TestRunners;
 import org.robolectric.res.ContentProviderData;
@@ -449,6 +450,16 @@ public class ContentResolverTest {
     AndroidManifest manifest = Robolectric.getShadowApplication().getAppManifest();
     manifest.getContentProviders().add(new ContentProviderData("org.robolectric.shadows.ContentResolverTest$TestContentProvider", AUTHORITY));
     assertThat(ShadowContentResolver.getProvider(Uri.parse("content://" + AUTHORITY + "/shadows"))).isNotNull();
+  }
+
+  @Test
+  public void getProvider_shouldNotReturnAnyProviderWhenManifestIsNull() {
+    givenRobolectricApplicationWithNoManifest();
+    assertThat(ShadowContentResolver.getProvider(Uri.parse("content://"))).isNull();
+  }
+
+  private void givenRobolectricApplicationWithNoManifest() {
+    Robolectric.application = new DefaultTestLifecycle().createApplication(null, null);
   }
 
   static class QueryParamTrackingTestCursor extends TestCursor {


### PR DESCRIPTION
When testing with ContentResolver if @Config(manifest=Config.NONE) is
used then getProvider() method will get into a NullPointerException when
attempting to iterate through the list of the AndroidManifest's
ContentProviders.

Wrapped the statement in a null check to fix the issue.
