### PR TITLE
Major enhancements to ShadowMediaPlayer

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
@@ -1,14 +1,25 @@
 package org.robolectric.shadows;
 
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Random;
+
 import android.content.Context;
 import android.media.MediaPlayer;
 import android.net.Uri;
+import android.os.Handler;
+import android.os.SystemClock;
+
+import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
 import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.shadows.ShadowMediaPlayer.State.*;
 
 /**
  * Shadows the Android {@code MediaPlayer} class.
@@ -20,16 +31,100 @@ public class ShadowMediaPlayer {
     // don't bind the JNI library
   }
 
-  @RealObject private MediaPlayer player;
+  @RealObject
+  private MediaPlayer player;
 
-  private boolean playing;
-  private boolean prepared;
-  private int currentPosition;
+  /** Possible states for the media player to be in. */
+  public static enum State {
+    IDLE, INITIALIZED, PREPARING, PREPARED, STARTED, STOPPED, PAUSED, PLAYBACK_COMPLETED, END, ERROR
+  }
+
+  /** Current state of the media player. */
+  private State state = IDLE;
+
+  /** Delay for calls to {@link #prepare} and {@link #prepareAsync} (in ms). */
+  private int preparationDelay = 0;
+
+  /** Delay for calls to {@link #seekTo} (in ms). */
+  private int seekDelay = 0;
+
+  private int auxEffect;
+  private int audioSessionId;
+  private int duration;
+  private boolean looping;
+  private int pendingSeek = -1;
+  /** Various source variables from setDataSource() */
+  private String sourcePath;
   private Uri sourceUri;
+  private Map<String, String> sourceHeaders;
   private int sourceResId;
+  private FileDescriptor sourceFd;
+  private long sourceOffset = -1;
+  private long sourceLength = -1;
+
+  /** The time (in ms) at which playback was last started/resumed. */
+  private long startTime = 0;
+
+  /**
+   * The offset (in ms) from the start of the current clip at which the last
+   * call to seek/pause was. If the MediaPlayer is not in the STARTED state,
+   * then this is equal to currentPosition; if it is in the STARTED state and no
+   * seek is pending then you need to add the number of ms since start() was
+   * called to get the current position (see {@link #startTime}).
+   */
+  private int startOffset = 0;
+
+  private int videoHeight;
+  private int videoWidth;
   private MediaPlayer.OnCompletionListener completionListener;
+  private MediaPlayer.OnSeekCompleteListener seekCompleteListener;
   private MediaPlayer.OnPreparedListener preparedListener;
   private MediaPlayer.OnErrorListener errorListener;
+  private Handler handler;
+
+  private final Runnable completionCallback = new Runnable() {
+    public void run() {
+      if (looping) {
+        startOffset = 0;
+        doStart();
+      } else {
+        invokeCompletionListener();
+      }
+    }
+  };
+
+  private final Runnable preparedCallback = new Runnable() {
+    public void run() {
+      invokePreparedListener();
+    }
+  };
+
+  private final Runnable seekCompleteCallback = new Runnable() {
+    public void run() {
+      invokeSeekCompleteListener();
+    }
+  };
+
+  /**
+   * Playback offset at which to fire the scheduled error. Measured in ms
+   * relative to the start of playback. Negative indicates no error scheduled.
+   */
+  private int errorOffset = -1;
+
+  private class ErrorCallback implements Runnable {
+    public int what;
+    public int extra;
+
+    public void run() {
+      invokeErrorListener(what, extra);
+    }
+  }
+
+  /** Callback to use for scheduled errors. */
+  private final ErrorCallback errorCallback = new ErrorCallback();
+
+  /** Exception to throw when {@link #setDataSource} is called. */
+  private Exception setDataSourceException;
 
   @Implementation
   public static MediaPlayer create(Context context, int resId) {
@@ -37,7 +132,9 @@ public class ShadowMediaPlayer {
     Shadows.shadowOf(mp).sourceResId = resId;
     try {
       mp.prepare();
-    } catch (Exception e) { return null; }
+    } catch (Exception e) {
+      return null;
+    }
 
     return mp;
   }
@@ -48,23 +145,84 @@ public class ShadowMediaPlayer {
     try {
       mp.setDataSource(context, uri);
       mp.prepare();
-    } catch (Exception e) { return null; }
+    } catch (Exception e) {
+      return null;
+    }
 
     return mp;
   }
 
   public void __constructor__() {
-    playing = false;
+    // Contract of audioSessionId is that if it is 0 (which represents
+    // the master mix) then that's an error. By default it generates
+    // an ID that is unique system-wide. We could simulate guaranteed
+    // uniqueness (get AudioManager's help?) but it's probably not
+    // worth the effort.
+    Random random = new Random();
+    audioSessionId = random.nextInt(Integer.MAX_VALUE) + 1;
+    handler = new Handler();
   }
 
   @Implementation
-  public void  setDataSource(Context context, Uri uri) {
-    this.sourceUri = uri;
+  public void setDataSource(String path) throws IOException {
+    doSetDataSourceExceptions();
+    this.sourcePath = path;
   }
 
+  @Implementation
+  public void setDataSource(Context context, Uri uri,
+      Map<String, String> headers) throws IOException {
+    doSetDataSourceExceptions();
+    this.sourceUri = uri;
+    this.sourceHeaders = headers;
+  }
+
+  @Implementation
+  public void setDataSource(FileDescriptor fd, long offset, long length)
+    throws IOException {
+    doSetDataSourceExceptions();
+    this.sourceFd = fd;
+    this.sourceOffset = offset;
+    this.sourceLength = length;
+  }
+
+  static private final EnumSet<State> idleState = EnumSet.of(IDLE); 
+  private void doSetDataSourceExceptions() throws IOException {
+    checkState("setDataSource()", idleState);
+    if (setDataSourceException != null) {
+      state = ERROR;
+      if (setDataSourceException instanceof IOException) {
+        throw (IOException)setDataSourceException;
+      }
+      if (setDataSourceException instanceof RuntimeException) {
+        throw (RuntimeException)setDataSourceException;
+      }  
+      throw new AssertionError("Invalid exception type specified: " + setDataSourceException);
+    }    
+    state = INITIALIZED;
+  }
+
+  private void checkState(String method, EnumSet<State> allowedStates) {
+    if (state == END) {
+      String msg = "Can't call " + method + " from state " + state;
+      throw new IllegalStateException(msg);      
+    }
+    if (!allowedStates.contains(state)) {
+      String msg = "Can't call " + method + " from state " + state;
+      state = ERROR;
+      throw new IllegalStateException(msg);
+    }
+  }
+  
   @Implementation
   public void setOnCompletionListener(MediaPlayer.OnCompletionListener listener) {
     completionListener = listener;
+  }
+
+  @Implementation
+  public void setOnSeekCompleteListener(
+      MediaPlayer.OnSeekCompleteListener listener) {
+    seekCompleteListener = listener;
   }
 
   @Implementation
@@ -77,90 +235,377 @@ public class ShadowMediaPlayer {
     errorListener = listener;
   }
 
-
-
   @Implementation
-  public boolean isPlaying() {
-    return playing;
+  public boolean isLooping() {
+    return looping;
+  }
+
+  static private final EnumSet<State> nonErrorStates =
+    EnumSet.complementOf(EnumSet.of(ERROR));
+  @Implementation
+  public void setLooping(boolean looping) {
+    checkState("setLooping()", nonErrorStates);
+    this.looping = looping;
   }
 
   @Implementation
+  public boolean isPlaying() {
+    checkState("setLooping()", nonErrorStates);
+    return state == STARTED;
+  }
+
+  private static EnumSet<State> preparableStates =
+      EnumSet.of(INITIALIZED, STOPPED);
+
+  @Implementation
   public void prepare() {
-    prepared = true;
+    checkState("prepare()", preparableStates);
+    if (preparationDelay > 0) {
+      SystemClock.sleep(preparationDelay);
+    }
     invokePreparedListener();
   }
 
   /**
-   * Test cases are expected to simulate completion of the 'prepare' phase
-   * by manually invoking {@code #invokePreparedListener}.
+   * Test cases are expected to simulate completion of the 'prepare' phase by
+   * manually invoking {@code #invokePreparedListener}.
    */
   @Implementation
   public void prepareAsync() {
-    prepared = true;
+    checkState("prepareAsync()", preparableStates);
+    state = PREPARING;
+    if (preparationDelay >= 0) {
+      handler.postDelayed(preparedCallback, preparationDelay);
+    }
   }
+
+  private static EnumSet<State> startableStates =
+    EnumSet.of(PREPARED, STARTED, PAUSED, PLAYBACK_COMPLETED);
 
   @Implementation
   public void start() {
-    playing = true;
+    checkState("start()", startableStates);
+    if (state == PLAYBACK_COMPLETED) {
+      startOffset = 0;
+    }
+    state = STARTED;
+    doStart();
   }
+
+  private void doStart() {
+    startTime = SystemClock.uptimeMillis();
+    if (errorOffset >= startOffset) {
+      handler.postDelayed(errorCallback, errorOffset - startOffset);
+    } else {
+      handler.postDelayed(completionCallback, duration - startOffset);
+    }
+  }
+
+  private void doStop() {
+    startOffset = getCurrentPosition();
+    handler.removeCallbacks(completionCallback);
+    handler.removeCallbacks(errorCallback);
+  }
+
+  private static final EnumSet<State> pausableStates = EnumSet.of(STARTED,
+      PAUSED, PLAYBACK_COMPLETED);
 
   @Implementation
   public void pause() {
-    playing = false;
+    checkState("pause()", pausableStates);
+    doStop();
+    state = PAUSED;
   }
 
+  static final EnumSet<State> allStates = EnumSet.allOf(State.class);
   @Implementation
   public void release() {
-    playing = false;
-    prepared = false;
+    checkState("release()", allStates);
+    state = END;
   }
 
   @Implementation
   public void reset() {
-    playing = false;
-    prepared = false;
+    checkState("reset()", allStates);
+    state = IDLE;
   }
+
+  static private final EnumSet<State> stoppableStates =
+      EnumSet.of(PREPARED, STARTED, PAUSED, STOPPED, PLAYBACK_COMPLETED);
 
   @Implementation
   public void stop() {
-    playing = false;
+    checkState("stop()", stoppableStates);
+    doStop();
+    state = STOPPED;
+  }
+
+  private static final EnumSet<State> attachableStates = EnumSet
+      .of(INITIALIZED, PREPARING, PREPARED, STARTED, PAUSED, STOPPED,
+          PLAYBACK_COMPLETED);
+
+  @Implementation
+  public void attachAuxEffect(int effectId) {
+    checkState("attachAuxEffect()", attachableStates);
+    auxEffect = effectId;
+  }
+
+  @Implementation
+  public int getAudioSessionId() {
+    checkState("getAudioSessionId()", allStates);
+    return audioSessionId;
   }
 
   @Implementation
   public int getCurrentPosition() {
-    return currentPosition;
+    checkState("getCurrentPosition()", nonErrorStates);
+    int currentPos = startOffset;
+    if (state == STARTED && pendingSeek < 0) {
+      currentPos += (int) (SystemClock.uptimeMillis() - startTime);
+    }
+    return currentPos;
   }
 
-  public void setCurrentPosition(int position) {
-    currentPosition = position;
+  @Implementation
+  public int getDuration() {
+    checkState("getDuration()", stoppableStates);
+    return duration;
+  }
+
+  @Implementation
+  public int getVideoHeight() {
+    checkState("getVideoHeight()", nonErrorStates);
+    return videoHeight;
+  }
+
+  @Implementation
+  public int getVideoWidth() {
+    checkState("getVideoWidth()", nonErrorStates);
+    return videoWidth;
+  }
+
+  private static final EnumSet<State> seekableStates =
+    EnumSet.of(PREPARED, STARTED, PAUSED, PLAYBACK_COMPLETED);
+
+  /**
+   * Simulates seeking to specified position. The seek will complete after
+   * {@link #seekDelay} ms (defaults to 0), or else if seekDelay is negative
+   * then the controlling test is expected to simulate seek completion by
+   * manually invoking {@link #invokeSeekCompletedListener}.
+   * 
+   * @param seekTo
+   *          the offset (in ms) from the start of the track to seek to.
+   */
+  @Implementation
+  public void seekTo(int seekTo) {
+    checkState("seekTo()", seekableStates);
+    // Cancel any pending seek operations.
+    handler.removeCallbacks(seekCompleteCallback);
+    // Need to call doStop() before setting pendingSeek,
+    // because if pendingSeek is called it changes
+    // the behavior of getCurrentPosition(), which doStop()
+    // depends on.
+    doStop();
+    pendingSeek = seekTo;
+    if (seekDelay >= 0) {
+      handler.postDelayed(seekCompleteCallback, seekDelay);
+    }
+  }
+
+  @Implementation
+  public void setAudioSessionId(int sessionId) {
+    checkState("setAudioSessionId()", idleState);
+    audioSessionId = sessionId;
   }
 
   /**
-   * Non-Android accessor.  Use for assertions.
-   * @return The Source URI
+   * Retrieves the Handler object used by this <code>ShadowMediaPlayer</code>.
+   * Can be used for posting custom asynchronous events to the thread (eg,
+   * asynchronous errors). Use this for scheduling events to take place at a
+   * particular "real" time (ie, time as measured by the scheduler). For
+   * scheduling errors to occur at a particular point in playback (no matter how
+   * long playback may be paused for, or where you seek to, etc), see
+   * {@link #scheduleErrorAtOffset}. Non-Android accessor.
+   * 
+   * @return Handler object that can be used to schedule asynchronous events on
+   *         this media player.
+   */
+  public Handler getHandler() {
+    return handler;
+  }
+
+  /**
+   * Sets the exception to throw when setDataSource() is called.
+   * <code>null</code> means no exception will be thrown. Note that emulation of
+   * IllegalStateException is already handled by the shadow implementation of
+   * setDataSource() and does not need to be emulated using this method.
+   * 
+   * @param e the exception to be thrown.
+   */
+  public void setSetDataSourceException(Exception e) {
+    if (e != null
+        && !(e instanceof IOException)
+        && !(e instanceof RuntimeException) ) {
+      throw new AssertionError("Invalid exception type: " + e);
+    }
+    setDataSourceException = e;
+  }
+
+  /**
+   * Non-Android setter.
+   * 
+   * @param position
+   */
+  public void setCurrentPosition(int position) {
+    startOffset = position;
+  }
+
+  /**
+   * Non-Android setter.
+   * 
+   * @param duration
+   */
+
+  public void setDuration(int duration) {
+    this.duration = duration;
+  }
+
+  /**
+   * Non-Android accessor. Used for assertions.
+   * 
+   * @return The current state of the {@link MediaPlayer}, as defined in the
+   *         MediaPlayer documentation.
+   * @see MediaPlayer
+   */
+  public State getState() {
+    return state;
+  }
+
+  /**
+   * Non-Android setter.
+   * 
+   * @param state
+   */
+  public void setState(State state) {
+    this.state = state;
+  }
+
+  /**
+   * Non-Android accessor.
+   * 
+   * @return preparationDelay
+   */
+  public int getPreparationDelay() {
+    return preparationDelay;
+  }
+
+  /**
+   * Sets the length of time that prepare()/prepareAsync() will wait for before
+   * completing. Default is 0. If set to -1, then prepare() will complete
+   * instantly but prepareAsync() will not call the OnPreparedListener
+   * automatically; you will need to call invokePreparedListener() manually.
+   * 
+   * @param preparationDelay
+   */
+  public void setPreparationDelay(int preparationDelay) {
+    this.preparationDelay = preparationDelay;
+  }
+
+  /**
+   * Non-Android accessor.
+   * 
+   * @return seekDelay
+   */
+  public int getSeekDelay() {
+    return seekDelay;
+  }
+
+  /**
+   * Sets the length of time (ms) that seekTo() will delay before completing.
+   * Default is 0. If set to -1, then seekTo() will not call the
+   * OnSeekCompleteListener automatically; you will need to call
+   * invokeSeekCompleteListener() manually.
+   * 
+   * @param seekDelay
+   *          length of time to delay (ms)
+   */
+  public void setSeekDelay(int seekDelay) {
+    this.seekDelay = seekDelay;
+  }
+
+  /**
+   * Non-Android accessor. Used for assertions.
+   * 
+   * @return
+   */
+  public int getAuxEffect() {
+    return auxEffect;
+  }
+
+  /**
+   * Non-Android accessor. Used for assertions.
+   * 
+   * @return the position to which the shadow player is seeking for the seek in
+   *         progress (ie, after the call to {@link #seekTo} but before a call
+   *         to invokeOnSeekCompleteListener). Returns -1 if no seek is in
+   *         progress.
+   */
+  public int getPendingSeek() {
+    return pendingSeek;
+  }
+
+  /**
+   * Non-Android accessor. Use for assertions.
+   * 
+   * @return
+   */
+  public String getSourcePath() {
+    return sourcePath;
+  }
+
+  /**
+   * Non-Android accessor. Use for assertions.
+   * 
+   * @return
    */
   public Uri getSourceUri() {
     return sourceUri;
   }
 
   /**
+   * Non-Android accessor. Use for assertions.
+   * 
+   * @return
+   */
+  public Map<String, String> getSourceHeaders() {
+    return sourceHeaders;
+  }
+
+  /**
    * Non-Android accessor.  Use for assertions.
+   *
    * @return The Source Res ID
    */
   public int getSourceResId() {
     return sourceResId;
   }
 
+  private static EnumSet<State> preparedStates =
+    EnumSet.of(PREPARED, STARTED, PAUSED, PLAYBACK_COMPLETED);
+
   /**
-   * Non-Android accessor.  Use for assertions.
-   * @return Is the media player prepared
+   * Non-Android accessor. Use for assertions. This is mainly used for backward
+   * compatibility. {@link #getState} may be more useful.
+   * 
+   * @return true if the MediaPlayer is in the PREPARED state, false otherwise.
    */
   public boolean isPrepared() {
-    return prepared;
+    return preparedStates.contains(state);
   }
 
   /**
    * Non-Android accessor.  Use for assertions.
+   *
    * @return the OnCompletionListener
    */
   public MediaPlayer.OnCompletionListener getOnCompletionListener() {
@@ -179,27 +624,92 @@ public class ShadowMediaPlayer {
    * Allows test cases to simulate 'prepared' state by invoking callback.
    */
   public void invokePreparedListener() {
-    if (preparedListener == null) return;
-    preparedListener.onPrepared( player );
+    state = PREPARED;
+    if (preparedListener == null)
+      return;
+    preparedListener.onPrepared(player);
   }
 
   /**
    * Allows test cases to simulate 'completed' state by invoking callback.
    */
   public void invokeCompletionListener() {
-    if (completionListener == null) return;
-    completionListener.onCompletion( player );
+    state = PLAYBACK_COMPLETED;
+    setCurrentPosition(duration);
+    if (completionListener == null)
+      return;
+    completionListener.onCompletion(player);
   }
 
-
-  public void invokeErrorListener(int what,int extra){
-    playing = false;
-    prepared = false;
-    if (errorListener == null) return;
-    boolean handled = errorListener.onError(player,what,extra);
-    if (!handled){
-      invokeCompletionListener();
+  /**
+   * Allows test cases to simulate seek completion by invoking callback.
+   */
+  public void invokeSeekCompleteListener() {
+    setCurrentPosition(pendingSeek > duration ? duration : pendingSeek < 0 ? 0
+        : pendingSeek);
+    pendingSeek = -1;
+    if (state == STARTED) {
+      doStart();
     }
+    if (seekCompleteListener == null)
+      return;
+    seekCompleteListener.onSeekComplete(player);
+  }
 
+  /**
+   * Schedules a callback to {@link #invokeErrorListener(int, int) invoke
+   * ErrorListener()} at the given playback offset.
+   * 
+   * @param offset
+   *          the offset (in ms) from the start of playback at which to fire the
+   *          error. Setting to a negative number effectively disabled the
+   *          scheduled error.
+   * @param what
+   *          parameter to pass in to <code>what</code> in
+   *          {@link OnErrorListener#onError()}.
+   * @param extra
+   *          parameter to pass in to <code>extra</code> in
+   *          {@link OnErrorListener#onError()}.
+   */
+  public void scheduleErrorAtOffset(int offset, int what, int extra) {
+    errorOffset = offset;
+    errorCallback.what = what;
+    errorCallback.extra = extra;
+    if (state == STARTED) {
+      // If we're already in the STARTED state then we need
+      // to reschedule the pending error/completion callback.
+      doStop();
+      doStart();
+    }
+  }
+
+  /**
+   * Allows test cases to directly simulate invocation of the OnError event.
+   * 
+   * @param what
+   *          parameter to pass in to <code>what</code> in
+   *          {@link OnErrorListener#onError()}.
+   * @param extra
+   *          parameter to pass in to <code>extra</code> in
+   *          {@link OnErrorListener#onError()}.
+   */
+  public void invokeErrorListener(int what, int extra) {
+    state = ERROR;
+    handler.removeCallbacks(completionCallback);
+    boolean handled = errorListener != null
+        && errorListener.onError(player, what, extra);
+    if (!handled) {
+      // XXX
+      // The documentation isn't very clear if onCompletion is
+      // supposed to be called from non-playing states
+      // (ie, states other than STARTED or PAUSED). It
+      // wouldn't seem to make sense to me to notify
+      // of completion before it has started...
+      invokeCompletionListener();
+      // Need to set this again because
+      // invokeCompletionListener() will set the state
+      // to PLAYBACK_COMPLETED
+      state = ERROR;
+    }
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
@@ -2,9 +2,13 @@ package org.robolectric.shadows;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Random;
+import java.util.TreeMap;
 
 import android.content.Context;
 import android.media.MediaPlayer;
@@ -23,6 +27,63 @@ import static org.robolectric.shadows.ShadowMediaPlayer.State.*;
 
 /**
  * Shadows the Android {@code MediaPlayer} class.
+ * 
+ * Automated testing of media playback can be a difficult thing - especially
+ * testing that your code properly handles asynchronous errors and events. This
+ * near impossible task is made quite straightforward using this implementation
+ * of <code>ShadowMediaPlayer</code> with Robolectric.
+ * 
+ * This shadow implementation provides much of the functionality needed to
+ * emulate {@link MediaPlayer} initialization & playback behavior without having
+ * to play actual media files. A summary of the features included are:
+ * 
+ * <ul>
+ * <li>Construction-time callback hook {@link CreateListener} so that
+ * newly-created {@link MediaPlayer} instances can have their shadows configured
+ * before they are used.</li>
+ * <li>Emulation of the {@link android.media.MediaPlayer.OnCompletionListener
+ * OnCompletionListener}, {@link android.media.MediaPlayer.OnErrorListener
+ * OnErrorListener}, {@link android.media.MediaPlayer.OnInfoListener
+ * OnInfoListener}, {@link android.media.MediaPlayer.OnPreparedListener
+ * OnPreparedListener} and
+ * {@link android.media.MediaPlayer.OnSeekCompleteListener
+ * OnSeekCompleteListener}.</li>
+ * <li>Full support of the {@link MediaPlayer} internal states and their
+ * transition map.</li>
+ * <li>Configure time parameters such as playback duration, preparation delay
+ * and (@link #setSeekDelay seek delay}.</li>
+ * <li>Emulation of asynchronous callback events during playback through
+ * Robolectric's scheduling system using the {@link MediaInfo} inner class.</li>
+ * <li>Emulation of error behavior when methods are called from invalid states,
+ * or to throw assertions when methods are invoked in invalid states (using
+ * {@link #setAssertOnError}).</li>
+ * <li>Emulation of different playback behaviors based on the current data
+ * source, as passed in to {@link #setDataSource(String)}, using
+ * {@link #setDataSourceMap}.</li>
+ * <li>Emulation of exceptions when calling {@link #setDataSource} using
+ * {@link MediaInfo#setDataSourceException}.</li>
+ * </ul>
+ * 
+ * Known gaps in the current feature set are:
+ * 
+ * <ul>
+ * <li>The current features of <code>ShadowMediaPlayer</code> were developed for
+ * testing playback of audio tracks. Thus support for emulating timed text and
+ * video events is incomplete.</li>
+ * <li>The {@link #setDataSourceMap(Map) dataSourceMap} currently only supports
+ * the {@link #setDataSource(String)} method. Other overloaded forms of
+ * <code>setDataSource()</code> are not yet supported.</li>
+ * <li>Due to what appears to be a bug in Robolectric's {@link Scheduler}/
+ * {@link ShadowHandler} implementation, some events (including manually
+ * scheduled events) can fire after the {@link MediaPlayer} is
+ * {@link MediaPlayer#release()}d.</li>
+ * feature-complete while reducing the maintenance overhead.</li>
+ * </ul>
+ * 
+ * None of these features/bugs would be particularly onerous to add/fix - contributions
+ * welcome.
+ * 
+ * @author Fr Jeremy Krieg, Holy Monastery of St Nectarios, Adelaide, Australia
  */
 @Implements(MediaPlayer.class)
 public class ShadowMediaPlayer {
@@ -30,40 +91,358 @@ public class ShadowMediaPlayer {
     // don't bind the JNI library
   }
 
-  /** Listener that is called when a new MediaPlayer is constructed. */
+  /**
+   * Listener that is called when a new MediaPlayer is constructed.
+   * 
+   * @see #setCreateListener(CreateListener)
+   */
   protected static CreateListener createListener;
-  
+
   @RealObject
   private MediaPlayer player;
 
-  /** Possible states for the media player to be in. */
+  /**
+   * Possible states for the media player to be in. These states are as defined
+   * in the documentation for {@link android.media.MediaPlayer}.
+   */
   public static enum State {
     IDLE, INITIALIZED, PREPARING, PREPARED, STARTED, STOPPED, PAUSED, PLAYBACK_COMPLETED, END, ERROR
   }
 
-  /** Class specifying information for an emulated media object. Used by
-   *  ShadowMediaPlayer when setDataSource() is called to populate the 
-   *  shadow player with the specified values. */
-  public static class MediaInfo {
+  /**
+   * Possible behavior modes for the media player when a method is invoked in an
+   * invalid state.
+   * 
+   * @see #setInvalidStateBehavior
+   */
+  public static enum InvalidStateBehavior {
+    SILENT, EMULATE, ASSERT
+  }
+
+  /**
+   * Reference to the next playback event scheduled to run. We keep a reference
+   * to this handy in case we need to cancel it.
+   */
+  private RunList nextPlaybackEvent;
+
+  /**
+   * Class for grouping events that are meant to fire at the same time. Also
+   * schedules the next event to run.
+   */
+  @SuppressWarnings("serial")
+  private class RunList extends ArrayList<Runnable> implements Runnable {
+
+    public RunList() {
+      // Set the default size to one as most of the time we will
+      // only have one event.
+      super(1);
+    }
+
+    public void run() {
+      for (Runnable r : this) {
+        r.run();
+      }
+      scheduleNextPlaybackEvent();
+    }
+  }
+
+  /**
+   * Class specifying information for an emulated media object. Used by
+   * ShadowMediaPlayer when setDataSource() is called to populate the shadow
+   * player with the specified values.
+   */
+  public class MediaInfo {
     public int duration;
-    public int preparationDelay;
-    
+    private int preparationDelay;
+
+    /** Exception to throw when {@link #setDataSource} is called. */
+    private Exception setDataSourceException;
+
+    /** Map that maps time offsets to runnable events. */
+    public TreeMap<Integer, RunList> events = new TreeMap<Integer, RunList>();
+
+    /**
+     * Creates a new <code>MediaInfo</code> object with the given duration and
+     * preparation delay. A completion callback event is scheduled at
+     * <code>duration</code> ms from the end.
+     * 
+     * @param duration
+     *          the duration (in ms) of this emulated media. A callback event
+     *          will be scheduled at this offset to stop playback simulation &
+     *          invoke the completion callback.
+     * @param preparationDelay
+     *          the preparation delay (in ms) to emulate for this media. If set
+     *          to -1, then {@link #prepare()} will complete instantly but
+     *          {@link #prepareAsync()} will not complete automatically; you
+     *          will need to call {@link #invokePreparedListener()} manually.
+     */
     public MediaInfo(int duration, int preparationDelay) {
       this.duration = duration;
       this.preparationDelay = preparationDelay;
+
+      scheduleEventAtOffset(duration, completionCallback);
+    }
+
+    /**
+     * Retrieves the current preparation delay for this media.
+     * 
+     * @return The current preparation delay (in ms).
+     */
+    public int getPreparationDelay() {
+      return preparationDelay;
+    }
+
+    /**
+     * Sets the current preparation delay for this media.
+     * 
+     * @param preparationDelay
+     *          the new preparation delay (in ms).
+     */
+    public void setPreparationDelay(int preparationDelay) {
+      this.preparationDelay = preparationDelay;
+    }
+
+    /**
+     * Gets the exception that will be thrown when setDataSource() is called.
+     * 
+     * @return The exception that will be thrown when setDataSource() is called.
+     */
+    public Exception getSetDataSourceException() {
+      return setDataSourceException;
+    }
+
+    /**
+     * Sets the exception to throw when setDataSource() is called.
+     * <code>null</code> means no exception will be thrown. Note that emulation
+     * of IllegalStateException is already handled by the shadow implementation
+     * of setDataSource() and does not need to be emulated using this method.
+     * 
+     * @param e
+     *          the exception to be thrown.
+     */
+    public void setSetDataSourceException(Exception e) {
+      if (e != null && !(e instanceof IOException)
+          && !(e instanceof RuntimeException)) {
+        throw new AssertionError("Invalid exception type: " + e);
+      }
+      setDataSourceException = e;
+    }
+
+    /**
+     * Schedules a generic event to run at the specified playback offset. Events
+     * are run on the thread on which the {@link android.media.MediaPlayer
+     * MediaPlayer} was created.
+     * 
+     * @param offset
+     *          the offset from the start of playback at which this event will
+     *          run.
+     * @param event
+     *          the event to run.
+     */
+    public void scheduleEventAtOffset(int offset, Runnable event) {
+      RunList runList = events.get(offset);
+      final boolean reallyPlaying = isReallyPlaying();
+      if (reallyPlaying) {
+        // Need to stop while modifying the collections
+        // otherwise we can cause a ConcurrentModificationException
+        doStop();
+      }
+      if (runList == null) {
+        // Given that most run lists will only contain one event,
+        // we use 1 as the default capacity.
+        runList = new RunList();
+        events.put(offset, runList);
+      }
+      runList.add(event);
+      // If we were playing make sure we restart again to reschedule
+      // the new events.
+      if (reallyPlaying) {
+        doStart();
+      }
+    }
+
+    /**
+     * Schedules an error event to run at the specified playback offset. A
+     * reference to the actual Runnable that is scheduled is returned, which can
+     * be used in a subsequent call to {@link #removeEventAtOffset}.
+     * 
+     * @param offset
+     *          the offset from the start of playback at which this error will
+     *          trigger.
+     * @param what
+     *          the value for the <code>what</code> parameter to use in the call
+     *          to
+     *          {@link android.media.MediaPlayer.OnErrorListener#onError(MediaPlayer, int, int)
+     *          onError()}.
+     * @param extra
+     *          the value for the <code>extra</code> parameter to use in the
+     *          call to
+     *          {@link android.media.MediaPlayer.OnErrorListener#onError(MediaPlayer, int, int)
+     *          onError()}.
+     * @return A reference to the Runnable object that was created & scheduled.
+     */
+    public Runnable scheduleErrorAtOffset(int offset, int what, int extra) {
+      ErrorCallback callback = new ErrorCallback(what, extra);
+      scheduleEventAtOffset(offset, callback);
+      return callback;
+    }
+
+    /**
+     * Schedules an info event to run at the specified playback offset. A
+     * reference to the actual Runnable that is scheduled is returned, which can
+     * be used in a subsequent call to {@link #removeEventAtOffset}.
+     * 
+     * @param offset
+     *          the offset from the start of playback at which this event will
+     *          trigger.
+     * @param what
+     *          the value for the <code>what</code> parameter to use in the call
+     *          to
+     *          {@link android.media.MediaPlayer.OnInfoListener#onInfo(MediaPlayer, int, int)
+     *          onInfo()}.
+     * @param extra
+     *          the value for the <code>extra</code> parameter to use in the
+     *          call to
+     *          {@link android.media.MediaPlayer.OnInfoListener#onInfo(MediaPlayer, int, int)
+     *          onInfo()}.
+     * @return A reference to the Runnable object that was created & scheduled.
+     */
+    public Runnable scheduleInfoAtOffset(int offset, final int what,
+        final int extra) {
+      Runnable callback = new Runnable() {
+        public void run() {
+          invokeInfoListener(what, extra);
+        }
+      };
+      scheduleEventAtOffset(offset, callback);
+      return callback;
+    }
+
+    /**
+     * Schedules a simulated buffer underrun event to run at the specified
+     * playback offset. A reference to the actual Runnable that is scheduled is
+     * returned, which can be used in a subsequent call to
+     * {@link #removeEventAtOffset}.
+     * 
+     * This event will issue an {@link MediaPlayer.OnInfoListener#onInfo
+     * onInfo()} callback with {@link MediaPlayer#MEDIA_INFO_BUFFERING_START} to
+     * signal the start of buffering and then call {@link #doStop()} to
+     * internally pause playback. Finally it will schedule an event to fire
+     * after <code>length</code> ms which fires a
+     * {@link MediaPlayer#MEDIA_INFO_BUFFERING_END} info event and invokes
+     * {@link #doStart()} to resume playback.
+     * 
+     * @param offset
+     *          the offset from the start of playback at which this underrun
+     *          will trigger.
+     * @param length
+     *          the length of time (in ms) for which playback will be paused.
+     * @return A reference to the Runnable object that was created & scheduled.
+     */
+    public Runnable scheduleBufferUnderrunAtOffset(int offset, final int length) {
+      final Runnable restart = new Runnable() {
+        public void run() {
+          invokeInfoListener(MediaPlayer.MEDIA_INFO_BUFFERING_END, 0);
+          doStart();
+        }
+      };
+      Runnable callback = new Runnable() {
+        public void run() {
+          doStop();
+          invokeInfoListener(MediaPlayer.MEDIA_INFO_BUFFERING_START, 0);
+          handler.postDelayed(restart, length);
+        }
+      };
+      scheduleEventAtOffset(offset, callback);
+      return callback;
+    }
+
+    /**
+     * Removes the specified event from the playback schedule at the given
+     * playback offset.
+     * 
+     * @param offset
+     *          the offset at which the event was scheduled.
+     * @param event
+     *          the event to remove.
+     * @see #removeEvent(Runnable)
+     */
+    public void removeEventAtOffset(int offset, Runnable event) {
+      ArrayList<Runnable> runList = events.get(offset);
+      if (runList != null) {
+        final boolean reallyPlaying = isReallyPlaying();
+        if (reallyPlaying) {
+          // Need to stop while modifying the collections
+          // otherwise we can cause a ConcurrentModificationException
+          doStop();
+        }
+        runList.remove(event);
+        if (runList.isEmpty()) {
+          events.remove(offset);
+        }
+        if (reallyPlaying) {
+          // If we were playing make sure we restart again to reschedule
+          // the new events.
+          doStart();
+        }
+      }
+    }
+
+    /**
+     * Removes the specified event from the playback schedule at all playback
+     * offsets where it has been scheduled.
+     * 
+     * @param event
+     *          the event to remove.
+     * @see #removeEventAtOffset(int,Runnable)
+     */
+    public void removeEvent(Runnable event) {
+      final boolean reallyPlaying = isReallyPlaying();
+      if (reallyPlaying) {
+        // Need to stop while modifying the collections
+        // otherwise we can cause a ConcurrentModificationException
+        doStop();
+      }
+      for (Iterator<Entry<Integer, RunList>> iter = events.entrySet()
+          .iterator(); iter.hasNext();) {
+        Entry<Integer, RunList> entry = iter.next();
+        RunList runList = entry.getValue();
+        runList.remove(event);
+        if (runList.isEmpty()) {
+          iter.remove();
+        }
+      }
+      // If we were playing make sure we restart again to reschedule
+      // the new events.
+      if (reallyPlaying) {
+        doStart();
+      }
     }
   }
-  
+
+  /**
+   * Callback interface for clients that wish to be informed when a new
+   * {@link MediaPlayer} instance is constructed.
+   * 
+   * @see #setCreateListener
+   */
   public static interface CreateListener {
-    public void onCreate(MediaPlayer player,
-                         ShadowMediaPlayer shadow);
+    /**
+     * Method that is invoked when a new {@link MediaPlayer} is created. This
+     * method is invoked at the end of the constructor, after all of the default
+     * setup has been completed.
+     * 
+     * @param player
+     *          reference to the newly-created media player object.
+     * @param shadow
+     *          reference to the corresponding shadow object for the
+     *          newly-created media player (provided for convenience).
+     */
+    public void onCreate(MediaPlayer player, ShadowMediaPlayer shadow);
   }
-  
+
   /** Current state of the media player. */
   private State state = IDLE;
-
-  /** Delay for calls to {@link #prepare} and {@link #prepareAsync} (in ms). */
-  private int preparationDelay = 0;
 
   /** Delay for calls to {@link #seekTo} (in ms). */
   private int seekDelay = 0;
@@ -71,7 +450,6 @@ public class ShadowMediaPlayer {
   private int auxEffect;
   private int audioSessionId;
   private int audioStreamType;
-  private int duration;
   private boolean looping;
   private int pendingSeek = -1;
   /** Various source variables from setDataSource() */
@@ -79,12 +457,12 @@ public class ShadowMediaPlayer {
   private Uri sourceUri;
   private Map<String, String> sourceHeaders;
   private int sourceResId;
-  private FileDescriptor sourceFd;
+  private FileDescriptor sourceFD;
   private long sourceOffset = -1;
   private long sourceLength = -1;
 
   /** The time (in ms) at which playback was last started/resumed. */
-  private long startTime = 0;
+  private long startTime = -1;
 
   /**
    * The offset (in ms) from the start of the current clip at which the last
@@ -102,15 +480,14 @@ public class ShadowMediaPlayer {
   private MediaPlayer.OnCompletionListener completionListener;
   private MediaPlayer.OnSeekCompleteListener seekCompleteListener;
   private MediaPlayer.OnPreparedListener preparedListener;
+  private MediaPlayer.OnInfoListener infoListener;
   private MediaPlayer.OnErrorListener errorListener;
 
   /**
-   * Flag indicating that the shadow should assert if any 
-   * operations are invoked in invalid states, rather than
-   * the default (which is to emulate actual onError or
-   * exception behavior).
+   * Flag indicating how the shadow media player should behave when a method is
+   * invoked in an invalid state.
    */
-  private boolean assertOnError;
+  private InvalidStateBehavior invalidStateBehavior = InvalidStateBehavior.SILENT;
   private Handler handler;
 
   private final Runnable completionCallback = new Runnable() {
@@ -119,6 +496,7 @@ public class ShadowMediaPlayer {
         startOffset = 0;
         doStart();
       } else {
+        doStop();
         invokeCompletionListener();
       }
     }
@@ -137,32 +515,44 @@ public class ShadowMediaPlayer {
   };
 
   /**
-   * Playback offset at which to fire the scheduled error. Measured in ms
-   * relative to the start of playback. Negative indicates no error scheduled.
+   * Callback to use when a method is invoked from an invalid state. Has
+   * <code>what = -38</code> and <code>extra = 0</code>, which are values that
+   * were determined by inspection.
    */
-  private int errorOffset = -1;
+  private final ErrorCallback invalidStateErrorCallback = new ErrorCallback(
+      -38, 0);
 
+  /** Callback to use for scheduled errors. */
   private class ErrorCallback implements Runnable {
     private int what;
     private int extra;
 
-    public void setParams(int what, int extra) {
+    public ErrorCallback(int what, int extra) {
       this.what = what;
       this.extra = extra;
     }
+
     public void run() {
       invokeErrorListener(what, extra);
     }
   }
 
-  /** Callback to use for scheduled errors. */
-  private final ErrorCallback errorCallback = new ErrorCallback();
-
-  /** Exception to throw when {@link #setDataSource} is called. */
-  private Exception setDataSourceException;
-
-  /** Map of strings to media metadata. Used by {@link #setDataSource(String)}. */
+  /**
+   * Map of strings to {@link #MediaInfo} instances. Used by
+   * {@link #setDataSource(String)} to set the {@link #currentMediaInfo} field
+   * based on the current data source.
+   */
   private Map<String, MediaInfo> dataSourceMap;
+
+  /**
+   * The MediaInfo object describing the default playback schedule currently
+   * selected. If there is no overriding {@link #MediaInfo} instance invoked by
+   * {@link #setDataSource(String)}, then this instance is used.
+   */
+  private MediaInfo defaultMediaInfo = new MediaInfo(1000, 0);
+
+  /** The MediaInfo object describing the playback schedule currently selected. */
+  private MediaInfo mediaInfo = defaultMediaInfo;
 
   @Implementation
   public static MediaPlayer create(Context context, int resId) {
@@ -197,7 +587,7 @@ public class ShadowMediaPlayer {
     // the master mix) then that's an error. By default it generates
     // an ID that is unique system-wide. We could simulate guaranteed
     // uniqueness (get AudioManager's help?) but it's probably not
-    // worth the effort.
+    // worth the effort - a random non-zero number will probably do.
     Random random = new Random();
     audioSessionId = random.nextInt(Integer.MAX_VALUE) + 1;
     handler = new Handler();
@@ -212,90 +602,153 @@ public class ShadowMediaPlayer {
   @Implementation
   public void setDataSource(String path) throws IOException {
     MediaInfo info = dataSourceMap == null ? null : dataSourceMap.get(path);
-    doSetDataSourceExceptions(info);
+    setCurrentMediaInfo(info);
+    doSetDataSourceExceptions();
     this.sourcePath = path;
   }
 
   @Implementation
   public void setDataSource(Context context, Uri uri,
       Map<String, String> headers) throws IOException {
-    doSetDataSourceExceptions(null);
+    doSetDataSourceExceptions();
     this.sourceUri = uri;
     this.sourceHeaders = headers;
   }
 
   @Implementation
   public void setDataSource(FileDescriptor fd, long offset, long length)
-    throws IOException {
-    doSetDataSourceExceptions(null);
-    this.sourceFd = fd;
+      throws IOException {
+    doSetDataSourceExceptions();
+    this.sourceFD = fd;
     this.sourceOffset = offset;
     this.sourceLength = length;
   }
 
-  private void doSetDataSourceExceptions(MediaInfo info) throws IOException {
+  private void doSetDataSourceExceptions() throws IOException {
+    Exception setDataSourceException = mediaInfo.getSetDataSourceException();
     // By inspection I determined that the state check is one
     // of the last things to happen (once you get into native
     // code land) - there is plenty of code in Java land for
     // another type of exception to be thrown before then.
     if (setDataSourceException != null) {
       if (setDataSourceException instanceof IOException) {
-        throw (IOException)setDataSourceException;
+        throw (IOException) setDataSourceException;
       }
       if (setDataSourceException instanceof RuntimeException) {
-        throw (RuntimeException)setDataSourceException;
-      }  
-      throw new AssertionError("Invalid exception type specified: " + setDataSourceException);
-    }    
-    checkState("setDataSource()", idleState);
-    if (info != null) {
-      setDuration(info.duration);
-      setPreparationDelay(info.preparationDelay);
+        throw (RuntimeException) setDataSourceException;
+      }
+      throw new AssertionError("Invalid exception type specified: "
+          + setDataSourceException);
     }
+    checkStateException("setDataSource()", idleState);
     state = INITIALIZED;
   }
 
+  /**
+   * Checks states for methods that only log when there is an error. Such
+   * methods throw an {@link IllegalArgumentException} when invoked in the END
+   * state, but log an error in other disallowed states. This method will either
+   * emulate this behavior or else will generate an assertion if invoked from a
+   * disallowed state if {@link #setAssertOnError assertOnError} is set.
+   * 
+   * @param method
+   *          the name of the method being tested.
+   * @param allowedStates
+   *          the states that this method is allowed to be called from.
+   * @see #setAssertOnError
+   * @see #checkStateError(String, EnumSet)
+   * @see #checkStateException(String, EnumSet)
+   */
   private void checkStateLog(String method, EnumSet<State> allowedStates) {
-    if (assertOnError && (!allowedStates.contains(state) || state == END)) {
-      String msg = "Can't call " + method + " from state " + state;
-      throw new AssertionError(msg);
-    } 
-    if (state == END) {
-      String msg = "Can't call " + method + " from state " + state;
-      throw new IllegalStateException(msg);
-    } 
-  }
-  
-  private boolean checkStateError(String method, EnumSet<State> allowedStates) {
-    if (!allowedStates.contains(state)) {
-      if (assertOnError) {
-        String msg = "Can't call " + method + " from state " + state;
-        throw new AssertionError(msg);
-      }
+    switch (invalidStateBehavior) {
+    case SILENT:
+      break;
+    case EMULATE:
       if (state == END) {
         String msg = "Can't call " + method + " from state " + state;
         throw new IllegalStateException(msg);
-      } 
-      state = ERROR;
-      // -38 and 0 are values that I obtained via
-      // inspection on a live device.
-      errorCallback.setParams(-38, 0);
-      handler.post(errorCallback);
-      return false;
-    }
-    return true;
-  }
-  private void checkState(String method, EnumSet<State> allowedStates) {
-    if (!allowedStates.contains(state)) {
-      String msg = "Can't call " + method + " from state " + state;
-      if (assertOnError) {
+      }
+      break;
+    case ASSERT:
+      if (!allowedStates.contains(state) || state == END) {
+        String msg = "Can't call " + method + " from state " + state;
         throw new AssertionError(msg);
-      } else {
-        throw new IllegalStateException(msg);
       }
     }
   }
-  
+
+  /**
+   * Checks states for methods that asynchronously invoke
+   * {@link android.media.MediaPlayer.OnErrorListener#onError(MediaPlayer, int, int)
+   * onError()} when invoked in an illegal state. Such methods always throw
+   * {@link IllegalStateException} rather than invoke <code>onError()</code> if
+   * they are invoked from the END state.
+   * 
+   * This method will either emulate this behavior by posting an
+   * <code>onError()</code> callback to the current thread's message queue (or
+   * throw an {@link IllegalStateException} if invoked from the END state), or
+   * else it will generate an assertion if {@link #setAssertOnError
+   * assertOnError} is set.
+   * 
+   * @param method
+   *          the name of the method being tested.
+   * @param allowedStates
+   *          the states that this method is allowed to be called from.
+   * @see #getHandler
+   * @see #setAssertOnError
+   * @see #checkStateLog(String, EnumSet)
+   * @see #checkStateException(String, EnumSet)
+   */
+  private boolean checkStateError(String method, EnumSet<State> allowedStates) {
+    if (!allowedStates.contains(state)) {
+      switch (invalidStateBehavior) {
+      case SILENT:
+        break;
+      case EMULATE:
+        if (state == END) {
+          String msg = "Can't call " + method + " from state " + state;
+          throw new IllegalStateException(msg);
+        }
+        state = ERROR;
+        handler.post(invalidStateErrorCallback);
+        return false;
+      case ASSERT:
+        String msg = "Can't call " + method + " from state " + state;
+        throw new AssertionError(msg);
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Checks states for methods that synchronously throw an exception when
+   * invoked in an illegal state. This method will likewise throw an
+   * {@link IllegalArgumentException} if it determines that the method has been
+   * invoked from a disallowed state, or else it will generate an assertion if
+   * {@link #setAssertOnError assertOnError} is set.
+   * 
+   * @param method
+   *          the name of the method being tested.
+   * @param allowedStates
+   *          the states that this method is allowed to be called from.
+   * @see #setAssertOnError
+   * @see #checkStateLog(String, EnumSet)
+   * @see #checkStateException(String, EnumSet)
+   */
+  private void checkStateException(String method, EnumSet<State> allowedStates) {
+    if (!allowedStates.contains(state)) {
+      String msg = "Can't call " + method + " from state " + state;
+      switch (invalidStateBehavior) {
+      case SILENT:
+        break;
+      case EMULATE:
+        throw new IllegalStateException(msg);
+      case ASSERT:
+        throw new AssertionError(msg);
+      }
+    }
+  }
+
   @Implementation
   public void setOnCompletionListener(MediaPlayer.OnCompletionListener listener) {
     completionListener = listener;
@@ -313,20 +766,26 @@ public class ShadowMediaPlayer {
   }
 
   @Implementation
+  public void setOnInfoListener(MediaPlayer.OnInfoListener listener) {
+    infoListener = listener;
+  }
+
+  @Implementation
   public void setOnErrorListener(MediaPlayer.OnErrorListener listener) {
     errorListener = listener;
   }
 
   @Implementation
   public boolean isLooping() {
-    checkState("isLooping()", nonEndStates);
+    checkStateException("isLooping()", nonEndStates);
     return looping;
   }
 
-  static private final EnumSet<State> nonEndStates =
-      EnumSet.complementOf(EnumSet.of(END));
-  static private final EnumSet<State> nonErrorStates =
-    EnumSet.complementOf(EnumSet.of(ERROR, END));
+  static private final EnumSet<State> nonEndStates = EnumSet
+      .complementOf(EnumSet.of(END));
+  static private final EnumSet<State> nonErrorStates = EnumSet
+      .complementOf(EnumSet.of(ERROR, END));
+
   @Implementation
   public void setLooping(boolean looping) {
     checkStateError("setLooping()", nonErrorStates);
@@ -346,34 +805,61 @@ public class ShadowMediaPlayer {
     return state == STARTED;
   }
 
-  private static EnumSet<State> preparableStates =
-      EnumSet.of(INITIALIZED, STOPPED);
+  private static EnumSet<State> preparableStates = EnumSet.of(INITIALIZED,
+      STOPPED);
 
+  /**
+   * Simulates {@link MediaPlayer#prepareAsync()}. Sleeps for
+   * {@link MediaInfo#getPreparationDelay() preparationDelay} ms by calling
+   * {@link SystemClock#sleep(long)} before calling
+   * {@link #invokePreparedListener()}.
+   * 
+   * If <code>preparationDelay</code> is not positive and non-zero, there is no
+   * sleep.
+   * 
+   * @see MediaInfo#setPreparationDelay(int)
+   * @see #invokePreparedListener()
+   */
   @Implementation
   public void prepare() {
-    checkState("prepare()", preparableStates);
-    if (preparationDelay > 0) {
-      SystemClock.sleep(preparationDelay);
+    checkStateException("prepare()", preparableStates);
+    if (mediaInfo.preparationDelay > 0) {
+      SystemClock.sleep(mediaInfo.preparationDelay);
     }
     invokePreparedListener();
   }
 
   /**
-   * Test cases are expected to simulate completion of the 'prepare' phase by
-   * manually invoking {@code #invokePreparedListener}.
+   * Simulates {@link MediaPlayer#prepareAsync()}. Sets state to PREPARING and
+   * posts a callback to {@link #invokePreparedListener()} if the current
+   * preparation delay for the current media (see {@link #getMediaInfo()}) is >=
+   * 0, otherwise the test suite is responsible for calling
+   * {@link #invokePreparedListener()} directly if required.
+   * 
+   * @see MediaInfo#setPreparationDelay(int)
+   * @see #invokePreparedListener()
    */
   @Implementation
   public void prepareAsync() {
-    checkState("prepareAsync()", preparableStates);
+    checkStateException("prepareAsync()", preparableStates);
     state = PREPARING;
-    if (preparationDelay >= 0) {
-      handler.postDelayed(preparedCallback, preparationDelay);
+    if (mediaInfo.preparationDelay >= 0) {
+      handler.postDelayed(preparedCallback, mediaInfo.preparationDelay);
     }
   }
 
-  private static EnumSet<State> startableStates =
-    EnumSet.of(PREPARED, STARTED, PAUSED, PLAYBACK_COMPLETED);
+  private static EnumSet<State> startableStates = EnumSet.of(PREPARED, STARTED,
+      PAUSED, PLAYBACK_COMPLETED);
 
+  /**
+   * Simulates {@link MediaPlayer#start()}. Sets state to STARTED and calls
+   * {@link #doStart()} to start scheduling playback callback events.
+   * 
+   * If the current state is PLAYBACK_COMPLETED, the current position is reset
+   * to zero before starting playback.
+   * 
+   * @see #doStart()
+   */
   @Implementation
   public void start() {
     if (checkStateError("start()", startableStates)) {
@@ -385,24 +871,91 @@ public class ShadowMediaPlayer {
     }
   }
 
-  private void doStart() {
-    startTime = SystemClock.uptimeMillis();
-    if (errorOffset >= startOffset) {
-      handler.postDelayed(errorCallback, errorOffset - startOffset);
+  private void scheduleNextPlaybackEvent() {
+    if (!isReallyPlaying()) {
+      return;
+    }
+    final int currentPosition = getCurrentPositionRaw();
+    Entry<Integer, RunList> event = mediaInfo.events
+        .higherEntry(currentPosition);
+    if (event == null) {
+      // This means we've "seeked" past the end. Get the last
+      // event (which should be the completion event) and
+      // invoke that, setting the position to the duration.
+      handler.post(completionCallback);
     } else {
-      handler.postDelayed(completionCallback, duration - startOffset);
+      final int runListOffset = event.getKey();
+      nextPlaybackEvent = event.getValue();
+      handler.postDelayed(nextPlaybackEvent, runListOffset - currentPosition);
     }
   }
 
-  private void doStop() {
-    startOffset = getCurrentPosition();
-    handler.removeCallbacks(completionCallback);
-    handler.removeCallbacks(errorCallback);
+  /**
+   * Tests to see if the player is really playing.
+   * 
+   * The player is defined as "really playing" if simulated playback events
+   * (including playback completion) are being scheduled & invoked and
+   * {@link #getCurrentPosition currentPosition} is being updated as time
+   * passes. Note that while the player will normally be really playing if in
+   * the STARTED state, this is not always the case - for example, if a pending
+   * seek is in progress, or perhaps a buffer underrun is being simulated.
+   * 
+   * @return <code>true</code> if the player is really playing or
+   *         <code>false</code> if the player is internally paused.
+   * @see #doStart
+   * @see #doStop
+   */
+  public boolean isReallyPlaying() {
+    return startTime >= 0;
+  }
+
+  /**
+   * Starts simulated playback. Until this method is called, the player is not
+   * "really playing" (see {@link #isReallyPlaying} for a definition of
+   * "really playing").
+   * 
+   * This method is used internally by the various shadow method implementations
+   * of the MediaPlayer public API, but may also be called directly by the test
+   * suite if you wish to simulate an internal pause.
+   * 
+   * @see #isReallyPlaying()
+   * @see #doStop()
+   */
+  public void doStart() {
+    startTime = SystemClock.uptimeMillis();
+    scheduleNextPlaybackEvent();
+  }
+
+  /**
+   * Pauses simulated playback. After this method is called, the player is no
+   * longer "really playing" (see {@link #isReallyPlaying} for a definition of
+   * "really playing").
+   * 
+   * This method is used internally by the various shadow method implementations
+   * of the MediaPlayer public API, but may also be called directly by the test
+   * suite if you wish to simulate an internal pause.
+   * 
+   * @see #isReallyPlaying()
+   * @see #doStart()
+   */
+  public void doStop() {
+    startOffset = getCurrentPositionRaw();
+    if (nextPlaybackEvent != null) {
+      handler.removeCallbacks(nextPlaybackEvent);
+      nextPlaybackEvent = null;
+    }
+    startTime = -1;
   }
 
   private static final EnumSet<State> pausableStates = EnumSet.of(STARTED,
       PAUSED, PLAYBACK_COMPLETED);
 
+  /**
+   * Simulates {@link MediaPlayer#pause()}. Invokes {@link #doStop()} to suspend
+   * playback event callbacks and sets the state to PAUSED.
+   * 
+   * @see #doStop()
+   */
   @Implementation
   public void pause() {
     if (checkStateError("pause()", pausableStates)) {
@@ -412,21 +965,50 @@ public class ShadowMediaPlayer {
   }
 
   static final EnumSet<State> allStates = EnumSet.allOf(State.class);
+
+  /**
+   * Simulates call to {@link MediaPlayer#release()}. Calls {@link #doStop()} to
+   * suspend playback event callbacks and sets the state to END.
+   */
   @Implementation
   public void release() {
-    checkState("release()", allStates);
+    checkStateException("release()", allStates);
+    doStop();
     state = END;
+    // FIXME: This doesn't actually do the job due to a bug
+    // in the ShadowHandler implementation - the callbacks are
+    // removed from the Handler but not from the Scheduler, so
+    // they run anyway. Need to fix - otherwise (eg) a pending
+    // seek callback can be invoked some time after reset()
+    // has completed, which is not realistic.
+    handler.removeCallbacksAndMessages(null);
   }
 
+  /**
+   * Simulates call to {@link MediaPlayer#reset()}. Calls {@link #doStop()} to
+   * suspend playback event callbacks and sets the state to IDLE.
+   */
   @Implementation
   public void reset() {
-    checkState("reset()", nonEndStates);
+    checkStateException("reset()", nonEndStates);
+    doStop();
     state = IDLE;
+    // FIXME: This doesn't actually do the job due to a bug
+    // in the ShadowHandler implementation - the callbacks are
+    // removed from the Handler but not from the Scheduler, so
+    // they run anyway. Need to fix - otherwise (eg) a pending
+    // seek callback can be invoked some time after reset()
+    // has completed, which is not realistic.
+    handler.removeCallbacksAndMessages(null);
   }
 
-  static private final EnumSet<State> stoppableStates =
-      EnumSet.of(PREPARED, STARTED, PAUSED, STOPPED, PLAYBACK_COMPLETED);
+  static private final EnumSet<State> stoppableStates = EnumSet.of(PREPARED,
+      STARTED, PAUSED, STOPPED, PLAYBACK_COMPLETED);
 
+  /**
+   * Simulates call to {@link MediaPlayer#release()}. Calls {@link #doStop()} to
+   * suspend playback event callbacks and sets the state to STOPPED.
+   */
   @Implementation
   public void stop() {
     if (checkStateError("stop()", stoppableStates)) {
@@ -435,9 +1017,9 @@ public class ShadowMediaPlayer {
     }
   }
 
-  private static final EnumSet<State> attachableStates = EnumSet
-      .of(INITIALIZED, PREPARING, PREPARED, STARTED, PAUSED, STOPPED,
-          PLAYBACK_COMPLETED);
+  private static final EnumSet<State> attachableStates = EnumSet.of(
+      INITIALIZED, PREPARING, PREPARED, STARTED, PAUSED, STOPPED,
+      PLAYBACK_COMPLETED);
 
   @Implementation
   public void attachAuxEffect(int effectId) {
@@ -447,24 +1029,35 @@ public class ShadowMediaPlayer {
 
   @Implementation
   public int getAudioSessionId() {
-    checkState("getAudioSessionId()", allStates);
+    checkStateException("getAudioSessionId()", allStates);
     return audioSessionId;
   }
 
+  /**
+   * Simulates call to {@link MediaPlayer#getCurrentPosition()}. Simply does the
+   * state validity checks and then invokes {@link #getCurrentPositionRaw()} to
+   * calculate the simulated playback position.
+   * 
+   * @return The current offset (in ms) of the simulated playback.
+   * @see #getCurrentPositionRaw()
+   */
   @Implementation
   public int getCurrentPosition() {
     checkStateError("getCurrentPosition()", attachableStates);
-    int currentPos = startOffset;
-    if (state == STARTED && pendingSeek < 0) {
-      currentPos += (int) (SystemClock.uptimeMillis() - startTime);
-    }
-    return currentPos;
+    return getCurrentPositionRaw();
   }
 
+  /**
+   * Simulates call to {@link MediaPlayer#getDuration()}. Retrieves the duration
+   * as defined by the current {@link MediaInfo} instance.
+   * 
+   * @return The duration (in ms) of the current simulated playback.
+   * @see #getCurrentMediaInfo()
+   */
   @Implementation
   public int getDuration() {
     checkStateError("getDuration()", stoppableStates);
-    return duration;
+    return mediaInfo.duration;
   }
 
   @Implementation
@@ -479,8 +1072,8 @@ public class ShadowMediaPlayer {
     return videoWidth;
   }
 
-  private static final EnumSet<State> seekableStates =
-    EnumSet.of(PREPARED, STARTED, PAUSED, PLAYBACK_COMPLETED);
+  private static final EnumSet<State> seekableStates = EnumSet.of(PREPARED,
+      STARTED, PAUSED, PLAYBACK_COMPLETED);
 
   /**
    * Simulates seeking to specified position. The seek will complete after
@@ -511,31 +1104,51 @@ public class ShadowMediaPlayer {
   }
 
   static private final EnumSet<State> idleState = EnumSet.of(IDLE);
+
   @Implementation
   public void setAudioSessionId(int sessionId) {
     checkStateError("setAudioSessionId()", idleState);
     audioSessionId = sessionId;
   }
 
-  static private final EnumSet<State> nonPlayingStates = EnumSet.of(IDLE, INITIALIZED, STOPPED);
+  static private final EnumSet<State> nonPlayingStates = EnumSet.of(IDLE,
+      INITIALIZED, STOPPED);
+
   @Implementation
   public void setAudioStreamType(int audioStreamType) {
     checkStateError("setAudioStreamType()", nonPlayingStates);
     this.audioStreamType = audioStreamType;
   }
 
+  /**
+   * Sets a listener that is invoked whenever a new shadowed {@link MediaPlayer}
+   * object is constructed. Registering a listener gives you a chance to
+   * customize the shadowed object appropriately (eg, invoking
+   * {@link #setDefaultMediaInfo setDefaultMediaInfo()} or
+   * {@link #setDataSourceMap setDataSourceMap()} without needing to modify the
+   * application-under-test to provide access to the instance at the appropriate
+   * point in its life cycle. This is useful because normally a new
+   * {@link MediaPlayer} is created and {@link #setDataSource setDataSource()}
+   * is invoked soon after, without a break in the code. Using this callback
+   * means you don't have to change this common pattern just so that you can
+   * customize the shadow for testing.
+   * 
+   * @param createListener
+   *          the listener to be invoked
+   */
   public static void setCreateListener(CreateListener createListener) {
     ShadowMediaPlayer.createListener = createListener;
   }
-  
+
   /**
-   * Retrieves the Handler object used by this <code>ShadowMediaPlayer</code>.
-   * Can be used for posting custom asynchronous events to the thread (eg,
-   * asynchronous errors). Use this for scheduling events to take place at a
-   * particular "real" time (ie, time as measured by the scheduler). For
-   * scheduling errors to occur at a particular point in playback (no matter how
-   * long playback may be paused for, or where you seek to, etc), see
-   * {@link #scheduleErrorAtOffset}. Non-Android accessor.
+   * Retrieves the {@link Handler} object used by this
+   * <code>ShadowMediaPlayer</code>. Can be used for posting custom asynchronous
+   * events to the thread (eg, asynchronous errors). Use this for scheduling
+   * events to take place at a particular "real" time (ie, time as measured by
+   * the scheduler). For scheduling events to occur at a particular playback
+   * offset (no matter how long playback may be paused for, or where you seek
+   * to, etc), see {@link MediaInfo#scheduleEventAtOffset(int, Runnable)} and
+   * its various helpers.
    * 
    * @return Handler object that can be used to schedule asynchronous events on
    *         this media player.
@@ -545,85 +1158,203 @@ public class ShadowMediaPlayer {
   }
 
   /**
-   * Retrieves current setting of the flag that indicates
-   * methods should assert when there is an error.
-   * @return
-   */
-  public boolean isAssertOnError() {
-    return assertOnError;
-  }
-  
-  /**
-   * Sets or clears the flag indicating that the player should
-   * assert when methods are invoked that cause an error. If this
-   * flag isn't set then the player will emulate normal behavior
-   * (ie, call onError() or throw an exception, as appropriate).
-   * @param assertOnError <code>true</code> if the player should assert
-   *                      when there are errors, <code>false</code> if
-   *                      it should emulate real behavior.
-   */
-  public void setAssertOnError(boolean assertOnError) {
-    this.assertOnError = assertOnError;
-  }
-  
-  /**
-   * Sets the exception to throw when setDataSource() is called.
-   * <code>null</code> means no exception will be thrown. Note that emulation of
-   * IllegalStateException is already handled by the shadow implementation of
-   * setDataSource() and does not need to be emulated using this method.
+   * Retrieves current flag specifying the behavior of the media player when a
+   * method is invoked in an invalid state. See
+   * {@link #setInvalidStateBehavior(InvalidStateBehavior)} for a discussion of
+   * the available modes and their associated behaviors.
    * 
-   * @param e the exception to be thrown.
+   * @return The current invalid state behavior mode.
+   * @see #setInvalidStateBehavior
    */
-  public void setSetDataSourceException(Exception e) {
-    if (e != null
-        && !(e instanceof IOException)
-        && !(e instanceof RuntimeException) ) {
-      throw new AssertionError("Invalid exception type: " + e);
-    }
-    setDataSourceException = e;
+  public InvalidStateBehavior getInvalidStateBehavior() {
+    return invalidStateBehavior;
   }
 
   /**
-   * Non-Android setter.
+   * Specifies how the media player should behave when a method is invoked in an
+   * invalid state. Three modes are supported (as defined by the
+   * {@link InvalidStateBehavior} enum):
+   * 
+   * <ul>
+   * <li>SILENT: no invalid state checking is done at all. All methods can be
+   * invoked from any state without throwing any exceptions or invoking the
+   * error listener.
+   * 
+   * This mode is provided primarily for backwards compatibility, and for this
+   * reason it is the default. For proper testing one of the other two modes is
+   * probably preferable.</li>
+   * <li>EMULATE: the shadow will attempt to emulate the behavior of the actual
+   * {@link MediaPlayer} implementation. This is based on a reading of the
+   * documentation and on actual experiments done on a Jelly Bean device. The
+   * official documentation is not all that clear, but basically methods fall
+   * into three categories:
+   * <ul>
+   * <li>Those that log an error when invoked in an invalid state but don't
+   * throw an exception or invoke <code>onError()</code>. An example is
+   * {@link #getVideoHeight()}.</li>
+   * <li>Synchronous error handling: methods always throw an exception (usually
+   * {@link IllegalStateException} but don't invoke <code>onError()</code>.
+   * Examples are {@link #prepare()} and {@link #setDataSource(String)}.</li>
+   * <li>Asynchronous error handling: methods don't throw an exception but
+   * invoke <code>onError()</code>.</li>
+   * </ul>
+   * Additionally, all three methods behave synchronously (throwing
+   * {@link IllegalStateException} when invoked from the END state.
+   * 
+   * To complicate matters slightly, the official documentation sometimes
+   * contradicts observed behavior. For example, the documentation says it is
+   * illegal to call {@link #setDataSource} from the ERROR state - however, in
+   * practice it works fine. Conversely, the documentation says that it is legal
+   * to invoke {@link #getCurrentPosition()} from the INITIALIZED state, however
+   * testing showed that this caused an error. Wherever there is a discrepancy
+   * between documented and observed behavior, this implementation has gone with
+   * the most conservative implementation (ie, it is illegal to invoke
+   * {@link #setDataSource} from the ERROR state and likewise illegal to invoke
+   * {@link #getCurrentPosition()} from the INITIALIZED state.
+   * <li>ASSERT: the shadow will raise an assertion any time that a method is
+   * invoked in an invalid state. The philosophy behind this mode is that to
+   * invoke a method in an invalid state is a programming error - a bug, pure
+   * and simple. As such it should be discovered & eliminated at development &
+   * testing time, rather than anticipated and handled at runtime. Asserting is
+   * a way of testing for these bugs during testing.</li>
+   * </ul>
+   * 
+   * @param invalidStateBehavior
+   *          the behavior mode for this shadow to use during testing.
+   * @see #getInvalidStateBehavior()
+   */
+  public void setInvalidStateBehavior(InvalidStateBehavior invalidStateBehavior) {
+    this.invalidStateBehavior = invalidStateBehavior;
+  }
+
+  /**
+   * Retrieves the default {@link MediaInfo}. This is the {@link MediaInfo}
+   * instance that will be used if it is not overridden by something in the
+   * {@link #setDataSourceMap dataSourceMap}.
+   * 
+   * @return The default {@link MediaInfo} instance.
+   * @see #setDefaultMediaInfo(MediaInfo)
+   */
+  public MediaInfo getDefaultMediaInfo() {
+    return defaultMediaInfo;
+  }
+
+  /**
+   * Sets the default {@link MediaInfo} instance. See
+   * {@link #getDefaultMediaInfo()} for details.
+   * 
+   * @param defaultMediaInfo
+   *          the new default {@link MediaInfo} instance.
+   * @throws NullPointerException
+   *           if <code>defaultMediaInfo</code> is <code>null</code>.
+   * @see #getDefaultMediaInfo()
+   */
+  public void setDefaultMediaInfo(MediaInfo defaultMediaInfo) {
+    if (defaultMediaInfo == null) {
+      throw new NullPointerException();
+    }
+    this.defaultMediaInfo = defaultMediaInfo;
+  }
+
+  /**
+   * Retrieves the currently selected {@link MediaInfo}. This instance is used
+   * to define current duration, preparation delay, exceptions for
+   * <code>setDataSource()</code>, playback events, etc.
+   * 
+   * @return The currently selected {@link MediaInfo}.
+   * @see #setCurrentMediaInfo(MediaInfo)
+   */
+  public MediaInfo getCurrentMediaInfo() {
+    return mediaInfo;
+  }
+
+  /**
+   * Sets the current media info and configures playback simulation
+   * appropriately. Non-Android setter. Calling this during a playback
+   * simulation will have unpredictable results.
+   * 
+   * @param mediaInfo
+   *          the new {@link MediaInfo} instance to describe current playback
+   *          behavior. If <code>null</code>, will be set to
+   *          {@link #getDefaultMediaInfo defaultMediaInfo}.
+   * @see #getCurrentMediaInfo()
+   */
+  public void setCurrentMediaInfo(MediaInfo mediaInfo) {
+    if (mediaInfo == null) {
+      this.mediaInfo = defaultMediaInfo;
+    } else {
+      this.mediaInfo = mediaInfo;
+    }
+  }
+
+  /**
+   * Constructs a new {@link MediaInfo} object with the specified duration and
+   * preparation delay.
+   * 
+   * @param duration
+   *          the duration (in ms) for the MediaInfo object.
+   * @param preparationDelay
+   *          the preparation delay (in ms) for the MediaInfo object.
+   * @return The newly created MediaInfo instance with the specified initial
+   *         values.
+   */
+  public MediaInfo buildMediaInfo(int duration, int preparationDelay) {
+    return new MediaInfo(duration, preparationDelay);
+  }
+
+  /**
+   * Sets the current position, bypassing the normal state checking. Use with
+   * care. Non-Android setter.
    * 
    * @param position
+   *          the new playback position.
    */
   public void setCurrentPosition(int position) {
     startOffset = position;
   }
 
   /**
-   * Non-Android setter. Sets a map from String datasource
-   * to a MediaInfo instance containing info to use for that
-   * data source (eg, duration, preparation delay, etc).
+   * Non-Android setter. Sets a map from String datasource to a MediaInfo
+   * instance containing info to use for that data source (eg, duration,
+   * preparation delay, etc).
    */
   public void setDataSourceMap(Map<String, MediaInfo> map) {
     this.dataSourceMap = map;
   }
+
   /**
-   * Retrieves the current duration without doing
-   * the state checking that the emulated version does.
-   * Non-Android accessor.
+   * Retrieves the current position without doing the state checking that the
+   * emulated version of {@link #getCurrentPosition()} does. Non-Android
+   * accessor.
+   * 
+   * @return The current playback position within the current clip.
+   */
+  public int getCurrentPositionRaw() {
+    int currentPos = startOffset;
+    if (isReallyPlaying()) {
+      currentPos += (int) (SystemClock.uptimeMillis() - startTime);
+    }
+    return currentPos;
+  }
+
+  /**
+   * Retrieves the current duration without doing the state checking that the
+   * emulated version does. Non-Android accessor.
    * 
    * @return The duration of the current clip loaded by the player.
    */
   public int getDurationRaw() {
-    return duration;
-  }
-  /**
-   * Non-Android setter.
-   * 
-   * @param duration
-   */
-  public void setDuration(int duration) {
-    this.duration = duration;
+    return mediaInfo.duration;
   }
 
   /**
-   * Non-Android accessor. Used for assertions.
+   * Retrieves the current state of the {@link MediaPlayer}. Uses the states as
+   * defined in the {@link MediaPlayer} documentation. Non-Android accessor.
+   * Used for assertions.
    * 
    * @return The current state of the {@link MediaPlayer}, as defined in the
    *         MediaPlayer documentation.
+   * @see #setState
    * @see MediaPlayer
    */
   public State getState() {
@@ -631,9 +1362,18 @@ public class ShadowMediaPlayer {
   }
 
   /**
-   * Non-Android setter.
+   * Forces the @link MediaPlayer} into the specified state. Uses the states as
+   * defined in the {@link MediaPlayer} documentation.
+   * 
+   * Note that by invoking this method directly you can get the player into an
+   * inconsistent state that a real player could not be put in (eg, in the END
+   * state but with playback events still happening). Use with care.
    * 
    * @param state
+   *          the new state of the {@link MediaPlayer}, as defined in the
+   *          MediaPlayer documentation.
+   * @see #getState
+   * @see MediaPlayer
    */
   public void setState(State state) {
     this.state = state;
@@ -642,22 +1382,10 @@ public class ShadowMediaPlayer {
   /**
    * Non-Android accessor.
    * 
-   * @return preparationDelay
+   * @return audioStreamType
    */
-  public int getPreparationDelay() {
-    return preparationDelay;
-  }
-
-  /**
-   * Sets the length of time that prepare()/prepareAsync() will wait for before
-   * completing. Default is 0. If set to -1, then prepare() will complete
-   * instantly but prepareAsync() will not call the OnPreparedListener
-   * automatically; you will need to call invokePreparedListener() manually.
-   * 
-   * @param preparationDelay
-   */
-  public void setPreparationDelay(int preparationDelay) {
-    this.preparationDelay = preparationDelay;
+  public int getAudioStreamType() {
+    return audioStreamType;
   }
 
   /**
@@ -692,48 +1420,113 @@ public class ShadowMediaPlayer {
   }
 
   /**
-   * Non-Android accessor. Used for assertions.
+   * Retrieves the pending seek setting.
    * 
-   * @return the position to which the shadow player is seeking for the seek in
+   * @return The position to which the shadow player is seeking for the seek in
    *         progress (ie, after the call to {@link #seekTo} but before a call
-   *         to invokeOnSeekCompleteListener). Returns -1 if no seek is in
-   *         progress.
+   *         to {@link #invokeSeekCompleteListener()}). Returns <code>-1</code>
+   *         if no seek is in progress.
    */
   public int getPendingSeek() {
     return pendingSeek;
   }
 
   /**
+   * Retrieves the source path (if any) that was passed in to
+   * {@link MediaPlayer#setDataSource(String, Map)} or
+   * {@link MediaPlayer#setDataSource(String)}.
+   * 
    * Non-Android accessor. Use for assertions.
    * 
-   * @return
+   * @return The source path passed in to <code>setDataSource</code>.
    */
   public String getSourcePath() {
     return sourcePath;
   }
 
   /**
+   * Retrieves the source path (if any) that was passed in to
+   * {@link MediaPlayer#setDataSource(Context, Uri, Map)} or
+   * {@link MediaPlayer#setDataSource(Context, Uri)}.
+   * 
    * Non-Android accessor. Use for assertions.
    * 
-   * @return
+   * @return The source Uri passed in to <code>setDataSource</code>.
    */
   public Uri getSourceUri() {
     return sourceUri;
   }
 
   /**
+   * Retrieves the source headers (if any) that were passed in to
+   * {@link MediaPlayer#setDataSource(Context, Uri, Map)} or
+   * {@link MediaPlayer#setDataSource(String, Map)}.
+   * 
    * Non-Android accessor. Use for assertions.
    * 
-   * @return
+   * @return The source headers passed in to <code>setDataSource</code>.
    */
   public Map<String, String> getSourceHeaders() {
     return sourceHeaders;
   }
 
   /**
-   * Non-Android accessor.  Use for assertions.
-   *
-   * @return The Source Res ID
+   * Retrieves the {@link FileDescriptor} (if any) that was passed in to
+   * {@link MediaPlayer#setDataSource(FileDescriptor)} or
+   * {@link MediaPlayer#setDataSource(FileDescriptor, long, long)}.
+   * 
+   * Non-Android accessor. Use for assertions.
+   * 
+   * @return The source file descriptor passed in to <code>setDataSource</code>.
+   */
+  public FileDescriptor getSourceFD() {
+    return sourceFD;
+  }
+
+  /**
+   * Retrieves the file descriptor offset (if any) that was passed in to
+   * {@link MediaPlayer#setDataSource(FileDescriptor, long, long)}.
+   * 
+   * Non-Android accessor. Use for assertions.
+   * 
+   * @return The source file offset passed in to <code>setDataSource</code>.
+   */
+  public long getSourceOffset() {
+    return sourceOffset;
+  }
+
+  /**
+   * Retrieves the file descriptor length (if any) that was passed in to
+   * {@link MediaPlayer#setDataSource(FileDescriptor, long, long)}.
+   * 
+   * Non-Android accessor. Use for assertions.
+   * 
+   * @return The source file length passed in to <code>setDataSource</code>.
+   */
+  public long getSourceLength() {
+    return sourceLength;
+  }
+
+  /**
+   * Retrieves the resource ID used in the call to {@link #create(Context, int)}
+   * (if any).
+   * 
+   * Non-Android accessor. Use for assertions.
+   * 
+   * @return The resource ID passed in to <code>create()</code>, or
+   *         <code>-1</code> if a different method of setting the source was
+   *         used.
+   */
+  public int getSourceResId() {
+    return sourceResId;
+  }
+
+  /**
+   * Retrieves the current setting for the left channel volume.
+   * 
+   * Non-Android accessor. Use for assertions.
+   * 
+   * @return The left channel volume.
    */
   public float getLeftVolume() {
     return leftVolume;
@@ -748,23 +1541,16 @@ public class ShadowMediaPlayer {
     return rightVolume;
   }
 
-  /**
-   * Non-Android accessor. Use for assertions.
-   * 
-   * @return
-   */
-  public int getSourceResId() {
-    return sourceResId;
-  }
-
-  private static EnumSet<State> preparedStates =
-    EnumSet.of(PREPARED, STARTED, PAUSED, PLAYBACK_COMPLETED);
+  private static EnumSet<State> preparedStates = EnumSet.of(PREPARED, STARTED,
+      PAUSED, PLAYBACK_COMPLETED);
 
   /**
-   * Non-Android accessor. Use for assertions. This is mainly used for backward
-   * compatibility. {@link #getState} may be more useful for new testing applications.
+   * Tests to see if the player is in the PREPARED state. Non-Android accessor.
+   * Use for assertions. This is mainly used for backward compatibility.
+   * {@link #getState} may be more useful for new testing applications.
    * 
-   * @return true if the MediaPlayer is in the PREPARED state, false otherwise.
+   * @return <code>true</code> if the MediaPlayer is in the PREPARED state,
+   *         false otherwise.
    */
   public boolean isPrepared() {
     return preparedStates.contains(state);
@@ -788,7 +1574,9 @@ public class ShadowMediaPlayer {
   }
 
   /**
-   * Allows test cases to simulate 'prepared' state by invoking callback.
+   * Allows test cases to simulate 'prepared' state by invoking callback. Sets
+   * the player's state to PREPARED and invokes the
+   * {@link MediaPlayer.OnPreparedListener#onPrepare preparedListener()
    */
   public void invokePreparedListener() {
     state = PREPARED;
@@ -798,11 +1586,13 @@ public class ShadowMediaPlayer {
   }
 
   /**
-   * Allows test cases to simulate 'completed' state by invoking callback.
+   * Simulates end-of-playback. Changes the player into PLAYBACK_COMPLETED state
+   * and calls
+   * {@link MediaPlayer.OnCompletionListener#onCompletion(MediaPlayer)
+   * onCompletion()} if a listener has been set.
    */
   public void invokeCompletionListener() {
     state = PLAYBACK_COMPLETED;
-    setCurrentPosition(duration);
     if (completionListener == null)
       return;
     completionListener.onCompletion(player);
@@ -812,41 +1602,31 @@ public class ShadowMediaPlayer {
    * Allows test cases to simulate seek completion by invoking callback.
    */
   public void invokeSeekCompleteListener() {
-    setCurrentPosition(pendingSeek > duration ? duration : pendingSeek < 0 ? 0
-        : pendingSeek);
+    setCurrentPosition(pendingSeek > mediaInfo.duration ? mediaInfo.duration
+        : pendingSeek < 0 ? 0 : pendingSeek);
     pendingSeek = -1;
     if (state == STARTED) {
       doStart();
     }
-    if (seekCompleteListener == null)
+    if (seekCompleteListener == null) {
       return;
+    }
     seekCompleteListener.onSeekComplete(player);
   }
 
   /**
-   * Schedules a callback to {@link #invokeErrorListener(int, int) invoke
-   * ErrorListener()} at the given playback offset.
+   * Allows test cases to directly simulate invocation of the OnInfo event.
    * 
-   * @param offset
-   *          the offset (in ms) from the start of playback at which to fire the
-   *          error. Setting to a negative number effectively disabled the
-   *          scheduled error.
    * @param what
    *          parameter to pass in to <code>what</code> in
-   *          {@link OnErrorListener#onError()}.
+   *          {@link OnInfoListener#onInfo onInfo()}.
    * @param extra
    *          parameter to pass in to <code>extra</code> in
-   *          {@link OnErrorListener#onError()}.
+   *          {@link OnInfoListener#onInfo onInfo()}.
    */
-  public void scheduleErrorAtOffset(int offset, int what, int extra) {
-    errorOffset = offset;
-    errorCallback.what = what;
-    errorCallback.extra = extra;
-    if (state == STARTED) {
-      // If we're already in the STARTED state then we need
-      // to reschedule the pending error/completion callback.
-      doStop();
-      doStart();
+  public void invokeInfoListener(int what, int extra) {
+    if (infoListener != null) {
+      infoListener.onInfo(player, what, extra);
     }
   }
 
@@ -861,17 +1641,18 @@ public class ShadowMediaPlayer {
    *          {@link OnErrorListener#onError()}.
    */
   public void invokeErrorListener(int what, int extra) {
+    // Calling doStop() un-schedules the next event and
+    // stops normal event flow from continuing.
+    doStop();
     state = ERROR;
-    handler.removeCallbacks(completionCallback);
     boolean handled = errorListener != null
         && errorListener.onError(player, what, extra);
     if (!handled) {
-      // XXX
       // The documentation isn't very clear if onCompletion is
       // supposed to be called from non-playing states
-      // (ie, states other than STARTED or PAUSED). It
-      // wouldn't seem to make sense to me to notify
-      // of completion before it has started...
+      // (ie, states other than STARTED or PAUSED). Testing
+      // revealed that onCompletion is invoked even if playback
+      // hasn't started or is not in progress.
       invokeCompletionListener();
       // Need to set this again because
       // invokeCompletionListener() will set the state

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
@@ -67,9 +67,15 @@ import static org.robolectric.shadows.util.DataSource.toDataSource;
  * <li>Emulation of exceptions when calling {@link #setDataSource} using
  * {@link #addException}.</li>
  * </ul>
+ *
+ * <b>Note</b>: One gotcha with this shadow is that you need to either configure an
+ * exception or a {@link ShadowMediaPlayer.MediaInfo} instance for that data source
+ * (using {@link #addException} or {@link addMediaInfo} respectively) <i>before</i>
+ * calling {@link #setDataSource}, otherwise you'll get an
+ * {@link IllegalArgumentException}.
  * 
- * The current features of <code>ShadowMediaPlayer</code> were developed for
- * testing playback of audio tracks. Thus support for emulating timed text and
+ * The current features of <code>ShadowMediaPlayer</code> were focussed on development
+ * for testing playback of audio tracks. Thus support for emulating timed text and
  * video events is incomplete. None of these features would be particularly onerous
  * to add/fix - contributions welcome, of course!
  * 
@@ -599,7 +605,7 @@ public class ShadowMediaPlayer {
    */
   public void doSetDataSource(DataSource dataSource) {
     if (mediaInfo.get(dataSource) == null) {
-      throw new AssertionError("Don't know what to do with dataSource " + dataSource +
+      throw new IllegalArgumentException("Don't know what to do with dataSource " + dataSource +
           " - either add an exception with addException() or media info with addMediaInfo()");
     }
     this.dataSource = dataSource;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
@@ -10,6 +10,7 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.TreeMap;
 
+import android.app.Activity;
 import android.content.Context;
 import android.media.MediaPlayer;
 import android.net.Uri;
@@ -17,7 +18,6 @@ import android.os.Handler;
 import android.os.SystemClock;
 
 import org.robolectric.Robolectric;
-import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -597,6 +597,8 @@ public class ShadowMediaPlayer {
     if (createListener != null) {
       createListener.onCreate(player, this);
     }
+    // Ensure that the real object is set up properly.
+    Robolectric.invokeConstructor(MediaPlayer.class, player);
   }
 
   @Implementation
@@ -852,7 +854,7 @@ public class ShadowMediaPlayer {
       PAUSED, PLAYBACK_COMPLETED);
 
   /**
-   * Simulates {@link MediaPlayer#start()}. Sets state to STARTED and calls
+   * Simulates private native method {@link MediaPlayer#_start()}. Sets state to STARTED and calls
    * {@link #doStart()} to start scheduling playback callback events.
    * 
    * If the current state is PLAYBACK_COMPLETED, the current position is reset
@@ -861,7 +863,7 @@ public class ShadowMediaPlayer {
    * @see #doStart()
    */
   @Implementation
-  public void start() {
+  public void _start() {
     if (checkStateError("start()", startableStates)) {
       if (state == PLAYBACK_COMPLETED) {
         startOffset = 0;
@@ -951,13 +953,13 @@ public class ShadowMediaPlayer {
       PAUSED, PLAYBACK_COMPLETED);
 
   /**
-   * Simulates {@link MediaPlayer#pause()}. Invokes {@link #doStop()} to suspend
+   * Simulates {@link MediaPlayer#_pause()}. Invokes {@link #doStop()} to suspend
    * playback event callbacks and sets the state to PAUSED.
    * 
    * @see #doStop()
    */
   @Implementation
-  public void pause() {
+  public void _pause() {
     if (checkStateError("pause()", pausableStates)) {
       doStop();
       state = PAUSED;
@@ -967,11 +969,11 @@ public class ShadowMediaPlayer {
   static final EnumSet<State> allStates = EnumSet.allOf(State.class);
 
   /**
-   * Simulates call to {@link MediaPlayer#release()}. Calls {@link #doStop()} to
+   * Simulates call to {@link MediaPlayer#_release()}. Calls {@link #doStop()} to
    * suspend playback event callbacks and sets the state to END.
    */
   @Implementation
-  public void release() {
+  public void _release() {
     checkStateException("release()", allStates);
     doStop();
     state = END;
@@ -985,11 +987,11 @@ public class ShadowMediaPlayer {
   }
 
   /**
-   * Simulates call to {@link MediaPlayer#reset()}. Calls {@link #doStop()} to
+   * Simulates call to {@link MediaPlayer#_reset()}. Calls {@link #doStop()} to
    * suspend playback event callbacks and sets the state to IDLE.
    */
   @Implementation
-  public void reset() {
+  public void _reset() {
     checkStateException("reset()", nonEndStates);
     doStop();
     state = IDLE;
@@ -1011,7 +1013,7 @@ public class ShadowMediaPlayer {
    * suspend playback event callbacks and sets the state to STOPPED.
    */
   @Implementation
-  public void stop() {
+  public void _stop() {
     if (checkStateError("stop()", stoppableStates)) {
       doStop();
       state = STOPPED;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
@@ -1000,6 +1000,7 @@ public class ShadowMediaPlayer {
     // seek callback can be invoked some time after reset()
     // has completed, which is not realistic.
     handler.removeCallbacksAndMessages(null);
+    startOffset = 0;
   }
 
   static private final EnumSet<State> stoppableStates = EnumSet.of(PREPARED,

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
@@ -598,6 +598,10 @@ public class ShadowMediaPlayer {
    * @see #setDataSource(DataSource)
    */
   public void doSetDataSource(DataSource dataSource) {
+    if (mediaInfo.get(dataSource) == null) {
+      throw new AssertionError("Don't know what to do with dataSource " + dataSource +
+          " - either add an exception with addException() or media info with addMediaInfo()");
+    }
     this.dataSource = dataSource;
   }
   

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/util/DataSource.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/util/DataSource.java
@@ -28,6 +28,10 @@ public class DataSource {
     return toDataSource(uri.toString());
   }
 
+  public static DataSource toDataSource(Context context, Uri uri, Map<String, String> headers) {
+    return toDataSource(context, uri);
+  }
+
   public static DataSource toDataSource(String uri, Map<String, String> headers) {
     return toDataSource(uri);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
@@ -1235,7 +1235,7 @@ public class ShadowMediaPlayerTest {
     shadowMediaPlayer.setCurrentPosition(400);
     shadowMediaPlayer.setState(PAUSED);
     shadowMediaPlayer.getDefaultMediaInfo().scheduleErrorAtOffset(200, 1, 2);
-    shadowMediaPlayer.start();
+    mediaPlayer.start();
     scheduler.unPause();
     Mockito.verifyZeroInteractions(errorListener);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
@@ -19,7 +19,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 import org.robolectric.internal.Shadow;
@@ -1152,25 +1151,6 @@ public class ShadowMediaPlayerTest {
     assertThat(shadowMediaPlayer.getCurrentPositionRaw()).isEqualTo(500);
   }
 
-//  @Test
-//  public void testScheduleErrorAtOffsetWhilePlaying() {
-//    shadowMediaPlayer.setState(PREPARED);
-//    mediaPlayer.start();
-//
-//    scheduler.advanceBy(200);
-//
-//    shadowMediaPlayer.getDefaultMediaInfo().scheduleErrorAtOffset(500, 1, 3);
-//
-//    scheduler.advanceBy(299);
-//    Mockito.verifyZeroInteractions(errorListener);
-//
-//    scheduler.advanceBy(1);
-//    Mockito.verify(errorListener).onError(mediaPlayer, 1, 3);
-//    Mockito.verify(completionListener).onCompletion(mediaPlayer);
-//    assertThat(scheduler.advanceToLastPostedRunnable()).isFalse();
-//    assertThat(shadowMediaPlayer.getCurrentPositionRaw()).isEqualTo(500);
-//  }
-
   @Test
   public void testScheduleErrorAtOffsetInPast() {
     info.scheduleErrorAtOffset(200, 1, 2);
@@ -1182,24 +1162,6 @@ public class ShadowMediaPlayerTest {
     Mockito.verifyZeroInteractions(errorListener);
   }
 
-//  @Ignore("Changing the schedule during playback is not currently supported")
-//  @Test
-//  public void testScheduleInfoAtOffsetWhilePlaying() {
-//    shadowMediaPlayer.setState(PREPARED);
-//    mediaPlayer.start();
-//
-//    scheduler.advanceBy(200);
-//
-//    shadowMediaPlayer.getDefaultMediaInfo().scheduleInfoAtOffset(500, 1, 3);
-//
-//    scheduler.advanceBy(299);
-//    Mockito.verifyZeroInteractions(infoListener);
-//
-//    scheduler.advanceBy(1);
-//    Mockito.verify(infoListener).onInfo(mediaPlayer, 1, 3);
-//    Mockito.verifyZeroInteractions(completionListener);
-//  }
-//
   @Test
   public void testScheduleBufferUnderrunAtOffset() {
     info.scheduleBufferUnderrunAtOffset(100, 50);
@@ -1231,77 +1193,83 @@ public class ShadowMediaPlayerTest {
 
   @Test
   public void testRemoveEventAtOffset() {
-//    shadowMediaPlayer.setState(PREPARED);
-//    mediaPlayer.start();
-//
-//    scheduler.advanceBy(200);
-//
-//    Runnable r = shadowMediaPlayer.getDefaultMediaInfo().scheduleInfoAtOffset(
-//        500, 1, 3);
-//
-//    scheduler.advanceBy(299);
-//    shadowMediaPlayer.getDefaultMediaInfo().removeEventAtOffset(500, r);
-//    scheduler.advanceToLastPostedRunnable();
-//    Mockito.verifyZeroInteractions(infoListener);
+    shadowMediaPlayer.setState(PREPARED);
+    mediaPlayer.start();
+
+    scheduler.advanceBy(200);
+
+    MediaEvent e = info.scheduleInfoAtOffset(
+        500, 1, 3);
+
+    scheduler.advanceBy(299);
+    info.removeEventAtOffset(500, e);
+    scheduler.advanceToLastPostedRunnable();
+    Mockito.verifyZeroInteractions(infoListener);
   }
 
   @Test
   public void testRemoveEvent() {
-//    shadowMediaPlayer.setState(PREPARED);
-//    mediaPlayer.start();
-//
-//    scheduler.advanceBy(200);
-//
-//    Runnable r = shadowMediaPlayer.getDefaultMediaInfo().scheduleInfoAtOffset(
-//        500, 1, 3);
-//
-//    scheduler.advanceBy(299);
-//    shadowMediaPlayer.getDefaultMediaInfo().removeEvent(r);
-//    scheduler.advanceToLastPostedRunnable();
-//    Mockito.verifyZeroInteractions(infoListener);
+    shadowMediaPlayer.setState(PREPARED);
+    mediaPlayer.start();
+
+    scheduler.advanceBy(200);
+
+    MediaEvent e = info.scheduleInfoAtOffset(500, 1, 3);
+
+    scheduler.advanceBy(299);
+    shadowMediaPlayer.doStop();
+    info.removeEvent(e);
+    shadowMediaPlayer.doStart();
+    scheduler.advanceToLastPostedRunnable();
+    Mockito.verifyZeroInteractions(infoListener);
   }
 
   @Test
   public void testScheduleMultipleRunnables() {
-//    shadowMediaPlayer.setState(PREPARED);
-//    scheduler.advanceBy(25);
-//    mediaPlayer.start();
-//
-//    scheduler.advanceBy(200);
-//    MediaInfo mediaInfo = shadowMediaPlayer.getDefaultMediaInfo();
-//    assertThat(scheduler.size()).isEqualTo(1);
-//    mediaInfo.scheduleInfoAtOffset(250, 2, 4);
-//    assertThat(scheduler.size()).isEqualTo(1);
-//
-//    Runnable r1 = Mockito.mock(Runnable.class);
-//
-//    mediaInfo.scheduleEventAtOffset(400, r1);
-//
-//    scheduler.advanceBy(49);
-//    Mockito.verifyZeroInteractions(infoListener);
-//    scheduler.advanceBy(1);
-//    Mockito.verify(infoListener).onInfo(mediaPlayer, 2, 4);
-//    scheduler.advanceBy(149);
-//    mediaInfo.scheduleErrorAtOffset(675, 32, 22);
-//    Mockito.verifyZeroInteractions(r1);
-//    scheduler.advanceBy(1);
-//    Mockito.verify(r1).run();
-//
-//    mediaPlayer.pause();
-//    assertThat(scheduler.size()).isEqualTo(0);
-//    scheduler.advanceBy(324);
-//    Runnable r2 = Mockito.mock(Runnable.class);
-//    mediaInfo.scheduleEventAtOffset(680, r2);
-//    mediaPlayer.start();
-//    scheduler.advanceBy(274);
-//    Mockito.verifyZeroInteractions(errorListener);
-//
-//    scheduler.advanceBy(1);
-//    Mockito.verify(errorListener).onError(mediaPlayer, 32, 22);
-//    assertThat(scheduler.size()).isEqualTo(0);
-//    assertThat(shadowMediaPlayer.getCurrentPositionRaw()).isEqualTo(675);
-//    assertThat(shadowMediaPlayer.getState()).isSameAs(ERROR);
-//    Mockito.verifyZeroInteractions(r2);
+    shadowMediaPlayer.setState(PREPARED);
+    scheduler.advanceBy(25);
+    mediaPlayer.start();
+
+    scheduler.advanceBy(200);
+    assertThat(scheduler.size()).isEqualTo(1);
+    shadowMediaPlayer.doStop();
+    info.scheduleInfoAtOffset(250, 2, 4);
+    shadowMediaPlayer.doStart();
+    assertThat(scheduler.size()).isEqualTo(1);
+
+    MediaEvent e1 = Mockito.mock(MediaEvent.class);
+
+    shadowMediaPlayer.doStop();
+    info.scheduleEventAtOffset(400, e1);
+    shadowMediaPlayer.doStart();
+
+    scheduler.advanceBy(49);
+    Mockito.verifyZeroInteractions(infoListener);
+    scheduler.advanceBy(1);
+    Mockito.verify(infoListener).onInfo(mediaPlayer, 2, 4);
+    scheduler.advanceBy(149);
+    shadowMediaPlayer.doStop();
+    info.scheduleErrorAtOffset(675, 32, 22);
+    shadowMediaPlayer.doStart();
+    Mockito.verifyZeroInteractions(e1);
+    scheduler.advanceBy(1);
+    Mockito.verify(e1).run(mediaPlayer, shadowMediaPlayer);
+
+    mediaPlayer.pause();
+    assertThat(scheduler.size()).isEqualTo(0);
+    scheduler.advanceBy(324);
+    MediaEvent e2 = Mockito.mock(MediaEvent.class);
+    info.scheduleEventAtOffset(680, e2);
+    mediaPlayer.start();
+    scheduler.advanceBy(274);
+    Mockito.verifyZeroInteractions(errorListener);
+
+    scheduler.advanceBy(1);
+    Mockito.verify(errorListener).onError(mediaPlayer, 32, 22);
+    assertThat(scheduler.size()).isEqualTo(0);
+    assertThat(shadowMediaPlayer.getCurrentPositionRaw()).isEqualTo(675);
+    assertThat(shadowMediaPlayer.getState()).isSameAs(ERROR);
+    Mockito.verifyZeroInteractions(e2);
   }
 
   @Test
@@ -1335,24 +1303,6 @@ public class ShadowMediaPlayerTest {
     } catch (Exception eThrown) {
       Assertions.fail(eThrown + " was thrown, expecting IOException");
     }
-  }
-
-  @Test
-  public void testMediaInfoOfSubsequentSDSCallsNotAffectedByEarlier()
-      throws IOException {
-//    MediaInfo dummyInfo = shadowMediaPlayer.buildMediaInfo(3000, 2);
-//    Map<String, MediaInfo> map = new HashMap<String, MediaInfo>();
-//    map.put("dummy", dummyInfo);
-//    shadowMediaPlayer.setDataSourceMap(map);
-//    mediaPlayer.setDataSource("dummy");
-//
-//    assertThat(shadowMediaPlayer.getCurrentMediaInfo()).isSameAs(dummyInfo);
-//
-//    shadowMediaPlayer.setState(IDLE);
-//    mediaPlayer.setDataSource("dummy2");
-//
-//    assertThat(shadowMediaPlayer.getCurrentMediaInfo()).isSameAs(
-//        shadowMediaPlayer.getDefaultMediaInfo());
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
@@ -91,6 +91,14 @@ public class ShadowMediaPlayerTest {
   }
 
   @Test
+  public void testResetResetsPosition() {
+    shadowMediaPlayer.setCurrentPosition(300);
+    mediaPlayer.reset();
+    assertThat(shadowMediaPlayer.getCurrentPositionRaw())
+      .isEqualTo(0);
+  }
+  
+  @Test
   public void testPrepare() throws IOException {
     int[] testDelays = { 0, 10, 100, 1500 };
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
@@ -1406,15 +1406,11 @@ public class ShadowMediaPlayerTest {
       .isNull();
 
     // Check that the mediaInfo was cleared.
-    boolean success = false;
     try {
       shadowMediaPlayer.doSetDataSource(defaultSource);
-      success = true;
-    } catch (AssertionError ae) {
+      Assertions.failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+    } catch (IllegalArgumentException ie) {
       // We expect this if the static state has been cleared.
-    }
-    if (success) {
-      Assertions.failBecauseExceptionWasNotThrown(AssertionError.class);
     }
 
     // Check that the exception was cleared.
@@ -1462,19 +1458,15 @@ public class ShadowMediaPlayerTest {
   
   @Test
   public void setDataSource_forNoDataSource_asserts() {
-    boolean success = false;
     try {
       mediaPlayer.setDataSource("some unspecified data source");
-      success = true;
+      Assertions.failBecauseExceptionWasNotThrown(AssertionError.class);
+    } catch (IllegalArgumentException a) {
+      assertThat(a.getMessage()).as("assertionMessage")
+      .contains("addException")
+      .contains("addMediaInfo");
     } catch (Exception e) {
       Assertions.fail("Unexpected exception", e);
-    } catch (AssertionError a) {
-      assertThat(a.getMessage()).as("assertionMessage")
-        .contains("addException")
-        .contains("addMediaInfo");
-    }
-    if (success) {
-      Assertions.failBecauseExceptionWasNotThrown(AssertionError.class);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
@@ -1,6 +1,17 @@
 package org.robolectric.shadows;
 
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Map;
+
+import android.content.Context;
 import android.media.MediaPlayer;
+import android.net.Uri;
+
+import org.assertj.core.api.Assertions;
+import org.fest.reflect.method.Invoker;
+import org.fest.reflect.method.MethodParameterTypes;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,32 +19,462 @@ import org.mockito.Mockito;
 import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
 import org.robolectric.internal.Shadow;
+import org.robolectric.shadows.ShadowMediaPlayer.State;
+import org.robolectric.util.Scheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.shadows.ShadowMediaPlayer.State.*;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ShadowMediaPlayerTest {
 
   private MediaPlayer mediaPlayer;
   private ShadowMediaPlayer shadowMediaPlayer;
+  private MediaPlayer.OnCompletionListener completionListener;
+  private MediaPlayer.OnErrorListener errorListener;
+  private MediaPlayer.OnPreparedListener preparedListener;
+  private MediaPlayer.OnSeekCompleteListener seekListener;
+  private Scheduler scheduler;
 
   @Before
   public void setUp() throws Exception {
     mediaPlayer = Shadow.newInstanceOf(MediaPlayer.class);
     shadowMediaPlayer = Shadows.shadowOf(mediaPlayer);
+    shadowMediaPlayer.setDuration(1000);
+
+    completionListener = Mockito.mock(MediaPlayer.OnCompletionListener.class);
+    mediaPlayer.setOnCompletionListener(completionListener);
+
+    preparedListener = Mockito.mock(MediaPlayer.OnPreparedListener.class);
+    mediaPlayer.setOnPreparedListener(preparedListener);
+
+    errorListener = Mockito.mock(MediaPlayer.OnErrorListener.class);
+    mediaPlayer.setOnErrorListener(errorListener);
+
+    seekListener = Mockito.mock(MediaPlayer.OnSeekCompleteListener.class);
+    mediaPlayer.setOnSeekCompleteListener(seekListener);
+
+    // Scheduler is used in many of the tests to simulate
+    // moving forward in time.
+    scheduler = Robolectric.getUiThreadScheduler();
   }
 
   @Test
-  public void isPlaying_shouldBeFalseUntilPlayIsCalled() {
-    assertThat(mediaPlayer.isPlaying()).isFalse();
+  public void testInitialState() {
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(IDLE);
+  }
+
+  @Test
+  public void testPrepare() throws IOException {
+    int[] testDelays = { 0, 10, 100, 1500 };
+    scheduler.pause();
+
+    for (int delay : testDelays) {
+      final long startTime = scheduler.getCurrentTime();
+      shadowMediaPlayer.setState(INITIALIZED);
+      shadowMediaPlayer.setPreparationDelay(delay);
+      mediaPlayer.prepare();
+
+      assertThat(shadowMediaPlayer.getState()).isEqualTo(PREPARED);
+      assertThat(scheduler.getCurrentTime()).isEqualTo(startTime + delay);
+    }
+  }
+
+  @Test
+  public void testPrepareAsyncAutoCallback() {
+    mediaPlayer.setOnPreparedListener(preparedListener);
+    int[] testDelays = { 0, 10, 100, 1500 };
+    scheduler.pause();
+
+    for (int delay : testDelays) {
+      shadowMediaPlayer.setState(INITIALIZED);
+      shadowMediaPlayer.setPreparationDelay(delay);
+      final long startTime = scheduler.getCurrentTime();
+      mediaPlayer.prepareAsync();
+
+      assertThat(shadowMediaPlayer.getState()).isEqualTo(PREPARING);
+      Mockito.verifyZeroInteractions(preparedListener);
+      scheduler.advanceToLastPostedRunnable();
+      assertThat(scheduler.getCurrentTime()).as("currentTime").isEqualTo(
+          startTime + delay);
+      assertThat(shadowMediaPlayer.getState()).isEqualTo(PREPARED);
+      Mockito.verify(preparedListener).onPrepared(mediaPlayer);
+      Mockito.verifyNoMoreInteractions(preparedListener);
+      Mockito.reset(preparedListener);
+    }
+  }
+
+  @Test
+  public void testPrepareAsyncManualCallback() {
+    mediaPlayer.setOnPreparedListener(preparedListener);
+
+    shadowMediaPlayer.setState(INITIALIZED);
+    shadowMediaPlayer.setPreparationDelay(-1);
+    final long startTime = scheduler.getCurrentTime();
+    mediaPlayer.prepareAsync();
+
+    assertThat(scheduler.getCurrentTime()).as("currentTime").isEqualTo(
+        startTime);
+    assertThat(shadowMediaPlayer.getState()).isSameAs(PREPARING);
+    Mockito.verifyZeroInteractions(preparedListener);
+    shadowMediaPlayer.invokePreparedListener();
+    assertThat(shadowMediaPlayer.getState()).isSameAs(PREPARED);
+    Mockito.verify(preparedListener).onPrepared(mediaPlayer);
+    Mockito.verifyNoMoreInteractions(preparedListener);
+  }
+
+  @Test
+  public void testDefaultPreparationDelay() {
+    assertThat(shadowMediaPlayer.getPreparationDelay()).as("preparationDelay")
+        .isEqualTo(0);
+  }
+
+  @Test
+  public void testIsPlaying() {
+    for (State state : State.values()) {
+      shadowMediaPlayer.setState(state);
+      boolean playing;
+      try {
+        playing = shadowMediaPlayer.isPlaying();
+        final State nextState = shadowMediaPlayer.getState();
+        assertThat(nextState)
+            .overridingErrorMessage(
+                "Expected state to remain unchanged <%s> when <isPlaying()> called, was <%s>",
+                state, nextState).isEqualTo(state);
+
+        if (state == STARTED) {
+          assertThat(playing).overridingErrorMessage(
+              "In state <%s>, expected isPlaying() to be true", state).isTrue();
+        } else if (state == ERROR || state == END) {
+          Assertions
+              .fail("Expected IllegalStateException to be thrown when <isPlaying()> called from state <"
+                  + state + ">");
+        } else {
+          assertThat(shadowMediaPlayer.isPlaying()).overridingErrorMessage(
+              "In state <%s>, expected isPlaying() to be false", state)
+              .isFalse();
+        }
+      } catch (IllegalStateException e) {
+        assertThat(state)
+            .overridingErrorMessage(
+                "<isPlaying()> should not throw IllegalStateException when in state <%s>",
+                state).isIn(ERROR, END);
+        final State nextState = shadowMediaPlayer.getState();
+        if (state == END) {
+          assertThat(nextState)
+            .overridingErrorMessage(
+              "Expected <isPlaying()> to leave state in <END>, was <%s>",
+              nextState).isSameAs(END);
+        }
+        else {
+          assertThat(nextState)
+            .overridingErrorMessage(
+                "Expected <isPlaying()> to change/leave state to <ERROR>, was <%s>",
+                nextState).isSameAs(ERROR);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testIsPrepared() {
+    EnumSet<State> prepStates = EnumSet.of(PREPARED, STARTED, PAUSED,
+        PLAYBACK_COMPLETED);
+
+    for (State state : State.values()) {
+      shadowMediaPlayer.setState(state);
+      if (prepStates.contains(state)) {
+        assertThat(shadowMediaPlayer.isPrepared()).overridingErrorMessage(
+            "In state <%s>, expected isPrepared() to be true", state).isTrue();
+      } else {
+        assertThat(shadowMediaPlayer.isPrepared()).overridingErrorMessage(
+            "In state <%s>, expected isPrepared() to be false", state)
+            .isFalse();
+      }
+    }
+  }
+
+  @Test
+  public void testPlaybackProgress() {
+    scheduler.pause();
+
+    shadowMediaPlayer.setState(PREPARED);
+    // This time offset is just to make sure that it doesn't work by
+    // accident because the offsets are calculated relative to 0.
+    scheduler.advanceBy(100);
+
     mediaPlayer.start();
-    assertThat(mediaPlayer.isPlaying()).isTrue();
+    assertThat(shadowMediaPlayer.getCurrentPosition()).isEqualTo(0);
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(STARTED);
+
+    scheduler.advanceBy(500);
+    assertThat(shadowMediaPlayer.getCurrentPosition()).isEqualTo(500);
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(STARTED);
+
+    scheduler.advanceBy(499);
+    assertThat(shadowMediaPlayer.getCurrentPosition()).isEqualTo(999);
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(STARTED);
+    Mockito.verifyZeroInteractions(completionListener);
+
+    scheduler.advanceBy(1);
+    assertThat(shadowMediaPlayer.getCurrentPosition()).isEqualTo(1000);
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(PLAYBACK_COMPLETED);
+    Mockito.verify(completionListener).onCompletion(mediaPlayer);
+    Mockito.verifyNoMoreInteractions(completionListener);
+
+    scheduler.advanceBy(1);
+    assertThat(shadowMediaPlayer.getCurrentPosition()).isEqualTo(1000);
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(PLAYBACK_COMPLETED);
+    Mockito.verifyZeroInteractions(completionListener);
+  }
+
+  @Test
+  public void testStop() {
+    scheduler.pause();
+    shadowMediaPlayer.setState(PREPARED);
+    mediaPlayer.start();
+    scheduler.advanceBy(300);
+
+    mediaPlayer.stop();
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(300);
+
+    scheduler.advanceBy(400);
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(300);
+  }
+
+  @Test
+  public void testPauseReschedulesCompletionCallback() {
+    scheduler.pause();
+    shadowMediaPlayer.setState(PREPARED);
+    mediaPlayer.start();
+
+    scheduler.advanceBy(200);
+    mediaPlayer.pause();
+    scheduler.advanceBy(800);
+    Mockito.verifyZeroInteractions(completionListener);
+
+    mediaPlayer.start();
+    scheduler.advanceBy(799);
+    Mockito.verifyZeroInteractions(completionListener);
+
+    scheduler.advanceBy(1);
+    Mockito.verify(completionListener).onCompletion(mediaPlayer);
+    Mockito.verifyNoMoreInteractions(completionListener);
+
+    assertThat(scheduler.advanceToLastPostedRunnable()).isFalse();
+    Mockito.verifyZeroInteractions(completionListener);
+  }
+
+  @Test
+  public void testPauseUpdatesPosition() {
+    scheduler.pause();
+    shadowMediaPlayer.setState(PREPARED);
+    mediaPlayer.start();
+
+    scheduler.advanceBy(200);
+    mediaPlayer.pause();
+    scheduler.advanceBy(200);
+
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(PAUSED);
+    assertThat(shadowMediaPlayer.getCurrentPosition()).isEqualTo(200);
+
+    mediaPlayer.start();
+    scheduler.advanceBy(200);
+
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(STARTED);
+    assertThat(shadowMediaPlayer.getCurrentPosition()).isEqualTo(400);
+  }
+
+  @Test
+  public void testSeekDuringPlaybackReschedulesCompletionCallback() {
+    scheduler.pause();
+    shadowMediaPlayer.setState(PREPARED);
+    mediaPlayer.start();
+
+    scheduler.advanceBy(300);
+    mediaPlayer.seekTo(400);
+    scheduler.advanceBy(599);
+    Mockito.verifyZeroInteractions(completionListener);
+    scheduler.advanceBy(1);
+    Mockito.verify(completionListener).onCompletion(mediaPlayer);
+    Mockito.verifyNoMoreInteractions(completionListener);
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(PLAYBACK_COMPLETED);
+
+    assertThat(scheduler.advanceToLastPostedRunnable()).isFalse();
+    Mockito.verifyZeroInteractions(completionListener);
+  }
+
+  @Test
+  public void testSeekDuringPlaybackUpdatesPosition() {
+    scheduler.pause();
+    shadowMediaPlayer.setState(PREPARED);
+
+    // This time offset is just to make sure that it doesn't work by
+    // accident because the offsets are calculated relative to 0.
+    scheduler.advanceBy(100);
+
+    mediaPlayer.start();
+
+    scheduler.advanceBy(400);
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(400);
+
+    mediaPlayer.seekTo(600);
+    scheduler.advanceBy(0);
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(600);
+
+    scheduler.advanceBy(300);
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(900);
+
+    mediaPlayer.seekTo(100);
+    scheduler.advanceBy(0);
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(100);
+
+    scheduler.advanceBy(900);
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(1000);
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(PLAYBACK_COMPLETED);
+
+    scheduler.advanceBy(100);
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(1000);
+  }
+
+  @Test
+  public void testPendingCompletionRemovedOnError() {
+    Mockito.when(errorListener.onError(mediaPlayer, 2, 3)).thenReturn(true);
+    shadowMediaPlayer.setState(PREPARED);
+    scheduler.pause();
+    mediaPlayer.start();
+    scheduler.advanceBy(200);
+
+    // We should have a pending completion callback.
+    assertThat(scheduler.enqueuedTaskCount()).isEqualTo(1);
+
+    shadowMediaPlayer.invokeErrorListener(2, 3);
+    assertThat(scheduler.advanceToLastPostedRunnable()).isFalse();
+    Mockito.verifyZeroInteractions(completionListener);
+  }
+
+  @Test
+  public void testAttachAuxEffectStates() {
+    testStates("attachAuxEffect(int)", method("attachAuxEffect")
+        .withParameterTypes(int.class), EnumSet.of(IDLE, ERROR), 37);
+  }
+
+  private static final EnumSet<State> emptyStateSet = EnumSet
+      .noneOf(State.class);
+
+  @Test
+  public void testGetAudioSessionIdStates() {
+    testStates("getAudioSessionId", emptyStateSet);
+  }
+
+  @Test
+  public void testGetCurrentPositionStates() {
+    testStates("getCurrentPosition", EnumSet.of(ERROR));
+  }
+
+  @Test
+  public void testGetDurationStates() {
+    testStates("getDuration", EnumSet.of(IDLE, INITIALIZED, ERROR));
+  }
+
+  @Test
+  public void testGetVideoHeightAndWidth() {
+    testStates("getVideoHeight", EnumSet.of(ERROR));
+    testStates("getVideoWidth", EnumSet.of(ERROR));
+  }
+
+  @Test
+  public void testPauseStates() {
+    testStates("pause",
+        EnumSet.of(IDLE, INITIALIZED, PREPARED, STOPPED, ERROR), PAUSED);
+  }
+
+  @Test
+  public void testPrepareStates() {
+    testStates("prepare",
+        EnumSet.of(IDLE, PREPARED, STARTED, PAUSED, PLAYBACK_COMPLETED, ERROR),
+        PREPARED);
+  }
+
+  @Test
+  public void testPrepareAsyncStates() {
+    // Must pause the scheduler else it will transition straight
+    // into the PREPARED state.
+    scheduler.pause();
+    testStates("prepareAsync",
+        EnumSet.of(IDLE, PREPARED, STARTED, PAUSED, PLAYBACK_COMPLETED, ERROR),
+        PREPARING);
+  }
+
+  @Test
+  public void testReleaseStates() {
+    testStates("release", emptyStateSet, END);
+  }
+
+  @Test
+  public void testResetStates() {
+    testStates("reset", emptyStateSet, IDLE);
+  }
+
+  @Test
+  public void testSeekToStates() {
+    testStates("seekTo()", method("seekTo").withParameterTypes(int.class),
+        EnumSet.of(IDLE, INITIALIZED, STOPPED, ERROR), 38);
+  }
+
+  @Test
+  public void testSetAudioSessionIdStates() {
+    testStates("setAudioSessionId()", method("setAudioSessionId")
+        .withParameterTypes(int.class), EnumSet.of(INITIALIZED, PREPARED,
+        STARTED, PAUSED, STOPPED, PLAYBACK_COMPLETED, ERROR), 38);
+  }
+
+  @Test
+  public void testSetLoopingStates() {
+    testStates("setLooping()", method("setLooping")
+        .withParameterTypes(boolean.class), EnumSet.of(ERROR), true);
+  }
+
+  @Test
+  public void testSetDataSourceStates() {
+    final EnumSet<State> invalidStates = EnumSet.complementOf(EnumSet.of(IDLE));
+    testStatesWithNext("setDataSource(String)", method("setDataSource")
+        .withParameterTypes(String.class), invalidStates, INITIALIZED,
+        "dummyFile");
+    testStatesWithNext("setDataSource(Context,Uri)", method("setDataSource")
+        .withParameterTypes(Context.class, Uri.class), invalidStates,
+        INITIALIZED, null, null);
+    testStatesWithNext(
+        "setDataSource(Context,Uri,Map)",
+        method("setDataSource").withParameterTypes(Context.class, Uri.class,
+            Map.class), invalidStates, INITIALIZED, null, null, null);
+    testStatesWithNext("setDataSource(FileDescriptor)", method("setDataSource")
+        .withParameterTypes(FileDescriptor.class), invalidStates, INITIALIZED,
+        (FileDescriptor) null);
+    testStatesWithNext(
+        "setDataSource(FileDescriptor,long,long)",
+        method("setDataSource").withParameterTypes(FileDescriptor.class,
+            long.class, long.class), invalidStates, INITIALIZED, null, 1L, 10L);
+  }
+
+  @Test
+  public void testStartStates() {
+    // Must pause the scheduler else it will transition straight
+    // into the PLAYBACK_COMPLETED state.
+    scheduler.pause();
+    testStates("start",
+        EnumSet.of(IDLE, INITIALIZED, PREPARING, STOPPED, ERROR), STARTED);
+  }
+
+  @Test
+  public void testStopStates() {
+    testStates("stop", EnumSet.of(IDLE, INITIALIZED, ERROR), STOPPED);
   }
 
   @Test
   public void testCurrentPosition() {
-    int[] positions = {0, 1, 2, 1024};
-
+    int[] positions = { 0, 1, 2, 1024 };
+    scheduler.pause();
     for (int position : positions) {
       shadowMediaPlayer.setCurrentPosition(position);
       assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(position);
@@ -41,38 +482,567 @@ public class ShadowMediaPlayerTest {
   }
 
   @Test
-  public void testErrorListenerCalled() {
-    MediaPlayer.OnErrorListener err = Mockito.mock(MediaPlayer.OnErrorListener.class);
-    shadowMediaPlayer.setOnErrorListener(err);
-    shadowMediaPlayer.invokeErrorListener(0,0);
-    Mockito.verify(err).onError(mediaPlayer,0,0);
+  public void testInitialAudioSessionIdIsNotZero() {
+    assertThat(mediaPlayer.getAudioSessionId()).as("initial audioSessionId")
+        .isNotEqualTo(0);
+  }
+
+  private void testStates(String methodName, MethodParameterTypes<?> params,
+      EnumSet<State> invalidStates, Object... args) {
+    testStates(methodName, params.in(mediaPlayer), invalidStates, null, args);
+  }
+
+  private void testStatesWithNext(String methodName,
+      MethodParameterTypes<?> params, EnumSet<State> invalidStates,
+      State nextState, Object... args) {
+    testStates(methodName, params.in(mediaPlayer), invalidStates, nextState,
+        args);
+  }
+
+  private void testStates(String methodName, EnumSet<State> invalidStates) {
+    testStates(methodName + "()", method(methodName).in(mediaPlayer),
+        invalidStates, null);
+  }
+
+  private void testStates(String methodName, EnumSet<State> invalidStates,
+      State nextState) {
+    testStates(methodName + "()", method(methodName).in(mediaPlayer),
+        invalidStates, nextState);
+  }
+
+  private void testStates(String methodName, Invoker<?> invoker,
+      EnumSet<State> invalidStates, State next, Object... args) {
+    final EnumSet<State> invalid = EnumSet.copyOf(invalidStates);
+
+    // The documentation specifies that the behavior of calling any
+    // function while in the PREPARING state is undefined. I tried
+    // to play it safe but reasonable, by looking at whether the PREPARED or
+    // INITIALIZED are allowed (ie, the two states that PREPARING
+    // sites between). Only if both these states are allowed is
+    // PREPARING allowed too, if either PREPARED or INITALIZED is
+    // disallowed then so is PREPARING.
+    if (invalid.contains(PREPARED) || invalid.contains(INITIALIZED)) {
+      invalid.add(PREPARING);
+    }
+    invalid.add(END);
+
+    for (State state : State.values()) {
+      shadowMediaPlayer.setState(state);
+      if (invalid.contains(state)) {
+        try {
+          invoker.invoke(args);
+          Assertions.fail("Expected IllegalStateException to be thrown when <"
+              + methodName + "> called from state <" + state + ">");
+        } catch (IllegalStateException e) {
+          final State finalState = shadowMediaPlayer.getState();
+          if (state == END) {
+            assertThat(finalState).overridingErrorMessage(
+              "Expected player to remain in END state when <%s> called, was <%s>",
+              methodName, finalState).isSameAs(END);
+          } else {
+            assertThat(finalState).overridingErrorMessage(
+              "Expected ERROR state when <%s> called in state <%s>, was <%s>",
+              methodName, state, finalState).isSameAs(ERROR);
+          }
+        }
+      } else {
+        try {
+          invoker.invoke(args);
+          final State finalState = shadowMediaPlayer.getState();
+          if (next == null) {
+            assertThat(finalState)
+                .overridingErrorMessage(
+                    "Expected state <%s> to remain unchanged when <%s> called, was <%s>",
+                    state, methodName, finalState).isEqualTo(state);
+          } else {
+            assertThat(finalState).overridingErrorMessage(
+                "Expected <%s> to change state from <%s> to <%s>, was <%s>",
+                methodName, state, next, finalState).isEqualTo(next);
+          }
+        } catch (IllegalStateException e) {
+          Assertions.fail("<" + methodName
+              + "> should not throw IllegalStateException when in state <"
+              + state + ">", e);
+        }
+      }
+    }
+  }
+
+  private static final State[] seekableStates = { PREPARED, PAUSED,
+      PLAYBACK_COMPLETED, STARTED };
+
+  // It is not 100% clear from the docs if seeking to < 0 should
+  // invoke an error. I have assumed from the documentation
+  // which says "Successful invoke of this method in a valid
+  // state does not change the state" that it doesn't invoke an
+  // error. Rounding the seek up to 0 seems to be the sensible
+  // alternative behavior.
+  @Test
+  public void testSeekBeforeStart() {
+    shadowMediaPlayer.setSeekDelay(-1);
+    for (State state : seekableStates) {
+      shadowMediaPlayer.setState(state);
+      shadowMediaPlayer.setCurrentPosition(500);
+
+      mediaPlayer.seekTo(-1);
+      shadowMediaPlayer.invokeSeekCompleteListener();
+
+      assertThat(mediaPlayer.getCurrentPosition()).as(
+          "Current postion while " + state).isEqualTo(0);
+      assertThat(shadowMediaPlayer.getState()).as("Final state " + state)
+          .isEqualTo(state);
+    }
+  }
+
+  // Similar comments apply to this test as to
+  // testSeekBeforeStart().
+  @Test
+  public void testSeekPastEnd() {
+    scheduler.pause();
+    shadowMediaPlayer.setSeekDelay(-1);
+    for (State state : seekableStates) {
+      shadowMediaPlayer.setState(state);
+      shadowMediaPlayer.setCurrentPosition(500);
+      mediaPlayer.seekTo(1001);
+      shadowMediaPlayer.invokeSeekCompleteListener();
+
+      assertThat(mediaPlayer.getCurrentPosition()).as(
+          "Current postion while " + state).isEqualTo(1000);
+      assertThat(shadowMediaPlayer.getState()).as("Final state " + state)
+          .isEqualTo(state);
+    }
+  }
+
+  @Test
+  public void testCompletionListener() {
+    shadowMediaPlayer.invokeCompletionListener();
+
+    Mockito.verify(completionListener).onCompletion(mediaPlayer);
+  }
+
+  @Test
+  public void testCompletionWithoutListenerDoesNotThrowException() {
+    mediaPlayer.setOnCompletionListener(null);
+    shadowMediaPlayer.invokeCompletionListener();
+
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(PLAYBACK_COMPLETED);
+    Mockito.verifyZeroInteractions(completionListener);
+  }
+
+  @Test
+  public void testSeekListener() {
+    shadowMediaPlayer.invokeSeekCompleteListener();
+
+    Mockito.verify(seekListener).onSeekComplete(mediaPlayer);
+  }
+
+  @Test
+  public void testSeekWithoutListenerDoesNotThrowException() {
+    mediaPlayer.setOnSeekCompleteListener(null);
+    shadowMediaPlayer.invokeSeekCompleteListener();
+
+    Mockito.verifyZeroInteractions(seekListener);
+  }
+
+  @Test
+  public void testSeekDuringPlaybackDelayedCallback() {
+    shadowMediaPlayer.setState(PREPARED);
+    scheduler.pause();
+    shadowMediaPlayer.setSeekDelay(100);
+
+    assertThat(shadowMediaPlayer.getSeekDelay()).isEqualTo(100);
+
+    mediaPlayer.start();
+    scheduler.advanceBy(200);
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(200);
+    mediaPlayer.seekTo(450);
+
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(200);
+
+    scheduler.advanceBy(99);
+
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(200);
+    Mockito.verifyZeroInteractions(seekListener);
+
+    scheduler.advanceBy(1);
+
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(450);
+    Mockito.verify(seekListener).onSeekComplete(mediaPlayer);
+
+    assertThat(scheduler.advanceToLastPostedRunnable()).isTrue();
+    Mockito.verifyNoMoreInteractions(seekListener);
+  }
+
+  @Test
+  public void testSeekWhilePausedDelayedCallback() {
+    shadowMediaPlayer.setState(PAUSED);
+    scheduler.pause();
+    shadowMediaPlayer.setSeekDelay(100);
+
+    scheduler.advanceBy(200);
+    mediaPlayer.seekTo(450);
+    scheduler.advanceBy(99);
+
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(0);
+    Mockito.verifyZeroInteractions(seekListener);
+
+    scheduler.advanceBy(1);
+
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(450);
+    Mockito.verify(seekListener).onSeekComplete(mediaPlayer);
+    // Check that no completion callback or alternative
+    // seek callbacks have been scheduled.
+    assertThat(scheduler.advanceToLastPostedRunnable()).isFalse();
+  }
+
+  @Test
+  public void testSeekWhileSeekingWhilePaused() {
+    shadowMediaPlayer.setState(PAUSED);
+    scheduler.pause();
+    shadowMediaPlayer.setSeekDelay(100);
+
+    scheduler.advanceBy(200);
+    mediaPlayer.seekTo(450);
+    scheduler.advanceBy(50);
+    mediaPlayer.seekTo(600);
+    scheduler.advanceBy(99);
+
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(0);
+    Mockito.verifyZeroInteractions(seekListener);
+
+    scheduler.advanceBy(1);
+
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(600);
+    Mockito.verify(seekListener).onSeekComplete(mediaPlayer);
+    // Check that no completion callback or alternative
+    // seek callbacks have been scheduled.
+    assertThat(scheduler.advanceToLastPostedRunnable()).isFalse();
+  }
+
+  @Test
+  public void testSeekWhileSeekingWhilePlaying() {
+    shadowMediaPlayer.setState(PREPARED);
+    scheduler.pause();
+    shadowMediaPlayer.setSeekDelay(100);
+
+    mediaPlayer.start();
+    scheduler.advanceBy(200);
+    mediaPlayer.seekTo(450);
+    scheduler.advanceBy(50);
+    mediaPlayer.seekTo(600);
+    scheduler.advanceBy(99);
+
+    // Not sure of the correct behaviour to emulate here, as the MediaPlayer
+    // documentation is not detailed enough. There are three possibilities:
+    // 1. Playback is paused for the entire time that a seek is in progress.
+    // 2. Playback continues normally until the seek is complete.
+    // 3. Somewhere between these two extremes - playback continues for
+    // a while and then pauses until the seek is complete.
+    // I have decided to emulate the first. I don't think that
+    // implementations should depend on any of these particular behaviours
+    // and consider the behaviour indeterminate.
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(200);
+    Mockito.verifyZeroInteractions(seekListener);
+
+    scheduler.advanceBy(1);
+
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(600);
+    Mockito.verify(seekListener).onSeekComplete(mediaPlayer);
+    // Check that the completion callback is scheduled properly
+    // but no alternative seek callbacks.
+    assertThat(scheduler.advanceToLastPostedRunnable()).isTrue();
+    Mockito.verify(completionListener).onCompletion(mediaPlayer);
+    Mockito.verifyNoMoreInteractions(seekListener);
+    assertThat(scheduler.getCurrentTime()).isEqualTo(750);
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(1000);
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(PLAYBACK_COMPLETED);
+  }
+
+  @Test
+  public void testSeekManualCallback() {
+    // Need to put the player into a state where seeking is allowed
+    shadowMediaPlayer.setState(STARTED);
+    // seekDelay of -1 signifies that OnSeekComplete won't be
+    // invoked automatically by the shadow player itself.
+    shadowMediaPlayer.setSeekDelay(-1);
+
+    assertThat(shadowMediaPlayer.getPendingSeek()).as("pendingSeek before")
+        .isEqualTo(-1);
+    int[] positions = { 0, 5, 2, 999 };
+    int prevPos = 0;
+    for (int position : positions) {
+      mediaPlayer.seekTo(position);
+
+      assertThat(shadowMediaPlayer.getPendingSeek()).as("pendingSeek")
+          .isEqualTo(position);
+      assertThat(mediaPlayer.getCurrentPosition()).as("pendingSeekCurrentPos")
+          .isEqualTo(prevPos);
+
+      shadowMediaPlayer.invokeSeekCompleteListener();
+
+      assertThat(shadowMediaPlayer.getPendingSeek()).isEqualTo(-1);
+      assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(position);
+      prevPos = position;
+    }
+  }
+
+  @Test
+  public void testPreparedListenerCalled() {
+    shadowMediaPlayer.invokePreparedListener();
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(PREPARED);
+    Mockito.verify(preparedListener).onPrepared(mediaPlayer);
+  }
+
+  @Test
+  public void testPreparedWithoutListenerDoesNotThrowException() {
+    mediaPlayer.setOnPreparedListener(null);
+    shadowMediaPlayer.invokePreparedListener();
+
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(PREPARED);
+    Mockito.verifyZeroInteractions(preparedListener);
   }
 
   @Test
   public void testErrorListenerCalledNoOnCompleteCalledWhenReturnTrue() {
-    MediaPlayer.OnErrorListener err = Mockito.mock(MediaPlayer.OnErrorListener.class);
-    MediaPlayer.OnCompletionListener complete =  Mockito.mock(MediaPlayer.OnCompletionListener.class);
-    Mockito.when(err.onError(mediaPlayer,0,0)).thenReturn(true);
-    shadowMediaPlayer.setOnErrorListener(err);
-    shadowMediaPlayer.setOnCompletionListener(complete);
+    Mockito.when(errorListener.onError(mediaPlayer, 0, 0)).thenReturn(true);
 
     shadowMediaPlayer.invokeErrorListener(0, 0);
 
-    Mockito.verify(err).onError(mediaPlayer,0,0);
-    Mockito.verifyZeroInteractions(complete);
+    assertThat(shadowMediaPlayer.getState()).isEqualTo(ERROR);
+    Mockito.verify(errorListener).onError(mediaPlayer, 0, 0);
+    Mockito.verifyZeroInteractions(completionListener);
   }
 
   @Test
   public void testErrorListenerCalledOnCompleteCalledWhenReturnFalse() {
-    MediaPlayer.OnErrorListener err = Mockito.mock(MediaPlayer.OnErrorListener.class);
-    MediaPlayer.OnCompletionListener complete =  Mockito.mock(MediaPlayer.OnCompletionListener.class);
-    Mockito.when(err.onError(mediaPlayer,0,0)).thenReturn(false);
-    shadowMediaPlayer.setOnErrorListener(err);
-    shadowMediaPlayer.setOnCompletionListener(complete);
+    Mockito.when(errorListener.onError(mediaPlayer, 0, 0)).thenReturn(false);
 
     shadowMediaPlayer.invokeErrorListener(0, 0);
 
-    Mockito.verify(err).onError(mediaPlayer,0,0);
-    Mockito.verify(complete).onCompletion(mediaPlayer);
+    Mockito.verify(errorListener).onError(mediaPlayer, 0, 0);
+    Mockito.verify(completionListener).onCompletion(mediaPlayer);
+  }
+
+  @Test
+  public void testErrorCausesOnCompleteCalledWhenNoErrorListener() {
+    mediaPlayer.setOnErrorListener(null);
+
+    shadowMediaPlayer.invokeErrorListener(0, 0);
+
+    Mockito.verifyZeroInteractions(errorListener);
+    Mockito.verify(completionListener).onCompletion(mediaPlayer);
+  }
+  
+  @Test
+  public void testScheduleErrorAtOffsetWhileNotPlaying() {
+    shadowMediaPlayer.scheduleErrorAtOffset(500, 1, 3);
+    shadowMediaPlayer.setState(PREPARED);
+    scheduler.pause();
+    mediaPlayer.start();
+    
+    scheduler.advanceBy(499);
+    Mockito.verifyZeroInteractions(errorListener);
+
+    scheduler.advanceBy(1);
+    Mockito.verify(errorListener).onError(mediaPlayer, 1, 3);
+    assertThat(shadowMediaPlayer.getState()).isSameAs(ERROR);
+    assertThat(scheduler.advanceToLastPostedRunnable()).isFalse();
+  }
+
+  @Test
+  public void testScheduleErrorAtOffsetWhilePlaying() {
+    shadowMediaPlayer.setState(PREPARED);
+    scheduler.pause();
+    mediaPlayer.start();
+
+    scheduler.advanceBy(200);
+    
+    shadowMediaPlayer.scheduleErrorAtOffset(500, 1, 3);
+
+    scheduler.advanceBy(299);
+    Mockito.verifyZeroInteractions(errorListener);
+
+    scheduler.advanceBy(1);
+    Mockito.verify(errorListener).onError(mediaPlayer, 1, 3);
+    Mockito.verify(completionListener).onCompletion(mediaPlayer);
+    assertThat(scheduler.advanceToLastPostedRunnable()).isFalse();
+  }
+  
+  @Test
+  public void testRescheduleErrorAtOffsetWhileNotPlaying() {
+    shadowMediaPlayer.setState(PREPARED);
+    shadowMediaPlayer.scheduleErrorAtOffset(300, 2, 3);
+    scheduler.pause();
+    shadowMediaPlayer.scheduleErrorAtOffset(400, 3, 4);
+    mediaPlayer.start();
+    scheduler.advanceBy(300);
+    
+    Mockito.verifyZeroInteractions(errorListener);
+
+    scheduler.advanceBy(100);
+    
+    Mockito.verify(errorListener).onError(mediaPlayer, 3, 4);
+    assertThat(scheduler.advanceToLastPostedRunnable()).isFalse();
+  }
+  
+  @Test
+  public void testRescheduleErrorAtOffsetWhilePlaying() {
+    shadowMediaPlayer.setState(PREPARED);
+    shadowMediaPlayer.scheduleErrorAtOffset(300, 2, 3);
+    scheduler.pause();
+    mediaPlayer.start();
+    scheduler.advanceBy(200);
+    shadowMediaPlayer.scheduleErrorAtOffset(400, 3, 4);
+    scheduler.advanceBy(100);
+    
+    Mockito.verifyZeroInteractions(errorListener);
+
+    scheduler.advanceBy(100);
+    
+    Mockito.verify(errorListener).onError(mediaPlayer, 3, 4);
+    assertThat(scheduler.advanceToLastPostedRunnable()).isFalse();
+  }
+  
+  @Test
+  public void testScheduleErrorAtOffsetInPast() {
+    scheduler.pause();
+    shadowMediaPlayer.setCurrentPosition(400);
+    shadowMediaPlayer.setState(PAUSED);
+    shadowMediaPlayer.scheduleErrorAtOffset(200,  1,  2);
+    shadowMediaPlayer.start();
+    scheduler.unPause();
+    Mockito.verifyZeroInteractions(errorListener);
+  }
+
+  @Test
+  public void testSetSetDataSourceExceptionWithWrongExceptionTypeAsserts() {
+    boolean fail = false;
+    try {
+      shadowMediaPlayer.setSetDataSourceException(new CloneNotSupportedException());
+      fail = true;
+    }
+    catch (AssertionError e) {
+    }
+    assertThat(fail)
+      .overridingErrorMessage("setSetDataSourceException() should assert with non-IOException,non-RuntimeException")
+      .isFalse();
+  }
+  
+  @Test
+  public void testSetDataSourceThrowsAllowedException() {
+    Exception[] exceptions = {
+      new IOException(),
+      new SecurityException(),
+      new IllegalArgumentException()
+    };
+    for (Exception e : exceptions) {
+      shadowMediaPlayer.setSetDataSourceException(e);
+
+      shadowMediaPlayer.setState(IDLE);
+      try {
+        mediaPlayer.setDataSource((FileDescriptor)null);
+        Assertions.fail("Expecting " + e + " to be thrown");
+      } catch (Exception eThrown) {
+        assertThat(eThrown).isSameAs(e);
+      }
+      assertThat(shadowMediaPlayer.getState()).as(e.toString()).isSameAs(ERROR);
+
+      // Test all three flavors of setDataSource()
+      shadowMediaPlayer.setState(IDLE);
+      try {
+        mediaPlayer.setDataSource(null, null, null);
+        Assertions.fail("Expecting " + e + " to be thrown");
+      } catch (Exception eThrown) {
+        assertThat(eThrown).isSameAs(e);
+      }
+      assertThat(shadowMediaPlayer.getState()).as(e.toString()).isSameAs(ERROR);
+
+      shadowMediaPlayer.setState(IDLE);
+      try {
+        mediaPlayer.setDataSource((String)null);
+        Assertions.fail("Expecting " + e + " to be thrown");
+      } catch (Exception eThrown) {
+        assertThat(eThrown).isSameAs(e);
+      }
+      assertThat(shadowMediaPlayer.getState()).as(e.toString()).isSameAs(ERROR);
+    } 
+  }
+  
+  @Test
+  public void testSetDataSourceIllegalStateOverridesCustomException() {
+    shadowMediaPlayer.setState(PREPARED);
+    shadowMediaPlayer.setSetDataSourceException(new IOException());
+    try {
+      mediaPlayer.setDataSource((String)null);
+      Assertions.fail("Expecting IllegalStateException to be thrown");
+    } catch (IllegalStateException eThrown) {
+    } catch (Exception eThrown) {
+      Assertions.fail(eThrown + " was thrown, expecting IllegalStateException");
+    }
+    assertThat(shadowMediaPlayer.getState()).isSameAs(ERROR);
+  }
+  
+  @Test
+  public void testGetSetLooping() {
+    assertThat(mediaPlayer.isLooping()).isFalse();
+    mediaPlayer.setLooping(true);
+    assertThat(mediaPlayer.isLooping()).isTrue();
+    mediaPlayer.setLooping(false);
+    assertThat(mediaPlayer.isLooping()).isFalse();
+  }
+  
+  /**
+   * If the looping mode was being set to <code>true</code> {@link MediaPlayer#setLooping(boolean)}, the
+   * MediaPlayer object shall remain in the Started state.
+   */
+  @Test
+  public void testSetLoopingCalledWhilePlaying() {
+    shadowMediaPlayer.setState(PREPARED);
+    scheduler.pause();
+    mediaPlayer.start();
+    scheduler.advanceBy(200);
+    
+    mediaPlayer.setLooping(true);
+    scheduler.advanceBy(1100);
+
+    Mockito.verifyZeroInteractions(completionListener);
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(300);
+
+    mediaPlayer.setLooping(false);
+    scheduler.advanceBy(699);
+    Mockito.verifyZeroInteractions(completionListener);
+
+    scheduler.advanceBy(1);
+    Mockito.verify(completionListener).onCompletion(mediaPlayer);    
+  }
+    
+  @Test
+  public void testSetLoopingCalledWhileStartable() {
+    final State[] startableStates = {PREPARED, PAUSED};
+    for (State state : startableStates) {
+      shadowMediaPlayer.setCurrentPosition(500);
+      shadowMediaPlayer.setState(state);
+      scheduler.pause();
+
+      mediaPlayer.setLooping(true);
+      mediaPlayer.start();
+
+      scheduler.advanceBy(700);
+      Mockito.verifyZeroInteractions(completionListener);
+      assertThat(mediaPlayer.getCurrentPosition()).as(state.toString()).isEqualTo(200);
+    }
+  }
+    
+  /**
+   * While in the PlaybackCompleted state, calling start() can restart the
+   * playback from the beginning of the audio/video source.
+   */
+  @Test
+  public void testStartAfterPlaybackCompleted() {
+    shadowMediaPlayer.setState(PLAYBACK_COMPLETED);
+    shadowMediaPlayer.setCurrentPosition(1000);
+
+    mediaPlayer.start();
+    assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(0);
   }
 }


### PR DESCRIPTION
This PR represents the final culmination of many months' part-time work after finally managing to back out of the several rabbit warrens that I was forced to go down. :wink:

Implementing media playback in Android (and probably in general) is tricky because of all the different asynchronous events and errors that can happen, and the requirements to make sure you are calling the right methods in the right states. This shadow implementation attempts to emulate all of the state transitions/error callbacks/exceptions that Android does so that you can thoroughly unit test your media playback routines, by (eg) asserting if you call a method while in the wrong state. Much of this was gleaned from the `MediaPlayer` documentation, but because the documentation was sometimes difficult to understand I also wrote a little test program & ran it on my Android device to compare documented behaviour with actual behaviour. Unsurprisingly, the two were not always the same; where they differed I implemented whichever of the two were stricter in order to encourage the most robust possible developer code.

This implementation also allows you to schedule playback events (errors, buffer underruns, info messages, etc) to occur during simulated playback, and you can control playback progess via the calling thread Looper's Scheduler instance (including pausing, advancing manually, or allowing the whole playback to run all the way to completion).

There is some Javadoc that explains the main features.

It also happens to be backward compatible with the old `ShadowMediaPlayer` - however, with the big changes in the works for Robolectric 3.0 this is probably not as big a selling point as it was when I started. Arguably now the "SILENT" error state emulation mode should not be the default (and arguably could be removed completely).

Comments/criticisms would be very welcome.