### PR TITLE
Remove empty onSaveInstanceState in ShadowActivity.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -577,10 +577,6 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public void onSaveInstanceState(Bundle outState) {
-  }
-
-  @Implementation
   public void startManagingCursor(Cursor c) {
     managedCusors.add(c);
   }


### PR DESCRIPTION
This implementation being empty meant that the actual Android
onSaveInstanceState code was never being run. This code does run fine
with current Robolectric implementations, and I suspect was only
overridden for Robolectric 1.0's sake. Without running this actual code,
View and Fragment state saving (and therefore later restoration) does
not work properly and cannot be tested.

Fixes #1280.
