### PR TITLE
Allow subclasses to override the base directory

### DIFF
--- a/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -333,7 +333,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
     String resourcesProperty = System.getProperty("android.resources");
     String assetsProperty = System.getProperty("android.assets");
 
-    FsFile fsFile = Fs.currentDirectory();
+    FsFile fsFile = getBaseDir();
     FsFile manifestFile;
     FsFile resDir;
     FsFile assetsDir;
@@ -362,6 +362,10 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
       }
       return appManifest;
     }
+  }
+
+  protected FsFile getBaseDir() {
+    return Fs.currentDirectory();
   }
 
   public Config getConfig(Method method) {


### PR DESCRIPTION
Base directory is considered to be the current directory but in our continuous build environment the base dir is different to that running on our local machines. By allowing it to be specified in the subclass we avoid the need for re-writing the directory paths later on in createAppManifest()
