### PR TITLE
ShadowValueAnimator: run infinite animations only once

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowValueAnimator.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowValueAnimator.java
@@ -2,12 +2,21 @@ package org.robolectric.shadows;
 
 import android.animation.ValueAnimator;
 
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
 import org.robolectric.util.ReflectionHelpers;
 
+import static org.robolectric.internal.Shadow.directlyOn;
+
 @Implements(ValueAnimator.class)
 public class ShadowValueAnimator {
+
+  @RealObject
+  private ValueAnimator realObject;
+
+  private int actualRepeatCount;
 
   @Resetter
   public static void reset() {
@@ -21,5 +30,22 @@ public class ShadowValueAnimator {
      * one will be created for each test with a fresh state.
      */
     ReflectionHelpers.setStaticField(ValueAnimator.class, "sAnimationHandler", new ThreadLocal<>());
+  }
+
+  @Implementation
+  public void setRepeatCount(int count) {
+    actualRepeatCount = count;
+    if (count == ValueAnimator.INFINITE) {
+      count = 1;
+    }
+    directlyOn(realObject, ValueAnimator.class).setRepeatCount(count);
+  }
+
+  /**
+   * Returns the value that was set as the repeat count. This is otherwise the same
+   * as getRepeatCount(), except when the count was set to infinite.
+   */
+  public int getActualRepeatCount() {
+    return actualRepeatCount;
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowValueAnimatorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowValueAnimatorTest.java
@@ -4,6 +4,7 @@ import android.animation.ValueAnimator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
 import org.robolectric.util.TimeUtils;
 
@@ -34,5 +35,28 @@ public class ShadowValueAnimatorTest {
     Robolectric.flushForegroundThreadScheduler();
 
     assertThat(values).containsExactly(0, 0, 0, 0, 2, 3, 5, 6, 7, 9, 9, 10);
+  }
+
+  @Test
+  public void test_WithInfiniteRepeatCount_CountIsSetToOne() {
+    final ValueAnimator animator = ValueAnimator.ofInt(0, 10);
+    animator.setRepeatCount(ValueAnimator.INFINITE);
+
+    assertThat(Shadows.shadowOf(animator).getActualRepeatCount()).isEqualTo(ValueAnimator.INFINITE);
+    assertThat(animator.getRepeatCount()).isEqualTo(1);
+  }
+
+  @Test(timeout = 1000)
+  public void test_WhenInfiniteAnimationIsPlayed_AnimationIsOnlyPlayedOnce() {
+    ShadowChoreographer.setFrameInterval(100 * TimeUtils.NANOS_PER_MS);
+
+    final ValueAnimator animator = ValueAnimator.ofInt(0, 10);
+    animator.setDuration(200);
+    animator.setRepeatCount(ValueAnimator.INFINITE);
+
+    animator.start();
+
+    Robolectric.flushForegroundThreadScheduler();
+    assertThat(animator.isRunning()).isFalse();
   }
 }


### PR DESCRIPTION
With the new animation realism, infinite animations keep on, well, just
running infinitely, blocking test execution. For testing purposes, the
shadow sets the repeat count to 1 for such animations, but you can still
obtain the actual set count from the shadow.

Change-Id: If54579dbd5a76123cd9d2ee9f2f9dd2bc44385b1