### PR TITLE
Change test file detection to include files with pattern Test*Test.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,9 +121,9 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.13</version>
           <configuration>
-            <excludes>
-              <exclude>**/Test*.java</exclude>
-            </excludes>
+            <includes>
+              <include>**/*Test.java</include>
+            </includes>
             <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=256m</argLine>
           </configuration>
         </plugin>


### PR DESCRIPTION
Previously, Maven was excluding tests that start with Test such as TestSharedPreferencesTest.java.
