### PR TITLE
Support custom item states in android selectors.

### DIFF
--- a/src/main/java/org/robolectric/res/builder/XmlFileBuilder.java
+++ b/src/main/java/org/robolectric/res/builder/XmlFileBuilder.java
@@ -283,7 +283,9 @@ public class XmlFileBuilder {
     public String getAttributeName(int index) {
       try {
         Node attr = getAttributeAt(index);
-        return attr.getNodeName();
+        return packageName.equals(attr.getNamespaceURI()) ?
+          attr.getLocalName() :
+          attr.getNodeName();
       } catch (IndexOutOfBoundsException ex) {
         return null;
       }

--- a/src/test/java/org/robolectric/R.java
+++ b/src/test/java/org/robolectric/R.java
@@ -146,6 +146,7 @@ public final class R {
     public static final int test_color_1 = 0x1040a;
     public static final int color_state_list = 0x1040b;
     public static final int list_separator = 0x1040c;
+    public static final int custom_state_view_text_color = 0x1040d;
   }
 
   public static final class drawable {
@@ -209,6 +210,7 @@ public final class R {
     public static final int activity_main = 0x10624;
     public static final int activity_main_1 = 0x10625;
     public static final int ordinal_scrollbar = 0x10626;
+    public static final int custom_layout6 = 0x10627;
   }
 
   public static final class anim {
@@ -240,6 +242,7 @@ public final class R {
     public static final int quitKeyCombo = 0x10a09;
     public static final int responses = 0x10a0a;
     public static final int animalStyle = 0x10a0b;
+    public static final int stateFoo = 0x10a0c;
   }
 
   public static final class menu {

--- a/src/test/java/org/robolectric/shadows/LayoutInflaterTest.java
+++ b/src/test/java/org/robolectric/shadows/LayoutInflaterTest.java
@@ -32,6 +32,7 @@ import org.robolectric.TestRunners;
 import org.robolectric.annotation.Config;
 import org.robolectric.res.ResName;
 import org.robolectric.res.ResourceLoader;
+import org.robolectric.util.CustomStateView;
 import org.robolectric.util.CustomView;
 import org.robolectric.util.CustomView2;
 import org.robolectric.util.TestUtil;
@@ -220,6 +221,17 @@ public class LayoutInflaterTest {
   public void shouldConstructCustomViewsWithAttributesConstructor() throws Exception {
     CustomView view = (CustomView) inflate("custom_layout");
     assertThat(view.attributeResourceValue).isEqualTo(R.string.hello);
+  }
+
+  @Test
+  public void shouldConstructCustomViewsWithCustomState() throws Exception {
+    CustomStateView view = (CustomStateView) inflate("custom_layout6");
+    assertThat(view.getDrawableState()).doesNotContain(R.attr.stateFoo);
+
+    view.isFoo = true;
+    view.refreshDrawableState();
+
+    assertThat(view.getDrawableState()).contains(R.attr.stateFoo);
   }
 
   @Test

--- a/src/test/java/org/robolectric/util/CustomStateView.java
+++ b/src/test/java/org/robolectric/util/CustomStateView.java
@@ -1,0 +1,34 @@
+package org.robolectric.util;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.TextView;
+import org.robolectric.R;
+
+public class CustomStateView extends TextView {
+
+  private static final int[] STATE_FOO = {R.attr.stateFoo};
+
+  public boolean isFoo;
+
+  public CustomStateView(Context context) {
+    super(context);
+  }
+
+  public CustomStateView(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  public CustomStateView(Context context, AttributeSet attrs, int defStyle) {
+    super(context, attrs, defStyle);
+  }
+
+  @Override
+  protected int[] onCreateDrawableState(int extraSpace) {
+    final int[] drawableState = super.onCreateDrawableState(extraSpace + 1);
+    if (isFoo) {
+      mergeDrawableStates(drawableState, STATE_FOO);
+    }
+    return drawableState;
+  }
+}

--- a/src/test/resources/res/color/custom_state_view_text_color.xml
+++ b/src/test/resources/res/color/custom_state_view_text_color.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:aCustomNamespace="org.robolectric">
+  <item android:color="#ffff0000" aCustomNamespace:stateFoo="true"/>
+  <item android:color="#ff000000"/>
+</selector>

--- a/src/test/resources/res/layout/custom_layout6.xml
+++ b/src/test/resources/res/layout/custom_layout6.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<org.robolectric.util.CustomStateView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:text="Some text"
+    android:textColor="@color/custom_state_view_text_color"
+    />

--- a/src/test/resources/res/values/attrs.xml
+++ b/src/test/resources/res/values/attrs.xml
@@ -42,4 +42,8 @@
   </attr>
 
   <attr name="responses" format="reference"/>
+
+  <declare-styleable name="CustomStateView">
+    <attr name="stateFoo" format="boolean" />
+  </declare-styleable>
 </resources>


### PR DESCRIPTION
This was failing because custom namespaced attributes are not correctly resolved, since the Node.getName()
returns the fully qualified name including the namespace which cannot be resolved in Robolectric's ResourceIndex. In this case XmlFileBuilder.getResourceId() returns a resource id == 0. Android's ColorStateList.java:207 inflate() method actually gives up processing ALL attributes if it detects a resId == 0 and results in the following error:-

Caused by: org.xmlpull.v1.XmlPullParserException: XML file /build/work/de60fbcefa06825f87444c8bfabcdc39/google3/runfiles/google3/java/com/google/android/apps/adwords/res/drawable/opportunity_detail_header_text_color.xml line #-1 (sorry, not yet implemented): <item> tag requires a 'android:color' attribute.
    at android.content.res.ColorStateList.inflate(ColorStateList.java:226)

Funnily enough, the naming of the attributes matters. The Xerces parser returns attributes in lexicographical order, so if you name your custom attibute > android (e.g: bandroid) then it doesn't fail since it has change to process android:color ;-)

We actually need to check here if the attribute's namespace is the default namespace and if so then we can just return the local name.

This PR is also related to https://github.com/robolectric/robolectric/pull/1272 which will
replace any res-auto custom namespaces with the default package.

Ideally we need both merged to support one of our projects use cases :-)
