### PR TITLE
Remove unnecessary interface

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/ClassInfo.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/ClassInfo.java
@@ -1,13 +1,38 @@
 package org.robolectric.internal.bytecode;
 
 import java.lang.annotation.Annotation;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.ClassNode;
 
-public interface ClassInfo {
-  String getName();
+public class ClassInfo {
+  private final String className;
+  private final ClassNode classNode;
 
-  boolean isInterface();
+  public ClassInfo(String className, ClassNode classNode) {
+    this.className = className;
+    this.classNode = classNode;
+  }
 
-  boolean isAnnotation();
+  public boolean isInterface() {
+    return (classNode.access & Opcodes.ACC_INTERFACE) != 0;
+  }
 
-  boolean hasAnnotation(Class<? extends Annotation> annotationClass);
+  public boolean isAnnotation() {
+    return (classNode.access & Opcodes.ACC_ANNOTATION) != 0;
+  }
+
+  public boolean hasAnnotation(Class<? extends Annotation> annotationClass) {
+    String internalName = "L" + annotationClass.getName().replace('.', '/') + ";";
+    if (classNode.visibleAnnotations == null) return false;
+    for (Object visibleAnnotation : classNode.visibleAnnotations) {
+      AnnotationNode annotationNode = (AnnotationNode) visibleAnnotation;
+      if (annotationNode.desc.equals(internalName)) return true;
+    }
+    return false;
+  }
+
+  public String getName() {
+    return className;
+  }
 }

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/InstrumentingClassLoaderConfigTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/InstrumentingClassLoaderConfigTest.java
@@ -1,8 +1,10 @@
 package org.robolectric.internal.bytecode;
 
 import org.junit.Test;
-import java.lang.annotation.Annotation;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class InstrumentingClassLoaderConfigTest {
   private final InstrumentingClassLoaderConfig config = new InstrumentingClassLoaderConfig();
@@ -39,22 +41,8 @@ public class InstrumentingClassLoaderConfigTest {
   }
 
   private ClassInfo wrap(final String className) {
-    return new ClassInfo() {
-      @Override public String getName() {
-        return className;
-      }
-
-      @Override public boolean isInterface() {
-        return false;
-      }
-
-      @Override public boolean isAnnotation() {
-        return false;
-      }
-
-      @Override public boolean hasAnnotation(Class<? extends Annotation> annotationClass) {
-        return false;
-      }
-    };
+    ClassInfo info = mock(ClassInfo.class);
+    when(info.getName()).thenReturn(className);
+    return info;
   }
 }


### PR DESCRIPTION
The ClassInfo interface is only used for testing so it can be replaced with the use of Mockito. This leads to a easier navigation of the code as you don't have to pass through the interface.

There are multiple places where interfaces are used to increase testability (which could be replaced with Mockito) but this is the simplest case.