### PR TITLE
added missing methods to ShadowStatFs implementation for API 18

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowStatFs.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowStatFs.java
@@ -26,7 +26,17 @@ public class ShadowStatFs {
   }
 
   @Implementation
+  public long getBlockSizeLong() {
+    return BLOCK_SIZE;
+  }
+
+  @Implementation
   public int getBlockCount() {
+    return stat.blockCount;
+  }
+
+  @Implementation
+  public long getBlockCountLong() {
     return stat.blockCount;
   }
 
@@ -37,6 +47,11 @@ public class ShadowStatFs {
 
   @Implementation
   public int getAvailableBlocks() {
+    return stat.availableBlocks;
+  }
+
+  @Implementation
+  public long getAvailableBlocksLong() {
     return stat.availableBlocks;
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStatFsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStatFsTest.java
@@ -17,8 +17,11 @@ public class ShadowStatFsTest {
     StatFs statsFs = new StatFs("/tmp");
 
     assertThat(statsFs.getBlockCount()).isEqualTo(100);
+    assertThat(statsFs.getBlockCountLong()).isEqualTo(100);
     assertThat(statsFs.getFreeBlocks()).isEqualTo(20);
     assertThat(statsFs.getAvailableBlocks()).isEqualTo(10);
+    assertThat(statsFs.getAvailableBlocksLong()).isEqualTo(10L);
+    assertThat(statsFs.getBlockSizeLong()).isEqualTo(ShadowStatFs.BLOCK_SIZE);
     assertThat(statsFs.getBlockSize()).isEqualTo(ShadowStatFs.BLOCK_SIZE);
   }
 
@@ -28,8 +31,11 @@ public class ShadowStatFsTest {
     StatFs statsFs = new StatFs(new File("/tmp").getAbsolutePath());
 
     assertThat(statsFs.getBlockCount()).isEqualTo(100);
+    assertThat(statsFs.getBlockCountLong()).isEqualTo(100);
     assertThat(statsFs.getFreeBlocks()).isEqualTo(20);
     assertThat(statsFs.getAvailableBlocks()).isEqualTo(10);
+    assertThat(statsFs.getAvailableBlocksLong()).isEqualTo(10L);
+    assertThat(statsFs.getBlockSizeLong()).isEqualTo(ShadowStatFs.BLOCK_SIZE);
     assertThat(statsFs.getBlockSize()).isEqualTo(ShadowStatFs.BLOCK_SIZE);
   }
 
@@ -37,8 +43,11 @@ public class ShadowStatFsTest {
   public void shouldResetStateBetweenTests() throws Exception {
     StatFs statsFs = new StatFs("/tmp");
     assertThat(statsFs.getBlockCount()).isEqualTo(0);
+    assertThat(statsFs.getBlockCountLong()).isEqualTo(0);
     assertThat(statsFs.getFreeBlocks()).isEqualTo(0);
     assertThat(statsFs.getAvailableBlocks()).isEqualTo(0);
+    assertThat(statsFs.getAvailableBlocksLong()).isEqualTo(0);
+    assertThat(statsFs.getBlockSizeLong()).isEqualTo(ShadowStatFs.BLOCK_SIZE);
     assertThat(statsFs.getBlockSize()).isEqualTo(ShadowStatFs.BLOCK_SIZE);
   }
 


### PR DESCRIPTION
Calling the alternate version of StatFs methods throws a null pointer without missing shadow methods.  Important because the original form of these calls is deprecated in API 18.

Implemented:
getBlockSizeLong()
getAvailableBlocksLong()
getBlockCountLong()
