### PR TITLE
Allow weaved byte code to be passed to Robolectric.

### DIFF
--- a/src/main/java/org/robolectric/bytecode/AsmInstrumentingClassLoader.java
+++ b/src/main/java/org/robolectric/bytecode/AsmInstrumentingClassLoader.java
@@ -123,19 +123,7 @@ public class AsmInstrumentingClassLoader extends ClassLoader implements Opcodes,
   @Override
   protected Class<?> findClass(final String className) throws ClassNotFoundException {
     if (setup.shouldAcquire(className)) {
-      String classFilename = className.replace('.', '/') + ".class";
-      InputStream classBytesStream = urls.getResourceAsStream(classFilename);
-      if (classBytesStream == null) {
-        classBytesStream = getResourceAsStream(classFilename);
-      }
-      if (classBytesStream == null) throw new ClassNotFoundException(className);
-
-      byte[] origClassBytes;
-      try {
-        origClassBytes = readBytes(classBytesStream);
-      } catch (IOException e) {
-        throw new ClassNotFoundException("couldn't load " + className, e);
-      }
+      byte[] origClassBytes = getByteCode(className);
 
       final ClassReader classReader = new ClassReader(origClassBytes);
       ClassNode classNode = new ClassNode(Opcodes.ASM4) {
@@ -173,6 +161,23 @@ public class AsmInstrumentingClassLoader extends ClassLoader implements Opcodes,
       throw new IllegalStateException("how did we get here? " + className);
 //            return super.findClass(className);
     }
+  }
+
+  protected byte[] getByteCode(String className) throws ClassNotFoundException {
+    String classFilename = className.replace('.', '/') + ".class";
+    InputStream classBytesStream = urls.getResourceAsStream(classFilename);
+    if (classBytesStream == null) {
+      classBytesStream = getResourceAsStream(classFilename);
+    }
+    if (classBytesStream == null) throw new ClassNotFoundException(className);
+
+    byte[] origClassBytes;
+    try {
+      origClassBytes = readBytes(classBytesStream);
+    } catch (IOException e) {
+      throw new ClassNotFoundException("couldn't load " + className, e);
+    }
+    return origClassBytes;
   }
 
   private void ensurePackage(final String className) {


### PR DESCRIPTION
This simple change allows to pass transformed/weaved byte code to Robolectric via a custom RobolectricTestRunner : 

``` java
public class CustomTestRunner extends RobolectricTestRunner {

  public CustomTestRunner(Class<?> testClass) throws InitializationError {
    super(testClass);
  }

  @Override protected ClassLoader createRobolectricClassLoader(Setup setup, SdkConfig sdkConfig) {
    URL[] urls = getJarResolver().getLocalArtifactUrls(sdkConfig.getSdkClasspathDependencies());
    return new AsmInstrumentingClassLoader(setup, urls) {
      @Override protected byte[] getByteCode(String className) throws ClassNotFoundException {
       // you can weave bytecode here and pass it to Robolectric
       // and/or call super..
      }
    };
  }
}
```

I need this mechanism for https://github.com/stephanenicolas/injectview/

I would love if it could be part of 2.4.0 as it doesn't change the API. 

Thx in advance.
