### PR TITLE
ShadowActivity: if dialog is not created, return null

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -480,7 +480,9 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
     if (dialog == null) {
       final ActivityInvoker invoker = new ActivityInvoker();
       dialog = (Dialog) invoker.call("onCreateDialog", Integer.TYPE).with(id);
-
+      if (dialog == null) {
+        return false;
+      }
       if (bundle == null) {
         invoker.call("onPrepareDialog", Integer.TYPE, Dialog.class)
             .with(id, dialog);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
@@ -295,6 +295,18 @@ public class ShadowActivityTest {
   }
 
   @Test
+  public void showDialog_shouldReturnFalseIfDialogDoesNotExist() {
+    final DialogLifeCycleActivity activity = create(DialogLifeCycleActivity.class);
+
+    boolean dialogCreated = activity.showDialog(97, new Bundle());
+
+    assertFalse(dialogCreated);
+    assertTrue(activity.createdDialog);
+    assertFalse(activity.preparedDialogWithBundle);
+  }
+
+
+  @Test
   public void showDialog_shouldReuseDialogs() {
     final DialogCreatingActivity activity = create(DialogCreatingActivity.class);
     activity.showDialog(1);


### PR DESCRIPTION
Otherwise, the code will later fail to a null pointer, and it also didn't
follow Android's API contract for showDialog().

Change-Id: I7a738c4a5ad8c59f689850fbf3512dc339fc7822