### PR TITLE
Use getName instead of getCanonicalName in DriverTestLifecycle

### DIFF
--- a/robolectric/src/main/java/org/robolectric/DefaultTestLifecycle.java
+++ b/robolectric/src/main/java/org/robolectric/DefaultTestLifecycle.java
@@ -40,7 +40,7 @@ public class DefaultTestLifecycle implements TestLifecycle {
       if (config.application().getCanonicalName() != null) {
         Class<? extends Application> applicationClass = null;
         try {
-          applicationClass = new ClassNameResolver<Application>(null, config.application().getCanonicalName()).resolve();
+          applicationClass = new ClassNameResolver<Application>(null, config.application().getName()).resolve();
         } catch (ClassNotFoundException e) {
           throw new RuntimeException(e);
         }

--- a/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
+++ b/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
@@ -89,6 +89,12 @@ public class DefaultTestLifecycleTest {
     assertThat(application).isExactlyInstanceOf(TestFakeApp.class);
   }
 
+  @Test public void shouldLoadConfigInnerClassApplication() throws Exception {
+    Application application = defaultTestLifecycle.createApplication(null,
+        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(-1, "", "", "", "", -1, new Class[0], TestFakeAppInner.class, new String[0]));
+    assertThat(application).isExactlyInstanceOf(TestFakeAppInner.class);
+  }
+
   @Test public void shouldLoadTestApplicationIfClassIsPresent() throws Exception {
     Application application = defaultTestLifecycle.createApplication(null,
         newConfigWith("<application android:name=\"" + FakeApp.class.getName() + "\"/>"), null);
@@ -115,4 +121,6 @@ public class DefaultTestLifecycleTest {
             "</manifest>\n");
     return new AndroidManifest(Fs.newFile(f), null, null);
   }
+
+  public static class TestFakeAppInner extends Application { }
 }


### PR DESCRIPTION
This allows the Config annotation to pull in Application objects that are static inner classes. Otherwise, the '$' gets dropped from the class name, which means newInstance in DriverTestLifecycle cannot create the Application.

Definitely makes testing easier in a world where a lot of tests override the base Application class.