### PR TITLE
Add a dummy shadow for the MultiDex class loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
     - echo "y" | android update sdk --no-ui --filter addon-google_apis-google-18,extra-android-support
     - ./scripts/install-maps-jar.sh
     - ./scripts/install-support-jar.sh
+    - ./scripts/install-multidex-aar.sh
 
 script:
     - ./scripts/install-robolectric.sh

--- a/robolectric-shadows/pom.xml
+++ b/robolectric-shadows/pom.xml
@@ -14,6 +14,7 @@
   <modules>
     <module>shadows-core</module>
     <module>shadows-maps</module>
+    <module>shadows-multidex</module>
     <module>shadows-support-v4</module>
     <module>shadows-httpclient</module>
   </modules>

--- a/robolectric-shadows/shadows-multidex/pom.xml
+++ b/robolectric-shadows/shadows-multidex/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.robolectric</groupId>
+    <artifactId>robolectric-shadows</artifactId>
+    <version>3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>shadows-multidex</artifactId>
+
+  <dependencies>
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit-dep</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Robolectric Dependencies -->
+    <dependency>
+      <groupId>org.robolectric</groupId>
+      <artifactId>robolectric</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.robolectric</groupId>
+      <artifactId>shadows-core</artifactId>
+      <classifier>${robolectric.api.level}</classifier>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Project Dependencies -->
+    <dependency>
+      <groupId>org.robolectric</groupId>
+      <artifactId>android-all</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.android.support</groupId>
+      <artifactId>multidex</artifactId>
+      <version>1.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.bsc.maven</groupId>
+        <artifactId>maven-processor-plugin</artifactId>
+        <configuration>
+          <additionalSourceDirectories>
+            <sourceDirectory>target/generated-shadows</sourceDirectory>
+          </additionalSourceDirectories>
+          <outputDirectory>target/generated-sources</outputDirectory>
+          <compilerArguments>-source ${maven.compiler.source} -target ${maven.compiler.target} -Aorg.robolectric.annotation.processing.shadowPackage=org.robolectric.support.v4</compilerArguments>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>process</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.robolectric</groupId>
+            <artifactId>robolectric-processor</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/robolectric-shadows/shadows-multidex/src/main/java/org/robolectric/shadows/ShadowMultiDex.java
+++ b/robolectric-shadows/shadows-multidex/src/main/java/org/robolectric/shadows/ShadowMultiDex.java
@@ -1,0 +1,15 @@
+package org.robolectric.shadows;
+
+import android.content.Context;
+import android.support.multidex.MultiDex;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(MultiDex.class)
+public class ShadowMultiDex {
+  @Implementation
+  public static void install(Context context) {
+    // Do nothing since with Robolectric nothing is dexed.
+  }
+}

--- a/scripts/install-multidex-aar.sh
+++ b/scripts/install-multidex-aar.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# This script extracts the Android Support multidex aar and installs the contained jar in your local Maven repository.
+#
+# Usage:
+#   install-multidex-aar.sh
+#
+# Assumptions:
+#  1. You've got one or more Android SDKs installed locally.
+#  2. Your ANDROID_HOME environment variable points to the Android SDK install dir.
+#  3. You have installed the Android Support (compatibility) libraries from the SDK installer.
+
+version=1.0.0
+aarLocation="$ANDROID_HOME/extras/android/m2repository/com/android/support/multidex/$version/multidex-$version.aar"
+if [ ! -f "$aarLocation" ]; then
+  echo "multidex $version artifact not found!"
+  exit 1
+fi
+
+if [ -d "$TMPDIR" ]; then
+    tmpDir=$TMPDIR
+elif [ -d "$TEMP" ]; then
+    tmpDir=$TEMP
+else
+    tmpDir=.
+fi
+
+jarLocation=$tmpDir/classes.jar
+unzip -o $aarLocation classes.jar -d $tmpDir
+
+echo "Installing com.android.support:multidex $version from $jarLocation"
+mvn -q install:install-file -DgroupId=com.android.support -DartifactId=multidex \
+  -Dversion=$version -Dpackaging=jar -Dfile="$jarLocation"
+
+rm $jarLocation
+
+echo "Done!"


### PR DESCRIPTION
This fixes #1328 if the shadow is globally used e.g. by adding

    shadows=org.robolectric.shadows.ShadowMultiDex

to "org.robolectric.Config.properties".