### PR TITLE
Fix NPE in ActivityController.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/robolectric/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -61,6 +61,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   private int streamType = -1;
   private boolean mIsTaskRoot = true;
   private Menu optionsMenu;
+  private Application testApplication;
 
   public void __constructor__() {
     Robolectric.invokeConstructor(Activity.class, realActivity);
@@ -88,9 +89,17 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
     return false;
   }
 
+  public void setTestApplication(Application testApplication) {
+    this.testApplication = testApplication;
+  }
+
+  public Application getTestApplication() {
+    return testApplication;
+  }
+
   @Implementation
   public final Application getApplication() {
-    return Robolectric.application;
+    return testApplication != null ? testApplication : Robolectric.application;
   }
 
   @Override

--- a/robolectric/src/main/java/org/robolectric/util/ActivityController.java
+++ b/robolectric/src/main/java/org/robolectric/util/ActivityController.java
@@ -37,6 +37,14 @@ public class ActivityController<T extends Activity>
 
   public ActivityController<T> attach() {
     Application application = this.application == null ? Robolectric.application : this.application;
+    if (this.application != null) {
+      ShadowApplication roboShadow = shadowOf_(Robolectric.application);
+      ShadowApplication testShadow = shadowOf_(this.application);
+      testShadow.bind(roboShadow.getAppManifest(), roboShadow.getResourceLoader());
+      testShadow.callAttachBaseContext(Robolectric.application.getBaseContext());
+      this.application.onCreate();
+      shadow.setTestApplication(this.application);
+    }
     Context baseContext = this.baseContext == null ? application : this.baseContext;
     Intent intent = getIntent();
     ActivityInfo activityInfo = new ActivityInfo();

--- a/robolectric/src/test/java/org/robolectric/util/ActivityControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/ActivityControllerTest.java
@@ -1,6 +1,7 @@
 package org.robolectric.util;
 
 import android.app.Activity;
+import android.app.Application;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.os.Bundle;
@@ -63,6 +64,28 @@ public class ActivityControllerTest {
 
     Robolectric.unPauseMainLooper();
     transcript.assertEventsInclude("onCreate");
+  }
+
+  @Test
+  public void withApplication_attachesTestApplicationToActivity() {
+    Application application = new Application();
+    MyActivity activity = controller.withApplication(application).create().get();
+    assertThat(activity.getApplication()).isEqualTo(application);
+  }
+
+  @Test
+  public void withApplication_setsBaseContext() {
+    Application application = new Application();
+    controller.withApplication(application).create().get();
+    assertThat(application.getBaseContext()).isNotNull();
+  }
+
+  @Test
+  public void withApplication_bindsResourcesAndAssets() {
+    Application application = new Application();
+    controller.withApplication(application).create().get();
+    assertThat(application.getBaseContext().getAssets()).isNotNull();
+    assertThat(application.getBaseContext().getResources()).isNotNull();
   }
 
   @Test


### PR DESCRIPTION
Using ActivityController.withApplication(Application) results in an NPE
because the base context is null.

Ensure that the Application object has a base context and is bound to
the proper resources.
