### PR TITLE
Preserve stack map frames.

### DIFF
--- a/src/main/java/org/robolectric/bytecode/AsmInstrumentingClassLoader.java
+++ b/src/main/java/org/robolectric/bytecode/AsmInstrumentingClassLoader.java
@@ -244,7 +244,18 @@ public class AsmInstrumentingClassLoader extends ClassLoader implements Opcodes,
   private byte[] getInstrumentedBytes(String className, ClassNode classNode, boolean containsStubs) throws ClassNotFoundException {
     new ClassInstrumentor(classNode, containsStubs).instrument();
 
-    ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS) {
+    /**
+     * Preserve stack map frames for V51 and newer bytecode. This fixes class verification errors
+     * for JDK7 and JDK8. The option to disable bytecode verification was removed in JDK8.
+     *
+     * Don't bother for V50 and earlier bytecode, because it doesn't contain stack map frames, and
+     * also because ASM's stack map frame handling doesn't support the JSR and RET instructions
+     * present in legacy bytecode.
+     */
+    int classWriterFlags = classNode.version >= 51
+        ? ClassWriter.COMPUTE_FRAMES
+        : ClassWriter.COMPUTE_MAXS;
+    ClassWriter classWriter = new ClassWriter(classWriterFlags) {
       @Override
       public int newNameType(String name, String desc) {
         return super.newNameType(name, desc.charAt(0) == ')' ? remapParams(desc) : remapParamType(desc));


### PR DESCRIPTION
Preserve stack map frames for V51 and newer bytecode. This fixes class verification errors for JDK7 and JDK8. The option to disable bytecode verification was removed in JDK8.

This solves the same problem as the AsmInstrumentingClassLoader change in
robolectric#881, but the custom getCommonSuperClass implementation in that patch doesn't seem to work reliably.
