### PR TITLE
Allow Application class to be specified in @Config annotation.

### DIFF
--- a/src/main/java/org/robolectric/TestLifecycle.java
+++ b/src/main/java/org/robolectric/TestLifecycle.java
@@ -1,9 +1,11 @@
 package org.robolectric;
 
+import org.robolectric.annotation.Config;
+
 import java.lang.reflect.Method;
 
 public interface TestLifecycle<T> {
-  T createApplication(Method method, AndroidManifest appManifest);
+  T createApplication(Method method, AndroidManifest appManifest, Config config);
 
   void beforeTest(Method method);
 

--- a/src/main/java/org/robolectric/annotation/Config.java
+++ b/src/main/java/org/robolectric/annotation/Config.java
@@ -1,5 +1,6 @@
 package org.robolectric.annotation;
 
+import android.app.Application;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.annotation.Annotation;
@@ -40,6 +41,12 @@ public @interface Config {
   String manifest() default DEFAULT;
 
   /**
+   * The {@link android.app.Application} class to use in the test, this takes precedence over any application
+   * specified in the AndroidManifest.xml.
+   */
+  Class<? extends Application> application() default Application.class;
+
+  /**
    * Qualifiers for the resource resolution, such as "fr-normal-port-hdpi".
    *
    * @see <a href="http://developer.android.com/guide/topics/resources/providing-resources.html">Providing Resources</a> in the Android Developer docs for more information.
@@ -72,6 +79,7 @@ public @interface Config {
     private final String resourceDir;
     private final int reportSdk;
     private final Class<?>[] shadows;
+    private final Class<? extends Application> application;
 
     public static Config fromProperties(Properties configProperties) {
       if (configProperties == null || configProperties.size() == 0) return null;
@@ -81,7 +89,8 @@ public @interface Config {
           configProperties.getProperty("qualifiers", ""),
           configProperties.getProperty("resourceDir", "res"),
           Integer.parseInt(configProperties.getProperty("reportSdk", "-1")),
-          parseClasses(configProperties.getProperty("shadows", ""))
+          parseClasses(configProperties.getProperty("shadows", "")),
+          parseApplication(configProperties.getProperty("application", "android.app.Application"))
       );
     }
 
@@ -99,13 +108,23 @@ public @interface Config {
       return classes;
     }
 
-    public Implementation(int emulateSdk, String manifest, String qualifiers, String resourceDir, int reportSdk, Class<?>[] shadows) {
+    private static <T extends Application> Class<T> parseApplication(String className) {
+      try {
+        Class<T> aClass = (Class<T>) Implementation.class.getClassLoader().loadClass(className);
+        return aClass;
+      } catch (ClassNotFoundException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    public Implementation(int emulateSdk, String manifest, String qualifiers, String resourceDir, int reportSdk, Class<?>[] shadows, Class<? extends Application> application) {
       this.emulateSdk = emulateSdk;
       this.manifest = manifest;
       this.qualifiers = qualifiers;
       this.resourceDir = resourceDir;
       this.reportSdk = reportSdk;
       this.shadows = shadows;
+      this.application = application;
     }
 
     public Implementation(Config baseConfig, Config overlayConfig) {
@@ -118,6 +137,7 @@ public @interface Config {
       shadows.addAll(Arrays.asList(baseConfig.shadows()));
       shadows.addAll(Arrays.asList(overlayConfig.shadows()));
       this.shadows = shadows.toArray(new Class[shadows.size()]);
+      this.application = pick(baseConfig.application(), overlayConfig.application(), null);
     }
 
     private <T> T pick(T baseValue, T overlayValue, T nullValue) {
@@ -130,6 +150,11 @@ public @interface Config {
 
     @Override public String manifest() {
       return manifest;
+    }
+
+    @Override
+    public Class<? extends Application> application() {
+      return application;
     }
 
     @Override public String qualifiers() {
@@ -164,6 +189,7 @@ public @interface Config {
       if (reportSdk != other.reportSdk) return false;
       if (!qualifiers.equals(other.qualifiers)) return false;
       if (!Arrays.equals(shadows, other.shadows)) return false;
+      if (application != other.application) return false;
 
       return true;
     }
@@ -174,6 +200,7 @@ public @interface Config {
       result = 31 * result + qualifiers.hashCode();
       result = 31 * result + reportSdk;
       result = 31 * result + Arrays.hashCode(shadows);
+      result = 31 * result + application.hashCode();
       return result;
     }
   }

--- a/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -112,7 +112,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
         .in(contextImplClass)
         .invoke(activityThread);
 
-    final Application application = (Application) testLifecycle.createApplication(method, appManifest);
+    final Application application = (Application) testLifecycle.createApplication(method, appManifest, config);
     if (application != null) {
       String packageName = appManifest != null ? appManifest.getPackageName() : null;
       if (packageName == null) packageName = DEFAULT_PACKAGE_NAME;

--- a/src/test/java/org/robolectric/ParallelUniverseTest.java
+++ b/src/test/java/org/robolectric/ParallelUniverseTest.java
@@ -1,5 +1,6 @@
 package org.robolectric;
 
+import android.app.Application;
 import org.junit.Test;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -24,7 +25,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromSdkConfig() {
     String givenQualifiers = "";
-    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", -1, new Class[0]);
+    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", -1, new Class[0], Application.class);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), false, null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("v18");
   }
@@ -32,7 +33,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromConfigQualifiers() {
     String givenQualifiers = "land-v17";
-    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", -1, new Class[0]);
+    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", -1, new Class[0], Application.class);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), false, null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("land-v17");
   }
@@ -40,7 +41,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromSdkConfigWithOtherQualifiers() {
     String givenQualifiers = "large-land";
-    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", -1, new Class[0]);
+    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", -1, new Class[0], Application.class);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), false, null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("large-land-v18");
   }

--- a/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
+++ b/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
@@ -87,7 +87,7 @@ public class RobolectricTestRunnerSelfTest {
     }
 
     public static class MyTestLifecycle extends DefaultTestLifecycle {
-      @Override public Application createApplication(Method method, AndroidManifest appManifest) {
+      @Override public Application createApplication(Method method, AndroidManifest appManifest, Config config) {
         return new MyTestApplication();
       }
     }

--- a/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -1,5 +1,6 @@
 package org.robolectric;
 
+import android.app.Application;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.model.InitializationError;
@@ -21,46 +22,46 @@ import static org.fest.reflect.core.Reflection.method;
 public class RobolectricTestRunnerTest {
   @Test public void whenClassHasConfigAnnotation_getConfig_shouldMergeClassAndMethodConfig() throws Exception {
     assertConfig(configFor(Test1.class, "withoutAnnotation"),
-        1, "foo", "from-test", "test/res", 2, new Class[]{Test1.class});
+        1, "foo", "from-test", "test/res", 2, new Class[]{Test1.class}, Application.class);
 
     assertConfig(configFor(Test1.class, "withDefaultsAnnotation"),
-        1, "foo", "from-test", "test/res", 2, new Class[]{Test1.class});
+        1, "foo", "from-test", "test/res", 2, new Class[]{Test1.class}, Application.class);
 
     assertConfig(configFor(Test1.class, "withOverrideAnnotation"),
-        9, "furf", "from-method", "method/res", 8, new Class[]{Test1.class, Test2.class});
+        9, "furf", "from-method", "method/res", 8, new Class[]{Test1.class, Test2.class}, Application.class);
   }
 
   @Test public void whenClassDoesntHaveConfigAnnotation_getConfig_shouldUseMethodConfig() throws Exception {
     assertConfig(configFor(Test2.class, "withoutAnnotation"),
-        -1, "--default", "", "res", -1, new Class[]{});
+        -1, "--default", "", "res", -1, new Class[]{}, Application.class);
 
     assertConfig(configFor(Test2.class, "withDefaultsAnnotation"),
-        -1, "--default", "", "res", -1, new Class[]{});
+        -1, "--default", "", "res", -1, new Class[]{}, Application.class);
 
     assertConfig(configFor(Test2.class, "withOverrideAnnotation"),
-        9, "furf", "from-method", "method/res", 8, new Class[]{Test1.class});
+        9, "furf", "from-method", "method/res", 8, new Class[]{Test1.class}, Application.class);
   }
 
   @Test public void whenClassAndSubclassHaveConfigAnnotation_getConfig_shouldMergeClassSubclassAndMethodConfig() throws Exception {
       assertConfig(configFor(Test3.class, "withoutAnnotation"),
-          1, "foo", "from-subclass", "test/res", 2, new Class[]{Test1.class});
+          1, "foo", "from-subclass", "test/res", 2, new Class[]{Test1.class}, Application.class);
 
     assertConfig(configFor(Test3.class, "withDefaultsAnnotation"),
-        1, "foo", "from-subclass", "test/res", 2, new Class[]{Test1.class});
+        1, "foo", "from-subclass", "test/res", 2, new Class[]{Test1.class}, Application.class);
 
     assertConfig(configFor(Test3.class, "withOverrideAnnotation"),
-        9, "furf", "from-method", "method/res", 8, new Class[]{Test1.class, Test2.class});
+        9, "furf", "from-method", "method/res", 8, new Class[]{Test1.class, Test2.class}, Application.class);
   }
 
   @Test public void whenClassDoesntHaveConfigAnnotationButSubclassDoes_getConfig_shouldMergeSubclassAndMethodConfig() throws Exception {
     assertConfig(configFor(Test4.class, "withoutAnnotation"),
-        -1, "--default", "from-subclass", "res", -1, new Class[]{});
+        -1, "--default", "from-subclass", "res", -1, new Class[]{}, Application.class);
 
     assertConfig(configFor(Test4.class, "withDefaultsAnnotation"),
-        -1, "--default", "from-subclass", "res", -1, new Class[]{});
+        -1, "--default", "from-subclass", "res", -1, new Class[]{}, Application.class);
 
     assertConfig(configFor(Test4.class, "withOverrideAnnotation"),
-        9, "furf", "from-method", "method/res", 8, new Class[]{Test1.class});
+        9, "furf", "from-method", "method/res", 8, new Class[]{Test1.class}, Application.class);
   }
 
   @Test public void shouldLoadDefaultsFromPropertiesFile() throws Exception {
@@ -70,15 +71,16 @@ public class RobolectricTestRunnerTest {
             "qualifiers: from-properties-file\n" +
             "resourceDir: from/properties/file/res\n" +
             "reportSdk: 234\n" +
-            "shadows: org.robolectric.shadows.ShadowView, org.robolectric.shadows.ShadowViewGroup\n");
+            "shadows: org.robolectric.shadows.ShadowView, org.robolectric.shadows.ShadowViewGroup\n" +
+            "application: org.robolectric.TestFakeApp");
     assertConfig(configFor(Test2.class, "withoutAnnotation", properties),
-        432, "--none", "from-properties-file", "from/properties/file/res", 234, new Class[] {ShadowView.class, ShadowViewGroup.class});
+        432, "--none", "from-properties-file", "from/properties/file/res", 234, new Class[] {ShadowView.class, ShadowViewGroup.class}, TestFakeApp.class);
   }
 
   @Test public void withEmptyShadowList_shouldLoadDefaultsFromPropertiesFile() throws Exception {
     Properties properties = properties("shadows:");
     assertConfig(configFor(Test2.class, "withoutAnnotation", properties),
-        -1, "--default", "", "res", -1, new Class[] {});
+        -1, "--default", "", "res", -1, new Class[] {}, Application.class);
   }
 
   @Test public void rememberThatSomeTestRunnerMethodsShouldBeOverridable() throws Exception {
@@ -115,7 +117,7 @@ public class RobolectricTestRunnerTest {
           .getConfig(method(methodName).withParameterTypes().in(testClass).info());
   }
 
-  private void assertConfig(Config config, int emulateSdk, String manifest, String qualifiers, String resourceDir, int reportSdk, Class[] shadows) {
+  private void assertConfig(Config config, int emulateSdk, String manifest, String qualifiers, String resourceDir, int reportSdk, Class[] shadows, Class<? extends Application> applicationClass) {
     assertThat(stringify(config)).isEqualTo(stringify(emulateSdk, manifest, qualifiers, resourceDir, reportSdk, shadows));
   }
 

--- a/src/test/java/org/robolectric/TestRunnerSequenceTest.java
+++ b/src/test/java/org/robolectric/TestRunnerSequenceTest.java
@@ -122,7 +122,7 @@ public class TestRunnerSequenceTest {
   }
 
   public static class MyTestLifecycle extends DefaultTestLifecycle {
-    @Override public Application createApplication(Method method, AndroidManifest appManifest) {
+    @Override public Application createApplication(Method method, AndroidManifest appManifest, Config config) {
       StateHolder.transcript.add("createApplication");
       return new MyApplication();
     }

--- a/src/test/java/org/robolectric/bytecode/CustomRobolectricTestRunnerTest.java
+++ b/src/test/java/org/robolectric/bytecode/CustomRobolectricTestRunnerTest.java
@@ -110,7 +110,7 @@ public class CustomRobolectricTestRunnerTest {
   }
 
   public static class X extends DefaultTestLifecycle {
-    @Override public Application createApplication(Method method, AndroidManifest appManifest) {
+    @Override public Application createApplication(Method method, AndroidManifest appManifest, Config config) {
       return new MyApplication();
     }
   }
@@ -177,7 +177,7 @@ public class CustomRobolectricTestRunnerTest {
         afterTestMethod = method;
       }
 
-      @Override public Application createApplication(Method method, AndroidManifest appManifest) {
+      @Override public Application createApplication(Method method, AndroidManifest appManifest, Config config) {
         return new CustomApplication();
       }
     }

--- a/src/test/java/org/robolectric/shadows/ActivityTest.java
+++ b/src/test/java/org/robolectric/shadows/ActivityTest.java
@@ -234,7 +234,7 @@ public class ActivityTest {
   @Test
   public void shouldRetrievePackageNameFromTheManifest() throws Exception {
     AndroidManifest appManifest = newConfigWith("com.wacka.wa", "");
-    Robolectric.application = new DefaultTestLifecycle().createApplication(null, appManifest);
+    Robolectric.application = new DefaultTestLifecycle().createApplication(null, appManifest, null);
     shadowOf(application).bind(appManifest, null);
 
     assertThat("com.wacka.wa").isEqualTo(new Activity().getPackageName());

--- a/src/test/java/org/robolectric/shadows/ApplicationTest.java
+++ b/src/test/java/org/robolectric/shadows/ApplicationTest.java
@@ -361,14 +361,14 @@ public class ApplicationTest {
 
   @Test
   public void shouldRememberResourcesAfterLazilyLoading() throws Exception {
-    Application application = new DefaultTestLifecycle().createApplication(null, newConfigWith("com.wacka.wa", ""));
+    Application application = new DefaultTestLifecycle().createApplication(null, newConfigWith("com.wacka.wa", ""), null);
     assertSame(application.getResources(), application.getResources());
   }
 
   @Test
   public void shouldBeAbleToResetResources() throws Exception {
     Application application = new DefaultTestLifecycle().createApplication(null,
-        newConfigWith("com.wacka.wa", ""));
+        newConfigWith("com.wacka.wa", ""), null);
     Resources res = application.getResources();
     shadowOf(application).resetResources();
     assertFalse(res == application.getResources());
@@ -377,7 +377,7 @@ public class ApplicationTest {
   @Test
   public void checkPermission_shouldTrackGrantedAndDeniedPermissions() throws Exception {
     Application application = new DefaultTestLifecycle().createApplication(null,
-        newConfigWith("com.wacka.wa", ""));
+        newConfigWith("com.wacka.wa", ""), null);
     shadowOf(application).grantPermissions("foo", "bar");
     shadowOf(application).denyPermissions("foo", "qux");
     assertThat(application.checkPermission("foo", -1, -1)).isEqualTo(PERMISSION_DENIED);
@@ -389,7 +389,7 @@ public class ApplicationTest {
   @Test
   public void startActivity_whenActivityCheckingEnabled_checksPackageManagerResolveInfo() throws Exception {
     Application application = new DefaultTestLifecycle().createApplication(null,
-        newConfigWith("com.wacka.wa", ""));
+        newConfigWith("com.wacka.wa", ""), null);
     shadowOf(application).checkActivities(true);
 
     String action = "com.does.not.exist.android.app.v2.mobile";

--- a/src/test/java/org/robolectric/shadows/ContentResolverTest.java
+++ b/src/test/java/org/robolectric/shadows/ContentResolverTest.java
@@ -540,7 +540,7 @@ public class ContentResolverTest {
 
   @Test
   public void getProvider_shouldNotReturnAnyProviderWhenManifestIsNull() {
-    Robolectric.application = new DefaultTestLifecycle().createApplication(null, null);
+    Robolectric.application = new DefaultTestLifecycle().createApplication(null, null, null);
     assertThat(ShadowContentResolver.getProvider(Uri.parse("content://"))).isNull();
   }
 


### PR DESCRIPTION
Currently the only way to override the application in tests is to follow the convention of having a TestFooApplication in the same package as FooApplication, doing so forces the parsing of the AndroidManifest.xml and the loading of resources. For tests where resources are not required this is a little cumbersome, also some would prefer the ability to set this explicitly for improved clarity.
