### PR TITLE
Re-added ShadowMessageQueue functionality with static reset

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowHandler.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowHandler.java
@@ -20,240 +20,54 @@ import static org.robolectric.Shadows.shadowOf;
  * separate thread.{@link Runnable}s that are scheduled to be executed immediately can be triggered by calling
  * {@link #idleMainLooper()}.
  * todo: add utility method to advance time and trigger execution of Runnables scheduled for a time in the future
+ * 
+ * @deprecated There is no special shadow implementation for the {@link android.os.Handler} class. The special
+ * handling is all done by {@link ShadowLooper} and {@link ShadowMessageQueue}. This class has been retained
+ * for backward compatibility with the various static method implementations.
  */
-@SuppressWarnings({"UnusedDeclaration"})
+// <b>Note</b>: If this shadow is ever completely removed it will still probably make sense to keep
+// the associated tests - if necessary we can copy them into ShadowLooperTest or ShadowMessageQueueTest.
+@Deprecated
+// Even though it doesn't implement anything, some parts of the system will fail if we don't have the
+// @Implements tag (ShadowWrangler).
 @Implements(Handler.class)
 public class ShadowHandler {
-  @RealObject
-  private Handler realHandler;
-  private Looper looper;
-  private final List<Message> messages = new ArrayList<Message>();
-  private Handler.Callback callback;
-
-  public void __constructor__() {
-    __constructor__(Looper.myLooper(), null);
-  }
-
-  public void __constructor__(Looper looper) {
-    __constructor__(looper, null);
-  }
-
-  public void __constructor__(Handler.Callback callback) {
-    __constructor__(Looper.myLooper(), callback);
-  }
-
-  public void __constructor__(Looper looper, Handler.Callback callback) {
-    this.looper = looper;
-    this.callback = callback;
-  }
-
-  @Implementation
-  public boolean post(Runnable r) {
-    return postDelayed(r, 0);
-  }
-
-  @Implementation
-  public boolean postDelayed(Runnable r, long delayMillis) {
-    return Shadows.shadowOf(looper).post(r, delayMillis);
-  }
-
-  @Implementation
-  public final boolean postAtFrontOfQueue(Runnable runnable) {
-    return Shadows.shadowOf(looper).postAtFrontOfQueue(runnable);
-  }
-
-  @Implementation
-  public Message obtainMessage() {
-    return obtainMessage(0);
-  }
-
-  @Implementation
-  public Message obtainMessage(int what) {
-    return obtainMessage(what, null);
-  }
-
-  @Implementation
-  public Message obtainMessage(int what, Object obj) {
-    return obtainMessage(what, 0, 0, obj);
-  }
-
-  @Implementation
-  public Message obtainMessage(int what, int arg1, int arg2) {
-    return obtainMessage(what, arg1, arg2, null);
-  }
-
-  @Implementation
-  public Message obtainMessage(int what, int arg1, int arg2, Object obj) {
-    Message message = new Message();
-    message.what = what;
-    message.arg1 = arg1;
-    message.arg2 = arg2;
-    message.obj = obj;
-    message.setTarget(realHandler);
-    return message;
-  }
-
-  @Implementation
-  public final boolean sendMessage(final Message msg) {
-    return sendMessageDelayed(msg, 0L);
-  }
-
-  @Implementation
-  public final boolean sendMessageDelayed(final Message msg, long delayMillis) {
-    long when = getCurrentUptimeMillis() + delayMillis;
-    setMessageWhen(msg, when);
-    messages.add(msg);
-    postDelayed(new Runnable() {
-      @Override
-      public void run() {
-        if (messages.contains(msg)) {
-          messages.remove(msg);
-          routeMessage(msg);
-        }
-      }
-    }, delayMillis);
-    return true;
-  }
-
-  private void setMessageWhen(Message msg, long when) {
-    ReflectionHelpers.setField(msg, "when", when);
-  }
-
-  private void routeMessage(Message msg) {
-    if(callback != null) {
-      callback.handleMessage(msg);
-    } else {
-      realHandler.handleMessage(msg);
-    }
-  }
-
-  @Implementation
-  public final boolean sendEmptyMessage(int what) {
-    return sendEmptyMessageDelayed(what, 0L);
-  }
-
-  @Implementation
-  public final boolean sendEmptyMessageDelayed(int what, long delayMillis) {
-    final Message msg = new Message();
-    msg.what = what;
-    return sendMessageDelayed(msg, delayMillis);
-  }
-
-  @Implementation
-  public final boolean sendMessageAtFrontOfQueue(final Message msg) {
-    setMessageWhen(msg, getCurrentUptimeMillis());
-    messages.add(0, msg);
-    postAtFrontOfQueue(new Runnable() {
-      @Override
-      public void run() {
-        if (messages.contains(msg)) {
-          messages.remove(msg);
-          routeMessage(msg);
-        }
-      }
-    });
-    return true;
-  }
-
-  @Implementation
-  public boolean sendMessageAtTime(Message msg, long uptimeMillis) {
-    long delay = uptimeMillis - getCurrentUptimeMillis();
-    sendMessageDelayed(msg, delay);
-    return true;
-  }
-
-  @Implementation
-  public final Looper getLooper() {
-    return looper;
-  }
-
-  @Implementation
-  public final void removeCallbacks(java.lang.Runnable r) {
-    shadowOf(looper).getScheduler().remove(r);
-  }
-
-  @Implementation
-  public final boolean hasMessages(int what) {
-    for (Message message : messages) {
-      if (message.what == what) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  @Implementation
-  public final boolean hasMessages(int what, Object object) {
-    for (Message message : messages) {
-      if(message.what == what && message.obj == object) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-
-  @Implementation
-  public final void removeMessages(int what) {
-    removeMessages(what, null);
-  }
-
-  @Implementation
-  public final void removeMessages(int what, Object object) {
-    for (Iterator<Message> iterator = messages.iterator(); iterator.hasNext(); ) {
-      Message message = iterator.next();
-      if (message.what == what && (object == null || object.equals(message.obj))) {
-        iterator.remove();
-      }
-    }
-  }
-
-  @Implementation
-  public final void removeCallbacksAndMessages(Object object) {
-    for (Iterator<Message> iterator = messages.iterator(); iterator.hasNext(); ) {
-      Message message = iterator.next();
-      if (object == null || object.equals(message.obj)) {
-        iterator.remove();
-      }
-    }
-  }
-
   /**
-   * @deprecated use {@link #idleMainLooper()} instead
+   * @deprecated use {@link ShadowLooper#idleMainLooper()} instead
    */
   public static void flush() {
     idleMainLooper();
   }
 
   /**
-   * @see org.robolectric.shadows.ShadowLooper#idle()
+   * @deprecated
+   * @see org.robolectric.shadows.ShadowLooper#idleMainLooper()
    */
   public static void idleMainLooper() {
-    shadowOf(Looper.myLooper()).idle();
+    ShadowLooper.idleMainLooper();
   }
 
   /**
-   * @see ShadowLooper#runToEndOfTasks() ()
+   * @deprecated
+   * @see ShadowLooper#runUiThreadTasksIncludingDelayedTasks()
    */
   public static void runMainLooperToEndOfTasks() {
-    shadowOf(Looper.myLooper()).runToEndOfTasks();
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
   }
 
   /**
-   * @see ShadowLooper#runOneTask() ()
+   * @deprecated
+   * @see ShadowLooper#runMainLooperOneTask() ()
    */
   public static void runMainLooperOneTask() {
     shadowOf(Looper.myLooper()).runOneTask();
   }
 
   /**
-   * @see ShadowLooper#runToNextTask() ()
+   * @deprecated
+   * @see ShadowLooper#runMainLooperToNextTask() ()
    */
   public static void runMainLooperToNextTask() {
     shadowOf(Looper.myLooper()).runToNextTask();
-  }
-
-  private long getCurrentUptimeMillis() {
-    return shadowOf(looper).getScheduler().getCurrentTime();
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
@@ -12,13 +12,15 @@ import org.robolectric.util.Scheduler;
 import org.robolectric.util.SoftThreadLocal;
 
 import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 /**
  * Shadow for {@code Looper} that enqueues posted {@link Runnable}s to be run (on this thread) later. {@code Runnable}s
  * that are scheduled to run immediately can be triggered by calling {@link #idle()}
  * todo: provide better support for advancing the clock and running queued tasks
+ *
+ * @see ShadowMessageQueue
  */
-@SuppressWarnings({"UnusedDeclaration"})
 @Implements(Looper.class)
 public class ShadowLooper {
   private static final Thread MAIN_THREAD = Thread.currentThread();
@@ -38,7 +40,7 @@ public class ShadowLooper {
   }
 
   private static Looper createLooper() {
-    return ReflectionHelpers.callConstructor(Looper.class);
+    return ReflectionHelpers.callConstructor(Looper.class, from(boolean.class, Thread.currentThread() != MAIN_THREAD));
   }
 
   @Resetter
@@ -81,10 +83,6 @@ public class ShadowLooper {
 
   public static Scheduler getUiThreadScheduler() {
     return shadowOf(Looper.getMainLooper()).getScheduler();
-  }
-
-  @HiddenApi
-  public void __constructor__() {
   }
 
   private void doLoop() {
@@ -146,15 +144,26 @@ public class ShadowLooper {
     unPauseLooper(Looper.getMainLooper());
   }
 
+  public static void idleMainLooper() {
+    shadowOf(Looper.getMainLooper()).idle();
+  }
+
   public static void idleMainLooper(long interval) {
     shadowOf(Looper.getMainLooper()).idle(interval);
   }
-
 
   public static void idleMainLooperConstantly(boolean shouldIdleConstantly) {
     shadowOf(Looper.getMainLooper()).idleConstantly(shouldIdleConstantly);
   }
 
+  public static void runMainLooperOneTask() {
+    shadowOf(Looper.getMainLooper()).runOneTask();
+  }
+
+  public static void runMainLooperToNextTask() {
+    shadowOf(Looper.getMainLooper()).runToNextTask();
+  }
+    
   /**
    * Runs any immediately runnable tasks previously queued on the UI thread,
    * e.g. by {@link android.app.Activity#runOnUiThread(Runnable)} or {@link android.os.AsyncTask#onPostExecute(Object)}.
@@ -223,7 +232,10 @@ public class ShadowLooper {
    * @param runnable    the task to be run
    * @param delayMillis how many milliseconds into the (virtual) future to run it
    * @return true if the runnable is enqueued
+   * @see android.os.Handler#postDelayed(Runnable,long)
+   * @deprecated Use a {@link android.os.Handler} instance to post to a looper.
    */
+  @Deprecated
   public boolean post(Runnable runnable, long delayMillis) {
     if (!quit) {
       scheduler.postDelayed(runnable, delayMillis);
@@ -232,7 +244,16 @@ public class ShadowLooper {
       return false;
     }
   }
-
+  
+  /**
+   * Enqueue a task to be run ahead of all other delayed tasks.
+   *
+   * @param runnable    the task to be run
+   * @return true if the runnable is enqueued
+   * @see android.os.Handler#postAtFrontOfQueue(Runnable)
+   * @deprecated Use a {@link android.os.Handler} instance to post to a looper.
+   */
+  @Deprecated
   public boolean postAtFrontOfQueue(Runnable runnable) {
     if (!quit) {
       scheduler.postAtFrontOfQueue(runnable);
@@ -269,6 +290,7 @@ public class ShadowLooper {
    */
   public void reset() {
     scheduler = new Scheduler();
+    shadowOf(realObject.getQueue()).reset();
     quit = false;
   }
 

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessage.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessage.java.vm
@@ -1,0 +1,143 @@
+#set($Integer = 0)
+#set($apiLevel = $Integer.parseInt($apiLevel))
+
+package org.robolectric.shadows;
+
+import android.os.Handler;
+import android.os.Message;
+
+import javax.annotation.Generated;
+
+#if ($apiLevel >= 21)import org.robolectric.annotation.HiddenApi;
+#end
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.annotation.Resetter;
+
+import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.internal.Shadow.*;
+import static org.robolectric.util.ReflectionHelpers.*;
+
+/**
+ * Shadow for Message that removes the message from its corresponding scheduler.
+ */
+@Generated("org.robolectric.shadows.ShadowMessage.java.vm")
+@Implements(Message.class)
+public class ShadowMessage {
+  @RealObject
+  private Message realMessage;
+  private Runnable scheduledRunnable;
+
+  private void unschedule() {
+    Handler target = realMessage.getTarget();
+
+	if (target != null && scheduledRunnable != null) {
+	  shadowOf(target.getLooper()).getScheduler().remove(scheduledRunnable);
+	  scheduledRunnable = null;
+	}
+  }
+
+  @Implementation
+#if ($apiLevel >= 21)
+  @HiddenApi
+  /**
+   * Hook to unscheduled the callback when the message is recycled.
+   * Invokes {@link #unschedule()} and then calls through to the
+   * package private method {@link Message}<code>.recycleUnchecked()
+   * on the real object.
+   */
+  public void recycleUnchecked() {
+    unschedule();
+    directlyOn(realMessage, Message.class, "recycleUnchecked");
+  }
+#else
+  /**
+   * Hook to unscheduled the callback when the message is recycled.
+   * Invokes {@link #unschedule()} and then calls through to
+   * {@link Message#recycle()} on the real object.
+   */
+  public void recycle() {
+    unschedule();
+    directlyOn(realMessage, Message.class, "recycle");
+  }
+  
+  /**
+   * Invokes {@link #recycle()}. Provided for forward compatibility
+   * with API 21.
+   */
+  public void recycleUnchecked() {
+    recycle();
+  }
+#end
+
+  /**
+   * Stores the <code>Runnable</code> instance that has been scheduled
+   * to invoke this message. This is called when the message is
+   * enqueued by {@link ShadowMessageQueue#enqueueMessage} and is used when
+   * the message is recycled to ensure that the correct
+   * {@link Runnable} instance is removed from the associated scheduler.
+   *
+   * @param r the <code>Runnable</code> instance that is scheduled to
+   * trigger this message.
+   *
+#if ($apiLevel >= 21)   * @see #recycleUnchecked()
+#else   * @see #recycle()
+#end
+   */
+  public void setScheduledRunnable(Runnable r) {
+	scheduledRunnable = r;
+  }
+
+  @Implementation
+  /**
+   * Convenience method to provide access to the private <code>Message.isInUse()</code>
+   * method. Note that the definition of "in use" changed with API 21:
+   *
+   * In API 19, a message was only considered "in use" during its dispatch. In API 21, the
+   * message is considered "in use" from the time it is enqueued until the time that
+   * it is freshly obtained via a call to {@link Message#obtain()}. This means that
+   * in API 21 messages that are in the recycled pool will still be marked as "in use". 
+   *
+   * @return <code>true</code> if the message is currently "in use", <code>false</code>
+   * otherwise.
+   */
+  public boolean isInUse() {
+  	return directlyOn(realMessage, Message.class, "isInUse");
+  }
+
+  /**
+   * Convenience method to provide getter access to the private field
+   * <code>Message.next</code>.
+   *
+   * @return The next message in the current message chain.
+   * @see #setNext(Message) 
+   */
+  public Message getNext() {
+    return getField(realMessage, "next");    
+  }
+  
+  /**
+   * Convenience method to provide setter access to the private field
+   * <code>Message.next</code>.
+   *
+   * @param next the new next message for the current message.
+   * @see #getNext() 
+   */
+  public void setNext(Message next) {
+    setField(realMessage, "next", next);
+  }
+  
+  /**
+   * Resets the static state of the {@link Message} class by
+   * emptying the message pool.
+   */
+  @Resetter
+  public static void reset() {
+    Object lock = getStaticField(Message.class, "sPoolSync");
+    synchronized (lock) {
+	  setStaticField(Message.class, "sPoolSize", 0);
+	  setStaticField(Message.class, "sPool", null);
+	}
+  }
+}

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
@@ -1,0 +1,143 @@
+#set($Integer = 0)
+#set($apiLevel = $Integer.parseInt($apiLevel))
+
+package org.robolectric.shadows;
+
+import android.os.Handler;
+import android.os.Message;
+import android.os.MessageQueue;
+
+import javax.annotation.Generated;
+
+import org.robolectric.annotation.HiddenApi;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.util.Scheduler;
+
+import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.internal.Shadow.*;
+import static org.robolectric.util.ReflectionHelpers.*;
+import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
+
+/**
+ * Shadow for MessageQueue that puts {@link Message}s into the scheduler queue instead of sending them to be handled on a
+ * separate thread. {@link Message}s that are scheduled to be dispatched can be triggered by calling
+ * {@link ShadowLooper#idleMainLooper}.
+ * 
+ * @see ShadowLooper
+ */
+@Generated("org.robolectric.shadows.ShadowMessageQueue.java.vm")
+@Implements(MessageQueue.class)
+public class ShadowMessageQueue {
+  @RealObject
+  private MessageQueue realQueue;
+
+#if ($apiLevel >= 21)
+#set($ptrClass = "long")
+#set($recycle = "recycleUnchecked")
+#else
+#set($ptrClass = "int")
+#set($recycle = "recycle")
+#end
+
+#set($Integer = 0)
+
+  // Stub out the native peer - scheduling
+  // is handled by the Scheduler class which is user-driven
+  // rather than automatic.
+  @HiddenApi
+  @Implementation
+  public static $ptrClass nativeInit() {
+    return 1;
+  }
+  
+  @HiddenApi
+  @Implementation
+  public static void nativeDestroy($ptrClass ptr) {}
+  
+  @HiddenApi
+  @Implementation
+  public static void nativePollOnce($ptrClass ptr, int timeoutMillis) {
+    throw new AssertionError("Should not be called");
+  }
+
+  @HiddenApi
+  @Implementation
+  public static void nativeWake($ptrClass ptr) {
+    throw new AssertionError("Should not be called");    
+  }
+  
+  @HiddenApi
+  @Implementation
+  public static boolean nativeIsIdling($ptrClass ptr) {
+    return false;
+  }
+
+  public Message getHead() {
+    return getField(realQueue, "mMessages");
+  }
+  
+  public void setHead(Message msg) {
+    setField(realQueue, "mMessages", msg);
+  }
+
+  public void reset() {
+    setHead(null);
+  }
+  
+  @Implementation
+  public boolean enqueueMessage(final Message msg, long when) {
+    final boolean retval = directlyOn(realQueue, MessageQueue.class, "enqueueMessage", from(Message.class, msg), from(long.class, when));
+    if (retval) {
+      final Scheduler scheduler = shadowOf(msg.getTarget().getLooper()).getScheduler();
+      final Runnable callback = new Runnable() {
+        @Override
+        public void run() {
+          Message m = getHead();
+          if (m == null) {
+            return;
+          }
+          
+          Message n = shadowOf(m).getNext();
+          if (m == msg) {
+            setHead(n);
+            dispatchMessage(msg);
+            return;
+          }
+          
+          while (n != null) {
+            if (n == msg) {
+              n = shadowOf(n).getNext();
+              shadowOf(m).setNext(n);
+              dispatchMessage(msg);
+              return;
+            }
+            m = n;
+            n = shadowOf(m).getNext();
+          }
+        }
+      };
+      shadowOf(msg).setScheduledRunnable(callback);
+      if (when == 0) {
+        scheduler.postAtFrontOfQueue(callback);
+      } else {
+        scheduler.postDelayed(callback, when - scheduler.getCurrentTime());
+      }
+    }
+    return retval;
+  }
+
+  private static void dispatchMessage(Message msg) {
+    final Handler target = msg.getTarget();
+    
+    shadowOf(msg).setNext(null);
+    // If target is null it means the message has been removed
+    // from the queue prior to being dispatched by the scheduler.
+    if (target != null) {
+      callInstanceMethod(msg, "markInUse");
+      target.dispatchMessage(msg);
+      callInstanceMethod(msg, "$recycle");
+    }
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
@@ -3,11 +3,12 @@ package org.robolectric.shadows;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
-import org.robolectric.internal.Shadow;
+import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.TestRunnable;
 import org.robolectric.util.Transcript;
 
@@ -18,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ShadowHandlerTest {
@@ -41,7 +43,7 @@ public class ShadowHandlerTest {
 
   @Test
   public void testInsertsRunnablesBasedOnLooper() throws Exception {
-    Looper looper = Shadow.newInstanceOf(Looper.class);
+    Looper looper = newLooper(false);
 
     Handler handler1 = new Handler(looper);
     handler1.post(new Say("first thing"));
@@ -67,12 +69,16 @@ public class ShadowHandlerTest {
     transcript.assertEventsSoFar("first thing", "second thing");
   }
 
+  private static Looper newLooper(boolean canQuit) {
+    return ReflectionHelpers.callConstructor(Looper.class, from(boolean.class, canQuit));
+  }
+  
   @Test
   public void testDifferentLoopersGetDifferentQueues() throws Exception {
-    Looper looper1 = Shadow.newInstanceOf(Looper.class);
+    Looper looper1 = newLooper(true);
     ShadowLooper.pauseLooper(looper1);
 
-    Looper looper2 = Shadow.newInstanceOf(Looper.class);
+    Looper looper2 = newLooper(true);
     ShadowLooper.pauseLooper(looper2);
 
     Handler handler1 = new Handler(looper1);
@@ -96,21 +102,21 @@ public class ShadowHandlerTest {
   @Test
   public void testPostAndIdleMainLooper() throws Exception {
     new Handler().post(scratchRunnable);
-    ShadowHandler.idleMainLooper();
+    ShadowLooper.idleMainLooper();
     assertThat(scratchRunnable.wasRun).isTrue();
   }
 
   @Test
   public void postDelayedThenIdleMainLooper_shouldNotRunRunnable() throws Exception {
     new Handler().postDelayed(scratchRunnable, 1);
-    ShadowHandler.idleMainLooper();
+    ShadowLooper.idleMainLooper();
     assertThat(scratchRunnable.wasRun).isFalse();
   }
 
   @Test
   public void testPostDelayedThenRunMainLooperOneTask() throws Exception {
     new Handler().postDelayed(scratchRunnable, 1);
-    ShadowHandler.runMainLooperOneTask();
+    ShadowLooper.runMainLooperOneTask();
     assertThat(scratchRunnable.wasRun).isTrue();
   }
 
@@ -142,7 +148,7 @@ public class ShadowHandlerTest {
     new Handler().postDelayed(task1, 1);
     new Handler().postDelayed(task2, 1);
 
-    ShadowHandler.runMainLooperToNextTask();
+    ShadowLooper.runMainLooperToNextTask();
     assertThat(task1.wasRun).isTrue();
     assertThat(task2.wasRun).isTrue();
   }
@@ -155,7 +161,7 @@ public class ShadowHandlerTest {
     new Handler().postDelayed(task1, 1);
     new Handler().postDelayed(task2, 1);
 
-    ShadowHandler.runMainLooperOneTask();
+    ShadowLooper.runMainLooperOneTask();
     assertThat(task1.wasRun).isTrue();
     assertThat(task2.wasRun).isFalse();
   }
@@ -170,7 +176,7 @@ public class ShadowHandlerTest {
     new Handler().postDelayed(task2, 10);
     new Handler().postDelayed(task3, 100);
 
-    ShadowHandler.runMainLooperToEndOfTasks();
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
     assertThat(task1.wasRun).isTrue();
     assertThat(task2.wasRun).isTrue();
     assertThat(task3.wasRun).isTrue();
@@ -187,10 +193,10 @@ public class ShadowHandlerTest {
 
     assertTrue(result);
 
-    ShadowHandler.runMainLooperOneTask();
+    ShadowLooper.runMainLooperOneTask();
     assertThat(task2.wasRun).isTrue();
     assertThat(task1.wasRun).isFalse();
-    ShadowHandler.runMainLooperOneTask();
+    ShadowLooper.runMainLooperOneTask();
     assertThat(task1.wasRun).isTrue();
   }
 
@@ -209,10 +215,10 @@ public class ShadowHandlerTest {
 
     assertTrue(handler.hasMessages(123));
     assertTrue(handler.hasMessages(345));
-    ShadowHandler.runMainLooperOneTask();
+    ShadowLooper.runMainLooperOneTask();
     assertTrue(handler.hasMessages(123));
     assertFalse(handler.hasMessages(345));
-    ShadowHandler.runMainLooperOneTask();
+    ShadowLooper.runMainLooperOneTask();
     assertFalse(handler.hasMessages(123));
     assertFalse(handler.hasMessages(345));
   }
@@ -327,7 +333,30 @@ public class ShadowHandlerTest {
   }
 
   @Test
-  public void shouldRemoveAllMessages() throws Exception {
+  public void scheduler_wontDispatchRemovedMessage_evenIfMessageReused() {
+    final ArrayList<Long> runAt = new ArrayList<>();
+    ShadowLooper.pauseMainLooper();
+    Handler handler = new Handler() {
+      @Override
+      public void handleMessage(Message msg) {
+        runAt.add(shadowOf(ShadowLooper.myLooper()).getScheduler().getCurrentTime());
+      }
+    };
+
+    Message msg = handler.obtainMessage(123);
+    handler.sendMessageDelayed(msg, 200);
+    handler.removeMessages(123);
+    Message newMsg = handler.obtainMessage(123);
+    assertThat(newMsg).as("new message").isSameAs(msg);
+    handler.sendMessageDelayed(newMsg, 400);
+    ShadowLooper.unPauseMainLooper();
+    // Original implementation had a bug which caused reused messages to still
+    // be invoked at their original post time.
+    assertThat(runAt).as("handledAt").containsExactly(400L);
+  }
+
+  @Test
+  public void shouldRemoveAllCallbacksAndMessages() throws Exception {
     final boolean[] wasRun = new boolean[1];
     ShadowLooper.pauseMainLooper();
     Handler handler = new Handler() {
@@ -337,9 +366,13 @@ public class ShadowHandlerTest {
       }
     };
     handler.sendEmptyMessage(0);
+    handler.post(scratchRunnable);
+
     handler.removeCallbacksAndMessages(null);
-    ShadowLooper.unPauseMainLooper();
-    assertThat(wasRun[0]).isFalse();
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
+
+    assertThat(wasRun[0]).as("Message").isFalse();
+    assertThat(scratchRunnable.wasRun).as("Callback").isFalse();
   }
 
   @Test
@@ -363,8 +396,34 @@ public class ShadowHandlerTest {
     handler.removeCallbacksAndMessages(secondObj);
     ShadowLooper.unPauseMainLooper();
 
-    assertThat(objects.contains(firstObj)).isTrue();
-    assertThat(objects.contains(secondObj)).isFalse();
+    assertThat(objects).containsExactly(firstObj);
+  }
+
+  @Test
+  public void shouldRemoveTaggedCallback() throws Exception {
+    ShadowLooper.pauseMainLooper();
+    Handler handler = new Handler();
+    
+    final int[] count = new int[1];
+    Runnable r = new Runnable() {
+      @Override
+      public void run() {
+        count[0]++;  
+      }
+    };
+    
+    String tag1 = "tag1", tag2 = "tag2";
+    
+    handler.postAtTime(r, tag1, 100);
+    handler.postAtTime(r, tag2, 105);
+
+    handler.removeCallbacks(r, tag2);
+    ShadowLooper.unPauseMainLooper();
+
+    assertThat(count[0]).as("run count").isEqualTo(1);
+    // This assertion proves that it was the first runnable that ran,
+    // which proves that the correctly tagged runnable was removed.
+    assertThat(shadowOf(handler.getLooper()).getScheduler().getCurrentTime()).as("currentTime").isEqualTo(100);
   }
 
   @Test
@@ -396,11 +455,11 @@ public class ShadowHandlerTest {
 
   @Test
   public void shouldSetWhenOnMessage() throws Exception {
-    final List<Message>  msgs = new ArrayList<Message>();
+    final List<Long>  whens = new ArrayList<Long>();
     Handler h = new Handler(new Handler.Callback() {
       @Override
       public boolean handleMessage(Message msg) {
-        msgs.add(msg);
+        whens.add(msg.getWhen());
         return false;
       }
     });
@@ -410,15 +469,8 @@ public class ShadowHandlerTest {
     ShadowLooper.getUiThreadScheduler().advanceToLastPostedRunnable();
     h.sendEmptyMessageDelayed(0, 12000l);
     ShadowLooper.getUiThreadScheduler().advanceToLastPostedRunnable();
-    assertThat(msgs.size()).isEqualTo(3);
 
-    Message m0 = msgs.get(0);
-    Message m1 = msgs.get(1);
-    Message m2 = msgs.get(2);
-
-    assertThat(m0.getWhen()).isEqualTo(0l);
-    assertThat(m1.getWhen()).isEqualTo(4000l);
-    assertThat(m2.getWhen()).isEqualTo(16000l);
+    assertThat(whens).as("whens").containsExactly(0l, 4000l, 16000l);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
@@ -105,7 +105,7 @@ public class ShadowLooperTest {
 
   @Test
   public void shouldThrowawayRunnableQueueIfLooperQuits() throws Exception {
-    HandlerThread ht = new HandlerThread("test1");
+    HandlerThread ht = new HandlerThread("shouldThrowawayRunnableQueueIfLooperQuits");
     ht.start();
     Looper looper = ht.getLooper();
     shadowOf(looper).pause();
@@ -117,8 +117,28 @@ public class ShadowLooperTest {
     looper.quit();
     assertTrue(shadowOf(looper).hasQuit());
     assertFalse(shadowOf(looper).getScheduler().areAnyRunnable());
+    assertThat(shadowOf(looper.getQueue()).getHead()).as("queue").isNull();
   }
 
+  @Test
+  public void shouldResetQueue_whenLooperIsReset() {
+    HandlerThread ht = new HandlerThread("shouldResetQueue_whenLooperIsReset");
+    ht.start();
+    Looper looper = ht.getLooper();
+    Handler h = new Handler(looper);
+    ShadowLooper sLooper = shadowOf(looper);
+    sLooper.pause();
+    h.post(new Runnable() {
+      @Override
+      public void run() {
+      }
+    });
+    assertThat(shadowOf(looper.getQueue()).getHead()).as("queue").isNotNull();
+    sLooper.reset();
+    assertFalse(sLooper.getScheduler().areAnyRunnable());
+    assertThat(shadowOf(looper.getQueue()).getHead()).as("queue").isNull();
+  }
+  
   @Test
   public void testLoopThread() {
     assertTrue(shadowOf(Looper.getMainLooper()).getThread() == Thread.currentThread());

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageQueueTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageQueueTest.java
@@ -1,0 +1,211 @@
+package org.robolectric.shadows;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import android.os.Handler;
+import android.os.Message;
+import android.os.MessageQueue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
+import org.robolectric.util.Scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.util.ReflectionHelpers.*;
+import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class ShadowMessageQueueTest {
+  private MessageQueue queue;
+  private ShadowMessageQueue shadowQueue;
+  private Message testMessage;
+  private TestHandler handler;
+  private Scheduler scheduler;
+  
+  private static class TestHandler extends Handler {
+    public List<Message> handled = new ArrayList<>();
+    
+    @Override
+    public void handleMessage(Message msg) {
+      handled.add(msg);
+    }
+  }
+  
+  @Before
+  public void setUp() throws Exception {
+    handler = new TestHandler();
+    scheduler = shadowOf(handler.getLooper()).getScheduler();
+    scheduler.pause();
+    queue = callConstructor(MessageQueue.class, from(boolean.class, true));
+    shadowQueue = shadowOf(queue);
+    testMessage = handler.obtainMessage();
+  }
+
+  private static void shouldAssert(String method, ClassParameter<?>... params) {
+    boolean ran = false;
+    try {
+      callStaticMethod(MessageQueue.class, method, params);
+      ran = true;
+    } catch (Throwable t) {
+      assertThat(t).as(method).isInstanceOf(AssertionError.class);
+    }
+    assertThat(ran).as(method).overridingErrorMessage("Should have asserted but no exception was thrown").isFalse();
+  }
+  
+  @Test
+  @Config(emulateSdk=19)
+  public void nativePollOnce_shouldAssert_19() {
+    shouldAssert("nativePollOnce", from(int.class, 1), from(int.class, 2));
+  }
+  
+  @Test
+  @Config(emulateSdk=19)
+  public void nativeWake_shouldAssert_19() {
+    shouldAssert("nativeWake", from(int.class, 1));
+  }
+  
+  @Test
+  @Config(emulateSdk=21)
+  public void nativePollOnce_shouldAssert_21() {
+    shouldAssert("nativePollOnce", from(long.class, 1), from(int.class, 2));
+  }
+  
+  @Test
+  @Config(emulateSdk=21)
+  public void nativeWake_shouldAssert_21() {
+    shouldAssert("nativeWake", from(long.class, 1));
+  }
+  
+  @Test
+  public void test_setGetHead() {
+    shadowQueue.setHead(testMessage);
+    assertThat(shadowQueue.getHead()).as("getHead()").isSameAs(testMessage);
+  }
+
+  private boolean enqueueMessage(Message msg, long when) {
+    return callInstanceMethod(queue, "enqueueMessage",
+        from(Message.class, msg),
+        from(long.class, when)
+        );    
+  }
+
+  private void removeMessages(Handler handler, int what, Object token) {
+    callInstanceMethod(queue, "removeMessages",
+        from(Handler.class, handler),
+        from(int.class, what),
+        from(Object.class, token)
+        );    
+  }
+  
+  
+  @Test
+  public void enqueueMessage_setsHead() {
+    enqueueMessage(testMessage, 100);
+    assertThat(shadowQueue.getHead()).as("head").isSameAs(testMessage);
+  }
+
+  @Test
+  public void enqueueMessage_returnsTrue() {
+    assertThat(enqueueMessage(testMessage, 100)).as("retval").isTrue();
+  }
+
+  public void enqueueMessage_setsWhen() {
+    enqueueMessage(testMessage, 123);
+    assertThat(testMessage.getWhen()).as("when").isEqualTo(123);
+  }
+  
+  @Test
+  public void enqueueMessage_returnsFalse_whenQuitting() {
+    setField(queue, "mQuitting", true);
+    assertThat(enqueueMessage(testMessage, 1)).as("enqueueMessage()").isFalse();
+  }
+  
+  @Test
+  public void enqueueMessage_doesntSchedule_whenQuitting() {
+    setField(queue, "mQuitting", true);
+    enqueueMessage(testMessage, 1);
+    assertThat(scheduler.size()).as("scheduler_size").isEqualTo(0);
+  }
+  
+  @Test
+  public void enqueuedMessage_isSentToHandler() {
+    enqueueMessage(testMessage, 200);
+    scheduler.advanceTo(199);
+    assertThat(handler.handled).as("handled:before").isEmpty();
+    scheduler.advanceTo(200);
+    assertThat(handler.handled).as("handled:after").containsExactly(testMessage);
+  }
+  
+  @Test
+  public void removedMessage_isNotSentToHandler() {
+    enqueueMessage(testMessage, 200);
+    assertThat(scheduler.size()).as("scheduler size:before").isEqualTo(1);
+    removeMessages(handler, testMessage.what, null);
+    scheduler.advanceToLastPostedRunnable();
+    assertThat(scheduler.size()).as("scheduler size:after").isEqualTo(0);
+    assertThat(handler.handled).as("handled").isEmpty();
+  }
+
+  @Test
+  public void enqueueMessage_withZeroWhen_postsAtFront() {
+    enqueueMessage(testMessage, 0);
+    Message m2 = handler.obtainMessage(2);
+    enqueueMessage(m2, 0);
+    scheduler.advanceToLastPostedRunnable();
+    assertThat(handler.handled).as("handled").containsExactly(m2, testMessage);
+  }
+  
+  @Test
+  @Config(emulateSdk = 19)
+  public void dispatchedMessage_isMarkedInUse_andRecycled_19() {
+    dispatchedMessage_isMarkedInUse_andRecycled();
+  }
+
+  @Test
+  @Config(emulateSdk = 21)
+  public void dispatchedMessage_isMarkedInUse_andRecycled_21() {
+    dispatchedMessage_isMarkedInUse_andRecycled();
+  }
+
+  private void dispatchedMessage_isMarkedInUse_andRecycled() {
+    Handler handler = new Handler() {
+      @Override
+      public void handleMessage(Message msg) {
+        boolean inUse = callInstanceMethod(msg, "isInUse");
+        assertThat(inUse).as(msg.what + ":inUse").isTrue();
+        Message next = getField(msg, "next");
+        assertThat(next).as(msg.what + ":next").isNull();
+      }
+    };
+    Message msg = handler.obtainMessage(1);
+    enqueueMessage(msg, 200);
+    Message msg2 = handler.obtainMessage(2);
+    enqueueMessage(msg2, 205);
+    scheduler.advanceToNextPostedRunnable();
+    
+    // Check that it's been properly recycled.
+    assertThat(msg.what).as("msg.what").isZero();
+    
+    scheduler.advanceToNextPostedRunnable();
+
+    assertThat(msg2.what).as("msg2.what").isZero();
+  }
+  
+  @Test 
+  public void reset_shouldClearMessageQueue() {
+    Message msg  = handler.obtainMessage(1234);
+    Message msg2 = handler.obtainMessage(5678);
+    handler.sendMessage(msg);
+    handler.sendMessage(msg2);
+    assertThat(handler.hasMessages(1234)).as("before-1234").isTrue();
+    assertThat(handler.hasMessages(5678)).as("before-5678").isTrue();
+    shadowOf(handler.getLooper().getQueue()).reset();
+    assertThat(handler.hasMessages(1234)).as("after-1234").isFalse();
+    assertThat(handler.hasMessages(5678)).as("after-5678").isFalse();
+  }
+}


### PR DESCRIPTION
This is a continuation of PR #1431. I'm sorry for the new PR but I couldn't figure out how to re-open the old one.

This commit adds the static reset capability that I mentioned in the old PR. Seems to have fixed the test flakiness.