### PR TITLE
A typed broadcast intent must only be delivered to matching receivers.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -390,15 +390,18 @@ public class ShadowApplication extends ShadowContextWrapper {
     for (Wrapper wrapper : copy) {
       if (hasMatchingPermission(wrapper.broadcastPermission, receiverPermission)
           && wrapper.intentFilter.matchAction(intent.getAction())) {
-        final Handler scheduler = (wrapper.scheduler != null) ? wrapper.scheduler : this.mainHandler;
-        final BroadcastReceiver receiver = wrapper.broadcastReceiver;
-        final Intent broadcastIntent = intent;
-        scheduler.post(new Runnable() {
-          @Override
-          public void run() {
-            receiver.onReceive(realApplication, broadcastIntent);
-          }
-        });
+        final int match = wrapper.intentFilter.matchData(intent.getType(), intent.getScheme(), intent.getData());
+        if (match != IntentFilter.NO_MATCH_DATA && match != IntentFilter.NO_MATCH_TYPE) {
+          final Handler scheduler = (wrapper.scheduler != null) ? wrapper.scheduler : this.mainHandler;
+          final BroadcastReceiver receiver = wrapper.broadcastReceiver;
+          final Intent broadcastIntent = intent;
+          scheduler.post(new Runnable() {
+            @Override
+            public void run() {
+              receiver.onReceive(realApplication, broadcastIntent);
+            }
+          });
+        }
       }
     }
   }

--- a/src/main/java/org/robolectric/shadows/ShadowIntentFilter.java
+++ b/src/main/java/org/robolectric/shadows/ShadowIntentFilter.java
@@ -97,8 +97,23 @@ public class ShadowIntentFilter {
   }
 
   @Implementation
-  public void addDataType(String type) {
-    types.add(type);
+  public void addDataType(String type) throws IntentFilter.MalformedMimeTypeException {
+    final int slashpos = type.indexOf('/');
+    final int typelen = type.length();
+    if (slashpos > 0 && typelen >= slashpos+2) {
+      if (typelen == slashpos+2 && type.charAt(slashpos+1) == '*') {
+        String str = type.substring(0, slashpos);
+        if (!types.contains(str)) {
+          types.add(str.intern());
+        }
+      } else {
+        if (!types.contains(type)) {
+          types.add(type.intern());
+        }
+      }
+      return;
+    }
+    throw new IntentFilter.MalformedMimeTypeException(type);
   }
 
   @Implementation
@@ -108,7 +123,40 @@ public class ShadowIntentFilter {
 
   @Implementation
   public boolean hasDataType(String type) {
-    return types.contains(type);
+    final List<String> t = types;
+    if (type == null) {
+      return false;
+    }
+    if (t.contains(type)) {
+      return true;
+    }
+    // Deal with an Intent wanting to match every type in the IntentFilter.
+    final int typeLength = type.length();
+    if (typeLength == 3 && type.equals("*/*")) {
+      return !t.isEmpty();
+    }
+    // Deal with this IntentFilter wanting to match every Intent type.
+    if (t.contains("*")) {
+      return true;
+    }
+    final int slashpos = type.indexOf('/');
+    if (slashpos > 0) {
+      if (t.contains(type.substring(0, slashpos))) {
+        return true;
+      }
+      if (typeLength == slashpos + 2 && type.charAt(slashpos + 1) == '*') {
+        // Need to look through all types for one that matches
+        // our base...
+        final int numTypes = t.size();
+        for (int i = 0; i < numTypes; i++) {
+          final String v = t.get(i);
+          if (type.regionMatches(0, v, 0, slashpos + 1)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
   }
 
   @Implementation

--- a/src/test/java/org/robolectric/shadows/ContextWrapperTest.java
+++ b/src/test/java/org/robolectric/shadows/ContextWrapperTest.java
@@ -373,4 +373,42 @@ public class ContextWrapperTest {
 
     assertThat(pref1).isNotSameAs(pref2);
   }
+
+  @Test
+  public void sendBroadcast_shouldOnlySendIntentWithTypeWhenReceiverMatchesType()
+          throws IntentFilter.MalformedMimeTypeException {
+
+    final BroadcastReceiver viewAllTypesReceiver = broadcastReceiver("ViewActionWithAnyTypeReceiver");
+    final IntentFilter allTypesIntentFilter = intentFilter("view");
+    allTypesIntentFilter.addDataType("*/*");
+    contextWrapper.registerReceiver(viewAllTypesReceiver, allTypesIntentFilter);
+
+    final BroadcastReceiver imageReceiver = broadcastReceiver("ImageReceiver");
+    final IntentFilter imageIntentFilter = intentFilter("view");
+    imageIntentFilter.addDataType("img/*");
+    contextWrapper.registerReceiver(imageReceiver, imageIntentFilter);
+
+    final BroadcastReceiver videoReceiver = broadcastReceiver("VideoReceiver");
+    final IntentFilter videoIntentFilter = intentFilter("view");
+    videoIntentFilter.addDataType("video/*");
+    contextWrapper.registerReceiver(videoReceiver, videoIntentFilter);
+
+    final BroadcastReceiver viewReceiver = broadcastReceiver("ViewActionReceiver");
+    final IntentFilter viewIntentFilter = intentFilter("view");
+    contextWrapper.registerReceiver(viewReceiver, viewIntentFilter);
+
+    final Intent imageIntent = new Intent("view");
+    imageIntent.setType("img/jpeg");
+    contextWrapper.sendBroadcast(imageIntent);
+
+    final Intent videoIntent = new Intent("view");
+    videoIntent.setType("video/mp4");
+    contextWrapper.sendBroadcast(videoIntent);
+
+    transcript.assertEventsSoFar(
+            "ViewActionWithAnyTypeReceiver notified of view",
+            "ImageReceiver notified of view",
+            "ViewActionWithAnyTypeReceiver notified of view",
+            "VideoReceiver notified of view");
+  }
 }

--- a/src/test/java/org/robolectric/shadows/IntentFilterTest.java
+++ b/src/test/java/org/robolectric/shadows/IntentFilterTest.java
@@ -48,13 +48,13 @@ public class IntentFilterTest {
 
     assertThat(intentFilter.hasAction("test")).isTrue();
   }
-  
+
   @Test
   public void hasDataScheme() {
     IntentFilter intentFilter = new IntentFilter();
     assertThat(intentFilter.hasDataScheme("test")).isFalse();
     intentFilter.addDataScheme("test");
-  
+
     assertThat(intentFilter.hasDataScheme("test")).isTrue();
   }
 
@@ -193,5 +193,29 @@ public class IntentFilterTest {
     Uri uriTest1 = Uri.parse("http://testHost1:1");
     assertThat(intentFilter.matchData("image/test", "http", uriTest1))
         .isLessThan(0);
+  }
+
+  @Test
+  public void matchData_MatchesPartialType() throws IntentFilter.MalformedMimeTypeException {
+    IntentFilter intentFilter = new IntentFilter();
+    intentFilter.addDataScheme("content");
+    intentFilter.addDataType("image/*");
+
+    Uri uri = Uri.parse("content://authority/images");
+    assertThat(intentFilter.matchData("image/test", "content", uri)).isGreaterThanOrEqualTo(0);
+    assertThat(intentFilter.matchData("video/test", "content", uri)).isLessThan(0);
+  }
+
+  @Test
+  public void matchData_MatchesAnyTypeAndSubtype() throws IntentFilter.MalformedMimeTypeException {
+    IntentFilter intentFilter = new IntentFilter();
+    intentFilter.addDataScheme("content");
+    intentFilter.addDataType("*/*");
+
+    Uri uri = Uri.parse("content://authority/images");
+    assertThat(intentFilter.matchData("image/test", "content", uri)).isGreaterThanOrEqualTo(0);
+    assertThat(intentFilter.matchData("image/*", "content", uri)).isGreaterThanOrEqualTo(0);
+    assertThat(intentFilter.matchData("video/test", "content", uri)).isGreaterThanOrEqualTo(0);
+    assertThat(intentFilter.matchData("video/*", "content", uri)).isGreaterThanOrEqualTo(0);
   }
 }


### PR DESCRIPTION
An Intent with a specified data mime type must only be delivered to 
IntentFilter instances matching the Intent's data mime type.

This patch adds type matching to the ShadowApplication in order
to properly filter the target receivers.

This patch also adds support to partial data type such as "_/_" and "<type>/*"

Signed-off-by: David Marques dpsmarques@gmail.com
