### PR TITLE
IntentFilter MatchData Bug Fix 

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowIntentFilter.java
+++ b/src/main/java/org/robolectric/shadows/ShadowIntentFilter.java
@@ -155,6 +155,7 @@ public class ShadowIntentFilter {
 
   @Implementation
   public final int matchData(String type, String scheme, Uri data) {
+    boolean schemeMatch = false;
     if (types.isEmpty() && schemes.isEmpty()) {
       if (type == null && data == null) {
         return IntentFilter.MATCH_CATEGORY_EMPTY + IntentFilter.MATCH_ADJUSTMENT_NORMAL;
@@ -175,9 +176,8 @@ public class ShadowIntentFilter {
           if (matchDataAuthority(data) == IntentFilter.NO_MATCH_DATA) {
             return IntentFilter.NO_MATCH_DATA;
           }
-        } else {
-          return IntentFilter.MATCH_CATEGORY_SCHEME + IntentFilter.MATCH_ADJUSTMENT_NORMAL;
         }
+        schemeMatch = true;
       } else {
         return IntentFilter.NO_MATCH_DATA;
       }
@@ -194,7 +194,8 @@ public class ShadowIntentFilter {
         }
       }
     }
-    return IntentFilter.NO_MATCH_DATA;
+    return schemeMatch ? IntentFilter.MATCH_CATEGORY_SCHEME + IntentFilter.MATCH_ADJUSTMENT_NORMAL :
+        IntentFilter.NO_MATCH_DATA;
   }
 
   @Implementation

--- a/src/test/java/org/robolectric/shadows/IntentFilterTest.java
+++ b/src/test/java/org/robolectric/shadows/IntentFilterTest.java
@@ -183,4 +183,15 @@ public class IntentFilterTest {
     assertThat(intentFilter.matchData("image/test", "http", uriTest1))
         .isLessThan(0);
   }
+
+  @Test
+  public void matchData_MatchSchemeNoMatchType() throws IntentFilter.MalformedMimeTypeException {
+    IntentFilter intentFilter = new IntentFilter();
+    intentFilter.addDataScheme("http");
+    intentFilter.addDataType("image/testFail");
+
+    Uri uriTest1 = Uri.parse("http://testHost1:1");
+    assertThat(intentFilter.matchData("image/test", "http", uriTest1))
+        .isLessThan(0);
+  }
 }


### PR DESCRIPTION
Fixing IntentFilter matchData bug where type matching gets skipped if scheme matches.
