### PR TITLE
Implement View animations through shadows.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
@@ -10,9 +10,13 @@ import android.graphics.drawable.Drawable;
 import android.os.Looper;
 import android.text.TextUtils;
 import android.util.AttributeSet;
+import android.view.Choreographer;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewParent;
+import android.view.animation.Animation;
+import android.view.animation.Transformation;
+
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -475,20 +479,20 @@ public class ShadowView {
   }
 
   @Implementation
-  public void onAnimationEnd() {
-  }
+  public void setAnimation(final Animation animation) {
+    directly().setAnimation(animation);
 
-  /*
-   * Non-Android accessor.
-   */
-  public void finishedAnimation() {
-    try {
-      Method onAnimationEnd = realView.getClass().getDeclaredMethod("onAnimationEnd", new Class[0]);
-      onAnimationEnd.setAccessible(true);
-      onAnimationEnd.invoke(realView);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    ShadowChoreographer.getInstance().postCallbackDelayed(Choreographer.CALLBACK_ANIMATION, new Runnable() {
+      @Override
+      public void run() {
+        boolean complete = false;
+        while(!complete) {
+          complete = !animation.getTransformation(ShadowChoreographer.getInstance().getFrameTime(), new Transformation());
+        }
+
+      }
+    }, null, animation.getStartTime());
+
   }
 
   @Implementation

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
@@ -19,10 +19,12 @@ import android.view.View.OnLongClickListener;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
+import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
@@ -46,6 +48,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.robolectric.Robolectric.buildActivity;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -433,11 +438,34 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void dispatchOnAnimationEnd() throws Exception {
-    TestView view1 = new TestView(buildActivity(Activity.class).create().get());
-    assertFalse(view1.onAnimationEndWasCalled);
-    shadowOf(view1).finishedAnimation();
-    assertTrue(view1.onAnimationEndWasCalled);
+  public void startAnimation() {
+    TestView view = new TestView(buildActivity(Activity.class).create().get());
+    AlphaAnimation animation = new AlphaAnimation(0, 1);
+
+    Animation.AnimationListener listener = mock(Animation.AnimationListener.class);
+    animation.setAnimationListener(listener);
+    view.startAnimation(animation);
+
+    verify(listener).onAnimationStart(animation);
+    verify(listener).onAnimationEnd(animation);
+  }
+
+  @Test
+  public void setAnimation() {
+    TestView view = new TestView(buildActivity(Activity.class).create().get());
+    AlphaAnimation animation = new AlphaAnimation(0, 1);
+
+    Animation.AnimationListener listener = mock(Animation.AnimationListener.class);
+    animation.setAnimationListener(listener);
+    animation.setStartTime(1000);
+    view.setAnimation(animation);
+
+    verifyZeroInteractions(listener);
+
+    ShadowLooper.getUiThreadScheduler().advanceToNextPostedRunnable();
+
+    verify(listener).onAnimationStart(animation);
+    verify(listener).onAnimationEnd(animation);
   }
 
   @Test


### PR DESCRIPTION
Real android executes these animations through the call to RootViewImpl.setView() but this invokes an out of process binder calls to WindowSession.addToDisplay(...) and requires the return value to be meaningful, plus some other conditions also need to be right.

https://github.com/android/platform_frameworks_base/blob/master/core/java/android/view/ViewRootImpl.java#L527

Somehow then the following calls are invoked by the Android system:-

 RootViewImpl.scheduleTraversals() -> TraversalRunnable() -> doTraversal() -> performTraversals() that eventually calls onDraw() which the calls ViewGroup.draw() and eventually ViewGroup.drawChild() which performs the animations.

The other more complicated solution would be to try and mimic what is happening on real android when we set up the Activity through the ActivityController, we might be able to set the state correctly so that the animations happen but I tried it for a while and it is much more involved.