### PR TITLE
#973 AndroidManifest should ignore empty library directories

### DIFF
--- a/src/main/java/org/robolectric/AndroidManifest.java
+++ b/src/main/java/org/robolectric/AndroidManifest.java
@@ -466,8 +466,13 @@ public class AndroidManifest {
       String lib;
       while ((lib = properties.getProperty("android.library.reference." + libRef)) != null) {
         FsFile libraryBaseDir = baseDir.join(lib);
-        if (libraryBaseDir.exists()) {
-          libraryBaseDirs.add(libraryBaseDir);
+        // #973: Check if library directory is not empty. This can happen for example with Git submodules.
+        // In that case, we should simply ignore the library.
+        if (libraryBaseDir.isDirectory()) {
+          FsFile[] libraryBaseDirFiles = libraryBaseDir.listFiles();
+          if (libraryBaseDirFiles != null && libraryBaseDirFiles.length > 0) {
+            libraryBaseDirs.add(libraryBaseDir);
+          }
         }
 
         libRef++;


### PR DESCRIPTION
See #973! Please check as I'm not sure this Pull Request is really appropriate.

Robolectric ignores manifests of library projects it cannot find. To do so, it checks if the directory exists. However, when using for example git submodules, library projects may exist but be empty. This fix proposes to check not only if library project directory exists but also if it's empty.
