### PR TITLE
Issue #1212 : minimal handling of domains and subdomains in cookies

### DIFF
--- a/src/main/java/org/robolectric/shadows/ShadowCookieManager.java
+++ b/src/main/java/org/robolectric/shadows/ShadowCookieManager.java
@@ -1,7 +1,9 @@
 package org.robolectric.shadows;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -53,7 +55,13 @@ public class ShadowCookieManager {
   @Implementation
   public String getCookie(String url) {
     final List<Cookie> matchedCookies;
-    if( url.startsWith(".")) {
+    try {
+      url = URLDecoder.decode(url, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    }
+
+      if( url.startsWith(".")) {
         matchedCookies = filter(url.substring(1));
     } else if( url.contains("//.")) {
         matchedCookies = filter(url.substring(url.indexOf("//.")+3));

--- a/src/main/java/org/robolectric/shadows/ShadowCookieManager.java
+++ b/src/main/java/org/robolectric/shadows/ShadowCookieManager.java
@@ -52,8 +52,15 @@ public class ShadowCookieManager {
 
   @Implementation
   public String getCookie(String url) {
-    CookieOrigin origin = getOrigin(url);
-    List<Cookie> matchedCookies = filter(origin);
+    final List<Cookie> matchedCookies;
+    if( url.startsWith(".")) {
+        matchedCookies = filter(url.substring(1));
+    } else if( url.contains("//.")) {
+        matchedCookies = filter(url.substring(url.indexOf("//.")+3));
+    } else {
+        CookieOrigin origin = getOrigin(url);
+        matchedCookies = filter(origin);
+    }
     if (matchedCookies.isEmpty()) {
       return null;
     }
@@ -90,6 +97,20 @@ public class ShadowCookieManager {
     return matchedCookies;
   }
 
+  private List<Cookie> filter(String domain) {
+      List<Cookie> matchedCookies = new ArrayList<Cookie>();
+      Date now = new Date();
+      CookieSpec cookieSpec = createSpec();
+      for (Cookie cookie : store.getCookies()) {
+          if (!cookie.isExpired(now)) {
+              if (cookie.getDomain().endsWith(domain)) {
+                  matchedCookies.add(cookie);
+              }
+          }
+      }
+      return matchedCookies;
+  }
+
   @Implementation
   public void setAcceptCookie(boolean accept) {
     this.accept = accept;
@@ -104,7 +125,7 @@ public class ShadowCookieManager {
   public void removeAllCookie() {
     store.clear();
   }
-  
+
   @Implementation
   public void removeExpiredCookie() {
     store.clearExpired(new Date());

--- a/src/test/java/org/robolectric/shadows/CookieManagerTest.java
+++ b/src/test/java/org/robolectric/shadows/CookieManagerTest.java
@@ -52,9 +52,18 @@ public class CookieManagerTest {
   public void shouldGetCookieForHostInDomain() {
     CookieManager cookieManager = CookieManager.getInstance();
     String value1 = "my cookie";
-    cookieManager.setCookie("foo.com/", value1);
+    cookieManager.setCookie("foo.com/this%20is%20a%20test", value1);
 
     assertThat(cookieManager.getCookie(".foo.com")).isEqualTo(value1);
+  }
+
+  @Test
+  public void shouldNotGetCookieForHostNotInDomain() {
+    CookieManager cookieManager = CookieManager.getInstance();
+    String value1 = "my cookie";
+    cookieManager.setCookie("bar.foo.com/this%20is%20a%20test", value1);
+
+    assertNull(cookieManager.getCookie(".bar.com"));
   }
 
   @Test

--- a/src/test/java/org/robolectric/shadows/CookieManagerTest.java
+++ b/src/test/java/org/robolectric/shadows/CookieManagerTest.java
@@ -1,6 +1,7 @@
 package org.robolectric.shadows;
 
 import android.webkit.CookieManager;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -16,7 +17,7 @@ public class CookieManagerTest {
   String httpUrl = "http://robolectric.org/";
   String httpsUrl = "https://robolectric.org/";
   CookieManager cookieManager = Robolectric.newInstanceOf(CookieManager.class);;
-  
+
   @Test
   public void shouldGetASingletonInstance() {
     assertNotNull(CookieManager.getInstance());
@@ -48,6 +49,33 @@ public class CookieManagerTest {
   }
 
   @Test
+  public void shouldGetCookieForHostInDomain() {
+    CookieManager cookieManager = CookieManager.getInstance();
+    String value1 = "my cookie";
+    cookieManager.setCookie("foo.com/", value1);
+
+    assertThat(cookieManager.getCookie(".foo.com")).isEqualTo(value1);
+  }
+
+  @Test
+  public void shouldGetCookieForHostInSubDomain() {
+    CookieManager cookieManager = CookieManager.getInstance();
+    String value1 = "my cookie";
+    cookieManager.setCookie("host.in.subdomain.bar.com", value1);
+
+    assertThat(cookieManager.getCookie(".bar.com")).isEqualTo(value1);
+  }
+
+  @Test
+  public void shouldGetCookieForHostInDomainDefinedWithProtocol() {
+    CookieManager cookieManager = CookieManager.getInstance();
+    String value1 = "my cookie";
+    cookieManager.setCookie("qutz.com/", value1);
+
+    assertThat(cookieManager.getCookie("http://.qutz.com")).isEqualTo(value1);
+  }
+
+  @Test
   public void shouldRecordAcceptCookie() {
     CookieManager cookieManager = CookieManager.getInstance();
     cookieManager.setCookie("foo", "bar");
@@ -57,7 +85,7 @@ public class CookieManagerTest {
     assertNull(cookieManager.getCookie("foo"));
     assertNull(cookieManager.getCookie("baz"));
   }
-  
+
   @Test
   public void shouldHaveCookieWhenCookieIsSet() {
     cookieManager.setCookie(url, "name=value; Expires=Wed, 09 Jun 2021 10:18:14 GMT");
@@ -79,7 +107,7 @@ public class CookieManagerTest {
     cookieManager.setCookie(httpUrl, "name=value; Expires=Wed, 11 Jul 2035 08:12:26 GMT");
     assertThat(cookieManager.getCookie("http://google.com")).isNull();
   }
- 
+
   @Test
   public void shouldSetAndGetOneCookie() {
     cookieManager.setCookie(httpUrl, "name=value; Expires=Wed, 11 Jul 2035 08:12:26 GMT");
@@ -116,7 +144,7 @@ public class CookieManagerTest {
     cookieManager.setCookie(httpUrl, "name=");
     assertThat(cookieManager.getCookie(url)).isEqualTo("name=");
   }
-  
+
   @Test
   public void shouldSetCookieWithNameOnly() {
     cookieManager.setCookie(httpUrl, "name");


### PR DESCRIPTION
This should solve issue #1212  in a minimal way. 

The problem is that the actual implementation of `getCookie(String url)` didn't take subdomains into account. If the domain starts with a `'.'` (dot char) then all cookies in this domain and subdomains should be returned.

The fix doesn't intend to provide a proper implementation of subdomain cookie handling but something that works well enough for testing...and for facebook api to be happy while testing.