### PR TITLE
Fixing #1194: Adding ShadowView.getOnCreateContextMenuListener

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowView.java
+++ b/src/main/java/org/robolectric/shadows/ShadowView.java
@@ -54,6 +54,7 @@ public class ShadowView {
   private float scaleY = 1.0f;
   private int hapticFeedbackPerformed = -1;
   private boolean onLayoutWasCalled;
+  private View.OnCreateContextMenuListener onCreateContextMenuListener;
 
   public void __constructor__(Context context, AttributeSet attributeSet, int defStyle) {
     if (context == null) throw new NullPointerException("no context");
@@ -128,6 +129,12 @@ public class ShadowView {
   public void setOnSystemUiVisibilityChangeListener(View.OnSystemUiVisibilityChangeListener onSystemUiVisibilityChangeListener) {
     this.onSystemUiVisibilityChangeListener = onSystemUiVisibilityChangeListener;
     directly().setOnSystemUiVisibilityChangeListener(onSystemUiVisibilityChangeListener);
+  }
+
+  @Implementation
+  public void setOnCreateContextMenuListener(View.OnCreateContextMenuListener onCreateContextMenuListener) {
+    this.onCreateContextMenuListener = onCreateContextMenuListener;
+    directly().setOnCreateContextMenuListener(onCreateContextMenuListener);
   }
 
   @Implementation
@@ -307,6 +314,14 @@ public class ShadowView {
   public View.OnSystemUiVisibilityChangeListener getOnSystemUiVisibilityChangeListener() {
     return onSystemUiVisibilityChangeListener;
   }
+
+  /**
+   * Non-android accessor.  Returns create ContextMenu listener, if set.
+   */
+  public View.OnCreateContextMenuListener getOnCreateContextMenuListener() {
+    return onCreateContextMenuListener;
+  }
+
 
   @Implementation
   public Bitmap getDrawingCache() {

--- a/src/test/java/org/robolectric/shadows/ViewTest.java
+++ b/src/test/java/org/robolectric/shadows/ViewTest.java
@@ -8,6 +8,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.view.ContextMenu;
 import android.view.HapticFeedbackConstants;
 import android.view.MotionEvent;
 import android.view.View;
@@ -721,6 +722,21 @@ public class ViewTest {
     testView.setOnSystemUiVisibilityChangeListener(changeListener);
 
     assertThat(changeListener).isEqualTo(shadowOf(testView).getOnSystemUiVisibilityChangeListener());
+  }
+  @Test public void capturesOnCreateContextMenuListener() throws Exception {
+    TestView testView = new TestView(buildActivity(Activity.class).create().get());
+    assertThat(shadowOf(testView).getOnCreateContextMenuListener()).isNull();
+
+    View.OnCreateContextMenuListener createListener = new View.OnCreateContextMenuListener() {
+      @Override
+      public void onCreateContextMenu(ContextMenu contextMenu, View view, ContextMenu.ContextMenuInfo contextMenuInfo) {}
+    };
+
+    testView.setOnCreateContextMenuListener(createListener);
+    assertThat(shadowOf(testView).getOnCreateContextMenuListener()).isEqualTo(createListener);
+
+    testView.setOnCreateContextMenuListener(null);
+    assertThat(shadowOf(testView).getOnCreateContextMenuListener()).isNull();
   }
 
   public static class MyActivity extends Activity {


### PR DESCRIPTION
By getting the OnCreateContextMenuListener from the View,
it is possible to test its functionality (by using TestMenu).
