### PR TITLE
Fix Permgen leak in BackgroundThread

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowBackgroundThread.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowBackgroundThread.java.vm
@@ -1,0 +1,30 @@
+package org.robolectric.shadows;
+
+#if ($api >= 19)
+
+import com.android.internal.os.BackgroundThread;
+
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
+import org.robolectric.internal.Shadow;
+import org.robolectric.util.ReflectionHelpers;
+
+@Implements(value = BackgroundThread.class, inheritImplementationMethods = true)
+public class ShadowBackgroundThread extends ShadowHandlerThread {
+
+  @Resetter
+  public static void reset() {
+    BackgroundThread instance = ReflectionHelpers.getStaticField(BackgroundThread.class, "sInstance");
+    if (instance != null) {
+      instance.quit();
+      ReflectionHelpers.setStaticField(BackgroundThread.class, "sInstance", null);
+      ReflectionHelpers.setStaticField(BackgroundThread.class, "sHandler", null);
+    }
+  }
+}
+
+#else
+public class ShadowBackgroundThread  {
+  // Does not exist pre KK.
+}
+#end


### PR DESCRIPTION
BackgroundThread (introduced in KK) is a cause of permgen leaks since as a Thread it holds a reference to its contextClassloader.

Shutdown its looper and reset the static Singleton between test runs.

https://github.com/robolectric/robolectric/issues/1700