### PR TITLE
Add constructor with the 'flags' parameter to ShadowSimpleCursorAdapter.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowSimpleCursorAdapter.java
+++ b/src/main/java/org/robolectric/shadows/ShadowSimpleCursorAdapter.java
@@ -99,6 +99,10 @@ public class ShadowSimpleCursorAdapter extends ShadowResourceCursorAdapter {
     findColumns(from);
   }
 
+  public void __constructor__(Context context, int layout, Cursor c, String[] from, int[] to, int flags) {
+    this.__constructor__(context, layout, c, from, to);
+  }
+
   /**
    * Binds all of the field names passed into the "to" parameter of the
    * constructor with their corresponding cursor columns as specified in the


### PR DESCRIPTION
Enables shadows for SimpleCursorAdapters created with the [standard](http://developer.android.com/reference/android/widget/SimpleCursorAdapter.html#SimpleCursorAdapter%28android.content.Context, int, android.database.Cursor, java.lang.String[], int[], int%29) constructor.
