### PR TITLE
ShadowNumberPicker should not check for array lengths.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNumberPicker.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNumberPicker.java
@@ -30,9 +30,6 @@ public class ShadowNumberPicker extends ShadowLinearLayout {
 
   @Implementation
   public void setDisplayedValues(String[] displayedValues) {
-    if (displayedValues != null && displayedValues.length != (maxValue - minValue) + 1) {
-      throw new RuntimeException("Displayed values should fit into range min and max values");
-    }
     this.displayedValues = displayedValues;
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNumberPickerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNumberPickerTest.java
@@ -8,35 +8,14 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
 
+import java.text.DateFormatSymbols;
+
 import static junit.framework.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ShadowNumberPickerTest {
-
-  @Test
-  public void setDisplayedValues_shouldCheckArraySize() throws Exception {
-    NumberPicker picker = new NumberPicker(RuntimeEnvironment.application);
-    picker.setMaxValue(2);
-    picker.setDisplayedValues(null);
-
-    try {
-      picker.setDisplayedValues(new String[] {"0", "1"});
-      fail("should have complained about being too small");
-    } catch (Exception e) {
-      // pass
-    }
-
-    picker.setDisplayedValues(new String[] {"0", "1", "2"});
-
-    try {
-      picker.setDisplayedValues(new String[] {"0", "1", "2", "3"});
-      fail("should have complained about being too big");
-    } catch (Exception e) {
-      // pass
-    }
-  }
 
   @Test
   public void shouldFireListeners() {


### PR DESCRIPTION
On KitKat, in DatePicker:-

https://github.com/android/platform_frameworks_base/blob/kitkat-mr2-release/core/java/android/widget/DatePicker.java#L484

sets the number picker values for the month to the result of new DateFormatSymbols().getShortMonths() which includes an extra
value for "" causing the shadow to blow up with the size check.

The real implementation does not have a size check so neither should the shadow.