### PR TITLE
Enabling checkPermmissions method and enabling querying broadcast receivers through Robolectric package manager

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -199,6 +199,10 @@ public class AndroidManifest {
             receiver.addAction(nameNode.getTextContent());
           }
         }
+        Node permissionItem = receiverNode.getAttributes().getNamedItem("android:permission");
+        if (permissionItem != null) {
+          receiver.setPermission(permissionItem.getTextContent());
+        }
       }
       receivers.add(receiver);
     }
@@ -597,6 +601,11 @@ public class AndroidManifest {
   public List<BroadcastReceiverData> getBroadcastReceivers() {
     parseAndroidManifest();
     return receivers;
+  }
+
+  public String getReceiverPermission(final int receiverIndex) {
+    parseAndroidManifest();
+    return receivers.get(receiverIndex).getPermission();
   }
 
   private static String getTagAttributeText(final Document doc, final String tag, final String attribute) {

--- a/robolectric-resources/src/main/java/org/robolectric/manifest/BroadcastReceiverData.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/BroadcastReceiverData.java
@@ -7,6 +7,8 @@ public class BroadcastReceiverData {
   private final String className;
   private final MetaData metaData;
   private final List<String> actions;
+  private String permission;
+
 
   public BroadcastReceiverData(String className, MetaData metaData) {
     this.actions = new ArrayList<>();
@@ -28,5 +30,13 @@ public class BroadcastReceiverData {
 
   public void addAction(String action) {
     this.actions.add(action);
+  }
+
+  public void setPermission(final String permission) {
+    this.permission = permission;
+  }
+
+  public String getPermission() {
+    return permission;
   }
 }

--- a/robolectric-resources/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
@@ -73,6 +73,8 @@ public interface RobolectricPackageManager {
 
   Drawable getDrawable(String packageName, int resourceId, ApplicationInfo applicationInfo);
 
+  int checkPermission(String permName, String pkgName);
+
   boolean isQueryIntentImplicitly();
 
   void setQueryIntentImplicitly(boolean queryIntentImplicitly);

--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -6,6 +6,7 @@ import android.content.IntentFilter;
 import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.content.pm.ProviderInfo;
 import android.content.pm.ResolveInfo;
 import android.graphics.drawable.Drawable;
@@ -571,6 +572,20 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
   @Override
   public void setQueryIntentImplicitly(boolean queryIntentImplicitly) {
     this.queryIntentImplicitly = queryIntentImplicitly;
+  }
+
+  @Override
+  public int checkPermission(String permName, String pkgName) {
+    PackageInfo permissionsInfo = packageInfos.get(pkgName);
+    if (permissionsInfo == null) {
+      return PackageManager.PERMISSION_DENIED;
+    }
+    for (String permission : permissionsInfo.requestedPermissions) {
+      if (permission != null && permission.toString().equals(permName)) {
+        return PackageManager.PERMISSION_GRANTED;
+      }
+    }
+    return PackageManager.PERMISSION_DENIED;
   }
 
   /***

--- a/robolectric/src/test/java/org/robolectric/AndroidManifestTest.java
+++ b/robolectric/src/test/java/org/robolectric/AndroidManifestTest.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import org.junit.Rule;
 import org.junit.Test;
@@ -71,7 +72,7 @@ public class AndroidManifestTest {
   @Test
   public void parseManifest_shouldReadBroadcastReceivers() throws Exception {
     AndroidManifest config = newConfig("TestAndroidManifestWithReceivers.xml");
-    assertThat(config.getBroadcastReceivers()).hasSize(7);
+    assertThat(config.getBroadcastReceivers()).hasSize(8);
 
     assertThat(config.getBroadcastReceivers().get(0).getClassName()).isEqualTo("org.robolectric.AndroidManifestTest.ConfigTestReceiver");
     assertThat(config.getBroadcastReceivers().get(0).getActions()).contains("org.robolectric.ACTION1", "org.robolectric.ACTION2");
@@ -93,6 +94,15 @@ public class AndroidManifestTest {
 
     assertThat(config.getBroadcastReceivers().get(6).getClassName()).isEqualTo("com.bar.ReceiverWithoutIntentFilter");
     assertThat(config.getBroadcastReceivers().get(6).getActions()).isEmpty();
+
+    assertThat(config.getBroadcastReceivers().get(7).getClassName()).isEqualTo("org.robolectric.ConfigTestReceiverPermissionsAndActions");
+    assertThat(config.getBroadcastReceivers().get(7).getActions()).contains("org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testManifestWithNoApplicationElement() throws Exception {
+    AndroidManifest config = newConfig("TestAndroidManifestNoApplicationElement.xml");
+    config.parseAndroidManifest();
   }
 
   @Test
@@ -141,6 +151,16 @@ public class AndroidManifestTest {
 
     metaValue = meta.get("org.robolectric.metaStringRes");
     assertEquals("@string/app_name", metaValue);
+  }
+
+  @Test
+  public void shouldReadBroadcastReceiverPermissions() throws Exception {
+    AndroidManifest config = newConfig("TestAndroidManifestWithReceivers.xml");
+
+    assertThat(config.getBroadcastReceivers().get(7).getClassName()).isEqualTo("org.robolectric.ConfigTestReceiverPermissionsAndActions");
+    assertThat(config.getBroadcastReceivers().get(7).getActions()).contains("org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE");
+
+    assertEquals("org.robolectric.CUSTOM_PERM", config.getReceiverPermission(7));
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/ConfigTestReceiverPermissionsAndActions.java
+++ b/robolectric/src/test/java/org/robolectric/ConfigTestReceiverPermissionsAndActions.java
@@ -1,0 +1,11 @@
+package org.robolectric;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class ConfigTestReceiverPermissionsAndActions extends BroadcastReceiver {
+  @Override
+  public void onReceive(Context context, Intent intent) {
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
+++ b/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
@@ -63,7 +63,7 @@ public class DefaultTestLifecycleTest {
     shadowOf(application).bind(appManifest, null);
 
     List<ShadowApplication.Wrapper> receivers = shadowOf(application).getRegisteredReceivers();
-    assertThat(receivers.size()).isEqualTo(5);
+    assertThat(receivers.size()).isEqualTo(6);
     assertTrue(receivers.get(0).intentFilter.matchAction("org.robolectric.ACTION1"));
   }
 

--- a/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
@@ -357,6 +357,52 @@ public class DefaultRobolectricPackageManagerTest {
   }
 
   @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithReceivers.xml")
+  public void testQueryBroadcastReceiverSucceeds() {
+    Intent intent = new Intent("org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE");
+    intent.setPackage(RuntimeEnvironment.application.getPackageName());
+
+    List<ResolveInfo> receiverInfos = rpm.queryBroadcastReceivers(intent, PackageManager.GET_INTENT_FILTERS);
+    assertTrue(receiverInfos.size() == 1);
+    assertEquals("org.robolectric.ConfigTestReceiverPermissionsAndActions", receiverInfos.get(0).activityInfo.name);
+    assertEquals("org.robolectric.CUSTOM_PERM", receiverInfos.get(0).activityInfo.permission);
+    assertEquals("org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE", receiverInfos.get(0).filter.getAction(0));
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithReceivers.xml")
+  public void testQueryBroadcastReceiverFailsForMissingPackageName() {
+    Intent intent = new Intent("org.robolectric.ACTION_ONE_MORE_PACKAGE");
+    List<ResolveInfo> receiverInfos = rpm.queryBroadcastReceivers(intent, PackageManager.GET_INTENT_FILTERS);
+    assertTrue(receiverInfos.size() == 0);
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithReceivers.xml")
+  public void testQueryBroadcastReceiverFailsForMissingAction() {
+    Intent intent = new Intent();
+    intent.setPackage(RuntimeEnvironment.application.getPackageName());
+    List<ResolveInfo> receiverInfos = rpm.queryBroadcastReceivers(intent, PackageManager.GET_INTENT_FILTERS);
+    assertTrue(receiverInfos.size() == 0);
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithReceiversCustomPackage.xml")
+  public void testGetPackageInfo_ForReceiversSucceeds() throws Exception {
+    PackageInfo receiverInfos = rpm.getPackageInfo(RuntimeEnvironment.application.getPackageName(), PackageManager.GET_RECEIVERS);
+
+    assertEquals(1, receiverInfos.receivers.length);
+    assertEquals("org.robolectric.ConfigTestReceiverPermissionsAndActions", receiverInfos.receivers[0].name);
+    assertEquals("org.robolectric.CUSTOM_PERM", receiverInfos.receivers[0].permission);
+  }
+
+  @Test(expected = PackageManager.NameNotFoundException.class)
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithReceiversCustomPackage.xml")
+  public void testGetPackageInfo_ForReceiversIncorrectPackage() throws Exception {
+    PackageInfo receiverInfos = rpm.getPackageInfo("unknown_package", PackageManager.GET_RECEIVERS);
+  }
+
+  @Test
   @Config(manifest = "src/test/resources/TestAndroidManifestWithPermissions.xml")
   public void getPackageInfo_shouldReturnRequestedPermissions() throws Exception {
     PackageInfo packageInfo = rpm.getPackageInfo(RuntimeEnvironment.application.getPackageName(), PackageManager.GET_PERMISSIONS);

--- a/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -348,6 +347,17 @@ public class DefaultRobolectricPackageManagerTest {
 
   @Test
   @Config(manifest = "src/test/resources/TestAndroidManifestWithPermissions.xml")
+  public void testCheckPermissions() throws Exception {
+    assertEquals(PackageManager.PERMISSION_GRANTED, rpm.checkPermission("android.permission.INTERNET", RuntimeEnvironment.application.getPackageName()));
+    assertEquals(PackageManager.PERMISSION_GRANTED, rpm.checkPermission("android.permission.SYSTEM_ALERT_WINDOW", RuntimeEnvironment.application.getPackageName()));
+    assertEquals(PackageManager.PERMISSION_GRANTED, rpm.checkPermission("android.permission.GET_TASKS", RuntimeEnvironment.application.getPackageName()));
+
+    assertEquals(PackageManager.PERMISSION_DENIED, rpm.checkPermission("android.permission.ACCESS_FINE_LOCATION", RuntimeEnvironment.application.getPackageName()));
+    assertEquals(PackageManager.PERMISSION_DENIED, rpm.checkPermission("android.permission.ACCESS_FINE_LOCATION", "random-package"));
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithPermissions.xml")
   public void getPackageInfo_shouldReturnRequestedPermissions() throws Exception {
     PackageInfo packageInfo = rpm.getPackageInfo(RuntimeEnvironment.application.getPackageName(), PackageManager.GET_PERMISSIONS);
     String[] permissions = packageInfo.requestedPermissions;
@@ -503,7 +513,6 @@ public class DefaultRobolectricPackageManagerTest {
     resolveInfo.activityInfo.packageName = TEST_PACKAGE_LABEL;
     resolveInfo.activityInfo.name = "LauncherActivity";
     RuntimeEnvironment.getRobolectricPackageManager().addResolveInfoForIntent(intent1, resolveInfo);
-    
     // the original intent object should yield a result
     ResolveInfo result  = rpm.resolveActivity(intent1, -1);
     assertThat(result).isNotNull();

--- a/robolectric/src/test/resources/TestAndroidManifestWithReceivers.xml
+++ b/robolectric/src/test/resources/TestAndroidManifestWithReceivers.xml
@@ -59,5 +59,11 @@
     </receiver>
 
     <receiver android:name="com.bar.ReceiverWithoutIntentFilter"/>
+    <receiver android:name="org.robolectric.ConfigTestReceiverPermissionsAndActions"
+        android:permission="org.robolectric.CUSTOM_PERM">
+      <intent-filter>
+        <action android:name="org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE"/>
+      </intent-filter>
+    </receiver>
   </application>
 </manifest>

--- a/robolectric/src/test/resources/TestAndroidManifestWithReceiversCustomPackage.xml
+++ b/robolectric/src/test/resources/TestAndroidManifestWithReceiversCustomPackage.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.robolectric.mypackage">
+  <uses-sdk android:targetSdkVersion="18"/>
+
+  <application>
+    <receiver android:name="org.robolectric.ConfigTestReceiverPermissionsAndActions"
+        android:permission="org.robolectric.CUSTOM_PERM">
+      <intent-filter>
+        <action android:name="org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE"/>
+      </intent-filter>
+    </receiver>
+  </application>
+</manifest>


### PR DESCRIPTION
Enabling querying broadcast receivers through package manger and also checking for permissions.