### PR TITLE
Remove automatic instrumentation of com.google.android.gms package 

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
@@ -124,7 +124,7 @@ public class InstrumentationConfiguration {
       classNameTranslations.put("java.net.ResponseSource", RoboResponseSource.class.getName());
       classNameTranslations.put("java.nio.charset.Charsets", RoboCharsets.class.getName());
 
-      instrumentedPackages.addAll(Arrays.asList("dalvik.", "libcore.", "android.", "com.android.internal.", "com.google.android.gms.", "org.apache.http."));
+      instrumentedPackages.addAll(Arrays.asList("dalvik.", "libcore.", "android.", "com.android.internal.", "org.apache.http."));
       for (ShadowProvider provider : ServiceLoader.load(ShadowProvider.class)) {
         instrumentedPackages.addAll(Arrays.asList(provider.getProvidedPackageNames()));
       }


### PR DESCRIPTION
since this should be instrumented using the ShadowProvider interface (including play servcies shadows on classpath)

Existing tests that relied on having this package instrumented (e.g: for allowing mocks of final classes) can use the following configuration in their test runner temporarily as they shouldn't be relying on this behaviour.

    return InstrumentationConfiguration.newBuilder()
        .addInstrumentedPackage("com.google.android.gms")
        .build();