### PR TITLE
Fixes TestSharedPreferences behavior when using putString or putStringSe...

### DIFF
--- a/src/main/java/org/robolectric/tester/android/content/TestSharedPreferences.java
+++ b/src/main/java/org/robolectric/tester/android/content/TestSharedPreferences.java
@@ -106,8 +106,12 @@ public class TestSharedPreferences implements SharedPreferences {
 
     @Override
     public Editor putString(String key, String value) {
-      editsThatNeedCommit.put(key, value);
-      editsThatNeedRemove.remove(key);
+      if (value == null) {
+        editsThatNeedRemove.add(key);
+      } else {
+        editsThatNeedCommit.put(key, value);
+        editsThatNeedRemove.remove(key);
+      }
       return this;
     }
 
@@ -141,8 +145,12 @@ public class TestSharedPreferences implements SharedPreferences {
 
     @Override
     public Editor putStringSet(String key, Set<String> value ){
-      editsThatNeedCommit.put( key, value );
-      editsThatNeedRemove.remove(key);
+      if (value == null) {
+        editsThatNeedRemove.add(key);
+      } else {
+        editsThatNeedCommit.put(key, value);
+        editsThatNeedRemove.remove(key);
+      }
       return this;
     }
 

--- a/src/test/java/org/robolectric/tester/android/content/TestSharedPreferencesTest.java
+++ b/src/test/java/org/robolectric/tester/android/content/TestSharedPreferencesTest.java
@@ -46,7 +46,7 @@ public class TestSharedPreferencesTest {
     editor.putInt("int", 2);
     editor.putLong("long", 3l);
     editor.putString("string", "foobar");
-    editor.putStringSet( "stringSet", stringSet );
+    editor.putStringSet("stringSet", stringSet);
   }
 
   @Test
@@ -112,6 +112,28 @@ public class TestSharedPreferencesTest {
 
     assertThat(anotherSharedPreferences.getString("deleteMe", "awol")).isEqualTo("awol");
     assertThat(anotherSharedPreferences.getString("dontDeleteMe", "oops")).isEqualTo("baz");
+  }
+
+  @Test
+  public void putString_shouldRemovePairIfValueIsNull() throws Exception {
+    content.put(FILENAME, new HashMap<String, Object>());
+    content.get(FILENAME).put("deleteMe", "foo");
+
+    editor.putString("deleteMe", null);
+    editor.commit();
+
+    assertThat(sharedPreferences.getString("deleteMe", null)).isNull();
+  }
+
+  @Test
+  public void putStringSet_shouldRemovePairIfValueIsNull() throws Exception {
+    content.put(FILENAME, new HashMap<String, Object>());
+    content.get(FILENAME).put("deleteMe", stringSet);
+
+    editor.putStringSet("deleteMe", null);
+    editor.commit();
+
+    assertThat(sharedPreferences.getStringSet("deleteMe", null)).isNull();
   }
 
   @Test


### PR DESCRIPTION
Fixes TestSharedPreferences behavior when using putString or putStringSet with a null value. Default Android behavior is to remove the object for that key.
