### PR TITLE
WebView.MustOverrideException can be thrown for setJavascriptCanOpenAutomatically

### DIFF
--- a/src/main/java/android/webkit/TestWebSettings.java
+++ b/src/main/java/android/webkit/TestWebSettings.java
@@ -20,6 +20,7 @@ public class TestWebSettings extends WebSettings {
   private boolean domStorageEnabled = false;
   private boolean geolocationEnabled = false;
   private boolean javaScriptEnabled = false;
+  private boolean javaScriptCanOpenWindowAutomatically = false;
   private boolean lightTouchEnabled = false;
   private boolean loadWithOverviewMode = false;
   private boolean needInitialFocus = false;
@@ -289,5 +290,15 @@ public class TestWebSettings extends WebSettings {
   @Implementation
   public void setGeolocationEnabled(boolean geolocationEnabled) {
     this.geolocationEnabled = geolocationEnabled;
+  }
+  
+  @Implementation
+  public void setJavaScriptCanOpenWindowsAutomatically(boolean javaScriptCanOpenWindowAutomatically) {
+    this.javaScriptCanOpenWindowAutomatically = javaScriptCanOpenWindowAutomatically;
+  }
+  
+  @Implementation
+  public boolean getJavaScriptCanOpenWindowsAutomatically() {
+    return this.javaScriptCanOpenWindowAutomatically;
   }
 }

--- a/src/test/java/android/webkit/TestWebSettingsTest.java
+++ b/src/test/java/android/webkit/TestWebSettingsTest.java
@@ -240,4 +240,17 @@ public class TestWebSettingsTest {
     webSettings.setGeolocationDatabasePath("new_path");
     assertThat(webSettings.getGeolocationDatabasePath()).isEqualTo("new_path");
   }
+  
+  @Test
+  public void testSetJavascriptCanOpenWindowsAutomaticallyIsTrue() throws Exception {
+	  webSettings.setJavaScriptCanOpenWindowsAutomatically(true);
+	  assertThat(webSettings.getJavaScriptCanOpenWindowsAutomatically()).isTrue();
+  }
+  
+  @Test
+  public void testSetJavascriptCanOpenWindowsAutomaticallyIsFalse() throws Exception {
+    webSettings.setJavaScriptCanOpenWindowsAutomatically(false);
+    assertThat(webSettings.getJavaScriptCanOpenWindowsAutomatically()).isFalse();
+  }
+
 }


### PR DESCRIPTION
With robolectric 2.2 when we try to set the javaScriptCanOpenWindowAutomaticaly
we get the above error.  This is because the TestWebSettings class doesn't
override and implement this functionality.  This patch adds two tests and
implements the getter and setters for this functionality.
