### PR TITLE
Support Properties in ShadowObjectAnimator.ofFloat

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowObjectAnimator.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowObjectAnimator.java
@@ -4,6 +4,7 @@ import android.animation.ObjectAnimator;
 import android.animation.TypeEvaluator;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Property;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -39,6 +40,11 @@ public class ShadowObjectAnimator extends ShadowValueAnimator {
   @Implementation
   public void setPropertyName(String propertyName) {
     this.propertyName = propertyName;
+  }
+
+  @Implementation
+  public void setProperty(Property property) {
+    this.propertyName = property.getName();
   }
 
   @Implementation
@@ -103,7 +109,7 @@ public class ShadowObjectAnimator extends ShadowValueAnimator {
     Runnable animationRunnable = new AnimationRunnable(setter);
     if (keyFrameCount > 1) {
       long stepDuration = duration / (keyFrameCount - 1);
-      for (int i = 0; i * stepDuration <= duration; ++i) {
+      for (int i = 0; i < keyFrameCount; ++i) {
         new Handler(Looper.getMainLooper()).postDelayed(animationRunnable, stepDuration * i);
       }
     } else {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowObjectAnimatorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowObjectAnimatorTest.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import android.animation.ObjectAnimator;
 import android.animation.AnimatorInflater;
 import android.animation.TypeEvaluator;
+import android.util.Property;
 import android.view.View;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ShadowObjectAnimatorTest {
+
   @Test
   public void shouldCreateForFloat() throws Exception {
     Object expectedTarget = new Object();
@@ -23,6 +25,29 @@ public class ShadowObjectAnimatorTest {
     assertThat(animator).isNotNull();
     assertThat(animator.getTarget()).isEqualTo(expectedTarget);
     assertThat(animator.getPropertyName()).isEqualTo(propertyName);
+  }
+
+  @Test
+  public void shouldCreateForFloat_withPropertyValues() {
+    View expectedTarget = new View(RuntimeEnvironment.application);
+    Property<View, Float> expectedProperty = View.ALPHA;
+
+    ObjectAnimator animator = ObjectAnimator.ofFloat(expectedTarget, expectedProperty, 0.5f, 0.4f);
+
+    assertThat(animator).isNotNull();
+    assertThat(animator.getTarget()).isEqualTo(expectedTarget);
+    assertThat(animator.getPropertyName()).isEqualTo(expectedProperty.getName());
+  }
+
+
+  @Test
+  public void shouldNotThrowExceptionWithMultipleValues() {
+    View expectedTarget = new View(RuntimeEnvironment.application);
+    ObjectAnimator animator = ObjectAnimator.ofFloat(expectedTarget, View.ALPHA, 0.5f, 0.4f, 0.3f);
+
+    assertThat(animator).isNotNull();
+    assertThat(animator.getTarget()).isEqualTo(expectedTarget);
+    animator.start(); // should not throw an exception
   }
 
   @Test


### PR DESCRIPTION
Allow for passing `View.ALPA`, etc to `objectAnimator.ofFloat(Object, Property, float... values)` and also fix `ArrayOutOfBounds` exception that was being thrown.

Addresses milestone 3.0 issue #1235 

Added a test for new property function and a test simulating the case which caused the out of bounds exception