### PR TITLE
Fix #970 SocketTagger NoSuchMethodError

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowSocketTagger.java
+++ b/src/main/java/org/robolectric/shadows/ShadowSocketTagger.java
@@ -12,5 +12,8 @@ public class ShadowSocketTagger {
   public static final String REAL_CLASS_NAME = "dalvik.system.SocketTagger";
 
   @Implementation
+  public final void tag(Socket socket) throws SocketException { }
+
+  @Implementation
   public final void untag(Socket socket) throws SocketException { }
 }


### PR DESCRIPTION
Fix for SocketTagger which fails with NoSuchMethodError (#970)
