### PR TITLE
Update assertj to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>1.7.0</version>
+        <version>2.0.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
@@ -178,7 +178,7 @@ public class ShadowNotificationBuilderTest {
     PendingIntent action = PendingIntent.getBroadcast(RuntimeEnvironment.application, 0, null, 0);
     builder.addAction(0, "Action", action);
     build();
-    assertThat(s.getActions().get(0).actionIntent).isEqualsToByComparingFields(action);
+    assertThat(s.getActions().get(0).actionIntent).isEqualToComparingFieldByField(action);
   }
 
   private void build() {


### PR DESCRIPTION
Allows to test some Java 7 stuff, like Path (more to come).