### PR TITLE
Add flags to install-robolectric to allow including source and/or javadoc in install.

### DIFF
--- a/scripts/install-robolectric.sh
+++ b/scripts/install-robolectric.sh
@@ -2,28 +2,29 @@
 #
 # Install Robolectric into the local Maven repository.
 #
-
 set -e
 
 PROJECT=$(cd $(dirname "$0")/..; pwd)
+if [ -z ${INCLUDE_SOURCE+x} ]; then SOURCE_ARG=""; else SOURCE_ARG="source:jar"; fi
+if [ -z ${INCLUDE_JAVADOC+x} ]; then JAVADOC_ARG=""; else JAVADOC_ARG="javadoc:jar"; fi
 
 echo "Building Robolectric..."
-cd "$PROJECT"; mvn -D skipTests clean install
+cd "$PROJECT"; mvn -D skipTests clean $SOURCE_ARG $JAVADOC_ARG install
 
 echo "Building shadows for API 16..."
-cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P android-16 clean install
+cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P android-16 clean $SOURCE_ARG $JAVADOC_ARG install
 
 echo "Building shadows for API 17..."
-cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P android-17 clean install
+cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P android-17 clean $SOURCE_ARG $JAVADOC_ARG install
 
 echo "Building shadows for API 18..."
-cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P android-18 clean install
+cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P android-18 clean $SOURCE_ARG $JAVADOC_ARG install
 
 echo "Building shadows for API 19..."
-cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P android-19 clean install
+cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P android-19 clean $SOURCE_ARG $JAVADOC_ARG install
 
 echo "Building shadows for API 21..."
-cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P android-21 clean install
+cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P android-21 clean $SOURCE_ARG $JAVADOC_ARG install
 
 echo "Running Tests..."
 cd "$PROJECT"; mvn test


### PR DESCRIPTION
Changes to the pom.xml in the last few months made source/javadoc not get generated by running  `install-robolectric.sh`. Judging from the commit history this seems intentional, but it can be nice to be able to generate source and javadoc jars for all of the various targets in one simple step. This change makes it possible to do so by specifying a couple environment variables, e.g.:

```bash
$ INCLUDE_SOURCE=1 INCLUDE_JAVADOC=1 scripts/install-robolectric.sh
```