### PR TITLE
Make absolute paths work for getDatabasePath() on Windows.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import android.accounts.AccountManager;
 import android.content.Context;
 import android.os.Build;
+import android.os.FileUtils;
 import android.os.Handler;
 import android.view.Display;
 import android.view.accessibility.AccessibilityManager;
@@ -13,10 +14,14 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
+import java.io.File;
+
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.robolectric.internal.Shadow.directlyOn;
 import static org.robolectric.internal.Shadow.newInstanceOf;
+import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 @Implements(className = ShadowContextImpl.CLASS_NAME)
 public class ShadowContextImpl extends ShadowContext {
@@ -65,6 +70,27 @@ public class ShadowContextImpl extends ShadowContext {
 #if ($api >= 19)
     SYSTEM_SERVICE_MAP.put(Context.PRINT_SERVICE, "android.print.PrintManager");
 #end
+  }
+
+  @Implementation
+  public File validateFilePath(String name, boolean createDirectory) {
+    File dir;
+    File f = new File(name);
+
+    if (f.isAbsolute()) {
+      dir = f.getParentFile();
+    } else {
+      dir = directlyOn(realObject, "android.app.ContextImpl", "getDatabasesDir");
+      f = directlyOn(realObject, "android.app.ContextImpl", "makeFilename", from(File.class, dir), from(String.class, name));
+    }
+
+    if (createDirectory && !dir.isDirectory() && dir.mkdir()) {
+      FileUtils.setPermissions(dir.getPath(),
+          FileUtils.S_IRWXU|FileUtils.S_IRWXG|FileUtils.S_IXOTH,
+          -1, -1);
+    }
+
+    return f;
   }
 
   private Map<String, Object> systemServices = new HashMap<String, Object>();


### PR DESCRIPTION
Was getting the following error:

````
Running org.robolectric.shadows.ShadowContextTest
Tests run: 21, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 7.035 sec <<< FAILURE!
getDatabasePath_shouldAllowAbsolutePaths(org.robolectric.shadows.ShadowContextTest)  Time elapsed: 0.016 sec  <<< ERROR!

java.lang.IllegalArgumentException: File C:\absolute\full\path\to\db\abc.db contains a path separator
        at android.app.ContextImpl.makeFilename(ContextImpl.java:2366)
        at android.app.ContextImpl.validateFilePath(ContextImpl.java:2350)
        at android.app.ContextImpl.getDatabasePath(ContextImpl.java:1159)
        at android.content.ContextWrapper.getDatabasePath(ContextWrapper.java:277)
        at org.robolectric.shadows.ShadowContextTest.getDatabasePath_shouldAllowAbsolutePaths(ShadowContextTest.java:143
```

Managed to track this to #1499 - "Lean on real Android to provide the SQLite database path". Unfortunately it looks like real Android makes assumptions that don't hold on Windows - specifically, it checks for an absolute path in the `name` parameter by looking for a leading separator char. While it uses the OS-independent `File.separator`, the problem is that on Windows of course absolute paths don't start with a separator char - they typically start with the drive letter.

This fix re-implements the offending private method `ContextImpl.validateFilePath()` in a way that is OS-independent, but still leaning on Android as much as possible.