### PR TITLE
Add support for ContentProviderClient.

### DIFF
--- a/src/main/java/org/robolectric/Robolectric.java
+++ b/src/main/java/org/robolectric/Robolectric.java
@@ -24,6 +24,7 @@ import android.appwidget.AppWidgetHostView;
 import android.appwidget.AppWidgetManager;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
+import android.content.ContentProviderClient;
 import android.content.ContentProviderOperation;
 import android.content.ContentProviderResult;
 import android.content.ContentResolver;
@@ -200,6 +201,7 @@ import org.robolectric.shadows.ShadowColorMatrix;
 import org.robolectric.shadows.ShadowConfiguration;
 import org.robolectric.shadows.ShadowConnectivityManager;
 import org.robolectric.shadows.ShadowContentObserver;
+import org.robolectric.shadows.ShadowContentProviderClient;
 import org.robolectric.shadows.ShadowContentProviderOperation;
 import org.robolectric.shadows.ShadowContentProviderResult;
 import org.robolectric.shadows.ShadowContentResolver;
@@ -555,6 +557,10 @@ public class Robolectric {
 
   public static ShadowContentResolver shadowOf(ContentResolver instance) {
     return (ShadowContentResolver) shadowOf_(instance);
+  }
+
+  public static ShadowContentProviderClient shadowOf(ContentProviderClient client) {
+    return (ShadowContentProviderClient) shadowOf_(client);
   }
 
   public static ShadowContentProviderOperation shadowOf(ContentProviderOperation instance) {

--- a/src/main/java/org/robolectric/RobolectricBase.java
+++ b/src/main/java/org/robolectric/RobolectricBase.java
@@ -50,6 +50,7 @@ import org.robolectric.shadows.ShadowConfiguration;
 import org.robolectric.shadows.ShadowConnectivityManager;
 import org.robolectric.shadows.ShadowContentObserver;
 import org.robolectric.shadows.ShadowContentProvider;
+import org.robolectric.shadows.ShadowContentProviderClient;
 import org.robolectric.shadows.ShadowContentProviderOperation;
 import org.robolectric.shadows.ShadowContentProviderResult;
 import org.robolectric.shadows.ShadowContentResolver;
@@ -277,6 +278,7 @@ public class RobolectricBase {
       ShadowConnectivityManager.class,
       ShadowContentObserver.class,
       ShadowContentProvider.class,
+      ShadowContentProviderClient.class,
       ShadowContentProviderOperation.class,
       ShadowContentProviderResult.class,
       ShadowContentResolver.class,

--- a/src/main/java/org/robolectric/shadows/ShadowContentProviderClient.java
+++ b/src/main/java/org/robolectric/shadows/ShadowContentProviderClient.java
@@ -1,0 +1,136 @@
+package org.robolectric.shadows;
+
+import android.content.ContentProvider;
+import android.content.ContentProviderClient;
+import android.content.ContentProviderOperation;
+import android.content.ContentProviderResult;
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.content.IContentProvider;
+import android.content.OperationApplicationException;
+import android.content.res.AssetFileDescriptor;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.CancellationSignal;
+import android.os.ParcelFileDescriptor;
+import android.os.RemoteException;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(ContentProviderClient.class)
+public class ShadowContentProviderClient {
+
+  private ContentProvider provider;
+  private boolean stable;
+
+  private boolean released = false;
+
+  public void __constructor__(ContentResolver contentResolver, IContentProvider contentProvider,
+      boolean stable) {
+    this.stable = stable;
+  }
+
+  @Implementation
+  public Bundle call(String method, String arg, Bundle extras) throws RemoteException {
+    return provider.call(method, arg, extras);
+  }
+
+  @Implementation
+  public String getType(Uri uri) throws RemoteException {
+    return provider.getType(uri);
+  }
+
+  @Implementation
+  public String[] getStreamTypes(Uri uri, String mimeTypeFilter) {
+    return provider.getStreamTypes(uri, mimeTypeFilter);
+  }
+
+  @Implementation
+  public Cursor query(Uri url, String[] projection, String selection, String[] selectionArgs,
+      String sortOrder) throws RemoteException {
+    return provider.query(url, projection, selection, selectionArgs, sortOrder);
+  }
+
+  @Implementation
+  public Cursor query(Uri url, String[] projection, String selection, String[] selectionArgs,
+      String sortOrder, CancellationSignal cancellationSignal) throws RemoteException {
+    return provider.query(url, projection, selection, selectionArgs, sortOrder, cancellationSignal);
+  }
+
+  @Implementation
+  public Uri insert(Uri url, ContentValues initialValues) throws RemoteException {
+    return provider.insert(url, initialValues);
+  }
+
+  @Implementation
+  public int bulkInsert(Uri url, ContentValues[] initialValues) throws RemoteException {
+    return provider.bulkInsert(url, initialValues);
+  }
+
+  @Implementation
+  public int delete(Uri url, String selection, String[] selectionArgs)
+      throws RemoteException {
+    return provider.delete(url, selection, selectionArgs);
+  }
+
+  @Implementation
+  public int update(Uri url, ContentValues values, String selection, String[] selectionArgs)
+      throws RemoteException {
+    return provider.update(url, values, selection, selectionArgs);
+  }
+
+  @Implementation
+  public ParcelFileDescriptor openFile(Uri url, String mode)
+      throws RemoteException, FileNotFoundException {
+    return provider.openFile(url, mode);
+  }
+
+  @Implementation
+  public AssetFileDescriptor openAssetFile(Uri url, String mode)
+      throws RemoteException, FileNotFoundException {
+    return provider.openAssetFile(url, mode);
+  }
+
+  @Implementation
+  public final AssetFileDescriptor openTypedAssetFileDescriptor(Uri uri,
+      String mimeType, Bundle opts) throws RemoteException, FileNotFoundException {
+    return provider.openTypedAssetFile(uri, mimeType, opts);
+  }
+
+  @Implementation
+  public ContentProviderResult[] applyBatch(ArrayList<ContentProviderOperation> operations)
+      throws RemoteException, OperationApplicationException {
+    return provider.applyBatch(operations);
+  }
+
+  @Implementation
+  public boolean release() {
+    synchronized (this) {
+      if (released) {
+        throw new IllegalStateException("Already released");
+      }
+      released = true;
+    }
+    return true;
+  }
+
+  @Implementation
+  public ContentProvider getLocalContentProvider() {
+    return ContentProvider.coerceToLocalContentProvider(provider.getIContentProvider());
+  }
+
+  public boolean isStable() {
+    return stable;
+  }
+
+  public boolean isReleased() {
+    return released;
+  }
+
+  void setContentProvider(ContentProvider provider) {
+    this.provider = provider;
+  }
+}

--- a/src/test/java/org/robolectric/shadows/ContentProviderClientTest.java
+++ b/src/test/java/org/robolectric/shadows/ContentProviderClientTest.java
@@ -1,0 +1,125 @@
+package org.robolectric.shadows;
+
+import android.content.ContentProvider;
+import android.content.ContentProviderClient;
+import android.content.ContentProviderOperation;
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.CancellationSignal;
+import java.util.ArrayList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.robolectric.Robolectric;
+import org.robolectric.TestRunners;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.fail;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.robolectric.Robolectric.shadowOf;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class ContentProviderClientTest {
+
+  static final String AUTHORITY = "org.robolectric";
+  static final Uri URI = Uri.parse("content://" + AUTHORITY);
+  static final ContentValues VALUES = new ContentValues();
+  static final String[] PROJECTION = null;
+  static final String SELECTION = "1=?";
+  static final String[] SELECTION_ARGS = {"1"};
+  static final String SORT_ORDER = "DESC";
+  static final String MIME_TYPE = "application/octet-stream";
+
+  @Mock ContentProvider provider;
+  ContentResolver contentResolver = Robolectric.application.getContentResolver();
+
+  @Before
+  public void setUp() {
+    initMocks(this);
+    ShadowContentResolver.registerProvider(AUTHORITY, provider);
+  }
+
+  @Test
+  public void acquireContentProviderClient_isStable() {
+    ContentProviderClient client = contentResolver.acquireContentProviderClient(AUTHORITY);
+    assertThat(shadowOf(client).isStable()).isTrue();
+  }
+
+  @Test
+  public void acquireUnstableContentProviderClient_isUnstable() {
+    ContentProviderClient client = contentResolver.acquireUnstableContentProviderClient(AUTHORITY);
+    assertThat(shadowOf(client).isStable()).isFalse();
+  }
+
+  @Test
+  public void release_shouldRelease() {
+    ContentProviderClient client = contentResolver.acquireContentProviderClient(AUTHORITY);
+    ShadowContentProviderClient shadow = shadowOf(client);
+    assertThat(shadow.isReleased()).isFalse();
+    client.release();
+    assertThat(shadow.isReleased()).isTrue();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void release_shouldFailWhenCalledTwice() {
+    ContentProviderClient client = contentResolver.acquireContentProviderClient(AUTHORITY);
+    client.release();
+    client.release();
+    fail("client.release() was called twice and did not throw");
+  }
+
+  @Test
+  public void shouldDelegateToContentProvider() throws Exception {
+    ContentProviderClient client = contentResolver.acquireContentProviderClient(AUTHORITY);
+
+    client.query(URI, PROJECTION, SELECTION, SELECTION_ARGS, SORT_ORDER);
+    verify(provider).query(URI, PROJECTION, SELECTION, SELECTION_ARGS, SORT_ORDER);
+
+    CancellationSignal signal = new CancellationSignal();
+    client.query(URI, PROJECTION, SELECTION, SELECTION_ARGS, SORT_ORDER, signal);
+    verify(provider).query(URI, PROJECTION, SELECTION, SELECTION_ARGS, SORT_ORDER, signal);
+
+    client.insert(URI, VALUES);
+    verify(provider).insert(URI, VALUES);
+
+    client.update(URI, VALUES, SELECTION, SELECTION_ARGS);
+    verify(provider).update(URI, VALUES, SELECTION, SELECTION_ARGS);
+
+    client.delete(URI, SELECTION, SELECTION_ARGS);
+    verify(provider).delete(URI, SELECTION, SELECTION_ARGS);
+
+    client.getType(URI);
+    verify(provider).getType(URI);
+
+    client.openFile(URI, "rw");
+    verify(provider).openFile(URI, "rw");
+
+    client.openAssetFile(URI, "r");
+    verify(provider).openAssetFile(URI, "r");
+
+    final Bundle opts = new Bundle();
+    client.openTypedAssetFileDescriptor(URI, MIME_TYPE, opts);
+    verify(provider).openTypedAssetFile(URI, MIME_TYPE, opts);
+
+    client.getStreamTypes(URI, MIME_TYPE);
+    verify(provider).getStreamTypes(URI, MIME_TYPE);
+
+    final ArrayList<ContentProviderOperation> ops = new ArrayList<ContentProviderOperation>();
+    client.applyBatch(ops);
+    verify(provider).applyBatch(ops);
+
+    final ContentValues[] values = {VALUES};
+    client.bulkInsert(URI, values);
+    verify(provider).bulkInsert(URI, values);
+
+    final String method = "method";
+    final String arg = "arg";
+    final Bundle extras = new Bundle();
+    client.call(method, arg, extras);
+    verify(provider).call(method, arg, extras);
+  }
+}

--- a/src/test/java/org/robolectric/shadows/ContentResolverTest.java
+++ b/src/test/java/org/robolectric/shadows/ContentResolverTest.java
@@ -214,30 +214,18 @@ public class ContentResolverTest {
   }
 
   @Test
-  public void acquireUnstableProvider_shouldReturn() throws Exception {
-    ContentProvider cp = new ContentProvider() {
-      @Override public boolean onCreate() {
-        return false;
-      }
-      @Override public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
-        return new TestCursor();
-      }
-      @Override public Uri insert(Uri uri, ContentValues values) {
-        return null;
-      }
-      @Override public int delete(Uri uri, String selection, String[] selectionArgs) {
-        return -1;
-      }
-      @Override public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
-        return -1;
-      }
-      @Override public String getType(Uri uri) {
-        return null;
-      }
-    };
+  public void acquireUnstableProvider_shouldReturnWithUri() throws Exception {
+    ContentProvider cp = mock(ContentProvider.class);
     ShadowContentResolver.registerProvider(AUTHORITY, cp);
     final Uri uri = Uri.parse("content://" + AUTHORITY);
     assertThat(contentResolver.acquireUnstableProvider(uri)).isSameAs(cp.getIContentProvider());
+  }
+
+  @Test
+  public void acquireUnstableProvider_shouldReturnWithString() throws Exception {
+    ContentProvider cp = mock(ContentProvider.class);
+    ShadowContentResolver.registerProvider(AUTHORITY, cp);
+    assertThat(contentResolver.acquireUnstableProvider(AUTHORITY)).isSameAs(cp.getIContentProvider());
   }
 
   @Test


### PR DESCRIPTION
Added support for ContentProviderClient.

Right now I'm using the ShadowContentProviderClient to directly attach the correct ContentProvider to the ContentProviderClient. The actual implementation uses an IContentProvider internally, but I've had some issues with NoSuchMethodError coming from contentResolver.getPackageName(), and IContentProvider methods. It seems to work correctly in the unit tests for robolectric, but when importing the SNAPSHOT to test it on a separate project, I see the errors I mentioned. All that to say, I've forgone the IContentProvider connection and attached directly to the relevant ContentProvider instance.

I'm not entirely convinced that's the absolute best way to go about this, but it's the best I've been able to come up with so far. It may be better to use the IContentProvider connection to more closely emulate the actual implementation, see above issues. It seems to be enough to use the direct connection, though. I'm open to suggestions.
