### PR TITLE
Rename ExperimentalRobolectricTestRunner to MultiApiRobolectricTestRunner

### DIFF
--- a/robolectric/src/test/java/org/robolectric/MultiApiRobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/MultiApiRobolectricTestRunnerTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(JUnit4.class)
-public class ExperimentalRobolectricTestRunnerTest {
+public class MultiApiRobolectricTestRunnerTest {
 
   private int numSupportedApis;
 
@@ -32,7 +32,7 @@ public class ExperimentalRobolectricTestRunnerTest {
 
   @Test
   public void createChildrenForEachSupportedApi() throws Throwable {
-    ExperimentalRobolectricTestRunner runner = new ExperimentalRobolectricTestRunner(TestWithNoConfig.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestWithNoConfig.class);
 
     assertThat(runner.getChildren()).hasSize(numSupportedApis);
 
@@ -43,7 +43,7 @@ public class ExperimentalRobolectricTestRunnerTest {
 
   @Test
   public void noConfig() throws Throwable {
-    ExperimentalRobolectricTestRunner runner = new ExperimentalRobolectricTestRunner(TestWithNoConfig.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestWithNoConfig.class);
 
     RunNotifier runNotifier = new RunNotifier();
     RunListener runListener = mock(RunListener.class);
@@ -56,7 +56,7 @@ public class ExperimentalRobolectricTestRunnerTest {
 
   @Test
   public void classConfig() throws Throwable {
-    ExperimentalRobolectricTestRunner runner = new ExperimentalRobolectricTestRunner(TestWithClassConfig.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestWithClassConfig.class);
 
     assertThat(runner.getChildren()).hasSize(numSupportedApis);
 
@@ -73,7 +73,7 @@ public class ExperimentalRobolectricTestRunnerTest {
 
   @Test
   public void methodConfig() throws Throwable {
-    ExperimentalRobolectricTestRunner runner = new ExperimentalRobolectricTestRunner(TestWithMethodConfig.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestWithMethodConfig.class);
 
     assertThat(runner.getChildren()).hasSize(numSupportedApis);
 
@@ -88,13 +88,13 @@ public class ExperimentalRobolectricTestRunnerTest {
     verify(runListener, times(5)).testFinished(any(Description.class));
   }
 
-  @RunWith(ExperimentalRobolectricTestRunner.class)
+  @RunWith(MultiApiRobolectricTestRunner.class)
   public class TestWithNoConfig {
 
     @Test public void test() {}
   }
 
-  @RunWith(ExperimentalRobolectricTestRunner.class)
+  @RunWith(MultiApiRobolectricTestRunner.class)
   @Config(sdk = 18)
   public class TestWithClassConfig {
 
@@ -103,7 +103,7 @@ public class ExperimentalRobolectricTestRunnerTest {
     }
   }
 
-  @RunWith(ExperimentalRobolectricTestRunner.class)
+  @RunWith(MultiApiRobolectricTestRunner.class)
   public class TestWithMethodConfig {
 
     @Config(sdk = 16)

--- a/robolectric/src/test/java/org/robolectric/MultiApiRobolectricTestRunnerUriTest.java
+++ b/robolectric/src/test/java/org/robolectric/MultiApiRobolectricTestRunnerUriTest.java
@@ -11,8 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author John Ferlisi
  */
-@RunWith(ExperimentalRobolectricTestRunner.class)
-public final class ExperimentalRobolectricTestRunnerUriTest {
+@RunWith(MultiApiRobolectricTestRunner.class)
+public final class MultiApiRobolectricTestRunnerUriTest {
 
   @Test
   @Config(manifest = Config.NONE)

--- a/robolectric/src/test/java/org/robolectric/TestRunners.java
+++ b/robolectric/src/test/java/org/robolectric/TestRunners.java
@@ -2,9 +2,6 @@ package org.robolectric;
 
 import org.junit.runners.model.InitializationError;
 import org.robolectric.annotation.Config;
-import org.robolectric.internal.bytecode.AndroidTranslatorClassInstrumentedTest;
-import org.robolectric.internal.bytecode.ClassInfo;
-import org.robolectric.internal.bytecode.InstrumentingClassLoaderConfig;
 import org.robolectric.internal.bytecode.ShadowMap;
 import org.robolectric.internal.ParallelUniverseInterface;
 import org.robolectric.manifest.AndroidManifest;
@@ -52,6 +49,30 @@ public class TestRunners {
     @Override
     protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetDir) {
       return new AndroidManifest(resourceFile("TestAndroidManifest.xml"), resourceFile("res"), resourceFile("assets"));
+    }
+  }
+
+  public static class MultiApiWithDefaults extends MultiApiRobolectricTestRunner {
+
+    public MultiApiWithDefaults(Class<?> testClass) throws Throwable {
+      super(testClass);
+      Locale.setDefault(Locale.ENGLISH);
+    }
+
+    protected TestRunnerForApiVersion createTestRunner(Integer integer) throws InitializationError {
+      return new DefaultRunnerWithApiVersion(getTestClass().getJavaClass(), integer);
+    }
+
+    private static class DefaultRunnerWithApiVersion extends TestRunnerForApiVersion {
+
+      DefaultRunnerWithApiVersion(Class<?> type, Integer apiVersion) throws InitializationError {
+        super(type, apiVersion);
+      }
+
+      @Override
+      protected AndroidManifest createAppManifest(FsFile manifestFile, FsFile resDir, FsFile assetDir) {
+        return new AndroidManifest(resourceFile("TestAndroidManifest.xml"), resourceFile("res"), resourceFile("assets"));
+      }
     }
   }
 


### PR DESCRIPTION
Create a default configuration version in TestRunners for testing Robolectric classes.

When applied to all Shadow tests there are around 10 ShadowXXXTest classes with issues left to fix.

We need to determine the API for this, I'm thinking

@Config(minSdk = x, maxSdk = y) - which would be totally exclusive with sdk which would run tests ONLY at the specific api specified - thoughts?