### PR TITLE
Make fest-util a test only dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
       <groupId>org.easytesting</groupId>
       <artifactId>fest-util</artifactId>
       <version>1.2.5</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/robolectric/AndroidManifest.java
+++ b/src/main/java/org/robolectric/AndroidManifest.java
@@ -2,7 +2,6 @@ package org.robolectric;
 
 import android.app.Activity;
 import android.graphics.Color;
-import org.fest.util.Lists;
 import org.robolectric.res.*;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -491,7 +490,7 @@ public class AndroidManifest {
     for (AndroidManifest libraryManifest : getLibraryManifests()) {
       resourcePaths.addAll(libraryManifest.getIncludedResourcePaths());
     }
-    return Lists.newArrayList(resourcePaths);
+    return new ArrayList<ResourcePath>(resourcePaths);
   }
 
   public List<ContentProviderData> getContentProviders() {

--- a/src/main/java/org/robolectric/res/ResourcePath.java
+++ b/src/main/java/org/robolectric/res/ResourcePath.java
@@ -1,7 +1,5 @@
 package org.robolectric.res;
 
-import org.fest.util.Objects;
-
 public class ResourcePath {
   public final Class<?> rClass;
   public final String packageName;
@@ -36,8 +34,8 @@ public class ResourcePath {
 
     if (!assetsDir.equals(that.assetsDir)) return false;
     if (!packageName.equals(that.packageName)) return false;
-    if (!Objects.areEqual(rClass, that.rClass)) return false;
-    if (!Objects.areEqual(rawDir, that.rawDir)) return false;
+    if (!(rClass == null ? that.rClass == null : rClass.equals(that.rClass))) return false;
+    if (!(rawDir == null ? that.rawDir == null : rawDir.equals(that.rawDir))) return false;
     if (!resourceBase.equals(that.resourceBase)) return false;
 
     return true;

--- a/src/main/java/org/robolectric/shadows/ShadowCamera.java
+++ b/src/main/java/org/robolectric/shadows/ShadowCamera.java
@@ -3,14 +3,13 @@ package org.robolectric.shadows;
 import android.graphics.ImageFormat;
 import android.hardware.Camera;
 import android.view.SurfaceHolder;
-
-import org.fest.util.Lists;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -222,7 +221,7 @@ public class ShadowCamera {
     private int previewFps = 30;
     private int exposureCompensation = 0;
     private String focusMode;
-    private List<String> supportedFocusModes = Lists.newArrayList();
+    private List<String> supportedFocusModes = new ArrayList<String>();
 
     @Implementation
     public Camera.Size getPictureSize() {
@@ -307,7 +306,7 @@ public class ShadowCamera {
     }
 
     public void setSupportedFocusModes(String... focusModes) {
-      supportedFocusModes = Lists.newArrayList(focusModes);
+      supportedFocusModes = Arrays.asList(focusModes);
     }
 
     @Implementation


### PR DESCRIPTION
The fest-util that is used by Robolectric has version skew with both fest-reflect
(as seen by the exclusion in Robolectric's pom.xml) and also fest-assert.

Unfortunately many projects here use a version of fest assert that is runtime incompatible
with the version of fest-util that ships with Robolectric and this is blocking our
company wide upgrade to the latest version of Robolectric.

Until there is a public version of fest (assert,reflect,util) that is free of version skew
I reccomend against including fest-util as a production dependency of Robolectric.
