### PR TITLE
Fix issue with loading jar resources on Windows.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -159,8 +159,7 @@ public final class ShadowAssetManager {
 
   @HiddenApi @Implementation
   public final InputStream openNonAsset(int cookie, String fileName, int accessMode) throws IOException {
-    final String packageName = getPackageNameForFile(fileName);
-    final ResName resName = ResName.qualifyFromFilePath(packageName, fileName);
+    final ResName resName = qualifyFromNonAssetFileName(fileName);
     final DrawableNode drawableNode = resourceLoader.getDrawableNode(resName, getQualifiers());
 
     if (drawableNode == null) {
@@ -170,11 +169,12 @@ public final class ShadowAssetManager {
     return new ByteArrayInputStream(drawableNode.getFsFile().getBytes());
   }
 
-  private String getPackageNameForFile(final String fileName) {
-    if (fileName.startsWith("jar")) {
-      return "android";
+  private ResName qualifyFromNonAssetFileName(String fileName) {
+    if (fileName.startsWith("jar:")) {
+      // Must remove "jar:" prefix, or else qualifyFromFilePath fails on Windows
+      return ResName.qualifyFromFilePath("android", fileName.replaceFirst("jar:", ""));
     } else {
-      return appManifest.getPackageName();
+      return ResName.qualifyFromFilePath(appManifest.getPackageName(), fileName);
     }
   }
 


### PR DESCRIPTION
Hopefully fixes #1049.

The issue is that `ShadowAssetManager.openNonAsset()` receives a file name prefixed with "jar:", which is then passed to `ResName.qualifyFromFilePath()`, that creates a new `FileFsFile`. The constructor runs `file.getCanonicalFile()`, which throws an IOException:

```
Caused by: android.content.res.Resources$NotFoundException: File jar:C:\Users\someone\.m2\repository\org\robolectric\android-all\4.3_r2-robolectric-0\android-all-4.3_r2-robolectric-0.jar!/res/drawable-hdpi/ab_solid_dark_holo.9.png from drawable resource ID #0x1140007
...
Caused by: java.lang.RuntimeException: java.io.IOException: The filename, directory name, or volume label syntax is incorrect
    at org.robolectric.res.FileFsFile.<init>(FileFsFile.java:23)
    at org.robolectric.res.ResName.qualifyFromFilePath(ResName.java:77)
    at org.robolectric.shadows.ShadowAssetManager.openNonAsset(ShadowAssetManager.java:163)
    at android.content.res.AssetManager.openNonAsset(AssetManager.java)
    at android.content.res.Resources.loadDrawable(Resources.java:2102)
```

This does not happen on Linux or Mac. Only Windows.
Removing the "jar:" prefix seems to work, as the file path is then valid on Windows as well.

I do not know how to create a unit test that fails on the build server, which I assume is running Linux.
But the existing tests fail on Windows.

I have not verified this exact fix on Windows yet. 
Can test tomorrow.
