### PR TITLE
Shadow resource subclasses should have app resourceloader

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -160,8 +160,8 @@ public class ShadowApplication extends ShadowContextWrapper {
   @Override
   @Implementation
   public Resources getResources() {
-    if (resources == null ) {
-      resources = ShadowResources.bind(new Resources(realApplication.getAssets(), null, new Configuration()), resourceLoader);
+    if (resources == null) {
+      resources = new Resources(realApplication.getAssets(), null, new Configuration());
     }
     return resources;
   }

--- a/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -300,7 +300,7 @@ public class ShadowResources {
 
   @Implementation
   public int getIdentifier(String name, String defType, String defPackage) {
-    ResourceIndex resourceIndex = resourceLoader.getResourceIndex();
+    ResourceIndex resourceIndex = getResourceLoader().getResourceIndex();
     ResName resName = ResName.qualifyResName(name, defPackage, defType);
     Integer resourceId = resourceIndex.getResourceId(resName);
     if (resourceId == null) return 0;
@@ -332,7 +332,7 @@ public class ShadowResources {
   }
 
   private @NotNull ResName getResName(int id) {
-    ResName resName = resourceLoader.getResourceIndex().getResName(id);
+    ResName resName = getResourceLoader().getResourceIndex().getResName(id);
     if (resName == null) {
       throw new Resources.NotFoundException("Unable to find resource ID #0x" + Integer.toHexString(id));
     }
@@ -340,7 +340,7 @@ public class ShadowResources {
   }
 
   private ResName tryResName(int id) {
-    return resourceLoader.getResourceIndex().getResName(id);
+    return getResourceLoader().getResourceIndex().getResName(id);
   }
 
   private String getQualifiers() {
@@ -362,7 +362,7 @@ public class ShadowResources {
   @Implementation
   public String getQuantityString(int id, int quantity) throws Resources.NotFoundException {
     ResName resName = getResName(id);
-    Plural plural = resourceLoader.getPlural(resName, quantity, getQualifiers());
+    Plural plural = getResourceLoader().getPlural(resName, quantity, getQualifiers());
     String string = plural.getString();
     ShadowAssetManager shadowAssetManager = shadowOf(realResources.getAssets());
     TypedResource typedResource = shadowAssetManager.resolve(
@@ -373,7 +373,7 @@ public class ShadowResources {
 
   @Implementation
   public InputStream openRawResource(int id) throws Resources.NotFoundException {
-    return resourceLoader.getRawValue(getResName(id));
+    return getResourceLoader().getRawValue(getResName(id));
   }
 
   @Implementation
@@ -421,20 +421,23 @@ public class ShadowResources {
   @Implementation
   public XmlResourceParser getXml(int id) throws Resources.NotFoundException {
     ResName resName = getResName(id);
-    Document document = resourceLoader.getXml(resName, getQualifiers());
+    Document document = getResourceLoader().getXml(resName, getQualifiers());
     if (document == null) {
       throw new Resources.NotFoundException();
     }
-    return new XmlFileBuilder().getXml(document, resName.getFullyQualifiedName(), resName.packageName, resourceLoader.getResourceIndex());
+    return new XmlFileBuilder().getXml(document, resName.getFullyQualifiedName(), resName.packageName, getResourceLoader().getResourceIndex());
   }
 
   @HiddenApi @Implementation
   public XmlResourceParser loadXmlResourceParser(String file, int id, int assetCookie, String type) throws Resources.NotFoundException {
     String packageName = getResName(id).packageName;
-    return XmlFileBuilder.getXmlResourceParser(file, packageName, resourceLoader.getResourceIndex());
+    return XmlFileBuilder.getXmlResourceParser(file, packageName, getResourceLoader().getResourceIndex());
   }
 
   public ResourceLoader getResourceLoader() {
+    if (resourceLoader == null) {
+      resourceLoader = Robolectric.getShadowApplication().getResourceLoader();
+    }
     return resourceLoader;
   }
 

--- a/src/test/java/org/robolectric/shadows/ResourcesTest.java
+++ b/src/test/java/org/robolectric/shadows/ResourcesTest.java
@@ -6,9 +6,12 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.content.res.XmlResourceParser;
-import android.graphics.drawable.*;
+import android.graphics.drawable.AnimationDrawable;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.NinePatchDrawable;
 import android.util.DisplayMetrics;
-
 import android.util.TypedValue;
 import org.fest.assertions.data.Offset;
 import org.junit.Before;
@@ -452,6 +455,19 @@ public class ResourcesTest {
     arr.recycle();
 
     assertThat(value.type).isGreaterThanOrEqualTo(TypedValue.TYPE_FIRST_COLOR_INT).isLessThanOrEqualTo(TypedValue.TYPE_LAST_INT);
+  }
+
+  @Test
+  public void subClassInitializedOK() {
+    SubClassResources subClassResources = new SubClassResources(Robolectric.getShadowApplication().getResources());
+    assertThat(subClassResources.openRawResource(R.raw.raw_resource)).isNotNull();
+  }
+
+  private static class SubClassResources extends Resources {
+
+    public SubClassResources(Resources res) {
+      super(res.getAssets(), res.getDisplayMetrics(), res.getConfiguration());
+    }
   }
 
   /////////////////////////////


### PR DESCRIPTION
Subclasses of Resources also need to have their resourceLoader bound, but these could be created anywhere in the system, so we don't get to bind it in the way that we do setting up the application resources.

Modify ShadowResources to obtain the application resource loader itself by default, and protect all references to it through the accessor method. Only System Resources requires having its resource loader explicitly set.
