### PR TITLE
Decouples fastest time and min distance checks in simulateLocation()

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowLocationManager.java
+++ b/src/main/java/org/robolectric/shadows/ShadowLocationManager.java
@@ -412,7 +412,7 @@ public class ShadowLocationManager {
         float distanceChange = distanceBetween(location, listenerReg.lastSeenLocation);
         boolean withinMinDistance = distanceChange < listenerReg.minDistance;
         boolean exceededMinTime = location.getTime() - listenerReg.lastSeenTime > listenerReg.minTime;
-        if (withinMinDistance && !exceededMinTime) continue;
+        if (withinMinDistance || !exceededMinTime) continue;
       }
       listenerReg.lastSeenLocation = copyOf(location);
       listenerReg.lastSeenTime = location == null ? 0 : location.getTime();

--- a/src/test/java/org/robolectric/shadows/LocationManagerTest.java
+++ b/src/test/java/org/robolectric/shadows/LocationManagerTest.java
@@ -386,6 +386,41 @@ public class LocationManagerTest {
     assertThat(shadowLocationManager.getRequestLocationUdpateCriteriaPendingIntents().get(someLocationListenerPendingIntent)).isEqualTo(someCriteria);
   }
 
+  @Test
+  public void simulateLocation_shouldNotNotifyListenerIfLessThanFastestInterval() throws Exception {
+    TestLocationListener listener = new TestLocationListener();
+    shadowLocationManager.requestLocationUpdates(GPS_PROVIDER, 2000, 0, listener);
+    long time = System.currentTimeMillis();
+
+    Location location1 = new Location(GPS_PROVIDER);
+    location1.setTime(time);
+
+    Location location2 = new Location(GPS_PROVIDER);
+    location2.setTime(time + 1000);
+
+    shadowLocationManager.simulateLocation(location1);
+    shadowLocationManager.simulateLocation(location2);
+    assertThat(listener.location).isEqualTo(location1);
+  }
+
+  @Test
+  public void simulateLocation_shouldNotNotifyListenerIfLessThanMinimumDistance() throws Exception {
+    TestLocationListener listener = new TestLocationListener();
+    shadowLocationManager.requestLocationUpdates(GPS_PROVIDER, 0, 200000, listener);
+
+    Location location1 = new Location(GPS_PROVIDER);
+    location1.setLatitude(0);
+    location1.setLongitude(0);
+
+    Location location2 = new Location(GPS_PROVIDER);
+    location2.setLatitude(1);
+    location2.setLongitude(1);
+
+    shadowLocationManager.simulateLocation(location1);
+    shadowLocationManager.simulateLocation(location2);
+    assertThat(listener.location).isEqualTo(location1);
+  }
+
   private Listener addGpsListenerToLocationManager() {
     Listener listener = new TestGpsListener();
     locationManager.addGpsStatusListener(listener);
@@ -394,9 +429,11 @@ public class LocationManagerTest {
 
   private static class TestLocationListener implements LocationListener {
     public boolean providerEnabled;
+    public Location location;
 
     @Override
     public void onLocationChanged(Location location) {
+      this.location = location;
     }
 
     @Override


### PR DESCRIPTION
The listener should not be notified if either the fastest time or minimum distance requirement is not met.

https://github.com/android/platform_frameworks_base/blob/master/services/java/com/android/server/LocationManagerService.java#L1870
