### PR TITLE
Run tests in headless mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,9 @@
             </includes>
             <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=256m</argLine>
             <runOrder>random</runOrder>
+            <systemProperties>
+              <java.awt.headless>true</java.awt.headless>
+            </systemProperties>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
This stops the JVM from putting an item in the OS X dock which can be really annoying :)