### PR TITLE
Guard against null tag and message being passed to Log class

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLog.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLog.java
@@ -98,7 +98,9 @@ public class ShadowLog {
   @Implementation
   public static int println(int priority, String tag, String msg) {
     addLog(priority, tag, msg, null);
-    return extraLogLength + tag.length() + msg.length();
+    int tagLength = tag == null ? 0 : tag.length();
+    int msgLength = msg == null ? 0 : msg.length();
+    return extraLogLength + tagLength + msgLength;
   }
 
   /**

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
@@ -128,6 +128,27 @@ public class ShadowLogTest {
   }
 
   @Test
+  public void println_shouldLogNullTagAppropriately() {
+    int len = Log.println(Log.ASSERT, null, "msg");
+    assertLogged(Log.ASSERT, null, "msg", null);
+    assertThat(len).isEqualTo(8);
+  }
+
+  @Test
+  public void println_shouldLogNullMessageAppropriately() {
+    int len = Log.println(Log.ASSERT, "tag", null);
+    assertLogged(Log.ASSERT, "tag", null, null);
+    assertThat(len).isEqualTo(8);
+  }
+
+  @Test
+  public void println_shouldLogNullTagAndNullMessageAppropriately() {
+    int len = Log.println(Log.ASSERT, null, null);
+    assertLogged(Log.ASSERT, null, null, null);
+    assertThat(len).isEqualTo(5);
+  }
+
+  @Test
   public void shouldLogToProvidedStream() throws Exception {
     final ByteArrayOutputStream bos = new ByteArrayOutputStream();
     PrintStream old = ShadowLog.stream;


### PR DESCRIPTION
Guard against a `NullPointerException` when a tag or message is passed as null. This matches the behaviour exhibited on-device (at least on api-level 22).

Also added some appropriate unit tests.