### PR TITLE
Let ShadowView.setAnimation() accept null

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
@@ -482,6 +482,8 @@ public class ShadowView {
   public void setAnimation(final Animation animation) {
     directly().setAnimation(animation);
 
+    if (animation == null) return;
+
     ShadowChoreographer.getInstance().postCallbackDelayed(Choreographer.CALLBACK_ANIMATION, new Runnable() {
       @Override
       public void run() {
@@ -492,7 +494,6 @@ public class ShadowView {
 
       }
     }, null, animation.getStartTime());
-
   }
 
   @Implementation

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
@@ -469,6 +469,13 @@ public class ShadowViewTest {
   }
 
   @Test
+  public void setNullAnimation() {
+    TestView view = new TestView(buildActivity(Activity.class).create().get());
+    view.setAnimation(null);
+    assertThat(view.getAnimation()).isNull();
+  }
+
+  @Test
   public void test_measuredDimension() {
     // View does not provide its own onMeasure implementation
     TestView view1 = new TestView(buildActivity(Activity.class).create().get());


### PR DESCRIPTION
The implementation of `setAnimation()` done in 7b1c2d95d341eac22e41e318ddce6ff373d9a04a fails to accept null as the Android implementation does: https://github.com/android/platform_frameworks_base/blob/master/core/java/android/view/View.java#L17889