### PR TITLE
Handle null strings in ShadowNotification.Builder.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowNotification.java
+++ b/src/main/java/org/robolectric/shadows/ShadowNotification.java
@@ -122,11 +122,11 @@ public class ShadowNotification {
   public static class ShadowBuilder {
 
     @RealObject private Notification.Builder realBuilder;
-    private String contentTitle;
-    private String contentText;
-    private String ticker;
-    private String contentInfo;
-    private int icon;
+    private CharSequence contentTitle;
+    private CharSequence contentInfo;
+    private CharSequence contentText;
+    private CharSequence ticker;
+    private int smallIcon;
     private long when;
 
     @Implementation
@@ -135,7 +135,7 @@ public class ShadowNotification {
       ShadowNotification shadowResult = shadowOf(result);
       shadowResult.setContentTitle(contentTitle);
       shadowResult.setContentText(contentText);
-      shadowResult.setSmallIcon(icon);
+      shadowResult.setSmallIcon(smallIcon);
       shadowResult.setTicker(ticker);
       shadowResult.setWhen(when);
       shadowResult.setContentInfo(contentInfo);
@@ -143,26 +143,23 @@ public class ShadowNotification {
     }
 
     @Implementation
-    public Notification.Builder setContentTitle(CharSequence title) {
-      contentTitle = title.toString();
-      directlyOn(realBuilder, Notification.Builder.class, "setContentTitle", CharSequence.class).invoke(title);
-
+    public Notification.Builder setContentTitle(CharSequence contentTitle) {
+      this.contentTitle = contentTitle;
+      directlyOn(realBuilder, Notification.Builder.class, "setContentTitle", CharSequence.class).invoke(contentTitle);
       return realBuilder;
     }
 
     @Implementation
     public Notification.Builder setContentText(CharSequence text) {
-      contentText = text.toString();
+      this.contentText = text;
       directlyOn(realBuilder, Notification.Builder.class, "setContentText", CharSequence.class).invoke(text);
-
       return realBuilder;
     }
 
     @Implementation
     public Notification.Builder setSmallIcon(int smallIcon) {
-      this.icon = smallIcon;
+      this.smallIcon = smallIcon;
       directlyOn(realBuilder, Notification.Builder.class, "setSmallIcon", int.class).invoke(smallIcon);
-
       return realBuilder;
     }
 
@@ -170,24 +167,21 @@ public class ShadowNotification {
     public Notification.Builder setWhen(long when) {
       this.when = when;
       directlyOn(realBuilder, Notification.Builder.class, "setWhen", long.class).invoke(when);
-
       return realBuilder;
     }
 
     @Implementation
-    public Notification.Builder setTicker(CharSequence ticker){
-     this.ticker = ticker.toString();
-     directlyOn(realBuilder, Notification.Builder.class, "setTicker", CharSequence.class).invoke(ticker);
-
-     return realBuilder;
+    public Notification.Builder setTicker(CharSequence ticker) {
+      this.ticker = ticker;
+      directlyOn(realBuilder, Notification.Builder.class, "setTicker", CharSequence.class).invoke(ticker);
+      return realBuilder;
     }
 
     @Implementation
-    public Notification.Builder setContentInfo(CharSequence info){
-     this.contentInfo = info.toString();
-     directlyOn(realBuilder, Notification.Builder.class, "setContentInfo", CharSequence.class).invoke(info);
-
-     return realBuilder;
+    public Notification.Builder setContentInfo(CharSequence contentInfo) {
+      this.contentInfo = contentInfo;
+      directlyOn(realBuilder, Notification.Builder.class, "setContentInfo", CharSequence.class).invoke(contentInfo);
+      return realBuilder;
     }
   }
 }

--- a/src/test/java/org/robolectric/shadows/NotificationBuilderTest.java
+++ b/src/test/java/org/robolectric/shadows/NotificationBuilderTest.java
@@ -1,64 +1,73 @@
 package org.robolectric.shadows;
 
-import android.app.Activity;
-import android.app.Notification;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
+import android.app.Notification;
 import org.robolectric.TestRunners;
-
-import static org.junit.Assert.assertEquals;
-import static org.robolectric.Robolectric.shadowOf;
+import static org.robolectric.Robolectric.*;
+import static org.fest.assertions.api.Assertions.*;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class NotificationBuilderTest {
-  Notification.Builder builder;
-
-  @Before
-  public void setup() {
-    builder = new Notification.Builder(Robolectric.buildActivity(Activity.class).get());
-  }
+  private final Notification.Builder builder = new Notification.Builder(application);
 
   @Test
   public void build_setsContentTitleOnNotification() throws Exception {
-    builder.setContentTitle("Hello");
-    Notification notification = builder.build();
-    assertEquals("Hello", shadowOf(notification).getContentTitle());
+    Notification notification = builder.setContentTitle("Hello").build();
+    assertThat("Hello").isEqualTo(shadowOf(notification).getContentTitle().toString());
   }
 
   @Test
   public void build_setsContentTextOnNotification() throws Exception {
-    builder.setContentText("Hello Text");
-    Notification notification = builder.build();
-    assertEquals("Hello Text", shadowOf(notification).getContentText());
-  }
-
-  @Test
-  public void build_setsIconOnNotification() throws Exception {
-    builder.setSmallIcon(9001);
-    Notification notification = builder.build();;
-    assertEquals(9001, shadowOf(notification).getSmallIcon());
-  }
-
-  @Test
-  public void build_setsWhenOnNotification() throws Exception {
-    builder.setWhen(11L);
-    Notification notification = builder.build();
-    assertEquals(11L, shadowOf(notification).getWhen());
+    Notification notification = builder.setContentText("Hello Text").build();
+    assertThat("Hello Text").isEqualTo(shadowOf(notification).getContentText().toString());
   }
 
   @Test
   public void build_setsTickerOnNotification() throws Exception {
-    builder.setTicker("My ticker");
-    Notification notification = builder.build();
-    assertEquals("My ticker", shadowOf(notification).getTicker());
+    Notification notification = builder.setTicker("My ticker").build();
+    assertThat("My ticker").isEqualTo(shadowOf(notification).getTicker().toString());
   }
 
   @Test
   public void build_setsContentInfoOnNotification() throws Exception {
-    builder.setContentInfo("11");
-    Notification notification = builder.build();
-    assertEquals("11", shadowOf(notification).getContentInfo());
+    Notification notification = builder.setContentInfo("11").build();
+    assertThat("11").isEqualTo(shadowOf(notification).getContentInfo().toString());
+  }
+
+  @Test
+  public void build_setsIconOnNotification() throws Exception {
+    Notification notification = builder.setSmallIcon(9001).build();
+    assertThat(9001).isEqualTo(shadowOf(notification).getSmallIcon());
+  }
+
+  @Test
+  public void build_setsWhenOnNotification() throws Exception {
+    Notification notification = builder.setWhen(11L).build();
+    assertThat(11L).isEqualTo(shadowOf(notification).getWhen());
+  }
+
+  @Test
+  public void build_handlesNullContentTitle() {
+    Notification notification = builder.setContentTitle(null).build();
+    assertThat(shadowOf(notification).getContentTitle()).isNull();
+  }
+
+  @Test
+  public void build_handlesNullContentText() {
+    Notification notification = builder.setContentText(null).build();
+    assertThat(shadowOf(notification).getContentText()).isNull();
+  }
+
+  @Test
+  public void build_handlesNullTicker() {
+    Notification notification = builder.setTicker(null).build();
+    assertThat(shadowOf(notification).getTicker()).isNull();
+  }
+
+  @Test
+  public void build_handlesNullContentInfo() {
+    Notification notification = builder.setContentInfo(null).build();
+    assertThat(shadowOf(notification).getContentInfo()).isNull();
   }
 }


### PR DESCRIPTION
This fixes an NPE when using NotificationCompat.Builder from the
support library, since it will call the builder methods with null inputs.
