### PR TITLE
Add support for registerNetworkCallback/unregisterNetworkCallback

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowConnectivityManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowConnectivityManager.java.vm
@@ -2,12 +2,19 @@ package org.robolectric.shadows;
 
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+
+#if ($api >= 21)
+import android.net.NetworkRequest;
+#end
+
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.HiddenApi;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 @Implements(ConnectivityManager.class)
 public class ShadowConnectivityManager {
@@ -16,6 +23,10 @@ public class ShadowConnectivityManager {
   private boolean backgroundDataSetting;
   private int networkPreference = ConnectivityManager.DEFAULT_NETWORK_PREFERENCE;
   private final Map<Integer, NetworkInfo> networkTypeToNetworkInfo = new HashMap<>();
+
+#if ($api >= 21)
+  private HashSet<ConnectivityManager.NetworkCallback> networkCallbacks = new HashSet<>();
+#end
 
   public ShadowConnectivityManager() {
     NetworkInfo wifi = ShadowNetworkInfo.newInstance(NetworkInfo.DetailedState.DISCONNECTED, ConnectivityManager.TYPE_WIFI, 0, true, false);
@@ -26,6 +37,31 @@ public class ShadowConnectivityManager {
 
     this.activeNetwork = mobile;
   }
+
+#if ($api >= 21)
+  public Set<ConnectivityManager.NetworkCallback> getNetworkCallbacks() {
+    return networkCallbacks;
+  }
+#end
+
+#if ($api >= 21)
+  @Implementation
+  public void registerNetworkCallback(NetworkRequest request, ConnectivityManager.NetworkCallback networkCallback) {
+    networkCallbacks.add(networkCallback);
+  }
+#end
+
+#if ($api >= 21)
+  @Implementation
+  public void unregisterNetworkCallback (ConnectivityManager.NetworkCallback networkCallback) {
+    if (networkCallback == null) {
+      throw new IllegalArgumentException("Invalid NetworkCallback");
+    }
+    if (networkCallbacks.contains(networkCallback)) {
+      networkCallbacks.remove(networkCallback);
+    }
+  }
+#end
 
   @Implementation
   public NetworkInfo getActiveNetworkInfo() {

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowConnectivityManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowConnectivityManager.java.vm
@@ -42,16 +42,12 @@ public class ShadowConnectivityManager {
   public Set<ConnectivityManager.NetworkCallback> getNetworkCallbacks() {
     return networkCallbacks;
   }
-#end
 
-#if ($api >= 21)
   @Implementation
   public void registerNetworkCallback(NetworkRequest request, ConnectivityManager.NetworkCallback networkCallback) {
     networkCallbacks.add(networkCallback);
   }
-#end
 
-#if ($api >= 21)
   @Implementation
   public void unregisterNetworkCallback (ConnectivityManager.NetworkCallback networkCallback) {
     if (networkCallback == null) {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
@@ -2,13 +2,16 @@ package org.robolectric.shadows;
 
 import android.content.Context;
 import android.net.ConnectivityManager;
+import android.net.Network;
 import android.net.NetworkInfo;
+import android.net.NetworkRequest;
 import android.telephony.TelephonyManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
@@ -105,5 +108,50 @@ public class ShadowConnectivityManagerTest {
     assertThat(connectivityManager.getNetworkPreference()).isEqualTo(connectivityManager.getNetworkPreference());
     connectivityManager.setNetworkPreference(ConnectivityManager.TYPE_WIFI);
     assertThat(connectivityManager.getNetworkPreference()).isEqualTo(ConnectivityManager.TYPE_WIFI);
+  }
+
+  @Test @Config(sdk = 21)
+  public void getNetworkCallbacks_shouldHaveEmptyDefault() throws Exception {
+    assertEquals(0, shadowConnectivityManager.getNetworkCallbacks().size());
+  }
+
+  @Config(sdk = 21)
+  private ConnectivityManager.NetworkCallback getSimpleCallback() {
+    return new ConnectivityManager.NetworkCallback() {
+      @Override
+      public void onAvailable(Network network) {}
+      @Override
+      public void onLost(Network network) {}
+    };
+  }
+
+  @Test @Config(sdk = 21)
+  public void registerCallback_shouldAddCallback() throws Exception {
+    NetworkRequest.Builder builder = new NetworkRequest.Builder();
+    ConnectivityManager.NetworkCallback callback = getSimpleCallback();
+    connectivityManager.registerNetworkCallback(builder.build(), callback);
+    assertEquals(1, shadowConnectivityManager.getNetworkCallbacks().size());
+  }
+
+  @Test @Config(sdk = 21)
+  public void unregisterCallback_shouldRemoveCallbacks() throws Exception {
+    NetworkRequest.Builder builder = new NetworkRequest.Builder();
+    // Add two different callbacks.
+    ConnectivityManager.NetworkCallback callback1 = getSimpleCallback();
+    ConnectivityManager.NetworkCallback callback2 = getSimpleCallback();
+    connectivityManager.registerNetworkCallback(builder.build(), callback1);
+    connectivityManager.registerNetworkCallback(builder.build(), callback2);
+    // Remove one at the time.
+    assertEquals(2, shadowConnectivityManager.getNetworkCallbacks().size());
+    connectivityManager.unregisterNetworkCallback(callback2);
+    assertEquals(1, shadowConnectivityManager.getNetworkCallbacks().size());
+    connectivityManager.unregisterNetworkCallback(callback1);
+    assertEquals(0, shadowConnectivityManager.getNetworkCallbacks().size());
+  }
+
+  @Test(expected=IllegalArgumentException.class) @Config(sdk = 21)
+  public void unregisterCallback_shouldNotAllowNullCallback() throws Exception {
+    // Verify that exception is thrown.
+    connectivityManager.unregisterNetworkCallback(null);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
@@ -115,8 +115,7 @@ public class ShadowConnectivityManagerTest {
     assertEquals(0, shadowConnectivityManager.getNetworkCallbacks().size());
   }
 
-  @Config(sdk = 21)
-  private ConnectivityManager.NetworkCallback getSimpleCallback() {
+  private static ConnectivityManager.NetworkCallback createSimpleCallback() {
     return new ConnectivityManager.NetworkCallback() {
       @Override
       public void onAvailable(Network network) {}
@@ -128,7 +127,7 @@ public class ShadowConnectivityManagerTest {
   @Test @Config(sdk = 21)
   public void registerCallback_shouldAddCallback() throws Exception {
     NetworkRequest.Builder builder = new NetworkRequest.Builder();
-    ConnectivityManager.NetworkCallback callback = getSimpleCallback();
+    ConnectivityManager.NetworkCallback callback = createSimpleCallback();
     connectivityManager.registerNetworkCallback(builder.build(), callback);
     assertEquals(1, shadowConnectivityManager.getNetworkCallbacks().size());
   }
@@ -137,8 +136,8 @@ public class ShadowConnectivityManagerTest {
   public void unregisterCallback_shouldRemoveCallbacks() throws Exception {
     NetworkRequest.Builder builder = new NetworkRequest.Builder();
     // Add two different callbacks.
-    ConnectivityManager.NetworkCallback callback1 = getSimpleCallback();
-    ConnectivityManager.NetworkCallback callback2 = getSimpleCallback();
+    ConnectivityManager.NetworkCallback callback1 = createSimpleCallback();
+    ConnectivityManager.NetworkCallback callback2 = createSimpleCallback();
     connectivityManager.registerNetworkCallback(builder.build(), callback1);
     connectivityManager.registerNetworkCallback(builder.build(), callback2);
     // Remove one at the time.


### PR DESCRIPTION
This change adds support for registerNetworkCallback/unregisterNetworkCallback, which were added in API 21.