### PR TITLE
Add simple implementation of AccountManager.addAccount()

### DIFF
--- a/src/test/java/org/robolectric/shadows/AccountManagerTest.java
+++ b/src/test/java/org/robolectric/shadows/AccountManagerTest.java
@@ -420,4 +420,37 @@ public class AccountManagerTest {
     assertThat(am.peekAuthToken(account, "token_type_1")).isNull();
     assertThat(am.peekAuthToken(account, "token_type_2")).isNull();
   }
+
+  @Test
+  public void addAccount_noActivitySpecified() throws Exception {
+    Robolectric.shadowOf(am).addAuthenticator("google.com");
+
+    AccountManagerFuture<Bundle> result = am.addAccount("google.com", "auth_token_type", null, null, null, null, null);
+
+    Bundle resultBundle = result.getResult();
+
+    assertThat(resultBundle.getParcelable(AccountManager.KEY_INTENT)).isNotNull();
+  }
+
+  @Test
+  public void addAccount_activitySpecified() throws Exception {
+    Robolectric.shadowOf(am).addAuthenticator("google.com");
+
+    AccountManagerFuture<Bundle> result = am.addAccount("google.com", "auth_token_type", null, null, new Activity(), null, null);
+
+    Bundle resultBundle = result.getResult();
+
+    assertThat(resultBundle.getString(AccountManager.KEY_ACCOUNT_TYPE)).isEqualTo("google.com");
+    assertThat(resultBundle.getString(AccountManager.KEY_ACCOUNT_NAME)).isNotNull();
+  }
+
+  @Test
+  public void addAccount_noAuthenticatorDefined() throws Exception {
+    try {
+      am.addAccount("unknown_account_type", "auth_token_type", null, null, new Activity(), null, null).getResult();
+      fail("addAccount() should throw an authenticator exception if no authenticator was registered for this account type");
+    } catch(AuthenticatorException e) {
+      // Expected
+    }
+  }
 }


### PR DESCRIPTION
- Returns correct bundle values depending on presence of activity parameter
- Throws AuthenticatorException if no authenticator matches accountType parameter

As defined here: http://developer.android.com/reference/android/accounts/AccountManager.html#addAccount(java.lang.String, java.lang.String, java.lang.String[], android.os.Bundle, android.app.Activity, android.accounts.AccountManagerCallback<android.os.Bundle>, android.os.Handler)

TODO: Should check permissions for http://developer.android.com/reference/android/Manifest.permission.html#MANAGE_ACCOUNTS
