### PR TITLE
Rename setup() and setupActivity() to launch() and launchActivity().

### DIFF
--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -38,8 +38,8 @@ public class Robolectric {
     return ActivityController.of(shadowsAdapter, activityClass);
   }
 
-  public static <T extends Activity> T setupActivity(Class<T> activityClass) {
-    return ActivityController.of(shadowsAdapter, activityClass).setup().get();
+  public static <T extends Activity> T launchActivity(Class<T> activityClass) {
+    return ActivityController.of(shadowsAdapter, activityClass).launch().get();
   }
 
   private static ShadowsAdapter instantiateShadowsAdapter() {

--- a/robolectric/src/main/java/org/robolectric/util/ActivityController.java
+++ b/robolectric/src/main/java/org/robolectric/util/ActivityController.java
@@ -198,7 +198,7 @@ public class ActivityController<T extends Activity> extends ComponentController<
    *
    * @return Activity controller instance.
    */
-  public ActivityController<T> setup() {
+  public ActivityController<T> launch() {
     return create().start().postCreate(null).resume().visible();
   }
 
@@ -208,7 +208,7 @@ public class ActivityController<T extends Activity> extends ComponentController<
    * @param savedInstanceState Saved instance state.
    * @return Activity controller instance.
    */
-  public ActivityController<T> setup(Bundle savedInstanceState) {
+  public ActivityController<T> launch(Bundle savedInstanceState) {
     return create(savedInstanceState)
         .start()
         .restoreInstanceState(savedInstanceState)

--- a/robolectric/src/main/java/org/robolectric/util/FragmentTestUtil.java
+++ b/robolectric/src/main/java/org/robolectric/util/FragmentTestUtil.java
@@ -32,7 +32,7 @@ public final class FragmentTestUtil {
   }
 
   private static FragmentManager buildFragmentManager(Class<? extends Activity> activityClass) {
-    Activity activity = Robolectric.setupActivity(activityClass);
+    Activity activity = Robolectric.launchActivity(activityClass);
     return activity.getFragmentManager();
   }
 

--- a/robolectric/src/test/java/org/robolectric/RobolectricTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTest.java
@@ -129,8 +129,8 @@ public class RobolectricTest {
   }
 
   @Test
-  public void setupActivity_returnsAVisibleActivity() throws Exception {
-    LifeCycleActivity activity = Robolectric.setupActivity(LifeCycleActivity.class);
+  public void launchActivity_returnsAVisibleActivity() throws Exception {
+    LifeCycleActivity activity = Robolectric.launchActivity(LifeCycleActivity.class);
 
     assertThat(activity.isCreated()).isTrue();
     assertThat(activity.isStarted()).isTrue();

--- a/robolectric/src/test/java/org/robolectric/res/PreferenceIntegrationTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/PreferenceIntegrationTest.java
@@ -119,7 +119,7 @@ public class PreferenceIntegrationTest {
   }
 
   private PreferenceScreen inflatePreferenceActivity() {
-    TestPreferenceActivity activity = Robolectric.setupActivity(TestPreferenceActivity.class);
+    TestPreferenceActivity activity = Robolectric.launchActivity(TestPreferenceActivity.class);
     return activity.getPreferenceScreen();
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
@@ -456,7 +456,7 @@ public class ShadowActivityTest {
 
   @Test
   public void onKeyUp_callsOnBackPressedWhichFinishesTheActivity() throws Exception {
-    OnBackPressedActivity activity = buildActivity(OnBackPressedActivity.class).setup().get();
+    OnBackPressedActivity activity = buildActivity(OnBackPressedActivity.class).launch().get();
     boolean downConsumed =
         activity.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK));
     boolean upConsumed =

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDialogPreferenceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDialogPreferenceTest.java
@@ -28,7 +28,7 @@ public class ShadowDialogPreferenceTest {
   }
 
   private PreferenceScreen inflatePreferenceActivity() {
-    PreferenceActivity activity = Robolectric.setupActivity(TestPreferenceActivity.class);
+    PreferenceActivity activity = Robolectric.launchActivity(TestPreferenceActivity.class);
     return activity.getPreferenceScreen();
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPreferenceActivityTestWithFragment.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPreferenceActivityTestWithFragment.java
@@ -22,7 +22,7 @@ import org.robolectric.TestRunners;
  */
 @RunWith(TestRunners.WithDefaults.class)
 public class ShadowPreferenceActivityTestWithFragment {
-  private TestPreferenceActivity activity = Robolectric.setupActivity(TestPreferenceActivity.class);
+  private TestPreferenceActivity activity = Robolectric.launchActivity(TestPreferenceActivity.class);
   private TestPreferenceFragment fragment;
   private static final String FRAGMENT_TAG = "fragmentPreferenceTag";
 

--- a/robolectric/src/test/java/org/robolectric/util/ActivityControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/ActivityControllerTest.java
@@ -167,15 +167,15 @@ public class ActivityControllerTest {
   }
 
   @Test
-  public void setup_callsLifecycleMethodsAndMakesVisible() {
-    controller.setup();
+  public void launch_callsLifecycleMethodsAndMakesVisible() {
+    controller.launch();
     transcript.assertEventsInclude("onCreate", "onStart", "onPostCreate", "onResume", "onPostResume");
     assertEquals(controller.get().getWindow().getDecorView().getParent().getClass().getName(), "android.view.ViewRootImpl");
   }
 
   @Test
-  public void setupWithBundle_callsLifecycleMethodsAndMakesVisible() {
-    controller.setup(new Bundle());
+  public void launchWithBundle_callsLifecycleMethodsAndMakesVisible() {
+    controller.launch(new Bundle());
     transcript.assertEventsInclude("onCreate", "onStart", "onRestoreInstanceState", "onPostCreate", "onResume", "onPostResume");
     assertEquals(controller.get().getWindow().getDecorView().getParent().getClass().getName(), "android.view.ViewRootImpl");
   }


### PR DESCRIPTION
Since it looks like you're making lots of breaking API changes for 3.0...
A humble request to rename these two methods, I find "launch" to be more descriptive of what they do than "setup".