### PR TITLE
Add ShadowPorterDuffColorFilter for inspecting colors and modes of filters.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowPorterDuffColorFilter.java
+++ b/src/main/java/org/robolectric/shadows/ShadowPorterDuffColorFilter.java
@@ -1,0 +1,25 @@
+package org.robolectric.shadows;
+
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
+
+import org.robolectric.annotation.Implements;
+
+@Implements(PorterDuffColorFilter.class)
+public class ShadowPorterDuffColorFilter {
+  private int srcColor;
+  private PorterDuff.Mode mode;
+
+  public void __constructor__(int srcColor, PorterDuff.Mode mode) {
+    this.srcColor = srcColor;
+    this.mode = mode;
+  }
+
+  public int getSrcColor() {
+    return srcColor;
+  }
+
+  public PorterDuff.Mode getMode() {
+    return mode;
+  }
+}

--- a/src/test/java/org/robolectric/shadows/PorterDuffColorFilterTest.java
+++ b/src/test/java/org/robolectric/shadows/PorterDuffColorFilterTest.java
@@ -1,0 +1,24 @@
+package org.robolectric.shadows;
+
+import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.TestRunners;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class PorterDuffColorFilterTest {
+  @Test
+  public void testConstructor() {
+    PorterDuffColorFilter colorFilter = new PorterDuffColorFilter(Color.RED, PorterDuff.Mode.ADD);
+    ShadowPorterDuffColorFilter shadow = Robolectric.shadowOf_(colorFilter);
+
+    assertThat(shadow.getSrcColor()).isEqualTo(Color.RED);
+    assertThat(shadow.getMode()).isEqualTo(PorterDuff.Mode.ADD);
+  }
+}


### PR DESCRIPTION
This allows for inspecting/asserting against PorterDuffColorFilters, which are otherwise completely opaque.
