### PR TITLE
Check for negative/zero input in createBitmap()

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowBitmap.java
+++ b/src/main/java/org/robolectric/shadows/ShadowBitmap.java
@@ -126,6 +126,9 @@ public class ShadowBitmap {
 
   @Implementation
   public static Bitmap createBitmap(int width, int height, Bitmap.Config config) {
+    if (width <= 0 || height <= 0) {
+      throw new IllegalArgumentException("width and height must be > 0");
+    }
     Bitmap scaledBitmap = Robolectric.newInstanceOf(Bitmap.class);
     ShadowBitmap shadowBitmap = shadowOf(scaledBitmap);
 

--- a/src/test/java/org/robolectric/shadows/BitmapTest.java
+++ b/src/test/java/org/robolectric/shadows/BitmapTest.java
@@ -191,6 +191,16 @@ public class BitmapTest {
     Bitmap b = Bitmap.createBitmap(10, 20, Config.ARGB_8888);
     Bitmap.createBitmap(b, 0, 0, 20, 10, null, false);
   }
+  
+  @Test(expected = IllegalArgumentException.class)
+  public void throwsExceptionForNegativeWidth() {
+    Bitmap.createBitmap(-100, 10, Config.ARGB_8888);
+  }
+  
+  @Test(expected = IllegalArgumentException.class)
+  public void throwsExceptionForZeroHeight() {
+    Bitmap.createBitmap(100, 0, Config.ARGB_8888);
+  }
 
   private static Bitmap create(String name) {
     Bitmap bitmap = Robolectric.newInstanceOf(Bitmap.class);


### PR DESCRIPTION
Adds a check for negative or zero values for Width/Height in
ShadowBitmap.createBitmap(int width, int height, Bitmap.Config config)
implementation. Raises IllegalArgumentException if params are negative
or zero. Follows implementation in android.graphics.bitmap.

This fixes issue #1215.
