### PR TITLE
Ability to replace ClassLoader on test run

### DIFF
--- a/src/main/java/org/robolectric/SdkEnvironment.java
+++ b/src/main/java/org/robolectric/SdkEnvironment.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 public class SdkEnvironment {
   private final SdkConfig sdkConfig;
-  private final ClassLoader robolectricClassLoader;
+  private ClassLoader robolectricClassLoader;
   public final Map<ShadowMap, ShadowWrangler> classHandlersByShadowMap = new HashMap<ShadowMap, ShadowWrangler>();
   private ClassHandler currentClassHandler;
   private ResourceLoader systemResourceLoader;
@@ -50,6 +50,10 @@ public class SdkEnvironment {
 
   public ClassLoader getRobolectricClassLoader() {
     return robolectricClassLoader;
+  }
+
+  void setRobolectricClassLoader(ClassLoader classLoader) {
+    robolectricClassLoader = classLoader;
   }
 
   /**

--- a/src/main/java/org/robolectric/annotation/TestRunnerAcceptor.java
+++ b/src/main/java/org/robolectric/annotation/TestRunnerAcceptor.java
@@ -1,0 +1,17 @@
+package org.robolectric.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that a method wants to receive active RobolectricTestRunner instance before running tests.
+ * Methods marked with TestRunnerAcceptor annotation will be called before all the methods with BeforeClass annotation,
+ * and these methods must accept exactly one argument with type RobolectricTestRunner.
+ */
+@java.lang.annotation.Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface TestRunnerAcceptor {
+}

--- a/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
+++ b/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
@@ -4,10 +4,12 @@ import android.app.Application;
 import android.content.res.Resources;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.BeforeClass;
 import org.junit.runners.model.InitializationError;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.DisableStrictI18n;
 import org.robolectric.annotation.EnableStrictI18n;
+import org.robolectric.annotation.TestRunnerAcceptor;
 
 import java.lang.reflect.Method;
 
@@ -16,6 +18,8 @@ import static org.robolectric.Robolectric.shadowOf;
 
 @RunWith(RobolectricTestRunnerSelfTest.RunnerForTesting.class)
 public class RobolectricTestRunnerSelfTest {
+
+  private static RobolectricTestRunner runner = null;
 
   @Test
   public void shouldInitializeAndBindApplicationButNotCallOnCreate() throws Exception {
@@ -74,6 +78,31 @@ public class RobolectricTestRunnerSelfTest {
     assertFalse(Robolectric.getShadowApplication().isStrictI18n());
   }
 
+  @BeforeClass
+  public static void checkRunnerReceived() {
+    assertNotNull("expected that runner is not null", runner);
+  }
+
+  @Test
+  public void shouldReplaceClassLoader() throws Exception {
+    String className = "org.robolectric.RobolectricTestRunnerSelfTest$MySimpleClass";
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    assertNotNull(cl);
+    Class<?> class1 = cl.loadClass(className);
+
+    runner.replaceClassLoader(className);
+
+    ClassLoader cl2 = Thread.currentThread().getContextClassLoader();
+    assertNotNull(cl2);
+    Class<?> class2 = cl2.loadClass(className);
+    assertNotSame("loaded classes", class1, class2);
+  }
+
+  @TestRunnerAcceptor
+  public static void acceptRunner(RobolectricTestRunner runner) {
+    RobolectricTestRunnerSelfTest.runner = runner;
+  }
+
   public static class RunnerForTesting extends TestRunners.WithDefaults {
     public static RunnerForTesting instance;
 
@@ -99,5 +128,9 @@ public class RobolectricTestRunnerSelfTest {
     @Override public void onCreate() {
       this.onCreateWasCalled = true;
     }
+  }
+
+  public static class MySimpleClass {
+
   }
 }


### PR DESCRIPTION
In my particular case Robolectric has to be launched for a long period of time, processing different classes (probably with the same names but different). So the way is to replace ClassLoader from time to time.
The method that actually replaces ClassLoader is located in `RobolectricTestRunner`. To be able to get the current instance of `RobolectricTestRunner`, new annotation was added.
