### PR TITLE
add getter for ShadowTextView#onEditorActionListener

### DIFF
--- a/robolectric/src/main/java/org/robolectric/shadows/ShadowTextView.java
+++ b/robolectric/src/main/java/org/robolectric/shadows/ShadowTextView.java
@@ -12,6 +12,7 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.TextView;
+import org.robolectric.Robolectric;
 import org.robolectric.internal.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -60,7 +61,6 @@ public class ShadowTextView extends ShadowView {
   private List<KeyEvent> previousKeyEvents = new ArrayList<KeyEvent>();
   private Layout layout;
   private int paintFlags;
-
 
   @Implementation
   public void setTextAppearance(Context context, int resid) {
@@ -150,5 +150,15 @@ public class ShadowTextView extends ShadowView {
   @Implementation
   public void setPaintFlags(int paintFlags) {
     this.paintFlags = paintFlags;
+  }
+
+  @Implementation
+  public void setOnEditorActionListener(TextView.OnEditorActionListener l) {
+    this.onEditorActionListener = l;
+    directlyOn(realTextView, TextView.class).setOnEditorActionListener(l);
+  }
+
+  public TextView.OnEditorActionListener getOnEditorActionListener() {
+    return onEditorActionListener;
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/TextViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/TextViewTest.java
@@ -71,6 +71,16 @@ public class TextViewTest {
   }
 
   @Test
+  public void shouldCreateGetterForEditorActionListener() {
+    TextView textView = new TextView(Robolectric.application);
+    TestOnEditorActionListener actionListener = new TestOnEditorActionListener();
+
+    textView.setOnEditorActionListener(actionListener);
+
+    assertThat(shadowOf(textView).getOnEditorActionListener()).isSameAs(actionListener);
+  }
+
+  @Test
   public void testGetUrls() throws Exception {
     textView.setAutoLinkMask(Linkify.ALL);
     textView.setText("here's some text http://google.com/\nblah\thttp://another.com/123?456 blah");


### PR DESCRIPTION
Simple getter for the editor action listener. This is needed to test the return value of the listener for different actions performed on the keyboard.
