### PR TITLE
Custom exceptions for MediaMetadataRetriever.setDataSource()

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaMetadataRetriever.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaMetadataRetriever.java
@@ -10,35 +10,48 @@ import com.google.android.collect.Maps;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
+import org.robolectric.shadows.util.DataSource;
 
 import java.io.FileDescriptor;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.robolectric.shadows.util.DataSource.toDataSource;
+
 @Implements(MediaMetadataRetriever.class)
 public class ShadowMediaMetadataRetriever {
-  private String dataSource;
-  private static final Map<String, HashMap<Integer, String>> metadata = Maps.newHashMap();
-  private static final Map<String, HashMap<Long, Bitmap>> frames= Maps.newHashMap();
+  private DataSource dataSource;
+  private static final Map<DataSource, HashMap<Integer, String>> metadata = Maps.newHashMap();
+  private static final Map<DataSource, HashMap<Long, Bitmap>> frames = Maps.newHashMap();
+  private static final Map<DataSource, RuntimeException> exceptions = Maps.newHashMap();
 
+  public void setDataSource(DataSource dataSource) {
+    RuntimeException e = exceptions.get(dataSource);
+    if (e != null) {
+      e.fillInStackTrace();
+      throw e;
+    }
+    this.dataSource = dataSource;
+  }
+  
   @Implementation
   public void setDataSource(String path) {
-    this.dataSource = path;
+    setDataSource(toDataSource(path));
   }
 
   @Implementation
   public void setDataSource(Context context, Uri uri) {
-    dataSource = uri.toString();
+    setDataSource(toDataSource(context, uri));
   }
 
   @Implementation
   public void setDataSource(String uri, Map<String, String> headers) {
-    dataSource = uri;
+    setDataSource(toDataSource(uri, headers));
   }
 
   @Implementation
   public void setDataSource(FileDescriptor fd, long offset, long length) {
-    dataSource = fd.toString() + offset;
+    setDataSource(toDataSource(fd, offset, length));
   }
 
   @Implementation
@@ -51,51 +64,140 @@ public class ShadowMediaMetadataRetriever {
 
   @Implementation
   public Bitmap getFrameAtTime(long timeUs, int option) {
-    return frames.get(dataSource).get(timeUs);
+    return (frames.containsKey(dataSource) ?
+            frames.get(dataSource).get(timeUs) : null);
   }
 
+  /**
+   * Configures an exception to be thrown when {@link #setDataSource}
+   * is called for the given data source.
+   * 
+   * @param ds the data source that will trigger an exception
+   * @param e the exception to trigger, or <tt>null</tt> to 
+   * avoid throwing an exception.
+   */
+  public static void addException(DataSource ds, RuntimeException e) {
+    exceptions.put(ds, e);
+  }
+
+  public static void addMetadata(DataSource ds, int keyCode, String value) {
+    if (!metadata.containsKey(ds)) {
+      metadata.put(ds, new HashMap<Integer, String>());
+    }
+    metadata.get(ds).put(keyCode, value);
+  }
+
+  /**
+   * Adds the given keyCode/value pair for the given data source.
+   * Uses <tt>path</tt> to call {@link org.robolectric.shadows.util.DataSource#toDataSource(String)} and
+   * then calls {@link #addMetadata(DataSource, int, String)}. This
+   * method is retained mostly for backwards compatibility;
+   * you can call {@link #addMetadata(DataSource, int, String)} directly.
+   *
+   * @param path the path to the data source whose metadata is being set.
+   * @param keyCode the keyCode for the metadata being set, as used by {@link MediaMetadataRetriever#extractMetadata(int)}. 
+   * @param value the value for the specified metadata.
+   */
   public static void addMetadata(String path, int keyCode, String value) {
-    if (!metadata.containsKey(path)) {
-      metadata.put(path, new HashMap<Integer, String>());
-    }
-    metadata.get(path).put(keyCode, value);
+    addMetadata(toDataSource(path), keyCode, value);
   }
 
+  public static void addFrame(DataSource ds, long time, Bitmap bitmap) {
+    if (!frames.containsKey(ds)) {
+      frames.put(ds, new HashMap<Long, Bitmap>());
+    }
+    frames.get(ds).put(time, bitmap);
+  }
+  
+  /**
+   * Adds the given bitmap at the given time for the given data source.
+   * Uses <tt>path</tt> to call {@link org.robolectric.shadows.util.DataSource#toDataSource(String)} and
+   * then calls {@link #addFrame(DataSource, long, Bitmap)}. This
+   * method is retained mostly for backwards compatibility;
+   * you can call {@link #addFrame(DataSource, long, Bitmap)} directly.
+   * 
+   * @param path the path to the data source.
+   * @param time the playback time at which the specified bitmap
+   * should be retrieved.
+   * @param bitmap the bitmap to retrieve.
+   */
   public static void addFrame(String path, long time, Bitmap bitmap) {
-    if (!frames.containsKey(path)) {
-      frames.put(path, new HashMap<Long, Bitmap>());
-    }
-    frames.get(path).put(time, bitmap);
+    addFrame(toDataSource(path), time, bitmap);
   }
 
+  /**
+   * Adds the given bitmap at the given time for the given data source.
+   * Uses <tt>path</tt> to call {@link org.robolectric.shadows.util.DataSource#toDataSource(Context, Uri)} and
+   * then calls {@link #addFrame(DataSource, long, Bitmap)}. This
+   * method is retained mostly for backwards compatibility;
+   * you can call {@link #addFrame(DataSource, long, Bitmap)} directly.
+   *
+   * @param context the Context object to match on the data source.
+   * @param uri the Uri of the data source.
+   * @param time the playback time at which the specified bitmap
+   * should be retrieved.
+   * @param bitmap the bitmap to retrieve.
+   */
   public static void addFrame(Context context, Uri uri, long time, Bitmap bitmap) {
-    String uriString = uri.toString();
-    if (!frames.containsKey(uriString)) {
-      frames.put(uriString, new HashMap<Long, Bitmap>());
-    }
-    frames.get(uriString).put(time, bitmap);
+    addFrame(toDataSource(context, uri), time, bitmap);
   }
 
+  /**
+   * Adds the given bitmap at the given time for the given data source.
+   * Uses <tt>path</tt> to call {@link org.robolectric.shadows.util.DataSource#toDataSource(String, Map)} and
+   * then calls {@link #addFrame(DataSource, long, Bitmap)}. This
+   * method is retained mostly for backwards compatibility;
+   * you can call {@link #addFrame(DataSource, long, Bitmap)} directly.
+   *
+   * @param uri the Uri of the data source.
+   * @param headers the headers to use when requesting the specified uri.
+   * @param time the playback time at which the specified bitmap
+   * should be retrieved.
+   * @param bitmap the bitmap to retrieve.
+   */
   public static void addFrame(String uri, Map<String, String> headers, long time, Bitmap bitmap) {
-    addFrame(null, Uri.parse(uri), time, bitmap);
+    addFrame(toDataSource(uri, headers), time, bitmap);
   }
 
+  /**
+   * Adds the given bitmap at the given time for the given data source.
+   * Uses <tt>path</tt> to call {@link org.robolectric.shadows.util.DataSource#toDataSource(FileDescriptor)} and
+   * then calls {@link #addFrame(DataSource, long, Bitmap)}. This
+   * method is retained mostly for backwards compatibility;
+   * you can call {@link #addFrame(DataSource, long, Bitmap)} directly.
+   *
+   * @param fd file descriptor of the data source.
+   * @param time the playback time at which the specified bitmap
+   * should be retrieved.
+   * @param bitmap the bitmap to retrieve.
+   */
   public static void addFrame(FileDescriptor fd, long time, Bitmap bitmap) {
-    addFrame(fd, 0, 0, time, bitmap);
+    addFrame(toDataSource(fd), time, bitmap);
   }
 
+  /**
+   * Adds the given bitmap at the given time for the given data source.
+   * Uses <tt>path</tt> to call {@link org.robolectric.shadows.util.DataSource#toDataSource(FileDescriptor, long, long)} and
+   * then calls {@link #addFrame(DataSource, long, Bitmap)}. This
+   * method is retained mostly for backwards compatibility;
+   * you can call {@link #addFrame(DataSource, long, Bitmap)} directly.
+   *
+   * @param fd file descriptor of the data source.
+   * @param offset the byte offset within the specified file from which to start reading the data.
+   * @param length the number of bytes to read from the file.
+   * @param time the playback time at which the specified bitmap
+   * should be retrieved.
+   * @param bitmap the bitmap to retrieve.
+   */
   public static void addFrame(FileDescriptor fd, long offset, long length,
                               long time, Bitmap bitmap) {
-    String dataSource = fd.toString() + offset;
-    if (!frames.containsKey(dataSource)) {
-      frames.put(dataSource, new HashMap<Long, Bitmap>());
-    }
-    frames.get(dataSource).put(time, bitmap);
+    addFrame(toDataSource(fd, offset, length), time, bitmap);
   }
 
   @Resetter
   public static void reset() {
     metadata.clear();
     frames.clear();
+    exceptions.clear();
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/util/DataSource.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/util/DataSource.java
@@ -1,0 +1,66 @@
+package org.robolectric.shadows.util;
+
+import java.io.FileDescriptor;
+import java.util.Map;
+
+import android.content.Context;
+import android.net.Uri;
+
+/**
+ * Opaque class for uniquely identifying a media data source,
+ * as used by {@link org.robolectric.shadows.ShadowMediaPlayer}
+ * and {@link org.robolectric.shadows.ShadowMediaMetadataRetriever}.
+ *
+ * @author Fr Jeremy Krieg
+ */
+public class DataSource {
+  private String dataSource;
+
+  private DataSource(String dataSource) {
+    this.dataSource = dataSource;
+  }
+  
+  public static DataSource toDataSource(String path) {
+    return new DataSource(path);
+  }
+
+  public static DataSource toDataSource(Context context, Uri uri) {
+    return toDataSource(uri.toString());
+  }
+
+  public static DataSource toDataSource(String uri, Map<String, String> headers) {
+    return toDataSource(uri);
+  }
+
+  public static DataSource toDataSource(FileDescriptor fd) {
+    return toDataSource(fd, 0, 0);
+  }
+
+  public static DataSource toDataSource(FileDescriptor fd, long offset, long length) {
+    return toDataSource(fd.toString() + offset);
+  }
+
+  @Override
+  public int hashCode() {
+    return ((dataSource == null) ? 0 : dataSource.hashCode());
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || !(obj instanceof DataSource)) {
+      return false;
+    }
+    final DataSource other = (DataSource) obj;
+    if (dataSource == null) {
+      if (other.dataSource != null) {
+        return false;
+      }
+    } else if (!dataSource.equals(other.dataSource)) {
+      return false;
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
- Add ability to specify an exception when `MediaMetadataRetriever.setDataSource()` is called to facilitate test exception-handling code.
- Abstracted data source specification into an opaque ID class `org.robolectric.shadows.util.DataSource` so that we don't have to specify every different flavour of data source specification in the `addFrame()/addException()/addMetadata()` methods.
- Plan in pipeline to reuse `DataSource` with similar enhancements to `ShadowMediaPlayer`.
