### PR TITLE
Inherit configuration from the current test class

### DIFF
--- a/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -372,9 +372,14 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
       config = new Config.Implementation(config, globalConfig);
     }
 
-    Config classConfig = method.getDeclaringClass().getAnnotation(Config.class);
-    if (classConfig != null) {
-      config = new Config.Implementation(config, classConfig);
+    Config methodClassConfig = method.getDeclaringClass().getAnnotation(Config.class);
+    if (methodClassConfig != null) {
+      config = new Config.Implementation(config, methodClassConfig);
+    }
+
+    Config testClassConfig = getTestClass().getJavaClass().getAnnotation(Config.class);
+    if (testClassConfig != null) {
+      config = new Config.Implementation(config, testClassConfig);
     }
 
     Config methodConfig = method.getAnnotation(Config.class);

--- a/src/main/java/org/robolectric/annotation/Config.java
+++ b/src/main/java/org/robolectric/annotation/Config.java
@@ -8,9 +8,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * Indicate that robolectric should look for values that is specific by those qualifiers
@@ -113,7 +114,7 @@ public @interface Config {
       this.qualifiers = pick(baseConfig.qualifiers(), overlayConfig.qualifiers(), "");
       this.resourceDir = pick(baseConfig.resourceDir(), overlayConfig.resourceDir(), "res");
       this.reportSdk = pick(baseConfig.reportSdk(), overlayConfig.reportSdk(), -1);
-      ArrayList<Class<?>> shadows = new ArrayList<Class<?>>();
+      Set<Class<?>> shadows = new HashSet<Class<?>>();
       shadows.addAll(Arrays.asList(baseConfig.shadows()));
       shadows.addAll(Arrays.asList(overlayConfig.shadows()));
       this.shadows = shadows.toArray(new Class[shadows.size()]);

--- a/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -41,6 +41,28 @@ public class RobolectricTestRunnerTest {
         9, "furf", "from-method", "method/res", 8, new Class[]{Test1.class});
   }
 
+  @Test public void whenClassAndSubclassHaveConfigAnnotation_getConfig_shouldMergeClassSubclassAndMethodConfig() throws Exception {
+      assertConfig(configFor(Test3.class, "withoutAnnotation"),
+          1, "foo", "from-subclass", "test/res", 2, new Class[]{Test1.class});
+
+    assertConfig(configFor(Test3.class, "withDefaultsAnnotation"),
+        1, "foo", "from-subclass", "test/res", 2, new Class[]{Test1.class});
+
+    assertConfig(configFor(Test3.class, "withOverrideAnnotation"),
+        9, "furf", "from-method", "method/res", 8, new Class[]{Test1.class, Test2.class});
+  }
+
+  @Test public void whenClassDoesntHaveConfigAnnotationButSubclassDoes_getConfig_shouldMergeSubclassAndMethodConfig() throws Exception {
+    assertConfig(configFor(Test4.class, "withoutAnnotation"),
+        -1, "--default", "from-subclass", "res", -1, new Class[]{});
+
+    assertConfig(configFor(Test4.class, "withDefaultsAnnotation"),
+        -1, "--default", "from-subclass", "res", -1, new Class[]{});
+
+    assertConfig(configFor(Test4.class, "withOverrideAnnotation"),
+        9, "furf", "from-method", "method/res", 8, new Class[]{Test1.class});
+  }
+
   @Test public void shouldLoadDefaultsFromPropertiesFile() throws Exception {
     Properties properties = properties(
         "emulateSdk: 432\n" +
@@ -123,6 +145,16 @@ public class RobolectricTestRunnerTest {
     @Config(emulateSdk = 9, manifest = "furf", reportSdk = 8, shadows = Test1.class, qualifiers = "from-method", resourceDir = "method/res")
     @Test public void withOverrideAnnotation() throws Exception {
     }
+  }
+
+  @Ignore
+  @Config(qualifiers = "from-subclass")
+  public static class Test3 extends Test1 {
+  }
+
+  @Ignore
+  @Config(qualifiers = "from-subclass")
+  public static class Test4 extends Test2 {
   }
 
   private String stringify(Config config) {


### PR DESCRIPTION
The current test class may be different from the declaring class of the
test method if the test method is in a superclass.

This makes it possible to have an abstract test class and then extend it
with multiple subclasses that specify different qualifiers in @Config.
