### PR TITLE
Relax modifiers on RobolectricTestRunner so that we can override with so...

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -420,7 +420,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
     parallelUniverseInterface.setUpApplicationState(method, testLifecycle, systemResourceLoader, appManifest, config);
   }
 
-  private SdkConfig pickSdkVersion(AndroidManifest appManifest, Config config) {
+  protected SdkConfig pickSdkVersion(AndroidManifest appManifest, Config config) {
     if (config != null && config.emulateSdk() > 0) {
       return new SdkConfig(config.emulateSdk());
     } else {
@@ -432,7 +432,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
     }
   }
 
-  private int pickReportedSdkVersion(Config config, AndroidManifest appManifest) {
+  protected int pickReportedSdkVersion(Config config, AndroidManifest appManifest) {
     // Check if the user has explicitly overridden the reported version
     if (config != null && config.reportSdk() > 0) {
       return config.reportSdk();


### PR DESCRIPTION
...me custom logic. We wish to set globally the default emulated SDK version as we need to peg it artificially at 18 until all projects run against 19 and then 21. Tests are free to override the default value but currently there are too many failing tests to invert this logic (i.e: set the default to 21 and then ask test writers to override a fall back). This approach allows us to incrementally fix failures and then bump up the default. A better mechanism would be to provide a getDefaultApiVersion() method that by default returns the latest but is overridable for this usecase but this approach now allows me to remove our Google specific patches and get back onto mainline Robolectric.