### PR TITLE
Convert FileFsFile to canonical paths

### DIFF
--- a/src/main/java/org/robolectric/AndroidManifest.java
+++ b/src/main/java/org/robolectric/AndroidManifest.java
@@ -2,6 +2,7 @@ package org.robolectric;
 
 import android.app.Activity;
 import android.graphics.Color;
+import org.fest.util.Lists;
 import org.robolectric.res.*;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -14,11 +15,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.Properties;
 
 import static android.content.pm.ApplicationInfo.FLAG_ALLOW_BACKUP;
@@ -298,7 +301,7 @@ public class AndroidManifest {
   /***
    * Allows {@link org.robolectric.res.builder.RobolectricPackageManager} to provide
    * a resource index for initialising the resource attributes in all the metadata elements
-   * @param resIndex used for getting resource IDs from string identifiers
+   * @param resLoader used for getting resource IDs from string identifiers
    */
   public void initMetaData(ResourceLoader resLoader) {
     applicationMetaData.init(resLoader, packageName);
@@ -426,12 +429,12 @@ public class AndroidManifest {
   }
 
   public List<ResourcePath> getIncludedResourcePaths() {
-    List<ResourcePath> resourcePaths = new ArrayList<ResourcePath>();
+    Collection<ResourcePath> resourcePaths = new LinkedHashSet<ResourcePath>(); // Needs stable ordering and no duplicates
     resourcePaths.add(getResourcePath());
     for (AndroidManifest libraryManifest : getLibraryManifests()) {
       resourcePaths.addAll(libraryManifest.getIncludedResourcePaths());
     }
-    return resourcePaths;
+    return Lists.newArrayList(resourcePaths);
   }
 
   public List<ContentProviderData> getContentProviders() {

--- a/src/main/java/org/robolectric/res/FileFsFile.java
+++ b/src/main/java/org/robolectric/res/FileFsFile.java
@@ -12,7 +12,16 @@ public class FileFsFile implements FsFile {
   private File file;
 
   FileFsFile(File file) {
-    this.file = file;
+    try {
+      // Android library references in project.properties are all
+      // relative paths, so using a canonical path guarantees that
+      // there won't be duplicates.
+      this.file = file.getCanonicalFile();
+    } catch (IOException e) {
+      // In a case where file system queries are failing, it makes
+      // sense for the test to fail.
+      throw new RuntimeException(e);
+    }
   }
 
   @Override public boolean exists() {

--- a/src/main/java/org/robolectric/res/ResourcePath.java
+++ b/src/main/java/org/robolectric/res/ResourcePath.java
@@ -1,5 +1,7 @@
 package org.robolectric.res;
 
+import org.fest.util.Objects;
+
 public class ResourcePath {
   public final Class<?> rClass;
   public final String packageName;
@@ -34,8 +36,8 @@ public class ResourcePath {
 
     if (!assetsDir.equals(that.assetsDir)) return false;
     if (!packageName.equals(that.packageName)) return false;
-    if (rClass != null ? !rClass.equals(that.rClass) : that.rClass != null) return false;
-    if (!rawDir.equals(that.rawDir)) return false;
+    if (!Objects.areEqual(rClass, that.rClass)) return false;
+    if (!Objects.areEqual(rawDir, that.rawDir)) return false;
     if (!resourceBase.equals(that.resourceBase)) return false;
 
     return true;
@@ -47,7 +49,9 @@ public class ResourcePath {
     result = 31 * result + packageName.hashCode();
     result = 31 * result + resourceBase.hashCode();
     result = 31 * result + assetsDir.hashCode();
-    result = 31 * result + rawDir.hashCode();
+    if (rawDir != null) {
+      result = 31 * result + rawDir.hashCode();
+    }
     return result;
   }
 }

--- a/src/test/java/org/robolectric/AndroidManifestTest.java
+++ b/src/test/java/org/robolectric/AndroidManifestTest.java
@@ -18,6 +18,7 @@ import org.robolectric.test.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +41,7 @@ import static java.util.Arrays.asList;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.robolectric.util.TestUtil.joinPath;
+import static org.robolectric.util.TestUtil.joinCanonicalPath;
 import static org.robolectric.util.TestUtil.newConfig;
 import static org.robolectric.util.TestUtil.resourceFile;
 
@@ -205,16 +206,16 @@ public class AndroidManifestTest {
     assertEquals("@string/app_name", metaValue);
   }
   
-  @Test public void shouldLoadAllResourcesForExistingLibraries() {
+  @Test public void shouldLoadAllResourcesForExistingLibraries() throws Exception {
     AndroidManifest appManifest = new AndroidManifest(resourceFile("TestAndroidManifest.xml"), resourceFile("res"));
 
     // This intentionally loads from the non standard resources/project.properties
     List<String> resourcePaths = stringify(appManifest.getIncludedResourcePaths());
     assertEquals(asList(
-        joinPath(".", "src", "test", "resources", "res"),
-        joinPath(".", "src", "test", "resources", "lib1", "res"),
-        joinPath(".", "src", "test", "resources", "lib1", "..", "lib3", "res"),
-        joinPath(".", "src", "test", "resources", "lib2", "res")),
+        joinCanonicalPath(".", "src", "test", "resources", "res"),
+        joinCanonicalPath(".", "src", "test", "resources", "lib1", "res"),
+        joinCanonicalPath(".", "src", "test", "resources", "lib3", "res"),
+        joinCanonicalPath(".", "src", "test", "resources", "lib2", "res")),
         resourcePaths);
   }
 
@@ -301,7 +302,7 @@ public class AndroidManifestTest {
     return new AndroidManifest(Fs.newFile(f), null, null);
   }
 
-  private List<String> stringify(List<ResourcePath> resourcePaths) {
+  private List<String> stringify(Collection<ResourcePath> resourcePaths) {
     List<String> resourcePathBases = new ArrayList<String>();
     for (ResourcePath resourcePath : resourcePaths) {
       resourcePathBases.add(resourcePath.resourceBase.toString());

--- a/src/test/java/org/robolectric/shadows/ResourcesTest.java
+++ b/src/test/java/org/robolectric/shadows/ResourcesTest.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.shadowOf;
+import static org.robolectric.util.TestUtil.joinCanonicalPath;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ResourcesTest {
@@ -65,7 +66,7 @@ public class ResourcesTest {
   @Test
   public void getText_withLayoutId() throws Exception {
     // todo: this needs to change...
-    assertThat(resources.getText(R.layout.different_screen_sizes, "value")).isEqualTo("." + File.separator + "src" + File.separator + "test" + File.separator + "resources" + File.separator + "res" + File.separator + "layout" + File.separator + "different_screen_sizes.xml");
+    assertThat(resources.getText(R.layout.different_screen_sizes, "value")).isEqualTo(joinCanonicalPath(".", "src", "test", "resources", "res", "layout", "different_screen_sizes.xml"));
   }
 
   @Test

--- a/src/test/java/org/robolectric/util/TestUtil.java
+++ b/src/test/java/org/robolectric/util/TestUtil.java
@@ -144,6 +144,10 @@ public abstract class TestUtil {
     return file.getPath();
   }
 
+  public static String joinCanonicalPath(String... parts) throws IOException {
+    return new File(joinPath(parts)).getCanonicalPath();
+  }
+
   public static Resources createResourcesFor(ResourceLoader resourceLoader) {
     return ShadowResources.createFor(resourceLoader);
   }

--- a/src/test/resources/lib1/project.properties
+++ b/src/test/resources/lib1/project.properties
@@ -4,3 +4,4 @@
 # Project target.
 target=android-42
 android.library.reference.1=../lib3
+android.library.reference.2=../lib2


### PR DESCRIPTION
Fixes multiple inclusions of res/ directories with transitive
libraries.

This also required making ResourcePaths’s equals and hashcode methods
null safe.
