### PR TITLE
Allow overriding the package name when using RobolectricGradleTestRunner.

### DIFF
--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/Config.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/Config.java
@@ -61,6 +61,17 @@ public @interface Config {
   Class<? extends Application> application() default Application.class;
 
   /**
+   * Java package name where the "R.class" file is located. This only needs to be specified if you define
+   * an {@code applicationId} associated with {@code productFlavors} or specify {@code applicationIdSuffix}
+   * in your build.gradle.
+   *
+   * <p>If not specified, Robolectric defaults to the {@code applicationId}.</p>
+   *
+   * @return The java package name for R.class.
+   */
+  String packageName() default "";
+
+  /**
    * Qualifiers for the resource resolution, such as "fr-normal-port-hdpi".
    *
    * @return Qualifiers used for resource resolution.
@@ -70,8 +81,7 @@ public @interface Config {
   /**
    * The directory from which to load resources.  This should be relative to the directory containing AndroidManifest.xml.
    *
-   * <p>
-   * If not specified, Robolectric defaults to {@code res}.
+   * <p>If not specified, Robolectric defaults to {@code res}.</p>
    *
    * @return Android resource directory.
    */
@@ -80,8 +90,7 @@ public @interface Config {
   /**
    * The directory from which to load assets. This should be relative to the directory containing AndroidManifest.xml.
    *
-   * <p>
-   * If not specified, Robolectric defaults to {@code assets}.
+   * <p>If not specified, Robolectric defaults to {@code assets}.</p>
    *
    * @return Android asset directory.
    */
@@ -115,6 +124,7 @@ public @interface Config {
     private final String qualifiers;
     private final String resourceDir;
     private final String assetDir;
+    private final String packageName;
     private final Class<?> constants;
     private final Class<?>[] shadows;
     private final Class<? extends Application> application;
@@ -126,6 +136,7 @@ public @interface Config {
           Integer.parseInt(properties.getProperty("emulateSdk", "-1")),
           properties.getProperty("manifest", DEFAULT),
           properties.getProperty("qualifiers", ""),
+          properties.getProperty("packageName", ""),
           properties.getProperty("resourceDir", Config.DEFAULT_RES_FOLDER),
           properties.getProperty("assetDir", Config.DEFAULT_ASSET_FOLDER),
           Integer.parseInt(properties.getProperty("reportSdk", "-1")),
@@ -165,10 +176,11 @@ public @interface Config {
       return pathList.split("[, ]+");
     }
 
-    public Implementation(int emulateSdk, String manifest, String qualifiers, String resourceDir, String assetDir, int reportSdk, Class<?>[] shadows, Class<? extends Application> application, String[] libraries, Class<?> constants) {
+    public Implementation(int emulateSdk, String manifest, String qualifiers, String packageName, String resourceDir, String assetDir, int reportSdk, Class<?>[] shadows, Class<? extends Application> application, String[] libraries, Class<?> constants) {
       this.emulateSdk = emulateSdk;
       this.manifest = manifest;
       this.qualifiers = qualifiers;
+      this.packageName = packageName;
       this.resourceDir = resourceDir;
       this.assetDir = assetDir;
       this.reportSdk = reportSdk;
@@ -183,6 +195,7 @@ public @interface Config {
       this.emulateSdk = other.emulateSdk();
       this.manifest = other.manifest();
       this.qualifiers = other.qualifiers();
+      this.packageName = other.packageName();
       this.resourceDir = other.resourceDir();
       this.assetDir = other.assetDir();
       this.constants = other.constants();
@@ -195,6 +208,7 @@ public @interface Config {
       this.emulateSdk = pick(baseConfig.emulateSdk(), overlayConfig.emulateSdk(), -1);
       this.manifest = pick(baseConfig.manifest(), overlayConfig.manifest(), DEFAULT);
       this.qualifiers = pick(baseConfig.qualifiers(), overlayConfig.qualifiers(), "");
+      this.packageName = pick(baseConfig.packageName(), overlayConfig.packageName(), "");
       this.resourceDir = pick(baseConfig.resourceDir(), overlayConfig.resourceDir(), Config.DEFAULT_RES_FOLDER);
       this.assetDir = pick(baseConfig.assetDir(), overlayConfig.assetDir(), Config.DEFAULT_ASSET_FOLDER);
       this.reportSdk = pick(baseConfig.reportSdk(), overlayConfig.reportSdk(), -1);
@@ -240,6 +254,11 @@ public @interface Config {
     @Override
     public String qualifiers() {
       return qualifiers;
+    }
+
+    @Override
+    public String packageName() {
+      return packageName;
     }
 
     @Override

--- a/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
@@ -32,7 +32,7 @@ public class RobolectricGradleTestRunner extends RobolectricTestRunner {
 
     final String type = getType(config);
     final String flavor = getFlavor(config);
-    final String applicationId = getApplicationId(config);
+    final String packageName = getPackageName(config);
 
     final FileFsFile res;
     final FileFsFile assets;
@@ -59,8 +59,8 @@ public class RobolectricGradleTestRunner extends RobolectricTestRunner {
     Logger.debug("Robolectric assets directory: " + assets.getPath());
     Logger.debug("   Robolectric res directory: " + res.getPath());
     Logger.debug("   Robolectric manifest path: " + manifest.getPath());
-    Logger.debug("    Robolectric package name: " + applicationId);
-    return new AndroidManifest(manifest, res, assets, applicationId);
+    Logger.debug("    Robolectric package name: " + packageName);
+    return new AndroidManifest(manifest, res, assets, packageName);
   }
 
   private String getType(Config config) {
@@ -79,9 +79,14 @@ public class RobolectricGradleTestRunner extends RobolectricTestRunner {
     }
   }
 
-  private String getApplicationId(Config config) {
+  private String getPackageName(Config config) {
     try {
-      return ReflectionHelpers.getStaticField(config.constants(), "APPLICATION_ID");
+      final String packageName = config.packageName();
+      if (packageName != null && !packageName.isEmpty()) {
+        return packageName;
+      } else {
+        return ReflectionHelpers.getStaticField(config.constants(), "APPLICATION_ID");
+      }
     } catch (Throwable e) {
       return null;
     }

--- a/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
+++ b/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
@@ -85,13 +85,13 @@ public class DefaultTestLifecycleTest {
 
   @Test public void shouldLoadConfigApplicationIfSpecified() throws Exception {
     Application application = defaultTestLifecycle.createApplication(null,
-        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(-1, "", "", "", "", -1, new Class[0], TestFakeApp.class, new String[0], null));
+        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(-1, "", "", null, "", "", -1, new Class[0], TestFakeApp.class, new String[0], null));
     assertThat(application).isExactlyInstanceOf(TestFakeApp.class);
   }
 
   @Test public void shouldLoadConfigInnerClassApplication() throws Exception {
     Application application = defaultTestLifecycle.createApplication(null,
-        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(-1, "", "", "", "", -1, new Class[0], TestFakeAppInner.class, new String[0], null));
+        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(-1, "", "", null, "", "", -1, new Class[0], TestFakeAppInner.class, new String[0], null));
     assertThat(application).isExactlyInstanceOf(TestFakeAppInner.class);
   }
 

--- a/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
@@ -38,7 +38,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromSdkConfig() {
     String givenQualifiers = "";
-    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", "assets", -1, new Class[0], Application.class, new String[0], null);
+    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, null, "res", "assets", -1, new Class[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("v18");
     assertThat(getQualifiersFromAppAssetManager()).isEqualTo("v18");
@@ -48,7 +48,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromConfigQualifiers() {
     String givenQualifiers = "land-v17";
-    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", "assets", -1, new Class[0], Application.class, new String[0], null);
+    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, null, "res", "assets", -1, new Class[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("land-v17");
     assertThat(getQualifiersFromAppAssetManager()).isEqualTo("land-v17");
@@ -58,7 +58,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromSdkConfigWithOtherQualifiers() {
     String givenQualifiers = "large-land";
-    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, "res", "assets", -1, new Class[0], Application.class, new String[0], null);
+    Config c = new Config.Implementation(-1, Config.DEFAULT, givenQualifiers, null, "res", "assets", -1, new Class[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("large-land-v18");
     assertThat(getQualifiersFromAppAssetManager()).isEqualTo("large-land-v18");

--- a/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
@@ -67,6 +67,17 @@ public class RobolectricGradleTestRunnerTest {
   }
 
   @Test
+  public void getAppManifest_withPackageNameOverride_shouldCreateManifest() throws Exception {
+    final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(PackageNameTest.class);
+    final AndroidManifest manifest = runner.getAppManifest(runner.getConfig(PackageNameTest.class.getMethod("withoutAnnotation")));
+
+    assertThat(manifest.getPackageName()).isEqualTo("fake.package.name");
+    assertThat(manifest.getResDirectory().getPath()).isEqualTo("build/intermediates/res/flavor1/type1");
+    assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo("build/intermediates/assets/flavor1/type1");
+    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo("build/intermediates/manifests/full/flavor1/type1/AndroidManifest.xml");
+  }
+
+  @Test
   public void getAppManifest_shouldThrowException_whenConstantsNotSpecified() throws Exception {
     final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(NoConstantsTest.class);
     exception.expect(RuntimeException.class);
@@ -99,6 +110,15 @@ public class RobolectricGradleTestRunnerTest {
   @Ignore
   @Config
   public static class NoConstantsTest {
+
+    @Test
+    public void withoutAnnotation() throws Exception {
+    }
+  }
+
+  @Ignore
+  @Config(constants = BuildConfig.class, packageName = "fake.package.name")
+  public static class PackageNameTest {
 
     @Test
     public void withoutAnnotation() throws Exception {


### PR DESCRIPTION
This allows the user to specify the package name containing "R.class" when an
applicationId or applicationIdSuffix is used in conjunction with productFlavors.

Closes #1623.