### PR TITLE
Use invokedynamic for shadows and intrinsics

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSmsManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSmsManager.java.vm
@@ -7,7 +7,6 @@ import android.telephony.SmsManager;
 import android.text.TextUtils;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
-import org.robolectric.annotation.RealObject;
 import org.robolectric.internal.Shadow;
 
 /**
@@ -15,7 +14,6 @@ import org.robolectric.internal.Shadow;
  */
 @Implements(SmsManager.class)
 public class ShadowSmsManager {
-  @RealObject
   private static SmsManager realManager = Shadow.newInstanceOf(SmsManager.class);
   private TextSmsParams lastTextSmsParams;
   private TextMultipartParams lastTextMultipartParams;

--- a/robolectric-utils/pom.xml
+++ b/robolectric-utils/pom.xml
@@ -24,7 +24,25 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Project Dependencies -->
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>5.0.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+      <version>5.0.1</version>
+    </dependency>
+
     <dependency>
       <groupId>org.robolectric</groupId>
       <artifactId>android-all</artifactId>

--- a/robolectric-utils/src/main/java/org/robolectric/internal/ProxyMaker.java
+++ b/robolectric-utils/src/main/java/org/robolectric/internal/ProxyMaker.java
@@ -1,0 +1,117 @@
+package org.robolectric.internal;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+import sun.misc.Unsafe;
+
+import static org.objectweb.asm.Opcodes.ACC_FINAL;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.V1_7;
+
+public class ProxyMaker {
+  private static final String TARGET_FIELD = "__proxy__";
+  private static final String PROXY_NAME =
+      Type.getInternalName(ProxyMaker.class) + "$GeneratedProxy";
+  private static final Type PROXY_TYPE = Type.getType(PROXY_NAME);
+
+  private static final Unsafe UNSAFE;
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.publicLookup();
+
+  static {
+    try {
+      Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+      unsafeField.setAccessible(true);
+      UNSAFE = (Unsafe) unsafeField.get(null);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private final MethodMapper methodMapper;
+  private final ClassValue<Factory> factories;
+
+  public ProxyMaker(MethodMapper methodMapper) {
+    this.methodMapper = methodMapper;
+    factories = new ClassValue<Factory>() {
+      @Override protected Factory computeValue(Class<?> type) {
+        return createProxyFactory(type);
+      }
+    };
+  }
+
+  public <T> T createProxy(Class<T> targetClass, T target) {
+    return factories.get(targetClass).createProxy(targetClass, target);
+  }
+
+  <T> Factory createProxyFactory(Class<T> targetClass) {
+    Type targetType = Type.getType(targetClass);
+    String targetName = targetType.getInternalName();
+    ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES| ClassWriter.COMPUTE_MAXS);
+    writer.visit(V1_7, ACC_PUBLIC | ACC_SUPER | ACC_FINAL, PROXY_NAME, null, targetName, null);
+
+    writer.visitField(ACC_PUBLIC, TARGET_FIELD, targetType.getDescriptor(), null, null);
+
+    for (java.lang.reflect.Method method : targetClass.getMethods()) {
+      if (!shouldProxy(method)) continue;
+
+      Method proxyMethod = Method.getMethod(method);
+      GeneratorAdapter m = new GeneratorAdapter(ACC_PUBLIC, Method.getMethod(method), null, null, writer);
+      m.loadThis();
+      m.getField(PROXY_TYPE, TARGET_FIELD, targetType);
+      m.loadArgs();
+      String targetMethod = methodMapper.getName(targetClass.getName(), method.getName());
+      // In Java 8 we could use invokespecial here but not in 7, from jvm spec:
+      // If an invokespecial instruction names a method which is not an instance
+      // initialization method, then the type of the target reference on the operand
+      // stack must be assignment compatible with the current class (JLS §5.2).
+      m.visitMethodInsn(INVOKEVIRTUAL, targetName, targetMethod, proxyMethod.getDescriptor(), false);
+      m.returnValue();
+      m.endMethod();
+    }
+
+    writer.visitEnd();
+
+    final Class<?> proxyClass = UNSAFE.defineAnonymousClass(targetClass, writer.toByteArray(), null);
+
+    try {
+      final MethodHandle setter = LOOKUP.findSetter(proxyClass, TARGET_FIELD, targetClass);
+      return new Factory() {
+        @Override public <E> E createProxy(Class<E> targetClass, E target) {
+          try {
+            Object proxy = UNSAFE.allocateInstance(proxyClass);
+
+            setter.invoke(proxy, target);
+
+            return targetClass.cast(proxy);
+          } catch (Throwable t) {
+            throw new AssertionError(t);
+          }
+        }
+      };
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static boolean shouldProxy(java.lang.reflect.Method method) {
+    int modifiers = method.getModifiers();
+    return !Modifier.isAbstract(modifiers) && !Modifier.isFinal(modifiers) && !Modifier.isPrivate(
+        modifiers) && !Modifier.isNative(modifiers);
+  }
+
+  interface MethodMapper {
+    String getName(String className, String methodName);
+  }
+
+  interface Factory {
+    <T> T createProxy(Class<T> targetClass, T target);
+  }
+}

--- a/robolectric-utils/src/main/java/org/robolectric/internal/Shadow.java
+++ b/robolectric-utils/src/main/java/org/robolectric/internal/Shadow.java
@@ -1,11 +1,18 @@
 package org.robolectric.internal;
 
 import org.robolectric.internal.bytecode.DirectObjectMarker;
+import org.robolectric.internal.bytecode.InvokeDynamic;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 import org.robolectric.util.ReflectionHelpers.StringParameter;
 
 public class Shadow {
+  private static final ProxyMaker PROXY_MAKER = new ProxyMaker(new ProxyMaker.MethodMapper() {
+    @Override public String getName(String className, String methodName) {
+      return directMethodName(methodName);
+    }
+  });
+
   public static <T> T newInstanceOf(Class<T> clazz) {
     return ReflectionHelpers.callConstructor(clazz);
   }
@@ -26,7 +33,13 @@ public class Shadow {
   }
 
   public static <T> T directlyOn(T shadowedObject, Class<T> clazz) {
-    return ReflectionHelpers.callConstructor(clazz, ClassParameter.fromComponentLists(new Class[]{DirectObjectMarker.class, clazz}, new Object[]{DirectObjectMarker.INSTANCE, shadowedObject}));
+    if (InvokeDynamic.ENABLED) {
+      return PROXY_MAKER.createProxy(clazz, shadowedObject);
+    } else {
+      return ReflectionHelpers.callConstructor(clazz,
+          ClassParameter.fromComponentLists(new Class[] { DirectObjectMarker.class, clazz },
+              new Object[] { DirectObjectMarker.INSTANCE, shadowedObject }));
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/robolectric-utils/src/main/java/org/robolectric/internal/bytecode/InvokeDynamic.java
+++ b/robolectric-utils/src/main/java/org/robolectric/internal/bytecode/InvokeDynamic.java
@@ -1,0 +1,23 @@
+package org.robolectric.internal.bytecode;
+
+import org.robolectric.util.JavaVersion;
+
+public class InvokeDynamic {
+  public static final boolean ENABLED = useInvokeDynamic();
+
+  private static final String ENABLE_INVOKEDYNAMIC = "robolectric.invokedynamic.enable";
+  // We currently crash on versions earlier than 8u40 because of a bug in the C2 compiler.
+  // This seems to be the bug http://bugs.java.com/view_bug.do?bug_id=8059556 but I have been
+  // unable to pinpoint exactly why this affects us.
+  private static final String INVOKEDYNAMIC_MINIMUM_VERSION = "1.8.0_40";
+
+  private static boolean useInvokeDynamic() {
+    String property = System.getProperty(ENABLE_INVOKEDYNAMIC);
+    if (property != null) {
+      return Boolean.valueOf(property);
+    } else {
+      JavaVersion javaVersion = new JavaVersion(System.getProperty("java.version"));
+      return javaVersion.compareTo(new JavaVersion(INVOKEDYNAMIC_MINIMUM_VERSION)) >= 0;
+    }
+  }
+}

--- a/robolectric-utils/src/main/java/org/robolectric/util/JavaVersion.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/JavaVersion.java
@@ -1,0 +1,31 @@
+package org.robolectric.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+public class JavaVersion implements Comparable<JavaVersion> {
+  private final List<Integer> versions;
+
+  public JavaVersion(String version) {
+    versions = new ArrayList<>();
+    Scanner s = new Scanner(version).useDelimiter("[^\\d]+");
+    while (s.hasNext()) {
+      versions.add(s.nextInt());
+    }
+  }
+
+  @Override public int compareTo(JavaVersion o) {
+    List<Integer> versions2 = o.versions;
+    int max = Math.min(versions.size(), versions2.size());
+    for (int i = 0; i < max; i++) {
+      int compare = versions.get(i).compareTo(versions2.get(i));
+      if (compare != 0) {
+        return compare;
+      }
+    }
+
+    // Assume longer is newer
+    return Integer.compare(versions.size(), versions2.size());
+  }
+}

--- a/robolectric-utils/src/test/java/org/robolectric/internal/ProxyMakerTest.java
+++ b/robolectric-utils/src/test/java/org/robolectric/internal/ProxyMakerTest.java
@@ -1,0 +1,65 @@
+package org.robolectric.internal;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ProxyMakerTest {
+  private static final ProxyMaker.MethodMapper IDENTITY_NAME = new ProxyMaker.MethodMapper() {
+    @Override public String getName(String className, String methodName) {
+      return methodName;
+    }
+  };
+
+  @Test
+  public void proxyCall() {
+    ProxyMaker maker = new ProxyMaker(IDENTITY_NAME);
+
+    Thing mock = mock(Thing.class);
+    Thing proxy = maker.createProxyFactory(Thing.class).createProxy(Thing.class, mock);
+    assertThat(proxy.getClass()).isNotSameAs(Thing.class);
+
+    proxy.returnNothing();
+    verify(mock).returnNothing();
+
+    when(mock.returnInt()).thenReturn(42);
+    assertThat(proxy.returnInt()).isEqualTo(42);
+    verify(mock).returnInt();
+
+    proxy.argument("hello");
+    verify(mock).argument("hello");
+  }
+
+  @Test
+  public void cachesProxyClass() {
+    ProxyMaker maker = new ProxyMaker(IDENTITY_NAME);
+    Thing thing1 = mock(Thing.class);
+    Thing thing2 = mock(Thing.class);
+
+    Thing proxy1 = maker.createProxy(Thing.class, thing1);
+    Thing proxy2 = maker.createProxy(Thing.class, thing2);
+
+    assertThat(proxy1.getClass()).isSameAs(proxy2.getClass());
+  }
+
+  public class Thing {
+    public Thing() {
+      throw new UnsupportedOperationException();
+    }
+
+    public void returnNothing() {
+      throw new UnsupportedOperationException();
+    }
+
+    public int returnInt() {
+      throw new UnsupportedOperationException();
+    }
+
+    public void argument(String arg) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/robolectric-utils/src/test/java/org/robolectric/internal/bytecode/JavaVersionTest.java
+++ b/robolectric-utils/src/test/java/org/robolectric/internal/bytecode/JavaVersionTest.java
@@ -1,0 +1,48 @@
+package org.robolectric.internal.bytecode;
+
+import org.junit.Test;
+import org.robolectric.util.JavaVersion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaVersionTest {
+  @Test
+  public void jdk8() {
+    check("1.8.1u40", "1.8.5u60");
+    check("1.8.0u40", "1.8.0u60");
+    check("1.8.0u40", "1.8.0u100");
+  }
+
+  @Test
+  public void jdk9() {
+    check("9.0.1+12", "9.0.2+12");
+    check("9.0.2+60", "9.0.2+100");
+  }
+
+  @Test
+  public void differentJdk() {
+    check("1.7.0", "1.8.0u60");
+    check("1.8.1u40", "9.0.2+12");
+  }
+
+  @Test
+  public void longer() {
+    check("1.8.0", "1.8.0.1");
+  }
+
+  @Test
+  public void longerEquality() {
+    checkEqual("1.8.0", "1.8.0");
+    checkEqual("1.8.0u33", "1.8.0u33");
+    checkEqual("5", "5");
+  }
+
+  private static void check(String v1, String v2) {
+    assertThat(new JavaVersion(v1).compareTo(new JavaVersion(v2))).isNegative();
+  }
+
+  private static void checkEqual(String v1, String v2) {
+    assertThat(new JavaVersion(v1).compareTo(new JavaVersion(v2))).isZero();
+  }
+
+}

--- a/robolectric/src/main/java/org/robolectric/internal/SdkEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SdkEnvironment.java
@@ -1,5 +1,6 @@
 package org.robolectric.internal;
 
+import org.robolectric.internal.bytecode.ShadowInvalidator;
 import org.robolectric.internal.dependency.DependencyResolver;
 import org.robolectric.internal.bytecode.ShadowMap;
 import org.robolectric.internal.bytecode.ShadowWrangler;
@@ -15,12 +16,15 @@ import java.util.Map;
 public class SdkEnvironment {
   private final SdkConfig sdkConfig;
   private final ClassLoader robolectricClassLoader;
+  private final ShadowInvalidator shadowInvalidator;
   public final Map<ShadowMap, ShadowWrangler> classHandlersByShadowMap = new HashMap<>();
+  private ShadowMap shadowMap = ShadowMap.EMPTY;
   private ResourceLoader systemResourceLoader;
 
   public SdkEnvironment(SdkConfig sdkConfig, ClassLoader robolectricClassLoader) {
     this.sdkConfig = sdkConfig;
     this.robolectricClassLoader = robolectricClassLoader;
+    shadowInvalidator = new ShadowInvalidator();
   }
 
   public PackageResourceLoader createSystemResourceLoader(DependencyResolver dependencyResolver) {
@@ -54,7 +58,17 @@ public class SdkEnvironment {
     return robolectricClassLoader;
   }
 
+  public ShadowInvalidator getShadowInvalidator() {
+    return shadowInvalidator;
+  }
+
   public SdkConfig getSdkConfig() {
     return sdkConfig;
+  }
+
+  public ShadowMap replaceShadowMap(ShadowMap shadowMap) {
+    ShadowMap oldMap = this.shadowMap;
+    this.shadowMap = shadowMap;
+    return oldMap;
   }
 }

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/ClassHandler.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/ClassHandler.java
@@ -1,11 +1,20 @@
 package org.robolectric.internal.bytecode;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+
 public interface ClassHandler {
   void classInitializing(Class clazz);
 
   Object initializing(Object instance);
 
   Plan methodInvoked(String signature, boolean isStatic, Class<?> theClass);
+
+  MethodHandle getShadowCreator(Class<?> caller);
+
+  MethodHandle findShadowMethod(Class<?> theClass, String name, MethodType type,
+      boolean isStatic)
+      throws IllegalAccessException;
 
   Object intercept(String signature, Object instance, Object[] params, Class theClass) throws Throwable;
 

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
@@ -114,22 +114,7 @@ public class InstrumentationConfiguration {
     }
 
     public InstrumentationConfiguration build() {
-      interceptedMethods.addAll(Arrays.asList(
-          new MethodRef(LinkedHashMap.class, "eldest"),
-          new MethodRef(System.class, "loadLibrary"),
-          new MethodRef("android.os.StrictMode", "trackActivity"),
-          new MethodRef("android.os.StrictMode", "incrementExpectedActivityCount"),
-          new MethodRef("java.lang.AutoCloseable", "*"),
-          new MethodRef("android.util.LocaleUtil", "getLayoutDirectionFromLocale"),
-          new MethodRef("com.android.internal.policy.PolicyManager", "*"),
-          new MethodRef("android.view.FallbackEventHandler", "*"),
-          new MethodRef("android.view.IWindowSession", "*"),
-          new MethodRef("java.lang.System", "nanoTime"),
-          new MethodRef("java.lang.System", "currentTimeMillis"),
-          new MethodRef("java.lang.System", "arraycopy"),
-          new MethodRef("java.lang.System", "logE"),
-          new MethodRef("java.util.Locale", "adjustLanguageCode")
-      ));
+      interceptedMethods.addAll(Intrinsics.allRefs());
       classesToNotAquire.addAll(stringify(
           TestLifecycle.class,
           ShadowWrangler.class,
@@ -145,6 +130,7 @@ public class InstrumentationConfiguration {
           XmlBlock.class,
           ClassHandler.class,
           ClassHandler.Plan.class,
+          ShadowInvalidator.class,
           RealObject.class,
           Implements.class,
           Implementation.class,
@@ -318,50 +304,5 @@ public class InstrumentationConfiguration {
     result = 31 * result + classesToNotAquire.hashCode();
     cachedHashCode = result;
     return result;
-  }
-
-  /**
-   * Reference to a specific method on a class.
-   */
-  public static class MethodRef {
-    public final String className;
-    public final String methodName;
-
-    public MethodRef(Class<?> clazz, String methodName) {
-      this(clazz.getName(), methodName);
-    }
-
-    public MethodRef(String className, String methodName) {
-      this.className = className;
-      this.methodName = methodName;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-
-      MethodRef methodRef = (MethodRef) o;
-
-      if (!className.equals(methodRef.className)) return false;
-      if (!methodName.equals(methodRef.methodName)) return false;
-
-      return true;
-    }
-
-    @Override
-    public int hashCode() {
-      int result = className.hashCode();
-      result = 31 * result + methodName.hashCode();
-      return result;
-    }
-
-    @Override
-    public String toString() {
-      return "MethodRef{" +
-          "className='" + className + '\'' +
-          ", methodName='" + methodName + '\'' +
-          '}';
-    }
   }
 }

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentingClassLoader.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentingClassLoader.java
@@ -1,8 +1,13 @@
 package org.robolectric.internal.bytecode;
 
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -16,6 +21,7 @@ import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.InvokeDynamicInsnNode;
 import org.objectweb.asm.tree.LdcInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
@@ -39,6 +45,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 
+import static java.lang.invoke.MethodType.methodType;
 import static org.objectweb.asm.Type.ARRAY;
 import static org.objectweb.asm.Type.OBJECT;
 import static org.objectweb.asm.Type.VOID;
@@ -61,12 +68,32 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
   private static final String DIRECT_OBJECT_MARKER_TYPE_DESC = Type.getObjectType(DirectObjectMarker.class.getName().replace('.', '/')).getDescriptor();
   private static final String ROBO_INIT_METHOD_NAME = "$$robo$init";
   private static final String GET_ROBO_DATA_SIGNATURE = "()Ljava/lang/Object;";
+  private static final Handle BOOTSTRAP_INIT;
+  private static final Handle BOOTSTRAP;
+  private static final Handle BOOTSTRAP_STATIC;
+  private static final Handle BOOTSTRAP_INTRINSIC;
+
+  static {
+    String className = Type.getInternalName(InvokeDynamicSupport.class);
+
+    MethodType boostrap =
+        methodType(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class);
+    String bootstrapMethod =
+        boostrap.appendParameterTypes(MethodHandle.class).toMethodDescriptorString();
+    String bootstrapIntristic =
+        boostrap.appendParameterTypes(String.class).toMethodDescriptorString();
+
+    BOOTSTRAP_INIT = new Handle(H_INVOKESTATIC, className, "bootstrapInit", boostrap.toMethodDescriptorString());
+    BOOTSTRAP = new Handle(H_INVOKESTATIC, className, "bootstrap", bootstrapMethod);
+    BOOTSTRAP_STATIC = new Handle(H_INVOKESTATIC, className, "bootstrapStatic", bootstrapMethod);
+    BOOTSTRAP_INTRINSIC = new Handle(H_INVOKESTATIC, className, "bootstrapIntrinsic", bootstrapIntristic);
+  }
 
   private final URLClassLoader urls;
   private final InstrumentationConfiguration config;
   private final Map<String, Class> classes = new HashMap<>();
   private final Map<String, String> classesToRemap;
-  private final Set<InstrumentationConfiguration.MethodRef> methodsToIntercept;
+  private final Set<MethodRef> methodsToIntercept;
 
   public InstrumentingClassLoader(InstrumentationConfiguration config, URL... urls) {
     super(InstrumentingClassLoader.class.getClassLoader());
@@ -346,10 +373,10 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
     return newMap;
   }
 
-  private Set<InstrumentationConfiguration.MethodRef> convertToSlashes(Set<InstrumentationConfiguration.MethodRef> methodRefs) {
-    HashSet<InstrumentationConfiguration.MethodRef> transformed = new HashSet<>();
-    for (InstrumentationConfiguration.MethodRef methodRef : methodRefs) {
-      transformed.add(new InstrumentationConfiguration.MethodRef(internalize(methodRef.className), methodRef.methodName));
+  private Set<MethodRef> convertToSlashes(Set<MethodRef> methodRefs) {
+    HashSet<MethodRef> transformed = new HashSet<>();
+    for (MethodRef methodRef : methodRefs) {
+      transformed.add(new MethodRef(internalize(methodRef.className), methodRef.methodName));
     }
     return transformed;
   }
@@ -377,6 +404,9 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
     public void instrument() {
       makePublic(classNode);
       classNode.access = classNode.access & ~ACC_FINAL;
+
+      // Need Java version >=7 to allow invokedynamic
+      classNode.version = Math.max(classNode.version, V1_7);
 
       Set<String> foundMethods = new HashSet<>();
       List<MethodNode> methods = new ArrayList<>(classNode.methods);
@@ -408,7 +438,7 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
         classNode.methods.add(defaultConstructor);
       }
 
-      {
+      if (!InvokeDynamic.ENABLED) {
         MethodNode directCallConstructor = new MethodNode(ACC_PUBLIC,
             "<init>", "(" + DIRECT_OBJECT_MARKER_TYPE_DESC + classType.getDescriptor() + ")V", null, null);
         MyGenerator m = new MyGenerator(directCallConstructor);
@@ -442,7 +472,12 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
         m.ifNonNull(alreadyInitialized);
         m.loadThis();                                         // this
         m.loadThis();                                         // this, this
-        m.invokeStatic(ROBOLECTRIC_INTERNALS_TYPE, INITIALIZING_METHOD); // this, __robo_data__
+        if (InvokeDynamic.ENABLED) {
+          m.invokeDynamic("initializing", Type.getMethodDescriptor(OBJECT_TYPE, classType), BOOTSTRAP_INIT);
+        } else {
+          m.invokeStatic(ROBOLECTRIC_INTERNALS_TYPE, INITIALIZING_METHOD);
+        }
+        // this, __robo_data__
         m.putField(classType, ShadowConstants.CLASS_HANDLER_DATA_FIELD_NAME, OBJECT_TYPE);
         m.mark(alreadyInitialized);
         m.returnValue();
@@ -509,7 +544,7 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
 
       m.loadThis();
       m.invokeVirtual(classType, new Method(ROBO_INIT_METHOD_NAME, "()V"));
-      generateCallToClassHandler(method, ShadowConstants.CONSTRUCTOR_METHOD_NAME, m);
+      generateShadowCall(method, ShadowConstants.CONSTRUCTOR_METHOD_NAME, m);
 
       m.endMethod();
       classNode.methods.add(methodNode);
@@ -558,7 +593,6 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
     }
 
     private void instrumentNormalMethod(MethodNode method) {
-      makePrivate(method);
       if ((method.access & ACC_ABSTRACT) == 0) method.access = method.access | ACC_FINAL;
       if ((method.access & ACC_NATIVE) != 0) {
         method.access = method.access & ~ACC_NATIVE;
@@ -574,11 +608,12 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
 
       MethodNode delegatorMethodNode = new MethodNode(method.access, originalName, method.desc, method.signature, exceptionArray(method));
       delegatorMethodNode.access &= ~(ACC_NATIVE | ACC_ABSTRACT | ACC_FINAL);
-      makePublic(delegatorMethodNode);
+
+      makePrivate(method);
 
       MyGenerator m = new MyGenerator(delegatorMethodNode);
 
-      generateCallToClassHandler(method, originalName, m);
+      generateShadowCall(method, originalName, m);
 
       m.endMethod();
 
@@ -628,7 +663,11 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
             if (isGregorianCalendar(targetMethod)) {
               replaceNastyGregorianCalendarConstructor(instructions, targetMethod);
             } else if (shouldIntercept(targetMethod)) {
-              interceptNastyMethod(instructions, targetMethod);
+              if (InvokeDynamic.ENABLED) {
+                invokeDynamicNastyMethod(instructions, targetMethod);
+              } else {
+                interceptNastyMethod(instructions, targetMethod);
+              }
             }
             break;
 
@@ -656,6 +695,20 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
 
       // Call GregorianCalendar(int, int, int)
       instructions.add(new MethodInsnNode(INVOKESPECIAL, targetMethod.owner, targetMethod.name, "(III)V", targetMethod.itf));
+    }
+
+    private void invokeDynamicNastyMethod(ListIterator<AbstractInsnNode> instructions, MethodInsnNode targetMethod) {
+      instructions.remove(); // remove the method invocation
+
+      Type type = Type.getObjectType(targetMethod.owner);
+      String description = targetMethod.desc;
+      if (targetMethod.getOpcode() != INVOKESTATIC) {
+        String thisType = type.getDescriptor();
+        description = "(" + thisType + description.substring(1, description.length());
+      }
+
+      String owner = type.getClassName();
+      instructions.add(new InvokeDynamicInsnNode(targetMethod.name, description, BOOTSTRAP_INTRINSIC, owner));
     }
 
     private void interceptNastyMethod(ListIterator<AbstractInsnNode> instructions, MethodInsnNode targetMethod) {
@@ -769,6 +822,36 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
       m.returnValue();
       m.endMethod();
       return methodNode;
+    }
+
+    private void generateShadowCall(MethodNode originalMethod, String originalMethodName, MyGenerator m) {
+      if (InvokeDynamic.ENABLED) {
+        generateInvokeDynamic(originalMethod, originalMethodName, m);
+      } else {
+        generateCallToClassHandler(originalMethod, originalMethodName, m);
+      }
+    }
+
+    private int getTag(MethodNode m) {
+      return Modifier.isStatic(m.access) ? H_INVOKESTATIC : H_INVOKESPECIAL;
+    }
+
+    private void generateInvokeDynamic(MethodNode originalMethod, String originalMethodName, MyGenerator m) {
+      Handle original =
+          new Handle(getTag(originalMethod), classType.getInternalName(), originalMethod.name,
+              originalMethod.desc);
+
+      if (m.isStatic()) {
+        m.loadArgs();
+        m.invokeDynamic(originalMethodName, originalMethod.desc, BOOTSTRAP_STATIC, original);
+      } else {
+        String desc = "(" + classType.getDescriptor() + originalMethod.desc.substring(1);
+        m.loadThis();
+        m.loadArgs();
+        m.invokeDynamic(originalMethodName, desc, BOOTSTRAP, original);
+      }
+
+      m.returnValue();
     }
 
     private void generateCallToClassHandler(MethodNode originalMethod, String originalMethodName, MyGenerator m) {
@@ -942,8 +1025,8 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
 
   private boolean shouldIntercept(MethodInsnNode targetMethod) {
     if (targetMethod.name.equals("<init>")) return false; // sorry, can't strip out calls to super() in constructor
-    return methodsToIntercept.contains(new InstrumentationConfiguration.MethodRef(targetMethod.owner, targetMethod.name))
-        || methodsToIntercept.contains(new InstrumentationConfiguration.MethodRef(targetMethod.owner, "*"));
+    return methodsToIntercept.contains(new MethodRef(targetMethod.owner, targetMethod.name))
+        || methodsToIntercept.contains(new MethodRef(targetMethod.owner, "*"));
   }
 
   /**

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/Intrinsics.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/Intrinsics.java
@@ -1,0 +1,142 @@
+package org.robolectric.internal.bytecode;
+
+import android.content.Context;
+import android.view.Window;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.robolectric.shadows.ShadowSystemClock;
+import org.robolectric.shadows.ShadowWindow;
+
+import static java.lang.invoke.MethodHandles.constant;
+import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.identity;
+import static java.lang.invoke.MethodType.methodType;
+
+public enum Intrinsics {
+  ELDEST(LinkedHashMap.class, "eldest"),
+  LOAD_LIBRARY(System.class, "loadLibrary"),
+  TRACK_ACTIVITY("android.os.StrictMode", "trackActivity"),
+  INCREMENT_EXPECTED_ACTIVITY_COUNT("android.os.StrictMode", "incrementExpectedActivityCount"),
+  AUTO_CLOSEABLE("java.lang.AutoCloseable", "*"),
+  GET_LAYOUT_DIRECTION_FROM_LOCALE("android.util.LocaleUtil", "getLayoutDirectionFromLocale"),
+  MAKE_NEW_WINDOW("com.android.internal.policy.PolicyManager", "makeNewWindow"),
+  POLICY_MANAGER("com.android.internal.policy.PolicyManager", "*"),
+  FALLBACK_EVENT_HANDLER("android.view.FallbackEventHandler", "*"),
+  I_WINDOW_SESSION("android.view.IWindowSession", "*"),
+  NANO_TIME("java.lang.System", "nanoTime"),
+  CURRENT_TIME_MILLIS("java.lang.System", "currentTimeMillis"),
+  ARRAYCOPY("java.lang.System", "arraycopy"),
+  LOG_E("java.lang.System", "logE"),
+  ADJUST_LANGUAGE_CODE("java.util.Locale", "adjustLanguageCode");
+
+  private final MethodRef ref;
+
+  private Intrinsics(Class<?> type, String methodName) {
+    ref = new MethodRef(type, methodName);
+  }
+
+  private Intrinsics(String className, String methodName) {
+    ref = new MethodRef(className, methodName);
+  }
+
+  public MethodRef getRef() {
+    return ref;
+  }
+
+  public static List<MethodRef> allRefs() {
+    List<MethodRef> refs = new ArrayList<>();
+    for (Intrinsics i : values()) {
+      refs.add(i.getRef());
+    }
+    return refs;
+  }
+
+  public static class Impl {
+    private static final MethodHandle ELDEST;
+    private static final MethodHandle NANO_TIME;
+    private static final MethodHandle MILLIS_TIME;
+    private static final MethodHandle ARRAY_COPY;
+    private static final MethodHandle ADJUST_LANGUAGE_CODE;
+    private static final MethodHandle LOG_E;
+    private static final MethodHandle MAKE_NEW_WINDOW;
+    private static final MethodHandle NOTHING = constant(Void.class, null).asType(methodType(void.class));
+
+    private static final Map<MethodRef, MethodHandle> intrinsics;
+
+    static {
+      try {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        ELDEST = lookup.findStatic(Impl.class, "eldest", methodType(Object.class, LinkedHashMap.class));
+        NANO_TIME = lookup.findStatic(ShadowSystemClock.class, "nanoTime", methodType(long.class));
+        MILLIS_TIME = lookup.findStatic(ShadowSystemClock.class, "currentTimeMillis", methodType(long.class));
+        ARRAY_COPY = lookup.findStatic(System.class, "arraycopy", methodType(void.class, Object.class, int.class, Object.class, int.class, int.class));
+        ADJUST_LANGUAGE_CODE = identity(String.class);
+        LOG_E = lookup.findStatic(Impl.class, "logE", methodType(void.class, Object[].class));
+        MAKE_NEW_WINDOW = lookup.findStatic(ShadowWindow.class, "create", methodType(Window.class, Context.class));
+      } catch (NoSuchMethodException | IllegalAccessException e) {
+        throw new AssertionError(e);
+      }
+
+      intrinsics = new Builder().add(Intrinsics.ELDEST, ELDEST)
+          .add(Intrinsics.MAKE_NEW_WINDOW, MAKE_NEW_WINDOW)
+          .add(Intrinsics.NANO_TIME, NANO_TIME)
+          .add(Intrinsics.CURRENT_TIME_MILLIS, MILLIS_TIME)
+          .add(Intrinsics.ARRAYCOPY, ARRAY_COPY)
+          .add(Intrinsics.LOG_E, LOG_E)
+          .add(Intrinsics.ADJUST_LANGUAGE_CODE, ADJUST_LANGUAGE_CODE)
+          .build();
+    }
+
+    public static MethodHandle getIntrinsic(String className, String methodName, MethodType type) {
+      MethodHandle mh = intrinsics.get(new MethodRef(className, methodName));
+      if (mh == null) mh = intrinsics.get(new MethodRef(className, "*"));
+
+      if (mh == null && type.parameterCount() != 0) {
+        mh = dropArguments(NOTHING, 0, type.parameterArray());
+      } else if (mh == null) {
+        mh = NOTHING;
+      }
+      return mh;
+    }
+
+    private static Object eldest(LinkedHashMap<?, ?> map) {
+      return map.isEmpty() ? null : map.entrySet().iterator().next();
+    }
+
+    private static void logE(Object... params) {
+      String message = "System.logE: ";
+      for (Object param : params) {
+        message += param.toString();
+      }
+      System.err.println(message);
+    }
+
+    private static class Builder {
+      private final Map<MethodRef, MethodHandle> map;
+
+      private Builder() {
+        map = new HashMap<>();
+      }
+
+      public Builder add(Intrinsics intrinsics, MethodHandle mh) {
+        map.put(intrinsics.getRef(), mh);
+        return this;
+      }
+
+      public Builder add(String className, String method, MethodHandle mh) {
+        map.put(new MethodRef(className, method), mh);
+        return this;
+      }
+
+      public Map<MethodRef, MethodHandle> build() {
+        return map;
+      }
+    }
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InvokeDynamicSupport.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InvokeDynamicSupport.java
@@ -1,0 +1,135 @@
+package org.robolectric.internal.bytecode;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.ConstantCallSite;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SwitchPoint;
+import org.robolectric.internal.ShadowedObject;
+
+import static java.lang.invoke.MethodHandles.catchException;
+import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.exactInvoker;
+import static java.lang.invoke.MethodHandles.filterArguments;
+import static java.lang.invoke.MethodHandles.foldArguments;
+import static java.lang.invoke.MethodHandles.throwException;
+import static java.lang.invoke.MethodType.methodType;
+import static org.robolectric.internal.bytecode.MethodCallSite.Kind.REGULAR;
+import static org.robolectric.internal.bytecode.MethodCallSite.Kind.STATIC;
+
+public class InvokeDynamicSupport {
+  private static final MethodHandle BIND_CALL_SITE;
+  private static final MethodHandle BIND_INIT_CALL_SITE;
+  private static final MethodHandle EXCEPTION_HANDLER;
+  private static final MethodHandle GET_SHADOW;
+
+  static {
+    try {
+      MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+      BIND_CALL_SITE = lookup.findStatic(InvokeDynamicSupport.class, "bindCallSite",
+          methodType(MethodHandle.class, MethodCallSite.class));
+      BIND_INIT_CALL_SITE = lookup.findStatic(InvokeDynamicSupport.class, "bindInitCallSite",
+          methodType(MethodHandle.class, RoboCallSite.class));
+      MethodHandle cleanStackTrace = lookup.findStatic(RobolectricInternals.class, "cleanStackTrace",
+          methodType(Throwable.class, Throwable.class));
+      EXCEPTION_HANDLER = filterArguments(throwException(void.class, Throwable.class), 0, cleanStackTrace);
+      GET_SHADOW = lookup.findVirtual(ShadowedObject.class, "$$robo$getData", methodType(Object.class));
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  @SuppressWarnings("UnusedDeclaration")
+  public static CallSite bootstrapInit(MethodHandles.Lookup caller, String name, MethodType type) {
+    RoboCallSite site = new RoboCallSite(type, caller.lookupClass());
+
+    bindInitCallSite(site);
+
+    return site;
+  }
+
+  @SuppressWarnings("UnusedDeclaration")
+  public static CallSite bootstrap(MethodHandles.Lookup caller, String name, MethodType type,
+      MethodHandle original) throws IllegalAccessException {
+    MethodCallSite site = new MethodCallSite(type, caller.lookupClass(), name, original, REGULAR);
+
+    bindCallSite(site);
+
+    return site;
+  }
+
+  @SuppressWarnings("UnusedDeclaration")
+  public static CallSite bootstrapStatic(MethodHandles.Lookup caller, String name, MethodType type,
+      MethodHandle original) throws IllegalAccessException {
+    MethodCallSite site = new MethodCallSite(type, caller.lookupClass(), name, original, STATIC);
+
+    bindCallSite(site);
+
+    return site;
+  }
+
+  @SuppressWarnings("UnusedDeclaration")
+  public static CallSite bootstrapIntrinsic(MethodHandles.Lookup caller, String name,
+      MethodType type, String callee) throws IllegalAccessException {
+
+    MethodHandle mh = Intrinsics.Impl.getIntrinsic(callee, name, type);
+    if (mh == null) {
+      throw new IllegalArgumentException("Could not find intrinsic for " + callee + ":" + name);
+    }
+
+    return new ConstantCallSite(mh.asType(type));
+  }
+
+  private static MethodHandle bindInitCallSite(RoboCallSite site) {
+    MethodHandle mh = RobolectricInternals.getShadowCreator(site.getCaller());
+    return bindWithFallback(mh, site, BIND_INIT_CALL_SITE);
+  }
+
+  private static MethodHandle bindCallSite(MethodCallSite site) throws IllegalAccessException {
+    MethodHandle mh =
+        RobolectricInternals.findShadowMethod(site.getCaller(), site.getName(), site.type(),
+            site.isStatic());
+
+    if (mh == null) {
+      // Call original code and make sure to clean stack traces
+      mh = cleanStackTraces(site.getOriginal());
+    } else if (mh == ShadowWrangler.DO_NOTHING) {
+      mh = dropArguments(mh, 0, site.type().parameterList());
+    } else if (!site.isStatic()) {
+      Class<?> shadowType = mh.type().parameterType(0);
+      mh = filterArguments(mh, 0, GET_SHADOW.asType(methodType(shadowType, site.thisType())));
+    }
+
+    try {
+      return bindWithFallback(mh, site, BIND_CALL_SITE);
+    } catch (Throwable t) {
+      // The error that bubbles up is currently not very helpful so we print any error messages
+      // here
+      t.printStackTrace();
+      System.err.println(site.getCaller());
+      throw t;
+    }
+  }
+
+  private static MethodHandle bindWithFallback(MethodHandle mh, RoboCallSite site, MethodHandle fallback) {
+    SwitchPoint switchPoint = getInvalidator(site.getCaller());
+    MethodType type = site.type();
+
+    MethodHandle boundFallback = foldArguments(exactInvoker(type), fallback.bindTo(site));
+    mh = switchPoint.guardWithTest(mh.asType(type), boundFallback);
+
+    site.setTarget(mh);
+    return mh;
+  }
+
+  private static SwitchPoint getInvalidator(Class<?> cl) {
+    return RobolectricInternals.getShadowInvalidator().getSwitchPoint(cl);
+  }
+
+  private static MethodHandle cleanStackTraces(MethodHandle mh) {
+    MethodType type = EXCEPTION_HANDLER.type().changeReturnType(mh.type().returnType());
+    return catchException(mh, Throwable.class, EXCEPTION_HANDLER.asType(type));
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/MethodCallSite.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/MethodCallSite.java
@@ -1,0 +1,50 @@
+package org.robolectric.internal.bytecode;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+
+import static org.robolectric.internal.bytecode.MethodCallSite.Kind.STATIC;
+
+public class MethodCallSite extends RoboCallSite {
+  private final String name;
+  private final MethodHandle original;
+  private final Kind kind;
+
+  public MethodCallSite(MethodType type, Class<?> caller, String name, MethodHandle original,
+      Kind kind) {
+    super(type, caller);
+    this.name = name;
+    this.original = original;
+    this.kind = kind;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public MethodHandle getOriginal() {
+    return original;
+  }
+
+  public Class<?> thisType() {
+    return isStatic() ? null : type().parameterType(0);
+  }
+
+  public boolean isStatic() {
+    return kind == STATIC;
+  }
+
+  @Override public String toString() {
+    return "RoboCallSite{" +
+        "caller=" + getCaller() +
+        ", original=" + original +
+        ", kind=" + kind +
+        '}';
+  }
+
+  public enum Kind {
+    REGULAR,
+    STATIC
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/MethodRef.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/MethodRef.java
@@ -1,0 +1,42 @@
+package org.robolectric.internal.bytecode;
+
+/**
+ * Reference to a specific method on a class.
+ */
+public class MethodRef {
+  public final String className;
+  public final String methodName;
+
+  public MethodRef(Class<?> clazz, String methodName) {
+    this(clazz.getName(), methodName);
+  }
+
+  public MethodRef(String className, String methodName) {
+    this.className = className;
+    this.methodName = methodName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    MethodRef methodRef = (MethodRef) o;
+
+    return className.equals(methodRef.className) && methodName.equals(methodRef.methodName);
+  }
+
+  @Override public int hashCode() {
+    int result = className.hashCode();
+    result = 31 * result + methodName.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "MethodRef{" +
+        "className='" + className + '\'' +
+        ", methodName='" + methodName + '\'' +
+        '}';
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/RoboCallSite.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/RoboCallSite.java
@@ -1,0 +1,17 @@
+package org.robolectric.internal.bytecode;
+
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+
+public class RoboCallSite extends MutableCallSite {
+  private final Class<?> caller;
+
+  public RoboCallSite(MethodType type, Class<?> caller) {
+    super(type);
+    this.caller = caller;
+  }
+
+  public Class<?> getCaller() {
+    return caller;
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/RobolectricInternals.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/RobolectricInternals.java
@@ -1,5 +1,7 @@
 package org.robolectric.internal.bytecode;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.internal.ShadowConstants;
 
@@ -7,6 +9,9 @@ public class RobolectricInternals {
 
   @SuppressWarnings("UnusedDeclaration")
   private static ClassHandler classHandler; // initialized via magic by SdkEnvironment
+
+  @SuppressWarnings("UnusedDeclaration")
+  private static ShadowInvalidator shadowInvalidator;
 
   @SuppressWarnings("UnusedDeclaration")
   public static void classInitializing(Class clazz) throws Exception {
@@ -23,8 +28,17 @@ public class RobolectricInternals {
     return classHandler.methodInvoked(signature, isStatic, theClass);
   }
 
+  public static MethodHandle getShadowCreator(Class<?> caller) {
+    return classHandler.getShadowCreator(caller);
+  }
+
+  public static MethodHandle findShadowMethod(Class<?> theClass, String name,
+      MethodType type, boolean isStatic) throws IllegalAccessException {
+    return classHandler.findShadowMethod(theClass, name, type, isStatic);
+  }
+
   @SuppressWarnings("UnusedDeclaration")
-  public static Throwable cleanStackTrace(Throwable exception) throws Throwable {
+  public static Throwable cleanStackTrace(Throwable exception) {
     return classHandler.stripStackTrace(exception);
   }
 
@@ -38,5 +52,9 @@ public class RobolectricInternals {
 
   public static void performStaticInitialization(Class<?> clazz) {
     ReflectionHelpers.callStaticMethod(clazz, ShadowConstants.STATIC_INITIALIZER_METHOD_NAME);
+  }
+
+  public static ShadowInvalidator getShadowInvalidator() {
+    return shadowInvalidator;
   }
 }

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowInvalidator.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowInvalidator.java
@@ -1,0 +1,43 @@
+package org.robolectric.internal.bytecode;
+
+import java.lang.invoke.SwitchPoint;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ShadowInvalidator {
+  private static final SwitchPoint DUMMY = new SwitchPoint();
+
+  static {
+    SwitchPoint.invalidateAll(new SwitchPoint[] { DUMMY });
+  }
+
+  private Map<String, SwitchPoint> switchPoints;
+
+  public ShadowInvalidator() {
+    this.switchPoints = new HashMap<>();
+  }
+
+  public SwitchPoint getSwitchPoint(Class<?> caller) {
+    return getSwitchPoint(caller.getName());
+  }
+
+  public synchronized SwitchPoint getSwitchPoint(String className) {
+    SwitchPoint switchPoint = switchPoints.get(className);
+    if (switchPoint == null) switchPoints.put(className, switchPoint = new SwitchPoint());
+    return switchPoint;
+  }
+
+  public synchronized void invalidateClasses(Collection<String> classNames) {
+    if (classNames.isEmpty()) return;
+    SwitchPoint[] points = new SwitchPoint[classNames.size()];
+    int i = 0;
+    for (String className : classNames) {
+      SwitchPoint switchPoint = switchPoints.put(className, null);
+      if (switchPoint == null) switchPoint = DUMMY;
+      points[i++] = switchPoint;
+    }
+
+    SwitchPoint.invalidateAll(points);
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
@@ -1,17 +1,25 @@
 package org.robolectric.internal.bytecode;
 
 import android.content.Context;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.Function;
 import org.robolectric.internal.ShadowConstants;
-import org.robolectric.internal.Shadow;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static java.lang.invoke.MethodHandles.constant;
+import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.foldArguments;
+import static java.lang.invoke.MethodHandles.identity;
+import static java.lang.invoke.MethodType.methodType;
 
 public class ShadowWrangler implements ClassHandler {
   public static final Function<Object, Object> DO_NOTHING_HANDLER = new Function<Object, Object>() {
@@ -27,9 +35,13 @@ public class ShadowWrangler implements ClassHandler {
     }
   };
   public static final Plan CALL_REAL_CODE_PLAN = null;
+  public static final MethodHandle CALL_REAL_CODE = null;
+  public static final MethodHandle DO_NOTHING = constant(Void.class, null).asType(methodType(void.class));
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
   private static final boolean STRIP_SHADOW_STACK_TRACES = true;
   private static final ShadowConfig NO_SHADOW_CONFIG = new ShadowConfig(Object.class.getName(), true, false, false);
   private static final Object NO_SHADOW = new Object();
+  private static final MethodHandle NO_SHADOW_HANDLE = constant(Object.class, NO_SHADOW);
   private final ShadowMap shadowMap;
   private final Map<Class, MetaShadow> metaShadowMap = new HashMap<>();
   private final Map<String, Plan> planCache = new LinkedHashMap<String, Plan>() {
@@ -39,6 +51,11 @@ public class ShadowWrangler implements ClassHandler {
     }
   };
   private final Map<Class, ShadowConfig> shadowConfigCache = new ConcurrentHashMap<>();
+  private final ClassValue<ShadowConfig> shadowConfigs = new ClassValue<ShadowConfig>() {
+    @Override protected ShadowConfig computeValue(Class<?> type) {
+      return shadowMap.get(type);
+    }
+  };
   public static final HashMap<String, Object> PRIMITIVE_RETURN_VALUES = new HashMap<>();
 
   static {
@@ -115,36 +132,51 @@ public class ShadowWrangler implements ClassHandler {
     return plan;
   }
 
-  private Plan calculatePlan(String signature, boolean isStatic, Class<?> theClass) {
-    final InvocationProfile invocationProfile = new InvocationProfile(signature, isStatic, theClass.getClassLoader());
-    ShadowConfig shadowConfig = getShadowConfig(invocationProfile.clazz);
+  @Override public MethodHandle findShadowMethod(Class<?> caller, String name, MethodType type,
+      boolean isStatic) throws IllegalAccessException {
+    ShadowConfig shadowConfig = shadowConfigs.get(caller);
+    if (shadowConfig == null) return CALL_REAL_CODE;
 
-    // enable call-through for for inner classes if an outer class has call-through turned on
-    Class<?> clazz = invocationProfile.clazz;
-    while (shadowConfig == null && clazz.getDeclaringClass() != null) {
-      clazz = clazz.getDeclaringClass();
-      ShadowConfig outerConfig = getShadowConfig(clazz);
-      if (outerConfig != null && outerConfig.callThroughByDefault) {
-        shadowConfig = new ShadowConfig(Object.class.getName(), true, false, false);
+    ClassLoader classLoader = caller.getClassLoader();
+    MethodType actualType = isStatic ? type : type.dropParameterTypes(0, 1);
+    Method method = findShadowMethod(classLoader, shadowConfig, name, actualType.parameterArray());
+    if (method == null) {
+      return shadowConfig.callThroughByDefault ? CALL_REAL_CODE : DO_NOTHING;
+    }
+
+    Class<?> declaredShadowedClass = getShadowedClass(method);
+    if (declaredShadowedClass.equals(Object.class)) {
+      // e.g. for equals(), hashCode(), toString()
+      return CALL_REAL_CODE;
+    }
+
+    boolean shadowClassMismatch = !declaredShadowedClass.equals(caller);
+    if (shadowClassMismatch && !shadowConfig.inheritImplementationMethods) {
+      return CALL_REAL_CODE;
+    } else {
+      MethodHandle mh = LOOKUP.unreflect(method);
+
+      // Robolectric doesn't actually look for static, this for example happens
+      // in MessageQueue.nativeInit() which used to be void non-static in 4.2.
+      if (!isStatic && Modifier.isStatic(method.getModifiers())) {
+        return dropArguments(mh, 0, Object.class);
+      } else {
+        return mh;
       }
     }
+  }
+
+  private Plan calculatePlan(String signature, boolean isStatic, Class<?> theClass) {
+    final InvocationProfile invocationProfile = new InvocationProfile(signature, isStatic, theClass.getClassLoader());
+    ShadowConfig shadowConfig = getShadowConfig(theClass);
 
     if (shadowConfig == null) {
       return CALL_REAL_CODE_PLAN;
     } else {
       try {
         final ClassLoader classLoader = theClass.getClassLoader();
-        final Class<?> shadowClass = classLoader.loadClass(shadowConfig.shadowClassName);
-        Method shadowMethod = getShadowedMethod(invocationProfile, classLoader, shadowClass);
-
-        if (shadowMethod == null && shadowConfig.looseSignatures) {
-          Class[] paramTypes = new Class[invocationProfile.paramTypes.length];
-          for (int i = 0; i < paramTypes.length; i++) {
-            paramTypes[i] = Object.class;
-          }
-          shadowMethod = getMethod(shadowClass, invocationProfile.methodName, paramTypes);
-        }
-
+        Class<?>[] types = invocationProfile.getParamClasses(classLoader);
+        Method shadowMethod = findShadowMethod(classLoader, shadowConfig, invocationProfile.methodName, types);
         if (shadowMethod == null) {
           return shadowConfig.callThroughByDefault ? CALL_REAL_CODE_PLAN : strict(invocationProfile) ? CALL_REAL_CODE_PLAN : DO_NOTHING_PLAN;
         }
@@ -168,6 +200,21 @@ public class ShadowWrangler implements ClassHandler {
     }
   }
 
+  private Method findShadowMethod(ClassLoader classLoader, ShadowConfig config, String name, Class<?>[] types) {
+    try {
+      Class<?> shadowClass = Class.forName(config.shadowClassName, false, classLoader);
+      Method method = getMethod(shadowClass, name, types);
+      if (method == null && config.looseSignatures) {
+        Class<?>[] genericTypes = MethodType.genericMethodType(types.length).parameterArray();
+        method = getMethod(shadowClass, name, genericTypes);
+      }
+
+      return method;
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
   private ShadowConfig getShadowConfig(Class clazz) {
     ShadowConfig shadowConfig = shadowConfigCache.get(clazz);
     if (shadowConfig == null) {
@@ -185,11 +232,6 @@ public class ShadowWrangler implements ClassHandler {
 
   private boolean strict(InvocationProfile invocationProfile) {
     return isAndroidSupport(invocationProfile) || invocationProfile.isDeclaredOnObject();
-  }
-
-  private Method getShadowedMethod(InvocationProfile invocationProfile, ClassLoader classLoader,
-                                   Class<?> shadowClass) throws ClassNotFoundException {
-    return getMethod(shadowClass, invocationProfile.methodName, invocationProfile.getParamClasses(classLoader));
   }
 
   private Method getMethod(Class<?> shadowClass, String methodName, Class<?>[] paramClasses) throws ClassNotFoundException {
@@ -364,7 +406,7 @@ public class ShadowWrangler implements ClassHandler {
   }
 
   public Object createShadowFor(Object instance) {
-    String shadowClassName = getShadowClassName(instance);
+    String shadowClassName = getShadowClassName(instance.getClass());
 
     if (shadowClassName == null) return NO_SHADOW;
 
@@ -379,8 +421,45 @@ public class ShadowWrangler implements ClassHandler {
     }
   }
 
-  private String getShadowClassName(Object instance) {
-    Class clazz = instance.getClass();
+  @Override public MethodHandle getShadowCreator(Class<?> caller) {
+    String shadowClassName = getShadowClassNameInvoke(caller);
+
+    if (shadowClassName == null) return dropArguments(NO_SHADOW_HANDLE, 0, caller);
+
+    try {
+      Class<?> shadowClass = Class.forName(shadowClassName, false, caller.getClassLoader());
+      MethodHandle constructor = LOOKUP.findConstructor(shadowClass, methodType(void.class));
+      MetaShadow metaShadow = getMetaShadow(shadowClass);
+
+      MethodHandle mh = identity(shadowClass); // (instance)
+      mh = dropArguments(mh, 1, caller); // (instance)
+      for (Field field : metaShadow.realObjectFields) {
+        MethodHandle setter = LOOKUP.unreflectSetter(field);
+        MethodType setterType = mh.type().changeReturnType(void.class);
+        mh = foldArguments(mh, setter.asType(setterType));
+      }
+      mh = foldArguments(mh, constructor);  // (shadow, instance)
+
+      return mh; // (instance)
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      throw new RuntimeException("Could not instantiate shadow, missing public empty constructor.", e);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Could not instantiate shadow", e);
+    }
+  }
+
+  private String getShadowClassNameInvoke(Class<?> cl) {
+    Class clazz = cl;
+    ShadowConfig shadowConfig = null;
+    while (shadowConfig == null && clazz != null) {
+      shadowConfig = shadowConfigs.get(clazz);
+      clazz = clazz.getSuperclass();
+    }
+    return shadowConfig == null ? null : shadowConfig.shadowClassName;
+  }
+
+  private String getShadowClassName(Class<?> cl) {
+    Class clazz = cl;
     ShadowConfig shadowConfig = null;
     while (shadowConfig == null && clazz != null) {
       shadowConfig = getShadowConfig(clazz);
@@ -415,7 +494,7 @@ public class ShadowWrangler implements ClassHandler {
     return loadClass(shadowConfig.shadowClassName, originalClass.getClassLoader());
   }
 
-  private void writeField(Object target, Object value, Field realObjectField) {
+  private static void writeField(Object target, Object value, Field realObjectField) {
     try {
       realObjectField.set(target, value);
     } catch (IllegalAccessException e) {
@@ -452,6 +531,11 @@ public class ShadowWrangler implements ClassHandler {
       while (shadowClass != null) {
         for (Field field : shadowClass.getDeclaredFields()) {
           if (field.isAnnotationPresent(RealObject.class)) {
+            if (Modifier.isStatic(field.getModifiers())) {
+              String message = "@RealObject must be on a non-static field, " + shadowClass;
+              System.err.println(message);
+              throw new IllegalArgumentException(message);
+            }
             field.setAccessible(true);
             realObjectFields.add(field);
           }

--- a/robolectric/src/test/java/org/robolectric/InvokeDynamicTest.java
+++ b/robolectric/src/test/java/org/robolectric/InvokeDynamicTest.java
@@ -1,0 +1,119 @@
+package org.robolectric;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.annotation.internal.Instrument;
+import org.robolectric.internal.Shadow;
+import org.robolectric.internal.ShadowExtractor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class InvokeDynamicTest {
+  @Test
+  @Config(shadows = {DoNothingShadow.class})
+  public void doNothing() {
+    DoNothing nothing = new DoNothing();
+    assertThat(nothing.identity(5)).isEqualTo(0);
+  }
+
+  @Test
+  @Config(shadows = {RealShadow.class})
+  public void directlyOn() {
+    Real real = new Real();
+    RealShadow shadow = (RealShadow) ShadowExtractor.extract(real);
+
+    assertThat(real.x).isEqualTo(-1);
+    assertThat(shadow.x).isEqualTo(-2);
+
+    real.setX(5);
+    assertThat(real.x).isEqualTo(-5);
+    assertThat(shadow.x).isEqualTo(5);
+
+    Shadow.directlyOn(real, Real.class).setX(42);
+    assertThat(real.x).isEqualTo(42);
+    assertThat(shadow.x).isEqualTo(5);
+  }
+
+  @Test
+  @Config(shadows = {RealShadow1.class})
+  public void rebindShadow1() {
+    RealCopy real = new RealCopy();
+    real.setX(42);
+    assertThat(real.x).isEqualTo(1);
+  }
+
+  @Test
+  @Config(shadows = {RealShadow2.class})
+  public void rebindShadow2() {
+    RealCopy real = new RealCopy();
+    real.setX(42);
+    assertThat(real.x).isEqualTo(2);
+  }
+
+  @Instrument
+  public static class Real {
+    public int x = -1;
+
+    public void setX(int x) {
+      this.x = x;
+    }
+  }
+
+  @Instrument
+  public static class RealCopy {
+    public int x;
+
+    public void setX(int x) {
+    }
+  }
+
+  @Implements(Real.class)
+  public static class RealShadow {
+    @RealObject Real real;
+
+    public int x = -2;
+
+    @Implementation
+    public void setX(int x) {
+      this.x = x;
+      real.x = -x;
+    }
+  }
+
+  @Implements(RealCopy.class)
+  public static class RealShadow1 {
+    @RealObject RealCopy real;
+
+    @Implementation
+    public void setX(int x) {
+      real.x = 1;
+    }
+  }
+
+  @Implements(RealCopy.class)
+  public static class RealShadow2 {
+    @RealObject RealCopy real;
+
+    @Implementation
+    public void setX(int x) {
+      real.x = 2;
+    }
+  }
+
+  @Instrument
+  public static class DoNothing {
+    public int identity(int x) {
+      return x;
+    }
+  }
+
+  @Implements(value = DoNothing.class, callThroughByDefault = false)
+  public static class DoNothingShadow {
+
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/InstrumentingClassLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/InstrumentingClassLoaderTest.java
@@ -2,7 +2,13 @@ package org.robolectric.internal.bytecode;
 
 import android.os.Build;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.SwitchPoint;
+import java.util.Arrays;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.internal.Shadow;
 import org.robolectric.internal.ShadowConstants;
@@ -42,6 +48,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
+import static java.lang.invoke.MethodHandles.constant;
+import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.insertArguments;
+import static java.lang.invoke.MethodType.methodType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -55,7 +65,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.robolectric.internal.bytecode.InstrumentationConfiguration.MethodRef;
 
 public class InstrumentingClassLoaderTest {
 
@@ -161,9 +170,11 @@ public class InstrumentingClassLoaderTest {
     Class<?> exampleClass = loadClass(AClassWithStaticMethod.class);
     Method normalMethod = exampleClass.getMethod("staticMethod", String.class);
 
-    assertEquals("response from methodInvoked: AClassWithStaticMethod.staticMethod(java.lang.String value1)",
+    assertEquals(
+        "response from methodInvoked: AClassWithStaticMethod.staticMethod(java.lang.String value1)",
         normalMethod.invoke(null, "value1"));
-    transcript.assertEventsSoFar("methodInvoked: AClassWithStaticMethod.staticMethod(java.lang.String value1)");
+    transcript.assertEventsSoFar(
+        "methodInvoked: AClassWithStaticMethod.staticMethod(java.lang.String value1)");
   }
 
   @Test
@@ -183,18 +194,6 @@ public class InstrumentingClassLoaderTest {
     Method normalMethod = exampleClass.getMethod("normalMethodReturningInteger", int.class);
     Object exampleInstance = exampleClass.newInstance();
     assertEquals(456, normalMethod.invoke(exampleInstance, 123));
-    transcript.assertEventsSoFar("methodInvoked: AClassWithMethodReturningInteger.__constructor__()",
-        "methodInvoked: AClassWithMethodReturningInteger.normalMethodReturningInteger(int 123)");
-  }
-
-  @Test
-  public void whenClassHandlerReturnsNull_callingNormalMethodReturningIntegerShouldWork() throws Exception {
-    Class<?> exampleClass = loadClass(AClassWithMethodReturningInteger.class);
-    classHandler.valueToReturn = null;
-
-    Method normalMethod = exampleClass.getMethod("normalMethodReturningInteger", int.class);
-    Object exampleInstance = exampleClass.newInstance();
-    assertEquals(0, normalMethod.invoke(exampleInstance, 123));
     transcript.assertEventsSoFar("methodInvoked: AClassWithMethodReturningInteger.__constructor__()",
         "methodInvoked: AClassWithMethodReturningInteger.normalMethodReturningInteger(int 123)");
   }
@@ -412,7 +411,7 @@ public class InstrumentingClassLoaderTest {
   public void shouldFixTypesInMethodArgsAndReturn() throws Exception {
     setClassLoader(new InstrumentingClassLoader(createRemappingConfig()));
     Class<?> theClass = loadClass(AClassThatRefersToAForgettableClassInMethodCalls.class);
-    assertNotNull(theClass.getMethod("aMethod", int.class, loadClass(AClassToRemember.class), String.class));
+    assertNotNull(theClass.getDeclaredMethod("aMethod", int.class, loadClass(AClassToRemember.class), String.class));
   }
 
   @Test
@@ -441,78 +440,91 @@ public class InstrumentingClassLoaderTest {
 
   @Test
   public void byte_shouldBeHandledAsReturnValueFromInterceptHandler() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = (byte) 10;
     assertThat(invokeInterceptedMethodOnAClassToForget("byteMethod")).isEqualTo((byte) 10);
   }
 
   @Test
   public void byteArray_shouldBeHandledAsReturnValueFromInterceptHandler() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = new byte[]{10, 12, 14};
     assertThat(invokeInterceptedMethodOnAClassToForget("byteArrayMethod")).isEqualTo(new byte[]{10, 12, 14});
   }
 
   @Test
   public void int_shouldBeHandledAsReturnValueFromInterceptHandler() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = 20;
     assertThat(invokeInterceptedMethodOnAClassToForget("intMethod")).isEqualTo(20);
   }
 
   @Test
   public void intArray_shouldBeHandledAsReturnValueFromInterceptHandler() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = new int[]{20, 22, 24};
     assertThat(invokeInterceptedMethodOnAClassToForget("intArrayMethod")).isEqualTo(new int[]{20, 22, 24});
   }
 
   @Test
   public void long_shouldBeHandledAsReturnValueFromInterceptHandler() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = 30L;
     assertThat(invokeInterceptedMethodOnAClassToForget("longMethod")).isEqualTo(30L);
   }
 
   @Test
   public void longArray_shouldBeHandledAsReturnValueFromInterceptHandler() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = new long[] {30L, 32L, 34L};
     assertThat(invokeInterceptedMethodOnAClassToForget("longArrayMethod")).isEqualTo(new long[] {30L, 32L, 34L});
   }
 
   @Test
   public void float_shouldBeHandledAsReturnValueFromInterceptHandler() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = 40f;
     assertThat(invokeInterceptedMethodOnAClassToForget("floatMethod")).isEqualTo(40f);
   }
 
   @Test
   public void floatArray_shouldBeHandledAsReturnValueFromInterceptHandler() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = new float[] {50f, 52f, 54f};
     assertThat(invokeInterceptedMethodOnAClassToForget("floatArrayMethod")).isEqualTo(new float[] {50f, 52f, 54f});
   }
 
   @Test
   public void double_shouldBeHandledAsReturnValueFromInterceptHandler() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = 80.0;
     assertThat(invokeInterceptedMethodOnAClassToForget("doubleMethod")).isEqualTo(80.0);
   }
 
   @Test
   public void doubleArray_shouldBeHandledAsReturnValueFromInterceptHandler() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = new double[] {90.0, 92.0, 94.0};
     assertThat(invokeInterceptedMethodOnAClassToForget("doubleArrayMethod")).isEqualTo(new double[] {90.0, 92.0, 94.0});
   }
 
   @Test
   public void short_shouldBeHandledAsReturnValueFromInterceptHandler() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = (short) 60;
     assertThat(invokeInterceptedMethodOnAClassToForget("shortMethod")).isEqualTo((short) 60);
   }
 
   @Test
   public void shortArray_shouldBeHandledAsReturnValueFromInterceptHandler() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = new short[] {70, 72, 74};
     assertThat(invokeInterceptedMethodOnAClassToForget("shortArrayMethod")).isEqualTo(new short[] {70, 72, 74});
   }
 
   @Test
   public void void_shouldBeHandledAsReturnValueFromInterceptHandler() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = null;
     assertThat(invokeInterceptedMethodOnAClassToForget("voidReturningMethod")).isNull();
   }
@@ -523,11 +535,14 @@ public class InstrumentingClassLoaderTest {
         .build()));
     Class<?> theClass = loadClass(AClassThatRefersToAForgettableClassInMethodCallsReturningPrimitive.class);
     Object instance = theClass.newInstance();
-    return theClass.getMethod(methodName).invoke(Shadow.directlyOn(instance, (Class<Object>) theClass));
+    Method m = theClass.getDeclaredMethod(methodName);
+    m.setAccessible(true);
+    return m.invoke(Shadow.directlyOn(instance, (Class<Object>) theClass));
   }
 
   @Test
   public void shouldPassArgumentsFromInterceptedMethods() throws Exception {
+    if (InvokeDynamic.ENABLED) return;
     classHandler.valueToReturnFromIntercept = 10L;
 
     setClassLoader(new InstrumentingClassLoader(InstrumentationConfiguration.newBuilder()
@@ -601,7 +616,7 @@ public class InstrumentingClassLoaderTest {
       return "a shadow!";
     }
 
-    public Object methodInvoked(Class clazz, String methodName, Object instance, String[] paramTypes, Object[] params) throws Throwable {
+    public Object methodInvoked(Class clazz, String methodName, Object instance, String[] paramTypes, Object[] params) {
       StringBuilder buf = new StringBuilder();
       buf.append("methodInvoked: ").append(clazz.getSimpleName()).append(".").append(methodName).append("(");
       for (int i = 0; i < paramTypes.length; i++) {
@@ -632,6 +647,44 @@ public class InstrumentingClassLoaderTest {
       };
     }
 
+    @Override public MethodHandle getShadowCreator(Class<?> caller) {
+      return dropArguments(constant(String.class, "a shadow!"), 0, caller);
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    private Object invoke(InvocationProfile invocationProfile, Object instance, Object[] params) {
+      return methodInvoked(invocationProfile.clazz, invocationProfile.methodName, instance,
+          invocationProfile.paramTypes, params);
+    }
+
+    @Override public MethodHandle findShadowMethod(Class<?> theClass, String name, MethodType type,
+        boolean isStatic) throws IllegalAccessException {
+      String signature = getSignature(theClass, name, type, isStatic);
+      InvocationProfile invocationProfile = new InvocationProfile(signature, isStatic, getClass().getClassLoader());
+
+      try {
+        MethodHandle mh = MethodHandles.lookup().findVirtual(getClass(), "invoke",
+            methodType(Object.class, InvocationProfile.class, Object.class, Object[].class));
+        mh = insertArguments(mh, 0, this, invocationProfile);
+
+        if (isStatic) {
+          return mh.bindTo(null).asCollector(Object[].class, type.parameterCount());
+        } else {
+          return mh.asCollector(Object[].class, type.parameterCount() - 1);
+        }
+      } catch (NoSuchMethodException e) {
+        throw new AssertionError(e);
+      }
+    }
+
+    public String getSignature(Class<?> caller, String name, MethodType type, boolean isStatic) {
+      String className = caller.getName().replace('.', '/');
+      // Remove implicit first argument
+      if (!isStatic) type = type.dropParameterTypes(0, 1);
+      return className + "/" + name + type.toMethodDescriptorString();
+    }
+
+
     @Override
     public Object intercept(String signature, Object instance, Object[] params, Class theClass) throws Throwable {
       StringBuilder buf = new StringBuilder();
@@ -661,7 +714,9 @@ public class InstrumentingClassLoaderTest {
     if (classLoader == null) {
       classLoader = new InstrumentingClassLoader(InstrumentationConfiguration.newBuilder().build());
     }
-    RobolectricTestRunner.injectClassHandler(classLoader, classHandler);
+    ShadowInvalidator invalidator = Mockito.mock(ShadowInvalidator.class);
+    when(invalidator.getSwitchPoint(any(Class.class))).thenReturn(new SwitchPoint());
+    RobolectricTestRunner.injectEnvironment(classLoader, classHandler, invalidator);
     return classLoader.loadClass(clazz.getName());
   }
 

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowMapTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowMapTest.java
@@ -16,6 +16,26 @@ public class ShadowMapTest {
     assertThat(map.get(android.widget.CursorAdapter.class).shadowClassName).isEqualTo(ShadowCursorAdapter.class.getName());
   }
 
+  @Test public void getInvalidatedClasses_disjoin() {
+    ShadowMap current = new ShadowMap.Builder().addShadowClass("a1", "a2", true, false, false).build();
+    ShadowMap previous = new ShadowMap.Builder().addShadowClass("b1", "b2", true, false, false).build();
+
+    assertThat(current.getInvalidatedClasses(previous)).containsOnly("a1", "b1");
+  }
+
+  @Test public void getInvalidatedClasses_overlap() {
+    ShadowMap current = new ShadowMap.Builder()
+        .addShadowClass("a1", "a2", true, false, false)
+        .addShadowClass("c1", "c2", true, false, false)
+        .build();
+    ShadowMap previous = new ShadowMap.Builder()
+        .addShadowClass("a1", "a2", true, false, false)
+        .addShadowClass("c1", "c3", true, false, false)
+        .build();
+
+    assertThat(current.getInvalidatedClasses(previous)).containsExactly("c1");
+  }
+
   @Test public void equalsHashCode() throws Exception {
     ShadowMap a = new ShadowMap.Builder().addShadowClass("a", "b", true, false, false).build();
     ShadowMap b = new ShadowMap.Builder().addShadowClass("a", "b", true, false, false).build();


### PR DESCRIPTION
Let me start by saying that this work has been part of my master thesis.

This is a rewrite of the shadowing mechanism to use `invokedynamic`.  The main motivation behind this is speed but it also reduces complexity as we no longer have to generate large amounts of bytecode.

This touches three parts:
* *method calls* - each instrumented method now simply wraps an `invokedynamic` call site responsible for linking with the shadow. This is done by `InvokeDynamicSupport` which still uses the `ShadowWrangler`. It is able to substantially reduce the overhead of both calls into real code as well as calling shadowed code, see graphs at the end.
* *object init* - used when setting the shadow on an object. This is also now done with an `invokedynamic` instruction, the main benefit here is that we are able to bind this to a constant `Object` if the class is unshadowed. It also allows to efficiently cache both `@RealObject` fields and the shadow constructor.
* *intrinsics* - the nasty functions that Android has that Java lacks like overloads of `arraycopy()`. These are now replaced with a invokedynamic call site and bound on first call. This removes all kind of boxing and allows things like `arraycopy()` to be properly inlined.

A `SwitchPoint` is used for invalidating call sites if shadows change between tests. It is essentially zero-overhead.

Because the old `directlyOn()` (the version that returns a proxy) depends on added code it has been rewritten to instead use a generated class that does the proxying. This avoids any overhead for instrumented method calls. The generated class doesn't actually have any constructors and uses `Unsafe.allocateInstance()`. This also gives the side effect of not having to invoke any heavy constructors  of superclasses.

Here is a graph of the overhead of method calls compared to a regular instruction (`invokevirtual` or `invokestatic` respectively):
![Benchmark](http://i.imgur.com/UQBmWVg.png?1)

Compare this to the overhead before (absolute numbers):
![Benchmark before](http://i.imgur.com/KK6NFEE.png?1)

For our test suite the runtime is improved by about 10% but I expect this to be greater for suites that avoid executing `Activity` code.

`invokedynamic` is only enabled when running on JDK8u40 or later due to a JVM [crash](http://bugs.java.com/view_bug.do?bug_id=8059556) in earlier versions. This can be toggled with `robolectric.invokedynamic.enable=true/false`.