### PR TITLE
Don't implement onCreate() in ShadowPreferenceActivity

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowPreferenceActivity.java
+++ b/src/main/java/org/robolectric/shadows/ShadowPreferenceActivity.java
@@ -19,11 +19,6 @@ public class ShadowPreferenceActivity extends ShadowActivity {
   private PreferenceScreen preferenceScreen;
 
   @Implementation
-  public void onCreate(Bundle savedInstanceState) {
-    realActivity.setContentView(android.R.layout.list_content);
-  }
-
-  @Implementation
   public void addPreferencesFromResource(int preferencesResId) {
     this.preferencesResId = preferencesResId;
     preferenceScreen = inflatePreferences(preferencesResId);


### PR DESCRIPTION
Activity#onCreate() is a very important method that needs to be called.
All the tests still pass without this.
