### PR TITLE
Expect null when parsing AndroidManifest metadata

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -364,8 +364,9 @@ public class AndroidManifest {
    * @param resLoader used for getting resource IDs from string identifiers
    */
   public void initMetaData(ResourceLoader resLoader) {
-    applicationMetaData.init(resLoader, packageName);
-
+    if (applicationMetaData != null) {
+      applicationMetaData.init(resLoader, packageName);
+    }
     for (BroadcastReceiverData receiver : receivers) {
       receiver.getMetaData().init(resLoader, packageName);
     }
@@ -373,7 +374,9 @@ public class AndroidManifest {
 
   private void parseApplicationMetaData(final Document manifestDocument) {
     Node application = manifestDocument.getElementsByTagName("application").item(0);
-    if (application == null) return;
+    if (application == null) {
+      return;
+    }
     applicationMetaData = new MetaData(getChildrenTags(application, "meta-data"));
   }
 
@@ -481,7 +484,11 @@ public class AndroidManifest {
 
   public Map<String, Object> getApplicationMetaData() {
     parseAndroidManifest();
-    return applicationMetaData.getValueMap();
+    if (applicationMetaData == null) {
+      return Collections.emptyMap();
+    } else {
+      return applicationMetaData.getValueMap();
+    }
   }
 
   public ResourcePath getResourcePath() {


### PR DESCRIPTION
An NPE can occur if an AndroidManifest.xml does not declare an
<application/> element, which is common for Android library projects.

To elaborate with an example, before this patch, this would not work:

```
<manifest xmlns:android="http://schemas.android.com/apk/res/android"
          package="com.my.library">
</manifest>
```

You'd have to declare it like this:

```
<manifest xmlns:android="http://schemas.android.com/apk/res/android"
          package="com.my.library">
    <application/>
</manifest>
```

Not a big deal, but hard to debug. I built and tested locally and also made an edit to conform to "Code Style" point No. 3.