### PR TITLE
Update R class name when package name is set

### DIFF
--- a/src/main/java/org/robolectric/AndroidManifest.java
+++ b/src/main/java/org/robolectric/AndroidManifest.java
@@ -460,6 +460,7 @@ public class AndroidManifest {
 
   public void setPackageName(String packageName) {
     this.packageName = packageName;
+    this.rClassName = packageName + ".R";
   }
 
   public String getPackageName() {


### PR DESCRIPTION
I had to do this to make testing work for non debug variants. Our build uses applicationId and applicationIdSuffix for variants. Though the R class should be the same for all variants now, Robolectric didn't want to load properly the resources without this change.

Actually we did it in a different way by sublcassing the RobolectricTestRunner and overriding the getManifest method. But this should be more direct.

I write this PR because I think there is something wrong in Robolectric to deal with this situation but I am not super sure to have done things right and would like some feedback. At least, in the state of our build, it would be nice to have a method to set
1) the targetSDK on a manifest
2) the R class name

more than providing a sublcass that does so.
