### PR TITLE
prevent duplicate dependencies from importing maven-ant-tasks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,19 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-ant-tasks</artifactId>
       <version>2.1.3</version>
+     <!-- This artefact is a kind of jar-with-dependencies already,
+          we don't need any of its dependencies -->
+      <exclusions>
+         <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+      <version>1.8.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The maven-ant-tasks Maven dependency is a shaded JAR, i.e. it includes some of its declared dependencies already. This results in duplicate class errors.
