### PR TITLE
Fix for https://github.com/robolectric/robolectric/issues/1485

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/ShadowsAdapter.java
+++ b/robolectric-resources/src/main/java/org/robolectric/ShadowsAdapter.java
@@ -44,8 +44,6 @@ public interface ShadowsAdapter {
 
   ResourceLoader getResourceLoader();
 
-  File getFilesDir();
-
   public interface ShadowActivityAdapter {
     public void setTestApplication(Application application);
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
@@ -116,8 +116,4 @@ public class CoreShadowsAdapter implements ShadowsAdapter {
     return ShadowApplication.getInstance().getResourceLoader();
   }
 
-  @Override
-  public File getFilesDir() {
-    return ShadowContext.FILES_DIR;
-  }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
@@ -28,9 +28,7 @@ import static org.robolectric.Shadows.shadowOf;
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Context.class)
 abstract public class ShadowContext {
-  public static final File CACHE_DIR = createTempDir("android-cache");
   public static final File EXTERNAL_CACHE_DIR = createTempDir("android-external-cache");
-  public static final File FILES_DIR = createTempDir("android-tmp");
   public static final File EXTERNAL_FILES_DIR = createTempDir("android-external-files");
   public static final File DATABASE_DIR = createTempDir("android-database");
 
@@ -62,23 +60,6 @@ abstract public class ShadowContext {
   }
 
   @Implementation
-  public File getCacheDir() {
-    CACHE_DIR.mkdirs();
-    return CACHE_DIR;
-  }
-
-  @Implementation
-  public File getFilesDir() {
-    FILES_DIR.mkdirs();
-    return FILES_DIR;
-  }
-
-  @Implementation
-  public String[] fileList() {
-    return getFilesDir().list();
-  }
-
-  @Implementation
   public File getDatabasePath(String name) {
     File file = new File(name);
     if (file.isAbsolute()) {
@@ -103,39 +84,13 @@ abstract public class ShadowContext {
   }
 
   @Implementation
-  public FileInputStream openFileInput(String path) throws FileNotFoundException {
-    return new FileInputStream(getFileStreamPath(path));
-  }
-
-  @Implementation
-  public FileOutputStream openFileOutput(String path, int mode) throws FileNotFoundException {
-    if ((mode & Context.MODE_APPEND) == Context.MODE_APPEND) {
-      return new FileOutputStream(getFileStreamPath(path), true);
-    }
-    return new FileOutputStream(getFileStreamPath(path));
-  }
-
-  @Implementation
-  public File getFileStreamPath(String name) {
-    if (name.contains(File.separator)) {
-      throw new IllegalArgumentException("File " + name + " contains a path separator");
-    }
-    return new File(getFilesDir(), name);
-  }
-
-  @Implementation
   public SQLiteDatabase openOrCreateDatabase(String name, int mode, SQLiteDatabase.CursorFactory factory) {
     return openOrCreateDatabase(name, mode, factory, null);
   }
 
   @Implementation
   public SQLiteDatabase openOrCreateDatabase(String name, int mode, SQLiteDatabase.CursorFactory factory, DatabaseErrorHandler databaseErrorHandler) {
-    return SQLiteDatabase.openOrCreateDatabase(getDatabasePath(name).getAbsolutePath(), factory, databaseErrorHandler);
-  }
-
-  @Implementation
-  public boolean deleteFile(String name) {
-    return getFileStreamPath(name).delete();
+    return SQLiteDatabase.openOrCreateDatabase(realContext.getDatabasePath(name).getAbsolutePath(), factory, databaseErrorHandler);
   }
 
   /**
@@ -153,8 +108,6 @@ abstract public class ShadowContext {
 
   @Resetter
   public static void reset() {
-    clearFiles(FILES_DIR);
-    clearFiles(CACHE_DIR);
     clearFiles(EXTERNAL_CACHE_DIR);
     clearFiles(EXTERNAL_FILES_DIR);
     clearFiles(DATABASE_DIR);

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
@@ -29,9 +29,6 @@ import org.robolectric.res.ResourceLoader;
 import org.robolectric.fakes.RoboSharedPreferences;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,44 +63,13 @@ public class ShadowContextWrapper extends ShadowContext {
   }
 
   @Implementation
-  public ApplicationInfo getApplicationInfo() {
-    ApplicationInfo applicationInfo = Shadow.newInstance(ApplicationInfo.class, new Class[0], new Object[0]);
-    AndroidManifest appManifest = ShadowApplication.getInstance().getAppManifest();
-    if (appManifest != null) {
-      applicationInfo.packageName = appManifest.getPackageName();
-      applicationInfo.targetSdkVersion = appManifest.getTargetSdkVersion();
-    }
-    return applicationInfo;
-  }
-
-  @Implementation
   public int getUserId() {
     return 0;
   }
 
   @Implementation
-  @Override public File getFilesDir() {
-    return super.getFilesDir();
-  }
-
-  @Implementation
-  @Override public File getCacheDir() {
-    return super.getCacheDir();
-  }
-
-  @Implementation
-  @Override public String[] fileList() {
-    return super.fileList();
-  }
-
-  @Implementation
   @Override public File getDatabasePath(String name) {
     return super.getDatabasePath(name);
-  }
-
-  @Implementation
-  @Override public File getFileStreamPath(String name) {
-    return super.getFileStreamPath(name);
   }
 
   @Override public ResourceLoader getResourceLoader() {
@@ -133,21 +99,6 @@ public class ShadowContextWrapper extends ShadowContext {
   @Implementation
   @Override public File getExternalFilesDir(String type) {
     return super.getExternalFilesDir(type);
-  }
-
-  @Implementation
-  @Override public FileInputStream openFileInput(String path) throws FileNotFoundException {
-    return super.openFileInput(path);
-  }
-
-  @Implementation
-  @Override public FileOutputStream openFileOutput(String path, int mode) throws FileNotFoundException {
-    return super.openFileOutput(path, mode);
-  }
-
-  @Implementation
-  @Override public boolean deleteFile(String name) {
-    return super.deleteFile(name);
   }
 
   @Implementation

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -16,7 +16,10 @@ import org.robolectric.res.builder.DefaultPackageManager;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.ShadowsAdapter;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.UUID;
 
 import static org.robolectric.util.ReflectionHelpers.ClassParameter;
 
@@ -130,7 +133,24 @@ public class ParallelUniverse implements ParallelUniverseInterface {
   @Override
   public void tearDownApplication() {
     if (RuntimeEnvironment.application != null) {
+      clearFiles(new File(RuntimeEnvironment.application.getApplicationInfo().dataDir));
       RuntimeEnvironment.application.onTerminate();
+    }
+  }
+
+  private static void clearFiles(File dir) {
+    if (dir != null && dir.isDirectory()) {
+      File[] files = dir.listFiles();
+      if (files != null) {
+        for (File f : files) {
+          if (f.isDirectory()) {
+            clearFiles(f);
+          }
+          f.delete();
+        }
+      }
+      dir.delete();
+      dir.getParentFile().delete();
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
@@ -216,7 +216,7 @@ public class ShadowActivityTest {
   @Test
   public void onContentChangedShouldBeCalledAfterContentViewIsSet() throws RuntimeException {
     final Transcript transcript = new Transcript();
-    ActivityWithContentChangedTranscript customActivity = buildActivity(ActivityWithContentChangedTranscript.class).create().get();
+    ActivityWithContentChangedTranscript customActivity = Robolectric.setupActivity(ActivityWithContentChangedTranscript.class);
     customActivity.setTranscript(transcript);
     customActivity.setContentView(R.layout.main);
     transcript.assertEventsSoFar("onContentChanged was called; title is \"Main Layout\"");
@@ -224,11 +224,7 @@ public class ShadowActivityTest {
 
   @Test
   public void shouldRetrievePackageNameFromTheManifest() throws Exception {
-    AndroidManifest appManifest = newConfigWith("com.wacka.wa", "");
-    RuntimeEnvironment.application = new DefaultTestLifecycle().createApplication(null, appManifest, null);
-    shadowOf(application).bind(appManifest, null);
-
-    assertThat("com.wacka.wa").isEqualTo(new Activity().getPackageName());
+    assertThat(Robolectric.setupActivity(Activity.class).getPackageName()).isEqualTo(RuntimeEnvironment.application.getPackageName());
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
@@ -2,12 +2,14 @@ package org.robolectric.shadows;
 
 import android.accounts.Account;
 import android.app.Activity;
+import android.app.Application;
 import android.content.ContentProvider;
 import android.content.ContentProviderOperation;
 import android.content.ContentProviderResult;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
+import android.content.Context;
 import android.content.Intent;
 import android.content.OperationApplicationException;
 import android.content.PeriodicSync;
@@ -28,6 +30,7 @@ import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
 import org.robolectric.manifest.ContentProviderData;
 import org.robolectric.fakes.BaseCursor;
+import org.robolectric.util.ReflectionHelpers;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -675,7 +678,8 @@ public class ShadowContentResolverTest {
 
   @Test
   public void getProvider_shouldNotReturnAnyProviderWhenManifestIsNull() {
-    RuntimeEnvironment.application = new DefaultTestLifecycle().createApplication(null, null, null);
+    Application application = new DefaultTestLifecycle().createApplication(null, null, null);
+    ReflectionHelpers.callInstanceMethod(application, "attach", ReflectionHelpers.ClassParameter.from(Context.class, RuntimeEnvironment.application.getBaseContext()));
     assertThat(ShadowContentResolver.getProvider(Uri.parse("content://"))).isNull();
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
@@ -1,6 +1,7 @@
 package org.robolectric.shadows;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import org.junit.After;
@@ -36,13 +37,12 @@ public class ShadowContextTest {
 
   @Before
   public void setUp() throws Exception {
-    File[] files = context.getFilesDir().listFiles();
+    File dataDir = new File(RuntimeEnvironment.getPackageManager()
+        .getPackageInfo("org.robolectric", 0).applicationInfo.dataDir);
+
+    File[] files = dataDir.listFiles();
     assertNotNull(files);
     assertThat(files.length).isEqualTo(0);
-
-    File[] cachedFiles = context.getFilesDir().listFiles();
-    assertNotNull(cachedFiles);
-    assertThat(cachedFiles.length).isEqualTo(0);
   }
 
   @After
@@ -52,17 +52,16 @@ public class ShadowContextTest {
 
   @Test
   public void shouldGetApplicationDataDirectory() throws IOException {
-    File dataDir = new File(ShadowContext.FILES_DIR, "data");
-    assertThat(dataDir.mkdir()).isTrue();
-
-    dataDir = context.getDir("data", Context.MODE_PRIVATE);
+    File dataDir = context.getDir("data", Context.MODE_PRIVATE);
     assertThat(dataDir).isNotNull();
     assertThat(dataDir.exists()).isTrue();
   }
 
   @Test
-  public void shouldCreateIfDoesNotExistAndGetApplicationDataDirectory() {
-    File dataDir = new File(ShadowContext.FILES_DIR, "data");
+  public void shouldCreateIfDoesNotExistAndGetApplicationDataDirectory() throws Exception {
+    File dataDir = new File(RuntimeEnvironment.getPackageManager()
+        .getPackageInfo("org.robolectric", 0).applicationInfo.dataDir, "data");
+
     assertThat(dataDir.exists()).isFalse();
 
     dataDir = context.getDir("data", Context.MODE_PRIVATE);
@@ -94,7 +93,6 @@ public class ShadowContextTest {
     File cacheTest = new File(context.getCacheDir(), "__test__");
 
     assertThat(cacheTest.getAbsolutePath()).startsWith(System.getProperty("java.io.tmpdir"));
-    assertThat(cacheTest.getAbsolutePath()).contains("android-cache");
     assertThat(cacheTest.getAbsolutePath()).endsWith(File.separator + "__test__");
 
     FileOutputStream fos = null;
@@ -354,19 +352,10 @@ public class ShadowContextTest {
   public void reset_shouldCleanupTempDirectories() {
     ShadowContext.reset();
 
-    assertThat(ShadowContext.CACHE_DIR.exists()).isFalse();
-    assertThat(ShadowContext.CACHE_DIR.getParentFile().exists()).isFalse();
-
-    assertThat(ShadowContext.FILES_DIR.exists()).isFalse();
-    assertThat(ShadowContext.FILES_DIR.getParentFile().exists()).isFalse();
-
     assertThat(ShadowContext.EXTERNAL_CACHE_DIR.exists()).isFalse();
     assertThat(ShadowContext.EXTERNAL_CACHE_DIR.getParentFile().exists()).isFalse();
 
     assertThat(ShadowContext.EXTERNAL_FILES_DIR.exists()).isFalse();
     assertThat(ShadowContext.EXTERNAL_FILES_DIR.getParentFile().exists()).isFalse();
-
-    assertThat(ShadowContext.DATABASE_DIR.exists()).isFalse();
-    assertThat(ShadowContext.DATABASE_DIR.getParentFile().exists()).isFalse();
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
@@ -1,14 +1,15 @@
 package org.robolectric.shadows;
 
 import android.app.Application;
+import android.content.Context;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.Scheduler;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -151,10 +152,11 @@ public class ShadowLooperTest {
     assertThat(RuntimeEnvironment.application.getMainLooper()).isSameAs(mainLooper);
 
     ShadowLooper.resetThreadLoopers();
-    RuntimeEnvironment.application = new Application();
+    Application application = new Application();
+    ReflectionHelpers.callInstanceMethod(application, "attach", ReflectionHelpers.ClassParameter.from(Context.class, RuntimeEnvironment.application.getBaseContext()));
 
     assertThat(Looper.getMainLooper()).isSameAs(mainLooper);
-    assertThat(RuntimeEnvironment.application.getMainLooper()).isSameAs(mainLooper);
+    assertThat(application.getMainLooper()).isSameAs(mainLooper);
     assertThat(shadowOf(mainLooper).getScheduler()).isNotSameAs(scheduler);
     assertThat(shadowOf(mainLooper).hasQuit()).isFalse();
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowServiceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowServiceTest.java
@@ -11,8 +11,10 @@ import android.content.ServiceConnection;
 import android.media.MediaScannerConnection;
 import android.os.IBinder;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 import org.robolectric.internal.Shadow;
@@ -22,13 +24,21 @@ import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ShadowServiceTest {
-  private final MyService service = new MyService();
-  private final ShadowService shadow = shadowOf(service);
-  private final Notification.Builder notBuilder = new Notification.Builder(
-      service).setSmallIcon(1).setContentTitle("Test")
-      .setContentText("Hi there");
+  private MyService service ;
+  private ShadowService shadow;
+  private Notification.Builder notBuilder;
+
   private final ShadowNotificationManager nm = shadowOf((NotificationManager) RuntimeEnvironment.application
       .getSystemService(Context.NOTIFICATION_SERVICE));
+
+  @Before
+  public void setup() {
+    service = Robolectric.setupService(MyService.class);
+    shadow = shadowOf(service);
+    notBuilder = new Notification.Builder(
+        service).setSmallIcon(1).setContentTitle("Test")
+        .setContentText("Hi there");
+  }
 
   @Test(expected = IllegalStateException.class)
   public void shouldComplainIfServiceIsDestroyedWithRegisteredBroadcastReceivers() throws Exception {
@@ -119,7 +129,7 @@ public class ShadowServiceTest {
     assertThat(shadow.isStoppedBySelf()).isTrue();
   }
 
-  private static class MyService extends Service {
+  public static class MyService extends Service {
     @Override
     public void onDestroy() {
       super.onDestroy();


### PR DESCRIPTION
Fix for https://github.com/robolectric/robolectric/issues/1485

Lean on real android for creation of application data dirs - The Android environment provides and creates a "data dir" for the installed application through the ApplicationInfo. Change Robolectric infrastructure to create and assign this value and remove custom shadow code that manages this.

Remove ShadowContextWrapper.getApplicationInfo() we should delegate to real android for this (which provides us with the ApplicationInfo we create in the DefaultPackageManager) instead of creating a new instance with limited content.

ParallelUniverse ensures the application's data dir is removed at the end of the test.

Fix up tests that relied on ShadowContextWrapper.getApplicationInfo(), now that we rely on real Android these components must be attached to a base activity.