### PR TITLE
Only create BouncyCastleProvider the first time

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -73,7 +73,9 @@ public class ParallelUniverse implements ParallelUniverseInterface {
       resourceLoader = systemResourceLoader;
     }
 
-    Security.insertProviderAt(new BouncyCastleProvider(), 1);
+    if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+      Security.insertProviderAt(new BouncyCastleProvider(), 1);
+    }
 
     shadowsAdapter.setSystemResources(systemResourceLoader);
     String qualifiers = addVersionQualifierToQualifiers(config.qualifiers());


### PR DESCRIPTION
Constructing BouncyCastleProvider is fairly expensive.

This could probably be done in a static initializer but delaying it seems nicer.