### PR TITLE
AndroidManifest must be parsed before returning ActivityDatas

### DIFF
--- a/src/main/java/org/robolectric/AndroidManifest.java
+++ b/src/main/java/org/robolectric/AndroidManifest.java
@@ -582,6 +582,7 @@ public class AndroidManifest {
   }
 
   public Map<String, ActivityData> getActivityDatas() {
+    parseAndroidManifest();
     return activityDatas;
   }
 

--- a/src/test/java/org/robolectric/AndroidManifestTest.java
+++ b/src/test/java/org/robolectric/AndroidManifestTest.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -244,6 +245,16 @@ public class AndroidManifestTest {
     ActivityData activityData = appManifest.getActivityData("org.robolectric.shadows.TestTaskAffinityActivity");
     assertThat(activityData).isNotNull();
     assertThat(activityData.getTaskAffinity()).isEqualTo("org.robolectric.shadows.TestTaskAffinity");
+  }
+
+  @Test
+  public void shouldReadPartiallyQualifiedActivities() throws Exception {
+    AndroidManifest config = newConfig("TestAndroidManifestForActivities.xml");
+    assertThat(config.getActivityDatas()).hasSize(2);
+    Map<String, ActivityData> d = config.getActivityDatas();
+    for (String key : d.keySet()) {
+    	assertTrue(key, key.equals("org.robolectric.shadows.TestActivity") || key.equals("org.robolectric.shadows.TestActivity2"));
+	}
   }
 
   /////////////////////////////


### PR DESCRIPTION
Encountered an issue where partially qualified activities were not
getting recognized in my tests.
