### PR TITLE
Adding CompositeDependencyResolver 

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/dependency/CompositeDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/internal/dependency/CompositeDependencyResolver.java
@@ -1,0 +1,37 @@
+package org.robolectric.internal.dependency;
+
+import java.net.URL;
+import java.util.List;
+
+public class CompositeDependencyResolver implements DependencyResolver {
+  private final List<DependencyResolver> dependencyResolvers;
+
+  public CompositeDependencyResolver(List<DependencyResolver> dependencyResolvers) {
+    super();
+    this.dependencyResolvers = dependencyResolvers;
+  }
+
+  @Override
+  public URL getLocalArtifactUrl(DependencyJar dependency) {
+    if (dependencyResolvers != null) {
+      for (DependencyResolver resolver : dependencyResolvers) {
+        URL url = resolver.getLocalArtifactUrl(dependency);
+        if (url != null) {
+          return url;
+        }
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public URL[] getLocalArtifactUrls(DependencyJar... dependencies) {
+    URL[] urls = new URL[dependencies.length];
+
+    for (int i=0; i<dependencies.length; i++) {
+      urls[i] = getLocalArtifactUrl(dependencies[i]);
+    }
+
+    return urls;
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/internal/dependency/LocalDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/internal/dependency/LocalDependencyResolver.java
@@ -16,6 +16,9 @@ public class LocalDependencyResolver implements DependencyResolver {
 
   @Override
   public URL getLocalArtifactUrl(DependencyJar dependency) {
+    if (offlineJarDir == null){
+      return null;
+    }
     StringBuilder filenameBuilder = new StringBuilder();
     filenameBuilder.append(dependency.getArtifactId())
         .append("-")

--- a/robolectric/src/test/java/org/robolectric/internal/dependency/CompositeDependencyResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/dependency/CompositeDependencyResolverTest.java
@@ -1,0 +1,100 @@
+package org.robolectric.internal.dependency;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.InitializationError;
+import org.robolectric.test.TemporaryFolder;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CompositeDependencyResolverTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private DependencyJar[] dependencies = new DependencyJar[]{
+      createDependency("group1", "artifact1"),
+      createDependency("group2", "artifact2"),
+  };
+  private DependencyJar dependency = dependencies[0];
+  private URL url1;
+  private URL url2;
+
+  @Before
+  public void setUp() throws InitializationError, MalformedURLException {
+    url1 = new URL("http://localhost");
+    url2 = new URL("http://127.0.0.1");
+  }
+
+  @Test
+  public void constructorShouldAcceptNullList() throws Exception {
+    CompositeDependencyResolver resolver = new CompositeDependencyResolver(null);
+    assertEquals(resolver.getLocalArtifactUrl(dependency), null);
+  }
+
+  @Test
+  public void constructorShouldAcceptEmptyList() throws Exception {
+    CompositeDependencyResolver resolver = new CompositeDependencyResolver(new ArrayList<DependencyResolver>());
+    assertEquals(resolver.getLocalArtifactUrl(dependency), null);
+  }
+
+  @Test
+  public void dependencyResolutionShallRespectInputOrder() throws Exception {
+    List<DependencyResolver> resolverList = new ArrayList<>();
+    DependencyResolver resolver1 = mock(DependencyResolver.class);
+    when(resolver1.getLocalArtifactUrl(dependency)).thenReturn(url1);
+    resolverList.add(resolver1);
+    DependencyResolver resolver2 = mock(DependencyResolver.class);
+    when(resolver2.getLocalArtifactUrl(dependency)).thenReturn(url2);
+    resolverList.add(resolver2);
+    CompositeDependencyResolver resolver = new CompositeDependencyResolver(resolverList);
+    assertEquals(resolver.getLocalArtifactUrl(dependency), url1);
+  }
+
+  @Test
+  public void dependencyResolutionShallProceedToNextResolver() throws Exception {
+    List<DependencyResolver> resolverList = new ArrayList<>();
+    DependencyResolver resolver1 = mock(DependencyResolver.class);
+    when(resolver1.getLocalArtifactUrl(dependency)).thenReturn(null);
+    resolverList.add(resolver1);
+    DependencyResolver resolver2 = mock(DependencyResolver.class);
+    when(resolver2.getLocalArtifactUrl(dependency)).thenReturn(url2);
+    resolverList.add(resolver2);
+    CompositeDependencyResolver resolver = new CompositeDependencyResolver(resolverList);
+    assertEquals(resolver.getLocalArtifactUrl(dependency), url2);
+  }
+
+  @Test
+  public void dependencyResolutionShallReturnNullIfNoResolverCanResolveDependency() throws Exception {
+    List<DependencyResolver> resolverList = new ArrayList<>();
+    DependencyResolver resolver1 = mock(DependencyResolver.class);
+    when(resolver1.getLocalArtifactUrl(dependency)).thenReturn(null);
+    resolverList.add(resolver1);
+    DependencyResolver resolver2 = mock(DependencyResolver.class);
+    when(resolver2.getLocalArtifactUrl(dependency)).thenReturn(null);
+    resolverList.add(resolver2);
+    CompositeDependencyResolver resolver = new CompositeDependencyResolver(resolverList);
+    assertEquals(resolver.getLocalArtifactUrl(dependency), null);
+  }
+
+  private DependencyJar createDependency(final String groupId, final String artifactId) {
+    return new DependencyJar(groupId, artifactId, null, "") {
+
+      @Override
+      public boolean equals(Object o) {
+        if(!(o instanceof DependencyJar)) return false;
+
+        DependencyJar d = (DependencyJar) o;
+
+        return this.getArtifactId().equals(d.getArtifactId()) && this.getGroupId().equals(groupId);
+      }
+    };
+  }
+}


### PR DESCRIPTION
This is a new pull request for previous pull 1575.

Robolectric has currently two variables controlling offline behavior:
<b>robolectric.offline</b> and <b>robolectric.dependency.dir</b>
Both are tightly coupled, in the sense that one does not work without the other. They also do not solve all problems related with offline behavior. 
For instance, I want Robolectric to use some dependencies from a local folder (offline behavior), while still downloading others from maven/sonatype (online behavior). With the current code, I can only either have all dependencies on a local folder or download all dependencies.
In my case, I only wanted to use my local shadows-core library and I didn't want to download all other dependencies to do that.

Based on comments on pull 1575, here are the changes:
- Crested a CompositeDependencyResolver that will try to resolve dependencies asking the resolvers in the order they were added.
- Modify TestRunner to use CompositeDependencyResolver.
- Checking local dependency folder at environment variable ROBOLECTRIC_DEPENDENCY_DIR a well as on system variable robolectric.dependency.dir
