### PR TITLE
Remove dependency on com.google.android.collect.Lists from BroadcastReceiverData

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/manifest/BroadcastReceiverData.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/BroadcastReceiverData.java
@@ -1,7 +1,7 @@
 package org.robolectric.manifest;
 
+import java.util.ArrayList;
 import java.util.List;
-import com.google.android.collect.Lists;
 
 public class BroadcastReceiverData {
   private final String className;
@@ -9,7 +9,7 @@ public class BroadcastReceiverData {
   private final List<String> actions;
 
   public BroadcastReceiverData(String className, MetaData metaData) {
-    this.actions = Lists.newArrayList();
+    this.actions = new ArrayList<>();
     this.className = className;
     this.metaData = metaData;
   }


### PR DESCRIPTION
These classes are now obsolete since the diamond operator plus the Robolectric framework really shouldn't be depending on AOSP code for its implementation.

This causes a java.lang.NoClassDefFoundError: com/google/android/collect/Lists error if the manifest is parsed early outside of a context using Robolectrics AOSP classloader.

Note: We parse the manifest early as our build system requires us to reconcile ids across all library projects with resources in the transative build closure.
