### PR TITLE
Support AccountManager#getPreviousName().

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
@@ -44,6 +44,7 @@ public class ShadowAccountManager {
   private List<OnAccountsUpdateListener> listeners = new ArrayList<OnAccountsUpdateListener>();
   private Map<Account, Map<String, String>> userData = new HashMap<Account, Map<String,String>>();
   private Map<Account, String> passwords = new HashMap<Account, String>();
+  private Map<Account, String> previousNames = new HashMap<Account, String>();
   private AccountManagerCallback<Bundle> pendingAddCallback;
   private RoboAccountManagerFuture pendingAddFuture;
 
@@ -368,6 +369,20 @@ public class ShadowAccountManager {
 
     pendingAddFuture = new RoboAccountManagerFuture(accountType, resultBundle);
     return pendingAddFuture;
+  }
+
+  /**
+   * Non-android accessor.
+   *
+   * @param account User account.
+   */
+  public void setPreviousAccountName(Account account, String previousName) {
+    previousNames.put(account, previousName);
+  }
+  
+  @Implementation
+  public String getPreviousName(Account account) {
+    return previousNames.get(account);
   }
 
   /**

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
@@ -504,6 +504,21 @@ public class ShadowAccountManagerTest {
     assertThat(am).isEqualTo(systemService);
   }
 
+  @Test
+  public void testGetPreviousName_noPreviousName() {
+    Account account = new Account("name_a", "type_a");
+    
+    assertThat(am.getPreviousName(account)).isNull();
+  }
+
+  @Test
+  public void testGetPreviousName_hasPreviousName() {
+    Account account = new Account("name_a", "type_a");
+    shadowOf(am).setPreviousName(account, "previous_name_a");
+    
+    assertThat(am.getPreviousName(account)).is("previous_name_a");
+  }
+  
   private static class AccountManagerFutureMatcher<T> extends BaseMatcher<AccountManagerFuture<T>> {
 
     private final Matcher<T> matcher;


### PR DESCRIPTION
Support the new AccountManager#getPreviousName() method added in API 21.