### PR TITLE
Use "res/merged" for resource dir when on gradle 1.3, else fall back to "res"

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
@@ -38,7 +38,10 @@ public class RobolectricGradleTestRunner extends RobolectricTestRunner {
     final FileFsFile assets;
     final FileFsFile manifest;
 
-    if (FileFsFile.from(BUILD_OUTPUT, "res").exists()) {
+    // res/merged added in Android Gradle plugin 1.3-beta1
+    if (FileFsFile.from(BUILD_OUTPUT, "res", "merged").exists()) {
+      res = FileFsFile.from(BUILD_OUTPUT, "res", "merged", flavor, type);
+    } else if (FileFsFile.from(BUILD_OUTPUT, "res").exists()) {
       res = FileFsFile.from(BUILD_OUTPUT, "res", flavor, type);
     } else {
       res = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "res");

--- a/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
@@ -27,6 +27,7 @@ public class RobolectricGradleTestRunnerTest {
     delete(FileFsFile.from("build", "intermediates", "res").getFile());
     delete(FileFsFile.from("build", "intermediates", "assets").getFile());
     delete(FileFsFile.from("build", "intermediates", "manifests").getFile());
+    delete(FileFsFile.from("build", "intermediates", "res", "merged").getFile());
   }
 
   private static String convertPath(String path) {
@@ -77,6 +78,19 @@ public class RobolectricGradleTestRunnerTest {
 
     assertThat(manifest.getPackageName()).isEqualTo("fake.package.name");
     assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("build/intermediates/res/flavor1/type1"));
+    assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("build/intermediates/assets/flavor1/type1"));
+    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("build/intermediates/manifests/full/flavor1/type1/AndroidManifest.xml"));
+  }
+
+  @Test
+  public void getAppManifest_withMergedResources_shouldHaveMergedResPath() throws Exception {
+    FileFsFile.from("build", "intermediates", "res", "merged").getFile().mkdirs();
+
+    final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(PackageNameTest.class);
+    final AndroidManifest manifest = runner.getAppManifest(runner.getConfig(PackageNameTest.class.getMethod("withoutAnnotation")));
+
+    assertThat(manifest.getPackageName()).isEqualTo("fake.package.name");
+    assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("build/intermediates/res/merged/flavor1/type1"));
     assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("build/intermediates/assets/flavor1/type1"));
     assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("build/intermediates/manifests/full/flavor1/type1/AndroidManifest.xml"));
   }


### PR DESCRIPTION
This patch updates the `RobolectricGradleTestRunner` to prefer the new `res/merged` dir added in gradle plugin 1.3 (when available), else it will fall back to the old `res` dir used in previous versions of the plugin.

The decision to go this route instead of updating the `RobolectricGradleTestRunner` to allow overriding the path of the `res` dir was outlined in #1857