### PR TITLE
Added ContentResolver. acquireUnstableProvider() shadow implementation a...

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
+++ b/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
@@ -6,12 +6,15 @@ import android.content.ContentProviderOperation;
 import android.content.ContentProviderResult;
 import android.content.ContentResolver;
 import android.content.ContentValues;
+import android.content.IContentProvider;
 import android.content.OperationApplicationException;
 import android.content.PeriodicSync;
+import android.content.res.AssetFileDescriptor;
 import android.database.ContentObserver;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.ParcelFileDescriptor;
 
 import org.robolectric.AndroidManifest;
 import org.robolectric.Robolectric;
@@ -21,6 +24,7 @@ import org.robolectric.internal.NamedStream;
 import org.robolectric.res.ContentProviderData;
 import org.robolectric.tester.android.database.TestCursor;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -158,6 +162,15 @@ public class ShadowContentResolver {
     } else {
       return null;
     }
+  }
+
+  @Implementation
+  public final IContentProvider acquireUnstableProvider(Uri uri) {
+    ContentProvider cp = getProvider(uri);
+    if (cp != null) {
+      return cp.getIContentProvider();
+    }
+    return null;
   }
 
   @Implementation

--- a/src/test/java/org/robolectric/shadows/ContentResolverTest.java
+++ b/src/test/java/org/robolectric/shadows/ContentResolverTest.java
@@ -205,7 +205,39 @@ public class ContentResolverTest {
     assertThat(testCursor.selectionArgs).isEqualTo(selectionArgs);
     assertThat(testCursor.sortOrder).isEqualTo(sortOrder);
   }
+  
+  @Test
+  public void acquireUnstableProvider_shouldDefaultToNull() throws Exception {
+    assertThat(contentResolver.acquireUnstableProvider(uri21)).isNull();
+  }
 
+  @Test
+  public void acquireUnstableProvider_shouldReturn() throws Exception {
+    ContentProvider cp = new ContentProvider() {
+      @Override public boolean onCreate() {
+        return false;
+      }
+      @Override public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        return new TestCursor();
+      }
+      @Override public Uri insert(Uri uri, ContentValues values) {
+        return null;
+      }
+      @Override public int delete(Uri uri, String selection, String[] selectionArgs) {
+        return -1;
+      }
+      @Override public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        return -1;
+      }
+      @Override public String getType(Uri uri) {
+        return null;
+      }
+    };
+    ShadowContentResolver.registerProvider(AUTHORITY, cp);
+    final Uri uri = Uri.parse("content://" + AUTHORITY);
+    assertThat(contentResolver.acquireUnstableProvider(uri)).isSameAs(cp.getIContentProvider());
+  }
+  
   @Test
   public void openInputStream_shouldReturnAnInputStream() throws Exception {
     assertThat(contentResolver.openInputStream(uri21)).isInstanceOf(InputStream.class);


### PR DESCRIPTION
...nd test cases.  This method is used by various ContentResolver methods in the android source, so should help with re-using existing logic more.  It helped with ContentResolver.openAssetFileDescriptor().
