### PR TITLE
Fix install_dependencies to install maps.jar

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -54,7 +54,7 @@ function install_maps() {
     exit 1
   fi
 
-  version=`grep ^revision= "${dir}/manifest.ini" | cut -d= -f2`
+  version=`grep --color=never ^revision= "${dir}/manifest.ini" | cut -d= -f2`
 
   if [ "$version" != "$revision" ]; then
     echo "${groupId}:${artifactId} is an incompatible revision! Make sure that 'Google APIs' is up to date in the SDK manager for API ${api}. Expected revision ${revision} but was ${version}."


### PR DESCRIPTION
Depending on the OS, the grep command would include the grep color output
in the version, causing the string comparison to fail if you had
set GREP_OPTIONS to --color=always.