### PR TITLE
Handle isUserAMonkey call to avoid NPE. Always return false.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
+++ b/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
@@ -96,4 +96,9 @@ public class ShadowActivityManager {
   public android.content.pm.ConfigurationInfo getDeviceConfigurationInfo() {
     return new ConfigurationInfo();
   }
+
+  @Implementation
+  public static boolean isUserAMonkey() {
+      return false;
+  }
 }

--- a/src/test/java/org/robolectric/shadows/ActivityManagerTest.java
+++ b/src/test/java/org/robolectric/shadows/ActivityManagerTest.java
@@ -36,4 +36,9 @@ public class ActivityManagerTest {
     ActivityManager activityManager = (ActivityManager) Robolectric.application.getSystemService(Context.ACTIVITY_SERVICE);
     assertThat(activityManager.getLauncherLargeIconDensity()).isGreaterThan(0);
   }
+
+  @Test
+  public void isUserAMonkey_should_be_always_false() {
+      assertThat(ActivityManager.isUserAMonkey()).isFalse();
+  }
 }


### PR DESCRIPTION
Fixes this issue: https://github.com/robolectric/robolectric/issues/1208
