### PR TITLE
Create AccessibilityManager using AccessibilityManager.getInstance() rat...

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
@@ -8,9 +8,11 @@ import android.content.Context;
 import android.os.Build;
 import android.os.Handler;
 import android.view.Display;
+import android.view.accessibility.AccessibilityManager;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
@@ -23,6 +25,9 @@ import static org.robolectric.internal.Shadow.newInstanceOf;
 public class ShadowContextImpl extends ShadowContext {
   public static final String CLASS_NAME = "android.app.ContextImpl";
   private static final Map<String, String> SYSTEM_SERVICE_MAP = new HashMap<String, String>();
+
+  @RealObject
+  private Context realObject;
 
   static {
     // note that these are different!
@@ -106,7 +111,8 @@ public class ShadowContextImpl extends ShadowContext {
 
         } else if (serviceClassName.equals("android.hardware.display.DisplayManager")) {
           service = ReflectionHelpers.callConstructor(clazz, ClassParameter.from(Context.class, RuntimeEnvironment.application));
-
+        } else if (serviceClassName.equals("android.view.accessibility.AccessibilityManager")) {
+          service = AccessibilityManager.getInstance(realObject);
 #if ($apiLevel >= 17)
         } else if (serviceClassName.equals("android.view.WindowManagerImpl")) {
           Display display = newInstanceOf(Display.class);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
@@ -16,6 +16,8 @@ import android.os.IBinder;
 import android.os.IInterface;
 import android.os.Parcel;
 import android.os.RemoteException;
+import android.view.accessibility.AccessibilityManager;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,6 +49,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.WithDefaults.class)
@@ -118,6 +121,14 @@ public class ShadowApplicationTest {
   @Test public void shouldProvideLayoutInflater() throws Exception {
     Object systemService = RuntimeEnvironment.application.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
     assertThat(systemService).isInstanceOf(RoboLayoutInflater.class);
+  }
+
+  @Test public void shouldCorrectlyInstantiatedAccessibilityService() throws Exception {
+    AccessibilityManager accessibilityManager = (AccessibilityManager) RuntimeEnvironment.application.getSystemService(Context.ACCESSIBILITY_SERVICE);
+
+    AccessibilityManager.TouchExplorationStateChangeListener mockListener = mock(AccessibilityManager.TouchExplorationStateChangeListener.class);
+    assertThat(accessibilityManager.addTouchExplorationStateChangeListener(mockListener)).isTrue();
+    assertThat(accessibilityManager.removeTouchExplorationStateChangeListener(mockListener)).isTrue();
   }
 
   private void checkSystemService(String name, Class expectedClass) {


### PR DESCRIPTION
...her than just calling

the default constructor which does not correctly instantiate the object. Infact, it doesn't
call the field level initializers so addTouchExplorationStateChangeListener() actually NPEs.

Ideally we should look at removing this error prone shadow code to instantiate system services
and leave it up to real android to do it see:-

https://github.com/android/platform_frameworks_base/blob/master/core/java/android/app/ContextImpl.java#L337