### PR TITLE
Like original implementation ignore when no typeface family is given

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowTypeface.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowTypeface.java.vm
@@ -58,6 +58,7 @@ public class ShadowTypeface {
 
   @Implementation
   public static Typeface create(Typeface family, int style) {
+    if(family == null) return createUnderlyingTypeface(null, style);
     return createUnderlyingTypeface(shadowOf(family).getFontDescription().getFamilyName(), style);
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTypefaceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTypefaceTest.java
@@ -48,6 +48,14 @@ public class ShadowTypefaceTest {
   }
 
   @Test
+  public void create_withoutFamily_shouldCreateTypeface() {
+    Typeface typeface = Typeface.create((Typeface) null, Typeface.ITALIC);
+    assertThat(typeface.getStyle()).isEqualTo(Typeface.ITALIC);
+    assertThat(shadowOf(typeface).getFontDescription().getFamilyName()).isEqualTo(null);
+    assertThat(shadowOf(typeface).getFontDescription().getStyle()).isEqualTo(Typeface.ITALIC);
+  }
+
+  @Test
   public void createFromFile_withFile_shouldCreateTypeface() {
     Typeface typeface = Typeface.createFromFile(fontFile);
 


### PR DESCRIPTION
 This case happens when you use the date picker from android sdk 21

Original I got the following exception when I try to start the DatePicker inside FragmentDialog.

    Caused by: java.lang.NullPointerException: can't get a shadow for null
	at org.robolectric.internal.ShadowExtractor.extract(ShadowExtractor.java:9)
	at org.robolectric.Shadows.shadowOf(Shadows.java:1266)
	at org.robolectric.shadows.ShadowTypeface.create(ShadowTypeface.java:50)
	at android.graphics.Typeface.create(Typeface.java)
	at android.widget.TextViewWithCircularIndicator.init(TextViewWithCircularIndicator.java:73)
	at android.widget.TextViewWithCircularIndicator.__constructor__(TextViewWithCircularIndicator.java:69)
	at android.widget.TextViewWithCircularIndicator.<init>(TextViewWithCircularIndicator.java)
	at android.view.LayoutInflater.createView(LayoutInflater.java:607)
	at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:743)
	at android.view.LayoutInflater.inflate(LayoutInflater.java:482)
        ...

With this patch the error is gone and I can access the started dialog.