### PR TITLE
Implement swapCursor in ShadowCursorAdapter.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/shadows/ShadowCursorAdapter.java
+++ b/robolectric/src/main/java/org/robolectric/shadows/ShadowCursorAdapter.java
@@ -286,20 +286,24 @@ public class ShadowCursorAdapter extends ShadowBaseAdapter {
 //  public abstract void bindView(View view, Context context, Cursor cursor);
 
   /**
-   * Change the underlying cursor to a new cursor. If there is an existing cursor it will be
+   * Swap in a new Cursor, returning the old Cursor. Unlike
+   * {@link #changeCursor(Cursor)}, the returned old Cursor is <em>not</em>
    * closed.
    *
-   * @param cursor the new cursor to be used
+   * @param newCursor The new cursor to be used.
+   * @return Returns the previously set Cursor, or null if there wasa not one.
+   * If the given new Cursor is the same instance is the previously set
+   * Cursor, null is also returned.
    */
   @Implementation
-  public void changeCursor(Cursor cursor) {
+  public Cursor swapCursor(Cursor cursor) {
     if (cursor == mCursor) {
-      return;
+      return null;
     }
+    Cursor old = mCursor;
     if (mCursor != null) {
       if (mChangeObserver != null) mCursor.unregisterContentObserver(mChangeObserver);
       if (mDataSetObserver != null) mCursor.unregisterDataSetObserver(mDataSetObserver);
-      mCursor.close();
     }
     mCursor = cursor;
     if (cursor != null) {
@@ -314,6 +318,21 @@ public class ShadowCursorAdapter extends ShadowBaseAdapter {
       mDataValid = false;
       // notify the observers about the lack of a data set
       realCursorAdapter.notifyDataSetInvalidated();
+    }
+    return old;
+  }
+
+  /**
+   * Change the underlying cursor to a new cursor. If there is an existing cursor it will be
+   * closed.
+   *
+   * @param cursor the new cursor to be used
+   */
+  @Implementation
+  public void changeCursor(Cursor newCursor) {
+    Cursor old = swapCursor(newCursor);
+    if (old != null) {
+      old.close();
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/CursorAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/CursorAdapterTest.java
@@ -60,6 +60,18 @@ public class CursorAdapterTest {
   }
 
   @Test
+  public void testSwapCursor() {
+    assertThat(adapter.getCursor()).isNotNull();
+    assertThat(adapter.getCursor()).isSameAs(curs);
+
+    Cursor oldCursor = adapter.swapCursor(null);
+
+    assertThat(oldCursor).isSameAs(curs);
+    assertThat(curs.isClosed()).isFalse();
+    assertThat(adapter.getCursor()).isNull();
+  }
+
+  @Test
   public void testCount() {
     assertThat(adapter.getCount()).isEqualTo(curs.getCount());
     adapter.changeCursor(null);


### PR DESCRIPTION
Hello! When writing my very first Robolectric test I was quite surprised by the behavior of swapCursor. Since it's not implemented on the ShadowCursorAdapter, using swapCursor puts you in a confusing state where mCursor on the real changes but mCursor on the shadow does not.

This pull request implements swapCursor on the shadow.

swapCursor is exactly like changeCursor, but it returns the old cursor instead of closing it. It's common to use swapCursor with CursorLoaders, since the CursorLoader is responsible for closing the old cursor.

PS. In my specific case, replacing the ShadowCursorAdapter entirely also worked:

```
// Disable the Robolectric ShadowCursorAdapter, which breaks swapCursor.
@Implements(CursorAdapter.class)
public static class FixedShadowCursorAdapter extends ShadowBaseAdapter {
    @RealObject CursorAdapter realCursorAdapter;

    public void __constructor__(Context context, Cursor c, int flags) {
        // Delegate all the work to the realCursorAdapter.
    }
}
```
