### PR TITLE
Remove duplicate RoboCursor.getCount definition

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboCursor.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboCursor.java
@@ -74,11 +74,6 @@ public class RoboCursor extends BaseCursor {
   }
 
   @Override
-  public int getCount() {
-    return results.length;
-  }
-
-  @Override
   public int getColumnCount() {
     return results[0].length;
   }


### PR DESCRIPTION
Introduced by a merge maybe? This should fix the build.