### PR TITLE
Fix auto-res namespace handling

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/builder/XmlBlock.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/builder/XmlBlock.java
@@ -1,10 +1,6 @@
 package org.robolectric.res.builder;
 
-import org.robolectric.res.Attribute;
 import org.w3c.dom.Document;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * An XML block is a parsed representation of a resource XML file. Similar in nature
@@ -16,7 +12,6 @@ public class XmlBlock {
   private final String packageName;
 
   public static XmlBlock create(Document document, String file, String packageName) {
-    replaceResAutoNamespace(document, packageName);
     return new XmlBlock(document, file, packageName);
   }
 
@@ -30,37 +25,6 @@ public class XmlBlock {
 
   public String getPackageName() {
     return packageName;
-  }
-
-  /**
-   * Replaces all instances of "http://schemas.android.com/apk/res-auto" with
-   * "http://schemas.android.com/apk/res/packageName" in the given Document.
-   */
-  private static void replaceResAutoNamespace(Document document, String packageName) {
-    String autoNs = Attribute.RES_AUTO_NS_URI;
-    String newNs = Attribute.ANDROID_RES_NS_PREFIX + packageName;
-    replaceAttributeNamespace(document, document.getDocumentElement(), autoNs, newNs);
-  }
-
-  private static void replaceAttributeNamespace(Document document, Node n, String oldNs, String newNs) {
-    NamedNodeMap attrs = n.getAttributes();
-    if (attrs != null) {
-      for (int i = 0; i < attrs.getLength(); i++) {
-        replaceNamespace(document, attrs.item(i), oldNs, newNs);
-      }
-    }
-    if (n.hasChildNodes()) {
-      NodeList list = n.getChildNodes();
-      for (int i = 0; i < list.getLength(); i++) {
-        replaceAttributeNamespace(document, list.item(i), oldNs, newNs);
-      }
-    }
-  }
-
-  private static void replaceNamespace(Document document, Node n, String oldNs, String newNs) {
-    if (oldNs.equals(n.getNamespaceURI())) {
-      document.renameNode(n, newNs, n.getNodeName());
-    }
   }
 
   private XmlBlock(Document document, String filename, String packageName) {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -431,7 +431,7 @@ public class ShadowResources {
     if (block == null) {
       throw new Resources.NotFoundException();
     }
-    return ResourceParser.from(block, getResourceLoader().getResourceIndex());
+    return ResourceParser.from(block, resName.packageName, getResourceLoader().getResourceIndex());
   }
 
   @HiddenApi @Implementation

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -211,7 +211,7 @@ public final class ShadowAssetManager {
 
   @Implementation
   public final XmlResourceParser openXmlResourceParser(int cookie, String fileName) throws IOException {
-    return ResourceParser.create(fileName, "fixme", null);
+    return ResourceParser.create(fileName, "fixme", "fixme", null);
   }
 
   @HiddenApi @Implementation

--- a/robolectric/src/test/java/org/robolectric/res/builder/XmlBlockLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/builder/XmlBlockLoaderTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.res;
+package org.robolectric.res.builder;
 
 import android.content.res.XmlResourceParser;
 import org.junit.After;
@@ -7,8 +7,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.TestRunners;
-import org.robolectric.res.builder.ResourceParser;
-import org.robolectric.res.builder.XmlBlock;
+import org.robolectric.res.DocumentLoader;
+import org.robolectric.res.MergedResourceIndex;
+import org.robolectric.res.ResBundle;
+import org.robolectric.res.ResName;
+import org.robolectric.res.ResourceExtractor;
+import org.robolectric.res.ResourceIndex;
+import org.robolectric.res.XmlBlockLoader;
 import org.robolectric.res.builder.ResourceParser.XmlResourceParserImpl;
 import org.robolectric.util.TestUtil;
 import org.w3c.dom.Document;
@@ -62,7 +67,7 @@ public class XmlBlockLoaderTest {
     ResName resName = new ResName(TEST_PACKAGE, "xml", "preferences");
     xmlBlock = resBundle.get(resName, "");
     resourceIndex = new MergedResourceIndex(new ResourceExtractor(testResources()), new ResourceExtractor());
-    parser = (XmlResourceParserImpl) ResourceParser.from(xmlBlock, resourceIndex);
+    parser = (XmlResourceParserImpl) ResourceParser.from(xmlBlock, TEST_PACKAGE, resourceIndex);
   }
 
   @After
@@ -98,7 +103,8 @@ public class XmlBlockLoaderTest {
       Document document = documentBuilder.parse(
           new ByteArrayInputStream(xmlValue.getBytes()));
 
-      parser = new XmlResourceParserImpl(document, "file", TestUtil.testResources().getPackageName(), resourceIndex);
+      parser = new XmlResourceParserImpl(document, "file", TestUtil.testResources().getPackageName(),
+          TEST_PACKAGE, resourceIndex);
       // Navigate to the root element
       parseUntilNext(XmlResourceParser.START_TAG);
     } catch (Exception parsingException) {


### PR DESCRIPTION
@holmari notified me that 8d0e0295 might cause a regression in regards to library handling. This is because resources from a library project will have `http://schemas.android.com/apk/res-auto` replaced with the library package name instead of the application package name.

This commit changes this so we never actually replace package names but instead look up by `http://schemas.android.com/apk/res-auto` if looking up by package name fail. I don't have a specific test case but regression tests pass.