### PR TITLE
Remove unneeded reflection

### DIFF
--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/Config.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/Config.java
@@ -178,6 +178,19 @@ public @interface Config {
       this.constants = constants;
     }
 
+    public Implementation(Config other) {
+      this.reportSdk = other.reportSdk();
+      this.emulateSdk = other.emulateSdk();
+      this.manifest = other.manifest();
+      this.qualifiers = other.qualifiers();
+      this.resourceDir = other.resourceDir();
+      this.assetDir = other.assetDir();
+      this.constants = other.constants();
+      this.shadows = other.shadows();
+      this.application = other.application();
+      this.libraries = other.libraries();
+    }
+
     public Implementation(Config baseConfig, Config overlayConfig) {
       this.emulateSdk = pick(baseConfig.emulateSdk(), overlayConfig.emulateSdk(), -1);
       this.manifest = pick(baseConfig.manifest(), overlayConfig.manifest(), DEFAULT);

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -75,7 +75,7 @@ public class ShadowResources {
   }
 
   public static void setSystemResources(ResourceLoader systemResourceLoader) {
-    AssetManager assetManager = ReflectionHelpers.callConstructor(AssetManager.class);
+    AssetManager assetManager = new AssetManager();
     ShadowAssetManager.bind(assetManager, null, systemResourceLoader);
     DisplayMetrics metrics = new DisplayMetrics();
     Configuration config = new Configuration();

--- a/robolectric-utils/src/main/java/org/robolectric/util/ReflectionHelpers.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/ReflectionHelpers.java
@@ -204,6 +204,17 @@ public class ReflectionHelpers {
   }
 
   /**
+   * Create a new instance of a class
+   */
+  public static <T> T newInstance(Class<T> cl) {
+    try {
+      return cl.newInstance();
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
    * Reflectively call the constructor of an object.
    *
    * @param clazz Target class.

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -49,6 +49,7 @@ import java.util.*;
  */
 public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
   private static final String CONFIG_PROPERTIES = "robolectric.properties";
+  private static final Config DEFAULT_CONFIG = new Config.Implementation(defaultsFor(Config.class));
   private static final Map<Class<? extends RobolectricTestRunner>, EnvHolder> envHoldersByTestRunner = new HashMap<>();
   private static Map<Pair<AndroidManifest, SdkConfig>, ResourceLoader> resourceLoadersByManifestAndConfig = new HashMap<>();
   private static ShadowMap mainShadowMap;
@@ -354,7 +355,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
   }
 
   public Config getConfig(Method method) {
-    Config config = defaultsFor(Config.class);
+    Config config = DEFAULT_CONFIG;
 
     Config globalConfig = Config.Implementation.fromProperties(getConfigProperties());
     if (globalConfig != null) {
@@ -541,13 +542,13 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
   }
 
   private static <A extends Annotation> A defaultsFor(Class<A> annotation) {
-    //noinspection unchecked
-    return (A) Proxy.newProxyInstance(annotation.getClassLoader(),
-        new Class[]{annotation}, new InvocationHandler() {
-          public Object invoke(Object proxy, @NotNull Method method, Object[] args)
-              throws Throwable {
-            return method.getDefaultValue();
-          }
-        });
+    return annotation.cast(
+        Proxy.newProxyInstance(annotation.getClassLoader(), new Class[] { annotation },
+            new InvocationHandler() {
+              public Object invoke(Object proxy, @NotNull Method method, Object[] args)
+                  throws Throwable {
+                return method.getDefaultValue();
+              }
+            }));
   }
 }


### PR DESCRIPTION
These make up around 15% of the runtime when profiling an empty test.