### PR TITLE
Fix leaky test runners.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/ExperimentalRobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/ExperimentalRobolectricTestRunner.java
@@ -46,11 +46,6 @@ public final class ExperimentalRobolectricTestRunner extends Suite {
     }
 
     @Override
-    protected Statement classBlock(RunNotifier notifier) {
-      return childrenInvoker(notifier);
-    }
-
-    @Override
     public String toString() {
       return "TestClassRunnerForParameters " + name;
     }

--- a/robolectric/src/main/java/org/robolectric/ParameterizedRobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/ParameterizedRobolectricTestRunner.java
@@ -98,11 +98,6 @@ public final class ParameterizedRobolectricTestRunner extends Suite {
     }
 
     @Override
-    protected Statement classBlock(RunNotifier notifier) {
-      return childrenInvoker(notifier);
-    }
-
-    @Override
     public String toString() {
       return "TestClassRunnerForParameters " + name;
     }


### PR DESCRIPTION
Both classes are overriding key behaviour in the parent test runner that  nulls out the test lifecycle preventing it being eligible for gc. This is particularly nasty for the Robolectric suite of tests as the TestLifeCycle holds a reference to its class which in turn holds a reference to its InstrumentingClassloader and all its loaded classes which eats up a lot of permgen.

https://github.com/robolectric/robolectric/issues/1700