### PR TITLE
Fix for #950

### DIFF
--- a/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
+++ b/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
@@ -7,7 +7,6 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.ResolveInfo;
-import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.util.Pair;
@@ -353,7 +352,7 @@ public class RobolectricPackageManager extends StubPackageManager {
     ResourceIndex resourceIndex = loader.getResourceIndex();
 
     // first opportunity to access a resource index for this manifest, use it to init the references
-    androidManifest.initMetaData(resourceIndex);
+    androidManifest.initMetaData(loader);
 
     PackageInfo packageInfo = new PackageInfo();
     packageInfo.packageName = androidManifest.getPackageName();
@@ -449,52 +448,22 @@ public class RobolectricPackageManager extends StubPackageManager {
    * @param meta Meta data to put in to a bundle
    * @return bundle containing the meta data
    */
-  private Bundle metaDataToBundle(Map<String, String> meta) {
+  private Bundle metaDataToBundle(Map<String, Object> meta) {
     if (meta.size() == 0) {
         return null;
     }
 
     Bundle bundle = new Bundle();
 
-    for (Map.Entry<String,String> entry : meta.entrySet()) {
-      if (entry.getValue() == null) {
-        // skip it
-      } else if ("true".equals(entry.getValue())) {
-        bundle.putBoolean(entry.getKey(), true);
-      } else if ("false".equals(entry.getValue())) {
-        bundle.putBoolean(entry.getKey(), false);
+    for (Map.Entry<String,Object> entry : meta.entrySet()) {
+      if (Boolean.class.isInstance(entry.getValue())) {
+        bundle.putBoolean(entry.getKey(), (Boolean) entry.getValue());
+      } else if (Float.class.isInstance(entry.getValue())) {
+        bundle.putFloat(entry.getKey(), (Float) entry.getValue());
+      } else if (Integer.class.isInstance(entry.getValue())) {
+        bundle.putInt(entry.getKey(), (Integer) entry.getValue());
       } else {
-        if (entry.getValue().contains(".")) {
-          // if it's a float, add it and continue
-          try {
-            bundle.putFloat(entry.getKey(), Float.parseFloat(entry.getValue()));
-          } catch (NumberFormatException ef) {
-            /* Not a float */
-          }
-        }
-
-        if (!bundle.containsKey(entry.getKey()) && !entry.getValue().startsWith("#")) {
-          // if it's an int, add it and continue
-          try {
-            bundle.putInt(entry.getKey(), Integer.parseInt(entry.getValue()));
-          } catch (NumberFormatException ei) {
-            /* Not an int */
-          }
-        }
-
-        if (!bundle.containsKey(entry.getKey())) {
-          // if it's a color, add it and continue
-          try {
-            bundle.putInt(entry.getKey(), Color.parseColor(entry.getValue()));
-          } catch (IllegalArgumentException e) {
-            /* Not a color */
-          }
-        }
-
-        if (!bundle.containsKey(entry.getKey())) {
-          // otherwise it's a string
-          bundle.putString(entry.getKey(), entry.getValue());
-        }
+        bundle.putString(entry.getKey(), entry.getValue().toString());
       }
     }
     return bundle;

--- a/src/test/java/org/robolectric/AndroidManifestTest.java
+++ b/src/test/java/org/robolectric/AndroidManifestTest.java
@@ -96,12 +96,11 @@ public class AndroidManifestTest {
     assertEquals("org.robolectric.test.ConfigTestReceiver", config.getReceiverClassName(5));
     assertEquals("org.robolectric.ACTION_DOT_SUBPACKAGE", config.getReceiverIntentFilterActions(5).get(0));
 
-    Map<String, String> meta = config.getReceiverMetaData(5);
+    Map<String, Object> meta = config.getReceiverMetaData(5);
     Object metaValue = meta.get("org.robolectric.metaName1");
     assertEquals("metaValue1", metaValue);
 
     metaValue = meta.get("org.robolectric.metaName2");
-    assertTrue(String.class.isInstance(metaValue));
     assertEquals("metaValue2", metaValue);
 
     metaValue = meta.get("org.robolectric.metaFalse");
@@ -115,6 +114,24 @@ public class AndroidManifestTest {
 
     metaValue = meta.get("org.robolectric.metaFloat");
     assertEquals("1.23", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaColor");
+    assertEquals("#FFFFFF", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaBooleanFromRes");
+    assertEquals("@bool/false_bool_value", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaIntFromRes");
+    assertEquals("@integer/test_integer1", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaColorFromRes");
+    assertEquals("@color/clear", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringFromRes");
+    assertEquals("@string/app_name", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringOfIntFromRes");
+    assertEquals("@string/str_int", metaValue);
 
     metaValue = meta.get("org.robolectric.metaStringRes");
     assertEquals("@string/app_name", metaValue);
@@ -146,13 +163,12 @@ public class AndroidManifestTest {
   @Test
   @Config(manifest = "src/test/resources/TestAndroidManifestWithAppMetaData.xml")
   public void shouldReturnApplicationMetaData() throws PackageManager.NameNotFoundException {
-    Map<String, String> meta = newConfig("TestAndroidManifestWithAppMetaData.xml").getApplicationMetaData();
+    Map<String, Object> meta = newConfig("TestAndroidManifestWithAppMetaData.xml").getApplicationMetaData();
 
     Object metaValue = meta.get("org.robolectric.metaName1");
     assertEquals("metaValue1", metaValue);
 
     metaValue = meta.get("org.robolectric.metaName2");
-    assertTrue(String.class.isInstance(metaValue));
     assertEquals("metaValue2", metaValue);
 
     metaValue = meta.get("org.robolectric.metaFalse");
@@ -166,6 +182,24 @@ public class AndroidManifestTest {
 
     metaValue = meta.get("org.robolectric.metaFloat");
     assertEquals("1.23", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaColor");
+    assertEquals("#FFFFFF", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaBooleanFromRes");
+    assertEquals("@bool/false_bool_value", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaIntFromRes");
+    assertEquals("@integer/test_integer1", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaColorFromRes");
+    assertEquals("@color/clear", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringFromRes");
+    assertEquals("@string/app_name", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringOfIntFromRes");
+    assertEquals("@string/str_int", metaValue);
 
     metaValue = meta.get("org.robolectric.metaStringRes");
     assertEquals("@string/app_name", metaValue);

--- a/src/test/java/org/robolectric/R.java
+++ b/src/test/java/org/robolectric/R.java
@@ -129,6 +129,7 @@ public final class R {
     public static final int activity_name = 0x10111;
     public static final int minute_singular = 0x10112;
     public static final int minute_plural = 0x10113;
+    public static final int str_int = 0x10114;
   }
 
   public static final class plurals {

--- a/src/test/java/org/robolectric/res/RobolectricPackageManagerTest.java
+++ b/src/test/java/org/robolectric/res/RobolectricPackageManagerTest.java
@@ -8,6 +8,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.graphics.Color;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
@@ -24,13 +25,13 @@ import org.junit.runner.RunWith;
 import org.robolectric.*;
 import org.robolectric.annotation.Config;
 import org.robolectric.res.builder.RobolectricPackageManager;
+import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowDrawable;
 import org.robolectric.test.TemporaryFolder;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.robolectric.util.TestUtil.resourceFile;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -229,8 +230,9 @@ public class RobolectricPackageManagerTest {
   @Test
   @Config(manifest = "src/test/resources/TestAndroidManifestWithReceivers.xml")
   public void testReceiverInfo() throws Exception {
-    rpm.addManifest(Robolectric.getShadowApplication().getAppManifest(), Robolectric.getShadowApplication().getResourceLoader());
-    ActivityInfo info = rpm.getReceiverInfo(new ComponentName(Robolectric.getShadowApplication().getApplicationContext(), ".test.ConfigTestReceiver"), PackageManager.GET_META_DATA);
+    ShadowApplication app = Robolectric.getShadowApplication();
+    rpm.addManifest(app.getAppManifest(), Robolectric.getShadowApplication().getResourceLoader());
+    ActivityInfo info = rpm.getReceiverInfo(new ComponentName(app.getApplicationContext(), ".test.ConfigTestReceiver"), PackageManager.GET_META_DATA);
     Bundle meta = info.metaData;
     Object metaValue = meta.get("org.robolectric.metaName1");
     assertTrue(String.class.isInstance(metaValue));
@@ -255,6 +257,32 @@ public class RobolectricPackageManagerTest {
     metaValue = meta.get("org.robolectric.metaFloat");
     assertTrue(Float.class.isInstance(metaValue));
     assertEquals(new Float(1.23), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaColor");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(Color.WHITE, metaValue);
+
+
+    metaValue = meta.get("org.robolectric.metaBooleanFromRes");
+    assertTrue(Boolean.class.isInstance(metaValue));
+    assertEquals(app.getResources().getBoolean(R.bool.false_bool_value), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaIntFromRes");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(app.getResources().getInteger(R.integer.test_integer1), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaColorFromRes");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(app.getResources().getColor(R.color.clear), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringFromRes");
+    assertTrue(String.class.isInstance(metaValue));
+    assertEquals(app.getString(R.string.app_name), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringOfIntFromRes");
+    assertTrue(String.class.isInstance(metaValue));
+    assertEquals(app.getString(R.string.str_int), metaValue);
+
 
     metaValue = meta.get("org.robolectric.metaStringRes");
     assertTrue(Integer.class.isInstance(metaValue));
@@ -329,8 +357,10 @@ public class RobolectricPackageManagerTest {
   @Test
   @Config(manifest = "src/test/resources/TestAndroidManifestWithAppMetaData.xml")
   public void shouldAssignTheAppMetaDataFromTheManifest() throws Exception {
-    String packageName = Robolectric.getShadowApplication().getAppManifest().getPackageName();
-    ApplicationInfo info = Robolectric.getShadowApplication().getPackageManager().getApplicationInfo(packageName, 0);
+    ShadowApplication app = Robolectric.getShadowApplication();
+    String appName = app.getString(R.string.app_name);
+    String packageName = app.getAppManifest().getPackageName();
+    ApplicationInfo info = app.getPackageManager().getApplicationInfo(packageName, 0);
     Bundle meta = info.metaData;
 
     Object metaValue = meta.get("org.robolectric.metaName1");
@@ -356,6 +386,32 @@ public class RobolectricPackageManagerTest {
     metaValue = meta.get("org.robolectric.metaFloat");
     assertTrue(Float.class.isInstance(metaValue));
     assertEquals(new Float(1.23), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaColor");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(Color.WHITE, metaValue);
+
+
+    metaValue = meta.get("org.robolectric.metaBooleanFromRes");
+    assertTrue(Boolean.class.isInstance(metaValue));
+    assertEquals(app.getResources().getBoolean(R.bool.false_bool_value), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaIntFromRes");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(app.getResources().getInteger(R.integer.test_integer1), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaColorFromRes");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(app.getResources().getColor(R.color.clear), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringFromRes");
+    assertTrue(String.class.isInstance(metaValue));
+    assertEquals(app.getString(R.string.app_name), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringOfIntFromRes");
+    assertTrue(String.class.isInstance(metaValue));
+    assertEquals(app.getString(R.string.str_int), metaValue);
+
 
     metaValue = meta.get("org.robolectric.metaStringRes");
     assertTrue(Integer.class.isInstance(metaValue));

--- a/src/test/resources/TestAndroidManifestWithAppMetaData.xml
+++ b/src/test/resources/TestAndroidManifestWithAppMetaData.xml
@@ -10,6 +10,14 @@
     <meta-data android:name="org.robolectric.metaFalse" android:value="false" />
     <meta-data android:name="org.robolectric.metaInt" android:value="123" />
     <meta-data android:name="org.robolectric.metaFloat" android:value="1.23" />
+    <meta-data android:name="org.robolectric.metaColor" android:value="#FFFFFF" />
+
+    <meta-data android:name="org.robolectric.metaBooleanFromRes" android:value="@bool/false_bool_value" />
+    <meta-data android:name="org.robolectric.metaIntFromRes" android:value="@integer/test_integer1" />
+    <meta-data android:name="org.robolectric.metaColorFromRes" android:value="@color/clear" />
+    <meta-data android:name="org.robolectric.metaStringFromRes" android:value="@string/app_name" />
+    <meta-data android:name="org.robolectric.metaStringOfIntFromRes" android:value="@string/str_int" />
+
     <meta-data android:name="org.robolectric.metaStringRes" android:resource="@string/app_name" />
   </application>
 </manifest>

--- a/src/test/resources/TestAndroidManifestWithReceivers.xml
+++ b/src/test/resources/TestAndroidManifestWithReceivers.xml
@@ -43,6 +43,14 @@
       <meta-data android:name="org.robolectric.metaFalse" android:value="false" />
       <meta-data android:name="org.robolectric.metaInt" android:value="123" />
       <meta-data android:name="org.robolectric.metaFloat" android:value="1.23" />
+      <meta-data android:name="org.robolectric.metaColor" android:value="#FFFFFF" />
+
+      <meta-data android:name="org.robolectric.metaBooleanFromRes" android:value="@bool/false_bool_value" />
+      <meta-data android:name="org.robolectric.metaIntFromRes" android:value="@integer/test_integer1" />
+      <meta-data android:name="org.robolectric.metaColorFromRes" android:value="@color/clear" />
+      <meta-data android:name="org.robolectric.metaStringFromRes" android:value="@string/app_name" />
+        <meta-data android:name="org.robolectric.metaStringOfIntFromRes" android:value="@string/str_int" />
+
       <meta-data android:name="org.robolectric.metaStringRes" android:resource="@string/app_name" />
     </receiver>
 

--- a/src/test/resources/res/values/strings.xml
+++ b/src/test/resources/res/values/strings.xml
@@ -19,4 +19,5 @@
   <string name="activity_name">Testing App Activity</string>
   <string name="minute_singular">minute</string>
   <string name="minute_plural">minutes</string>
+  <string name="str_int">123456</string>
 </resources>


### PR DESCRIPTION
Fixes #950. Differentiates between meta-data specified using the `android:value` and `android:resource` attributes. Resolves value attributes as the correct type. No longer does over-parsing of values (i.e. a string resource value that was all numbers was previously being resolved to an int in the meta-data bundle).
