### PR TITLE
added resources and asset fix for libraries

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
@@ -34,15 +34,19 @@ public class RobolectricGradleTestRunner extends RobolectricTestRunner {
     final String flavor = getFlavor(config);
     final String applicationId = getApplicationId(config);
 
-    final FileFsFile res = FileFsFile.from(BUILD_OUTPUT, "res", flavor, type);
-    final FileFsFile assets = FileFsFile.from(BUILD_OUTPUT, "assets", flavor, type);
-
+    final FileFsFile res;
+    final FileFsFile assets;
     final FileFsFile manifest;
+    
     if (FileFsFile.from(BUILD_OUTPUT, "manifests").exists()) {
       manifest = FileFsFile.from(BUILD_OUTPUT, "manifests", "full", flavor, type, "AndroidManifest.xml");
+      res = FileFsFile.from(BUILD_OUTPUT, "res", flavor, type);
+      assets = FileFsFile.from(BUILD_OUTPUT, "assets", flavor, type);
     } else {
       // Fallback to the location for library manifests
       manifest = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "AndroidManifest.xml");
+      res = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "res");
+      assets = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "assets");
     }
 
     Logger.debug("Robolectric assets directory: " + assets.getPath());

--- a/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
@@ -37,15 +37,25 @@ public class RobolectricGradleTestRunner extends RobolectricTestRunner {
     final FileFsFile res;
     final FileFsFile assets;
     final FileFsFile manifest;
-    
+
     if (FileFsFile.from(BUILD_OUTPUT, "manifests").exists()) {
       manifest = FileFsFile.from(BUILD_OUTPUT, "manifests", "full", flavor, type, "AndroidManifest.xml");
-      res = FileFsFile.from(BUILD_OUTPUT, "res", flavor, type);
-      assets = FileFsFile.from(BUILD_OUTPUT, "assets", flavor, type);
     } else {
       // Fallback to the location for library manifests
       manifest = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "AndroidManifest.xml");
+    }
+
+    if (FileFsFile.from(BUILD_OUTPUT, "res").exists()) {
+      res = FileFsFile.from(BUILD_OUTPUT, "res", flavor, type);
+    } else {
+      // Fallback to the location for library manifests
       res = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "res");
+    }
+
+    if (FileFsFile.from(BUILD_OUTPUT, "assets").exists()) {
+      assets = FileFsFile.from(BUILD_OUTPUT, "assets", flavor, type);
+    } else {
+      // Fallback to the location for library manifests
       assets = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "assets");
     }
 


### PR DESCRIPTION
For some reason it seems that res and asset folders don't follow the same library fallback strategy that the manifest does. This fixes that.