### PR TITLE
Remove old constructors

### DIFF
--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/ShadowMapView.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/ShadowMapView.java
@@ -11,6 +11,7 @@ import com.google.android.maps.*;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.HiddenApi;
+import org.robolectric.annotation.RealObject;
 import org.robolectric.internal.ShadowExtractor;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.res.Attribute;
@@ -25,6 +26,8 @@ import static org.robolectric.internal.Shadow.invokeConstructor;
 
 @Implements(MapView.class)
 public class ShadowMapView extends ShadowViewGroup {
+  @SuppressWarnings("UnusedDeclaration") @RealObject
+  private MapView realMapView;
   private boolean satelliteOn;
   private MapController mapController;
   private List<Overlay> overlays = new ArrayList<>();
@@ -33,7 +36,6 @@ public class ShadowMapView extends ShadowViewGroup {
   int latitudeSpan = 30;
   int zoomLevel = 1;
   private ZoomButtonsController zoomButtonsController;
-  private MapView realMapView;
   private Projection projection;
   private boolean useBuiltInZoomMapControls;
   private boolean mouseDownOnMe = false;
@@ -42,15 +44,11 @@ public class ShadowMapView extends ShadowViewGroup {
   private boolean preLoadWasCalled;
   private boolean canCoverCenter = true;
 
-  public ShadowMapView(MapView mapView) {
-    realMapView = mapView;
-    zoomButtonsController = new ZoomButtonsController(mapView);
-  }
-
   @HiddenApi
   public void __constructor__(Context context) {
     setContextOnRealView(context);
     this.attributeSet = new RoboAttributeSet(new ArrayList<Attribute>(), ShadowApplication.getInstance().getResourceLoader());
+    zoomButtonsController = new ZoomButtonsController(realMapView);
     invokeConstructor(View.class, realView, ClassParameter.from(Context.class, context));
     invokeConstructor(ViewGroup.class, realView, ClassParameter.from(Context.class, context));
   }
@@ -58,6 +56,7 @@ public class ShadowMapView extends ShadowViewGroup {
   public void __constructor__(Context context, AttributeSet attributeSet) {
     setContextOnRealView(context);
     this.attributeSet = attributeSet;
+    zoomButtonsController = new ZoomButtonsController(realMapView);
     invokeConstructor(View.class, realView,
         ClassParameter.from(Context.class, context),
         ClassParameter.from(AttributeSet.class, attributeSet),
@@ -72,6 +71,7 @@ public class ShadowMapView extends ShadowViewGroup {
   @Override public void __constructor__(Context context, AttributeSet attributeSet, int defStyle) {
     setContextOnRealView(context);
     this.attributeSet = attributeSet;
+    zoomButtonsController = new ZoomButtonsController(realMapView);
     invokeConstructor(View.class, realView,
         ClassParameter.from(Context.class, context),
         ClassParameter.from(AttributeSet.class, attributeSet),

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -131,7 +131,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
   }
 
   protected ClassHandler createClassHandler(ShadowMap shadowMap, SdkConfig sdkConfig) {
-    return new ShadowWrangler(shadowMap, sdkConfig);
+    return new ShadowWrangler(shadowMap);
   }
 
   protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetDir) {

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowWranglerTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowWranglerTest.java
@@ -36,11 +36,10 @@ public class ShadowWranglerTest {
   }
 
   @Test
-  @Config(shadows = {ShadowFoo.class})
+  @Config(shadows = { ShadowFoo.class })
   public void testConstructorInvocation() throws Exception {
     Foo foo = new Foo(name);
     assertSame(name, shadowOf(foo).name);
-    assertSame(foo, shadowOf(foo).realFooCtor);
   }
 
   @Test
@@ -270,9 +269,6 @@ public class ShadowWranglerTest {
 
   @Implements(TextFoo.class)
   public static class ShadowTextFoo extends ShadowFoo {
-    public ShadowTextFoo(Foo foo) {
-      super(foo);
-    }
   }
 
   @Instrument

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowWranglerUnitTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowWranglerUnitTest.java
@@ -16,7 +16,7 @@ public class ShadowWranglerUnitTest {
 
   @Before
   public void setup() throws Exception {
-    shadowWrangler = new ShadowWrangler(ShadowMap.EMPTY, new SdkConfig(SdkConfig.FALLBACK_SDK_VERSION));
+    shadowWrangler = new ShadowWrangler(ShadowMap.EMPTY);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/testing/ShadowFoo.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/testing/ShadowFoo.java
@@ -8,12 +8,7 @@ import org.robolectric.annotation.RealObject;
 public class ShadowFoo extends ShadowWranglerTest.ShadowFooParent {
   @RealObject public Foo realFooField;
   public Foo realFooInConstructor;
-  public Foo realFooCtor;
   public String name;
-
-  public ShadowFoo(Foo foo) {
-    this.realFooCtor = foo;
-  }
 
   @Override
   @SuppressWarnings({"UnusedDeclaration"})


### PR DESCRIPTION
These were replaced by the `@RealObject` annotation and doing this before 3.0 seems smart. This perhaps breaks some compatibility but we don't have to reflectively try to find two different constructors recursively.