### PR TITLE
Add attach-sources to pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,18 @@
             </filesets>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/robolectric/pom.xml
+++ b/robolectric/pom.xml
@@ -162,6 +162,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
When packaging, assemble a sources JAR.

I'm not sure how useful this is for the main project, but we found it helpful to have the source available when debugging tests.
