### PR TITLE
ShadowMotionEvent: implement proper getPointerIdBits.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/shadows/ShadowMotionEvent.java
+++ b/robolectric/src/main/java/org/robolectric/shadows/ShadowMotionEvent.java
@@ -24,7 +24,7 @@ public class ShadowMotionEvent {
   private int pointerCount = 1;
   private long downTime;
   private long eventTime;
-  private int[] pointerIds = new int[2];
+  private int[] pointerIds = {0, 1};
   private int pointerIndex;
   private int source;
 
@@ -109,6 +109,15 @@ public class ShadowMotionEvent {
   @Implementation
   public final int getPointerId(int index) {
     return pointerIds[index];
+  }
+
+  @Implementation
+  public final int getPointerIdBits() {
+    int idBits = 0;
+    for (int i = 0; i < pointerCount; i++) {
+      idBits |= 1 << pointerIds[i];
+    }
+    return idBits;
   }
 
   @Implementation

--- a/robolectric/src/test/java/org/robolectric/shadows/MotionEventTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/MotionEventTest.java
@@ -8,6 +8,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.WithDefaults.class)
@@ -32,6 +33,7 @@ public class MotionEventTest {
     assertThat(event.getX(1)).isEqualTo(20.0f);
     assertThat(event.getY(1)).isEqualTo(30.0f);
     assertThat(event.getPointerCount()).isEqualTo(2);
+    assertThat(event.getPointerIdBits()).isEqualTo(0x3);
   }
 
   @Test
@@ -40,6 +42,7 @@ public class MotionEventTest {
     shadowMotionEvent.setPointerIds(2, 5);
     assertEquals(2, event.getPointerId(0));
     assertEquals(5, event.getPointerId(1));
+    assertThat(event.getPointerIdBits()).isEqualTo(0x24);
   }
 
   @Test


### PR DESCRIPTION
This makes ViewGroup.dispatchTouchEvent propagate the motion events
correctly down to their children.
