### PR TITLE
Implement `Toast#getXOffset()` and `Toast#getYOffset()` in the shadow

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowToast.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowToast.java
@@ -23,6 +23,8 @@ public class ShadowToast {
   private String text;
   private int duration;
   private int gravity;
+  private int xOffset;
+  private int yOffset;
   private View view;
 
   @RealObject Toast toast;
@@ -71,11 +73,23 @@ public class ShadowToast {
   @Implementation
   public void setGravity(int gravity, int xOffset, int yOffset) {
     this.gravity = gravity;
+    this.xOffset = xOffset;
+    this.yOffset = yOffset;
   }
 
   @Implementation
   public int getGravity() {
     return gravity;
+  }
+
+  @Implementation
+  public int getXOffset() {
+    return xOffset;
+  }
+
+  @Implementation
+  public int getYOffset() {
+    return yOffset;
   }
 
   @Implementation

--- a/robolectric/src/test/java/org/robolectric/shadows/ToastTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ToastTest.java
@@ -80,6 +80,14 @@ public class ToastTest {
   }
 
   @Test
+  public void shouldSetOffsetsCorrectly() throws Exception {
+    Toast toast = Toast.makeText(new Activity(), "short toast", Toast.LENGTH_SHORT);
+    toast.setGravity(0, 12, 34);
+    assertThat(toast.getXOffset()).isEqualTo(12);
+    assertThat(toast.getYOffset()).isEqualTo(34);
+  }
+
+  @Test
   public void shouldCountToastsCorrectly() throws Exception {
     assertThat(ShadowToast.shownToastCount()).isEqualTo(0);
     Toast toast = Toast.makeText(new Activity(), "short toast", Toast.LENGTH_SHORT);


### PR DESCRIPTION
Calling the real offset methods results in a NullPointerException, as
`mTN` is null.  This implements the methods similarly to how `getGravity()`
is done.
