### PR TITLE
Remove ICU4J from SdkConfig, there is no need to load this jar through t...

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
@@ -43,8 +43,7 @@ public class SdkConfig {
         createDependency("org.robolectric", "android-all", artifactVersionString, null),
         createDependency("org.robolectric", "shadows-core", "3.0-SNAPSHOT", Integer.toString(apiLevel)),
         createDependency("org.json", "json", "20080701", null),
-        createDependency("org.ccil.cowan.tagsoup", "tagsoup", "1.2", null),
-        createDependency("com.ibm.icu", "icu4j", "53.1", null)
+        createDependency("org.ccil.cowan.tagsoup", "tagsoup", "1.2", null)
     };
   }
 


### PR DESCRIPTION
...he instrumenting classloader.

This can be provided like a regular dependency which allows applications that use ICU4J themselves to
avoid version skew by Robolectric specifying a specific version.