### PR TITLE
LocalDependencyResolver needs to consider the classifier

### DIFF
--- a/robolectric/src/main/java/org/robolectric/LocalDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/LocalDependencyResolver.java
@@ -1,6 +1,8 @@
 package org.robolectric;
 
 import java.io.File;
+import java.lang.String;
+import java.lang.StringBuilder;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -14,11 +16,20 @@ public class LocalDependencyResolver implements DependencyResolver {
 
   @Override
   public URL getLocalArtifactUrl(DependencyJar dependency) {
-    String filename = dependency.getArtifactId() + "-" +
-        dependency.getVersion() + "." +
-        dependency.getType();
+    StringBuilder filenameBuilder = new StringBuilder();
+    filenameBuilder.append(dependency.getArtifactId())
+        .append("-")
+        .append(dependency.getVersion());
 
-    return fileToUrl(validateFile(new File(offlineJarDir, filename)));
+    if (dependency.getClassifier() != null) {
+      filenameBuilder.append("-")
+          .append(dependency.getClassifier());
+    }
+
+    filenameBuilder.append(".")
+        .append(dependency.getType());
+
+    return fileToUrl(validateFile(new File(offlineJarDir, filenameBuilder.toString())));
   }
 
   @Override

--- a/robolectric/src/main/java/org/robolectric/MavenDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/MavenDependencyResolver.java
@@ -32,7 +32,9 @@ public class MavenDependencyResolver implements DependencyResolver {
       dependency.setGroupId(dependencyJar.getGroupId());
       dependency.setType(dependencyJar.getType());
       dependency.setVersion(dependencyJar.getVersion());
-      dependency.setClassifier(dependencyJar.getClassifier());
+      if (dependencyJar.getClassifier() != null) {
+        dependency.setClassifier(dependencyJar.getClassifier());
+      }
       dependenciesTask.addDependency(dependency);
     }
     dependenciesTask.execute();
@@ -61,7 +63,7 @@ public class MavenDependencyResolver implements DependencyResolver {
 
   private String key(DependencyJar dependency) {
     String key = dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + dependency.getType();
-    if(!dependency.getClassifier().isEmpty()) {
+    if(dependency.getClassifier() != null) {
       key += ":" + dependency.getClassifier();
     }
     return key;

--- a/robolectric/src/main/java/org/robolectric/SdkConfig.java
+++ b/robolectric/src/main/java/org/robolectric/SdkConfig.java
@@ -33,15 +33,15 @@ public class SdkConfig {
   }
 
   public DependencyJar getSystemResourceDependency() {
-    return createDependency("org.robolectric", "android-all", artifactVersionString, "");
+    return createDependency("org.robolectric", "android-all", artifactVersionString, null);
   }
 
   public DependencyJar[] getSdkClasspathDependencies() {
     return new DependencyJar[] {
-        createDependency("org.robolectric", "android-all", artifactVersionString, ""),
+        createDependency("org.robolectric", "android-all", artifactVersionString, null),
         createDependency("org.robolectric", "shadows-core", "3.0-SNAPSHOT", Integer.toString(apiLevel)),
-        createDependency("org.json", "json", "20080701", ""),
-        createDependency("org.ccil.cowan.tagsoup", "tagsoup", "1.2", "")
+        createDependency("org.json", "json", "20080701", null),
+        createDependency("org.ccil.cowan.tagsoup", "tagsoup", "1.2", null)
     };
   }
 


### PR DESCRIPTION
We must consider the classifier when loading jars (since shadows are loaded based on android version).

Make null the unset value rather than empty string.
