### PR TITLE
Apply @Config annotation to TestClass hierarchy.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -365,9 +365,20 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
       config = new Config.Implementation(config, methodClassConfig);
     }
 
-    Config testClassConfig = getTestClass().getJavaClass().getAnnotation(Config.class);
-    if (testClassConfig != null) {
-      config = new Config.Implementation(config, testClassConfig);
+    ArrayList<Class> testClassHierarchy = new ArrayList<>();
+    Class testClass = getTestClass().getJavaClass();
+
+    while(testClass != null) {
+      // Prepend so that we reverse the hierarchy such that ancestors are first and the base class is last
+      testClassHierarchy.add(0, testClass);
+      testClass = testClass.getSuperclass();
+    }
+
+    for(Class clazz : testClassHierarchy) {
+      Config classConfig = (Config) clazz.getAnnotation(Config.class);
+      if(classConfig != null) {
+        config = new Config.Implementation(config, classConfig);
+      }
     }
 
     Config methodConfig = method.getAnnotation(Config.class);

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -46,6 +46,30 @@ public class RobolectricTestRunnerTest {
   }
 
   @Test
+  public void whenClassDoesntHaveConfigAnnotation_getConfig_shouldMergeParentClassAndMethodConfig() throws Exception {
+    assertConfig(configFor(Test5.class, "withoutAnnotation"),
+        1, "foo", "from-test", "test/res", "test/assets", 2, new Class[]{Test1.class});
+
+    assertConfig(configFor(Test5.class, "withDefaultsAnnotation"),
+        1, "foo", "from-test", "test/res", "test/assets", 2, new Class[]{Test1.class});
+
+    assertConfig(configFor(Test5.class, "withOverrideAnnotation"),
+        9, "foo", "from-method5", "test/res", "method5/assets", 8, new Class[]{Test1.class, Test5.class});
+  }
+
+  @Test
+  public void whenClassAndParentClassHaveConfigAnnotation_getConfig_shouldMergeParentClassAndMethodConfig() throws Exception {
+    assertConfig(configFor(Test6.class, "withoutAnnotation"),
+            1, "foo", "from-class6", "class6/res", "test/assets", 2, new Class[]{Test1.class, Test6.class});
+
+    assertConfig(configFor(Test6.class, "withDefaultsAnnotation"),
+            1, "foo", "from-class6", "class6/res", "test/assets", 2, new Class[]{Test1.class, Test6.class});
+
+    assertConfig(configFor(Test6.class, "withOverrideAnnotation"),
+            9, "foo", "from-method5", "class6/res", "method5/assets", 8, new Class[]{Test1.class, Test5.class, Test6.class});
+  }
+
+  @Test
   public void whenClassAndSubclassHaveConfigAnnotation_getConfig_shouldMergeClassSubclassAndMethodConfig() throws Exception {
     assertConfig(configFor(Test3.class, "withoutAnnotation"),
         1, "foo", "from-subclass", "test/res", "test/assets", 2, new Class[]{Test1.class});
@@ -176,6 +200,26 @@ public class RobolectricTestRunnerTest {
   @Ignore
   @Config(qualifiers = "from-subclass")
   public static class Test4 extends Test2 {
+  }
+
+  @Ignore
+  public static class Test5 extends Test1 {
+    @Test
+    public void withoutAnnotation() throws Exception {
+    }
+
+    @Test @Config
+    public void withDefaultsAnnotation() throws Exception {
+    }
+
+    @Test @Config(emulateSdk = 9, reportSdk = 8, shadows = Test5.class, qualifiers = "from-method5", assetDir = "method5/assets")
+    public void withOverrideAnnotation() throws Exception {
+    }
+  }
+
+  @Ignore
+  @Config(qualifiers = "from-class6", shadows = Test6.class, resourceDir = "class6/res")
+  public static class Test6 extends Test5 {
   }
 
   private String stringify(Config config) {


### PR DESCRIPTION
This change applies @Config annotations for a test classes entire hierarchy.  This is very useful for putting @RunsWith and @Config settings in a parent test class and extending the parent for individual tests classes.

My company's projects currently extend RobolectricTestRunner and overload the getConfig method to add this functionality allowing for a common place for our @RunsWith and @Config annotations.  We find that > 80% of the time we don't override them in the base test classes.

NOTE: This change could possibly break existing Robolectric tests IFF there exists a hierarchy and a parent of a test class has an @Config annotation which is currently being ignored.  Seems like this would only happen if someone extended an actual test class with @Test annotated methods which seems rare.  For this reason, this doesn't seem like a good change for a bug fix release.  It's probably a good candidate for 3.0 or a 2.x release.