### PR TITLE
Disable excessive logging.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/PackageResourceLoader.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/PackageResourceLoader.java
@@ -23,7 +23,10 @@ public class PackageResourceLoader extends XResourceLoader {
   }
 
   private void loadEverything() throws Exception {
-    System.out.println("DEBUG: Loading resources for " + resourcePath.getPackageName() + " from " + resourcePath.resourceBase + "...");
+    if (Boolean.getBoolean("robolectric.logging.enabled")) {
+      System.out.println("DEBUG: Loading resources for " + resourcePath.getPackageName() + " from " +
+          resourcePath.resourceBase + "...");
+    }
 
     DocumentLoader documentLoader = new DocumentLoader(resourcePath);
 

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentingClassLoader.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentingClassLoader.java
@@ -74,8 +74,10 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
     this.urls = new URLClassLoader(urls, null);
     classesToRemap = convertToSlashes(config.classNameTranslations());
     methodsToIntercept = convertToSlashes(config.methodsToIntercept());
-    for (URL url : urls) {
-      System.out.println("DEBUG: Loading classes from: " + url.toString());
+    if (Boolean.getBoolean("robolectric.logging.enabled")) {
+      for (URL url : urls) {
+        System.out.println("DEBUG: Loading classes from: " + url.toString());
+      }
     }
   }
 


### PR DESCRIPTION
We are loading resources and jars from many places. In effect, for tests in a single package, we have 20 lines of output, where only one is important (all testspassed). We have now 5 packages, so when you want to run whole suite, your output is filled with useless debug output, and it's hard to easily skim lines to check, that all tests passed.