### PR TITLE
No getContentEncoding method in TestHttpResponse

### DIFF
--- a/src/main/java/org/robolectric/tester/org/apache/http/TestHttpResponse.java
+++ b/src/main/java/org/robolectric/tester/org/apache/http/TestHttpResponse.java
@@ -193,12 +193,11 @@ public class TestHttpResponse extends HttpResponseStub {
     }
 
     @Override public Header getContentType() {
-      for (Header header : headers) {
-        if (header.getName().equals("Content-Type")) {
-          return header;
-        }
-      }
-      return null;
+      return getFirstHeader("Content-Type");
+    }
+
+    @Override public Header getContentEncoding() {
+      return getFirstHeader("Content-Encoding");
     }
 
     @Override public boolean isStreaming() {


### PR DESCRIPTION
There was no such method for some reason, so I implemented it.
Also reimplemented getContentType, the previous version was incorrect due to case sensitivity.
Not sure if I should create a test for such a simple method (there was no test for getContentType either), but if you want one, I'll do that.
