### PR TITLE
Implement `ContentResolver.isSyncActive(Account,String)`

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
+++ b/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
@@ -301,6 +301,13 @@ public class ShadowContentResolver {
   }
 
   @Implementation
+  public static boolean isSyncActive(Account account, String authority) {
+    ShadowContentResolver.Status status = getStatus(account, authority);
+    // TODO: this means a sync is *perpetually* active after one request
+    return status != null && status.syncRequests > 0;
+  }
+
+  @Implementation
   public static void setIsSyncable(Account account, String authority, int syncable) {
     getStatus(account, authority, true).state = syncable;
   }

--- a/src/test/java/org/robolectric/shadows/ContentResolverTest.java
+++ b/src/test/java/org/robolectric/shadows/ContentResolverTest.java
@@ -387,6 +387,13 @@ public class ContentResolverTest {
   }
 
   @Test
+  public void shouldKnowIfSyncIsActive() throws Exception {
+    assertFalse(ContentResolver.isSyncActive(a, AUTHORITY));
+    ContentResolver.requestSync(a, AUTHORITY, new Bundle());
+    assertTrue(ContentResolver.isSyncActive(a, AUTHORITY));
+  }
+
+  @Test
   public void shouldSetIsSyncable() throws Exception {
     assertThat(ContentResolver.getIsSyncable(a, AUTHORITY)).isEqualTo(-1);
     assertThat(ContentResolver.getIsSyncable(b, AUTHORITY)).isEqualTo(-1);


### PR DESCRIPTION
Currently this falls to the shadowed implementation, which fails
with `NullPointerException` because `getContentService()` returns
`null`.

Since the Shadow is already keeping track of requested syncs, we
can use that to determine if a sync is "active" or not.

One caveat: after the initial `requestSync()` call, all future
calls to `isSyncActive()` will return true, because there is no
way to stop (or simulate stopping) a "sync request" in the shadow.
