### PR TITLE
Remove calls to postResume() from ActivityController.setup().

### DIFF
--- a/src/main/java/org/robolectric/util/ActivityController.java
+++ b/src/main/java/org/robolectric/util/ActivityController.java
@@ -196,7 +196,7 @@ public class ActivityController<T extends Activity>
    * Android the first time the Activity is created.
    */
   public ActivityController<T> setup() {
-    return create().start().postCreate(null).resume().postResume().visible();
+    return create().start().postCreate(null).resume().visible();
   }
 
   /**
@@ -209,7 +209,6 @@ public class ActivityController<T extends Activity>
         .restoreInstanceState(savedInstanceState)
         .postCreate(savedInstanceState)
         .resume()
-        .postResume()
         .visible();
   }
 }


### PR DESCRIPTION
Remove calls to postResume() from ActivityController.setup(). onPostResume() gets called just by doing activityController.resume(). These extraneous calls to postResume() mean that onPostResume() gets called twice.
