### PR TITLE
Use canonical file paths only for equivalence comparison in FileFsFile.

### DIFF
--- a/src/main/java/org/robolectric/res/FileFsFile.java
+++ b/src/main/java/org/robolectric/res/FileFsFile.java
@@ -9,14 +9,16 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public class FileFsFile implements FsFile {
-  private File file;
+    private final File canonicalFile;
+    private File file;
 
   FileFsFile(File file) {
+    this.file = file;
     try {
       // Android library references in project.properties are all
       // relative paths, so using a canonical path guarantees that
       // there won't be duplicates.
-      this.file = file.getCanonicalFile();
+      this.canonicalFile = file.getCanonicalFile();
     } catch (IOException e) {
       // In a case where file system queries are failing, it makes
       // sense for the test to fail.
@@ -99,14 +101,14 @@ public class FileFsFile implements FsFile {
 
     FileFsFile fsFile = (FileFsFile) o;
 
-    if (!file.equals(fsFile.file)) return false;
+    if (!canonicalFile.equals(fsFile.canonicalFile)) return false;
 
     return true;
   }
 
   @Override
   public int hashCode() {
-    return file.hashCode();
+    return canonicalFile.hashCode();
   }
 
   private FsFile[] asFsFiles(File[] files) {

--- a/src/test/java/org/robolectric/AndroidManifestTest.java
+++ b/src/test/java/org/robolectric/AndroidManifestTest.java
@@ -41,9 +41,7 @@ import static java.util.Arrays.asList;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.robolectric.util.TestUtil.joinCanonicalPath;
-import static org.robolectric.util.TestUtil.newConfig;
-import static org.robolectric.util.TestUtil.resourceFile;
+import static org.robolectric.util.TestUtil.*;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -207,16 +205,16 @@ public class AndroidManifestTest {
   }
 
   @Test
-  public void shouldLoadAllResourcesForExistingLibraries() throws Exception {
+  public void shouldLoadAllResourcesForExistingLibraries() {
     AndroidManifest appManifest = new AndroidManifest(resourceFile("TestAndroidManifest.xml"), resourceFile("res"));
 
     // This intentionally loads from the non standard resources/project.properties
     List<String> resourcePaths = stringify(appManifest.getIncludedResourcePaths());
     assertEquals(asList(
-        joinCanonicalPath(".", "src", "test", "resources", "res"),
-        joinCanonicalPath(".", "src", "test", "resources", "lib1", "res"),
-        joinCanonicalPath(".", "src", "test", "resources", "lib3", "res"),
-        joinCanonicalPath(".", "src", "test", "resources", "lib2", "res")),
+        joinPath(".", "src", "test", "resources", "res"),
+        joinPath(".", "src", "test", "resources", "lib1", "res"),
+        joinPath(".", "src", "test", "resources", "lib1", "..", "lib3", "res"),
+        joinPath(".", "src", "test", "resources", "lib1", "..", "lib2", "res")),
         resourcePaths);
   }
 

--- a/src/test/java/org/robolectric/shadows/ResourcesTest.java
+++ b/src/test/java/org/robolectric/shadows/ResourcesTest.java
@@ -5,12 +5,7 @@ import android.content.res.ColorStateList;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.content.res.XmlResourceParser;
-import android.graphics.drawable.AnimationDrawable;
-import android.graphics.drawable.BitmapDrawable;
-import android.graphics.drawable.ColorDrawable;
-import android.graphics.drawable.Drawable;
-import android.graphics.drawable.NinePatchDrawable;
-
+import android.graphics.drawable.*;
 import android.util.DisplayMetrics;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +22,6 @@ import java.io.InputStream;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.shadowOf;
-import static org.robolectric.util.TestUtil.joinCanonicalPath;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ResourcesTest {
@@ -83,7 +77,7 @@ public class ResourcesTest {
   @Test
   public void getText_withLayoutId() throws Exception {
     // todo: this needs to change...
-    assertThat(resources.getText(R.layout.different_screen_sizes, "value")).isEqualTo(joinCanonicalPath(".", "src", "test", "resources", "res", "layout", "different_screen_sizes.xml"));
+      assertThat(resources.getText(R.layout.different_screen_sizes, "value")).isEqualTo("." + File.separator + "src" + File.separator + "test" + File.separator + "resources" + File.separator + "res" + File.separator + "layout" + File.separator + "different_screen_sizes.xml");
   }
 
   @Test


### PR DESCRIPTION
Use of canonical file paths was introduced in

https://www.google.com/url?q=https%3A%2F%2Fgithub.com%2Frobolectric%2Frobolectric%2Fpull%2F1042%2Ffiles&sa=D&sntz=1&usg=AFQjCNHgI6ZgJBHEuSGMqKUlLYjd-RwhGQ

in order to de-dupe resource library projects. Unfortunately this broke our distributed continuous build system that works by building a symlink farm of file system dependencies whose canonical path does not match file names and extensions of the original file.

We still want to use canonical file paths for equivalence comparison in order to preserve the original behavior of pulling in dependency libraries only once each.
