### PR TITLE
Added most simple implementation of ShadowMediaRouter to avoid NPE.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaRouter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaRouter.java
@@ -1,0 +1,15 @@
+package org.robolectric.shadows;
+
+import android.media.MediaRouter;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(MediaRouter.class)
+public class ShadowMediaRouter {
+
+  @Implementation
+  public int getRouteCount() {
+    return 0;
+  }
+}


### PR DESCRIPTION
Real object needs creating by calling its constructor that takes a context. Even if we do this we are still faced with the problem of providing implementations for the stub services so I think this is the best layer to shadow.