### PR TITLE
Sort classes in `assertConfig` to avoid spurious failures on reading the properties back in

### DIFF
--- a/.pairs
+++ b/.pairs
@@ -46,6 +46,7 @@ pairs:
   mt: Mike Trewartha; miketrewartha
   mw: Matthew Wickman; mwickman
   ml: Michael Lavrisha; mlavrisha
+  tb: Tom Brand; tbrand
 email:
   prefix: pair
   domain: pivotallabs.com

--- a/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -168,12 +168,19 @@ public class RobolectricTestRunnerTest {
   }
 
   private String stringify(int emulateSdk, String manifest, String qualifiers, String resourceDir, int reportSdk, Class<?>[] shadows) {
-    return "emulateSdk=" + emulateSdk + "\n" +
+      String[] stringClasses = new String[shadows.length];
+      for (int i = 0; i < stringClasses.length; i++) {
+          stringClasses[i] = shadows[i].toString();
+      }
+
+      Arrays.sort(stringClasses);
+
+      return "emulateSdk=" + emulateSdk + "\n" +
         "manifest=" + manifest + "\n" +
         "qualifiers=" + qualifiers + "\n" +
         "resourceDir=" + resourceDir + "\n" +
         "reportSdk=" + reportSdk + "\n" +
-        "shadows=" + Arrays.toString(shadows);
+        "shadows=" +  Arrays.toString(stringClasses);
   }
 
   private Properties properties(String s) throws IOException {


### PR DESCRIPTION
Classes could be parsed back in out of order which was causing failures but not on all machines.
