### PR TITLE
Added test to reproduce NotSerializableException, sample stack:

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowIntent.java
+++ b/src/main/java/org/robolectric/shadows/ShadowIntent.java
@@ -260,7 +260,7 @@ public class ShadowIntent {
 
   @Implementation
   public Intent putExtra(String key, Serializable value) {
-    extras.putSerializable(key, serializeCycle(value));
+    extras.putSerializable(key, value);
     return realIntent;
   }
 
@@ -637,23 +637,6 @@ public class ShadowIntent {
             ifWeHave(type, "type")
         ) +
         '}';
-  }
-
-  private Serializable serializeCycle(Serializable serializable) {
-    try {
-      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-      ObjectOutputStream output = new ObjectOutputStream(byteArrayOutputStream);
-      output.writeObject(serializable);
-      output.close();
-
-      byte[] bytes = byteArrayOutputStream.toByteArray();
-      ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes));
-      return (Serializable) input.readObject();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    } catch (ClassNotFoundException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   private String ifWeHave(Object o, String name) {

--- a/src/test/java/org/robolectric/shadows/IntentTest.java
+++ b/src/test/java/org/robolectric/shadows/IntentTest.java
@@ -100,9 +100,17 @@ public class IntentTest {
     TestSerializable serializable = new TestSerializable("some string");
     assertSame(intent, intent.putExtra("foo", serializable));
     assertEquals(serializable, intent.getExtras().get("foo"));
-    assertNotSame(serializable, intent.getExtras().get("foo"));
     assertEquals(serializable, intent.getSerializableExtra("foo"));
-    assertNotSame(serializable, intent.getSerializableExtra("foo"));
+  }
+
+  @Test
+  public void testSerializableOfParcelableExtra() throws Exception {
+    Intent intent = new Intent();
+    ArrayList<Parcelable> serializable = new ArrayList();
+    serializable.add(new TestParcelable(12));
+    assertSame(intent, intent.putExtra("foo", serializable));
+    assertEquals(serializable, intent.getExtras().get("foo"));
+    assertEquals(serializable, intent.getSerializableExtra("foo"));
   }
 
   @Test


### PR DESCRIPTION
Fixed bug by removing unncecesary attempt to serialize a Serializable

Error before fixing the bug:
testSerializableOfParcelableExtra(org.robolectric.shadows.IntentTest)  Time elapsed: 0.015 sec  <<< ERROR!
java.lang.RuntimeException: java.io.NotSerializableException: org.robolectric.shadows.TestParcelable
    at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1183)
    at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:347)
    at java.util.ArrayList.writeObject(ArrayList.java:742)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at java.io.ObjectStreamClass.invokeWriteObject(ObjectStreamClass.java:988)
    at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1495)
    at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1431)
    at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1177)
    at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:347)
    at org.robolectric.shadows.ShadowIntent.serializeCycle(ShadowIntent.java:646)
    at org.robolectric.shadows.ShadowIntent.putExtra(ShadowIntent.java:263)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.robolectric.bytecode.ShadowWrangler$ShadowMethodPlan.run(ShadowWrangler.java:473)
    at android.content.Intent.putExtra(Intent.java)
    at org.robolectric.shadows.IntentTest.testSerializableOfParcelableExtra(IntentTest.java:113)
