### PR TITLE
Mark android-support library as optional.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
       <artifactId>support-v4</artifactId>
       <version>19.0.1</version>
       <scope>compile</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Projects that don't use the support library shouldn't have to install it
for robolectric to work. It should only be needed for projects that use
the support library shadows (and will have the support library available).
