### PR TITLE
Fix for permgen leak

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/EnvHolder.java
+++ b/robolectric/src/main/java/org/robolectric/internal/EnvHolder.java
@@ -3,20 +3,18 @@ package org.robolectric.internal;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.FsFile;
 
-import java.lang.ref.SoftReference;
 import java.util.HashMap;
 import java.util.Map;
 
 public class EnvHolder {
-  public final Map<FsFile, AndroidManifest> appManifestsByFile = new HashMap<>();
-  private final Map<SdkConfig, SoftReference<SdkEnvironment>> sdkToEnvironmentSoft = new HashMap<>();
+
+  private final Map<SdkConfig, SdkEnvironment> sdkToEnvironment = new HashMap<>();
 
   synchronized public SdkEnvironment getSdkEnvironment(SdkConfig sdkConfig, SdkEnvironment.Factory factory) {
-    SoftReference<SdkEnvironment> reference = sdkToEnvironmentSoft.get(sdkConfig);
-    SdkEnvironment sdkEnvironment = reference == null ? null : reference.get();
+    SdkEnvironment sdkEnvironment = sdkToEnvironment.get(sdkConfig);
     if (sdkEnvironment == null) {
       sdkEnvironment = factory.create();
-      sdkToEnvironmentSoft.put(sdkConfig, new SoftReference<>(sdkEnvironment));
+      sdkToEnvironment.put(sdkConfig, sdkEnvironment);
     }
     return sdkEnvironment;
   }


### PR DESCRIPTION
I think this should fix https://github.com/robolectric/robolectric/issues/1700

I profiled Robolectric's own test suite and noticed that we were creating and holding onto 17 SdkEnvironment objects, each of which has an InstrumentingClassloader referenced.

I think we want just a single SdkEnvironment+InstrumentingClassloader per SdkConfig for the whole VM.

I think the root cause was the circular references of RobolectricTestRunner -> lastTestRunnerClass when each test runner instance has a reference to both the current and last sdk config.

With this fix applied the perm gen peaks at ~150MB where as without the fix peaks at ~250MB - heap seems unaffected.

![without_fix_permgen](https://cloud.githubusercontent.com/assets/6314616/7311068/d1884626-e9eb-11e4-9535-38cf2c88477a.png)
![with_fix_heap](https://cloud.githubusercontent.com/assets/6314616/7311069/d1a993f8-e9eb-11e4-8e2d-ce601d403a09.png)
![with_fix_permgen](https://cloud.githubusercontent.com/assets/6314616/7311071/d49da216-e9eb-11e4-9a0c-0df8e3f5e4e7.png)
![without_fix_heap](https://cloud.githubusercontent.com/assets/6314616/7311072/d5fcc2fe-e9eb-11e4-86e6-ab90e614f298.png)
