### PR TITLE
Removed ShadowHandler, introduced ShadowMessageQueue

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowHandler.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowHandler.java
@@ -20,240 +20,54 @@ import static org.robolectric.Shadows.shadowOf;
  * separate thread.{@link Runnable}s that are scheduled to be executed immediately can be triggered by calling
  * {@link #idleMainLooper()}.
  * todo: add utility method to advance time and trigger execution of Runnables scheduled for a time in the future
+ * 
+ * @deprecated There is no special shadow implementation for the {@link android.os.Handler} class. The special
+ * handling is all done by {@link ShadowLooper} and {@link ShadowMessageQueue}. This class has been retained
+ * for backward compatibility with the various static method implementations.
  */
-@SuppressWarnings({"UnusedDeclaration"})
+// <b>Note</b>: If this shadow is ever completely removed it will still probably make sense to keep
+// the associated tests - if necessary we can copy them into ShadowLooperTest or ShadowMessageQueueTest.
+@Deprecated
+// Even though it doesn't implement anything, some parts of the system will fail if we don't have the
+// @Implements tag (ShadowWrangler).
 @Implements(Handler.class)
 public class ShadowHandler {
-  @RealObject
-  private Handler realHandler;
-  private Looper looper;
-  private final List<Message> messages = new ArrayList<Message>();
-  private Handler.Callback callback;
-
-  public void __constructor__() {
-    __constructor__(Looper.myLooper(), null);
-  }
-
-  public void __constructor__(Looper looper) {
-    __constructor__(looper, null);
-  }
-
-  public void __constructor__(Handler.Callback callback) {
-    __constructor__(Looper.myLooper(), callback);
-  }
-
-  public void __constructor__(Looper looper, Handler.Callback callback) {
-    this.looper = looper;
-    this.callback = callback;
-  }
-
-  @Implementation
-  public boolean post(Runnable r) {
-    return postDelayed(r, 0);
-  }
-
-  @Implementation
-  public boolean postDelayed(Runnable r, long delayMillis) {
-    return Shadows.shadowOf(looper).post(r, delayMillis);
-  }
-
-  @Implementation
-  public final boolean postAtFrontOfQueue(Runnable runnable) {
-    return Shadows.shadowOf(looper).postAtFrontOfQueue(runnable);
-  }
-
-  @Implementation
-  public Message obtainMessage() {
-    return obtainMessage(0);
-  }
-
-  @Implementation
-  public Message obtainMessage(int what) {
-    return obtainMessage(what, null);
-  }
-
-  @Implementation
-  public Message obtainMessage(int what, Object obj) {
-    return obtainMessage(what, 0, 0, obj);
-  }
-
-  @Implementation
-  public Message obtainMessage(int what, int arg1, int arg2) {
-    return obtainMessage(what, arg1, arg2, null);
-  }
-
-  @Implementation
-  public Message obtainMessage(int what, int arg1, int arg2, Object obj) {
-    Message message = new Message();
-    message.what = what;
-    message.arg1 = arg1;
-    message.arg2 = arg2;
-    message.obj = obj;
-    message.setTarget(realHandler);
-    return message;
-  }
-
-  @Implementation
-  public final boolean sendMessage(final Message msg) {
-    return sendMessageDelayed(msg, 0L);
-  }
-
-  @Implementation
-  public final boolean sendMessageDelayed(final Message msg, long delayMillis) {
-    long when = getCurrentUptimeMillis() + delayMillis;
-    setMessageWhen(msg, when);
-    messages.add(msg);
-    postDelayed(new Runnable() {
-      @Override
-      public void run() {
-        if (messages.contains(msg)) {
-          messages.remove(msg);
-          routeMessage(msg);
-        }
-      }
-    }, delayMillis);
-    return true;
-  }
-
-  private void setMessageWhen(Message msg, long when) {
-    ReflectionHelpers.setField(msg, "when", when);
-  }
-
-  private void routeMessage(Message msg) {
-    if(callback != null) {
-      callback.handleMessage(msg);
-    } else {
-      realHandler.handleMessage(msg);
-    }
-  }
-
-  @Implementation
-  public final boolean sendEmptyMessage(int what) {
-    return sendEmptyMessageDelayed(what, 0L);
-  }
-
-  @Implementation
-  public final boolean sendEmptyMessageDelayed(int what, long delayMillis) {
-    final Message msg = new Message();
-    msg.what = what;
-    return sendMessageDelayed(msg, delayMillis);
-  }
-
-  @Implementation
-  public final boolean sendMessageAtFrontOfQueue(final Message msg) {
-    setMessageWhen(msg, getCurrentUptimeMillis());
-    messages.add(0, msg);
-    postAtFrontOfQueue(new Runnable() {
-      @Override
-      public void run() {
-        if (messages.contains(msg)) {
-          messages.remove(msg);
-          routeMessage(msg);
-        }
-      }
-    });
-    return true;
-  }
-
-  @Implementation
-  public boolean sendMessageAtTime(Message msg, long uptimeMillis) {
-    long delay = uptimeMillis - getCurrentUptimeMillis();
-    sendMessageDelayed(msg, delay);
-    return true;
-  }
-
-  @Implementation
-  public final Looper getLooper() {
-    return looper;
-  }
-
-  @Implementation
-  public final void removeCallbacks(java.lang.Runnable r) {
-    shadowOf(looper).getScheduler().remove(r);
-  }
-
-  @Implementation
-  public final boolean hasMessages(int what) {
-    for (Message message : messages) {
-      if (message.what == what) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  @Implementation
-  public final boolean hasMessages(int what, Object object) {
-    for (Message message : messages) {
-      if(message.what == what && message.obj == object) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-
-  @Implementation
-  public final void removeMessages(int what) {
-    removeMessages(what, null);
-  }
-
-  @Implementation
-  public final void removeMessages(int what, Object object) {
-    for (Iterator<Message> iterator = messages.iterator(); iterator.hasNext(); ) {
-      Message message = iterator.next();
-      if (message.what == what && (object == null || object.equals(message.obj))) {
-        iterator.remove();
-      }
-    }
-  }
-
-  @Implementation
-  public final void removeCallbacksAndMessages(Object object) {
-    for (Iterator<Message> iterator = messages.iterator(); iterator.hasNext(); ) {
-      Message message = iterator.next();
-      if (object == null || object.equals(message.obj)) {
-        iterator.remove();
-      }
-    }
-  }
-
   /**
-   * @deprecated use {@link #idleMainLooper()} instead
+   * @deprecated use {@link ShadowLooper#idleMainLooper()} instead
    */
   public static void flush() {
     idleMainLooper();
   }
 
   /**
-   * @see org.robolectric.shadows.ShadowLooper#idle()
+   * @deprecated
+   * @see org.robolectric.shadows.ShadowLooper#idleMainLooper()
    */
   public static void idleMainLooper() {
-    shadowOf(Looper.myLooper()).idle();
+    ShadowLooper.idleMainLooper();
   }
 
   /**
-   * @see ShadowLooper#runToEndOfTasks() ()
+   * @deprecated
+   * @see ShadowLooper#runUiThreadTasksIncludingDelayedTasks()
    */
   public static void runMainLooperToEndOfTasks() {
-    shadowOf(Looper.myLooper()).runToEndOfTasks();
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
   }
 
   /**
-   * @see ShadowLooper#runOneTask() ()
+   * @deprecated
+   * @see ShadowLooper#runMainLooperOneTask() ()
    */
   public static void runMainLooperOneTask() {
     shadowOf(Looper.myLooper()).runOneTask();
   }
 
   /**
-   * @see ShadowLooper#runToNextTask() ()
+   * @deprecated
+   * @see ShadowLooper#runMainLooperToNextTask() ()
    */
   public static void runMainLooperToNextTask() {
     shadowOf(Looper.myLooper()).runToNextTask();
-  }
-
-  private long getCurrentUptimeMillis() {
-    return shadowOf(looper).getScheduler().getCurrentTime();
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
@@ -12,13 +12,15 @@ import org.robolectric.util.Scheduler;
 import org.robolectric.util.SoftThreadLocal;
 
 import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.util.ReflectionHelpers.ClassParameter.*;
 
 /**
  * Shadow for {@code Looper} that enqueues posted {@link Runnable}s to be run (on this thread) later. {@code Runnable}s
  * that are scheduled to run immediately can be triggered by calling {@link #idle()}
  * todo: provide better support for advancing the clock and running queued tasks
+ *
+ * @see ShadowMessageQueue
  */
-@SuppressWarnings({"UnusedDeclaration"})
 @Implements(Looper.class)
 public class ShadowLooper {
   private static final Thread MAIN_THREAD = Thread.currentThread();
@@ -38,7 +40,7 @@ public class ShadowLooper {
   }
 
   private static Looper createLooper() {
-    return ReflectionHelpers.callConstructor(Looper.class);
+    return ReflectionHelpers.callConstructor(Looper.class, from(boolean.class, Thread.currentThread() != MAIN_THREAD));
   }
 
   @Resetter
@@ -81,10 +83,6 @@ public class ShadowLooper {
 
   public static Scheduler getUiThreadScheduler() {
     return shadowOf(Looper.getMainLooper()).getScheduler();
-  }
-
-  @HiddenApi
-  public void __constructor__() {
   }
 
   private void doLoop() {
@@ -146,6 +144,10 @@ public class ShadowLooper {
     unPauseLooper(Looper.getMainLooper());
   }
 
+  public static void idleMainLooper() {
+    shadowOf(Looper.getMainLooper()).idle();
+  }
+
   public static void idleMainLooper(long interval) {
     shadowOf(Looper.getMainLooper()).idle(interval);
   }
@@ -153,6 +155,14 @@ public class ShadowLooper {
 
   public static void idleMainLooperConstantly(boolean shouldIdleConstantly) {
     shadowOf(Looper.getMainLooper()).idleConstantly(shouldIdleConstantly);
+  }
+
+  public static void runMainLooperOneTask() {
+    shadowOf(Looper.getMainLooper()).runOneTask();
+  }
+
+  public static void runMainLooperToNextTask() {
+    shadowOf(Looper.getMainLooper()).runToNextTask();
   }
 
   /**

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSslErrorHandler.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSslErrorHandler.java
@@ -5,7 +5,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 @Implements(SslErrorHandler.class)
-public class ShadowSslErrorHandler extends ShadowHandler {
+public class ShadowSslErrorHandler {
 
   private boolean cancelCalled = false;
   private boolean proceedCalled = false;

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessage.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessage.java.vm
@@ -1,0 +1,129 @@
+#set($Integer = 0)
+#set($apiLevel = $Integer.parseInt($apiLevel))
+
+package org.robolectric.shadows;
+
+import android.os.Handler;
+import android.os.Message;
+
+import javax.annotation.Generated;
+
+#if ($apiLevel >= 21)import org.robolectric.annotation.HiddenApi;
+#end
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+
+import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.internal.Shadow.*;
+import static org.robolectric.util.ReflectionHelpers.*;
+
+/**
+ * Shadow for Message that removes the message from its corresponding scheduler.
+ */
+@Generated("org.robolectric.shadows.ShadowMessage.java.vm")
+@Implements(Message.class)
+public class ShadowMessage {
+  @RealObject
+  private Message realMessage;
+  private Runnable scheduledRunnable;
+
+  private void unschedule() {
+    Handler target = realMessage.getTarget();
+
+	if (target != null && scheduledRunnable != null) {
+	  shadowOf(target.getLooper()).getScheduler().remove(scheduledRunnable);
+	  scheduledRunnable = null;
+	}
+  }
+
+  @Implementation
+#if ($apiLevel >= 21)
+  @HiddenApi
+  /**
+   * Hook to unscheduled the callback when the message is recycled.
+   * Invokes {@link #unschedule()} and then calls through to the
+   * package private method {@link Message}<code>.recycleUnchecked()
+   * on the real object.
+   */
+  public void recycleUnchecked() {
+    unschedule();
+    directlyOn(realMessage, Message.class, "recycleUnchecked");
+  }
+#else
+  /**
+   * Hook to unscheduled the callback when the message is recycled.
+   * Invokes {@link #unschedule()} and then calls through to
+   * {@link Message#recycle()} on the real object.
+   */
+  public void recycle() {
+    unschedule();
+    directlyOn(realMessage, Message.class, "recycle");
+  }
+  
+  /**
+   * Invokes {@link #recycle()}. Provided for forward compatibility
+   * with API 21.
+   */
+  public void recycleUnchecked() {
+    recycle();
+  }
+#end
+
+  /**
+   * Stores the <code>Runnable</code> instance that has been scheduled
+   * to invoke this message. This is called when the message is
+   * enqueued by {@link ShadowMessageQueue#enqueueMessage} and is used when
+   * the message is recycled to ensure that the correct
+   * {@link Runnable} instance is removed from the associated scheduler.
+   *
+   * @param r the <code>Runnable</code> instance that is scheduled to
+   * trigger this message.
+   *
+#if ($apiLevel >= 21)   * @see #recycleUnchecked()
+#else   * @see #recycle()
+#end
+   */
+  public void setScheduledRunnable(Runnable r) {
+	scheduledRunnable = r;
+  }
+
+  @Implementation
+  /**
+   * Convenience method to provide access to the private <code>Message.isInUse()</code>
+   * method. Note that the definition of "in use" changed with API 21:
+   *
+   * In API 19, a message was only considered "in use" during its dispatch. In API 21, the
+   * message is considered "in use" from the time it is enqueued until the time that
+   * it is freshly obtained via a call to {@link Message#obtain()}. This means that
+   * in API 21 messages that are in the recycled pool will still be marked as "in use". 
+   *
+   * @return <code>true</code> if the message is currently "in use", <code>false</code>
+   * otherwise.
+   */
+  public boolean isInUse() {
+  	return directlyOn(realMessage, Message.class, "isInUse");
+  }
+
+  /**
+   * Convenience method to provide getter access to the private field
+   * <code>Message.next</code>.
+   *
+   * @return The next message in the current message chain.
+   * @see #setNext(Message) 
+   */
+  public Message getNext() {
+    return getField(realMessage, "next");    
+  }
+  
+  /**
+   * Convenience method to provide setter access to the private field
+   * <code>Message.next</code>.
+   *
+   * @param next the new next message for the current message.
+   * @see #getNext() 
+   */
+  public void setNext(Message next) {
+    setField(realMessage, "next", next);
+  }
+}

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
@@ -1,0 +1,150 @@
+#set($Integer = 0)
+#set($apiLevel = $Integer.parseInt($apiLevel))
+
+package org.robolectric.shadows;
+
+import android.os.Handler;
+import android.os.Message;
+import android.os.MessageQueue;
+
+import javax.annotation.Generated;
+
+import org.robolectric.annotation.HiddenApi;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.util.Scheduler;
+
+import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.internal.Shadow.*;
+import static org.robolectric.util.ReflectionHelpers.*;
+import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
+
+/**
+ * Shadow for MessageQueue that puts {@link Message}s into the scheduler queue instead of sending them to be handled on a
+ * separate thread. {@link Message}s that are scheduled to be dispatched can be triggered by calling
+ * {@link ShadowLooper#idleMainLooper}.
+ * 
+ * @see ShadowLooper
+ */
+@Generated("org.robolectric.shadows.ShadowMessageQueue.java.vm")
+@Implements(MessageQueue.class)
+public class ShadowMessageQueue {
+  @RealObject
+  private MessageQueue realQueue;
+
+#if ($apiLevel >= 21)
+#set($ptrClass = "long")
+#set($recycle = "recycleUnchecked")
+#else
+#set($ptrClass = "int")
+#set($recycle = "recycle")
+#end
+
+#set($Integer = 0)
+
+  // Stub out the native peer - scheduling
+  // is handled by the Scheduler class which is user-driven
+  // rather than automatic.
+  @HiddenApi
+  @Implementation
+  public static $ptrClass nativeInit() {
+    return 1;
+  }
+  
+  @HiddenApi
+  @Implementation
+  public static void nativeDestroy($ptrClass ptr) {}
+  
+  @HiddenApi
+  @Implementation
+  public static void nativePollOnce($ptrClass ptr, int timeoutMillis) {
+    throw new AssertionError("Should not be called");
+  }
+
+  @HiddenApi
+  @Implementation
+  public static void nativeWake($ptrClass ptr) {
+    throw new AssertionError("Should not be called");    
+  }
+  
+  @HiddenApi
+  @Implementation
+  public static boolean nativeIsIdling($ptrClass ptr) {
+    return false;
+  }
+
+  public Message getHead() {
+    return getField(realQueue, "mMessages");
+  }
+  
+  public void setHead(Message msg) {
+    setField(realQueue, "mMessages", msg);
+  }
+  
+  public static Message getNext(Message msg) {
+    return getField(msg, "next");    
+  }
+  
+  public static void setNext(Message msg, Message next) {
+    setField(msg, "next", next);
+  }
+  
+  public static Handler getTarget(Message msg) {
+    return getField(msg, "target");
+  }
+  
+  @Implementation
+  public boolean enqueueMessage(final Message msg, long when) {
+    final boolean retval = directlyOn(realQueue, MessageQueue.class, "enqueueMessage", from(Message.class, msg), from(long.class, when));
+    if (retval) {
+      final Scheduler scheduler = shadowOf(getTarget(msg).getLooper()).getScheduler();
+      final Runnable callback = new Runnable() {
+        @Override
+        public void run() {
+          Message m = getHead();
+          if (m == null) {
+            return;
+          }
+          
+          Message n = getNext(m);
+          if (m == msg) {
+            setHead(n);
+            dispatchMessage(msg);
+            return;
+          }
+          
+          while (n != null) {
+            if (n == msg) {
+              n = getNext(n);
+              setNext(m, n);
+              dispatchMessage(msg);
+              return;
+            }
+            m = n;
+            n = getNext(m);
+          }
+        }
+      };
+      if (when == 0) {
+        scheduler.postAtFrontOfQueue(callback);
+      } else {
+        scheduler.postDelayed(callback, when - scheduler.getCurrentTime());
+      }
+    }
+    return retval;
+  }
+
+  private static void dispatchMessage(Message msg) {
+    final Handler target = getTarget(msg);
+    
+    setNext(msg, null);
+    // If target is null it means the message has been removed
+    // from the queue prior to being dispatched by the scheduler.
+    if (target != null) {
+      callInstanceMethod(msg, "markInUse");
+      target.dispatchMessage(msg);
+      callInstanceMethod(msg, "$recycle");
+    }
+  }
+}

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
@@ -126,6 +126,7 @@ public class ShadowMessageQueue {
           }
         }
       };
+      shadowOf(msg).setScheduledRunnable(callback);
       if (when == 0) {
         scheduler.postAtFrontOfQueue(callback);
       } else {

--- a/robolectric/src/test/java/org/robolectric/shadows/AdapterViewBehavior.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/AdapterViewBehavior.java
@@ -4,6 +4,7 @@ import android.os.Looper;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.TextView;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,10 +41,10 @@ abstract public class AdapterViewBehavior {
       }
     });
 
-    ShadowHandler.idleMainLooper();
+    ShadowLooper.idleMainLooper();
     transcript.assertNoEventsSoFar();
     adapterView.setSelection(AdapterView.INVALID_POSITION);
-    ShadowHandler.idleMainLooper();
+    ShadowLooper.idleMainLooper();
     transcript.assertNoEventsSoFar();
   }
 
@@ -101,7 +102,7 @@ abstract public class AdapterViewBehavior {
 
     adapter.setCount(1);
 
-    ShadowHandler.idleMainLooper();
+    ShadowLooper.idleMainLooper();
 
     assertThat(adapterView.getVisibility()).isEqualTo(View.VISIBLE);
     assertThat(emptyView.getVisibility()).isEqualTo(View.GONE);
@@ -119,7 +120,7 @@ abstract public class AdapterViewBehavior {
 
     adapter.setCount(0);
 
-    ShadowHandler.idleMainLooper();
+    ShadowLooper.idleMainLooper();
 
     assertThat(adapterView.getVisibility()).isEqualTo(View.GONE);
     assertThat(emptyView.getVisibility()).isEqualTo(View.VISIBLE);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
@@ -3,11 +3,12 @@ package org.robolectric.shadows;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
-import org.robolectric.internal.Shadow;
+import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.TestRunnable;
 import org.robolectric.util.Transcript;
 
@@ -18,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ShadowHandlerTest {
@@ -41,7 +43,7 @@ public class ShadowHandlerTest {
 
   @Test
   public void testInsertsRunnablesBasedOnLooper() throws Exception {
-    Looper looper = Shadow.newInstanceOf(Looper.class);
+    Looper looper = newLooper(false);
 
     Handler handler1 = new Handler(looper);
     handler1.post(new Say("first thing"));
@@ -67,12 +69,16 @@ public class ShadowHandlerTest {
     transcript.assertEventsSoFar("first thing", "second thing");
   }
 
+  private static Looper newLooper(boolean canQuit) {
+    return ReflectionHelpers.callConstructor(Looper.class, from(boolean.class, canQuit));
+  }
+  
   @Test
   public void testDifferentLoopersGetDifferentQueues() throws Exception {
-    Looper looper1 = Shadow.newInstanceOf(Looper.class);
+    Looper looper1 = newLooper(true);
     ShadowLooper.pauseLooper(looper1);
 
-    Looper looper2 = Shadow.newInstanceOf(Looper.class);
+    Looper looper2 = newLooper(true);
     ShadowLooper.pauseLooper(looper2);
 
     Handler handler1 = new Handler(looper1);
@@ -96,21 +102,21 @@ public class ShadowHandlerTest {
   @Test
   public void testPostAndIdleMainLooper() throws Exception {
     new Handler().post(scratchRunnable);
-    ShadowHandler.idleMainLooper();
+    ShadowLooper.idleMainLooper();
     assertThat(scratchRunnable.wasRun).isTrue();
   }
 
   @Test
   public void postDelayedThenIdleMainLooper_shouldNotRunRunnable() throws Exception {
     new Handler().postDelayed(scratchRunnable, 1);
-    ShadowHandler.idleMainLooper();
+    ShadowLooper.idleMainLooper();
     assertThat(scratchRunnable.wasRun).isFalse();
   }
 
   @Test
   public void testPostDelayedThenRunMainLooperOneTask() throws Exception {
     new Handler().postDelayed(scratchRunnable, 1);
-    ShadowHandler.runMainLooperOneTask();
+    ShadowLooper.runMainLooperOneTask();
     assertThat(scratchRunnable.wasRun).isTrue();
   }
 
@@ -142,7 +148,7 @@ public class ShadowHandlerTest {
     new Handler().postDelayed(task1, 1);
     new Handler().postDelayed(task2, 1);
 
-    ShadowHandler.runMainLooperToNextTask();
+    ShadowLooper.runMainLooperToNextTask();
     assertThat(task1.wasRun).isTrue();
     assertThat(task2.wasRun).isTrue();
   }
@@ -155,7 +161,7 @@ public class ShadowHandlerTest {
     new Handler().postDelayed(task1, 1);
     new Handler().postDelayed(task2, 1);
 
-    ShadowHandler.runMainLooperOneTask();
+    ShadowLooper.runMainLooperOneTask();
     assertThat(task1.wasRun).isTrue();
     assertThat(task2.wasRun).isFalse();
   }
@@ -170,7 +176,7 @@ public class ShadowHandlerTest {
     new Handler().postDelayed(task2, 10);
     new Handler().postDelayed(task3, 100);
 
-    ShadowHandler.runMainLooperToEndOfTasks();
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
     assertThat(task1.wasRun).isTrue();
     assertThat(task2.wasRun).isTrue();
     assertThat(task3.wasRun).isTrue();
@@ -187,10 +193,10 @@ public class ShadowHandlerTest {
 
     assertTrue(result);
 
-    ShadowHandler.runMainLooperOneTask();
+    ShadowLooper.runMainLooperOneTask();
     assertThat(task2.wasRun).isTrue();
     assertThat(task1.wasRun).isFalse();
-    ShadowHandler.runMainLooperOneTask();
+    ShadowLooper.runMainLooperOneTask();
     assertThat(task1.wasRun).isTrue();
   }
 
@@ -209,10 +215,10 @@ public class ShadowHandlerTest {
 
     assertTrue(handler.hasMessages(123));
     assertTrue(handler.hasMessages(345));
-    ShadowHandler.runMainLooperOneTask();
+    ShadowLooper.runMainLooperOneTask();
     assertTrue(handler.hasMessages(123));
     assertFalse(handler.hasMessages(345));
-    ShadowHandler.runMainLooperOneTask();
+    ShadowLooper.runMainLooperOneTask();
     assertFalse(handler.hasMessages(123));
     assertFalse(handler.hasMessages(345));
   }
@@ -327,7 +333,7 @@ public class ShadowHandlerTest {
   }
 
   @Test
-  public void shouldRemoveAllMessages() throws Exception {
+  public void shouldRemoveAllCallbacksAndMessages() throws Exception {
     final boolean[] wasRun = new boolean[1];
     ShadowLooper.pauseMainLooper();
     Handler handler = new Handler() {
@@ -337,9 +343,13 @@ public class ShadowHandlerTest {
       }
     };
     handler.sendEmptyMessage(0);
+    handler.post(scratchRunnable);
+
     handler.removeCallbacksAndMessages(null);
     ShadowLooper.unPauseMainLooper();
-    assertThat(wasRun[0]).isFalse();
+
+    assertThat(wasRun[0]).as("Message").isFalse();
+    assertThat(scratchRunnable.wasRun).as("Callback").isFalse();
   }
 
   @Test
@@ -363,8 +373,34 @@ public class ShadowHandlerTest {
     handler.removeCallbacksAndMessages(secondObj);
     ShadowLooper.unPauseMainLooper();
 
-    assertThat(objects.contains(firstObj)).isTrue();
-    assertThat(objects.contains(secondObj)).isFalse();
+    assertThat(objects).containsExactly(firstObj);
+  }
+
+  @Test
+  public void shouldRemoveTaggedCallback() throws Exception {
+    ShadowLooper.pauseMainLooper();
+    Handler handler = new Handler();
+    
+    final int[] count = new int[1];
+    Runnable r = new Runnable() {
+      @Override
+      public void run() {
+        count[0]++;  
+      }
+    };
+    
+    String tag1 = "tag1", tag2 = "tag2";
+    
+    handler.postAtTime(r, tag1, 100);
+    handler.postAtTime(r, tag2, 105);
+
+    handler.removeCallbacks(r, tag2);
+    ShadowLooper.unPauseMainLooper();
+
+    assertThat(count[0]).as("run count").isEqualTo(1);
+    // This assertion proves that it was the first runnable that ran,
+    // which proves that the correctly tagged runnable was removed.
+    assertThat(shadowOf(handler.getLooper()).getScheduler().getCurrentTime()).as("currentTime").isEqualTo(105);
   }
 
   @Test
@@ -396,11 +432,11 @@ public class ShadowHandlerTest {
 
   @Test
   public void shouldSetWhenOnMessage() throws Exception {
-    final List<Message>  msgs = new ArrayList<Message>();
+    final List<Long>  whens = new ArrayList<Long>();
     Handler h = new Handler(new Handler.Callback() {
       @Override
       public boolean handleMessage(Message msg) {
-        msgs.add(msg);
+        whens.add(msg.getWhen());
         return false;
       }
     });
@@ -410,15 +446,8 @@ public class ShadowHandlerTest {
     ShadowLooper.getUiThreadScheduler().advanceToLastPostedRunnable();
     h.sendEmptyMessageDelayed(0, 12000l);
     ShadowLooper.getUiThreadScheduler().advanceToLastPostedRunnable();
-    assertThat(msgs.size()).isEqualTo(3);
 
-    Message m0 = msgs.get(0);
-    Message m1 = msgs.get(1);
-    Message m2 = msgs.get(2);
-
-    assertThat(m0.getWhen()).isEqualTo(0l);
-    assertThat(m1.getWhen()).isEqualTo(4000l);
-    assertThat(m2.getWhen()).isEqualTo(16000l);
+    assertThat(whens).as("whens").containsExactly(0l, 4000l, 16000l);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowListViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowListViewTest.java
@@ -4,7 +4,6 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 import static org.robolectric.RuntimeEnvironment.application;
 import static org.robolectric.Shadows.shadowOf;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageQueueTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageQueueTest.java
@@ -1,0 +1,198 @@
+package org.robolectric.shadows;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import android.os.Handler;
+import android.os.Message;
+import android.os.MessageQueue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
+import org.robolectric.util.Scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.util.ReflectionHelpers.*;
+import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class ShadowMessageQueueTest {
+  private MessageQueue queue;
+  private ShadowMessageQueue shadowQueue;
+  private Message testMessage;
+  private TestHandler handler;
+  private Scheduler scheduler;
+  
+  private static class TestHandler extends Handler {
+    public List<Message> handled = new ArrayList<>();
+    
+    @Override
+    public void handleMessage(Message msg) {
+      handled.add(msg);
+    }
+  }
+  
+  @Before
+  public void setUp() throws Exception {
+    handler = new TestHandler();
+    scheduler = shadowOf(handler.getLooper()).getScheduler();
+    scheduler.pause();
+    queue = callConstructor(MessageQueue.class, from(boolean.class, true));
+    shadowQueue = shadowOf(queue);
+    testMessage = handler.obtainMessage();
+  }
+
+  private static void shouldAssert(String method, ClassParameter<?>... params) {
+    boolean ran = false;
+    try {
+      callStaticMethod(MessageQueue.class, method, params);
+      ran = true;
+    } catch (Throwable t) {
+      assertThat(t).as(method).isInstanceOf(AssertionError.class);
+    }
+    assertThat(ran).as(method).overridingErrorMessage("Should have asserted but no exception was thrown").isFalse();
+  }
+  
+  @Test
+  @Config(emulateSdk=19)
+  public void nativePollOnce_shouldAssert_19() {
+    shouldAssert("nativePollOnce", from(int.class, 1), from(int.class, 2));
+  }
+  
+  @Test
+  @Config(emulateSdk=19)
+  public void nativeWake_shouldAssert_19() {
+    shouldAssert("nativeWake", from(int.class, 1));
+  }
+  
+  @Test
+  @Config(emulateSdk=21)
+  public void nativePollOnce_shouldAssert_21() {
+    shouldAssert("nativePollOnce", from(long.class, 1), from(int.class, 2));
+  }
+  
+  @Test
+  @Config(emulateSdk=21)
+  public void nativeWake_shouldAssert_21() {
+    shouldAssert("nativeWake", from(long.class, 1));
+  }
+  
+  @Test
+  public void test_setGetHead() {
+    shadowQueue.setHead(testMessage);
+    assertThat(shadowQueue.getHead()).as("getHead()").isSameAs(testMessage);
+  }
+
+  private boolean enqueueMessage(Message msg, long when) {
+    return callInstanceMethod(queue, "enqueueMessage",
+        from(Message.class, msg),
+        from(long.class, when)
+        );    
+  }
+
+  private void removeMessages(Handler handler, int what, Object token) {
+    callInstanceMethod(queue, "removeMessages",
+        from(Handler.class, handler),
+        from(int.class, what),
+        from(Object.class, token)
+        );    
+  }
+  
+  
+  @Test
+  public void enqueueMessage_setsHead() {
+    enqueueMessage(testMessage, 100);
+    assertThat(shadowQueue.getHead()).as("head").isSameAs(testMessage);
+  }
+
+  @Test
+  public void enqueueMessage_returnsTrue() {
+    assertThat(enqueueMessage(testMessage, 100)).as("retval").isTrue();
+  }
+
+  public void enqueueMessage_setsWhen() {
+    enqueueMessage(testMessage, 123);
+    assertThat(testMessage.getWhen()).as("when").isEqualTo(123);
+  }
+  
+  @Test
+  public void enqueueMessage_returnsFalse_whenQuitting() {
+    setField(queue, "mQuitting", true);
+    assertThat(enqueueMessage(testMessage, 1)).as("enqueueMessage()").isFalse();
+  }
+  
+  @Test
+  public void enqueueMessage_doesntSchedule_whenQuitting() {
+    setField(queue, "mQuitting", true);
+    enqueueMessage(testMessage, 1);
+    assertThat(scheduler.size()).as("scheduler_size").isEqualTo(0);
+  }
+  
+  @Test
+  public void enqueuedMessage_isSentToHandler() {
+    enqueueMessage(testMessage, 200);
+    scheduler.advanceTo(199);
+    assertThat(handler.handled).as("handled:before").isEmpty();
+    scheduler.advanceTo(200);
+    assertThat(handler.handled).as("handled:after").containsExactly(testMessage);
+  }
+  
+  @Test
+  public void removedMessage_isNotSentToHandler() {
+    enqueueMessage(testMessage, 200);
+    assertThat(scheduler.size()).as("scheduler size:before").isEqualTo(1);
+    removeMessages(handler, testMessage.what, null);
+    scheduler.advanceToLastPostedRunnable();
+    assertThat(scheduler.size()).as("scheduler size:after").isEqualTo(0);
+    assertThat(handler.handled).as("handled").isEmpty();
+  }
+
+  @Test
+  public void enqueueMessage_withZeroWhen_postsAtFront() {
+    enqueueMessage(testMessage, 0);
+    Message m2 = handler.obtainMessage(2);
+    enqueueMessage(m2, 0);
+    scheduler.advanceToLastPostedRunnable();
+    assertThat(handler.handled).as("handled").containsExactly(m2, testMessage);
+  }
+  
+  @Test
+  @Config(emulateSdk = 19)
+  public void dispatchedMessage_isMarkedInUse_andRecycled_19() {
+    dispatchedMessage_isMarkedInUse_andRecycled();
+  }
+
+  @Test
+  @Config(emulateSdk = 21)
+  public void dispatchedMessage_isMarkedInUse_andRecycled_21() {
+    dispatchedMessage_isMarkedInUse_andRecycled();
+  }
+
+  private void dispatchedMessage_isMarkedInUse_andRecycled() {
+    Handler handler = new Handler() {
+      @Override
+      public void handleMessage(Message msg) {
+        boolean inUse = callInstanceMethod(msg, "isInUse");
+        assertThat(inUse).as(msg.what + ":inUse").isTrue();
+        Message next = getField(msg, "next");
+        assertThat(next).as(msg.what + ":next").isNull();
+      }
+    };
+    Message msg = handler.obtainMessage(1);
+    enqueueMessage(msg, 200);
+    Message msg2 = handler.obtainMessage(2);
+    enqueueMessage(msg2, 205);
+    scheduler.advanceToNextPostedRunnable();
+    
+    // Check that it's been properly recycled.
+    assertThat(msg.what).as("msg.what").isZero();
+    
+    scheduler.advanceToNextPostedRunnable();
+
+    assertThat(msg2.what).as("msg2.what").isZero();
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageTest.java
@@ -3,12 +3,17 @@ package org.robolectric.shadows;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
+import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.Scheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
+import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ShadowMessageTest {
@@ -159,5 +164,67 @@ public class ShadowMessageTest {
     Handler h = new Handler();
     Message.obtain(h, 123).sendToTarget();
     assertTrue(h.hasMessages(123));
+  }
+  
+  @Test
+  public void testSetGetNext() {
+    Message msg = Message.obtain();
+    Message msg2 = Message.obtain();
+    ShadowMessage sMsg = shadowOf(msg);
+    sMsg.setNext(msg2);
+    assertThat(sMsg.getNext()).isSameAs(msg2);
+  }
+  
+  @Test
+  public void testIsInUse() {
+    ShadowLooper.pauseMainLooper();
+    Handler h = new Handler();
+    Message msg = Message.obtain(h, 123);
+    ShadowMessage sMsg = shadowOf(msg);
+    assertThat(sMsg.isInUse()).isFalse();
+    msg.sendToTarget();
+    assertThat(sMsg.isInUse()).isTrue();
+  }
+  
+  @Test
+  @Config(emulateSdk=19)
+  public void recycle_shouldInvokeRealObject19() {
+    recycle_shouldInvokeRealObject("recycle");
+  }
+
+  @Test
+  @Config(emulateSdk=21)
+  public void recycle_shouldInvokeRealObject21() {
+    recycle_shouldInvokeRealObject("recycleUnchecked");
+  }
+  
+  private void recycle_shouldInvokeRealObject(String recycleMethod) {
+    Handler h = new Handler();
+    Message msg = Message.obtain(h, 234);
+    ReflectionHelpers.callInstanceMethod(msg, recycleMethod);
+    assertThat(msg.what).isZero();
+  }
+  
+  @Test
+  @Config(emulateSdk=19)
+  public void recycle_shouldRemoveMessageFromScheduler19() {
+    recycle_shouldRemoveMessageFromScheduler();
+  }
+  
+  @Test
+  @Config(emulateSdk=21)
+  public void recycle_shouldRemoveMessageFromScheduler21() {
+    recycle_shouldRemoveMessageFromScheduler();
+  }
+  
+  private void recycle_shouldRemoveMessageFromScheduler() {
+    ShadowLooper.pauseMainLooper();
+    Handler h = new Handler();
+    Message msg = Message.obtain(h, 234);
+    msg.sendToTarget();
+    Scheduler scheduler = ShadowLooper.getUiThreadScheduler();
+    assertThat(scheduler.enqueuedTaskCount()).as("before recycle").isEqualTo(1);
+    shadowOf(msg).recycleUnchecked();
+    assertThat(scheduler.enqueuedTaskCount()).as("after recycle").isEqualTo(0);    
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMessengerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMessengerTest.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import android.os.Handler;
 import android.os.Message;
 import android.os.Messenger;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
@@ -23,7 +24,7 @@ public class ShadowMessengerTest {
     messenger.send(msg);
 
     assertTrue(handler.hasMessages(123));
-    ShadowHandler.runMainLooperOneTask();
+    ShadowLooper.runMainLooperOneTask();
     assertFalse(handler.hasMessages(123));
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSslErrorHandlerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSslErrorHandlerTest.java
@@ -1,6 +1,7 @@
 package org.robolectric.shadows;
 
 import android.webkit.SslErrorHandler;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,11 +21,6 @@ public class ShadowSslErrorHandlerTest {
   public void setUp() throws Exception {
     handler = Shadow.newInstanceOf(SslErrorHandler.class);
     shadow = Shadows.shadowOf(handler);
-  }
-
-  @Test
-  public void shouldInheritFromShadowHandler() {
-    assertThat(shadow).isInstanceOf(ShadowHandler.class);
   }
 
   @Test


### PR DESCRIPTION
Started as a requirement for `ShadowHandler`'s `remove()` functionality to work better.

`ShadowHandler` attempted to emulate the message queuing of Android. Unfortunately it did so imperfectly, with problems including:

* `removeCallbacksAndMessages()` only removed messages and not callbacks.
* It didn't honour tags on callbacks (posted `Runnable`s) - only on messages.
* `Handler`s connected to the same `Looper` in Android are isolated from each other - doing a remove on one `Handler` instance will not interfere with the messages associated with a different `Handler` even if they have the same tags. The previous `ShadowHandler` implementation didn't honour this (eg, `removeCallbacksAndMessages()` would remove all callbacks for all handlers associated with the same looper).

When I looked at trying to add this functionality to the `ShadowHandler` I realised I would basically be reinventing the Android implementation of `MessageQueue` for most of it. Hence `ShadowMessageQueue` was born, which basically only needs to reimplement one method to interface it with the `Scheduler`.

I kept most of `ShadowHandlerTest` as a regression test to make sure that no existing functionality was broken. Added a couple of more tests to ensure that the broken functionality mentioned above was fixed.

I also kept `ShadowHandler` only because of the static methods (which client code might be using). This could be removed completely in a later revision.