### PR TITLE
Some test tidy-ups for `ShadowContextTest`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
@@ -1,7 +1,6 @@
 package org.robolectric.shadows;
 
 import android.content.Context;
-import android.content.res.Resources;
 import android.content.res.TypedArray;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,9 +21,6 @@ import java.io.IOException;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.robolectric.util.TestUtil.TEST_PACKAGE;
 import static org.robolectric.util.TestUtil.TEST_RESOURCE_PATH;
 
@@ -38,15 +34,17 @@ public class ShadowContextTest {
         .getPackageInfo("org.robolectric", 0).applicationInfo.dataDir);
 
     File[] files = dataDir.listFiles();
-    assertNotNull(files);
-    assertThat(files.length).isEqualTo(0);
+    assertThat(files)
+      .isNotNull()
+      .isEmpty();
   }
 
   @Test
   public void shouldGetApplicationDataDirectory() throws IOException {
     File dataDir = context.getDir("data", Context.MODE_PRIVATE);
-    assertThat(dataDir).isNotNull();
-    assertThat(dataDir.exists()).isTrue();
+    assertThat(dataDir)
+      .isNotNull()
+      .exists();
   }
 
   @Test
@@ -54,11 +52,12 @@ public class ShadowContextTest {
     File dataDir = new File(RuntimeEnvironment.getPackageManager()
         .getPackageInfo("org.robolectric", 0).applicationInfo.dataDir, "data");
 
-    assertThat(dataDir.exists()).isFalse();
+    assertThat(dataDir).doesNotExist();
 
     dataDir = context.getDir("data", Context.MODE_PRIVATE);
-    assertThat(dataDir).isNotNull();
-    assertThat(dataDir.exists()).isTrue();
+    assertThat(dataDir)
+      .isNotNull()
+      .exists();
   }
 
   @Test
@@ -71,56 +70,48 @@ public class ShadowContextTest {
 
   @Test
   public void getCacheDir_shouldCreateDirectory() throws Exception {
-    assertTrue(context.getCacheDir().exists());
+    assertThat(context.getCacheDir()).exists();
   }
 
   @Test
   public void getExternalCacheDir_shouldCreateDirectory() throws Exception {
-    assertTrue(context.getExternalCacheDir().exists());
+    assertThat(context.getExternalCacheDir()).exists();
   }
 
   @Test
   public void shouldWriteToCacheDir() throws Exception {
-    assertNotNull(context.getCacheDir());
+    assertThat(context.getCacheDir()).isNotNull();
     File cacheTest = new File(context.getCacheDir(), "__test__");
 
-    assertThat(cacheTest.getAbsolutePath()).startsWith(System.getProperty("java.io.tmpdir"));
-    assertThat(cacheTest.getAbsolutePath()).endsWith(File.separator + "__test__");
+    assertThat(cacheTest.getAbsolutePath())
+      .startsWith(System.getProperty("java.io.tmpdir"))
+      .endsWith(File.separator + "__test__");
 
-    FileOutputStream fos = null;
-    try {
-      fos = new FileOutputStream(cacheTest);
+    try (FileOutputStream fos = new FileOutputStream(cacheTest)) {
       fos.write("test".getBytes());
-    } finally {
-      if (fos != null)
-        fos.close();
     }
-    assertTrue(cacheTest.exists());
+    assertThat(cacheTest).exists();
   }
 
   @Test
   public void shouldWriteToExternalCacheDir() throws Exception {
-    assertNotNull(context.getExternalCacheDir());
+    assertThat(context.getExternalCacheDir()).isNotNull();
     File cacheTest = new File(context.getExternalCacheDir(), "__test__");
 
-    assertThat(cacheTest.getAbsolutePath()).startsWith(System.getProperty("java.io.tmpdir"));
-    assertThat(cacheTest.getAbsolutePath()).endsWith(File.separator + "__test__");
+    assertThat(cacheTest.getAbsolutePath())
+      .startsWith(System.getProperty("java.io.tmpdir"))
+      .endsWith(File.separator + "__test__");
 
-    FileOutputStream fos = null;
-    try {
-      fos = new FileOutputStream(cacheTest);
+    try (FileOutputStream fos = new FileOutputStream(cacheTest)) {
       fos.write("test".getBytes());
-    } finally {
-      if (fos != null)
-        fos.close();
     }
 
-    assertTrue(cacheTest.exists());
+    assertThat(cacheTest).exists();
   }
 
   @Test
   public void getFilesDir_shouldCreateDirectory() throws Exception {
-    assertTrue(context.getFilesDir().exists());
+    assertThat(context.getFilesDir()).exists();
   }
 
   @Test
@@ -130,14 +121,14 @@ public class ShadowContextTest {
 
   @Test
   public void getExternalFilesDir_shouldCreateDirectory() throws Exception {
-    assertTrue(context.getExternalFilesDir(null).exists());
+    assertThat(context.getExternalFilesDir(null)).exists();
   }
 
   @Test
   public void getExternalFilesDir_shouldCreateNamedDirectory() throws Exception {
     File f = context.getExternalFilesDir("__test__");
-    assertTrue(f.exists());
-    assertTrue(f.getAbsolutePath().endsWith("__test__"));
+    assertThat(f).exists();
+    assertThat(f.getAbsolutePath()).endsWith("__test__");
   }
 
   @Test
@@ -150,7 +141,7 @@ public class ShadowContextTest {
         testDbName = "/absolute/full/path/to/db/abc.db";
       }
       File dbFile = context.getDatabasePath(testDbName);
-      assertEquals(dbFile, new File(testDbName));
+      assertThat(dbFile).isEqualTo(new File(testDbName));
   }
 
   @Test
@@ -158,67 +149,39 @@ public class ShadowContextTest {
     String fileContents = "blah";
 
     File file = new File(context.getFilesDir(), "__test__");
-    FileWriter fileWriter = new FileWriter(file);
-    fileWriter.write(fileContents);
-    fileWriter.close();
+    try (FileWriter fileWriter = new FileWriter(file)) {
+      fileWriter.write(fileContents);
+    }
 
-    FileInputStream fileInputStream = null;
-    try {
-      fileInputStream = context.openFileInput("__test__");
-
+    try (FileInputStream fileInputStream = context.openFileInput("__test__")) {
       byte[] bytes = new byte[fileContents.length()];
       fileInputStream.read(bytes);
       assertThat(bytes).isEqualTo(fileContents.getBytes());
-    } finally {
-      if (fileInputStream != null)
-        fileInputStream.close();
     }
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void openFileInput_shouldNotAcceptPathsWithSeparatorCharacters() throws Exception {
-    FileInputStream fileInputStream = null;
-    try {
-      fileInputStream = context.openFileInput("data" + File.separator + "test");
-    } finally {
-      if (fileInputStream != null)
-        fileInputStream.close();
-    }
+    try (FileInputStream fileInputStream = context.openFileInput("data" + File.separator + "test")) {}
   }
 
   @Test
   public void openFileOutput_shouldReturnAFileOutputStream() throws Exception {
     File file = new File("__test__");
     String fileContents = "blah";
-    FileOutputStream fileOutputStream = null;
-    try {
-      fileOutputStream = context.openFileOutput("__test__", -1);
+    try (FileOutputStream fileOutputStream = context.openFileOutput("__test__", -1)) {
       fileOutputStream.write(fileContents.getBytes());
-    } finally {
-      if (fileOutputStream != null)
-        fileOutputStream.close();
     }
-    FileInputStream fileInputStream = null;
-    try {
-      fileInputStream = new FileInputStream(new File(context.getFilesDir(), file.getName()));
+    try (FileInputStream fileInputStream = new FileInputStream(new File(context.getFilesDir(), file.getName()))) {
       byte[] readBuffer = new byte[fileContents.length()];
       fileInputStream.read(readBuffer);
       assertThat(new String(readBuffer)).isEqualTo(fileContents);
-    } finally {
-      if (fileInputStream != null)
-        fileInputStream.close();
     }
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void openFileOutput_shouldNotAcceptPathsWithSeparatorCharacters() throws Exception {
-    FileOutputStream fos = null;
-    try {
-      fos = context.openFileOutput(File.separator + "data" + File.separator + "test" + File.separator + "hi", 0);
-    } finally {
-      if (fos != null)
-        fos.close();
-    }
+    try (FileOutputStream fos = context.openFileOutput(File.separator + "data" + File.separator + "test" + File.separator + "hi", 0)) {}
   }
 
   @Test
@@ -227,30 +190,16 @@ public class ShadowContextTest {
     String initialFileContents = "foo";
     String appendedFileContents = "bar";
     String finalFileContents = initialFileContents + appendedFileContents;
-    FileOutputStream fileOutputStream = null;
-    try {
-      fileOutputStream = context.openFileOutput("__test__", Context.MODE_APPEND);
+    try (FileOutputStream fileOutputStream = context.openFileOutput("__test__", Context.MODE_APPEND)) {
       fileOutputStream.write(initialFileContents.getBytes());
-    } finally {
-      if (fileOutputStream != null)
-        fileOutputStream.close();
     }
-    try {
-      fileOutputStream = context.openFileOutput("__test__", Context.MODE_APPEND);
+    try (FileOutputStream fileOutputStream = context.openFileOutput("__test__", Context.MODE_APPEND)) {
       fileOutputStream.write(appendedFileContents.getBytes());
-    } finally {
-      if (fileOutputStream != null)
-        fileOutputStream.close();
     }
-    FileInputStream fileInputStream = null;
-    try {
-      fileInputStream = new FileInputStream(new File(context.getFilesDir(), file.getName()));
+    try (FileInputStream fileInputStream = new FileInputStream(new File(context.getFilesDir(), file.getName()))) {
       byte[] readBuffer = new byte[finalFileContents.length()];
       fileInputStream.read(readBuffer);
       assertThat(new String(readBuffer)).isEqualTo(finalFileContents);
-    } finally {
-      if (fileInputStream != null)
-        fileInputStream.close();
     }
   }
 
@@ -259,30 +208,16 @@ public class ShadowContextTest {
     File file = new File("__test__");
     String initialFileContents = "foo";
     String newFileContents = "bar";
-    FileOutputStream fileOutputStream = null;
-    try {
-      fileOutputStream = context.openFileOutput("__test__", 0);
+    try (FileOutputStream fileOutputStream = context.openFileOutput("__test__", 0)) {
       fileOutputStream.write(initialFileContents.getBytes());
-    } finally {
-      if (fileOutputStream != null)
-        fileOutputStream.close();
     }
-    try {
-      fileOutputStream = context.openFileOutput("__test__", 0);
+    try (FileOutputStream fileOutputStream = context.openFileOutput("__test__", 0)) {
       fileOutputStream.write(newFileContents.getBytes());
-    } finally {
-      if (fileOutputStream != null)
-        fileOutputStream.close();
     }
-    FileInputStream fileInputStream = null;
-    try {
-      fileInputStream = new FileInputStream(new File(context.getFilesDir(), file.getName()));
+    try (FileInputStream fileInputStream = new FileInputStream(new File(context.getFilesDir(), file.getName()))) {
       byte[] readBuffer = new byte[newFileContents.length()];
       fileInputStream.read(readBuffer);
       assertThat(new String(readBuffer)).isEqualTo(newFileContents);
-    } finally {
-      if (fileInputStream != null)
-        fileInputStream.close();
     }
   }
 
@@ -307,7 +242,7 @@ public class ShadowContextTest {
   @Test
   public void obtainStyledAttributes_shouldExtractAttributesFromAttributeSet() throws Exception {
     ResourceLoader resourceLoader = new PackageResourceLoader(TEST_RESOURCE_PATH);
-    Resources resources = TestUtil.createResourcesFor(resourceLoader);
+    TestUtil.createResourcesFor(resourceLoader);
 
     RoboAttributeSet roboAttributeSet = new RoboAttributeSet(asList(
         new Attribute(TEST_PACKAGE + ":attr/itemType", "ungulate", TEST_PACKAGE),


### PR DESCRIPTION
* Got rid of raw JUnit assertions in favour of AssertJ.
* Made better use of AssertJ assertions like file existence (`assertThat(file.exists()).isTrue()` => `assertThat(file).exists()`). 
* Chained AssertJ assertions where appropriate for more compact code.
* Changed to take advantage of Java 1.7 try-with-resources syntax for more compact code.