### PR TITLE
Added new Config value for libraries

### DIFF
--- a/src/main/java/org/robolectric/AndroidManifest.java
+++ b/src/main/java/org/robolectric/AndroidManifest.java
@@ -40,6 +40,10 @@ import static android.content.pm.ApplicationInfo.FLAG_TEST_ONLY;
 import static android.content.pm.ApplicationInfo.FLAG_VM_SAFE_MODE;
 
 public class AndroidManifest {
+  public static final String DEFAULT_MANIFEST_NAME = "AndroidManifest.xml";
+  public static final String DEFAULT_RES_FOLDER = "res";
+  public static final String DEFAULT_ASSETS_FOLDER = "assets";
+
   private final FsFile androidManifestFile;
   private final FsFile resDirectory;
   private final FsFile assetsDirectory;
@@ -62,6 +66,7 @@ public class AndroidManifest {
   private final Map<String, ActivityData> activityDatas = new LinkedHashMap<String, ActivityData>();
   private final List<String> usedPermissions = new ArrayList<String>();
   private MetaData applicationMetaData;
+  private List<FsFile> libraryDirectories;
   private List<AndroidManifest> libraryManifests;
 
   /**
@@ -77,14 +82,15 @@ public class AndroidManifest {
   }
 
   public AndroidManifest(final FsFile androidManifestFile, final FsFile resDirectory) {
-    this(androidManifestFile, resDirectory, resDirectory.getParent().join("assets"));
+    this(androidManifestFile, resDirectory, resDirectory.getParent().join(DEFAULT_ASSETS_FOLDER));
   }
 
   /**
    * @deprecated Use {@link #AndroidManifest(org.robolectric.res.FsFile, org.robolectric.res.FsFile, org.robolectric.res.FsFile)} instead.}
    */
   public AndroidManifest(final FsFile baseDir) {
-    this(baseDir.join("AndroidManifest.xml"), baseDir.join("res"), baseDir.join("assets"));
+    this(baseDir.join(DEFAULT_MANIFEST_NAME), baseDir.join(DEFAULT_RES_FOLDER),
+        baseDir.join(DEFAULT_ASSETS_FOLDER));
   }
 
   /**
@@ -498,11 +504,17 @@ public class AndroidManifest {
     return providers;
   }
 
+  public void setLibraryDirectories(List<FsFile> libraryDirectories) {
+    this.libraryDirectories = libraryDirectories;
+  }
+
   protected void createLibraryManifests() {
     libraryManifests = new ArrayList<AndroidManifest>();
-    List<FsFile> libraryBaseDirs = findLibraries();
+    if (libraryDirectories == null) {
+      libraryDirectories = findLibraries();
+    }
 
-    for (FsFile libraryBaseDir : libraryBaseDirs) {
+    for (FsFile libraryBaseDir : libraryDirectories) {
       AndroidManifest libraryManifest = createLibraryAndroidManifest(libraryBaseDir);
       libraryManifest.createLibraryManifests();
       libraryManifests.add(libraryManifest);

--- a/src/test/java/org/robolectric/AndroidManifestTest.java
+++ b/src/test/java/org/robolectric/AndroidManifestTest.java
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 import org.robolectric.res.ActivityData;
 import org.robolectric.res.Fs;
+import org.robolectric.res.FsFile;
 import org.robolectric.res.IntentFilterData;
 import org.robolectric.res.ResourcePath;
 import org.robolectric.test.TemporaryFolder;
@@ -391,5 +392,17 @@ public class AndroidManifestTest {
     @Override
     public void onReceive(Context context, Intent intent) {
     }
+  }
+
+  @Test
+  public void shouldLoadLibraryManifests() throws Exception {
+    AndroidManifest manifest = newConfig("TestAndroidManifest.xml");
+    List<FsFile> libraries = new ArrayList<FsFile>();
+    libraries.add(resourceFile("lib1"));
+    manifest.setLibraryDirectories(libraries);
+
+    List<AndroidManifest> libraryManifests = manifest.getLibraryManifests();
+    assertEquals(1, libraryManifests.size());
+    assertEquals("org.robolectric.lib1", libraryManifests.get(0).getPackageName());
   }
 }

--- a/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
+++ b/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
@@ -84,7 +84,7 @@ public class DefaultTestLifecycleTest {
 
   @Test public void shouldLoadConfigApplicationIfSpecified() throws Exception {
     Application application = defaultTestLifecycle.createApplication(null,
-        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(-1, "", "", "", -1, new Class[0], TestFakeApp.class));
+        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(-1, "", "", "", -1, new Class[0], TestFakeApp.class, new String[0]));
     assertThat(application).isExactlyInstanceOf(TestFakeApp.class);
   }
 

--- a/src/test/java/org/robolectric/LibraryHandlingTest.java
+++ b/src/test/java/org/robolectric/LibraryHandlingTest.java
@@ -4,6 +4,9 @@ import android.content.res.Resources;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -34,5 +37,14 @@ public class LibraryHandlingTest {
     assertEquals("from lib3", resources.getText(org.robolectric.R.string.in_lib2_and_lib3));
     assertEquals("from lib1", resources.getText(org.robolectric.R.string.in_lib1_and_lib3));
     assertEquals("from main", resources.getText(org.robolectric.R.string.in_main_and_lib1));
+  }
+
+  @Test
+  @Config(manifest="src/test/resources/TestAndroidManifest.xml", libraries="lib1")
+  public void libraryConfigShouldOverrideProjectProperties() throws Exception {
+    AndroidManifest manifest = Robolectric.shadowOf(Robolectric.application).getAppManifest();
+    List<AndroidManifest> libraryManifests = manifest.getLibraryManifests();
+    assertEquals(1, libraryManifests.size());
+    assertEquals("org.robolectric.lib1", libraryManifests.get(0).getPackageName());
   }
 }

--- a/src/test/java/org/robolectric/ParallelUniverseTest.java
+++ b/src/test/java/org/robolectric/ParallelUniverseTest.java
@@ -25,7 +25,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromSdkConfig() {
     String givenQualifiers = "";
-    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", -1, new Class[0], Application.class);
+    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", -1, new Class[0], Application.class, new String[0]);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), false, null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("v18");
   }
@@ -33,7 +33,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromConfigQualifiers() {
     String givenQualifiers = "land-v17";
-    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", -1, new Class[0], Application.class);
+    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", -1, new Class[0], Application.class, new String[0]);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), false, null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("land-v17");
   }
@@ -41,7 +41,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromSdkConfigWithOtherQualifiers() {
     String givenQualifiers = "large-land";
-    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", -1, new Class[0], Application.class);
+    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", -1, new Class[0], Application.class, new String[0]);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), false, null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("large-land-v18");
   }


### PR DESCRIPTION
This is a potential solution to #1196. It removes the requirement to maintain a project.properties file (though it will still fall back to reading one, so existing functionality is preserved).

This config value specifies the paths to required Android Library projects (relative to the project base dir). When present, it supercedes the libraries from project.properties.

Also added a few constants in AndroidManifest.java to replace hard-coded strings.
