### PR TITLE
issue #1779 : System clock should not fail when application is not ready yet

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
@@ -17,17 +17,28 @@ public class ShadowSystemClock {
   private static final int MILLIS_PER_NANO = 1000000;
 
   static long now() {
+    if(ShadowApplication.getInstance() == null) {
+        return 0;
+    }
     return ShadowApplication.getInstance().getForegroundThreadScheduler().getCurrentTime();
   }
 
   @Implementation
   public static void sleep(long millis) {
+    if(ShadowApplication.getInstance() == null) {
+      return;
+    }
+
     nanoTime = millis * MILLIS_PER_NANO;
     ShadowApplication.getInstance().getForegroundThreadScheduler().advanceBy(millis);
   }
 
   @Implementation
   public static boolean setCurrentTimeMillis(long millis) {
+    if(ShadowApplication.getInstance() == null) {
+      return false;
+    }
+
     if (now() > millis) {
       return false;
     }


### PR DESCRIPTION
This is simple/minimalist patch to avoid SystemClock to fail when application is not ready yet.
The use case is exposed in https://github.com/robolectric/robolectric/issues/1779.

This PR doesn't aim to solve the problem deeply, it is not so elegant, but provides enough robustness to solve the issue and doesn't alter common use case and behaviour of the system clock shadow : the patched state is very transient and is voided when the application becomes ready. It's not really an API change as the behaviour of the clock was not defined during that transient state.