### PR TITLE
Enable resourceDir and assetDir Config Overrides for RobolectricGradleTestRunner

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
@@ -38,16 +38,16 @@ public class RobolectricGradleTestRunner extends RobolectricTestRunner {
     final FileFsFile assets;
     final FileFsFile manifest;
 
-    if (FileFsFile.from(BUILD_OUTPUT, "res").exists()) {
-      res = FileFsFile.from(BUILD_OUTPUT, "res", flavor, type);
+    if (FileFsFile.from(BUILD_OUTPUT, config.resourceDir()).exists()) {
+      res = FileFsFile.from(BUILD_OUTPUT, config.resourceDir(), flavor, type);
     } else {
-      res = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "res");
+      res = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, config.resourceDir());
     }
 
-    if (FileFsFile.from(BUILD_OUTPUT, "assets").exists()) {
-      assets = FileFsFile.from(BUILD_OUTPUT, "assets", flavor, type);
+    if (FileFsFile.from(BUILD_OUTPUT, config.assetDir()).exists()) {
+      assets = FileFsFile.from(BUILD_OUTPUT, config.assetDir(), flavor, type);
     } else {
-      assets = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "assets");
+      assets = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, config.assetDir());
     }
 
     if (FileFsFile.from(BUILD_OUTPUT, "manifests").exists()) {

--- a/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
@@ -20,6 +20,8 @@ public class RobolectricGradleTestRunnerTest {
     FileFsFile.from("build", "intermediates", "res").getFile().mkdirs();
     FileFsFile.from("build", "intermediates", "assets").getFile().mkdirs();
     FileFsFile.from("build", "intermediates", "manifests").getFile().mkdirs();
+    FileFsFile.from("build", "intermediates", "res/foo").getFile().mkdirs();
+    FileFsFile.from("build", "intermediates", "assets/foo").getFile().mkdirs();
   }
 
   @After
@@ -27,6 +29,8 @@ public class RobolectricGradleTestRunnerTest {
     delete(FileFsFile.from("build", "intermediates", "res").getFile());
     delete(FileFsFile.from("build", "intermediates", "assets").getFile());
     delete(FileFsFile.from("build", "intermediates", "manifests").getFile());
+    delete(FileFsFile.from("build", "intermediates", "res/foo").getFile());
+    delete(FileFsFile.from("build", "intermediates", "assets/foo").getFile());
   }
 
   private static String convertPath(String path) {
@@ -82,6 +86,28 @@ public class RobolectricGradleTestRunnerTest {
   }
 
   @Test
+  public void getAppManifest_withResourceDirOverride_shouldCreateManifest() throws Exception {
+    final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(ResourceDirTest.class);
+    final AndroidManifest manifest = runner.getAppManifest(runner.getConfig(ResourceDirTest.class.getMethod("withoutAnnotation")));
+
+    assertThat(manifest.getPackageName()).isEqualTo("org.sandwich.foo");
+    assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("build/intermediates/res/foo/flavor1/type1"));
+    assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("build/intermediates/assets/flavor1/type1"));
+    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("build/intermediates/manifests/full/flavor1/type1/AndroidManifest.xml"));
+  }
+
+  @Test
+  public void getAppManifest_withAssetDirOverride_shouldCreateManifest() throws Exception {
+    final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(AssetsDirTest.class);
+    final AndroidManifest manifest = runner.getAppManifest(runner.getConfig(AssetsDirTest.class.getMethod("withoutAnnotation")));
+
+    assertThat(manifest.getPackageName()).isEqualTo("org.sandwich.foo");
+    assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("build/intermediates/res/flavor1/type1"));
+    assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("build/intermediates/assets/foo/flavor1/type1"));
+    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("build/intermediates/manifests/full/flavor1/type1/AndroidManifest.xml"));
+  }
+
+  @Test
   public void getAppManifest_shouldThrowException_whenConstantsNotSpecified() throws Exception {
     final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(NoConstantsTest.class);
     exception.expect(RuntimeException.class);
@@ -123,6 +149,24 @@ public class RobolectricGradleTestRunnerTest {
   @Ignore
   @Config(constants = BuildConfig.class, packageName = "fake.package.name")
   public static class PackageNameTest {
+
+    @Test
+    public void withoutAnnotation() throws Exception {
+    }
+  }
+
+  @Ignore
+  @Config(constants = BuildConfig.class, resourceDir = "res/foo")
+  public static class ResourceDirTest {
+
+    @Test
+    public void withoutAnnotation() throws Exception {
+    }
+  }
+
+  @Ignore
+  @Config(constants = BuildConfig.class, assetDir = "assets/foo")
+  public static class AssetsDirTest {
 
     @Test
     public void withoutAnnotation() throws Exception {


### PR DESCRIPTION
This patch enables the RobolectricGradleTestRunner to use the resourceDir and assetDir Config overrides. 

This creates an easy workaround for an issue that popped up with the 1.3-beta1 Android gradle plugin where the resources are no longer in `build/intermediates/res/flavor/type` but are in `build/intermediates/res/merged/flavor/type`

With this patch, adding `resourceDir = "res/merged"` to the `@Config` annotation will resolve the issues with resource loading.

It can also be overriden globally in `robolectric.properties` (probably what you want to do) by adding this line:

`resourceDir=res/merged`