### PR TITLE
include menu resource types for custom attributes

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/shadows/Converter.java
+++ b/robolectric-resources/src/main/java/org/robolectric/shadows/Converter.java
@@ -83,6 +83,8 @@ public class Converter<T> {
           return;
         } else if (resName.type.equals("interpolator")) {
           return;
+        } else if (resName.type.equals("menu")) {
+          return;
         } else if (DrawableResourceLoader.isStillHandledHere(resName)) {
           // wtf. color and drawable references reference are all kinds of stupid.
           DrawableNode drawableNode = resourceLoader.getDrawableNode(resName, qualifiers);


### PR DESCRIPTION
This fixes a bug where custom attributes in an xml layout that use a menu resource could not be tested.