### PR TITLE
Add method to ShadowPhoneWindow to get the indeterminate progress bar

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowPhoneWindow.java
+++ b/src/main/java/org/robolectric/shadows/ShadowPhoneWindow.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import android.graphics.drawable.Drawable;
 import android.view.Window;
 
+import android.widget.ProgressBar;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -34,5 +35,10 @@ public class ShadowPhoneWindow extends ShadowWindow {
 
   public Drawable getBackgroundDrawable() {
     return backgroundDrawable;
+  }
+
+  @Override
+  public ProgressBar getIndeterminateProgressBar() {
+    return (ProgressBar) directlyOn(realWindow, PHONE_WINDOW_CLASS_NAME, "getCircularProgressBar", boolean.class).invoke(false);
   }
 }

--- a/src/main/java/org/robolectric/shadows/ShadowWindow.java
+++ b/src/main/java/org/robolectric/shadows/ShadowWindow.java
@@ -5,6 +5,7 @@ import android.graphics.drawable.Drawable;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.ImageView;
+import android.widget.ProgressBar;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -72,5 +73,9 @@ public class ShadowWindow {
 
   public int getSoftInputMode() {
     return softInputMode;
+  }
+
+  public ProgressBar getIndeterminateProgressBar() {
+    return null;
   }
 }

--- a/src/test/java/org/robolectric/shadows/WindowTest.java
+++ b/src/test/java/org/robolectric/shadows/WindowTest.java
@@ -4,10 +4,12 @@ import android.R;
 import android.app.Activity;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Bundle;
+import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.ProgressBar;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -77,12 +79,28 @@ public class WindowTest {
     assertThat(shadowWindow.getSoftInputMode()).isEqualTo(7);
   }
 
+  @Test
+  public void getIndeterminateProgressBar_returnsTheIndeterminateProgressBar() {
+    Activity activity = Robolectric.buildActivity(TestActivity.class).create().get();
+    Window window = activity.getWindow();
+    ShadowWindow shadowWindow = shadowOf(window);
+
+    ProgressBar indeterminate = shadowWindow.getIndeterminateProgressBar();
+
+    assertThat(indeterminate.getVisibility()).isEqualTo(View.INVISIBLE);
+    activity.setProgressBarIndeterminateVisibility(true);
+    assertThat(indeterminate.getVisibility()).isEqualTo(View.VISIBLE);
+    activity.setProgressBarIndeterminateVisibility(false);
+    assertThat(indeterminate.getVisibility()).isEqualTo(View.GONE);
+  }
+
   public static class TestActivity extends Activity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
       super.onCreate(savedInstanceState);
       setTheme(R.style.Theme_Holo_Light);
+      getWindow().requestFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
       setContentView(new LinearLayout(this));
       getActionBar().setIcon(R.drawable.ic_lock_power_off);
     }


### PR DESCRIPTION
The problem I was trying to solve:

Testing that `getActivity().setProgressBarIndeterminateVisibility()` was called.

I went off reading Activity, Window, PhoneWindow, ProgressBar, did a bit of TDD, and came up with this. What do you think? If you like the approach, I could also whip this up for the regular progress bar as well.

At first I considered Activity#getProgressBarIndeterminateVisibility but thought it would produce tests overly coupled to the implementation, given that there are other ways of changing the bar's state. The more general Window#getFeatureInt seemed quite Robolectric-y, but has the potential to involve complicated logic which mirror's Android's).

This way I'm asking the question I really want to ask - is the progress bar visible? The use case for how I'm using this in my code is very similar to the test for it (but with the set call occuring in the SUT).
