### PR TITLE
Add cleanup to ContentResolverTest to remove some test pollution.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ContentResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ContentResolverTest.java
@@ -544,8 +544,13 @@ public class ContentResolverTest {
   @Test
   public void getProvider_shouldCreateProviderFromManifest() {
     AndroidManifest manifest = Robolectric.getShadowApplication().getAppManifest();
-    manifest.getContentProviders().add(new ContentProviderData("org.robolectric.shadows.ContentResolverTest$TestContentProvider", AUTHORITY));
-    assertThat(ShadowContentResolver.getProvider(Uri.parse("content://" + AUTHORITY + "/shadows"))).isNotNull();
+    ContentProviderData testProviderData = new ContentProviderData("org.robolectric.shadows.ContentResolverTest$TestContentProvider", AUTHORITY);
+    try {
+      manifest.getContentProviders().add(testProviderData);
+      assertThat(ShadowContentResolver.getProvider(Uri.parse("content://" + AUTHORITY + "/shadows"))).isNotNull();
+    } finally {
+      manifest.getContentProviders().remove(testProviderData);
+    }
   }
 
   @Test


### PR DESCRIPTION
This should fix flakey ContentResolverTest failures in the java 8 build due to test execution orders.
