### PR TITLE
ShadowViewTreeObserver: add new method implementation

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowViewTreeObserver.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowViewTreeObserver.java
@@ -19,6 +19,11 @@ public class ShadowViewTreeObserver {
   }
 
   @Implementation
+  public void removeOnGlobalLayoutListener(ViewTreeObserver.OnGlobalLayoutListener listener) {
+    this.globalLayoutListeners.remove(listener);
+  }
+
+  @Implementation
   public void removeGlobalOnLayoutListener(ViewTreeObserver.OnGlobalLayoutListener listener) {
     this.globalLayoutListeners.remove(listener);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTreeObserverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTreeObserverTest.java
@@ -38,7 +38,7 @@ public class ShadowViewTreeObserverTest {
 
     listener1.reset();
     listener2.reset();
-    viewTreeObserver.removeGlobalOnLayoutListener(listener1);
+    viewTreeObserver.removeOnGlobalLayoutListener(listener1);
     shadowOf(viewTreeObserver).fireOnGlobalLayoutListeners();
 
     assertFalse(listener1.onGlobalLayoutWasCalled);
@@ -46,7 +46,7 @@ public class ShadowViewTreeObserverTest {
 
     listener1.reset();
     listener2.reset();
-    viewTreeObserver.removeGlobalOnLayoutListener(listener2);
+    viewTreeObserver.removeOnGlobalLayoutListener(listener2);
     shadowOf(viewTreeObserver).fireOnGlobalLayoutListeners();
 
     assertFalse(listener1.onGlobalLayoutWasCalled);


### PR DESCRIPTION
Add implementation for removeOnGlobalLayoutListener() which in
Android replaces the deprecated removeGlobalOnLayoutListener().

Update UnitTests as well.