### PR TITLE
Fix bug introduced in https://github.com/robolectric/robolectric/commit/...

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNfcAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNfcAdapter.java
@@ -2,11 +2,14 @@ package org.robolectric.shadows;
 
 import android.app.Activity;
 import android.app.PendingIntent;
+import android.content.Context;
 import android.content.IntentFilter;
+import android.nfc.NdefMessage;
 import android.nfc.NfcAdapter;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
+import org.robolectric.util.ReflectionHelpers;
 
 @Implements(NfcAdapter.class)
 public class ShadowNfcAdapter {
@@ -16,6 +19,12 @@ public class ShadowNfcAdapter {
   private IntentFilter[] filters;
   private String[][] techLists;
   private Activity disabledActivity;
+  private NfcAdapter.CreateNdefMessageCallback callback;
+
+  @Implementation
+  public static NfcAdapter getNfcAdapter(Context context) {
+    return ReflectionHelpers.callConstructor(NfcAdapter.class);
+  }
 
   @Implementation
   public void enableForegroundDispatch(Activity activity, PendingIntent intent, IntentFilter[] filters, String[][] techLists) {
@@ -48,5 +57,15 @@ public class ShadowNfcAdapter {
 
   public Activity getDisabledActivity() {
     return disabledActivity;
+  }
+
+  @Implementation
+  public void setNdefPushMessageCallback(NfcAdapter.CreateNdefMessageCallback callback, Activity activity,
+                                         Activity ... activities) {
+    this.callback = callback;
+  }
+
+  public NfcAdapter.CreateNdefMessageCallback getNdefPushMessageCallback() {
+    return callback;
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
@@ -100,6 +100,10 @@ public class ShadowContextImpl extends ShadowContext {
         } else if (serviceClassName.equals("android.os.storage.StorageManager")) {
           service = ReflectionHelpers.callConstructor(clazz);
 
+        } else if (serviceClassName.equals("android.nfc.NfcManager")) {
+          service = ReflectionHelpers.callConstructor(clazz,
+              ClassParameter.from(Context.class, RuntimeEnvironment.application));
+
         } else if (serviceClassName.equals("android.hardware.display.DisplayManager")) {
           service = ReflectionHelpers.callConstructor(clazz, ClassParameter.from(Context.class, RuntimeEnvironment.application));
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNfcAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNfcAdapterTest.java
@@ -1,0 +1,32 @@
+package org.robolectric.shadows;
+
+import android.app.Activity;
+import android.nfc.NfcAdapter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.TestRunners;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class ShadowNfcAdapterTest {
+
+  @Test
+  public void testNdefPushMessageCallback() {
+    Activity activty = Robolectric.setupActivity(Activity.class);
+
+    NfcAdapter adapter = NfcAdapter.getDefaultAdapter(activty);
+
+    NfcAdapter.CreateNdefMessageCallback callback = mock(NfcAdapter.CreateNdefMessageCallback.class);
+    adapter.setNdefPushMessageCallback(callback, activty);
+
+    ShadowNfcAdapter shadowNfcAdapter = shadowOf(adapter);
+
+    assertThat(shadowNfcAdapter.getNdefPushMessageCallback())
+        .isSameAs(callback);
+  }
+}


### PR DESCRIPTION
...df98189

While it is true that NfcAdapter.getDefaultAdapter() queries the system service, this returns the NfcManager which calls back into NfcAdapter.getNfcAdapter() this makes several binder calls and basically NPEs, so needs shadowing to return a valid instance. Also, NfcManager needs calling with a context as its constructor parameter otherwise it is not initialized correctly.

Lastly, add support for NfcAdapter.setNdefPushMessageCallback() and a non-android accessor so the callback can be executed in tests.