### PR TITLE
Fix for issue #1711: automatically execute runnables when not paused

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowObjectAnimatorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowObjectAnimatorTest.java
@@ -20,6 +20,7 @@ public class ShadowObjectAnimatorTest {
   public void start_shouldRunAnimation() {
     final ObjectAnimator animator = ObjectAnimator.ofInt(target, "transparency", 0, 1, 2, 3, 4);
 
+    Robolectric.getForegroundThreadScheduler().pause();
     animator.setDuration(1000);
     animator.addListener(listener);
     animator.start();


### PR DESCRIPTION
Also fixed another bug I found where the clock was not being advanced in the "idling constantly" mode, and added some Javadoc explaining the difference between "idle constantly", unpaused, and paused operation.

See #1711 for a discussion of why I felt this PR was necessary. Hopefully this solution keeps everyone happy.