### PR TITLE
FIx NPE in PackageManager.getActivityInfo() that occurs if the activity ...

### DIFF
--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -132,13 +132,21 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
   }
 
   @Override public ActivityInfo getActivityInfo(ComponentName className, int flags) throws NameNotFoundException {
-    String packageName = className.getPackageName();
-    AndroidManifest androidManifest = androidManifests.get(packageName);
-    String activityName = className.getClassName();
-    ActivityData activityData = androidManifest.getActivityData(activityName);
     ActivityInfo activityInfo = new ActivityInfo();
-    activityInfo.packageName = packageName;
+    String packageName = className.getPackageName();
+    String activityName = className.getClassName();
     activityInfo.name = activityName;
+    activityInfo.packageName = packageName;
+
+    AndroidManifest androidManifest = androidManifests.get(packageName);
+
+    // In the cases where there is no manifest entry for the activity, e.g: a test that creates
+    // simply an android.app.Activity just return what we have.
+    if (androidManifest == null) {
+      return activityInfo;
+    }
+
+    ActivityData activityData = androidManifest.getActivityData(activityName);
     if (activityData != null) {
       activityInfo.parentActivityName = activityData.getParentActivityName();
       activityInfo.metaData = metaDataToBundle(activityData.getMetaData().getValueMap());

--- a/robolectric/src/test/java/org/robolectric/util/ActivityControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/ActivityControllerTest.java
@@ -34,6 +34,13 @@ public class ActivityControllerTest {
   }
 
   @Test
+  @Config(manifest = Config.NONE)
+  public void canCreateActivityNotListedInManifest() {
+    ActivityController<Activity> activityController = Robolectric.buildActivity(Activity.class);
+    assertThat(activityController.setup()).isNotNull();
+  }
+
+  @Test
   public void shouldSetIntent() throws Exception {
     MyActivity myActivity = controller.create().get();
     assertThat(myActivity.getIntent()).isNotNull();


### PR DESCRIPTION
...doesn't have a manifest entry. This is more common in tests where often test writers may just use an android.app.Activity for testing.