### PR TITLE
Removed equals for ShadowBitmap and ShadowBitmapDrawable.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmap.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmap.java
@@ -409,37 +409,8 @@ public class ShadowBitmap {
   }
 
   @Override
-  @Implementation
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof Bitmap)) return false;
-
-    ShadowBitmap that = shadowOf((Bitmap) o);
-
-    if (height != that.height) return false;
-    if (width != that.width) return false;
-    if (description != null ? !description.equals(that.description) : that.description != null) return false;
-
-    return true;
-  }
-
-  @Override
-  @Implementation
-  public int hashCode() {
-    int result = width;
-    result = 31 * result + height;
-    result = 31 * result + (description != null ? description.hashCode() : 0);
-    return result;
-  }
-
-  @Override
-  @Implementation
   public String toString() {
-    return "Bitmap{" +
-        "description='" + description + '\'' +
-        ", width=" + width +
-        ", height=" + height +
-        '}';
+    return "Bitmap{description='" + description + '\'' + ", width=" + width + ", height=" + height + '}';
   }
 
   public Bitmap getRealBitmap() {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapDrawable.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapDrawable.java
@@ -71,33 +71,4 @@ public class ShadowBitmapDrawable extends ShadowDrawable {
   public String getPath() {
     return drawableCreateFromPath;
   }
-
-  @Override
-  @Implementation
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != ShadowBitmapDrawable.class) return false;
-
-    ShadowBitmapDrawable that = shadowOf((BitmapDrawable) o);
-
-    Bitmap bitmap = realBitmapDrawable.getBitmap();
-    Bitmap thatBitmap = that.realBitmapDrawable.getBitmap();
-    if (bitmap != null ? !bitmap.equals(thatBitmap) : thatBitmap != null) return false;
-
-    return super.equals(o);
-  }
-
-  @Override
-  @Implementation
-  public int hashCode() {
-    Bitmap bitmap = realBitmapDrawable.getBitmap();
-    return bitmap != null ? bitmap.hashCode() : 0;
-  }
-
-  @Override
-  @Implementation
-  public String toString() {
-    Bitmap bitmap = realBitmapDrawable.getBitmap();
-    return "BitmapDrawable{bitmap=" + bitmap + '}';
-  }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapDrawableTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapDrawableTest.java
@@ -8,7 +8,6 @@ import android.graphics.ColorMatrixColorFilter;
 import android.graphics.Shader;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
@@ -20,41 +19,36 @@ import org.robolectric.internal.Shadow;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ShadowBitmapDrawableTest {
-  private Resources resources;
-
-  @Before
-  public void setUp() throws Exception {
-    resources = RuntimeEnvironment.application.getResources();
-  }
+  private final Resources resources = RuntimeEnvironment.application.getResources();
 
   @Test
   public void constructors_shouldSetBitmap() throws Exception {
     Bitmap bitmap = Shadow.newInstanceOf(Bitmap.class);
     BitmapDrawable drawable = new BitmapDrawable(bitmap);
-    assertEquals(bitmap, drawable.getBitmap());
+    assertThat(drawable.getBitmap()).isEqualTo(bitmap);
 
     drawable = new BitmapDrawable(resources, bitmap);
-    assertEquals(bitmap, drawable.getBitmap());
+    assertThat(drawable.getBitmap()).isEqualTo(bitmap);
   }
 
   @Test
   public void getBitmap_shouldReturnBitmapUsedToDraw() throws Exception {
     BitmapDrawable drawable = (BitmapDrawable) resources.getDrawable(R.drawable.an_image);
-    assertEquals("Bitmap for resource:org.robolectric:drawable/an_image", shadowOf(drawable.getBitmap()).getDescription());
+    assertThat(shadowOf(drawable.getBitmap()).getDescription()).isEqualTo("Bitmap for resource:org.robolectric:drawable/an_image");
   }
 
   @Test
   public void mutate_createsDeepCopy() throws Exception {
     BitmapDrawable original = (BitmapDrawable) resources.getDrawable(R.drawable.an_image);
     Drawable mutated = original.mutate();
-    assertNotSame(original, mutated);
-    assertTrue(mutated instanceof BitmapDrawable);
-    assertEquals(original, mutated);
+    assertThat(original).isNotSameAs(mutated);
+    assertThat(mutated instanceof BitmapDrawable).isTrue();
+    assertThat(original).isEqualTo(mutated);
   }
 
   @Test
@@ -63,14 +57,14 @@ public class ShadowBitmapDrawableTest {
     Canvas canvas = new Canvas();
     drawable.draw(canvas);
 
-    assertEquals("Bitmap for resource:org.robolectric:drawable/an_image", shadowOf(canvas).getDescription());
+    assertThat(shadowOf(canvas).getDescription()).isEqualTo("Bitmap for resource:org.robolectric:drawable/an_image");
   }
 
   @Test
   public void shouldInheritSourceStringFromDrawableDotCreateFromStream() throws Exception {
     InputStream emptyInputStream = new ByteArrayInputStream("".getBytes());
     BitmapDrawable drawable = (BitmapDrawable) Drawable.createFromStream(emptyInputStream, "source string value");
-    assertEquals("source string value", shadowOf(drawable).getSource());
+    assertThat(shadowOf(drawable).getSource()).isEqualTo("source string value");
   }
 
   @Test
@@ -80,59 +74,33 @@ public class ShadowBitmapDrawableTest {
     Canvas canvas = new Canvas();
     drawable.draw(canvas);
 
-    assertEquals("Bitmap for resource:org.robolectric:drawable/an_image with ColorMatrixColorFilter<1,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,1,0>",
-        shadowOf(canvas).getDescription());
-  }
-
-  @Test
-  public void equals_shouldTestResourceId() throws Exception {
-    Drawable drawable1a = resources.getDrawable(R.drawable.an_image);
-    Drawable drawable1b = resources.getDrawable(R.drawable.an_image);
-    Drawable drawable2 = resources.getDrawable(R.drawable.an_other_image);
-
-    assertEquals(drawable1a, drawable1b);
-    assertFalse(drawable1a.equals(drawable2));
-  }
-
-  @Test
-  public void equals_shouldTestBounds() throws Exception {
-    Drawable drawable1a = resources.getDrawable(R.drawable.an_image);
-    Drawable drawable1b = resources.getDrawable(R.drawable.an_image);
-
-    drawable1a.setBounds(1, 2, 3, 4);
-    drawable1b.setBounds(1, 2, 3, 4);
-
-    assertEquals(drawable1a, drawable1b);
-
-    drawable1b.setBounds(1, 2, 3, 5);
-    assertFalse(drawable1a.equals(drawable1b));
+    assertThat(shadowOf(canvas).getDescription()).isEqualTo("Bitmap for resource:org.robolectric:drawable/an_image with ColorMatrixColorFilter<1,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,1,0>");
   }
 
   @Test
   public void shouldStillHaveShadow() throws Exception {
     Drawable drawable = resources.getDrawable(R.drawable.an_image);
-    assertEquals(R.drawable.an_image, Shadows.shadowOf(drawable).getCreatedFromResId());
+    assertThat(Shadows.shadowOf(drawable).getCreatedFromResId()).isEqualTo(R.drawable.an_image);
   }
 
   @Test
   public void shouldSetTileModeXY() throws Exception {
     BitmapDrawable drawable = (BitmapDrawable) resources.getDrawable(R.drawable.an_image);
     drawable.setTileModeXY(Shader.TileMode.REPEAT, Shader.TileMode.MIRROR);
-    assertEquals(Shader.TileMode.REPEAT, drawable.getTileModeX());
-    assertEquals(Shader.TileMode.MIRROR, drawable.getTileModeY());
+    assertThat(drawable.getTileModeX()).isEqualTo(Shader.TileMode.REPEAT);
+    assertThat(drawable.getTileModeY()).isEqualTo(Shader.TileMode.MIRROR);
   }
 
   @Test
   public void constructor_shouldSetTheIntrinsicWidthAndHeightToTheWidthAndHeightOfTheBitmap() throws Exception {
     Bitmap bitmap = Bitmap.createBitmap(5, 10, Bitmap.Config.ARGB_8888);
     BitmapDrawable drawable = new BitmapDrawable(RuntimeEnvironment.application.getResources(), bitmap);
-    assertEquals(5, drawable.getIntrinsicWidth());
-    assertEquals(10, drawable.getIntrinsicHeight());
+    assertThat(drawable.getIntrinsicWidth()).isEqualTo(5);
+    assertThat(drawable.getIntrinsicHeight()).isEqualTo(10);
   }
 
   @Test
   public void constructor_shouldAcceptNullBitmap() throws Exception {
-    BitmapDrawable drawable = new BitmapDrawable(RuntimeEnvironment.application.getResources(), (Bitmap) null);
-    assertNotNull(drawable);
+    assertThat(new BitmapDrawable(RuntimeEnvironment.application.getResources(), (Bitmap) null)).isNotNull();
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
@@ -14,10 +14,6 @@ import org.robolectric.TestRunners;
 import org.robolectric.internal.Shadow;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.WithDefaults.class)
@@ -26,15 +22,15 @@ public class ShadowBitmapTest {
   public void shouldCreateScaledBitmap() throws Exception {
     Bitmap originalBitmap = create("Original bitmap");
     Bitmap scaledBitmap = Bitmap.createScaledBitmap(originalBitmap, 100, 200, false);
-    assertEquals("Original bitmap scaled to 100 x 200", shadowOf(scaledBitmap).getDescription());
-    assertEquals(100, scaledBitmap.getWidth());
-    assertEquals(200, scaledBitmap.getHeight());
+    assertThat(shadowOf(scaledBitmap).getDescription()).isEqualTo("Original bitmap scaled to 100 x 200");
+    assertThat(scaledBitmap.getWidth()).isEqualTo(100);
+    assertThat(scaledBitmap.getHeight()).isEqualTo(200);
   }
 
   @Test
   public void shouldCreateActiveBitmap() throws Exception {
     Bitmap bitmap = Bitmap.createBitmap(100, 200, Config.ARGB_8888);
-    assertFalse(bitmap.isRecycled());
+    assertThat(bitmap.isRecycled()).isFalse();
     assertThat(bitmap.getPixel(0, 0)).isZero();
     assertThat(bitmap.getWidth()).isEqualTo(100);
     assertThat(bitmap.getHeight()).isEqualTo(200);
@@ -63,39 +59,20 @@ public class ShadowBitmapTest {
   public void shouldCreateBitmapFromAnotherBitmap() {
     Bitmap originalBitmap = create("Original bitmap");
     Bitmap newBitmap = Bitmap.createBitmap(originalBitmap);
-    assertEquals("Original bitmap created from Bitmap object", shadowOf(newBitmap).getDescription());
+    assertThat(shadowOf(newBitmap).getDescription()).isEqualTo("Original bitmap created from Bitmap object");
   }
 
   @Test
   public void shouldCreateMutableBitmap() throws Exception {
     Bitmap mutableBitmap = Bitmap.createBitmap(100, 200, Config.ARGB_8888);
-    assertTrue(mutableBitmap.isMutable());
+    assertThat(mutableBitmap.isMutable()).isTrue();
   }
 
   @Test
   public void shouldRecycleBitmap() throws Exception {
     Bitmap bitmap = Bitmap.createBitmap(100, 200, Config.ARGB_8888);
     bitmap.recycle();
-    assertTrue(bitmap.isRecycled());
-  }
-
-  @Test
-  public void equals_shouldCompareDescriptions() throws Exception {
-    assertFalse(create("bitmap A").equals(create("bitmap B")));
-    assertTrue(create("bitmap A").equals(create("bitmap A")));
-  }
-
-  @Test
-  public void equals_shouldCompareWidthAndHeight() throws Exception {
-    Bitmap bitmapA1 = create("bitmap A");
-    shadowOf(bitmapA1).setWidth(100);
-    shadowOf(bitmapA1).setHeight(100);
-
-    Bitmap bitmapA2 = create("bitmap A");
-    shadowOf(bitmapA2).setWidth(101);
-    shadowOf(bitmapA2).setHeight(101);
-
-    assertFalse(bitmapA1.equals(bitmapA2));
+    assertThat(bitmap.isRecycled()).isTrue();
   }
 
   @Test
@@ -106,7 +83,7 @@ public class ShadowBitmapTest {
     Canvas canvas = new Canvas(bitmap1);
     canvas.drawBitmap(bitmap2, 0, 0, null);
 
-    assertEquals("Bitmap One\nBitmap Two", shadowOf(bitmap1).getDescription());
+    assertThat(shadowOf(bitmap1).getDescription()).isEqualTo("Bitmap One\nBitmap Two");
   }
 
   @Test
@@ -117,7 +94,7 @@ public class ShadowBitmapTest {
     Canvas canvas = new Canvas(bitmap1);
     canvas.drawBitmap(bitmap2, new Matrix(), null);
 
-    assertEquals("Bitmap One\nBitmap Two transformed by matrix", shadowOf(bitmap1).getDescription());
+    assertThat(shadowOf(bitmap1).getDescription()).isEqualTo("Bitmap One\nBitmap Two transformed by matrix");
   }
 
   @Test
@@ -130,24 +107,24 @@ public class ShadowBitmapTest {
     paint.setColorFilter(new ColorMatrixColorFilter(new ColorMatrix()));
     canvas.drawBitmap(bitmap2, new Matrix(), paint);
 
-    assertEquals("Bitmap One\nBitmap Two with ColorMatrixColorFilter<1,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,1,0> transformed by matrix", shadowOf(bitmap1).getDescription());
+    assertThat(shadowOf(bitmap1).getDescription()).isEqualTo("Bitmap One\nBitmap Two with ColorMatrixColorFilter<1,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,1,0> transformed by matrix");
   }
 
   @Test
   public void visualize_shouldReturnDescription() throws Exception {
     Bitmap bitmap = create("Bitmap One");
-    assertEquals("Bitmap One", ShadowBitmap.visualize(bitmap));
+    assertThat(ShadowBitmap.visualize(bitmap)).isEqualTo("Bitmap One");
   }
 
   @Test
   public void shouldCopyBitmap() {
     Bitmap bitmap = Shadow.newInstanceOf(Bitmap.class);
     Bitmap bitmapCopy = bitmap.copy(Config.ARGB_8888, true);
-    assertEquals(shadowOf(bitmapCopy).getConfig(), Config.ARGB_8888);
-    assertTrue(shadowOf(bitmapCopy).isMutable());
+    assertThat(shadowOf(bitmapCopy).getConfig()).isEqualTo(Config.ARGB_8888);
+    assertThat(shadowOf(bitmapCopy).isMutable()).isTrue();
   }
 
-  @Test
+  @Test(expected = NullPointerException.class)
   public void rowBytesIsAccurate() {
     Bitmap b1 = Bitmap.createBitmap(10, 10, Config.ARGB_8888);
     assertThat(b1.getRowBytes()).isEqualTo(40);
@@ -155,15 +132,11 @@ public class ShadowBitmapTest {
     assertThat(b2.getRowBytes()).isEqualTo(20);
 
     // Null config is not allowed.
-    try {
-      Bitmap b3 = Bitmap.createBitmap(10, 10, null);
-      b3.getRowBytes();
-      fail();
-    } catch (NullPointerException expected) {
-    }
+    Bitmap b3 = Bitmap.createBitmap(10, 10, null);
+    b3.getRowBytes();
   }
 
-  @Test
+  @Test(expected = NullPointerException.class)
   public void byteCountIsAccurate() {
     Bitmap b1 = Bitmap.createBitmap(10, 10, Config.ARGB_8888);
     assertThat(b1.getByteCount()).isEqualTo(400);
@@ -171,12 +144,8 @@ public class ShadowBitmapTest {
     assertThat(b2.getByteCount()).isEqualTo(200);
 
     // Null config is not allowed.
-    try {
-      Bitmap b3 = Bitmap.createBitmap(10, 10, null);
-      b3.getByteCount();
-      fail();
-    } catch (NullPointerException expected) {
-    }
+    Bitmap b3 = Bitmap.createBitmap(10, 10, null);
+    b3.getByteCount();
   }
 
   @Test


### PR DESCRIPTION
Converted the tests to use assertj matchers.

Closes #1684.