### PR TITLE
Updated ASM dependencies to v5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,25 +85,25 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>4.1</version>
+      <version>5.0.1</version>
     </dependency>
 
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-commons</artifactId>
-      <version>4.1</version>
+      <version>5.0.1</version>
     </dependency>
 
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-util</artifactId>
-      <version>4.1</version>
+      <version>5.0.1</version>
     </dependency>
 
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-analysis</artifactId>
-      <version>4.1</version>
+      <version>5.0.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
v5 of ASM fixes a few issues with JDK7, but also 'unbreaks' building with JDK8. I include v5 in my builds manually at the moment and they run fine.
