### PR TITLE
Replace SQL having Collate Localized/Unicode phrase with collate nocase

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSQLiteConnection.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSQLiteConnection.java
@@ -18,9 +18,15 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Implements(value = android.database.sqlite.SQLiteConnection.class, isInAndroidSdk = false)
 public class ShadowSQLiteConnection {
+
+  private static final Pattern COLLATE_LOCALIZED_UNICODE_PATTERN =
+          Pattern.compile("\\s+COLLATE\\s+(LOCALIZED|UNICODE)", Pattern.CASE_INSENSITIVE);
+
   private static final String IN_MEMORY_PATH = ":memory:";
   private static final Connections CONNECTIONS = new Connections();
 
@@ -52,7 +58,16 @@ public class ShadowSQLiteConnection {
 
   @Implementation // TODO: Handle API 21 int -> long changes
   public static long nativePrepareStatement(long connectionPtr, String sql) {
-    return CONNECTIONS.prepareStatement(connectionPtr, sql);
+    final String newSql = convertSQLWithLocalizedUnicodeCollator(sql);
+    return CONNECTIONS.prepareStatement(connectionPtr, newSql);
+  }
+
+  /**
+   * Convert SQL with phrase COLLATE LOCALIZED or COLLATE UNICODE to COLLATE NOCASE.
+   */
+  static String convertSQLWithLocalizedUnicodeCollator(String sql) {
+    Matcher matcher = COLLATE_LOCALIZED_UNICODE_PATTERN.matcher(sql);
+    return matcher.replaceAll(" COLLATE NOCASE");
   }
 
   @Implementation // TODO: Handle API 21 int -> long changes
@@ -297,6 +312,7 @@ public class ShadowSQLiteConnection {
 
   // TODO: Handle API 21 int -> long changes
   private static class Connections {
+
     private final AtomicLong pointerCounter = new AtomicLong(0);
     private final Map<Long, SQLiteStatement> statementsMap = new ConcurrentHashMap<Long, SQLiteStatement>();
     private final Map<Long, SQLiteConnection> connectionsMap = new ConcurrentHashMap<Long, SQLiteConnection>();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSQLiteConnectionTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSQLiteConnectionTest.java
@@ -1,0 +1,84 @@
+package org.robolectric.shadows;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteStatement;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.TestRunners;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.shadows.ShadowSQLiteConnection.convertSQLWithLocalizedUnicodeCollator;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class ShadowSQLiteConnectionTest {
+  private SQLiteDatabase database;
+
+  @Before
+  public void setUp() throws Exception {
+    database = SQLiteDatabase.openOrCreateDatabase(RuntimeEnvironment.application.getDatabasePath("path").getPath(), null);
+    SQLiteStatement createStatement = database.compileStatement(
+        "CREATE TABLE `routine` (`id` INTEGER PRIMARY KEY AUTOINCREMENT , `name` VARCHAR , `lastUsed` INTEGER DEFAULT 0 ,  UNIQUE (`name`)) ;");
+    createStatement.execute();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    database.close();
+  }
+
+  @Test
+  public void testSqlConversion() {
+
+    assertThat(convertSQLWithLocalizedUnicodeCollator("select * from `routine`"))
+        .isEqualTo("select * from `routine`");
+
+    assertThat(convertSQLWithLocalizedUnicodeCollator(
+        "select * from `routine` order by name \n\r \f collate\f\n\tunicode"
+        + "\n, id \n\n\t collate\n\t \n\flocalized"))
+        .isEqualTo("select * from `routine` order by name COLLATE NOCASE\n"
+            + ", id COLLATE NOCASE");
+
+    assertThat(convertSQLWithLocalizedUnicodeCollator("select * from `routine` order by name collate localized"))
+        .isEqualTo("select * from `routine` order by name COLLATE NOCASE");
+
+    assertThat(convertSQLWithLocalizedUnicodeCollator("select * from `routine` order by name collate unicode"))
+        .isEqualTo("select * from `routine` order by name COLLATE NOCASE");
+  }
+
+  @Test
+  public void testSQLWithLocalizedOrUnicodeCollatorShouldBeSortedAsNoCase() throws Exception {
+    database.execSQL("insert into routine(name) values ('الصحافة اليدوية')");
+    database.execSQL("insert into routine(name) values ('Hand press 1')");
+    database.execSQL("insert into routine(name) values ('hand press 2')");
+    database.execSQL("insert into routine(name) values ('Hand press 3')");
+
+    List<String> expected = Arrays.asList("Hand press 1", "hand press 2", "Hand press 3", "الصحافة اليدوية" );
+    String sqlLocalized = "SELECT `name` FROM `routine` ORDER BY `name` collate localized";
+    String sqlUnicode = "SELECT `name` FROM `routine` ORDER BY `name` collate unicode";
+
+    assertThat(simpleQueryForList(database, sqlLocalized)).isEqualTo(expected);
+    assertThat(simpleQueryForList(database, sqlUnicode)).isEqualTo(expected);
+  }
+
+  private List<String> simpleQueryForList(SQLiteDatabase db, String sql) {
+    Cursor cursor = db.rawQuery(sql, new String[0]);
+
+    List<String> result = new ArrayList<String>();
+    while (cursor.moveToNext()) {
+      result.add(cursor.getString(0));
+    }
+
+    cursor.close();
+
+    return result;
+  }
+
+}


### PR DESCRIPTION
This is a workaround for issue #1230 where it replace collate localized (or collate unicode) with collate nocase so that the test can work at least for ascii test data.

There is another more complex approach where we can pull sqlite from android that supports COLLATE LOCALIZED and COLLATE UNICODE natively and incorporate that in Robolectric.