### PR TITLE
Fixing ShadowPreferenceActivity to set preference screen

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreferenceActivity.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreferenceActivity.java
@@ -21,6 +21,7 @@ public class ShadowPreferenceActivity extends ShadowActivity {
   public void addPreferencesFromResource(int preferencesResId) {
     this.preferencesResId = preferencesResId;
     preferenceScreen = inflatePreferences(preferencesResId);
+    ((PreferenceActivity)realActivity).setPreferenceScreen(preferenceScreen);
   }
 
   private PreferenceScreen inflatePreferences(int preferencesResId) {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/util/PreferenceBuilder.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/util/PreferenceBuilder.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.preference.Preference;
+import android.preference.PreferenceActivity;
 import android.preference.PreferenceGroup;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
@@ -38,8 +39,7 @@ public class PreferenceBuilder {
     }
 
     Preference preference = create(preferenceNode, activity, (PreferenceGroup) parent);
-    PreferenceManager manager = ReflectionHelpers.callConstructor(PreferenceManager.class, ReflectionHelpers.ClassParameter.from(Activity.class, activity), ReflectionHelpers.ClassParameter.from(int.class, 0));
-    shadowOf(preference).callOnAttachedToHierarchy(manager);
+    shadowOf(preference).callOnAttachedToHierarchy(((PreferenceActivity)activity).getPreferenceManager());
 
     for (PreferenceNode child : preferenceNode.getChildren()) {
       inflate(child, activity, preference);

--- a/robolectric/src/test/java/org/robolectric/res/PreferenceIntegrationTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/PreferenceIntegrationTest.java
@@ -55,6 +55,13 @@ public class PreferenceIntegrationTest {
   }
 
   @Test
+  public void inflate_shouldBindPreferencesToPreferenceManager() throws Exception {
+    final PreferenceScreen screen = inflatePreferenceActivity();
+    final Preference preference = screen.findPreference("preference");
+    assertThat(preference.getPreferenceManager().findPreference("preference")).isNotNull();
+  }
+
+  @Test
   public void setPersistent_shouldMarkThePreferenceAsPersistent() throws Exception {
     final PreferenceScreen screen = inflatePreferenceActivity();
     final Preference preference = screen.findPreference("preference");


### PR DESCRIPTION
Current Robolectric version does not work with PreferenceActivity, when preferences are inflated from layout and there is a dependency between them.

Here is the test case example:

```
@LargeTest
@RunWith(RobolectricTestRunner.class)
public class MySettingsActivityUnitTest {

    private MySettingsActivity mActivity;

    @Before
    public void setUp() throws Exception {
        mActivity = Robolectric.buildActivity(MySettingsActivity.class).create().get();
        assertThat(mActivity, is(notNullValue()));
    }
(...)
}
```

Here is onCreate on MySettingsActivity:
```
@Override
public void onCreate(Bundle icicle) {
    super.onCreate(icicle);
    addPreferencesFromResource(R.xml.my_preferences);
}
```
Here is the xml my_preferences:

```
<?xml version="1.0" encoding="utf-8"?>
<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
    android:key="settings">
    <PreferenceScreen
        android:layout="@layout/first_setting"
        android:clickable="false"
        android:focusable="false"
        android:dependency="settings" >
    </PreferenceScreen>
</PreferenceScreen>
```

Here is the test output:
```
    java.lang.IllegalStateException: Dependency "settings" not found for preference "null" (title: "null"
        at android.preference.Preference.registerDependency(Preference.java:1194)
        at android.preference.Preference.onAttachedToActivity(Preference.java:1183)
        at android.preference.PreferenceGroup.onAttachedToActivity(PreferenceGroup.java:272)
        at android.preference.PreferenceGroup.onAttachedToActivity(PreferenceGroup.java:281)
        at android.preference.PreferenceScreen.bind(PreferenceScreen.java:146)
        at android.preference.PreferenceActivity.bindPreferences(PreferenceActivity.java:1416)
        at android.preference.PreferenceActivity.access$000(PreferenceActivity.java:123)
        at android.preference.PreferenceActivity$1.handleMessage(PreferenceActivity.java:230)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at org.robolectric.shadows.ShadowMessageQueue.dispatchMessage(ShadowMessageQueue.java:131)
        at org.robolectric.shadows.ShadowMessageQueue.access$100(ShadowMessageQueue.java:30)
        at org.robolectric.shadows.ShadowMessageQueue$1.run(ShadowMessageQueue.java:96)
        at org.robolectric.util.Scheduler$PostedRunnable.run(Scheduler.java:182)
        at org.robolectric.util.Scheduler.runOneTask(Scheduler.java:125)
        at org.robolectric.util.Scheduler.advanceTo(Scheduler.java:110)
        at org.robolectric.util.Scheduler.advanceToLastPostedRunnable(Scheduler.java:86)
        at org.robolectric.util.Scheduler.unPause(Scheduler.java:26)
        at org.robolectric.shadows.ShadowLooper.unPause(ShadowLooper.java:271)
        at org.robolectric.shadows.ShadowLooper.runPaused(ShadowLooper.java:311)
        at org.robolectric.shadows.CoreShadowsAdapter$2.runPaused(CoreShadowsAdapter.java:47)
        at org.robolectric.util.ActivityController.create(ActivityController.java:110)
        at org.robolectric.util.ActivityController.create(ActivityController.java:121)
        at com.company.app.settings.MySettingsActivityUnitTest.setUp(MySettingsActivityUnitTest.java:61)
```