### PR TITLE
Add exclude for scalatest in InstrumentationConfiguration.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/InstrumentationConfigurationTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/InstrumentationConfigurationTest.java
@@ -44,6 +44,14 @@ public class InstrumentationConfigurationTest {
     assertThat(config.shouldAcquire("com.whatever.R$anything")).isFalse();
     assertThat(config.shouldAcquire("com.whatever.R$anything$else")).isTrue();
   }
+
+  @Test
+  public void shouldNotAcquireExcludedPackages() throws Exception {
+    assertThat(config.shouldAcquire("scala.Test")).isFalse();
+    assertThat(config.shouldAcquire("scala.util.Test")).isFalse();
+    assertThat(config.shouldAcquire("org.specs2.whatever.foo")).isFalse();
+    assertThat(config.shouldAcquire("com.almworks.sqlite4java.whatever.Cls$anything$else")).isFalse();
+  }
   
   @Test
   public void shouldInstrumentCustomClasses() throws Exception {


### PR DESCRIPTION
This exclude is needed to run scalatest with robolectric, the same way specs2 is already there.
With 2.4 I was able to overwrite `InstrumentationConfiguration.shouldAcquire`, but now this class has private constructor, and this hack doesn't work. 
See: https://github.com/zbsz/robotest