### PR TITLE
Adding _item_ resource support. Fixes #1079

### DIFF
--- a/src/main/java/org/robolectric/res/PackageResourceLoader.java
+++ b/src/main/java/org/robolectric/res/PackageResourceLoader.java
@@ -29,10 +29,12 @@ public class PackageResourceLoader extends XResourceLoader {
 
     documentLoader.load("values",
         new ValueResourceLoader(data, "/resources/bool", "bool", ResType.BOOLEAN),
+        new ValueResourceLoader(data, "/resources/item[@type='bool']", "bool", ResType.BOOLEAN),
         new ValueResourceLoader(data, "/resources/color", "color", ResType.COLOR),
         new ValueResourceLoader(data, "/resources/dimen", "dimen", ResType.DIMEN),
         new ValueResourceLoader(data, "/resources/item[@type='dimen']", "dimen", ResType.DIMEN),
         new ValueResourceLoader(data, "/resources/integer", "integer", ResType.INTEGER),
+        new ValueResourceLoader(data, "/resources/item[@type='integer']", "integer", ResType.INTEGER),
         new ValueResourceLoader(data, "/resources/integer-array", "array", ResType.INTEGER_ARRAY),
         new ValueResourceLoader(data, "/resources/item", "layout", ResType.LAYOUT),
         new PluralResourceLoader(pluralsData),

--- a/src/test/java/org/robolectric/R.java
+++ b/src/test/java/org/robolectric/R.java
@@ -109,6 +109,7 @@ public final class R {
     public static final int surrounding_quotes = 0x10118;
     public static final int escaped_apostrophe = 0x10119;
     public static final int escaped_quotes = 0x10120;
+    public static final int say_it_with_item = 0x10121;
   }
 
   public static final class plurals {
@@ -290,6 +291,7 @@ public final class R {
     public static final int hex_int = 0x10d07;
     public static final int test_value_with_zero = 0x10d08;
     public static final int reference_to_meaning_of_life = 0x10d09;
+    public static final int meaning_of_life_as_item = 0x10d0a;
   }
 
   public static final class bool {
@@ -298,6 +300,7 @@ public final class R {
     public static final int zero_is_false = 0x10e02;
     public static final int integers_are_true = 0x10e03;
     public static final int reference_to_true = 0x10e04;
+    public static final int true_as_item = 0x10e05;
   }
 
   public static final class style {

--- a/src/test/java/org/robolectric/shadows/ResourcesTest.java
+++ b/src/test/java/org/robolectric/shadows/ResourcesTest.java
@@ -41,6 +41,7 @@ public class ResourcesTest {
   @Test
   public void getString() throws Exception {
     assertThat(resources.getString(R.string.hello)).isEqualTo("Hello");
+    assertThat(resources.getString(R.string.say_it_with_item)).isEqualTo("flowers");
   }
 
   @Test
@@ -98,6 +99,7 @@ public class ResourcesTest {
     assertThat(resources.getInteger(R.integer.test_integer2)).isEqualTo(9);
     assertThat(resources.getInteger(R.integer.test_large_hex)).isEqualTo(-65536);
     assertThat(resources.getInteger(R.integer.test_value_with_zero)).isEqualTo(7210);
+    assertThat(resources.getInteger(R.integer.meaning_of_life_as_item)).isEqualTo(42);
   }
 
   @Test
@@ -116,6 +118,7 @@ public class ResourcesTest {
   public void getBoolean() throws Exception {
     assertThat(resources.getBoolean(R.bool.false_bool_value)).isEqualTo(false);
     assertThat(resources.getBoolean(R.bool.integers_are_true)).isEqualTo(true);
+    assertThat(resources.getBoolean(R.bool.true_as_item)).isEqualTo(true);
   }
 
   @Test

--- a/src/test/resources/res/values/bools.xml
+++ b/src/test/resources/res/values/bools.xml
@@ -5,4 +5,5 @@
   <bool name="zero_is_false">0</bool>
   <bool name="integers_are_true">7</bool>
   <bool name="reference_to_true">@true_bool_value</bool>
+  <item name="true_as_item" type="bool">true</item>
 </resources>

--- a/src/test/resources/res/values/integers.xml
+++ b/src/test/resources/res/values/integers.xml
@@ -5,4 +5,5 @@
   <integer name="there_can_be_only">@integer/loneliest_number</integer>
   <integer name="hex_int">0xFFFF0000</integer>
   <integer name="reference_to_meaning_of_life">@meaning_of_life</integer>
+  <item name="meaning_of_life_as_item" type="integer">42</item>
 </resources>

--- a/src/test/resources/res/values/strings.xml
+++ b/src/test/resources/res/values/strings.xml
@@ -26,4 +26,5 @@
   <string name="preference_resource_key">preference_resource_key_value</string>
   <string name="preference_resource_title">preference_resource_title_value</string>
   <string name="preference_resource_summary">preference_resource_summary_value</string>
+  <item name="say_it_with_item" type="string">flowers</item>
 </resources>


### PR DESCRIPTION
Android allows defining resource either by a class name, e.g.,
`<integer... />` or by item&type, e.g., `<item ... type='integer'../>`
This commit add support for the latter.
