### PR TITLE
Add ActivityController launch().

### DIFF
--- a/src/main/java/org/robolectric/Robolectric.java
+++ b/src/main/java/org/robolectric/Robolectric.java
@@ -1673,7 +1673,7 @@ public class Robolectric {
   }
 
   public static <T extends Activity> T setupActivity(Class<T> activityClass) {
-    return new ActivityController<T>(activityClass).create().start().resume().visible().get();
+    return new ActivityController<T>(activityClass).setup().get();
   }
 
   /**

--- a/src/main/java/org/robolectric/util/ActivityController.java
+++ b/src/main/java/org/robolectric/util/ActivityController.java
@@ -195,7 +195,7 @@ public class ActivityController<T extends Activity>
    * Calls the same lifecycle methods on the Activity called by
    * Android the first time the Activity is created.
    */
-  public ActivityController<T> launch() {
+  public ActivityController<T> setup() {
     return create().start().postCreate(null).resume().postResume().visible();
   }
 }

--- a/src/test/java/org/robolectric/util/ActivityControllerTest.java
+++ b/src/test/java/org/robolectric/util/ActivityControllerTest.java
@@ -138,8 +138,8 @@ public class ActivityControllerTest {
   }
 
   @Test
-  public void launch() {
-    controller.launch();
+  public void setup_callsLifecycleMethodsAndMakesVisible() {
+    controller.setup();
     transcript.assertEventsInclude("onCreate", "onStart", "onPostCreate", "onResume", "onPostResume");
     assertEquals(controller.get().getWindow().getDecorView().getParent().getClass().getName(), "android.view.ViewRootImpl");
   }


### PR DESCRIPTION
I submitted a previous pull request for the same change (https://github.com/robolectric/robolectric/pull/1119#issuecomment-45047197), and closed it when it was pointed out to me that Robolectric.setupActivity() exists. I realize now though setupActivity() doesn't do what I need, because it doesn't give a chance to set dagger-injected dependencies on the Activity before calling the lifecycle methods. I.e., a common pattern in my test code is:

ActivityController activityController = Robolectric.buildActivity(SomeActivity.class);
// set dagger injected fields on the Activity
activityController.get().someDependency = mockSomeDependency;
activityController.create()....

There's an argument to be made against adding too many convenience methods, but in my particular case it would help alleviate some boilerplate.

I also like the idea of it being convenient to call every lifecycle method that Android calls as a matter of course - if the Activity is modified to override a new lifecycle method that breaks something, there is more hope the existing tests will catch it.
