### PR TITLE
Update to parse3339 time in the context of the correct time zone.

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowTime.java
+++ b/src/main/java/org/robolectric/shadows/ShadowTime.java
@@ -252,7 +252,7 @@ public class ShadowTime {
     // Special case Date without time first
     if (rfc3339String.matches("\\d{4}-\\d{2}-\\d{2}")) {
       final TimeZone tz = TimeZone.getTimeZone(time.timezone);
-        formatter.applyLocalizedPattern("yyyy-MM-dd");
+      formatter.applyLocalizedPattern("yyyy-MM-dd");
       // Make sure we parse the date in the context of the specified time zone
       // instead of the system default time zone.
       formatter.setTimeZone(tz);

--- a/src/test/java/org/robolectric/shadows/TimeTest.java
+++ b/src/test/java/org/robolectric/shadows/TimeTest.java
@@ -1,5 +1,6 @@
 package org.robolectric.shadows;
 
+import java.util.Arrays;
 import java.util.TimeZone;
 
 import android.os.SystemClock;
@@ -166,10 +167,9 @@ public class TimeTest {
   
   @Test
   public void shouldParseRfc3339() {
-    for (String tz : new String[] { "Europe/Berlin",
-                                    "America/Los Angeles",
-                                    "Australia/Adelaide"
-                     } ) {
+    for (String tz : Arrays.asList("Europe/Berlin",
+                                   "America/Los Angeles",
+                                   "Australia/Adelaide")) {
       String desc = "Eval when local timezone is " + tz;
       TimeZone.setDefault(TimeZone.getTimeZone(tz));
 


### PR DESCRIPTION
`TimeTest.shouldParseRfc3339()` was failing on my machine when parsing 2008-10-13. The day-of-month was getting set to 12 after parsing instead of 13.

Tracked this down to the timezone difference between my own local timezone (UTC+0930) and Europe/Berlin (which is the TZ that the test was specifying). The implementation of `parse3339()` was invoking `SimpleDateFormat.parse()` which was parsing the date in the context of the system default timezone rather than the timezone specified in the RealObject (Europe/Berlin). When the resulting time was used to set the time in the object itself, it did a timezone conversion between system. For timezones equal to or West of Berlin this still results in the same day-of-month result; however for those East of Berlin the time converts to the previous day. Hence on my machine it was calculating DOM as 12 instead of 13.

Updated the test for `parse3339()` so that the calculations are done in the context of three different system timezones spanning the globe, so that we can have test coverage of this issue regardless of where the test is run. Then fixed `ShadowTime.parse3339()` to pass the tests by setting the timezone on the `SimpleDateFormat` instance. Seems to work.

I have not done a full audit of the other ShadowTime implementations - it is possible that there are other similar bugs lurking here that have gone unnoticed. It perhaps wouldn't be a bad idea to parameterise all of the test methods to use a selection of time zones in order to prevent regressions.
