### PR TITLE
Add missing setLayoutAlgorithm method to TestWebSettings

### DIFF
--- a/src/main/java/android/webkit/TestWebSettings.java
+++ b/src/main/java/android/webkit/TestWebSettings.java
@@ -2,6 +2,7 @@ package android.webkit;
 
 import org.robolectric.internal.DoNotInstrument;
 import org.robolectric.annotation.Implementation;
+import android.webkit.WebSettings.LayoutAlgorithm;
 
 /**
  * Concrete implementation of the abstract WebSettings class.
@@ -38,6 +39,7 @@ public class TestWebSettings extends WebSettings {
   private int cacheMode;
   private long appCacheMaxSize;
   private int textZoom = 100;
+  private WebSettings.LayoutAlgorithm layoutAlgorithm = WebSettings.LayoutAlgorithm.NARROW_COLUMNS;
 
   public TestWebSettings() {
   }
@@ -322,4 +324,10 @@ public class TestWebSettings extends WebSettings {
   public void setTextZoom(int textZoom) {
     this.textZoom = textZoom;
   }
+
+  @Implementation
+  public synchronized void setLayoutAlgorithm(WebSettings.LayoutAlgorithm algorithm) {
+     this.layoutAlgorithm=algorithm;
+  }
+
 }


### PR DESCRIPTION
Testing with Robolectric a Fragment with a WebSettings, we are using a method that is missed in the TestWebSettings implementation.

2014-10-09 13:00:28.405+0200 - [WebviewFragmentTest] -  abstract function called: must be overriden!
2014-10-09 13:00:28.405+0200 - [WebviewFragmentTest] -  android.webkit.WebSettings.setLayoutAlgorithm(WebSettings.java:545)
2014-10-09 13:00:28.405+0200 - [WebviewFragmentTest] -  com.pdi.mca.go.fragments.WebviewFragment.onCreateView(WebviewFragment.java:241)
2014-10-09 13:00:28.405+0200 - [WebviewFragmentTest] -  android.app.FragmentManagerImpl.moveToState(FragmentManager.java:829)
2014-10-09 13:00:28.406+0200 - [WebviewFragmentTest] -  android.app.FragmentManagerImpl.moveToState(FragmentManager.java:1035)
2014-10-09 13:00:28.406+0200 - [WebviewFragmentTest] -  android.app.BackStackRecord.run(BackStackRecord.java:635)
2014-10-09 13:00:28.406+0200 - [WebviewFragmentTest] -  android.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:1397)
2014-10-09 13:00:28.406+0200 - [WebviewFragmentTest] -  android.app.FragmentManagerImpl$1.run(FragmentManager.java:426)
2014-10-09 13:00:28.407+0200 - [WebviewFragmentTest] -  org.robolectric.util.Scheduler.postDelayed(Scheduler.java:37)
2014-10-09 13:00:28.407+0200 - [WebviewFragmentTest] -  org.robolectric.shadows.ShadowLooper.post(ShadowLooper.java:207)
2014-10-09 13:00:28.407+0200 - [WebviewFragmentTest] -  org.robolectric.shadows.ShadowHandler.postDelayed(ShadowHandler.java:56)
2014-10-09 13:00:28.407+0200 - [WebviewFragmentTest] -  org.robolectric.shadows.ShadowHandler.post(ShadowHandler.java:51)
2014-10-09 13:00:28.407+0200 - [WebviewFragmentTest] -  android.os.Handler.post(Handler.java)
2014-10-09 13:00:28.408+0200 - [WebviewFragmentTest] -  android.app.FragmentManagerImpl.enqueueAction(FragmentManager.java:1303)
2014-10-09 13:00:28.408+0200 - [WebviewFragmentTest] -  android.app.BackStackRecord.commitInternal(BackStackRecord.java:548)
2014-10-09 13:00:28.408+0200 - [WebviewFragmentTest] -  android.app.BackStackRecord.commit(BackStackRecord.java:532)
2014-10-09 13:00:28.408+0200 - [WebviewFragmentTest] -  com.pdi.mca.go.testutils.BaseFragmentTestUtil.createFragment(BaseFragmentTestUtil.java:94)
2014-10-09 13:00:28.409+0200 - [WebviewFragmentTest] -  com.pdi.mca.go.testutils.BaseFragmentTestUtil.setUp(BaseFragmentTestUtil.java:127)
2014-10-09 13:00:28.409+0200 - [WebviewFragmentTest] -  com.pdi.mca.go.fragments.WebviewFragmentTest.setUp(WebviewFragmentTest.java:51)
2014-10-09 13:00:28.409+0200 - [WebviewFragmentTest] -  org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
2014-10-09 13:00:28.409+0200 - [WebviewFragmentTest] -  org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
2014-10-09 13:00:28.409+0200 - [WebviewFragmentTest] -  org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
2014-10-09 13:00:28.410+0200 - [WebviewFragmentTest] -  org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
2014-10-09 13:00:28.410+0200 - [WebviewFragmentTest] -  org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
2014-10-09 13:00:28.410+0200 - [WebviewFragmentTest] -  org.robolectric.RobolectricTestRunner$2.evaluate(RobolectricTestRunner.java:250)
2014-10-09 13:00:28.410+0200 - [WebviewFragmentTest] -  org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
2014-10-09 13:00:28.410+0200 - [WebviewFragmentTest] -  org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
2014-10-09 13:00:28.411+0200 - [WebviewFragmentTest] -  org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
2014-10-09 13:00:28.411+0200 - [WebviewFragmentTest] -  org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
2014-10-09 13:00:28.411+0200 - [WebviewFragmentTest] -  org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
2014-10-09 13:00:28.411+0200 - [WebviewFragmentTest] -  org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
2014-10-09 13:00:28.411+0200 - [WebviewFragmentTest] -  org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
2014-10-09 13:00:28.412+0200 - [WebviewFragmentTest] -  org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
2014-10-09 13:00:28.412+0200 - [WebviewFragmentTest] -  org.robolectric.RobolectricTestRunner$1.evaluate(RobolectricTestRunner.java:177)
2014-10-09 13:00:28.412+0200 - [WebviewFragmentTest] -  org.junit.runners.ParentRunner.run(ParentRunner.java:309)
2014-10-09 13:00:28.413+0200 - [WebviewFragmentTest] -  org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
2014-10-09 13:00:28.413+0200 - [WebviewFragmentTest] -  org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
2014-10-09 13:00:28.413+0200 - [WebviewFragmentTest] -  org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:467)
2014-10-09 13:00:28.413+0200 - [WebviewFragmentTest] -  org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:683)
2014-10-09 13:00:28.414+0200 - [WebviewFragmentTest] -  org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:390)
2014-10-09 13:00:28.414+0200 - [WebviewFragmentTest] -  org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:197)
