### PR TITLE
Made ShadowPreference call real object constructor.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowPreference.java
+++ b/src/main/java/org/robolectric/shadows/ShadowPreference.java
@@ -11,6 +11,7 @@ import android.util.TypedValue;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
+import org.robolectric.bytecode.RobolectricInternals;
 
 @Implements(Preference.class)
 public class ShadowPreference {
@@ -57,6 +58,17 @@ public class ShadowPreference {
       summary = typedArray.getString(com.android.internal.R.styleable.Preference_summary);
       initDefaultValue(typedArray);
     }
+
+    // Also invoke the constructor on the actual object to give it a Context.
+    Class[] paramTypes = new Class[3];
+    paramTypes[0] = Context.class;
+    paramTypes[1] = AttributeSet.class;
+    paramTypes[2] = Integer.TYPE;
+    RobolectricInternals.getConstructor(
+        Preference.class,
+        this.realPreference,
+        paramTypes)
+      .invoke(context, attributeSet, defStyle);
   }
 
   private void initDefaultValue(TypedArray typedArray) {

--- a/src/test/java/org/robolectric/shadows/PreferenceActivityTestWithFragment.java
+++ b/src/test/java/org/robolectric/shadows/PreferenceActivityTestWithFragment.java
@@ -1,0 +1,84 @@
+package org.robolectric.shadows;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import android.app.Activity;
+import android.app.FragmentManager;
+import android.os.Bundle;
+import android.preference.Preference;
+import android.preference.PreferenceFragment;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.R;
+import org.robolectric.Robolectric;
+import org.robolectric.TestRunners;
+
+/**
+ * Current Android examples show adding a PreferenceFragment as part of the
+ * hosting Activity lifecycle. This resulted in a null pointer exception when
+ * trying to access a Context while inflating the Preference objects defined in
+ * xml. This class tests that path.
+ */
+@RunWith(TestRunners.WithDefaults.class)
+public class PreferenceActivityTestWithFragment {
+
+  private TestPreferenceActivity activity;
+  private TestPreferenceFragment fragment;
+  private static final String FRAGMENT_TAG = "fragmentPreferenceTag";
+
+  @Before
+  public void before() {
+    this.activity = Robolectric.buildActivity(TestPreferenceActivity.class)
+        .create()
+        .start()
+        .resume()
+        .visible()
+        .get();
+    this.fragment = (TestPreferenceFragment)
+        this.activity.getFragmentManager().findFragmentByTag(FRAGMENT_TAG);
+  }
+
+  @Test
+  public void fragmentIsNotNull() {
+    // Make sure the activity can instantiate the fragment without getting
+    // errors.
+    assertThat(this.fragment).isNotNull();
+  }
+
+  @Test
+  public void preferenceAddedWithCorrectDetails() {
+    // Make sure we can find one of the preferences
+    Preference preference = this.fragment.findPreference("edit_text");
+    assertThat(preference).isNotNull();
+    assertThat(preference.getTitle()).isEqualTo("EditText Test");
+    assertThat(preference.getSummary()).isEqualTo("");
+  }
+
+  private static class TestPreferenceActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      // Add the fragment as part of the activity's life cycle.
+      FragmentManager fragmentManager = this.getFragmentManager();
+      TestPreferenceFragment fragment = new TestPreferenceFragment();
+      fragmentManager.beginTransaction().replace(
+          android.R.id.content,
+          fragment,
+          FRAGMENT_TAG)
+      .commit();
+    }
+
+  }
+
+  private static class TestPreferenceFragment extends PreferenceFragment {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      this.addPreferencesFromResource(R.xml.preferences);
+    }
+  }
+
+}

--- a/src/test/java/org/robolectric/shadows/PreferenceTest.java
+++ b/src/test/java/org/robolectric/shadows/PreferenceTest.java
@@ -42,7 +42,9 @@ public class PreferenceTest {
 
   @Test
   public void shouldConstruct() {
-    int defStyle = 7;
+    // Must be an attr that points to a style or else it won't be able to
+    // create the correctly styled view.
+    int defStyle = R.attr.animalStyle;
 
     preference = new TestPreference(context, attrs, defStyle);
     shadow = Robolectric.shadowOf(preference);


### PR DESCRIPTION
This ensures that `Preference` objects set their private Context member variables correctly. Allows `PreferenceFragment`s to be added during the lifecycle of the hosting activity. Closes #1133.

The [recommended way](http://developer.android.com/guide/topics/ui/settings.html) to handle preferences using fragments involves adding a `PreferenceFragment` during the hosting activity's lifecycle. This was throwing null pointer exceptions in robolectric because the `Preference`'s context was null.

It is strange that the `PreferenceFragment` objects were able to be instantiated and added to activities without this fix. Someone more familiar with the robolectric way of doing things should double check this to make sure it makes sense. Added tests for this case and modified the existing ShadowPreference tests to account for the fact that `defStyle` must now be a real style attr.
