### PR TITLE
Fixes #1357 ActivityThread.getPackageManager().getPackageInfo() should r...

### DIFF
--- a/robolectric/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
+++ b/robolectric/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
@@ -1,5 +1,7 @@
 package org.robolectric.shadows;
 
+import android.content.pm.PackageManager;
+
 import org.jetbrains.annotations.NotNull;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implementation;
@@ -15,27 +17,35 @@ public class ShadowActivityThread {
 
   @Implementation
   public static Object getPackageManager() {
+
     ClassLoader classLoader = ShadowActivityThread.class.getClassLoader();
     Class<?> iPackageManagerClass;
     try {
       iPackageManagerClass = classLoader.loadClass("android.content.pm.IPackageManager");
-    } catch (ClassNotFoundException e) {
+    } catch ( ClassNotFoundException e ) {
       throw new RuntimeException(e);
     }
-    return Proxy.newProxyInstance(classLoader, new Class[] {iPackageManagerClass}, new InvocationHandler() {
-      @Override public Object invoke(Object proxy, @NotNull Method method, Object[] args) throws Throwable {
-        if (method.getName().equals("getApplicationInfo")) {
+    return Proxy.newProxyInstance(classLoader, new Class[]{iPackageManagerClass}, new InvocationHandler() {
+      @Override
+      public Object invoke(Object proxy, @NotNull Method method, Object[] args) throws Exception {
+        if ( method.getName().equals("getApplicationInfo") ) {
           String packageName = (String) args[0];
           int flags = (Integer) args[1];
-          return Robolectric.packageManager.getApplicationInfo(packageName, flags);
+          try {
+            return Robolectric.packageManager.getApplicationInfo(packageName, flags);
+          } catch ( PackageManager.NameNotFoundException e ) {
+            return null;
+          }
         }
         throw new UnsupportedOperationException("sorry, not supporting " + method + " yet!");
       }
     });
+
   }
 
   @Implementation
   public static Object currentActivityThread() {
     return Robolectric.activityThread;
   }
+
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityThreadTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityThreadTest.java
@@ -1,0 +1,36 @@
+package org.robolectric.shadows;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.util.AttributeSet;
+import android.widget.TextView;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@RunWith(RobolectricTestRunner.class)
+public class ShadowActivityThreadTest {
+
+
+    @Test
+    public void testTriggersUndeclaredThrowableException() throws Exception {
+        // createPackageContext internally calls ActivityThread.getPackageInfo which is what we'd like to test here.
+        try {
+            Robolectric.application.createPackageContext("com.unknownpackage.ab", Context.CONTEXT_RESTRICTED);
+            Assert.fail("Should've triggered a NameNotFoundException and not UndeclaredThrowableException");
+        } catch (PackageManager.NameNotFoundException nnfe) {
+            assertThat(nnfe).hasMessageContaining("com.unknownpackage.ab");
+        }
+    }
+
+
+
+
+}


### PR DESCRIPTION
Fixes #1357 ActivityThread.getPackageManager().getPackageInfo() should return null if the package is not found in the system

and not forward the NameNotFoundException which will get Wrapped Around UndeclaredThrowableException since# Please enter the commit message for your changes. Lines starting
IPackageManager.getPackageInfo() has RemoteException as declared checked exception.# with '#' will be ignored, and an empty message aborts the commit.
See http://docs.oracle.com/javase/8/docs/technotes/guides/reflection/proxy.html
