### PR TITLE
Workaround for custom Android collating sequences

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSQLiteConnection.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSQLiteConnection.java
@@ -362,7 +362,13 @@ public class ShadowSQLiteConnection {
         @Override
         public SQLiteStatement call() throws Exception {
           SQLiteConnection connection = getConnection(connectionPtr);
-          return connection.prepare(sql);
+
+          // workaround for Android collation sequences
+          String sqlWithoutAndroidCollators = sql
+              .replaceAll("COLLATE LOCALIZED", "")
+              .replaceAll("COLLATE UNICODE", "");
+
+          return connection.prepare(sqlWithoutAndroidCollators);
         }
       });
 

--- a/robolectric/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
@@ -876,4 +876,16 @@ public class SQLiteDatabaseTest {
         data.moveToFirst();
         assertThat(data.getBlob(0)).isEqualTo(values.getAsString("first_column").getBytes());
     }
+
+    @Test
+    public void shouldNotFailOnAndroidCollators() {
+        database.execSQL("CREATE TABLE collators_test (\n" +
+             "  col_text_unicode_collate TEXT COLLATE UNICODE,\n" +
+             "  col_text_localized_collate TEXT COLLATE LOCALIZED,\n" +
+             "  col_text TEXT\n" +
+             ");");
+
+        database.query("collators_test", new String[] { "col_text COLLATE UNICODE" }, null, null, null, null, null);
+        database.query("collators_test", new String[] { "col_text COLLATE LOCALIZED" }, null, null, null, null, null);
+    }
 }


### PR DESCRIPTION
I wouldn't consider it a fix, but at least it allows testing of application using Android collation sequences.

Closes #1230 