### PR TITLE
Add ShadowOverScroller.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowOverScroller.java
+++ b/src/main/java/org/robolectric/shadows/ShadowOverScroller.java
@@ -1,0 +1,137 @@
+package org.robolectric.shadows;
+
+import static org.robolectric.Robolectric.shadowOf;
+
+import android.os.Looper;
+import android.widget.OverScroller;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.util.Scheduler;
+
+@Implements(OverScroller.class)
+public class ShadowOverScroller {
+  private int startX;
+  private int startY;
+  private int finalX;
+  private int finalY;
+  private long startTime;
+  private long duration;
+  private boolean started;
+
+  @Implementation
+  public int getStartX() {
+    return startX;
+  }
+
+  @Implementation
+  public int getStartY() {
+    return startY;
+  }
+
+  @Implementation
+  public int getCurrX() {
+    long dt = deltaTime();
+    return dt >= duration ? finalX : startX + (int) ((deltaX() * dt) / duration);
+  }
+
+  @Implementation
+  public int getCurrY() {
+    long dt = deltaTime();
+    return dt >= duration ? finalY : startY + (int) ((deltaY() * dt) / duration);
+  }
+
+  @Implementation
+  public int getFinalX() {
+    return finalX;
+  }
+
+  @Implementation
+  public int getFinalY() {
+    return finalY;
+  }
+
+  @Implementation
+  public int getDuration() {
+    return (int) duration;
+  }
+
+  @Implementation
+  public void startScroll(int startX, int startY, int dx, int dy, int duration) {
+    this.startX = startX;
+    this.startY = startY;
+    finalX = startX + dx;
+    finalY = startY + dy;
+    startTime = getScheduler().getCurrentTime();
+    this.duration = duration;
+    started = true;
+    // post a task so that the scheduler will actually run
+    getScheduler().postDelayed(new Runnable() {
+      @Override
+      public void run() {
+        // do nothing
+      }
+    }, duration);
+  }
+
+  @Implementation
+  public void abortAnimation() {
+    duration = deltaTime() - 1;
+  }
+
+  @Implementation
+  public void forceFinished(boolean finished) {
+    if (!finished) {
+      throw new RuntimeException("Not implemented.");
+    }
+
+    finalX = getCurrX();
+    finalY = getCurrY();
+    duration = deltaTime() - 1;
+  }
+
+  @Implementation
+  public boolean computeScrollOffset() {
+    if (!started) {
+      return false;
+    }
+    started &= deltaTime() < duration;
+    return true;
+  }
+
+  @Implementation
+  public boolean isFinished() {
+    return deltaTime() > duration;
+  }
+
+  @Implementation
+  public int timePassed() {
+    return (int) deltaTime();
+  }
+
+  @Implementation
+  public boolean isScrollingInDirection(float xvel, float yvel) {
+    final int dx = finalX - startX;
+    final int dy = finalY - startY;
+    return !isFinished()
+        && Math.signum(xvel) == Math.signum(dx)
+        && Math.signum(yvel) == Math.signum(dy);
+  }
+
+  private long deltaTime() {
+    return getScheduler().getCurrentTime() - startTime;
+  }
+
+  private Scheduler getScheduler() {
+    return shadowOf(Looper.getMainLooper()).getScheduler();
+  }
+
+  private int deltaX() {
+    return (finalX - startX);
+  }
+
+  private int deltaY() {
+    return (finalY - startY);
+  }
+}
+

--- a/src/test/java/org/robolectric/shadows/OverScrollerTest.java
+++ b/src/test/java/org/robolectric/shadows/OverScrollerTest.java
@@ -1,0 +1,98 @@
+package org.robolectric.shadows;
+
+import android.view.animation.LinearInterpolator;
+import android.widget.OverScroller;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.TestRunners;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class OverScrollerTest {
+  private OverScroller overScroller;
+
+  @Before
+  public void setUp() {
+    overScroller = new OverScroller(Robolectric.application, new LinearInterpolator());
+  }
+
+  @Test
+  public void shouldScrollOverTime() {
+    overScroller.startScroll(0, 0, 100, 200, 1000);
+
+    assertThat(overScroller.getStartX()).isEqualTo(0);
+    assertThat(overScroller.getStartY()).isEqualTo(0);
+    assertThat(overScroller.getFinalX()).isEqualTo(100);
+    assertThat(overScroller.getFinalY()).isEqualTo(200);
+    assertThat(overScroller.isScrollingInDirection(1, 1)).isTrue();
+    assertThat(overScroller.isScrollingInDirection(-1, -1)).isFalse();
+
+    assertThat(overScroller.getCurrX()).isEqualTo(0);
+    assertThat(overScroller.getCurrY()).isEqualTo(0);
+    assertThat(overScroller.timePassed()).isEqualTo(0);
+    assertThat(overScroller.isFinished()).isFalse();
+
+    Robolectric.idleMainLooper(100);
+    assertThat(overScroller.getCurrX()).isEqualTo(10);
+    assertThat(overScroller.getCurrY()).isEqualTo(20);
+    assertThat(overScroller.timePassed()).isEqualTo(100);
+    assertThat(overScroller.isFinished()).isFalse();
+
+    Robolectric.idleMainLooper(401);
+    assertThat(overScroller.getCurrX()).isEqualTo(50);
+    assertThat(overScroller.getCurrY()).isEqualTo(100);
+    assertThat(overScroller.timePassed()).isEqualTo(501);
+    assertThat(overScroller.isFinished()).isFalse();
+
+    Robolectric.idleMainLooper(1000);
+    assertThat(overScroller.getCurrX()).isEqualTo(100);
+    assertThat(overScroller.getCurrY()).isEqualTo(200);
+    assertThat(overScroller.timePassed()).isEqualTo(1501);
+    assertThat(overScroller.isFinished()).isEqualTo(true);
+    assertThat(overScroller.isScrollingInDirection(1, 1)).isFalse();
+    assertThat(overScroller.isScrollingInDirection(-1, -1)).isFalse();
+  }
+
+  @Test
+  public void computeScrollOffsetShouldCalculateWhetherScrollIsFinished() {
+    assertThat(overScroller.computeScrollOffset()).isFalse();
+
+    overScroller.startScroll(0, 0, 100, 200, 1000);
+    assertThat(overScroller.computeScrollOffset()).isTrue();
+
+    Robolectric.idleMainLooper(500);
+    assertThat(overScroller.computeScrollOffset()).isTrue();
+
+    Robolectric.idleMainLooper(500);
+    assertThat(overScroller.computeScrollOffset()).isTrue();
+    assertThat(overScroller.computeScrollOffset()).isFalse();
+  }
+
+  @Test
+  public void abortAnimationShouldMoveToFinalPositionImmediately() {
+    overScroller.startScroll(0, 0, 100, 200, 1000);
+    Robolectric.idleMainLooper(500);
+    overScroller.abortAnimation();
+
+    assertThat(overScroller.getCurrX()).isEqualTo(100);
+    assertThat(overScroller.getCurrY()).isEqualTo(200);
+    assertThat(overScroller.timePassed()).isEqualTo(500);
+    assertThat(overScroller.isFinished()).isTrue();
+  }
+
+  @Test
+  public void forceFinishedShouldFinishWithoutMovingFurther() {
+    overScroller.startScroll(0, 0, 100, 200, 1000);
+    Robolectric.idleMainLooper(500);
+    overScroller.forceFinished(true);
+
+    assertThat(overScroller.getCurrX()).isEqualTo(50);
+    assertThat(overScroller.getCurrY()).isEqualTo(100);
+    assertThat(overScroller.timePassed()).isEqualTo(500);
+    assertThat(overScroller.isFinished()).isTrue();
+  }
+}


### PR DESCRIPTION
This adds a shadow for OverScroller, which makes it possible to test usages of DrawerLayout with behavior that depends on DrawerListener. Prior to this shadow existing, DrawerLayouts wouldn't really respond to being opened/closed, as their animations never ran (which they depend on to update the open/closed state).

After this patch, the animations will run as expected. (Note that you still need to get the DrawerLayout to recompute it's scroll state after the animation runs, e.g:

``` java
Robolectric.getUiThreadScheduler().advanceToLastPostedRunnable(); // finish animation
drawerLayout.computeScroll(); // recompute scroll and open/closed state
```

)

Fixes #932.
