### PR TITLE
Changed default start time for scheduler from 0 to 100

### DIFF
--- a/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
@@ -23,7 +23,7 @@ import java.util.ListIterator;
  * </ul>
  */
 public class Scheduler {
-  private long currentTime = 0;
+  private long currentTime = 100;
   private boolean paused = false;
   private boolean isConstantlyIdling = false;
   private boolean isExecutingRunnable = false;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
@@ -939,6 +939,7 @@ public class ShadowMediaPlayerTest {
     shadowMediaPlayer.setState(PREPARED);
     shadowMediaPlayer.setSeekDelay(100);
 
+    final long startTime = scheduler.getCurrentTime();
     mediaPlayer.start();
     scheduler.advanceBy(200);
     mediaPlayer.seekTo(450);
@@ -967,7 +968,7 @@ public class ShadowMediaPlayerTest {
     assertThat(scheduler.advanceToLastPostedRunnable()).isTrue();
     Mockito.verify(completionListener).onCompletion(mediaPlayer);
     Mockito.verifyNoMoreInteractions(seekListener);
-    assertThat(scheduler.getCurrentTime()).isEqualTo(750);
+    assertThat(scheduler.getCurrentTime()).isEqualTo(startTime + 750);
     assertThat(mediaPlayer.getCurrentPosition()).isEqualTo(1000);
     assertThat(shadowMediaPlayer.getState()).isEqualTo(PLAYBACK_COMPLETED);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemClockTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemClockTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertTrue;
 public class ShadowSystemClockTest {
   @Test
   public void shouldAllowForFakingOfTime() throws Exception {
-    assertThat(SystemClock.uptimeMillis()).isEqualTo(0);
+    assertThat(SystemClock.uptimeMillis()).isNotEqualTo(1000);
     Robolectric.getForegroundThreadScheduler().advanceTo(1000);
     assertThat(SystemClock.uptimeMillis()).isEqualTo(1000);
   }


### PR DESCRIPTION
This is a fix for the issue identified at #1740, by setting the default system time to be something other than zero.

Arguably this is more realistic but it has the potential to break existing tests that are trying to test time. I had to fix nearly a dozen such instances in a half-dozen of Robolectric's own test classes. @jongerrish offered to test this against his own code base to see how invasive this change might be across a large installed code base.