### PR TITLE
Shutdown thread pool before removing connections.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSQLiteConnection.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSQLiteConnection.java.vm
@@ -1,5 +1,6 @@
 package org.robolectric.shadows;
 
+import java.util.concurrent.TimeUnit;
 #if ($api >= 21)
 import java.util.concurrent.atomic.AtomicLong;
 #else
@@ -407,6 +408,11 @@ public class ShadowSQLiteConnection {
         close(connectionPtr);  
       }
       dbExecutor.shutdown();
+      try {
+        dbExecutor.awaitTermination(30, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
       dbExecutor = Executors.newSingleThreadExecutor();
       connectionsMap.clear();
       statementsMap.clear();

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSQLiteConnection.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSQLiteConnection.java.vm
@@ -329,7 +329,7 @@ public class ShadowSQLiteConnection {
 #end
     private final Map<$ptrClassBoxed, SQLiteStatement> statementsMap = new ConcurrentHashMap<>();
     private final Map<$ptrClassBoxed, SQLiteConnection> connectionsMap = new ConcurrentHashMap<>();
-    private final ExecutorService dbExecutor = Executors.newSingleThreadExecutor();
+    private ExecutorService dbExecutor = Executors.newSingleThreadExecutor();
 
     public SQLiteConnection getConnection(final $ptrClass pointer) {
       SQLiteConnection connection = connectionsMap.get(pointer);
@@ -406,6 +406,8 @@ public class ShadowSQLiteConnection {
       for ($ptrClass connectionPtr : connectionsMap.keySet()) {
         close(connectionPtr);  
       }
+      dbExecutor.shutdown();
+      dbExecutor = Executors.newSingleThreadExecutor();
       connectionsMap.clear();
       statementsMap.clear();
     }


### PR DESCRIPTION
It is possible for reset() to be called and wipe out the map of connections while operations are still running.

Note: This doesn't fix the issue of tests that have spawened their own threads accessing the connection maps after reset() has been called.

This should be a partial fix for https://github.com/robolectric/robolectric/issues/1833

kriegfrj@ - thoughts?