### PR TITLE
Modifying TestRunner to read some dependencies from a local folder.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -98,18 +98,21 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
 
   protected DependencyResolver getJarResolver() {
     if (dependencyResolver == null) {
-      if (Boolean.getBoolean("robolectric.offline")) {
-        String dependencyDir = System.getProperty("robolectric.dependency.dir", ".");
-        dependencyResolver = new LocalDependencyResolver(new File(dependencyDir));
+      File cacheDir = new File(new File(System.getProperty("java.io.tmpdir")), "robolectric");
+      cacheDir.mkdir();
+      if (cacheDir.exists()) {
+        dependencyResolver = new CachedDependencyResolver(new MavenDependencyResolver(), cacheDir, 60 * 60 * 24 * 1000);
       } else {
-        File cacheDir = new File(new File(System.getProperty("java.io.tmpdir")), "robolectric");
-        cacheDir.mkdir();
+        dependencyResolver = new MavenDependencyResolver();
+      }
 
-        if (cacheDir.exists()) {
-          dependencyResolver = new CachedDependencyResolver(new MavenDependencyResolver(), cacheDir, 60 * 60 * 24 * 1000);
-        } else {
-          dependencyResolver = new MavenDependencyResolver();
-        }
+      String dependencyDir = System.getenv("ROBOLECTRIC_DEPENDENCY_DIR");
+      if (dependencyDir == null) {
+          dependencyDir = System.getProperty("robolectric.dependency.dir");
+      }
+
+      if (dependencyDir != null) {
+        dependencyResolver = new LocalDependencyResolver(dependencyResolver, new File(dependencyDir));
       }
     }
 

--- a/robolectric/src/main/java/org/robolectric/internal/dependency/LocalDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/internal/dependency/LocalDependencyResolver.java
@@ -8,9 +8,11 @@ import java.net.URL;
 
 public class LocalDependencyResolver implements DependencyResolver {
   private File offlineJarDir;
+  private final DependencyResolver dependencyResolver;
 
-  public LocalDependencyResolver(File offlineJarDir) {
+  public LocalDependencyResolver(DependencyResolver dependencyResolver, File offlineJarDir) {
     super();
+    this.dependencyResolver = dependencyResolver;
     this.offlineJarDir = offlineJarDir;
   }
 
@@ -29,7 +31,12 @@ public class LocalDependencyResolver implements DependencyResolver {
     filenameBuilder.append(".")
         .append(dependency.getType());
 
-    return fileToUrl(validateFile(new File(offlineJarDir, filenameBuilder.toString())));
+    File file = new File(offlineJarDir, filenameBuilder.toString());
+
+    if (isValidFile(file)) {
+      return fileToUrl(file);
+    }
+    return dependencyResolver.getLocalArtifactUrl(dependency);
   }
 
   @Override
@@ -43,24 +50,8 @@ public class LocalDependencyResolver implements DependencyResolver {
     return urls;
   }
 
-  /**
-   * Validates {@code file} as a File that exists and is a file, and is readable.
-   *
-   * @param file the File to test
-   * @return the provided file, if all validation passes
-   * @throws IllegalArgumentException if validation fails
-   */
-  private static File validateFile(File file) throws IllegalArgumentException {
-    if (!file.exists()) {
-      throw new IllegalArgumentException("File does not exist: " + file);
-    }
-    if (!file.isFile()) {
-      throw new IllegalArgumentException("Path is not a file: " + file);
-    }
-    if (!file.canRead()) {
-      throw new IllegalArgumentException("Unable to read file: " + file);
-    }
-    return file;
+  private boolean isValidFile(File file) {
+    return (file.exists() && file.isFile() && file.canRead());
   }
 
   /** Returns the given file as a {@link URL}. */


### PR DESCRIPTION
Robolectric has currently two variables controlling offline behavior:
<b>robolectric.offline</b> and <b>robolectric.dependency.dir</b>
Both are tightly coupled, in the sense that one does not work without the other. They also do not solve all problems related with offline behavior. 
For instance, I want Robolectric to use some dependencies from a local folder (offline behavior), while still downloading others from maven/sonatype (online behavior). With the current code, I can only either have all dependencies on a local folder or download all dependencies.
In my case, I only wanted to use my local shadows-core library and I didn't want to download all other dependencies to do that.
So, here is the proposal:
1 - Remove robolectric.offline, keeping only robolectric.dependency.dir. If robolectric.dependency.dir is not set, then we have the online behavior.
2 - Modify the LocalDependencyResolver with this behavior: Look for dependencies in robolectric.dependency.dir first. If dependency is not found, then use the cached/Maven dependencyResolver.
3 - Also, try to load the dependency folder from the environment variable ROBOLECTRIC_DEPENDENCY_DIR . The reason for this redundancy is that on Android Studio it is not simple to pass system variables to Robolectric, since the test executes on a forked process and gradle does not provide system variables to it.

This change is backwards compatible.

I have not added tests yet, but I will in case you agree with the changes.