### PR TITLE
Reset shadows before resetting package manager

### DIFF
--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -15,19 +15,18 @@ import static org.robolectric.Shadows.shadowOf;
 
 public class Robolectric {
   private static final ShadowsAdapter shadowsAdapter = instantiateShadowsAdapter();
-  private static ServiceLoader<ShadowProvider> providers;
+  private static Iterable<ShadowProvider> providers;
 
   public static void reset() {
-    RuntimeEnvironment.application = null;
-    RuntimeEnvironment.setRobolectricPackageManager(null);
-    RuntimeEnvironment.setActivityThread(null);
-
     if (providers == null) {
       providers = ServiceLoader.load(ShadowProvider.class);
     }
     for (ShadowProvider provider : providers) {
       provider.reset();
     }
+    RuntimeEnvironment.application = null;
+    RuntimeEnvironment.setRobolectricPackageManager(null);
+    RuntimeEnvironment.setActivityThread(null);
   }
 
   public static ShadowsAdapter getShadowsAdapter() {

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -3,25 +3,26 @@ package org.robolectric.internal;
 import android.app.Application;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
-import java.nio.file.Paths;
+
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.robolectric.*;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.ShadowsAdapter;
+import org.robolectric.TestLifecycle;
 import org.robolectric.annotation.Config;
 import org.robolectric.internal.fakes.RoboInstrumentation;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.ResBunch;
 import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.builder.DefaultPackageManager;
-import org.robolectric.res.builder.RobolectricPackageManager;
 import org.robolectric.util.ReflectionHelpers;
 
 import java.lang.reflect.Method;
 import java.security.Security;
-import org.robolectric.util.TempDirectory;
 
 import static org.robolectric.util.ReflectionHelpers.ClassParameter;
 
@@ -142,13 +143,6 @@ public class ParallelUniverse implements ParallelUniverseInterface {
 
   @Override
   public void tearDownApplication() {
-    // We would like to null this out (which would call reset) but that can kill async threads
-    // that run after a test complete (because they might call Context.getApplicationInfo()).
-    RobolectricPackageManager rpm = RuntimeEnvironment.getRobolectricPackageManager();
-    if (rpm != null) {
-      rpm.reset();
-    }
-
     if (RuntimeEnvironment.application != null) {
       RuntimeEnvironment.application.onTerminate();
     }

--- a/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
@@ -7,16 +7,20 @@ import org.junit.Test;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.InitializationError;
-import org.robolectric.annotation.Config;
+
 import android.content.res.Resources;
 import android.content.res.Configuration;
+
+import org.robolectric.annotation.Config;
 import org.robolectric.internal.ParallelUniverse;
 import org.robolectric.internal.SdkConfig;
+import org.robolectric.res.builder.RobolectricPackageManager;
 
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ParallelUniverseTest {
@@ -63,6 +67,21 @@ public class ParallelUniverseTest {
     assertThat(getQualifiersfromSystemResources()).isEqualTo("large-land-v18");
     assertThat(getQualifiersFromAppAssetManager()).isEqualTo("large-land-v18");
     assertThat(getQualifiersFromSystemAssetManager()).isEqualTo("large-land-v18");
+  }
+  
+  @Test
+  public void tearDownApplication_shouldNotResetPackageManager() {
+    RobolectricPackageManager pm = mock(RobolectricPackageManager.class);
+    RuntimeEnvironment.setRobolectricPackageManager(pm);
+    pu.tearDownApplication();
+    verify(pm, never()).reset();
+  }
+  
+  @Test
+  public void tearDownApplication_invokesOnTerminate() {
+    RuntimeEnvironment.application = mock(Application.class);
+    pu.tearDownApplication();
+    verify(RuntimeEnvironment.application).onTerminate();
   }
   
   private String getQualifiersfromSystemResources() {

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
@@ -2,37 +2,52 @@ package org.robolectric;
 
 import android.app.Application;
 import android.content.res.Resources;
+
+import org.assertj.core.api.Assertions;
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.InitializationError;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.robolectric.annotation.Config;
 import org.robolectric.manifest.AndroidManifest;
+import org.robolectric.res.builder.RobolectricPackageManager;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.util.ReflectionHelpers;
-import java.lang.reflect.Method;
 
-import static org.junit.Assert.*;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 @RunWith(RobolectricTestRunnerSelfTest.RunnerForTesting.class)
 public class RobolectricTestRunnerSelfTest {
 
   @Test
-  public void shouldInitializeAndBindApplicationButNotCallOnCreate() throws Exception {
-    assertNotNull(RuntimeEnvironment.application);
-    assertEquals(MyTestApplication.class, RuntimeEnvironment.application.getClass());
-    assertTrue(((MyTestApplication) RuntimeEnvironment.application).onCreateWasCalled);
-    assertNotNull(ShadowApplication.getInstance().getResourceLoader());
+  public void shouldInitializeAndBindApplicationButNotCallOnCreate() {
+    assertThat(RuntimeEnvironment.application).as("application")
+      .isNotNull()
+      .isInstanceOf(MyTestApplication.class);
+    assertThat(((MyTestApplication) RuntimeEnvironment.application).onCreateWasCalled).as("onCreate called").isTrue();
+    assertThat(ShadowApplication.getInstance().getResourceLoader()).as("resource loader").isNotNull();
   }
 
-  @Test public void shouldSetUpSystemResources() throws Exception {
-    assertNotNull(Resources.getSystem());
-    assertEquals(RuntimeEnvironment.application.getResources().getString(android.R.string.copy),
-        Resources.getSystem().getString(android.R.string.copy));
+  @Test
+  public void shouldSetUpSystemResources() {
+    assertThat(Resources.getSystem()).as("system resources").isNotNull();
+    assertThat(Resources.getSystem().getString(android.R.string.copy)).as("system resource")
+      .isEqualTo(RuntimeEnvironment.application.getResources().getString(android.R.string.copy));
 
-    assertNotNull(RuntimeEnvironment.application.getResources().getString(R.string.howdy));
+    assertThat(RuntimeEnvironment.application.getResources().getString(R.string.howdy)).as("app resource")
+      .isNotNull();
     try {
       Resources.getSystem().getString(R.string.howdy);
-      fail("should have thrown");
+      Assertions.failBecauseExceptionWasNotThrown(Resources.NotFoundException.class);
     } catch (Resources.NotFoundException e) {
     }
   }
@@ -41,26 +56,45 @@ public class RobolectricTestRunnerSelfTest {
   public void setStaticValue_shouldIgnoreFinalModifier() {
     ReflectionHelpers.setStaticField(android.os.Build.class, "MODEL", "expected value");
 
-    assertEquals("expected value", android.os.Build.MODEL);
+    assertThat(android.os.Build.MODEL).isEqualTo("expected value");
   }
 
   @Test
   @Config(qualifiers = "fr")
   public void internalBeforeTest_testValuesResQualifiers() {
     String expectedQualifiers = "fr" + TestRunners.WithDefaults.SDK_TARGETED_BY_MANIFEST;
-    assertEquals(expectedQualifiers, Shadows.shadowOf(ShadowApplication.getInstance().getResources().getAssets()).getQualifiers());
+    assertThat(Shadows.shadowOf(ShadowApplication.getInstance().getResources().getAssets()).getQualifiers()).isEqualTo(expectedQualifiers);
   }
 
   @Test
   public void internalBeforeTest_resetsValuesResQualifiers() {
-    assertEquals("", Shadows.shadowOf(ShadowApplication.getInstance().getResources().getConfiguration()).getQualifiers());
+    assertThat(Shadows.shadowOf(ShadowApplication.getInstance().getResources().getConfiguration()).getQualifiers())
+      .isEqualTo("");
   }
 
   @Test
   public void internalBeforeTest_doesNotSetI18nStrictModeFromSystemIfPropertyAbsent() {
-    assertFalse(ShadowApplication.getInstance().isStrictI18n());
+    assertThat(ShadowApplication.getInstance().isStrictI18n()).isFalse();
   }
 
+  @Before
+  public void clearOrder() {
+    order.clear();
+    RobolectricPackageManager mockManager = mock(RobolectricPackageManager.class);
+    doAnswer(new Answer<Void>() {
+      public Void answer(InvocationOnMock invocation) {
+        order.add("reset");
+        return null;
+      }
+    }).when(mockManager).reset();
+    
+    RuntimeEnvironment.setRobolectricPackageManager(mockManager);
+  }
+  @AfterClass
+  public static void resetStaticState_shouldBeCalled_afterAppTearDown() throws InitializationError {
+    assertThat(order).containsExactly("onTerminate", "reset");
+  }
+    
   public static class RunnerForTesting extends TestRunners.WithDefaults {
     public static RunnerForTesting instance;
 
@@ -80,11 +114,19 @@ public class RobolectricTestRunnerSelfTest {
     }
   }
 
+  private static List<String> order = new ArrayList<>();
+  
   public static class MyTestApplication extends Application {
     private boolean onCreateWasCalled;
 
-    @Override public void onCreate() {
+    @Override
+    public void onCreate() {
       this.onCreateWasCalled = true;
+    }
+    
+    @Override
+    public void onTerminate() {
+      order.add("onTerminate");
     }
   }
 }


### PR DESCRIPTION
This PR lays some groundwork for #1754.

I implemented a fix for #1510 and found that this didn't fix #1754 as I expected. Upon closer inspection, I discovered that the `RobolectricPackageManager.reset()` (which is ultimately what tries to clean up the temp directory for the DBs) was being called *before* the shadows were reset - so my DB cleanup in the shadow connection resetter came too late to fix the problem.

This PR solves this issue by ensuring that the package manager is not reset until after all of the shadows have been reset.

While I was at it I also converted the tests in `RobolectricTestRunnerSelfTest` to use AssertJ rather than plain JUnit assertions.