### PR TITLE
Add support for dependent preferences.

### DIFF
--- a/src/main/java/org/robolectric/res/builder/PreferenceBuilder.java
+++ b/src/main/java/org/robolectric/res/builder/PreferenceBuilder.java
@@ -1,11 +1,13 @@
 package org.robolectric.res.builder;
 
+import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.preference.Preference;
 import android.preference.PreferenceGroup;
+import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import org.robolectric.res.Attribute;
 import org.robolectric.res.PreferenceNode;
@@ -28,16 +30,17 @@ public class PreferenceBuilder {
   }
 
 
-  public Preference inflate(PreferenceNode preferenceNode, Context context, Preference parent) {
+  public Preference inflate(PreferenceNode preferenceNode, Activity activity, Preference parent) {
     if ("intent".equals(preferenceNode.getName())) {
       shadowOf(parent).setIntent(createIntent(preferenceNode));
       return null;
     }
 
-    Preference preference = create(preferenceNode, context, (PreferenceGroup) parent);
+    Preference preference = create(preferenceNode, activity, (PreferenceGroup) parent);
+    shadowOf(preference).onAttachedToHierarchy(new PreferenceManager(activity, 0));
 
     for (PreferenceNode child : preferenceNode.getChildren()) {
-      inflate(child, context, preference);
+      inflate(child, activity, preference);
     }
 
     return preference;

--- a/src/main/java/org/robolectric/shadows/ShadowPreference.java
+++ b/src/main/java/org/robolectric/shadows/ShadowPreference.java
@@ -8,6 +8,7 @@ import android.preference.Preference;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.util.TypedValue;
+import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -70,6 +71,11 @@ public class ShadowPreference {
     if (v != null) {
       defaultValue = v.coerceToString();
     }
+  }
+
+  @Implementation
+  public void onAttachedToHierarchy(PreferenceManager preferenceManager) {
+    Robolectric.directlyOn(realPreference, Preference.class, "onAttachedToHierarchy", PreferenceManager.class).invoke(preferenceManager);
   }
 
   @Implementation

--- a/src/main/java/org/robolectric/shadows/ShadowPreferenceGroup.java
+++ b/src/main/java/org/robolectric/shadows/ShadowPreferenceGroup.java
@@ -9,6 +9,8 @@ import org.robolectric.annotation.RealObject;
 
 import java.util.ArrayList;
 
+import static org.robolectric.Robolectric.shadowOf;
+
 /**
  * See: http://android.git.kernel.org/?p=platform/frameworks/base.git;a=blob_plain;f=core/java/android/preference/PreferenceGroup.java;hb=HEAD
  */
@@ -32,6 +34,7 @@ public class ShadowPreferenceGroup extends ShadowPreference {
 
     // TODO currently punting on ordering logic
     preferenceList.add(preference);
+    shadowOf(preference).onAttachedToHierarchy(realPreferenceGroup.getPreferenceManager());
 
     return true;
   }

--- a/src/test/java/org/robolectric/res/PreferenceLoaderTest.java
+++ b/src/test/java/org/robolectric/res/PreferenceLoaderTest.java
@@ -1,5 +1,6 @@
 package org.robolectric.res;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.preference.CheckBoxPreference;
@@ -39,32 +40,33 @@ public class PreferenceLoaderTest {
   @Test
   public void shouldCreateCorrectClasses() {
     PreferenceNode preferenceNode = resBundle.get(new ResName(TEST_PACKAGE + ":xml/preferences"), "");
-    PreferenceScreen screen = (PreferenceScreen) preferenceBuilder.inflate(preferenceNode, Robolectric.application, null);
+    PreferenceScreen screen = (PreferenceScreen) preferenceBuilder.inflate(preferenceNode, Robolectric.setupActivity(Activity.class), null);
     assertThatScreenMatchesExpected(screen);
   }
 
   @Test
   public void shouldSetContextInScreens() {
     PreferenceNode preferenceNode = resBundle.get(new ResName(TEST_PACKAGE + ":xml/preferences"), "");
-    PreferenceScreen screen = (PreferenceScreen) preferenceBuilder.inflate(preferenceNode, Robolectric.application, null);
+    Activity activity = Robolectric.setupActivity(Activity.class);
+    PreferenceScreen screen = (PreferenceScreen) preferenceBuilder.inflate(preferenceNode, activity, null);
 
-    assertThat(screen.getContext()).isEqualTo(Robolectric.application);
+    assertThat(screen.getContext()).isEqualTo(activity);
 
     PreferenceScreen innerScreen = (PreferenceScreen) screen.getPreference(1);
-    assertThat(innerScreen.getContext()).isEqualTo(Robolectric.application);
+    assertThat(innerScreen.getContext()).isEqualTo(activity);
   }
 
   @Test(expected = I18nException.class)
   public void shouldThrowI18nExceptionOnPrefsWithBareStrings() throws Exception {
     Robolectric.getShadowApplication().setStrictI18n(true);
     PreferenceNode preferenceNode = resBundle.get(new ResName(TEST_PACKAGE + ":xml/preferences"), "");
-    preferenceBuilder.inflate(preferenceNode, Robolectric.application, null);
+    preferenceBuilder.inflate(preferenceNode, Robolectric.setupActivity(Activity.class), null);
   }
 
   @Test
   public void shouldParseIntentContainedInPreference() throws Exception {
     PreferenceNode preferenceNode = resBundle.get(new ResName(TEST_PACKAGE + ":xml/intent_preference"), "");
-    PreferenceScreen screen = (PreferenceScreen) preferenceBuilder.inflate(preferenceNode, Robolectric.application, null);
+    PreferenceScreen screen = (PreferenceScreen) preferenceBuilder.inflate(preferenceNode, Robolectric.setupActivity(Activity.class), null);
 
     assertThat(screen.getPreferenceCount()).isEqualTo(1);
     Preference intentPreference = screen.getPreference(0);

--- a/src/test/java/org/robolectric/res/XmlFileLoaderTest.java
+++ b/src/test/java/org/robolectric/res/XmlFileLoaderTest.java
@@ -274,7 +274,7 @@ public class XmlFileLoaderTest {
   @Test
   public void testGetDepth() throws XmlPullParserException, IOException {
     // Recorded depths from preference file elements
-    List<Integer> expectedDepths = asList(1, 2, 3, 2, 3, 2, 2, 2, 2, 2, 2);
+    List<Integer> expectedDepths = asList(1, 2, 3, 2, 3, 3, 2, 2, 2, 2, 2, 2);
     List<Integer> actualDepths = new ArrayList<Integer>();
     int evt;
     while ((evt = parser.next()) != XmlResourceParser.END_DOCUMENT) {
@@ -453,6 +453,8 @@ public class XmlFileLoaderTest {
         ">",
 
         "<", // PreferenceScreen
+        "<", // Preference
+        ">",
         "<", // Preference
         ">",
         ">",

--- a/src/test/java/org/robolectric/shadows/PreferenceGroupTest.java
+++ b/src/test/java/org/robolectric/shadows/PreferenceGroupTest.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.preference.Preference;
 import android.preference.PreferenceGroup;
+import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,22 +24,23 @@ public class PreferenceGroupTest {
 
   private TestPreferenceGroup group;
   private ShadowPreferenceGroup shadow;
-  private Context context;
+  private Activity activity;
   private RoboAttributeSet attrs;
   private Preference pref1, pref2;
 
   @Before
   public void setUp() throws Exception {
-    context = buildActivity(Activity.class).create().get();
+    activity = buildActivity(Activity.class).create().get();
     attrs = new RoboAttributeSet(new ArrayList<Attribute>(), TestUtil.emptyResources(), null);
 
-    group = new TestPreferenceGroup(context, attrs);
+    group = new TestPreferenceGroup(activity, attrs);
     shadow = Robolectric.shadowOf(group);
+    shadow.onAttachedToHierarchy(new PreferenceManager(activity, 0));
 
-    pref1 = new Preference(context);
+    pref1 = new Preference(activity);
     pref1.setKey("pref1");
 
-    pref2 = new Preference(context);
+    pref2 = new Preference(activity);
     pref2.setKey("pref2");
   }
 
@@ -139,7 +141,8 @@ public class PreferenceGroupTest {
 
   @Test
   public void shouldFindPreferenceRecursively() {
-    TestPreferenceGroup group2 = new TestPreferenceGroup(context, attrs);
+    TestPreferenceGroup group2 = new TestPreferenceGroup(activity, attrs);
+    Robolectric.shadowOf(group2).onAttachedToHierarchy(new PreferenceManager(activity, 0));
     group2.addPreference(pref2);
 
     group.addPreference(pref1);
@@ -152,7 +155,8 @@ public class PreferenceGroupTest {
   public void shouldSetEnabledRecursively() {
     boolean[] values = {false, true};
 
-    TestPreferenceGroup group2 = new TestPreferenceGroup(context, attrs);
+    TestPreferenceGroup group2 = new TestPreferenceGroup(activity, attrs);
+    Robolectric.shadowOf(group2).onAttachedToHierarchy(new PreferenceManager(activity, 0));
     group2.addPreference(pref2);
 
     group.addPreference(pref1);

--- a/src/test/resources/res/xml/preferences.xml
+++ b/src/test/resources/res/xml/preferences.xml
@@ -23,6 +23,12 @@
         android:title="Inside Screen Test"
         android:summary=""/>
 
+    <Preference
+        android:key="inside_screen_dependent"
+        android:title="Inside Screen Dependent Test"
+        android:dependency="inside_screen"
+        android:summary=""/>
+
   </PreferenceScreen>
 
   <CheckBoxPreference


### PR DESCRIPTION
Pull request: https://github.com/robolectric/robolectric/commit/d61f0d61a95598d8aedf8add4ea14a8aad6ab3c4 caused dependencies to be set
when specified in the resources file. This was causing Preference.registerDependency() to throw an IllegalStateException since
no PreferenceManager was set with which to look up the dependency.
1. Added a dependency preference in preferences.xml which exposes this bug.
2. Fix bug by reflectively calling onAttachedToHierarchy() passing the PreferenceManager down the hierarchy of preferences.
