### PR TITLE
Support referenced colors in int arrays.

### DIFF
--- a/src/main/java/org/robolectric/shadows/Converter.java
+++ b/src/main/java/org/robolectric/shadows/Converter.java
@@ -242,6 +242,11 @@ public class Converter<T> {
       typedValue.data = Color.parseColor(data);
       typedValue.assetCookie = 0;
     }
+
+    @Override public int asInt(TypedResource typedResource) {
+      String rawValue = typedResource.asString();
+      return Color.parseColor(rawValue);
+    }
   }
 
   private static class FromFilePath extends Converter<String> {

--- a/src/test/java/org/robolectric/R.java
+++ b/src/test/java/org/robolectric/R.java
@@ -126,6 +126,7 @@ public final class R {
     public static final int zero_to_four_int_array = 0x10304;
     public static final int empty_int_array = 0x10305;
     public static final int with_references_int_array = 0x10306;
+    public static final int referenced_colors_int_array = 0x10307;
   }
 
   public static final class color {

--- a/src/test/java/org/robolectric/shadows/ResourcesTest.java
+++ b/src/test/java/org/robolectric/shadows/ResourcesTest.java
@@ -112,6 +112,7 @@ public class ResourcesTest {
     assertThat(resources.getIntArray(R.array.empty_int_array)).isEqualTo(new int[] {});
     assertThat(resources.getIntArray(R.array.zero_to_four_int_array)).isEqualTo(new int[] {0, 1, 2, 3, 4});
     assertThat(resources.getIntArray(R.array.with_references_int_array)).isEqualTo(new int[] {0, 2000, 1});
+    assertThat(resources.getIntArray(R.array.referenced_colors_int_array)).isEqualTo(new int[] { 0x1, 0xFFFFFFFF, 0xFF000000, 0xFFF5F5F5, 0x802C76AD });
   }
 
   @Test

--- a/src/test/resources/res/values/int_arrays.xml
+++ b/src/test/resources/res/values/int_arrays.xml
@@ -13,4 +13,11 @@
       <item>@integer/test_integer1</item>
       <item>1</item>
    </integer-array>
+   <integer-array name="referenced_colors_int_array">
+      <item>@color/clear</item>
+      <item>@color/white</item>
+      <item>@color/black</item>
+      <item>@color/grey42</item>
+      <item>@color/color_with_alpha</item>
+   </integer-array>
 </resources>


### PR DESCRIPTION
I am using a resource with int arrays composed of colors. A color state list wasn't appropriate, so I've made a patch for robolectric to support this sort of resource.
