### PR TITLE
Remove unnecessary generated methods

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowColor.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowColor.java
@@ -1,11 +1,12 @@
 package org.robolectric.shadows;
 
 import android.graphics.Color;
+import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
-import org.robolectric.internal.Shadow;
 
-import java.lang.reflect.Method;
+import org.robolectric.internal.Shadow;
+import org.robolectric.util.ReflectionHelpers;
 
 @Implements(Color.class)
 public class ShadowColor {
@@ -22,9 +23,8 @@ public class ShadowColor {
       colorString = buf.toString();
     }
     try {
-      Method parseColor = Color.class.getDeclaredMethod(Shadow.directMethodName(Color.class.getName(), "parseColor"), String.class);
-      parseColor.setAccessible(true);
-      return (Integer) parseColor.invoke(null, colorString);
+      return (int) Shadow.directlyOn(Color.class, "parseColor",
+          ReflectionHelpers.ClassParameter.from(String.class, colorString));
     } catch (Exception e) {
       throw new IllegalArgumentException("Can't parse value from color \"" + colorString + "\"", e);
     }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPhoneWindow.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPhoneWindow.java
@@ -2,15 +2,18 @@ package org.robolectric.shadows;
 
 import android.graphics.drawable.Drawable;
 import android.widget.ProgressBar;
+import com.android.internal.policy.impl.PhoneWindow;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
-@Implements(className = ShadowPhoneWindow.PHONE_WINDOW_CLASS_NAME, isInAndroidSdk = false)
+@Implements(value = PhoneWindow.class, isInAndroidSdk = false)
 public class ShadowPhoneWindow extends ShadowWindow {
-  public static final String PHONE_WINDOW_CLASS_NAME = "com.android.internal.policy.impl.PhoneWindow";
+  @SuppressWarnings("UnusedDeclaration")
+  private @RealObject PhoneWindow realWindow;
 
   private CharSequence title;
   private Drawable backgroundDrawable;
@@ -18,7 +21,7 @@ public class ShadowPhoneWindow extends ShadowWindow {
   @Implementation
   public void setTitle(CharSequence title) {
     this.title = title;
-    directlyOn(realWindow, PHONE_WINDOW_CLASS_NAME, "setTitle", ClassParameter.from(CharSequence.class, title));
+    directlyOn(realWindow, PhoneWindow.class, "setTitle", ClassParameter.from(CharSequence.class, title));
   }
 
   public CharSequence getTitle() {
@@ -28,7 +31,7 @@ public class ShadowPhoneWindow extends ShadowWindow {
   @Implementation
   public void setBackgroundDrawable(Drawable drawable) {
     this.backgroundDrawable = drawable;
-    directlyOn(realWindow, PHONE_WINDOW_CLASS_NAME, "setBackgroundDrawable", ClassParameter.from(Drawable.class, drawable));
+    directlyOn(realWindow, PhoneWindow.class, "setBackgroundDrawable", ClassParameter.from(Drawable.class, drawable));
   }
 
   public Drawable getBackgroundDrawable() {
@@ -37,11 +40,11 @@ public class ShadowPhoneWindow extends ShadowWindow {
 
   @Override
   public ProgressBar getProgressBar() {
-    return (ProgressBar) directlyOn(realWindow, PHONE_WINDOW_CLASS_NAME, "getHorizontalProgressBar", ClassParameter.from(boolean.class, false));
+    return (ProgressBar) directlyOn(realWindow, PhoneWindow.class, "getHorizontalProgressBar", ClassParameter.from(boolean.class, false));
   }
 
   @Override
   public ProgressBar getIndeterminateProgressBar() {
-    return (ProgressBar) directlyOn(realWindow, PHONE_WINDOW_CLASS_NAME, "getCircularProgressBar", ClassParameter.from(boolean.class, false));
+    return (ProgressBar) directlyOn(realWindow, PhoneWindow.class, "getCircularProgressBar", ClassParameter.from(boolean.class, false));
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWindow.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWindow.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.view.Window;
 import android.widget.ProgressBar;
+import com.android.internal.policy.impl.PhoneWindow;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -16,15 +17,13 @@ import static org.robolectric.internal.Shadow.directlyOn;
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Window.class)
 public class ShadowWindow {
-  @RealObject Window realWindow;
+  private @RealObject Window realWindow;
 
   private int flags;
   private int softInputMode;
 
   public static Window create(Context context) throws Exception {
-    Class<?> phoneWindowClass = ShadowWindow.class.getClassLoader().loadClass(ShadowPhoneWindow.PHONE_WINDOW_CLASS_NAME);
-    Constructor<?> constructor = phoneWindowClass.getConstructor(Context.class);
-    return (Window) constructor.newInstance(context);
+    return new PhoneWindow(context);
   }
 
   @Implementation

--- a/robolectric-utils/src/main/java/org/robolectric/internal/Shadow.java
+++ b/robolectric-utils/src/main/java/org/robolectric/internal/Shadow.java
@@ -40,49 +40,21 @@ public class Shadow {
   }
 
   public static <R, T> R directlyOn(T shadowedObject, Class<T> clazz, String methodName, ClassParameter... paramValues) {
-    String directMethodName = directMethodName(clazz.getName(), methodName);
-    return (R) ReflectionHelpers.callInstanceMethod(shadowedObject, directMethodName, paramValues);
+    String directMethodName = directMethodName(methodName);
+    return (R) ReflectionHelpers.callInstanceMethod(clazz, shadowedObject, directMethodName, paramValues);
   }
 
   public static <R, T> R directlyOn(Class<T> clazz, String methodName, ClassParameter... paramValues) {
-    String directMethodName = directMethodName(clazz.getName(), methodName);
+    String directMethodName = directMethodName(methodName);
     return (R) ReflectionHelpers.callStaticMethod(clazz, directMethodName, paramValues);
   }
 
-  public static <R> R invokeConstructor(Class<? extends R> clazz, R instance, StringParameter paramValue0, StringParameter... paramValues) {
-    ClassParameter[] classParamValues = new ClassParameter[paramValues.length + 1];
-    try {
-      Class<?> paramClass = clazz.getClassLoader().loadClass(paramValue0.className);
-      classParamValues[0] = ClassParameter.from(paramClass, paramValue0.val);
-    } catch (ClassNotFoundException e) {
-      throw new RuntimeException(e);
-    }
-    for (int i = 0; i < paramValues.length; i++) {
-      try {
-        Class<?> paramClass = clazz.getClassLoader().loadClass(paramValues[i].className);
-        classParamValues[i + 1] = ClassParameter.from(paramClass, paramValues[i].val);
-      } catch (ClassNotFoundException e) {
-        throw new RuntimeException(e);
-      }
-    }
-    return invokeConstructor(clazz, instance, classParamValues);
-  }
-
   public static <R> R invokeConstructor(Class<? extends R> clazz, R instance, ClassParameter... paramValues) {
-    String directMethodName = directMethodName(clazz.getName(), ShadowConstants.CONSTRUCTOR_METHOD_NAME);
-    return (R) ReflectionHelpers.callInstanceMethod(instance, directMethodName, paramValues);
+    String directMethodName = directMethodName(ShadowConstants.CONSTRUCTOR_METHOD_NAME);
+    return (R) ReflectionHelpers.callInstanceMethod(clazz, instance, directMethodName, paramValues);
   }
 
   public static String directMethodName(String methodName) {
-    return String.format(ShadowConstants.ROBO_PREFIX + "%s", methodName);
-  }
-
-  public static String directMethodName(String className, String methodName) {
-    String simpleName = className;
-    int lastDotIndex = simpleName.lastIndexOf(".");
-    if (lastDotIndex != -1) simpleName = simpleName.substring(lastDotIndex + 1);
-    int lastDollarIndex = simpleName.lastIndexOf("$");
-    if (lastDollarIndex != -1) simpleName = simpleName.substring(lastDollarIndex + 1);
-    return String.format(ShadowConstants.ROBO_PREFIX + "%s_%04x_%s", simpleName, className.hashCode() & 0xffff, methodName);
+    return ShadowConstants.ROBO_PREFIX + methodName;
   }
 }

--- a/robolectric-utils/src/main/java/org/robolectric/util/ReflectionHelpers.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/ReflectionHelpers.java
@@ -158,6 +158,37 @@ public class ReflectionHelpers {
   }
 
   /**
+   * Reflectively call an instance method on an object on a specific class.
+   *
+   * @param cl The class.
+   * @param instance Target object.
+   * @param methodName The method name to call.
+   * @param classParameters Array of parameter types and values.
+   * @param <R> The return type.
+   * @return The return value of the method.
+   */
+  public static <R> R callInstanceMethod(Class<?> cl, final Object instance, final String methodName, ClassParameter<?>... classParameters) {
+    try {
+      final Class<?>[] classes = ClassParameter.getClasses(classParameters);
+      final Object[] values = ClassParameter.getValues(classParameters);
+
+      Method declaredMethod = cl.getDeclaredMethod(methodName, classes);
+      declaredMethod.setAccessible(true);
+      return (R) declaredMethod.invoke(instance, values);
+    } catch (InvocationTargetException e) {
+      if (e.getTargetException() instanceof RuntimeException) {
+        throw (RuntimeException) e.getTargetException();
+      }
+      if (e.getTargetException() instanceof Error) {
+        throw (Error) e.getTargetException();
+      }
+      throw new RuntimeException(e.getTargetException());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
    * Reflectively call a static method on a class.
    *
    * @param clazz Target class.

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentingClassLoader.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentingClassLoader.java
@@ -500,7 +500,7 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
       }
 
       InsnList removedInstructions = extractCallToSuperConstructor(method);
-      method.name = Shadow.directMethodName(className, ShadowConstants.CONSTRUCTOR_METHOD_NAME);
+      method.name = Shadow.directMethodName(ShadowConstants.CONSTRUCTOR_METHOD_NAME);
       classNode.methods.add(redirectorMethod(method, ShadowConstants.CONSTRUCTOR_METHOD_NAME));
 
       String[] exceptions = exceptionArray(method);
@@ -573,8 +573,7 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
       }
 
       String originalName = method.name;
-      method.name = Shadow.directMethodName(className, originalName);
-      classNode.methods.add(redirectorMethod(method, Shadow.directMethodName(originalName)));
+      method.name = Shadow.directMethodName(originalName);
 
       MethodNode delegatorMethodNode = new MethodNode(method.access, originalName, method.desc, method.signature, exceptionArray(method));
       delegatorMethodNode.access &= ~(ACC_NATIVE | ACC_ABSTRACT | ACC_FINAL);

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
@@ -1,7 +1,6 @@
 package org.robolectric.internal.bytecode;
 
 import android.content.Context;
-import org.robolectric.internal.SdkConfig;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
@@ -343,12 +342,9 @@ public class ShadowWrangler implements ClassHandler {
         }
 
         if (methodName.startsWith(ShadowConstants.ROBO_PREFIX)) {
-          String fullPrefix = Shadow.directMethodName(stackTraceElement.getClassName(), "");
-          if (methodName.startsWith(fullPrefix)) {
-            methodName = methodName.substring(fullPrefix.length());
-            stackTraceElement = new StackTraceElement(className, methodName,
-                stackTraceElement.getFileName(), stackTraceElement.getLineNumber());
-          }
+          methodName = methodName.substring(ShadowConstants.ROBO_PREFIX.length());
+          stackTraceElement = new StackTraceElement(className, methodName,
+              stackTraceElement.getFileName(), stackTraceElement.getLineNumber());
         }
 
         if (className.startsWith("sun.reflect.") || className.startsWith("java.lang.reflect.")) {

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/InstrumentingClassLoaderTestBase.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/InstrumentingClassLoaderTestBase.java
@@ -98,7 +98,7 @@ abstract public class InstrumentingClassLoaderTestBase {
   @Test
   public void shouldGenerateClassSpecificDirectAccessMethod() throws Exception {
     Class<?> exampleClass = loadClass(AnExampleClass.class);
-    String methodName = Shadow.directMethodName(AnExampleClass.class.getName(), "normalMethod");
+    String methodName = Shadow.directMethodName("normalMethod");
     Method directMethod = exampleClass.getDeclaredMethod(methodName, String.class, int.class);
     directMethod.setAccessible(true);
     Object exampleInstance = exampleClass.newInstance();
@@ -107,18 +107,9 @@ abstract public class InstrumentingClassLoaderTestBase {
   }
 
   @Test
-  public void soMockitoDoesntExplodeDueToTooManyMethods_shouldGenerateDirectAccessMethodWhichIsPrivate() throws Exception {
-    Class<?> exampleClass = loadClass(AnExampleClass.class);
-    String methodName = Shadow.directMethodName("normalMethod");
-    Method directMethod = exampleClass.getDeclaredMethod(methodName, String.class, int.class);
-    assertTrue(Modifier.isPrivate(directMethod.getModifiers()));
-    assertFalse(Modifier.isFinal(directMethod.getModifiers()));
-  }
-
-  @Test
   public void soMockitoDoesntExplodeDueToTooManyMethods_shouldGenerateClassSpecificDirectAccessMethodWhichIsPrivateAndFinal() throws Exception {
     Class<?> exampleClass = loadClass(AnExampleClass.class);
-    String methodName = Shadow.directMethodName(AnExampleClass.class.getName(), "normalMethod");
+    String methodName = Shadow.directMethodName("normalMethod");
     Method directMethod = exampleClass.getDeclaredMethod(methodName, String.class, int.class);
     assertTrue(Modifier.isPrivate(directMethod.getModifiers()));
     assertTrue(Modifier.isFinal(directMethod.getModifiers()));
@@ -137,8 +128,7 @@ abstract public class InstrumentingClassLoaderTestBase {
   @Test
   public void callingStaticDirectAccessMethodShouldWork() throws Exception {
     Class<?> exampleClass = loadClass(AClassWithStaticMethod.class);
-    String methodName = Shadow.directMethodName(
-        AClassWithStaticMethod.class.getName(), "staticMethod");
+    String methodName = Shadow.directMethodName("staticMethod");
     Method directMethod = exampleClass.getDeclaredMethod(methodName, String.class);
     directMethod.setAccessible(true);
     assertEquals("staticMethod(value1)", directMethod.invoke(null, "value1"));
@@ -295,7 +285,7 @@ abstract public class InstrumentingClassLoaderTestBase {
   }
 
   private Method findDirectMethod(Class<?> declaringClass, String methodName, Class<?>... argClasses) throws NoSuchMethodException {
-    String directMethodName = Shadow.directMethodName(declaringClass.getName(), methodName);
+    String directMethodName = Shadow.directMethodName(methodName);
     Method directMethod = declaringClass.getDeclaredMethod(directMethodName, argClasses);
     directMethod.setAccessible(true);
     return directMethod;
@@ -366,7 +356,7 @@ abstract public class InstrumentingClassLoaderTestBase {
     setClassLoader(createClassLoader(new ClassRemappingConfig()));
     Class<?> theClass = loadClass(AClassThatRefersToAForgettableClassInItsConstructor.class);
     Object instance = theClass.newInstance();
-    Method method = theClass.getDeclaredMethod(Shadow.directMethodName(theClass.getName(), ShadowConstants.CONSTRUCTOR_METHOD_NAME));
+    Method method = theClass.getDeclaredMethod(Shadow.directMethodName(ShadowConstants.CONSTRUCTOR_METHOD_NAME));
     method.setAccessible(true);
     method.invoke(instance);
   }
@@ -501,9 +491,8 @@ abstract public class InstrumentingClassLoaderTestBase {
   }
 
   @Test
-  public void directMethodName_shouldGetSimpleName() throws Exception {
-    assertEquals("$$robo$$SomeName_5c63_method", Shadow.directMethodName("a.b.c.SomeName", "method"));
-    assertEquals("$$robo$$SomeName_3b43_method", Shadow.directMethodName("a.b.c.SomeClass$SomeName", "method"));
+  public void directMethodName() throws Exception {
+    assertEquals("$$robo$$method", Shadow.directMethodName("method"));
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/RobolectricInternalsTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/RobolectricInternalsTest.java
@@ -35,51 +35,6 @@ public class RobolectricInternalsTest {
   }
 
   @Test
-  public void getConstructor_withOneStringParam() {
-    Constructors a = new Constructors(PARAM1);
-    ShadowConstructors sa = shadowOf(a);
-
-    assertThat(a.param11).isNull();
-    assertThat(sa.shadowParam11).isEqualTo(PARAM1);
-    
-    Shadow.invokeConstructor(Constructors.class, a, StringParameter.from("java.lang.String", PARAM1));
-    assertThat(a.param11).isEqualTo(PARAM1);
-  }
-
-  @Test
-  public void getConstructor_withTwoStringParams() {
-    Constructors a = new Constructors(PARAM1, PARAM2);
-    ShadowConstructors sa = shadowOf(a);
-
-    assertThat(a.param21).isNull();
-    assertThat(a.param22).isNull();
-    assertThat(sa.shadowParam21).isEqualTo(PARAM1);
-    assertThat(sa.shadowParam22).isEqualTo(PARAM2);
-
-    Shadow.invokeConstructor(Constructors.class, a, StringParameter.from("java.lang.String", PARAM1), StringParameter.from("java.lang.Byte", PARAM2));
-    assertThat(a.param21).isEqualTo(PARAM1);
-    assertThat(a.param22).isEqualTo(PARAM2);
-  }
-
-  @Test
-  public void getConstructor_withThreeStringParams() {
-    Constructors a = new Constructors(PARAM1, PARAM2, PARAM3);
-    ShadowConstructors sa = shadowOf(a);
-
-    assertThat(a.param31).isNull();
-    assertThat(a.param32).isNull();
-    assertThat(a.param33).isNull();
-    assertThat(sa.shadowParam31).isEqualTo(PARAM1);
-    assertThat(sa.shadowParam32).isEqualTo(PARAM2);
-    assertThat(sa.shadowParam33).isEqualTo(PARAM3);
-
-    Shadow.invokeConstructor(Constructors.class, a, StringParameter.from("java.lang.String", PARAM1), StringParameter.from("java.lang.Byte", PARAM2), StringParameter.from("java.lang.Long", PARAM3));
-    assertThat(a.param31).isEqualTo(PARAM1);
-    assertThat(a.param32).isEqualTo(PARAM2);
-    assertThat(a.param33).isEqualTo(PARAM3);
-  }
-
-  @Test
   public void getConstructor_withOneClassParam() {
     Constructors a = new Constructors(PARAM1);
     ShadowConstructors sa = shadowOf(a);


### PR DESCRIPTION
directMethodName() generates a lot of garbage at runtime, around a few thousand object/sec and is unnecessary complex. The method name used to be unique per class because we would find the method recursively during directlyOn() calls but we can just look it up on the class instead, it's an `invokespecial` anyways.

I also removed the "redirectorMethod" because I can't find a use for them.