### PR TITLE
ASM 5.0 makes it illegal for subclasses to call ClassNode's default constructor.

### DIFF
--- a/src/main/java/org/robolectric/bytecode/AsmInstrumentingClassLoader.java
+++ b/src/main/java/org/robolectric/bytecode/AsmInstrumentingClassLoader.java
@@ -138,7 +138,7 @@ public class AsmInstrumentingClassLoader extends ClassLoader implements Opcodes,
       }
 
       final ClassReader classReader = new ClassReader(origClassBytes);
-      ClassNode classNode = new ClassNode() {
+      ClassNode classNode = new ClassNode(Opcodes.ASM4) {
         @Override
         public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
           desc = remapParamType(desc);


### PR DESCRIPTION
http://asm.ow2.org/asm50/javadoc/user/org/objectweb/asm/tree/ClassNode.html#ClassNode()
