### PR TITLE
Call the real onKeyUp code in ShadowActivity#onKeyUp.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -53,7 +53,6 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   private int pendingTransitionExitAnimResId = -1;
   private Object lastNonConfigurationInstance;
   private Map<Integer, Dialog> dialogForId = new HashMap<Integer, Dialog>();
-  private boolean onKeyUpWasCalled;
   private ArrayList<Cursor> managedCusors = new ArrayList<Cursor>();
 
   private int mDefaultKeyMode = Activity.DEFAULT_KEYS_DISABLE;
@@ -372,24 +371,6 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   @Implementation
   public View getCurrentFocus() {
     return currentFocus;
-  }
-
-  @Implementation
-  public boolean onKeyUp(int keyCode, KeyEvent event) {
-    onKeyUpWasCalled = true;
-    if (keyCode == KeyEvent.KEYCODE_BACK) {
-      onBackPressed();
-      return true;
-    }
-    return false;
-  }
-
-  public boolean onKeyUpWasCalled() {
-    return onKeyUpWasCalled;
-  }
-
-  public void resetKeyUpWasCalled() {
-    onKeyUpWasCalled = false;
   }
 
   public int getPendingTransitionEnterAnimationResourceId() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ActivityTest.java
@@ -455,24 +455,16 @@ public class ActivityTest {
   }
 
   @Test
-  public void onKeyUp_recordsThatItWasCalled() throws Exception {
-    Activity activity = new Activity();
-    boolean consumed = activity.onKeyUp(KeyEvent.KEYCODE_0, new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_0));
-
-    assertFalse(consumed);
-    assertTrue(shadowOf(activity).onKeyUpWasCalled());
-
-    shadowOf(activity).resetKeyUpWasCalled();
-    assertFalse(shadowOf(activity).onKeyUpWasCalled());
-  }
-
-  @Test
   public void onKeyUp_callsOnBackPressedWhichFinishesTheActivity() throws Exception {
-    Activity activity = new Activity();
-    boolean consumed = activity.onKeyUp(KeyEvent.KEYCODE_BACK, new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK));
+    OnBackPressedActivity activity = buildActivity(OnBackPressedActivity.class).setup().get();
+    boolean downConsumed =
+        activity.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK));
+    boolean upConsumed =
+        activity.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK));
 
-    assertTrue(consumed);
-    assertTrue(shadowOf(activity).onKeyUpWasCalled());
+    assertTrue(downConsumed);
+    assertTrue(upConsumed);
+    assertTrue(activity.onBackPressedCalled);
     assertTrue(activity.isFinishing());
   }
 
@@ -892,6 +884,16 @@ public class ActivityTest {
       getWindow().setFeatureInt(Window.FEATURE_CUSTOM_TITLE, R.layout.custom_title);
 
       customTitleText = (TextView) findViewById(R.id.custom_title_text);
+    }
+  }
+
+  private static class OnBackPressedActivity extends Activity {
+    public boolean onBackPressedCalled = false;
+
+    @Override
+    public void onBackPressed() {
+      onBackPressedCalled = true;
+      super.onBackPressed();
     }
   }
 }


### PR DESCRIPTION
Prior to this change, onKeyUp had a simplified copy of Activity#onKeyUp
which neglected to check whether the KeyEvent was being tracked (which
could result in divergent behavior in tests). It also called
onBackPressed directly which, due to how Robolectric's bytecode
replacement works, called directly to ShadowActivity#onBackPressed
rather than moving through the proper class hierarchy. In effect, this
meant that if an Activity had its own implementation of onBackPressed,
this implementation would be ignored and ShadowActivity's would be used
instead.

Changes include a modification to the onKeyUp -> onBackPressed test
to make it use real KeyEvent dispatch and check that the proper
onBackPressed call chain is preserved.
