### PR TITLE
Fixed null pointer using ValueAnimator ofInt

### DIFF
--- a/robolectric/src/main/java/org/robolectric/shadows/ShadowValueAnimator.java
+++ b/robolectric/src/main/java/org/robolectric/shadows/ShadowValueAnimator.java
@@ -36,7 +36,10 @@ public class ShadowValueAnimator extends ShadowAnimator {
 
   @Implementation
   public static ValueAnimator ofInt (int... values){
-    return new ValueAnimator();
+    ValueAnimator valueAnimator = new ValueAnimator();
+    valueAnimator.setIntValues(values);
+
+    return valueAnimator;
   }
 
   @Implementation

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowValueAnimatorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowValueAnimatorTest.java
@@ -1,0 +1,25 @@
+package org.robolectric.shadows;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.TestRunners;
+
+import android.animation.ValueAnimator;
+import android.app.Application;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class ShadowValueAnimatorTest {
+
+  final Application application = Robolectric.application;
+
+  @Test
+  public void testOfIntPassesArgumentsToAnimator() {
+    ValueAnimator valueAnimator = ShadowValueAnimator.ofInt(1,4,6);
+    valueAnimator.start();
+
+    assertThat(valueAnimator.getAnimatedValue()).isEqualTo(6);
+  }
+}


### PR DESCRIPTION
Robolectric tests on code using ValueAnimator were crashing due to a
null pointer when ValueAnimator.ofInt was used to initialise instance.

Updated shadow method to pass the int values to the value animator
returned and add simple test to verify end result matches passed in
value.
