### PR TITLE
Add support for resource as <item type=string ...

### DIFF
--- a/src/main/java/org/robolectric/res/PackageResourceLoader.java
+++ b/src/main/java/org/robolectric/res/PackageResourceLoader.java
@@ -39,6 +39,7 @@ public class PackageResourceLoader extends XResourceLoader {
         new ValueResourceLoader(data, "/resources/item", "layout", ResType.LAYOUT),
         new PluralResourceLoader(pluralsData),
         new ValueResourceLoader(data, "/resources/string", "string", ResType.CHAR_SEQUENCE),
+        new ValueResourceLoader(data, "/resources/item[@type='string']", "string", ResType.CHAR_SEQUENCE),
         new ValueResourceLoader(data, "/resources/string-array", "array", ResType.CHAR_SEQUENCE_ARRAY),
         new AttrResourceLoader(data),
         new StyleResourceLoader(data)

--- a/src/test/java/org/robolectric/res/PackageResourceLoaderTest.java
+++ b/src/test/java/org/robolectric/res/PackageResourceLoaderTest.java
@@ -30,4 +30,13 @@ public class PackageResourceLoaderTest {
     assertThat(value).describedAs("Item dimen from gradle output is not loaded").isNotNull();
     assertThat(value.asString()).isEqualTo("3.14");
   }
+
+  @Test
+  public void shouldLoadStringResourcesFromGradleOutputDirectoriesDefinedByItemTag() {
+    PackageResourceLoader loader = new PackageResourceLoader(gradleAppResources());
+    TypedResource value = loader.getValue(new ResName("org.robolectric.gradleapp", "string", "item_from_gradle_output"), "");
+    assertThat(value).describedAs("Item string from gradle output is not loaded").isNotNull();
+    assertThat(value.asString()).isEqualTo("3.14");
+  }
+
 }

--- a/src/test/resources/gradle/res/layoutFlavor/menuBuildType/values/strings.xml
+++ b/src/test/resources/gradle/res/layoutFlavor/menuBuildType/values/strings.xml
@@ -6,5 +6,6 @@
   -->
 
   <string name="from_gradle_output">string example taken from gradle output directory</string>
+  <item name="item_from_gradle_output" format="float" type="string">3.14</item>
 
 </resources>


### PR DESCRIPTION
While testing an activity using SmoothProgressBar from @castorflex (due to ActionBar-PullToRefresh), I had problems due to this resource:
`<item name="spb_default_speed" format="float" type="string">1.0</item>`

This bug has already been tracked on the Google groups at https://groups.google.com/forum/#!topic/robolectric/raKiC51lLzM

This PR only adds support for this kind of resources.
