### PR TITLE
ActivityController should use ActivityInfo from PackageManager rather than creating a dummy instance.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/manifest/ActivityData.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/ActivityData.java
@@ -43,22 +43,24 @@ public class ActivityData {
    * XML Namespace used for android.
    */
   private final String xmlns;
+  private final MetaData metaData;
 
   public ActivityData(Map<String, String> attrMap, List<IntentFilterData> intentFilters) {
     this("android", attrMap, intentFilters);
   }
 
   public ActivityData(String xmlns, Map<String, String> attrMap, List<IntentFilterData> intentFilters) {
-    this(xmlns, attrMap, intentFilters, null);
+    this(xmlns, attrMap, intentFilters, null, null);
   }
 
   public ActivityData(String xmlns, Map<String, String> attrMap, List<IntentFilterData> intentFilters,
-      ActivityData targetActivity) {
+      ActivityData targetActivity, MetaData metaData) {
     this.xmlns = xmlns;
-    attrs = new HashMap<String,String>();
+    attrs = new HashMap<>();
     attrs.putAll(attrMap);
-    this.intentFilters = new ArrayList<IntentFilterData>(intentFilters);
+    this.intentFilters = new ArrayList<>(intentFilters);
     this.targetActivity = targetActivity;
+    this.metaData = metaData;
   }
 
   public boolean isAllowTaskReparenting() {
@@ -230,6 +232,10 @@ public class ActivityData {
    */
   public List<IntentFilterData> getIntentFilters() {
     return intentFilters;
+  }
+
+  public MetaData getMetaData() {
+    return metaData;
   }
 
   public ActivityData getTargetActivity() {

--- a/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -218,7 +218,8 @@ public class AndroidManifest {
     final NamedNodeMap attributes = activityNode.getAttributes();
     final int attrCount = attributes.getLength();
     final List<IntentFilterData> intentFilterData = parseIntentFilters(activityNode);
-    final HashMap<String, String> activityAttrs = new HashMap<String, String>(attrCount);
+    final MetaData metaData = new MetaData(getChildrenTags(activityNode, "meta-data"));
+    final HashMap<String, String> activityAttrs = new HashMap<>(attrCount);
     for(int i = 0; i < attrCount; i++) {
       Node attr = attributes.item(i);
       String v = attr.getNodeValue();
@@ -243,7 +244,7 @@ public class AndroidManifest {
       activityAttrs.put(ActivityData.getTargetAttr("android"), targetName);
     }
     activityAttrs.put(ActivityData.getNameAttr("android"), activityName);
-    activityDatas.put(activityName, new ActivityData("android", activityAttrs, intentFilterData, targetActivity));
+    activityDatas.put(activityName, new ActivityData("android", activityAttrs, intentFilterData, targetActivity, metaData));
   }
 
   private List<IntentFilterData> parseIntentFilters(final Node activityNode) {

--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -140,6 +140,8 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
     activityInfo.packageName = packageName;
     activityInfo.name = activityName;
     if (activityData != null) {
+      activityInfo.parentActivityName = activityData.getParentActivityName();
+      activityInfo.metaData = metaDataToBundle(activityData.getMetaData().getValueMap());
       ResourceIndex resourceIndex = shadowsAdapter.getResourceLoader().getResourceIndex();
       String themeRef;
 

--- a/robolectric/src/main/java/org/robolectric/util/ActivityController.java
+++ b/robolectric/src/main/java/org/robolectric/util/ActivityController.java
@@ -2,10 +2,11 @@ package org.robolectric.util;
 
 import android.app.Activity;
 import android.app.Application;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
-import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.Bundle;
 import org.robolectric.RuntimeEnvironment;
@@ -51,8 +52,12 @@ public class ActivityController<T extends Activity> extends ComponentController<
     }
     Context baseContext = this.baseContext == null ? application : this.baseContext;
     Intent intent = getIntent();
-    ActivityInfo activityInfo = new ActivityInfo();
-    ReflectionHelpers.setField(activityInfo, "applicationInfo", new ApplicationInfo());
+    ActivityInfo activityInfo;
+    try {
+      activityInfo = application.getPackageManager().getActivityInfo(new ComponentName(application.getPackageName(), component.getClass().getName()), PackageManager.GET_ACTIVITIES|PackageManager.GET_META_DATA);
+    } catch (PackageManager.NameNotFoundException e) {
+      throw new RuntimeException(e);
+    }
     String activityTitle = getActivityTitle();
 
     ClassLoader cl = baseContext.getClassLoader();

--- a/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
@@ -1,5 +1,6 @@
 package org.robolectric.res;
 
+import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -34,6 +35,7 @@ import org.robolectric.test.TemporaryFolder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.robolectric.Robolectric.setupActivity;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -618,6 +620,17 @@ public class DefaultRobolectricPackageManagerTest {
     packageManager.setApplicationEnabledSetting("org.robolectric", PackageManager.COMPONENT_ENABLED_STATE_DISABLED, 0);
 
     assertThat(packageManager.getApplicationEnabledSetting("org.robolectric")).isEqualTo(PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+  }
+
+  public static class ActivityWithMetadata extends Activity { }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifest.xml")
+  public void getActivityMetaData() throws Exception {
+    Activity activity = setupActivity(ActivityWithMetadata.class);
+
+    ActivityInfo activityInfo = RuntimeEnvironment.getPackageManager().getActivityInfo(activity.getComponentName(), PackageManager.GET_ACTIVITIES|PackageManager.GET_META_DATA);
+    assertThat(activityInfo.metaData.get("someName")).isEqualTo("someValue");
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.robolectric.Robolectric.setupActivity;
 import static org.robolectric.RuntimeEnvironment.application;
 import static org.robolectric.Robolectric.buildActivity;
 import static org.robolectric.Shadows.shadowOf;
@@ -773,6 +774,18 @@ public class ShadowActivityTest {
 
     controller.destroy();
     transcript.assertEventsSoFar("onActivityDestroyed");
+  }
+
+  public static class ChildActivity extends Activity { }
+
+  public static class ParentActivity extends Activity { }
+
+  @Test
+  public void getParentActivityIntent() {
+    Activity activity = setupActivity(ChildActivity.class);
+
+    assertThat(activity.getParentActivityIntent().getComponent().getClassName())
+        .isEqualTo(ParentActivity.class.getName());
   }
 
   /////////////////////////////

--- a/robolectric/src/test/resources/TestAndroidManifest.xml
+++ b/robolectric/src/test/resources/TestAndroidManifest.xml
@@ -15,5 +15,13 @@
 
     <activity android:name="org.robolectric.shadows.ShadowThemeTest$TestActivityWithAThirdTheme"
           android:theme="@style/Theme.ThirdTheme"/>
+
+    <activity android:name="org.robolectric.shadows.ShadowActivityTest$ParentActivity"/>
+    <activity android:name="org.robolectric.shadows.ShadowActivityTest$ChildActivity"
+        android:parentActivityName="org.robolectric.shadows.ShadowActivityTest$ParentActivity"/>
+
+      <activity android:name="org.robolectric.res.DefaultRobolectricPackageManagerTest$ActivityWithMetadata">
+          <meta-data android:name="someName" android:value="someValue"/>
+      </activity>
   </application>
 </manifest>


### PR DESCRIPTION
Activity controller should use ActivityInfo from PackageManager rather than creating a dummy instance.

Add support for parentActivityName attribute and <meta-data> elements in ActivityInfo,