### PR TITLE
ShadowWebView.getLastLoadedUrl() should the same url from WebView.loadUrl(url, additionalHeaders)

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowWebView.java
+++ b/src/main/java/org/robolectric/shadows/ShadowWebView.java
@@ -1,24 +1,24 @@
 package org.robolectric.shadows;
 
-import static org.fest.reflect.core.Reflection.field;
-
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.util.HashMap;
-
-import org.fest.reflect.field.Invoker;
-import org.robolectric.annotation.Implementation;
-import org.robolectric.annotation.Implements;
-import org.robolectric.annotation.RealObject;
-import org.robolectric.internal.HiddenApi;
-
 import android.view.ViewGroup.LayoutParams;
 import android.webkit.TestWebSettings;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.fest.reflect.field.Invoker;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.internal.HiddenApi;
+
+import static org.fest.reflect.core.Reflection.field;
 
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(value = WebView.class, inheritImplementationMethods = true)
@@ -29,6 +29,7 @@ public class ShadowWebView extends ShadowAbsoluteLayout {
   private WebView realWebView;
   
   private String lastUrl;
+  private Map<String, String> lastAdditionalHttpHeaders;
   private HashMap<String, Object> javascriptInterfaces = new HashMap<String, Object>();
   private WebSettings webSettings = new TestWebSettings();
   private WebViewClient webViewClient = null;
@@ -107,7 +108,18 @@ public class ShadowWebView extends ShadowAbsoluteLayout {
 
   @Implementation
   public void loadUrl(String url) {
+    loadUrl(url, null);
+  }
+
+  @Implementation
+  public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
     lastUrl = url;
+
+    if (additionalHttpHeaders != null) {
+      this.lastAdditionalHttpHeaders = Collections.unmodifiableMap(additionalHttpHeaders);
+    } else {
+      this.lastAdditionalHttpHeaders = null;
+    }
   }
 
   @Implementation
@@ -127,6 +139,15 @@ public class ShadowWebView extends ShadowAbsoluteLayout {
    */
   public String getLastLoadedUrl() {
     return lastUrl;
+  }
+
+  /**
+   * Non-Android accessor.
+   *
+   * @return the additional Http headers that in the same request with last loaded url
+   */
+  public Map<String, String> getLastAdditionalHttpHeaders() {
+    return lastAdditionalHttpHeaders;
   }
 
   @Implementation

--- a/src/test/java/org/robolectric/shadows/WebViewTest.java
+++ b/src/test/java/org/robolectric/shadows/WebViewTest.java
@@ -42,6 +42,15 @@ public class WebViewTest {
   public void shouldRecordLastLoadedUrlForRequestWithAdditionalHeaders() {
     webView.loadUrl("http://example.com", null);
     assertThat(shadowOf(webView).getLastLoadedUrl()).isEqualTo("http://example.com");
+    assertThat(shadowOf(webView).getLastAdditionalHttpHeaders()).isNull();
+
+    Map<String, String> additionalHttpHeaders = new HashMap<String, String>(1);
+    additionalHttpHeaders.put("key1", "value1");
+    webView.loadUrl("http://example.com", additionalHttpHeaders);
+    assertThat(shadowOf(webView).getLastLoadedUrl()).isEqualTo("http://example.com");
+    assertThat(shadowOf(webView).getLastAdditionalHttpHeaders()).isNotNull();
+    assertThat(shadowOf(webView).getLastAdditionalHttpHeaders()).containsKey("key1");
+    assertThat(shadowOf(webView).getLastAdditionalHttpHeaders().get("key1")).isEqualTo("value1");
   }
 
   @Test


### PR DESCRIPTION
When we call WebView.loadUrl("http://www.google.com"), ShadowWebView.getLastLoadedUrl() will give correct result, "http://www.google.com". However, when we call WebView.loadUrl("http://www.google.com", null), ShadowWebView.getLastLoadedUrl() will return null, which is wrong. This patch will fix it.

This patch also provides a way to test the second parameter in the call WebView.loadUrl(url, additionalHttpHeaders)
