### PR TITLE
Allow an options bundle to be used in startActivity

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -422,10 +422,18 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   public class IntentForResult {
     public Intent intent;
     public int requestCode;
+    public Bundle options;
 
     public IntentForResult(Intent intent, int requestCode) {
       this.intent = intent;
       this.requestCode = requestCode;
+      this.options = null;
+    }
+
+    public IntentForResult(Intent intent, int requestCode, Bundle options) {
+      this.intent = intent;
+      this.requestCode = requestCode;
+      this.options = options;
     }
   }
 
@@ -435,9 +443,21 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
+  public void startActivity(Intent intent, Bundle options) {
+    startActivityForResult(intent, -1, options);
+  }
+
+  @Implementation
   public void startActivityForResult(Intent intent, int requestCode) {
     intentRequestCodeMap.put(intent, requestCode);
     startedActivitiesForResults.add(new IntentForResult(intent, requestCode));
+    getApplicationContext().startActivity(intent);
+  }
+
+  @Implementation
+  public void startActivityForResult(Intent intent, int requestCode, Bundle options) {
+    intentRequestCodeMap.put(intent, requestCode);
+    startedActivitiesForResults.add(new IntentForResult(intent, requestCode, options));
     getApplicationContext().startActivity(intent);
   }
 

--- a/src/test/java/org/robolectric/shadows/ActivityTest.java
+++ b/src/test/java/org/robolectric/shadows/ActivityTest.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import android.app.ActionBar;
 import android.app.Activity;
+import android.app.ActivityOptions;
 import android.app.Dialog;
 import android.app.Fragment;
 import android.appwidget.AppWidgetProvider;
@@ -744,6 +745,16 @@ public class ActivityTest {
     Intent intent = new Intent(Intent.ACTION_VIEW);
     activity.startActivityFromFragment(new Fragment(), intent, 0);
     assertThat(shadowOf(activity).getNextStartedActivity().getAction()).isEqualTo(Intent.ACTION_VIEW);
+  }
+
+  @Test
+  public void shouldUseAnimationOverride() {
+    Activity activity = buildActivity(Activity.class).create().get();
+    Intent intent = new Intent(activity, OptionsMenuActivity.class);
+
+    Bundle animationBundle = ActivityOptions.makeCustomAnimation(activity, R.anim.test_anim_1, R.anim.test_anim_1).toBundle();
+    activity.startActivity(intent, animationBundle);
+    assertThat(shadowOf(activity).getNextStartedActivityForResult().options).isSameAs(animationBundle);
   }
 
   /////////////////////////////


### PR DESCRIPTION
Prevents an NPE from being called when supplying an options bundle to
context.startActivity(intent, bundle). The bundle isn't passed on, but
instead stored in IntentForResult.

This is a patch for issue: https://github.com/robolectric/robolectric/issues/1046
