### PR TITLE
Shadow Environment.getExternalStorageState(File path)

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowEnvironment.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowEnvironment.java.vm
@@ -1,3 +1,6 @@
+#set($Integer = 0)
+#set($apiLevel = $Integer.parseInt($apiLevel))
+
 package org.robolectric.shadows;
 
 import android.os.Environment;
@@ -17,6 +20,20 @@ public class ShadowEnvironment {
   public static String getExternalStorageState() {
     return externalStorageState;
   }
+
+#if ($apiLevel >= 19)
+  @Implementation
+  public static String getStorageState(File path) {
+    return externalStorageState;
+  }
+#end
+
+#if ($apiLevel >= 21)
+  @Implementation
+  public static String getExternalStorageState(File path) {
+    return externalStorageState;
+  }
+#end
 
   public static void setExternalStorageState(String externalStorageState) {
     ShadowEnvironment.externalStorageState = externalStorageState;


### PR DESCRIPTION
For KitKat+ is called via EnvironmentCompat.getStorageState(File path) rather than Environment.getExternalStorageState() on JB and below.