### PR TITLE
Prefer AtomicBoolean over MutableBoolean.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -24,7 +24,6 @@ import android.view.LayoutInflater;
 import android.widget.ListPopupWindow;
 import android.widget.PopupWindow;
 import android.widget.Toast;
-import android.util.MutableBoolean;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.Shadows;
@@ -45,6 +44,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static android.content.pm.PackageManager.PERMISSION_DENIED;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
@@ -428,7 +428,7 @@ public class ShadowApplication extends ShadowContextWrapper {
     return result;
   }
 
-  private void postIntent(Intent intent, Wrapper wrapper, final MutableBoolean abort) {
+  private void postIntent(Intent intent, Wrapper wrapper, final AtomicBoolean abort) {
     final Handler scheduler = (wrapper.scheduler != null) ? wrapper.scheduler : this.mainHandler;
     final BroadcastReceiver receiver = wrapper.broadcastReceiver;
     final ShadowBroadcastReceiver shReceiver = Shadows.shadowOf(receiver);
@@ -442,7 +442,7 @@ public class ShadowApplication extends ShadowContextWrapper {
   }
 
   private void postToWrappers(List<Wrapper> wrappers, Intent intent, String receiverPermission) {
-    MutableBoolean abort = new MutableBoolean(false); // abort state is shared among all broadcast receivers
+    AtomicBoolean abort = new AtomicBoolean(false); // abort state is shared among all broadcast receivers
     for (Wrapper wrapper: wrappers) {
       postIntent(intent, wrapper, abort);
     }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBroadcastReceiver.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBroadcastReceiver.java
@@ -3,31 +3,32 @@ package org.robolectric.shadows;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.util.MutableBoolean;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Implements(BroadcastReceiver.class)
 public class ShadowBroadcastReceiver {
   @RealObject BroadcastReceiver receiver;
 
-  private MutableBoolean abort; // The abort state of the currently processed broadcast
+  private AtomicBoolean abort; // The abort state of the currently processed broadcast
 
   @Implementation
   public void abortBroadcast() {
     // TODO probably needs a check to prevent calling this method from ordinary Broadcasts
-    abort.value = true;
+    abort.set(true);
   }
 
   @Implementation
   public void onReceive(Context context, Intent intent) {
-    if (abort == null || !abort.value) {
+    if (abort == null || !abort.get()) {
       receiver.onReceive(context, intent);
     }
   }
 
-  public void onReceive(Context context, Intent intent, MutableBoolean abort) {
+  public void onReceive(Context context, Intent intent, AtomicBoolean abort) {
     this.abort = abort;
     onReceive(context, intent);
   }


### PR DESCRIPTION
Robolectric should avoid depending on classes internal to the Android SDK if possible.

If you include only the android stub jars on the system classpath you see the following runtime error.

java.lang.NoClassDefFoundError: Landroid/util/MutableBoolean;
	at java.lang.Class.getDeclaredFields0(Native Method)
	at java.lang.Class.privateGetDeclaredFields(Class.java:2497)
	at java.lang.Class.getDeclaredFields(Class.java:1807)
	at org.robolectric.internal.bytecode.ShadowWrangler$MetaShadow.<init>(ShadowWrangler.java:520)
	at org.robolectric.internal.bytecode.ShadowWrangler.getMetaShadow(ShadowWrangler.java:445)
	at org.robolectric.internal.bytecode.ShadowWrangler.injectRealObjectOn(ShadowWrangler.java:435)
	at org.robolectric.internal.bytecode.ShadowWrangler.createShadowFor(ShadowWrangler.java:412)
	at org.robolectric.internal.bytecode.ShadowWrangler.initializing(ShadowWrangler.java:111)
	at org.robolectric.internal.bytecode.RobolectricInternals.initializing(RobolectricInternals.java:18)
	at android.content.BroadcastReceiver.$$robo$init(BroadcastReceiver.java)
	at android.content.BroadcastReceiver.<init>(BroadcastReceiver.java)
