### PR TITLE
Install BouncyCastle security provider

### DIFF
--- a/robolectric/pom.xml
+++ b/robolectric/pom.xml
@@ -57,6 +57,12 @@
       <classifier>${robolectric.api.level}</classifier>
     </dependency>
 
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk16</artifactId>
+      <version>1.46</version>
+    </dependency>
+
     <!-- Project Dependencies -->
     <dependency>
       <groupId>org.ow2.asm</groupId>

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -6,6 +6,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.robolectric.*;
 import org.robolectric.annotation.Config;
 import org.robolectric.internal.fakes.RoboInstrumentation;
@@ -17,9 +18,8 @@ import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.ShadowsAdapter;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Method;
-import java.util.UUID;
+import java.security.Security;
 
 import static org.robolectric.util.ReflectionHelpers.ClassParameter;
 
@@ -72,6 +72,8 @@ public class ParallelUniverse implements ParallelUniverseInterface {
     } else {
       resourceLoader = systemResourceLoader;
     }
+
+    Security.insertProviderAt(new BouncyCastleProvider(), 1);
 
     shadowsAdapter.setSystemResources(systemResourceLoader);
     String qualifiers = addVersionQualifierToQualifiers(config.qualifiers());

--- a/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
@@ -1,6 +1,8 @@
 package org.robolectric;
 
 import android.app.Application;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Test;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -9,6 +11,9 @@ import android.content.res.Resources;
 import android.content.res.Configuration;
 import org.robolectric.internal.ParallelUniverse;
 import org.robolectric.internal.SdkConfig;
+
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 
 import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,7 +28,13 @@ public class ParallelUniverseTest {
     pu = new ParallelUniverse(mock(RobolectricTestRunner.class));
     pu.setSdkConfig(new SdkConfig(18));
   }
-  
+
+  @Test
+  public void ensureBouncyCastleInstalled() throws CertificateException {
+    CertificateFactory factory = CertificateFactory.getInstance("X.509");
+    assertThat(factory.getProvider().getName()).isEqualTo(BouncyCastleProvider.PROVIDER_NAME);
+  }
+
   @Test
   public void setUpApplicationState_setsVersionQualifierFromSdkConfig() {
     String givenQualifiers = "";


### PR DESCRIPTION
This is what real android uses. It is actually more lenient than the built in sun provider so this is more authentic. For example, some android tests were converted to Robolectric and will fail without the bouncy castle provider set.