### PR TITLE
Fix FileNotFoundException when reading dependencies

### DIFF
--- a/robolectric/src/main/java/org/robolectric/res/Fs.java
+++ b/robolectric/src/main/java/org/robolectric/res/Fs.java
@@ -7,6 +7,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -23,7 +24,11 @@ import static java.util.Arrays.asList;
 
 abstract public class Fs {
   public static Fs fromJar(URL url) {
-    return new JarFs(new File(url.getFile()));
+    try {
+      return new JarFs(new File(url.toURI().getPath()));
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
   }
 
   public static FsFile fileFromPath(String urlString) {


### PR DESCRIPTION
Robolectric throws an exception when `robolectric.offline=true` and `robolectric.dependency.dir` contains spaces.
Dependency path become wrapped into a `URL` in `org.robolectric.LocalDependencyResolver#fileToUrl` and then unwrapped back with `URL#getFile` which returns %20 instead of spaces.

Related stackoverflow question: http://stackoverflow.com/questions/6164448/convert-url-to-normal-windows-filename-java

Stacktrace:

```
java.lang.RuntimeException: java.lang.RuntimeException: java.io.FileNotFoundException: /Applications/Android%20Studio.app/system/Preview/deps/android-all-4.3_r2-robolectric-0.jar (No such file or directory)
    at org.robolectric.RobolectricTestRunner$2.evaluate(RobolectricTestRunner.java:281)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.robolectric.RobolectricTestRunner$1.evaluate(RobolectricTestRunner.java:196)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.junit.runners.Suite.runChild(Suite.java:127)
    at org.junit.runners.Suite.runChild(Suite.java:26)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
    at org.junit.runner.JUnitCore.run(JUnitCore.java:138)
    at org.junit.runner.JUnitCore.run(JUnitCore.java:117)
    at org.junit.runner.JUnitCore.runMain(JUnitCore.java:96)
    at org.junit.runner.JUnitCore.runMainAndExit(JUnitCore.java:47)
    at org.junit.runner.JUnitCore.main(JUnitCore.java:40)
    at com.jetbrains.robowrapper.Robowrapper.main(Robowrapper.java:9)
Caused by: java.lang.RuntimeException: java.io.FileNotFoundException: /Applications/Android%20Studio.app/system/Preview/deps/android-all-4.3_r2-robolectric-0.jar (No such file or directory)
    at org.robolectric.res.Fs$JarFs.<init>(Fs.java:62)
    at org.robolectric.res.Fs.fromJar(Fs.java:25)
    at org.robolectric.SdkEnvironment.createSystemResourceLoader(SdkEnvironment.java:30)
    at org.robolectric.SdkEnvironment.getSystemResourceLoader(SdkEnvironment.java:38)
    at org.robolectric.RobolectricTestRunner$2.evaluate(RobolectricTestRunner.java:276)
    ... 25 more
Caused by: java.io.FileNotFoundException: /Applications/Android%20Studio.app/system/Preview/deps/android-all-4.3_r2-robolectric-0.jar (No such file or directory)
    at java.util.zip.ZipFile.open(Native Method)
    at java.util.zip.ZipFile.<init>(ZipFile.java:215)
    at java.util.zip.ZipFile.<init>(ZipFile.java:145)
    at java.util.jar.JarFile.<init>(JarFile.java:153)
    at java.util.jar.JarFile.<init>(JarFile.java:117)
    at org.robolectric.res.Fs$JarFs.<init>(Fs.java:60)
    ... 29 more
```
