### PR TITLE
Add support for color resource defined by item tag.

### DIFF
--- a/src/main/java/org/robolectric/res/PackageResourceLoader.java
+++ b/src/main/java/org/robolectric/res/PackageResourceLoader.java
@@ -31,6 +31,7 @@ public class PackageResourceLoader extends XResourceLoader {
         new ValueResourceLoader(data, "/resources/bool", "bool", ResType.BOOLEAN),
         new ValueResourceLoader(data, "/resources/item[@type='bool']", "bool", ResType.BOOLEAN),
         new ValueResourceLoader(data, "/resources/color", "color", ResType.COLOR),
+        new ValueResourceLoader(data, "/resources/item[@type='color']", "color", ResType.COLOR),
         new ValueResourceLoader(data, "/resources/dimen", "dimen", ResType.DIMEN),
         new ValueResourceLoader(data, "/resources/item[@type='dimen']", "dimen", ResType.DIMEN),
         new ValueResourceLoader(data, "/resources/integer", "integer", ResType.INTEGER),

--- a/src/test/java/org/robolectric/res/PackageResourceLoaderTest.java
+++ b/src/test/java/org/robolectric/res/PackageResourceLoaderTest.java
@@ -37,4 +37,20 @@ public class PackageResourceLoaderTest {
     assertThat(value).describedAs("Item string from gradle output is not loaded").isNotNull();
     assertThat(value.asString()).isEqualTo("3.14");
   }
+
+  @Test
+  public void shouldLoadColorResourcesFromGradleOutputDirectoriesDefinedByColorTag() {
+    PackageResourceLoader loader = new PackageResourceLoader(gradleAppResources());
+    TypedResource value = loader.getValue(new ResName("org.robolectric.gradleapp", "color", "example_color"), "");
+    assertThat(value).describedAs("Color from gradle output is not loaded").isNotNull();
+    assertThat(value.asString()).isEqualTo("#00FF00FF");
+  }
+
+  @Test
+  public void shouldLoadColorResourcesFromGradleOutputDirectoriesDefinedByItemTag() {
+    PackageResourceLoader loader = new PackageResourceLoader(gradleAppResources());
+    TypedResource value = loader.getValue(new ResName("org.robolectric.gradleapp", "color", "example_item_color"), "");
+    assertThat(value).describedAs("Item color from gradle output is not loaded").isNotNull();
+    assertThat(value.asString()).isEqualTo("1.0");
+  }
 }

--- a/src/test/resources/gradle/res/layoutFlavor/menuBuildType/values/colors.xml
+++ b/src/test/resources/gradle/res/layoutFlavor/menuBuildType/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="example_item_color" format="float" type="color">1.0</item>
+    <color name="example_color">#00FF00FF</color>
+</resources>


### PR DESCRIPTION
Add support for color resource defined by item tag like &lt;item name="white" type="color"&gt;#FFFFFFFF&lt;/item&gt;.

For example
http://developer.android.com/samples/BasicMediaRouter/res/values/colors.html
