### PR TITLE
add shadow DownloadManager.Request headers

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDownloadManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDownloadManager.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import android.app.DownloadManager;
 import android.database.Cursor;
 import android.net.Uri;
+import android.util.Pair;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -117,6 +118,10 @@ public class ShadowDownloadManager {
 
     public boolean getVisibleInDownloadsUi() {
       return getFieldReflectively("mIsVisibleInDownloadsUi", realObject, DownloadManager.Request.class);
+    }
+
+    public List<Pair<String, String>> getRequestHeaders() {
+      return getFieldReflectively("mRequestHeaders", realObject, DownloadManager.Request.class);
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDownloadManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDownloadManagerTest.java
@@ -3,6 +3,8 @@ package org.robolectric.shadows;
 import android.app.DownloadManager;
 import android.database.Cursor;
 import android.net.Uri;
+import android.util.Pair;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
@@ -47,6 +49,15 @@ public class ShadowDownloadManagerTest {
   public void request_shouldGetMimeType() throws Exception {
     request.setMimeType("application/json");
     assertThat(shadow.getMimeType()).isEqualTo("application/json");
+  }
+
+  @Test
+  public void request_shouldGetRequestHeaders() throws Exception {
+    request.addRequestHeader("Authorization", "Bearer token");
+    List<Pair<String, String>> headers = shadow.getRequestHeaders();
+    assertThat(headers).isNotEmpty().hasSize(1);
+    assertThat(headers.get(0).first).isEqualTo("Authorization");
+    assertThat(headers.get(0).second).isEqualTo("Bearer token");
   }
 
   @Test


### PR DESCRIPTION
The current shadow implementation of the DownloadManager.Request does not expose request headers.  This pull request adds that exposure so that request headers can be examined.

A test case is also added.