### PR TITLE
Reuse empty data directories

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
+++ b/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
@@ -28,7 +28,10 @@ public class RuntimeEnvironment {
     }
 
     public static void setRobolectricPackageManager(RobolectricPackageManager newPackageManager) {
-        packageManager = newPackageManager;
+      if (packageManager != null) {
+        packageManager.reset();
+      }
+      packageManager = newPackageManager;
     }
 
     public static String getQualifiers() {

--- a/robolectric-resources/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
@@ -81,6 +81,8 @@ public interface RobolectricPackageManager {
 
   void setQueryIntentImplicitly(boolean queryIntentImplicitly);
 
+  void reset();
+
   class ComponentState {
     public int newState;
     public int flags;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
@@ -3,11 +3,11 @@ package org.robolectric.shadows;
 import android.app.Application;
 import android.content.Context;
 import android.content.res.Resources;
+import android.os.Environment;
 import android.view.View;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.annotation.Resetter;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.res.Attribute;
 import org.robolectric.res.ResName;
@@ -16,7 +16,6 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import java.io.*;
 import java.util.List;
-import java.util.UUID;
 
 import static org.robolectric.Shadows.shadowOf;
 
@@ -26,9 +25,6 @@ import static org.robolectric.Shadows.shadowOf;
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Context.class)
 abstract public class ShadowContext {
-  public static final File EXTERNAL_CACHE_DIR = createTempDir("android-external-cache");
-  public static final File EXTERNAL_FILES_DIR = createTempDir("android-external-files");
-
   @RealObject private Context realContext;
   private ShadowApplication shadowApplication;
 
@@ -58,15 +54,12 @@ abstract public class ShadowContext {
 
   @Implementation
   public File getExternalCacheDir() {
-    EXTERNAL_CACHE_DIR.mkdirs();
-    return EXTERNAL_CACHE_DIR;
+    return Environment.getExternalStorageDirectory();
   }
 
   @Implementation
   public File getExternalFilesDir(String type) {
-    File f = (type == null) ? EXTERNAL_FILES_DIR : new File( EXTERNAL_FILES_DIR, type );
-    f.mkdirs();
-    return f;
+    return Environment.getExternalStoragePublicDirectory(type);
   }
 
   /**
@@ -80,42 +73,6 @@ abstract public class ShadowContext {
 
   public boolean isStrictI18n() {
     return getShadowApplication().isStrictI18n();
-  }
-
-  @Resetter
-  public static void reset() {
-    clearFiles(EXTERNAL_CACHE_DIR);
-    clearFiles(EXTERNAL_FILES_DIR);
-  }
-
-  public static void clearFiles(File dir) {
-    if (dir != null && dir.isDirectory()) {
-      File[] files = dir.listFiles();
-      if (files != null) {
-        for (File f : files) {
-          if (f.isDirectory()) {
-            clearFiles(f);
-          }
-          f.delete();
-        }
-      }
-      dir.delete();
-      dir.getParentFile().delete();
-    }
-  }
-
-  private static File createTempDir(String name) {
-    try {
-      File tmp = File.createTempFile(name, "robolectric");
-      if (!tmp.delete()) throw new IOException("could not delete "+tmp);
-      tmp = new File(tmp, UUID.randomUUID().toString());
-      if (!tmp.mkdirs()) throw new IOException("could not create "+tmp);
-      tmp.deleteOnExit();
-
-      return tmp;
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   public ResName getResName(int resourceId) {

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowEnvironment.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowEnvironment.java.vm
@@ -1,18 +1,25 @@
 package org.robolectric.shadows;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.HashMap;
 import android.os.Environment;
 import org.robolectric.annotation.Resetter;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Implementation;
+import org.robolectric.util.TempDirectory;
 
 @Implements(Environment.class)
 public class ShadowEnvironment {
   private static String externalStorageState = Environment.MEDIA_REMOVED;
   private static final Map<File, Boolean> STORAGE_EMULATED = new HashMap<>();
   private static final Map<File, Boolean> STORAGE_REMOVABLE = new HashMap<>();
+
+  static Path EXTERNAL_CACHE_DIR;
+  static Path EXTERNAL_FILES_DIR;
 
   @Implementation
   public static String getExternalStorageState() {
@@ -30,21 +37,37 @@ public class ShadowEnvironment {
 
   @Implementation
   public static File getExternalStorageDirectory() {
-    ShadowContext.EXTERNAL_CACHE_DIR.mkdirs();
-    return ShadowContext.EXTERNAL_CACHE_DIR;
+    if (!exists(EXTERNAL_CACHE_DIR)) EXTERNAL_CACHE_DIR = TempDirectory.create();
+    return EXTERNAL_CACHE_DIR.toFile();
   }
 
   @Implementation
   public static File getExternalStoragePublicDirectory(String type) {
-    File f = (type == null) ? ShadowContext.EXTERNAL_FILES_DIR : new File(ShadowContext.EXTERNAL_FILES_DIR, type);
-    f.mkdirs();
-    return f;
+    if (!exists(EXTERNAL_FILES_DIR)) EXTERNAL_FILES_DIR = TempDirectory.create();
+    if (type == null) return EXTERNAL_FILES_DIR.toFile();
+    Path path = EXTERNAL_FILES_DIR.resolve(type);
+    try {
+      Files.createDirectory(path);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return path.toFile();
   }
 
   @Resetter
   public static void reset() {
+    TempDirectory.destroy(EXTERNAL_CACHE_DIR);
+    TempDirectory.destroy(EXTERNAL_FILES_DIR);
+
+    EXTERNAL_CACHE_DIR = null;
+    EXTERNAL_FILES_DIR = null;
+
     STORAGE_EMULATED.clear();
     STORAGE_REMOVABLE.clear();
+  }
+
+  private static boolean exists(Path path) {
+    return path != null && Files.exists(path);
   }
 
 #if ($api >= 19)

--- a/robolectric-utils/src/main/java/org/robolectric/util/TempDirectory.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/TempDirectory.java
@@ -1,0 +1,105 @@
+package org.robolectric.util;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayDeque;
+import java.util.LinkedHashSet;
+import java.util.Queue;
+import java.util.Set;
+
+public class TempDirectory {
+  private static final TempDirectory instance = new TempDirectory();
+
+  private final Queue<Path> paths;
+  private final Set<String> deletePaths;
+
+  TempDirectory() {
+    paths = new ArrayDeque<>();
+    deletePaths = new LinkedHashSet<>();
+
+    // Use a manual hook that actually clears the directory
+    Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+      @Override public void run() {
+        for (String file : deletePaths) {
+          try {
+            Path path = Paths.get(file);
+            clearDirectory(path);
+            Files.delete(path);
+          } catch (IOException ignored) {
+          }
+        }
+      }
+    }));
+  }
+
+  public static Path create() {
+    return instance.createImpl(false);
+  }
+
+  public static Path createDeleteOnExit() {
+    return instance.createImpl(true);
+  }
+
+  public static void destroy(Path path) {
+    if (path != null) {
+      instance.destroyImpl(path);
+    }
+  }
+
+  Path createImpl(boolean deleteOnExit) {
+    Path empty = paths.poll();
+    if (empty != null && Files.exists(empty)) return empty;
+
+    try {
+      Path directory = createTempDir("android-tmp");
+      if (deleteOnExit) deleteOnExit(directory);
+      return directory;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  void destroyImpl(Path path) {
+    try {
+      if (Files.exists(path)) {
+        clearDirectory(path);
+
+        paths.add(path);
+        deleteOnExit(path);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void clearDirectory(final Path directory) throws IOException {
+    Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+        if (!dir.equals(directory)) {
+          Files.delete(dir);
+        }
+        return FileVisitResult.CONTINUE;
+      }
+    });
+  }
+
+  private void deleteOnExit(Path path) {
+    deletePaths.add(path.toString());
+  }
+
+  private Path createTempDir(String name) throws IOException {
+    return Files.createTempDirectory(name + "-robolectric");
+  }
+}

--- a/robolectric-utils/src/test/java/org/robolectric/util/TempDirectoryTest.java
+++ b/robolectric-utils/src/test/java/org/robolectric/util/TempDirectoryTest.java
@@ -1,0 +1,49 @@
+package org.robolectric.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class TempDirectoryTest {
+  @Test
+  public void verifyReuse() {
+    TempDirectory dir = new TempDirectory();
+    Path path = dir.createImpl(false);
+    dir.destroyImpl(path);
+    assertThat(path).exists();
+    assertThat(dir.createImpl(false)).isSameAs(path);
+  }
+
+  @Test
+  public void directoryIsEmpty() throws IOException {
+    TempDirectory dir = new TempDirectory();
+    Path path = dir.createImpl(false);
+    Path temp = Files.createTempDirectory(path, "hello");
+    dir.destroyImpl(path);
+    assertThat(temp).doesNotExist();
+  }
+
+  @Test
+  public void rougeDeletion() throws IOException {
+    TempDirectory dir = new TempDirectory();
+    Path path = dir.createImpl(false);
+    Files.delete(path);
+    dir.destroyImpl(path);
+    assertThat(path).doesNotExist();
+    assertThat(dir.createImpl(false)).isNotSameAs(path);
+  }
+
+  @Test
+  public void rougeDeletionAfterDestroy() throws IOException {
+    TempDirectory dir = new TempDirectory();
+    Path path = dir.createImpl(false);
+    dir.destroyImpl(path);
+    Files.delete(path);
+    Path newPath = dir.createImpl(false);
+    assertThat(path).doesNotExist();
+    assertThat(path).isNotSameAs(newPath);
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentingClassLoaderConfig.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentingClassLoaderConfig.java
@@ -21,6 +21,7 @@ import org.robolectric.annotation.internal.Instrument;
 import org.robolectric.internal.ParallelUniverseInterface;
 import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.ResourcePath;
+import org.robolectric.util.TempDirectory;
 import org.robolectric.util.Transcript;
 
 import java.util.ArrayList;
@@ -65,7 +66,8 @@ public class InstrumentingClassLoaderConfig {
       DirectObjectMarker.class,
       DependencyJar.class,
       ParallelUniverseInterface.class,
-      ShadowedObject.class
+      ShadowedObject.class,
+      TempDirectory.class
   );
 
   static {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
@@ -3,7 +3,6 @@ package org.robolectric.shadows;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,11 +40,6 @@ public class ShadowContextTest {
     File[] files = dataDir.listFiles();
     assertNotNull(files);
     assertThat(files.length).isEqualTo(0);
-  }
-
-  @After
-  public void after() {
-    ShadowContext.reset();
   }
 
   @Test
@@ -110,7 +104,6 @@ public class ShadowContextTest {
     File cacheTest = new File(context.getExternalCacheDir(), "__test__");
 
     assertThat(cacheTest.getAbsolutePath()).startsWith(System.getProperty("java.io.tmpdir"));
-    assertThat(cacheTest.getAbsolutePath()).contains("android-external-cache");
     assertThat(cacheTest.getAbsolutePath()).endsWith(File.separator + "__test__");
 
     FileOutputStream fos = null;
@@ -335,16 +328,5 @@ public class ShadowContextTest {
     TypedArray typedArray = context.obtainStyledAttributes(roboAttributeSet, new int[]{R.attr.quitKeyCombo, R.attr.itemType});
     assertThat(typedArray.getString(0)).isEqualTo("^q");
     assertThat(typedArray.getInt(1, -1234)).isEqualTo(1 /* ungulate */);
-  }
-
-  @Test
-  public void reset_shouldCleanupTempDirectories() {
-    ShadowContext.reset();
-
-    assertThat(ShadowContext.EXTERNAL_CACHE_DIR.exists()).isFalse();
-    assertThat(ShadowContext.EXTERNAL_CACHE_DIR.getParentFile().exists()).isFalse();
-
-    assertThat(ShadowContext.EXTERNAL_FILES_DIR.exists()).isFalse();
-    assertThat(ShadowContext.EXTERNAL_FILES_DIR.getParentFile().exists()).isFalse();
   }
 }


### PR DESCRIPTION
This also fixes so we actually make sure to delete temp folders after a run. Previously this would fail if the folder wasn't empty. This made test run slower as the temp folder filled up.

Creating new directories is also not free and takes a large amount of time for smaller tests.

NOTE: This change also kills the `public static final` File's in ShadowContext in favor of the methods to retrieve them, this means tests that depends on these will break, however we can then lazily create these instead.

Here is a graph which shows the runtime based on number of temp files.
![Graph](https://www.dropbox.com/s/v7mb17wyhkz1cfb/Screenshot%202015-04-27%2018.35.33.png?dl=1)