### PR TITLE
Attach Robolectric Sources as part of the build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,18 @@
           </filesets>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Make sure that the build artifacts include the main sources.  This is
necessary to make contributions and bug fixes easier.  Tools can pull
down the source as necessary and allow for easier debugging.
