### PR TITLE
add Implementation Of ResolveActivityInfo in ShadowIntent class

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntent.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntent.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcel;
@@ -610,6 +613,25 @@ public class ShadowIntent {
   public ComponentName getComponent() {
     return componentName;
   }
+
+  @Implementation
+  public ActivityInfo resolveActivityInfo(PackageManager pm, int flags) {
+    ActivityInfo ai = null;
+      if (this.componentName != null) {
+         try {
+            ai = pm.getActivityInfo(this.componentName, flags);
+         } catch (PackageManager.NameNotFoundException e) {
+            // ignore
+         }
+      } else {
+         ResolveInfo info = pm.resolveActivity(
+            realIntent, PackageManager.MATCH_DEFAULT_ONLY | flags);
+         if (info != null) {
+            ai = info.activityInfo;
+         }
+      }
+      return ai;
+    }
 
   @Implementation
   public String toURI() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentTest.java
@@ -2,7 +2,10 @@ package org.robolectric.shadows;
 
 import android.app.Activity;
 import android.content.ComponentName;
+import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcel;
@@ -15,6 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
@@ -27,6 +31,20 @@ import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ShadowIntentTest {
+
+    private static final String TEST_ACTIVITY_CLASS_NAME = "org.robolectric.shadows.TestActivity";
+
+    @Test
+    @Config(manifest = "src/test/resources/TestAndroidManifestForActivities.xml")
+    public void test() {
+        Context context = RuntimeEnvironment.application;
+        PackageManager packageManager = context.getPackageManager();
+
+        Intent intent = new Intent();
+        intent.setClassName(context, TEST_ACTIVITY_CLASS_NAME);
+        ActivityInfo activityInfo = intent.resolveActivityInfo(packageManager, PackageManager.GET_ACTIVITIES);
+        assertThat(activityInfo).isNotNull();
+    }
 
   @Test
   public void testGetExtraReturnsNull_whenThereAreNoExtrasAdded() throws Exception {


### PR DESCRIPTION
when we create Intent as new Intent().setComponent() or new Intent().setClassName(), field mComponent == null, because  methods setComponent() & setClassName() are implemented in ShadowIntent class. Because of this, inside method intent.resolveActivityInfo() not called pm.getActivityInfo()