### PR TITLE
Add support for attributes defined in res-auto namespace

### DIFF
--- a/src/main/java/org/robolectric/res/Attribute.java
+++ b/src/main/java/org/robolectric/res/Attribute.java
@@ -12,7 +12,7 @@ public class Attribute {
   public static final String ANDROID_RES_NS_PREFIX = "http://schemas.android.com/apk/res/";
   private static final int ANDROID_RES_NS_PREFIX_LENGTH = ANDROID_RES_NS_PREFIX.length();
   private static final Logger LOGGER = Logger.getLogger(Attribute.class.getName());
-  private static final String RES_AUTO_NS_URI = "http://schemas.android.com/apk/res-auto";
+  public static final String RES_AUTO_NS_URI = "http://schemas.android.com/apk/res-auto";
 
   public final @NotNull ResName resName;
   public final @NotNull String value;

--- a/src/main/java/org/robolectric/res/builder/XmlFileBuilder.java
+++ b/src/main/java/org/robolectric/res/builder/XmlFileBuilder.java
@@ -17,6 +17,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xmlpull.v1.XmlPullParserException;
 
 public class XmlFileBuilder {
@@ -52,16 +53,48 @@ public class XmlFileBuilder {
   }
 
   public static XmlResourceParser getXmlResourceParser(String file, String packageName, ResourceIndex resourceIndex) {
-   FsFile fsFile = Fs.fileFromPath(file);
-   Document document = new XmlFileLoader(null, "xml").parse(fsFile);
-   if (document == null) {
-     throw new Resources.NotFoundException("couldn't find resource " + fsFile.getPath());
-   }
-   return new XmlFileBuilder().getXml(document, fsFile.getPath(), packageName, resourceIndex);
- }
+    FsFile fsFile = Fs.fileFromPath(file);
+    Document document = new XmlFileLoader(null, "xml").parse(fsFile);
+    if (document == null) {
+      throw new Resources.NotFoundException("couldn't find resource " + fsFile.getPath());
+    }
+    replaceResAutoNamespace(document, packageName);
+    return new XmlFileBuilder().getXml(document, fsFile.getPath(), packageName, resourceIndex);
+  }
 
   public XmlResourceParser getXml(Document document, String fileName, String packageName, ResourceIndex resourceIndex) {
     return new XmlResourceParserImpl(document, fileName, packageName, resourceIndex);
+  }
+
+  /**
+   * Replaces all instances of "http://schemas.android.com/apk/res-auto" with 
+   * "http://schemas.android.com/apk/res/packageName" in the given Document.
+   */
+  private static void replaceResAutoNamespace(Document document, String packageName) {
+    String autoNs = Attribute.RES_AUTO_NS_URI;
+    String newNs = Attribute.ANDROID_RES_NS_PREFIX + packageName;
+    replaceAttributeNamespace(document, document.getDocumentElement(), autoNs, newNs);
+  }
+
+  private static void replaceAttributeNamespace(Document document, Node n, String oldNs, String newNs) {
+    NamedNodeMap attrs = n.getAttributes();
+    if (attrs != null) {
+      for (int i = 0; i < attrs.getLength(); i++) {
+        replaceNamespace(document, attrs.item(i), oldNs, newNs);
+      }
+    }
+    if (n.hasChildNodes()) {
+      NodeList list = n.getChildNodes();
+      for (int i = 0; i < list.getLength(); i++) {
+        replaceAttributeNamespace(document, list.item(i), oldNs, newNs);
+      }
+    }
+  }
+
+  private static void replaceNamespace(Document document, Node n, String oldNs, String newNs) {
+    if (oldNs.equals(n.getNamespaceURI())) {
+      document.renameNode(n, newNs, n.getNodeName());
+    }
   }
 
   /**

--- a/src/test/java/org/robolectric/R.java
+++ b/src/test/java/org/robolectric/R.java
@@ -212,7 +212,8 @@ public final class R {
     public static final int activity_main = 0x10624;
     public static final int activity_main_1 = 0x10625;
     public static final int ordinal_scrollbar = 0x10626;
-    public static final int custom_layout6 = 0x10627;
+    public static final int custom_layout5 = 0x10627;
+    public static final int custom_layout6 = 0x10628;
   }
 
   public static final class anim {

--- a/src/test/java/org/robolectric/shadows/LayoutInflaterTest.java
+++ b/src/test/java/org/robolectric/shadows/LayoutInflaterTest.java
@@ -235,6 +235,12 @@ public class LayoutInflaterTest {
   }
 
   @Test
+  public void shouldConstructCustomViewsWithAttributesInResAutoNamespace() throws Exception {
+    CustomView view = (CustomView) inflate("custom_layout5");
+    assertThat(view.attributeResourceValue).isEqualTo(R.string.hello);
+  }
+
+  @Test
   public void shouldConstructCustomViewsWithAttributesWithURLEncodedNamespaces() throws Exception {
     CustomView view = (CustomView) inflate("custom_layout4")
         .findViewById(R.id.custom_view);

--- a/src/test/resources/res/layout/custom_layout5.xml
+++ b/src/test/resources/res/layout/custom_layout5.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<org.robolectric.util.CustomView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:robolectric="http://schemas.android.com/apk/res-auto"
+    android:gravity="center"
+    robolectric:message="@string/hello"
+    robolectric:itemType="string"
+    />


### PR DESCRIPTION
The "http://schemas.android.com/apk/res-auto" namespace in layout XML files is replaced with the manifest package name at build time by aapt.
Robolectric doesn't support this, causing attribute lookups in the res-auto namespace to fail.

This pull request adds some processing to the XML file loading. It goes through all the Nodes in the resource Document, looking for the res-auto namespace and replacing it.

Another way to solve the problem is by recognizing the res-auto namespace when looking up attributes, as in https://github.com/bastiaanve/robolectric/commit/ad7ff6092f72630bb9202c575b0626cf1ac54b3e

Please comment which approach is preferred.
