### PR TITLE
Enhancements to Shadow Service.setForeground() notification handling

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -50,6 +50,10 @@ public class ShadowNotificationManager {
     return notifications.size();
   }
 
+  public Notification getNotification(int id) {
+    return notifications.get(new Key(null, id));
+  }
+
   public Notification getNotification(String tag, int id) {
     return notifications.get(new Key(tag, id));
   }

--- a/src/test/java/org/robolectric/shadows/ServiceTest.java
+++ b/src/test/java/org/robolectric/shadows/ServiceTest.java
@@ -1,12 +1,16 @@
 package org.robolectric.shadows;
 
+import android.app.Notification;
+import android.app.NotificationManager;
 import android.app.Service;
 import android.appwidget.AppWidgetProvider;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
 import android.media.MediaScannerConnection;
 import android.os.IBinder;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -19,15 +23,22 @@ import static org.fest.assertions.api.Assertions.*;
 public class ServiceTest {
   private final MyService service = new MyService();
   private final ShadowService shadow = shadowOf(service);
+  private final Notification.Builder notBuilder = new Notification.Builder(
+      service).setSmallIcon(1).setContentTitle("Test")
+      .setContentText("Hi there");
+  private final ShadowNotificationManager nm = shadowOf((NotificationManager) Robolectric.application
+      .getSystemService(Context.NOTIFICATION_SERVICE));
 
   @Test(expected = IllegalStateException.class)
-  public void shouldComplainIfServiceIsDestroyedWithRegisteredBroadcastReceivers() throws Exception {
+  public void shouldComplainIfServiceIsDestroyedWithRegisteredBroadcastReceivers()
+      throws Exception {
     service.registerReceiver(new AppWidgetProvider(), new IntentFilter());
     service.onDestroy();
   }
 
   @Test
-  public void shouldNotComplainIfServiceIsDestroyedWhileAnotherServiceHasRegisteredBroadcastReceivers() throws Exception {
+  public void shouldNotComplainIfServiceIsDestroyedWhileAnotherServiceHasRegisteredBroadcastReceivers()
+      throws Exception {
     MyService service1 = new MyService();
     MyService service2 = new MyService();
     service2.registerReceiver(new AppWidgetProvider(), new IntentFilter());
@@ -36,11 +47,12 @@ public class ServiceTest {
 
   @Test
   public void shouldUnbindServiceSuccessfully() {
-    ServiceConnection conn = Robolectric.newInstanceOf(MediaScannerConnection.class);
+    ServiceConnection conn = Robolectric
+        .newInstanceOf(MediaScannerConnection.class);
     service.unbindService(conn);
   }
 
-  @Test (expected=IllegalArgumentException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void shouldUnbindServiceWithExceptionWhenRequested() {
     shadow.setUnbindServiceShouldThrowIllegalArgument(true);
     ServiceConnection conn = newInstanceOf(MediaScannerConnection.class);
@@ -48,10 +60,51 @@ public class ServiceTest {
   }
 
   @Test
+  public void startForeground() {
+    Notification n = notBuilder.build();
+    service.startForeground(23, n);
+    assertThat(shadow.getLastForegroundNotification()).isSameAs(n);
+    assertThat(shadow.getLastForegroundNotificationId()).isEqualTo(23);
+    assertThat(nm.getNotification(23)).isSameAs(n);
+    assertThat(n.flags & Notification.FLAG_FOREGROUND_SERVICE).isNotZero();
+  }
+
+  @Test
   public void stopForeground() {
     service.stopForeground(true);
     assertThat(shadow.isForegroundStopped()).isTrue();
     assertThat(shadow.getNotificationShouldRemoved()).isTrue();
+  }
+
+  @Test
+  public void stopForegroundRemovesNotificationIfAsked() {
+    service.startForeground(21, notBuilder.build());
+    service.stopForeground(true);
+    assertThat(nm.getNotification(21)).isNull();
+  }
+
+  /**
+   * According to spec, if the foreground notification is not removed earlier,
+   * then it will be removed when the service is destroyed.
+   */
+  @Test
+  public void stopForegroundDoesntRemoveNotificationUnlessAsked() {
+    Notification n = notBuilder.build();
+    service.startForeground(21, n);
+    service.stopForeground(false);
+    assertThat(nm.getNotification(21)).isSameAs(n);
+  }
+
+  /**
+   * According to spec, if the foreground notification is not removed earlier,
+   * then it will be removed when the service is destroyed.
+   */
+  @Test
+  public void onDestroyRemovesNotification() {
+    Notification n = notBuilder.build();
+    service.startForeground(21, n);
+    service.onDestroy();
+    assertThat(nm.getNotification(21)).isNull();
   }
 
   @Test
@@ -67,11 +120,13 @@ public class ServiceTest {
   }
 
   private static class MyService extends Service {
-    @Override public void onDestroy() {
+    @Override
+    public void onDestroy() {
       super.onDestroy();
     }
 
-    @Override public IBinder onBind(Intent intent) {
+    @Override
+    public IBinder onBind(Intent intent) {
       return null;
     }
   }


### PR DESCRIPTION
Some useful tweaks I added to help me with testing foregrounding of my service. In particular, the <code>Notification</code> that you supply in <code>setForeground()</code> is actually registered with the <code>NotificationManager</code> - making behaviour more closely match that of real Android. Plus added one-arg convenience version of <code>getNotification()</code> to <code>ShadowNotificationManager</code> to parallel the one-arg version of <code>notify()</code>.
