### PR TITLE
Fixed NPE on StrictMode.setVmPolicy

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowStrictMode.java
+++ b/src/main/java/org/robolectric/shadows/ShadowStrictMode.java
@@ -5,9 +5,6 @@ import android.os.StrictMode;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
-/**
- * Created by karlicos on 11.09.14.
- */
 @Implements(StrictMode.class)
 public class ShadowStrictMode {
   @Implementation

--- a/src/test/java/org/robolectric/shadows/ShadowStrictModeTest.java
+++ b/src/test/java/org/robolectric/shadows/ShadowStrictModeTest.java
@@ -5,9 +5,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
 
-/**
- * Created by karlicos on 11.09.14.
- */
 @RunWith(TestRunners.WithDefaults.class)
 public class ShadowStrictModeTest {
   @Test


### PR DESCRIPTION
There was an NPE on `StrictMode.setVmPolicy`, which I fixed just by ignoring setting the policy.
The fix might be a kind of overkill since the NPE actually happens because the `mQueue` on the line [1478](http://grepcode.com/file/repo1.maven.org/maven2/org.robolectric/android-all/4.3_r2-robolectric-0/android/os/StrictMode.java#1478) of `StrictMode.java` is null, however, I don't understand why it has been shadowed that way. Although, ignoring `setVmPolicy` still might be okay for testing purposes.
