### PR TITLE
Sanity enforcement for foreground flag in NotificationManager

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -10,7 +10,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@SuppressWarnings({"UnusedDeclaration"})
+import static android.app.Notification.FLAG_FOREGROUND_SERVICE;
+
 @Implements(NotificationManager.class)
 public class ShadowNotificationManager {
 
@@ -23,7 +24,12 @@ public class ShadowNotificationManager {
 
   @Implementation
   public void notify(String tag, int id, Notification notification) {
-    notifications.put(new Key(tag, id), notification);
+    Notification prev = notifications.put(new Key(tag, id), notification);
+    if (prev == null || (prev.flags & FLAG_FOREGROUND_SERVICE) == 0) {
+      notification.flags &= ~FLAG_FOREGROUND_SERVICE;
+    } else {
+      notification.flags |= FLAG_FOREGROUND_SERVICE;
+    }
   }
 
   @Implementation
@@ -46,6 +52,29 @@ public class ShadowNotificationManager {
 
   public int size() {
     return notifications.size();
+  }
+
+  /**
+   * Sets a notification per {@link #notify(int, Notification)}, without
+   * modifying the flags. Allows you to bypass the Android emulation of
+   * flag treatment by the standard notify implementation.
+   * @param id the id of this notification.
+   * @param notification the notification object itself.
+   */
+  public void notifyRaw(int id, Notification notification) {
+    notifyRaw(null, id, notification);
+  }
+
+  /**
+   * Sets a notification per {@link #notify(String, int, Notification)},
+   * without modifying the flags. Allows you to bypass the Android emulation of
+   * flag treatment by the standard notify implementation.
+   * @param tag the tag to associate with this notification.
+   * @param id the id of this notification.
+   * @param notification the notification object itself.
+   */
+  public void notifyRaw(String tag, int id, Notification notification) {
+    notifications.put(new Key(tag, id), notification);    
   }
 
   public Notification getNotification(int id) {

--- a/src/main/java/org/robolectric/shadows/ShadowService.java
+++ b/src/main/java/org/robolectric/shadows/ShadowService.java
@@ -65,11 +65,11 @@ public class ShadowService extends ShadowContextWrapper {
 
   @Implementation
   public final void startForeground(int id, Notification notification) {
-	  lastForegroundNotificationId = id;
+    lastForegroundNotificationId = id;
     lastForegroundNotification = notification;
+    ShadowNotificationManager sNM = shadowOf((NotificationManager)Robolectric.application.getSystemService(Context.NOTIFICATION_SERVICE));
     notification.flags |= Notification.FLAG_FOREGROUND_SERVICE;
-    NotificationManager nm = (NotificationManager)Robolectric.application.getSystemService(Context.NOTIFICATION_SERVICE);
-    nm.notify(id, notification);
+    sNM.notifyRaw(id, notification);
   }
 
   @Implementation

--- a/src/test/java/org/robolectric/shadows/NotificationManagerTest.java
+++ b/src/test/java/org/robolectric/shadows/NotificationManagerTest.java
@@ -9,29 +9,34 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.TestRunners;
 
+import static android.app.Notification.FLAG_FOREGROUND_SERVICE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.robolectric.Robolectric.shadowOf;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class NotificationManagerTest {
   private NotificationManager notificationManager;
+  private ShadowNotificationManager shadowNM;
   private Notification notification1 = new Notification();
   private Notification notification2 = new Notification();
 
-  @Before public void setUp() {
+  @Before
+  public void setUp() {
     notificationManager = (NotificationManager) Robolectric.application.getSystemService(Context.NOTIFICATION_SERVICE);
+    shadowNM = shadowOf(notificationManager);
   }
 
   @Test
   public void testNotify() throws Exception {
     notificationManager.notify(1, notification1);
-    assertEquals(1, shadowOf(notificationManager).size());
-    assertEquals(notification1, shadowOf(notificationManager).getNotification(null, 1));
+    assertEquals(1, shadowNM.size());
+    assertEquals(notification1, shadowNM.getNotification(null, 1));
 
     notificationManager.notify(31, notification2);
-    assertEquals(2, shadowOf(notificationManager).size());
-    assertEquals(notification2, shadowOf(notificationManager).getNotification(null, 31));
+    assertEquals(2, shadowNM.size());
+    assertEquals(notification2, shadowNM.getNotification(null, 31));
   }
 
   @Test
@@ -39,29 +44,43 @@ public class NotificationManagerTest {
     notificationManager.notify(1, notification1);
 
     notificationManager.notify(1, notification2);
-    assertEquals(1, shadowOf(notificationManager).size());
-    assertEquals(notification2, shadowOf(notificationManager).getNotification(null, 1));
+    assertEquals(1, shadowNM.size());
+    assertEquals(notification2, shadowNM.getNotification(null, 1));
   }
 
   @Test
   public void testNotifyWithTag() throws Exception {
     notificationManager.notify("a tag", 1, notification1);
-    assertEquals(1, shadowOf(notificationManager).size());
-    assertEquals(notification1, shadowOf(notificationManager).getNotification("a tag", 1));
+    assertEquals(1, shadowNM.size());
+    assertEquals(notification1, shadowNM.getNotification("a tag", 1));
+  }
+
+  @Test
+  public void testNotifyRaw() throws Exception {
+    shadowNM.notifyRaw(1, notification1);
+    assertEquals(1, shadowNM.size());
+    assertEquals(notification1, shadowNM.getNotification(1));
+  }
+
+  @Test
+  public void testNotifyRawWithTag() throws Exception {
+    shadowNM.notifyRaw("a tag", 1, notification1);
+    assertEquals(1, shadowNM.size());
+    assertEquals(notification1, shadowNM.getNotification("a tag", 1));
   }
 
   @Test
   public void notifyWithTag_shouldReturnNullForNullTag() throws Exception {
     notificationManager.notify("a tag", 1, notification1);
-    assertEquals(1, shadowOf(notificationManager).size());
-    assertNull(shadowOf(notificationManager).getNotification(null, 1));
+    assertEquals(1, shadowNM.size());
+    assertNull(shadowNM.getNotification(null, 1));
   }
 
   @Test
   public void notifyWithTag_shouldReturnNullForUnknownTag() throws Exception {
     notificationManager.notify("a tag", 1, notification1);
-    assertEquals(1, shadowOf(notificationManager).size());
-    assertNull(shadowOf(notificationManager).getNotification("unknown tag", 1));
+    assertEquals(1, shadowNM.size());
+    assertNull(shadowNM.getNotification("unknown tag", 1));
   }
 
   @Test
@@ -69,8 +88,8 @@ public class NotificationManagerTest {
     notificationManager.notify(1, notification1);
     notificationManager.cancel(1);
 
-    assertEquals(0, shadowOf(notificationManager).size());
-    assertNull(shadowOf(notificationManager).getNotification(null, 1));
+    assertEquals(0, shadowNM.size());
+    assertNull(shadowNM.getNotification(null, 1));
   }
 
   @Test
@@ -78,9 +97,9 @@ public class NotificationManagerTest {
     notificationManager.notify("a tag", 1, notification1);
     notificationManager.cancel("a tag", 1);
 
-    assertEquals(0, shadowOf(notificationManager).size());
-    assertNull(shadowOf(notificationManager).getNotification(null, 1));
-    assertNull(shadowOf(notificationManager).getNotification("a tag", 1));
+    assertEquals(0, shadowNM.size());
+    assertNull(shadowNM.getNotification(null, 1));
+    assertNull(shadowNM.getNotification("a tag", 1));
   }
 
   @Test
@@ -89,8 +108,45 @@ public class NotificationManagerTest {
     notificationManager.notify(31, notification2);
     notificationManager.cancelAll();
 
-    assertEquals(0, shadowOf(notificationManager).size());
-    assertNull(shadowOf(notificationManager).getNotification(null, 1));
-    assertNull(shadowOf(notificationManager).getNotification(null, 31));
+    assertEquals(0, shadowNM.size());
+    assertNull(shadowNM.getNotification(null, 1));
+    assertNull(shadowNM.getNotification(null, 31));
+  }
+
+  @Test
+  public void notify_clearsForegroundFlag() {
+    notification1.flags |= FLAG_FOREGROUND_SERVICE;
+    notification2.flags |= FLAG_FOREGROUND_SERVICE;
+    notificationManager.notify(54, notification1);
+    assertEquals("Foreground flag should be clear", 0, notification1.flags & FLAG_FOREGROUND_SERVICE);
+    notificationManager.notify("tag", 56, notification2);
+    assertEquals("Foreground flag should be clear", 0, notification2.flags & FLAG_FOREGROUND_SERVICE);
+  }
+
+  @Test
+  public void notifyRaw_preservesForegroundFlagIfOn() {
+    notification1.flags |= FLAG_FOREGROUND_SERVICE;
+    shadowNM.notifyRaw("tag", 57, notification1);
+    assertTrue("Foreground flag should be set", (notification1.flags & FLAG_FOREGROUND_SERVICE) != 0);
+    shadowNM.notifyRaw(954, notification1);
+    assertTrue("Foreground flag should be set", (notification1.flags & FLAG_FOREGROUND_SERVICE) != 0);
+  }
+
+  @Test
+  public void notify_preservesForegroundFlagIfOn() {
+    notification1.flags |= FLAG_FOREGROUND_SERVICE;
+    notification2.flags &= ~FLAG_FOREGROUND_SERVICE;
+    shadowNM.notifyRaw(1, notification1);
+    notificationManager.notify(1, notification2);
+    assertTrue((notification2.flags & FLAG_FOREGROUND_SERVICE) != 0);
+  }
+
+  @Test
+  public void notify_preservesForegroundFlagIfNotOn() {
+    notification1.flags &= ~FLAG_FOREGROUND_SERVICE;
+    notification2.flags |= FLAG_FOREGROUND_SERVICE;
+    notificationManager.notify(1, notification1);
+    notificationManager.notify(1, notification2);
+    assertEquals(0, (notification2.flags & FLAG_FOREGROUND_SERVICE));
   }
 }


### PR DESCRIPTION
Made some enhancements centered around enforcing the correct state of the <code>FLAG_FOREGROUND_SERVICE</code> notification flag. The standard Android <code>notify()</code> method does not honour this flag as it should only be set through <code>Service.setForeground()</code>, and so I have modified the code to do the same - if this flag is set by the caller then <code>ShadowNotificationManager</code> will clear it. A separate method has been provided for test code (such as <code>ShadowService.setForeground()</code>) that needs to bypass this sanity enforcement.

A possible future enhancement will be for <code>ShadowNotificationManager</code> to optionally assert if <code>notify()</code> is called with this flag set, because if ordinary Android code has this flag set it likely indicates a programming error and Android won't do what the developer might have been hoping to achieve.

One possible pushback to this PR is the fact that it is potentially a breaking change - if any test code out there relies on the loose implementation of <code>notify()</code>, then it might break. There are two ways in which it might break tests:
1. If someone has production code that relies on the old behaviour, or
2. If someone has test code that relies on the old behaviour.

I'm less concerned about upsetting people of the first type because we would be helping them uncover a bug that had hitherto gone unnoticed. However, if someone is calling <code>notify()</code> from a test method to (eg) emulate a foreground notification in their test, this will fail until they change their code to use <code>notifyRaw()</code> instead. Happy to take feedback on this issue from the wider team (who are likely to have more experience in this area) as to whether this possibility is likely enough to worry about, and if so how to handle it. Perhaps I could make the sanity enforcement a configurable option for the <code>ShadowNotificationManager</code>, and leave default behaviour as it currently is? This same configuration mechanism could be extended to do allow a mode that asserts later.
