### PR TITLE
Fix getActivityInfo() method in DefaultPackageManager class

### DIFF
--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -136,10 +136,10 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
     AndroidManifest androidManifest = androidManifests.get(packageName);
     String activityName = className.getClassName();
     ActivityData activityData = androidManifest.getActivityData(activityName);
-    ActivityInfo activityInfo = new ActivityInfo();
-    activityInfo.packageName = packageName;
-    activityInfo.name = activityName;
     if (activityData != null) {
+      ActivityInfo activityInfo = new ActivityInfo();
+      activityInfo.packageName = packageName;
+      activityInfo.name = activityName;
       activityInfo.parentActivityName = activityData.getParentActivityName();
       activityInfo.metaData = metaDataToBundle(activityData.getMetaData().getValueMap());
       ResourceIndex resourceIndex = shadowsAdapter.getResourceLoader().getResourceIndex();
@@ -155,9 +155,11 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
         ResName style = ResName.qualifyResName(themeRef.replace("@", ""), packageName, "style");
         activityInfo.theme = resourceIndex.getResourceId(style);
       }
+      activityInfo.applicationInfo = getApplicationInfo(packageName, flags);
+      return activityInfo;
+    } else {
+        throw new NameNotFoundException(activityName);
     }
-    activityInfo.applicationInfo = getApplicationInfo(packageName, flags);
-    return activityInfo;
   }
 
   @Override


### PR DESCRIPTION
PackageManager must return activity info only if androidManifest has activityData. Otherwise packagemanager will be return activity info even if androidManifest hasn't activity. In addition intent.resolveActivityInfo() never return null, despite the fact that it's recommended by developer.android.com:

"To first verify that an app exists to receive the intent, call resolveActivity() on your Intent object. If the result is non-null, there is at least one app that can handle the intent and it's safe to call startActivity(). If the result is null, you should not use the intent and, if possible, you should disable the feature that invokes the intent."