### PR TITLE
Interpolate string resource values in menu item titles

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowMenuInflater.java
+++ b/src/main/java/org/robolectric/shadows/ShadowMenuInflater.java
@@ -62,9 +62,13 @@ public class ShadowMenuInflater {
           MenuNode subMenuNode = child.getChildren().get(0);
           addChildrenInGroup(subMenuNode, groupId, sub);
         } else {
-          MenuItem item = root.add(groupId,
-              attributes.getAttributeResourceValue(ANDROID_NS, "id", 0),
-              0, attributes.getAttributeValue(ANDROID_NS, "title"));
+          String menuItemTitle = attributes.getAttributeValue(ANDROID_NS, "title");
+          if (isFullyQualifiedName(menuItemTitle)) {
+            menuItemTitle = getStringResourceValue(attributes);
+          }
+
+          int menuItemId = attributes.getAttributeResourceValue(ANDROID_NS, "id", 0);
+          MenuItem item = root.add(groupId, menuItemId, 0, menuItemTitle);
 
           addActionViewToItem(item, attributes);
         }
@@ -73,6 +77,15 @@ public class ShadowMenuInflater {
         addChildrenInGroup(child, newGroupId, root);
       }
     }
+  }
+
+  private String getStringResourceValue(RoboAttributeSet attributes) {
+    int menuItemTitleId = attributes.getAttributeResourceValue(ANDROID_NS, "title", 0);
+    return context.getString(menuItemTitleId);
+  }
+
+  private boolean isFullyQualifiedName(String menuItemTitle) {
+    return menuItemTitle != null && menuItemTitle.startsWith("@");
   }
 
   private void addActionViewToItem(MenuItem item, RoboAttributeSet attributes) {

--- a/src/test/java/org/robolectric/R.java
+++ b/src/test/java/org/robolectric/R.java
@@ -113,6 +113,7 @@ public final class R {
     public static final int escaped_apostrophe = 0x1011a;
     public static final int escaped_quotes = 0x1011b;
     public static final int say_it_with_item = 0x1011c;
+    public static final int test_menu_2 = 0x1011d;
   }
 
   public static final class plurals {

--- a/src/test/resources/res/menu/test.xml
+++ b/src/test/resources/res/menu/test.xml
@@ -2,5 +2,5 @@
   <item android:id="@+id/test_menu_1"
     android:title="Test menu item 1" />
   <item android:id="@+id/test_menu_2"
-    android:title="Test menu item 2" />
+    android:title="@string/test_menu_2" />
 </menu>

--- a/src/test/resources/res/values/strings.xml
+++ b/src/test/resources/res/values/strings.xml
@@ -27,5 +27,6 @@
   <string name="preference_resource_title">preference_resource_title_value</string>
   <string name="preference_resource_summary">preference_resource_summary_value</string>
   <string name="preference_resource_default_value">preference_resource_default_value</string>
+  <string name="test_menu_2">Test menu item 2</string>
   <item name="say_it_with_item" type="string">flowers</item>
 </resources>


### PR DESCRIPTION
There may be an issue if a string starts with an '@' symbol. We are not sure if this is our responsibility to handle this situation.

Fixes #1157
