### PR TITLE
Simply return when a resource attribute cannot be found rather than blow up.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/shadows/Converter.java
+++ b/robolectric-resources/src/main/java/org/robolectric/shadows/Converter.java
@@ -44,7 +44,7 @@ public class Converter<T> {
 
     TypedResource attrTypeData = resourceLoader.getValue(attribute.resName, qualifiers);
     if (attrTypeData == null) {
-      throw new Resources.NotFoundException("Couldn't find " + attribute.resName + " attr data");
+      return;
     }
 
     AttrData attrData = (AttrData) attrTypeData.getData();


### PR DESCRIPTION
When running with emulateSdk = 19 and using a theme that sets the following attribute

colorControlActivated

Results in the following exception because Robolectric cannot resolve the attribute as the attribute was introduced in API 21. This works fine on a device however so Robolectric should just ignore these attributes.

We could tighten this up a bit by parsing the api-versions.xml file and being lenient only for android attributes:-

https://android.googlesource.com/platform/development/+/15fcd984aedd64bec385cb54270ee5c387bdb51f/sdk/api-versions.xml

android.content.res.Resources$NotFoundException: Couldn't find ResName{android:attr/colorControlActivated} attr data
at org.robolectric.shadows.Converter.convertAndFill(Converter.java:47)
at org.robolectric.shadows.ShadowResources.createTypedArray(ShadowResources.java:231)
at org.robolectric.shadows.ShadowResources.attrsToTypedArray(ShadowResources.java:206)
at org.robolectric.shadows.ShadowResources.access$000(ShadowResources.java:51)
at org.robolectric.shadows.ShadowResources.obtainStyledAttributes(ShadowResources.java:489)
at android.content.res.Resources$Theme.obtainStyledAttributes(Resources.java)
at android.content.Context.obtainStyledAttributes(Context.java:425)
at com.android.internal.app.AlertController.constructor(AlertController.java:188)
at com.android.internal.app.AlertController.(AlertController.java)
at android.app.AlertDialog.constructor(AlertDialog.java:117)
at android.app.AlertDialog.(AlertDialog.java)
at android.app.AlertDialog$Builder.create(AlertDialog.java:931)