### PR TITLE
Initial version of a test runner that will run Robolectric tests on multiple API versions.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/ExperimentalRobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/ExperimentalRobolectricTestRunner.java
@@ -1,0 +1,134 @@
+package org.robolectric;
+
+import org.junit.Assert;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.Suite;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+import org.robolectric.annotation.Config;
+import org.robolectric.internal.SdkConfig;
+import org.robolectric.manifest.AndroidManifest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Constructor;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A Parameterized test runner for Robolectric. Copied from the {@link org.junit.runners.Parameterized} class, then modified the custom
+ * test runner to extend the {@link org.robolectric.RobolectricTestRunner}. The {@link org.robolectric.RobolectricTestRunner#getHelperTestRunner(Class)}
+ * is overridden in order to create instances of the test class with the appropriate apiVersion. Merged in the ability
+ * to name your tests through the {@link Parameters#name()} property.
+ */
+public final class ExperimentalRobolectricTestRunner extends Suite {
+
+  private static class TestClassRunnerForParameters extends RobolectricTestRunner {
+
+    private final String name;
+    private final Integer apiVersion;
+
+    TestClassRunnerForParameters(Class<?> type, Integer apiVersion) throws InitializationError {
+      super(type);
+      this.apiVersion = apiVersion;
+      this.name = apiVersion.toString();
+    }
+
+    @Override
+    protected String getName() {
+      return "[" + apiVersion + "]";
+    }
+
+    @Override
+    protected String testName(final FrameworkMethod method) {
+      return method.getName() + getName();
+    }
+
+    @Override
+    protected void validateConstructor(List<Throwable> errors) {
+      validateOnlyOneConstructor(errors);
+    }
+
+    @Override
+    protected Statement classBlock(RunNotifier notifier) {
+      return childrenInvoker(notifier);
+    }
+
+    @Override
+    public String toString() {
+      return "TestClassRunnerForParameters " + name;
+    }
+
+    @Override
+    protected SdkConfig pickSdkVersion(AndroidManifest appManifest, Config config) {
+      return new SdkConfig(apiVersion);
+//      if (config != null && config.emulateSdk() > 0) {
+//        return new SdkConfig(config.emulateSdk());
+//      } else {
+//        if (appManifest != null) {
+//          return new SdkConfig(appManifest.getTargetSdkVersion());
+//        } else {
+//          return new SdkConfig(SdkConfig.FALLBACK_SDK_VERSION);
+//        }
+//      }
+    }
+
+    protected int pickReportedSdkVersion(Config config, AndroidManifest appManifest) {
+      return apiVersion;
+      // Check if the user has explicitly overridden the reported version
+//      if (config != null && config.reportSdk() > 0) {
+//        return config.reportSdk();
+//      }
+//      if (config != null && config.emulateSdk() > 0) {
+//        return config.emulateSdk();
+//      } else {
+//        return appManifest != null ? appManifest.getTargetSdkVersion() : SdkConfig.FALLBACK_SDK_VERSION;
+//      }
+    }
+
+    @Override
+    protected HelperTestRunner getHelperTestRunner(Class bootstrappedTestClass) {
+      try {
+        return new HelperTestRunner(bootstrappedTestClass) {
+          @Override
+          protected void validateConstructor(List<Throwable> errors) {
+            TestClassRunnerForParameters.this.validateOnlyOneConstructor(errors);
+          }
+
+          @Override
+          public String toString() {
+            return "HelperTestRunner for " + TestClassRunnerForParameters.this.toString();
+          }
+        };
+      } catch (InitializationError initializationError) {
+        throw new RuntimeException(initializationError);
+      }
+    }
+  }
+
+  private final ArrayList<Runner> runners = new ArrayList<Runner>();
+
+  /*
+   * Only called reflectively. Do not use programmatically.
+   */
+  public ExperimentalRobolectricTestRunner(Class<?> klass) throws Throwable {
+    super(klass, Collections.<Runner>emptyList());
+
+    for (Integer integer : SdkConfig.getSupportedApis()) {
+      runners.add(new TestClassRunnerForParameters(getTestClass().getJavaClass(), integer));
+
+    }
+   }
+
+  @Override
+  protected List<Runner> getChildren() {
+    return runners;
+  }
+
+}

--- a/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
@@ -5,6 +5,7 @@ import org.robolectric.internal.dependency.DependencyJar;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class SdkConfig {
   private final int apiLevel;
@@ -13,12 +14,16 @@ public class SdkConfig {
   public static final int FALLBACK_SDK_VERSION = Build.VERSION_CODES.JELLY_BEAN;
 
   static {
-    SUPPORTED_APIS = new HashMap<Integer, SdkVersion>();
+    SUPPORTED_APIS = new HashMap<>();
     SUPPORTED_APIS.put(Build.VERSION_CODES.JELLY_BEAN, new SdkVersion("4.1.2_r1", "0"));
     SUPPORTED_APIS.put(Build.VERSION_CODES.JELLY_BEAN_MR1, new SdkVersion("4.2.2_r1.2", "0"));
     SUPPORTED_APIS.put(Build.VERSION_CODES.JELLY_BEAN_MR2, new SdkVersion("4.3_r2", "0"));
     SUPPORTED_APIS.put(Build.VERSION_CODES.KITKAT, new SdkVersion("4.4_r1", "1"));
     SUPPORTED_APIS.put(Build.VERSION_CODES.LOLLIPOP, new SdkVersion("5.0.0_r2", "1"));
+  }
+
+  public static Set<Integer> getSupportedApis() {
+    return SUPPORTED_APIS.keySet();
   }
 
   public SdkConfig(int apiLevel) {

--- a/robolectric/src/test/java/org/robolectric/ExperimentalRobolectricTestRunnerUriTest.java
+++ b/robolectric/src/test/java/org/robolectric/ExperimentalRobolectricTestRunnerUriTest.java
@@ -1,0 +1,34 @@
+package org.robolectric;
+
+import android.net.Uri;
+import android.os.Build;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Parameterized tests using an Android class.
+ *
+ * @author John Ferlisi
+ */
+@RunWith(ExperimentalRobolectricTestRunner.class)
+public final class ExperimentalRobolectricTestRunnerUriTest {
+
+  @Test
+  @Config(manifest = Config.NONE)
+  public void startsWith() {
+    assertThat("test_value").startsWith("test");
+  }
+
+  @Test
+  @Config(manifest = Config.NONE)
+  public void endsWith() {
+    assertThat("test_value").endsWith("value");
+  }
+}


### PR DESCRIPTION
Note: Not ready for submission, early feedback requested.

Based on a ParameterizedTestRunner, these test runners shard at the test runner level, so
one TestRunner is created for each API level. We will be able to apply class level @Config
emulateSdk filtering here, but not method level, e.g: if a method has emulateSdk on it then
it will still exist for each TestRunner, but maybe it can be considered ignored?

The alternative it to do it at the method level and override runChild() and for each API
version then call RobolectricTestRunner.methodBlock() I have a rough implementation that way I can also share.

How do you see the reportSdk / emulateSdk / inference of sdk version from manifest working on a test runner such as this?

Comments / Thoughts appreciated.