### PR TITLE
Switch shadow tests to run using MultiApiRobolectricTestRunner.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
             <includes>
               <include>**/*Test.java</include>
             </includes>
-            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=256m</argLine>
+            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=512m</argLine>
             <runOrder>random</runOrder>
             <systemProperties>
               <java.awt.headless>true</java.awt.headless>

--- a/robolectric/src/main/java/org/robolectric/MultiApiRobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/MultiApiRobolectricTestRunner.java
@@ -1,5 +1,7 @@
 package org.robolectric;
 
+import android.os.Build;
+
 import org.junit.runner.Runner;
 import org.junit.runners.Suite;
 import org.junit.runners.model.FrameworkMethod;
@@ -16,6 +18,36 @@ import java.util.List;
  * A test runner for Robolectric that will run a test against multiple API versions.
  */
 public class MultiApiRobolectricTestRunner extends Suite {
+
+  public static final int[] JELLY_BEAN_UP = {
+      Build.VERSION_CODES.JELLY_BEAN,
+      Build.VERSION_CODES.JELLY_BEAN_MR1,
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP
+  };
+
+  public static final int[] JELLY_BEAN_MR1_UP = {
+      Build.VERSION_CODES.JELLY_BEAN_MR1,
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP
+  };
+
+  public static final int[] JELLY_BEAN_MR2_UP = {
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP
+  };
+
+  public static final int[] KIT_KAT_UP = {
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP
+  };
+
+  public static final int[] LOLLIPOP_UP = {
+      Build.VERSION_CODES.LOLLIPOP
+  };
 
   protected static class TestRunnerForApiVersion extends RobolectricTestRunner {
 

--- a/robolectric/src/test/java/org/robolectric/shadows/AdapterViewBehavior.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/AdapterViewBehavior.java
@@ -14,7 +14,7 @@ import org.robolectric.util.Transcript;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 abstract public class AdapterViewBehavior {
   private AdapterView adapterView;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/SQLiteCursorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SQLiteCursorTest.java
@@ -13,7 +13,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class SQLiteCursorTest {
 
   private SQLiteDatabase database;

--- a/robolectric/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class SQLiteDatabaseTest {
     private SQLiteDatabase database;
     private static final String ANY_VALID_SQL = "SELECT 1";

--- a/robolectric/src/test/java/org/robolectric/shadows/SQLiteOpenHelperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SQLiteOpenHelperTest.java
@@ -15,7 +15,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class SQLiteOpenHelperTest {
 
   private TestOpenHelper helper;

--- a/robolectric/src/test/java/org/robolectric/shadows/SQLiteQueryBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SQLiteQueryBuilderTest.java
@@ -14,7 +14,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class SQLiteQueryBuilderTest {
 
   private static final String TABLE_NAME = "sqlBuilderTest";

--- a/robolectric/src/test/java/org/robolectric/shadows/SQLiteStatementTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SQLiteStatementTest.java
@@ -15,7 +15,7 @@ import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class SQLiteStatementTest {
   private SQLiteDatabase database;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAbsSeekBarTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAbsSeekBarTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAbsSeekBarTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAbsSpinnerAdapterViewBehaviorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAbsSpinnerAdapterViewBehaviorTest.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAbsSpinnerAdapterViewBehaviorTest extends AdapterViewBehavior {
   @Override public AdapterView createAdapterView() {
     return new Gallery(RuntimeEnvironment.application);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAbsSpinnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAbsSpinnerTest.java
@@ -14,7 +14,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAbsSpinnerTest {
   private Context context;
   private Spinner spinner;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAbsoluteLayoutTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAbsoluteLayoutTest.java
@@ -9,7 +9,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAbsoluteLayoutTest {
   @Test
   public void getLayoutParams_shouldReturnAbsoluteLayoutParams() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAbstractCursorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAbstractCursorTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAbstractCursorTest {
 
   private TestCursor cursor;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
@@ -16,7 +16,7 @@ import static android.content.Context.ACCESSIBILITY_SERVICE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAccessibilityManagerTest {
 
   private AccessibilityManager accessibilityManager;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
@@ -11,6 +11,7 @@ import android.accounts.OperationCanceledException;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -20,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
 import java.io.IOException;
 
@@ -36,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAccountManagerTest {
   Application app;
   AccountManager am;
@@ -527,6 +529,8 @@ public class ShadowAccountManagerTest {
   }
 
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.LOLLIPOP })
   public void addPreviousAccount() {
     Account account = new Account("name_a", "type_a");
     shadowOf(am).setPreviousAccountName(account, "old_name");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountTest.java
@@ -8,7 +8,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAccountTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityGroupTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityGroupTest.java
@@ -9,7 +9,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowActivityGroupTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityManagerTest.java
@@ -11,7 +11,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowActivityManagerTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityThreadTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityThreadTest.java
@@ -11,7 +11,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowActivityThreadTest {
     @Test
     public void testTriggersUndeclaredThrowableException() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
@@ -19,7 +19,7 @@ import java.util.Date;
 import static junit.framework.Assert.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAlarmManagerTest {
 
   private MyActivity activity;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAlertDialogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAlertDialogTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertTrue;
 import static org.robolectric.RuntimeEnvironment.application;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAlertDialogTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAnimationSetTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAnimationSetTest.java
@@ -13,7 +13,7 @@ import org.robolectric.TestRunners;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAnimationSetTest {
   final Animation.AnimationListener moveListener = mock(Animation.AnimationListener.class);
   final Animation.AnimationListener spinListener = mock(Animation.AnimationListener.class);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAnimationUtilsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAnimationUtilsTest.java
@@ -12,7 +12,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAnimationUtilsTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetHostTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetHostTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAppWidgetHostTest {
   private AppWidgetHost appWidgetHost;
   private ShadowAppWidgetHost shadowAppWidgetHost;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetHostViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetHostViewTest.java
@@ -12,7 +12,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAppWidgetHostViewTest {
   private AppWidgetHostView appWidgetHostView;
   private ShadowAppWidgetHostView shadowAppWidgetHostView;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetManagerTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAppWidgetManagerTest {
   private AppWidgetManager appWidgetManager;
   private ShadowAppWidgetManager shadowAppWidgetManager;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowArrayAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowArrayAdapterTest.java
@@ -20,7 +20,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowArrayAdapterTest {
   private ArrayAdapter<Integer> arrayAdapter;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.robolectric.util.TestUtil.joinPath;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAssetManagerTest {
 
   @Rule

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAsyncTaskTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAsyncTaskTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAsyncTaskTest {
   private Transcript transcript;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAudioEffectTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAudioEffectTest.java
@@ -8,7 +8,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAudioEffectTest {
 
   @Test public void queryEffects() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAudioManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAudioManagerTest.java
@@ -8,7 +8,7 @@ import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAudioManagerTest {
   private final AudioManager audioManager = new AudioManager(RuntimeEnvironment.application);
   private final ShadowAudioManager shadowAudioManager = Shadows.shadowOf(audioManager);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAutoCompleteTextViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAutoCompleteTextViewTest.java
@@ -16,7 +16,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowAutoCompleteTextViewTest {
   private final AutoCompleteAdapter adapter = new AutoCompleteAdapter(RuntimeEnvironment.application);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBaseAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBaseAdapterTest.java
@@ -11,7 +11,7 @@ import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowBaseAdapterTest {
   @Test
   public void shouldRecordNotifyDataSetChanged() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBinderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBinderTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 import static junit.framework.Assert.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowBinderTest {
   @Test
   public void transactCallsOnTransact() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapDrawableTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapDrawableTest.java
@@ -22,7 +22,7 @@ import java.io.InputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowBitmapDrawableTest {
   private final Resources resources = RuntimeEnvironment.application.getResources();
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapFactoryTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowBitmapFactoryTest {
   @Test
   public void decodeResource_shouldSetDescriptionAndCreatedFrom() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
@@ -8,6 +8,7 @@ import android.graphics.ColorMatrix;
 import android.graphics.ColorMatrixColorFilter;
 import android.graphics.Matrix;
 import android.graphics.Paint;
+import android.os.Build;
 import android.util.DisplayMetrics;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,7 +18,7 @@ import org.robolectric.internal.Shadow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowBitmapTest {
   @Test
   public void shouldCreateScaledBitmap() throws Exception {
@@ -70,6 +71,11 @@ public class ShadowBitmapTest {
   }
 
   @Test
+  @org.robolectric.annotation.Config(sdk = {
+      Build.VERSION_CODES.JELLY_BEAN_MR1,
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
   public void shouldCreateMutableBitmapWithDisplayMetrics() throws Exception {
     final DisplayMetrics metrics = new DisplayMetrics();
     metrics.densityDpi = 1000;
@@ -148,6 +154,11 @@ public class ShadowBitmapTest {
   }
 
   @Test(expected = NullPointerException.class)
+  @org.robolectric.annotation.Config(sdk = {
+      Build.VERSION_CODES.JELLY_BEAN_MR1,
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
   public void byteCountIsAccurate() {
     Bitmap b1 = Bitmap.createBitmap(10, 10, Config.ARGB_8888);
     assertThat(b1.getByteCount()).isEqualTo(400);
@@ -160,6 +171,11 @@ public class ShadowBitmapTest {
   }
 
   @Test
+  @org.robolectric.annotation.Config(sdk = {
+      Build.VERSION_CODES.JELLY_BEAN_MR1,
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
   public void shouldSetDensity() {
     final Bitmap bitmap = Bitmap.createBitmap(new DisplayMetrics(), 100, 100, Config.ARGB_8888);
     bitmap.setDensity(1000);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothAdapterTest.java
@@ -3,18 +3,21 @@ package org.robolectric.shadows;
 
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
+import android.os.Build;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 import org.robolectric.internal.Shadow;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowBluetoothAdapterTest {
   private BluetoothAdapter bluetoothAdapter;
   private ShadowBluetoothAdapter shadowBluetoothAdapter;
@@ -60,6 +63,10 @@ public class ShadowBluetoothAdapterTest {
   }
 
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
   public void testLeScan() {
     BluetoothAdapter.LeScanCallback callback1 = newLeScanCallback();
     BluetoothAdapter.LeScanCallback callback2 = newLeScanCallback();
@@ -76,6 +83,10 @@ public class ShadowBluetoothAdapterTest {
   }
 
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
   public void testGetSingleLeScanCallback() {
     BluetoothAdapter.LeScanCallback callback1 = newLeScanCallback();
     BluetoothAdapter.LeScanCallback callback2 = newLeScanCallback();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBundleTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBundleTest.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import static org.junit.Assert.*;
 
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowBundleTest {
 
   private Bundle bundle;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraParametersTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraParametersTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCameraParametersTest {
 
   private Camera.Parameters parameters;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraSizeTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraSizeTest.java
@@ -10,7 +10,7 @@ import org.robolectric.internal.Shadow;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCameraSizeTest {
 
   private Camera.Size cameraSize;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraTest.java
@@ -16,7 +16,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCameraTest {
 
   private Camera camera;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCanvasTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCanvasTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.shadows.ShadowPath.Point.Type.LINE_TO;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCanvasTest {
   private Bitmap targetBitmap;
   private Bitmap imageBitmap;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCharArrayBufferTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCharArrayBufferTest.java
@@ -6,7 +6,7 @@ import org.robolectric.TestRunners;
 import org.apache.http.util.CharArrayBuffer;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCharArrayBufferTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCheckBoxTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCheckBoxTest.java
@@ -8,7 +8,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCheckBoxTest {
   @Test
   public void testWorks() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCheckedTextViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCheckedTextViewTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCheckedTextViewTest {
 
   private CheckedTextView checkedTextView;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowChoreographerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowChoreographerTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowChoreographerTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowClipboardManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowClipboardManagerTest.java
@@ -13,7 +13,7 @@ import static android.content.ClipboardManager.OnPrimaryClipChangedListener;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowClipboardManagerTest {
 
   private ClipboardManager clipboardManager;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowColorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowColorTest.java
@@ -6,7 +6,7 @@ import org.robolectric.TestRunners;
 import android.graphics.Color;
 import static org.assertj.core.api.Assertions.*;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowColorTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowConfigurationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowConfigurationTest.java
@@ -12,7 +12,7 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowConfigurationTest {
 
   private Configuration configuration;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowConnectivityManagerTest {
   private ConnectivityManager connectivityManager;
   private ShadowNetworkInfo shadowOfActiveNetworkInfo;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentObserverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentObserverTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowContentObserverTest {
 
   private TestContentObserver observer;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentProviderClientTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentProviderClientTest.java
@@ -6,6 +6,7 @@ import android.content.ContentProviderOperation;
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.CancellationSignal;
 import org.junit.Before;
@@ -14,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 
@@ -23,7 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowContentProviderClientTest {
 
   static final String AUTHORITY = "org.robolectric";
@@ -74,6 +76,10 @@ public class ShadowContentProviderClientTest {
   }
 
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
   public void shouldDelegateToContentProvider() throws Exception {
     ContentProviderClient client = contentResolver.acquireContentProviderClient(AUTHORITY);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentProviderOperationBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentProviderOperationBuilderTest.java
@@ -13,7 +13,7 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowContentProviderOperationBuilderTest {
   private Builder builder;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentProviderOperationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentProviderOperationTest.java
@@ -15,7 +15,7 @@ import android.net.Uri;
 /**
  * Tests for {@link ShadowContentProviderOperation}.
  */
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowContentProviderOperationTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentProviderResultTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentProviderResultTest.java
@@ -8,7 +8,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowContentProviderResultTest {
   @Test
   public void count() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentProviderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentProviderTest.java
@@ -11,7 +11,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowContentProviderTest {
 
   class TestContentProvider extends ContentProvider {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowContentResolverTest {
   static final String AUTHORITY = "org.robolectric";
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentUrisTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentUrisTest.java
@@ -9,7 +9,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowContentUrisTest {
   Uri URI;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentValuesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentValuesTest.java
@@ -8,7 +8,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowContentValuesTest {
   private static final String KEY = "key";
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.util.TestUtil.TEST_PACKAGE;
 import static org.robolectric.util.TestUtil.TEST_RESOURCE_PATH;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowContextTest {
   private final Context context = RuntimeEnvironment.application;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 import static org.robolectric.Robolectric.buildActivity;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowContextWrapperTest {
   public Transcript transcript;
   private ContextWrapper contextWrapper;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCookieManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCookieManagerTest.java
@@ -8,7 +8,7 @@ import org.robolectric.internal.Shadow;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCookieManagerTest {
   private final String url = "robolectric.org/";
   private final String httpUrl = "http://robolectric.org/";

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCookieSyncManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCookieSyncManagerTest.java
@@ -1,16 +1,18 @@
 package org.robolectric.shadows;
 
 import android.app.Activity;
+import android.os.Build;
 import android.webkit.CookieManager;
 import android.webkit.CookieSyncManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCookieSyncManagerTest {
 
   @Test
@@ -25,6 +27,8 @@ public class ShadowCookieSyncManagerTest {
   }
 
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.LOLLIPOP })
   public void testSyncAndReset() {
     CookieSyncManager.createInstance(new Activity());
     CookieSyncManager mgr = CookieSyncManager.getInstance();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCornerPathEffectTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCornerPathEffectTest.java
@@ -9,7 +9,7 @@ import static junit.framework.Assert.assertEquals;
 import static org.robolectric.Shadows.shadowOf;
 
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCornerPathEffectTest {
   @Test
   public void shouldGetRadius() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCountDownTimerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCountDownTimerTest.java
@@ -9,7 +9,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCountDownTimerTest {
 
   private ShadowCountDownTimer shadowCountDownTimer;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCursorAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCursorAdapterTest.java
@@ -20,7 +20,7 @@ import static android.widget.CursorAdapter.FLAG_AUTO_REQUERY;
 import static android.widget.CursorAdapter.FLAG_REGISTER_CONTENT_OBSERVER;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCursorAdapterTest {
 
   private Cursor curs;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCursorWindowTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCursorWindowTest.java
@@ -9,7 +9,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCursorWindowTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCursorWrapperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCursorWrapperTest.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowCursorWrapperTest {
 
   private class ForwardVerifier {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDatabaseUtilsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDatabaseUtilsTest.java
@@ -7,7 +7,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowDatabaseUtilsTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDateFormatTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDateFormatTest.java
@@ -10,7 +10,7 @@ import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowDateFormatTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDateIntervalFormatTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDateIntervalFormatTest.java
@@ -2,11 +2,13 @@
 
 package org.robolectric.shadows;
 
+import android.os.Build;
 import android.text.format.DateUtils;
 import libcore.icu.DateIntervalFormat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
 import java.util.Calendar;
 import java.util.Locale;
@@ -14,7 +16,10 @@ import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+@Config(sdk = {
+    Build.VERSION_CODES.KITKAT,
+    Build.VERSION_CODES.LOLLIPOP })
 public class ShadowDateIntervalFormatTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDatePickerDialogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDatePickerDialogTest.java
@@ -1,11 +1,13 @@
 package org.robolectric.shadows;
 
+import android.os.Build;
 import android.widget.DatePicker;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import android.app.DatePickerDialog;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
 import java.lang.Override;
 import java.util.Locale;
@@ -13,7 +15,13 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+@Config(sdk = {
+    Build.VERSION_CODES.JELLY_BEAN,
+    Build.VERSION_CODES.JELLY_BEAN_MR1,
+    Build.VERSION_CODES.JELLY_BEAN_MR2,
+    // Build.VERSION_CODES.KITKAT, - Does not pass on Kit Kat
+    Build.VERSION_CODES.LOLLIPOP })
 public class ShadowDatePickerDialogTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDateUtilsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDateUtilsTest.java
@@ -10,24 +10,29 @@ import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowDateUtilsTest {
 
   @Test
-  public void formatDateTime_worksOnLollipop() {
+  @Config(sdk = {
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
+  public void formatDateTime_worksSinceKitKat() {
     String actual = DateUtils.formatDateTime(RuntimeEnvironment.application, 1420099200000L, DateUtils.FORMAT_NUMERIC_DATE);
     assertThat(actual).isEqualTo("1/1");
   }
 
   @Test
-  @Config(sdk = Build.VERSION_CODES.JELLY_BEAN_MR2)
-  public void formatDateTime_worksOnJellybean() {
+  @Config(sdk = {
+      Build.VERSION_CODES.JELLY_BEAN,
+      Build.VERSION_CODES.JELLY_BEAN_MR1,
+      Build.VERSION_CODES.JELLY_BEAN_MR2 })
+  public void formatDateTime_worksPreKitKat() {
     String actual = DateUtils.formatDateTime(RuntimeEnvironment.application, 1420099200000L, DateUtils.FORMAT_NUMERIC_DATE);
     assertThat(actual).isEqualTo("1/1/2015");
   }
 
   @Test
-  @Config(sdk = Build.VERSION_CODES.JELLY_BEAN_MR2)
   public void isToday_shouldReturnFalseForNotToday() {
     long today = java.util.Calendar.getInstance().getTimeInMillis();
     ShadowSystemClock.setCurrentTimeMillis(today);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDebugTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDebugTest.java
@@ -7,7 +7,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowDebugTest {
   @Test
   public void initNoCrash() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDialogPreferenceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDialogPreferenceTest.java
@@ -12,7 +12,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowDialogPreferenceTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDialogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDialogTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.robolectric.util.TestUtil.assertInstanceOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowDialogTest {
   @Test
   public void shouldCallOnDismissListener() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayTest.java
@@ -2,17 +2,19 @@ package org.robolectric.shadows;
 
 import android.graphics.Point;
 import android.graphics.Rect;
+import android.os.Build;
 import android.util.DisplayMetrics;
 import android.view.Display;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 import org.robolectric.internal.Shadow;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowDisplayTest {
   @Test
   public void shouldProvideDisplayMetrics() throws Exception {
@@ -89,6 +91,11 @@ public class ShadowDisplayTest {
   }
 
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.JELLY_BEAN_MR1,
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
   public void shouldProvideDisplayInformation() {
     Display display = Shadow.newInstanceOf(Display.class);
     ShadowDisplay shadow = Shadows.shadowOf(display);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDownloadManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDownloadManagerTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.shadows.ShadowDownloadManager.ShadowRequest;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowDownloadManagerTest {
 
   private final Uri uri = Uri.parse("http://example.com/foo.mp4");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDrawableTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDrawableTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowDrawableTest {
   @Test
   public void createFromStream__shouldReturnNullWhenAskedToCreateADrawableFromACorruptedSourceStream() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowEditTextPreferenceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowEditTextPreferenceTest.java
@@ -13,7 +13,7 @@ import org.robolectric.TestRunners;
 import static junit.framework.Assert.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowEditTextPreferenceTest {
 
   private static final String SOME_TEXT = "some text";

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowEditTextTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowEditTextTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.RuntimeEnvironment.application;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowEditTextTest {
   private EditText editText;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowEnvironmentTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowEnvironmentTest.java
@@ -1,10 +1,12 @@
 package org.robolectric.shadows;
 
+import android.os.Build;
 import android.os.Environment;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
 import java.io.File;
 
@@ -12,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowEnvironmentTest {
 
   @After
@@ -48,6 +50,8 @@ public class ShadowEnvironmentTest {
   }
 
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.LOLLIPOP })
   public void isExternalStorageRemovable_shouldReturnSavedValue() {
     final File file = new File("/mnt/media/file");
     assertThat(Environment.isExternalStorageRemovable(file)).isFalse();
@@ -56,6 +60,8 @@ public class ShadowEnvironmentTest {
   }
 
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.LOLLIPOP })
   public void isExternalStorageEmulated_shouldReturnSavedValue() {
     final File file = new File("/mnt/media/file");
     assertThat(Environment.isExternalStorageEmulated(file)).isFalse();
@@ -64,6 +70,8 @@ public class ShadowEnvironmentTest {
   }
 
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.LOLLIPOP })
   public void storageIsLazy() {
     assertNull(ShadowEnvironment.EXTERNAL_CACHE_DIR);
     assertNull(ShadowEnvironment.EXTERNAL_FILES_DIR);
@@ -76,6 +84,8 @@ public class ShadowEnvironmentTest {
   }
 
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.LOLLIPOP })
   public void reset_shouldClearRemovableFiles() {
     final File file = new File("foo");
     ShadowEnvironment.setExternalStorageRemovable(file, true);
@@ -86,6 +96,8 @@ public class ShadowEnvironmentTest {
   }
 
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.LOLLIPOP })
   public void reset_shouldClearEmulatedFiles() {
     final File file = new File("foo");
     ShadowEnvironment.setExternalStorageEmulated(file, true);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowExpandableListViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowExpandableListViewTest.java
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowExpandableListViewTest {
 
   private ExpandableListView expandableListView;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowFrameLayoutTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowFrameLayoutTest.java
@@ -11,7 +11,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowFrameLayoutTest {
 
   private FrameLayout frameLayout;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowGestureDetectorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowGestureDetectorTest.java
@@ -13,7 +13,7 @@ import org.robolectric.internal.Shadow;
 import static junit.framework.Assert.*;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowGestureDetectorTest {
 
   private GestureDetector detector;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowGradientDrawableTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowGradientDrawableTest.java
@@ -8,7 +8,7 @@ import android.graphics.drawable.GradientDrawable;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowGradientDrawableTest {
   @Test
   public void testGetColor_returnsColor() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowHandlerTest {
   private Transcript transcript;
   TestRunnable scratchRunnable = new TestRunnable();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerThreadTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerThreadTest.java
@@ -13,7 +13,7 @@ import org.robolectric.TestRunners;
 import static org.junit.Assert.*;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowHandlerThreadTest {
 
   private HandlerThread handlerThread;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowHtmlTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowHtmlTest.java
@@ -14,7 +14,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowHtmlTest {
   private Context context;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowHttpResponseCacheTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowHttpResponseCacheTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowHttpResponseCacheTest {
   @Before
   public void setUp() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowICUTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowICUTest.java
@@ -1,13 +1,18 @@
 package org.robolectric.shadows;
 
+import android.os.Build;
+
 import libcore.icu.ICU;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+@Config(sdk = {
+    Build.VERSION_CODES.LOLLIPOP })
 public class ShadowICUTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowImageViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowImageViewTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
 import static org.robolectric.RuntimeEnvironment.application;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowImageViewTest {
   private ImageView imageView;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowInputDeviceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowInputDeviceTest.java
@@ -7,7 +7,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowInputDeviceTest {
   @Test
   public void canConstructInputDeviceWithName() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowInputEventTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowInputEventTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowInputEventTest {
   @Test
   public void canSetInputDeviceOnKeyEvent() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowInputMethodManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowInputMethodManagerTest.java
@@ -11,7 +11,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowInputMethodManagerTest {
 
   private InputMethodManager manager;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentFilterAuthorityEntryTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentFilterAuthorityEntryTest.java
@@ -7,7 +7,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowIntentFilterAuthorityEntryTest {
   @Test(expected = NumberFormatException.class)
   public void constructor_shouldThrowAnExceptionIfPortIsNotAValidNumber() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentFilterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentFilterTest.java
@@ -8,7 +8,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowIntentFilterTest {
   @Test
   public void copyConstructorTest() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentServiceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentServiceTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowIntentServiceTest {
   @Test
   public void shouldSetIntentRedelivery() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowIntentTest {
   private static final String TEST_ACTIVITY_CLASS_NAME = "org.robolectric.shadows.TestActivity";
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowJsPromptResultTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowJsPromptResultTest.java
@@ -7,7 +7,7 @@ import org.robolectric.TestRunners;
 
 import static org.junit.Assert.assertNotNull;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowJsPromptResultTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowJsResultTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowJsResultTest.java
@@ -10,7 +10,7 @@ import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowJsResultTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowJsonReaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowJsonReaderTest.java
@@ -8,7 +8,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowJsonReaderTest {
   @Test public void shouldWork() throws Exception {
     JsonReader jsonReader = new JsonReader(new StringReader("{\"abc\": \"def\"}"));

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowKeyguardManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowKeyguardManagerTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowKeyguardManagerTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLayerDrawableTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLayerDrawableTest.java
@@ -13,7 +13,7 @@ import org.robolectric.TestRunners;
 import static org.junit.Assert.*;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowLayerDrawableTest {
   /**
    * drawables

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLayoutAnimationControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLayoutAnimationControllerTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowLayoutAnimationControllerTest {
   private ShadowLayoutAnimationController shadow;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLayoutInflaterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLayoutInflaterTest.java
@@ -45,7 +45,7 @@ import static org.robolectric.test.Assertions.assertThat;
 import static org.robolectric.util.TestUtil.TEST_PACKAGE;
 import static org.robolectric.util.TestUtil.assertInstanceOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowLayoutInflaterTest {
   private Activity context;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLayoutParamsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLayoutParamsTest.java
@@ -9,7 +9,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowLayoutParamsTest {
   @Test
   public void testConstructor() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLinearLayoutTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLinearLayoutTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertSame;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowLinearLayoutTest {
   private LinearLayout linearLayout;
   private ShadowLinearLayout shadow;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLinkMovementMethodTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLinkMovementMethodTest.java
@@ -7,7 +7,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowLinkMovementMethodTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowListPopupWindowTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowListPopupWindowTest.java
@@ -11,7 +11,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowListPopupWindowTest {
   @Test
   public void show_setsLastListPopupWindow() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowListPreferenceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowListPreferenceTest.java
@@ -11,7 +11,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.buildActivity;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowListPreferenceTest {
 
   private ListPreference listPreference;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowListViewAdapterViewBehaviorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowListViewAdapterViewBehaviorTest.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowListViewAdapterViewBehaviorTest extends AdapterViewBehavior {
   @Override public AdapterView createAdapterView() {
     return new ListView(RuntimeEnvironment.application);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowListViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowListViewTest.java
@@ -27,7 +27,7 @@ import android.widget.BaseAdapter;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowListViewTest {
 
   private Transcript transcript;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLocaleDataTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLocaleDataTest.java
@@ -1,13 +1,17 @@
 package org.robolectric.shadows;
 
+import android.os.Build;
+
 import java.util.Locale;
 import libcore.icu.LocaleData;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowLocaleDataTest {
 
   @Test
@@ -22,30 +26,20 @@ public class ShadowLocaleDataTest {
 
     assertThat(localeData.longMonthNames).isEqualTo(new String[]{"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"});
     assertThat(localeData.shortMonthNames).isEqualTo(new String[]{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"});
-    assertThat(localeData.tinyMonthNames).isEqualTo(new String[]{"J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"});
 
     assertThat(localeData.longStandAloneMonthNames).isEqualTo(localeData.longMonthNames);
     assertThat(localeData.shortStandAloneMonthNames).isEqualTo(localeData.shortMonthNames);
-    assertThat(localeData.tinyStandAloneMonthNames).isEqualTo(localeData.tinyMonthNames);
 
     assertThat(localeData.longWeekdayNames).isEqualTo(new String[]{"", "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"});
     assertThat(localeData.shortWeekdayNames).isEqualTo(new String[]{"", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"});
-    assertThat(localeData.tinyWeekdayNames).isEqualTo(new String[]{"", "S", "M", "T", "W", "T", "F", "S"});
 
     assertThat(localeData.longStandAloneWeekdayNames).isEqualTo(localeData.longWeekdayNames);
     assertThat(localeData.shortStandAloneWeekdayNames).isEqualTo(localeData.shortWeekdayNames);
-    assertThat(localeData.tinyStandAloneWeekdayNames).isEqualTo(localeData.tinyWeekdayNames);
-
-    assertThat(localeData.yesterday).isEqualTo("Yesterday");
-    assertThat(localeData.today).isEqualTo("Today");
-    assertThat(localeData.tomorrow).isEqualTo("Tomorrow");
 
     assertThat(localeData.fullTimeFormat).isEqualTo("h:mm:ss a zzzz");
     assertThat(localeData.longTimeFormat).isEqualTo("h:mm:ss a z");
     assertThat(localeData.mediumTimeFormat).isEqualTo("h:mm:ss a");
     assertThat(localeData.shortTimeFormat).isEqualTo("h:mm a");
-    assertThat(localeData.timeFormat12).isEqualTo("h:mm a");
-    assertThat(localeData.timeFormat24).isEqualTo("HH:mm");
 
     assertThat(localeData.fullDateFormat).isEqualTo("EEEE, MMMM d, y");
     assertThat(localeData.longDateFormat).isEqualTo("MMMM d, y");
@@ -59,7 +53,6 @@ public class ShadowLocaleDataTest {
     assertThat(localeData.percent).isEqualTo('%');
     assertThat(localeData.perMill).isEqualTo('‰');
     assertThat(localeData.monetarySeparator).isEqualTo('.');
-    assertThat(localeData.minusSign).isEqualTo("-");
 
     assertThat(localeData.exponentSeparator).isEqualTo("E");
     assertThat(localeData.infinity).isEqualTo("∞");
@@ -73,6 +66,48 @@ public class ShadowLocaleDataTest {
     assertThat(localeData.currencyPattern).isEqualTo("¤#,##0.00;(¤#,##0.00)");
     assertThat(localeData.percentPattern).isEqualTo("#,##0%");
   }
+
+  @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.JELLY_BEAN_MR1,
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
+  public void shouldSupportLocaleEn_US_since_jelly_bean_mr1() throws Exception {
+    LocaleData localeData = LocaleData.get(Locale.US);
+
+    assertThat(localeData.tinyMonthNames).isEqualTo(new String[]{"J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"});
+    assertThat(localeData.tinyStandAloneMonthNames).isEqualTo(localeData.tinyMonthNames);
+    assertThat(localeData.tinyWeekdayNames).isEqualTo(new String[]{"", "S", "M", "T", "W", "T", "F", "S"});
+    assertThat(localeData.tinyStandAloneWeekdayNames).isEqualTo(localeData.tinyWeekdayNames);
+
+    assertThat(localeData.yesterday).isEqualTo("Yesterday");
+    assertThat(localeData.today).isEqualTo("Today");
+    assertThat(localeData.tomorrow).isEqualTo("Tomorrow");
+  }
+
+  @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
+  public void shouldSupportLocaleEn_US_since_jelly_bean_mr2() throws Exception {
+    LocaleData localeData = LocaleData.get(Locale.US);
+
+    assertThat(localeData.timeFormat12).isEqualTo("h:mm a");
+    assertThat(localeData.timeFormat24).isEqualTo("HH:mm");
+
+  }
+
+  @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.LOLLIPOP })
+  public void shouldSupportLocaleEn_US_since_lollipop() throws Exception {
+    LocaleData localeData = LocaleData.get(Locale.US);
+
+    assertThat(localeData.minusSign).isEqualTo("-");
+  }
+
 
   @Test
   public void shouldDefaultToTheDefaultLocale() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLocationManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLocationManagerTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertSame;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowLocationManagerTest {
   private LocationManager locationManager;
   private ShadowLocationManager shadowLocationManager;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLocationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLocationTest.java
@@ -11,7 +11,7 @@ import org.robolectric.TestRunners;
 import static junit.framework.Assert.*;
 import static org.junit.Assert.assertArrayEquals;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowLocationTest {
 
   private Location location;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.robolectric.shadows.ShadowLog.LogItem;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowLogTest {
   @Test
   public void d_shouldLogAppropriately() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowLooperTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLruTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLruTest.java
@@ -7,7 +7,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowLruTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMarginLayoutParamsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMarginLayoutParamsTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * {@link org.robolectric.shadows.ShadowViewGroup.ShadowMarginLayoutParams} test suite.
  */
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowMarginLayoutParamsTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMatrixCursorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMatrixCursorTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowMatrixCursorTest {
 
   private MatrixCursor singleColumnSingleNullValueMatrixCursor;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMatrixTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMatrixTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowMatrixTest {
   @Test
   public void preOperationsAreStacked() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaMetadataRetrieverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaMetadataRetrieverTest.java
@@ -24,7 +24,7 @@ import static org.robolectric.shadows.ShadowMediaMetadataRetriever.addFrame;
 import static org.robolectric.shadows.ShadowMediaMetadataRetriever.addMetadata;
 import static org.robolectric.shadows.util.DataSource.toDataSource;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowMediaMetadataRetrieverTest {
   private final String path = "/media/foo.mp3";
   private final String path2 = "/media/foo2.mp3";

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
@@ -37,7 +37,7 @@ import static org.robolectric.shadows.ShadowMediaPlayer.addException;
 import static org.robolectric.shadows.ShadowMediaPlayer.State.*;
 import static org.robolectric.shadows.util.DataSource.toDataSource;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowMediaPlayerTest {
 
   private static final String DUMMY_SOURCE = "dummy-source";

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaRecorderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaRecorderTest.java
@@ -13,7 +13,7 @@ import org.robolectric.internal.Shadow;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowMediaRecorderTest {
 
   private MediaRecorder mediaRecorder;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaStoreTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaStoreTest.java
@@ -8,7 +8,7 @@ import static android.provider.MediaStore.Images;
 import static android.provider.MediaStore.Video;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowMediaStoreTest {
   @Test
   public void shouldInitializeFields() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMergeCursorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMergeCursorTest.java
@@ -11,7 +11,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowMergeCursorTest {
 
   private SQLiteDatabase database;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageQueueTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageQueueTest.java
@@ -20,7 +20,7 @@ import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.util.ReflectionHelpers.*;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowMessageQueueTest {
   private MessageQueue queue;
   private ShadowMessageQueue shadowQueue;
@@ -121,12 +121,18 @@ public class ShadowMessageQueueTest {
   }
   
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
   public void enqueueMessage_returnsFalse_whenQuitting() {
     setField(queue, "mQuitting", true);
     assertThat(enqueueMessage(testMessage, 1)).as("enqueueMessage()").isFalse();
   }
-  
+
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
   public void enqueueMessage_doesntSchedule_whenQuitting() {
     setField(queue, "mQuitting", true);
     enqueueMessage(testMessage, 1);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowMessageTest {
 
   @Test
@@ -178,6 +178,8 @@ public class ShadowMessageTest {
   }
   
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.LOLLIPOP })
   public void testIsInUse() {
     ShadowLooper.pauseMainLooper();
     Handler h = new Handler();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMessengerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMessengerTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowMessengerTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMimeTypeMapTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMimeTypeMapTest.java
@@ -9,7 +9,7 @@ import org.robolectric.TestRunners;
 import static org.junit.Assert.*;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowMimeTypeMapTest {
 
   private static final String IMAGE_EXTENSION = "jpg";

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMotionEventTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMotionEventTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowMotionEventTest {
   private MotionEvent event;
   private ShadowMotionEvent shadowMotionEvent;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNetworkInfoTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNetworkInfoTest.java
@@ -9,7 +9,7 @@ import org.robolectric.internal.Shadow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowNetworkInfoTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNfcAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNfcAdapterTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowNfcAdapterTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNonAppLibraryTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNonAppLibraryTest.java
@@ -13,7 +13,7 @@ import org.robolectric.annotation.Config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Config(manifest = Config.NONE)
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowNonAppLibraryTest {
   @Test public void shouldStillCreateAnApplication() throws Exception {
     assertThat(RuntimeEnvironment.application).isExactlyInstanceOf(Application.class);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBigTextStyleTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBigTextStyleTest.java
@@ -13,7 +13,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
 import org.robolectric.shadows.ShadowNotification.ShadowBigTextStyle;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowNotificationBigTextStyleTest {
 
   private final Builder builder = new Builder(application);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
@@ -3,16 +3,19 @@ package org.robolectric.shadows;
 import android.app.Notification;
 import android.app.Notification.Style;
 import android.app.PendingIntent;
+import android.os.Build;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowNotification.Progress;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowNotificationBuilderTest {
   private Notification notification;
   private ShadowNotification s;
@@ -45,6 +48,11 @@ public class ShadowNotificationBuilderTest {
   }
 
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.JELLY_BEAN_MR1,
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
   public void build_setShowWhenOnNotification() {
     builder.setShowWhen(false);
     build();
@@ -174,6 +182,10 @@ public class ShadowNotificationBuilderTest {
   }
 
   @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
   public void build_addsActionToNotification() throws Exception {
     PendingIntent action = PendingIntent.getBroadcast(RuntimeEnvironment.application, 0, null, 0);
     builder.addAction(0, "Action", action);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowNotificationManagerTest {
   private NotificationManager notificationManager;
   private Notification notification1 = new Notification();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowNotificationTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNumberPickerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNumberPickerTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowNumberPickerTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowObjectAnimatorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowObjectAnimatorTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowObjectAnimatorTest {
   private final AnimatorTarget target = new AnimatorTarget();
   private final Animator.AnimatorListener listener = mock(Animator.AnimatorListener.class);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowOverScrollerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowOverScrollerTest.java
@@ -11,7 +11,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowOverScrollerTest {
   private OverScroller overScroller;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPaintTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPaintTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
 
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowPaintTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPairTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPairTest.java
@@ -7,7 +7,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowPairTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelFileDescriptorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelFileDescriptorTest.java
@@ -12,7 +12,7 @@ import java.io.FileOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowParcelFileDescriptorTest {
   private File file;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelTest.java
@@ -20,7 +20,7 @@ import android.accounts.Account;
 import android.os.Bundle;
 import android.os.Parcel;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowParcelTest {
 
   private Parcel parcel;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPasswordTransformationMethodTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPasswordTransformationMethodTest.java
@@ -8,7 +8,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowPasswordTransformationMethodTest {
 
   private PasswordTransformationMethod transformationMethod;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPathTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPathTest.java
@@ -15,7 +15,7 @@ import static org.robolectric.shadows.ShadowPath.Point.Type.LINE_TO;
 import static org.robolectric.shadows.ShadowPath.Point.Type.MOVE_TO;
 
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowPathTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPendingIntentTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPendingIntentTest.java
@@ -15,7 +15,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowPendingIntentTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPopupMenuTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPopupMenuTest.java
@@ -13,7 +13,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowPopupMenuTest {
 
   private PopupMenu popupMenu;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPopupWindowTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPopupWindowTest.java
@@ -28,7 +28,7 @@ import static org.robolectric.Shadows.shadowOf;
 @RunWith(Enclosed.class)
 public class ShadowPopupWindowTest {
 
-  @RunWith(TestRunners.WithDefaults.class)
+  @RunWith(TestRunners.MultiApiWithDefaults.class)
   public static class WithoutContentView {
 
     private PopupWindow popupWindow;
@@ -104,7 +104,7 @@ public class ShadowPopupWindowTest {
     }
   }
 
-  @RunWith(TestRunners.WithDefaults.class)
+  @RunWith(TestRunners.MultiApiWithDefaults.class)
   public static class WithContentView {
 
     private WindowManager windowManager;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPorterDuffColorFilterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPorterDuffColorFilterTest.java
@@ -3,14 +3,18 @@ package org.robolectric.shadows;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
+import android.os.Build;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+@Config(sdk = {
+    Build.VERSION_CODES.LOLLIPOP })
 public class ShadowPorterDuffColorFilterTest {
   @Test
   public void constructor_shouldWork() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPowerManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPowerManagerTest.java
@@ -14,7 +14,7 @@ import org.robolectric.annotation.Config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowPowerManagerTest {
   private PowerManager powerManager;
   private ShadowPowerManager shadowPowerManager;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPreferenceActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPreferenceActivityTest.java
@@ -12,7 +12,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowPreferenceActivityTest {
 
   private TestPreferenceActivity activity;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPreferenceActivityTestWithFragment.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPreferenceActivityTestWithFragment.java
@@ -20,7 +20,7 @@ import org.robolectric.TestRunners;
  * trying to access a Context while inflating the Preference objects defined in
  * xml. This class tests that path.
  */
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowPreferenceActivityTestWithFragment {
   private TestPreferenceActivity activity = Robolectric.setupActivity(TestPreferenceActivity.class);
   private TestPreferenceFragment fragment;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPreferenceGroupTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPreferenceGroupTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.buildActivity;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowPreferenceGroupTest {
 
   private TestPreferenceGroup group;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPreferenceManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPreferenceManagerTest.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowPreferenceManagerTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowProcessTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowProcessTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowProcessTest {
   @Test
   public void shouldBeZeroWhenNotSet() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowProgressBarTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowProgressBarTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.*;
 import static org.robolectric.RuntimeEnvironment.application;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowProgressBarTest {
 
   private int[] testValues = {0, 1, 2, 100};

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowProgressDialogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowProgressDialogTest.java
@@ -12,7 +12,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowProgressDialogTest {
 
   private ProgressDialog dialog;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRadioButtonTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRadioButtonTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowRadioButtonTest {
   @Test
   public void canBeExplicitlyChecked() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRadioGroupTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRadioGroupTest.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowRadioGroupTest {
   private static final int BUTTON_ID = 3245;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRatingBarTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRatingBarTest.java
@@ -10,7 +10,7 @@ import org.robolectric.util.Transcript;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowRatingBarTest {
 
   private RatingBar ratingBar;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRectTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRectTest.java
@@ -8,7 +8,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowRectTest {
   @Before
   public void setUp() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRelativeLayoutTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRelativeLayoutTest.java
@@ -12,7 +12,7 @@ import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowRelativeLayoutTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRemoteCallbackListTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRemoteCallbackListTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowRemoteCallbackListTest {
   @Test
   public void testBasicWiring() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRemoteViewsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRemoteViewsTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.buildActivity;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowRemoteViewsTest {
   private final String packageName = RuntimeEnvironment.application.getPackageName();
   private final Activity activity = buildActivity(Activity.class).create().get();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResolveInfoTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResolveInfoTest.java
@@ -9,7 +9,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowResolveInfoTest {
 
   private ResolveInfo mResolveInfo;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import android.app.Activity;
 import android.content.res.*;
 import android.graphics.drawable.*;
+import android.os.Build;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import org.assertj.core.data.Offset;
@@ -24,7 +25,9 @@ import java.io.InputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+@Config(sdk = {
+    Build.VERSION_CODES.LOLLIPOP })
 public class ShadowResourcesTest {
   private Resources resources;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResultReceiverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResultReceiverTest.java
@@ -9,7 +9,7 @@ import org.robolectric.TestRunners;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowResultReceiverTest {
   @Test
   public void callingSend_shouldCallOverridenOnReceiveResultWithTheSameArguments() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSQLiteConnectionTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSQLiteConnectionTest.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteStatement;
+import android.os.Build;
 
 import org.assertj.core.api.Assertions;
 import org.junit.After;
@@ -11,6 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 import org.robolectric.util.ReflectionHelpers;
 
 import com.almworks.sqlite4java.SQLiteConnection;
@@ -24,7 +26,9 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.shadows.ShadowSQLiteConnection.convertSQLWithLocalizedUnicodeCollator;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+@Config(sdk = {
+    Build.VERSION_CODES.LOLLIPOP })
 public class ShadowSQLiteConnectionTest {
   private SQLiteDatabase database;
   private File databasePath;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowScaleGestureDetectorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowScaleGestureDetectorTest.java
@@ -11,7 +11,7 @@ import org.robolectric.TestRunners;
 import static junit.framework.Assert.*;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowScaleGestureDetectorTest {
 
   private ScaleGestureDetector detector;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowScanResultTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowScanResultTest.java
@@ -9,7 +9,7 @@ import static junit.framework.Assert.assertNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowScanResultTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowScrollViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowScrollViewTest.java
@@ -8,7 +8,7 @@ import org.robolectric.TestRunners;
 
 import static junit.framework.Assert.assertEquals;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowScrollViewTest {
   @Test
   public void shouldSmoothScrollTo() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowScrollerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowScrollerTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowScrollerTest {
   private Scroller scroller;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSeekBarTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSeekBarTest.java
@@ -11,7 +11,7 @@ import org.robolectric.util.Transcript;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowSeekBarTest {
 
   private SeekBar seekBar;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSensorManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSensorManagerTest.java
@@ -16,7 +16,7 @@ import org.robolectric.internal.Shadow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowSensorManagerTest {
 
   private SensorManager sensorManager;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowServiceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowServiceTest.java
@@ -22,7 +22,7 @@ import org.robolectric.internal.Shadow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowServiceTest {
   private MyService service ;
   private ShadowService shadow;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSettingsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSettingsTest.java
@@ -12,7 +12,7 @@ import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowSettingsTest {
   private Activity activity;
   private ContentResolver contentResolver;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowShapeDrawableTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowShapeDrawableTest.java
@@ -9,7 +9,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowShapeDrawableTest {
   @Test
   public void getPaint_ShouldReturnTheSamePaint() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSimpleCursorAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSimpleCursorAdapterTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowSimpleCursorAdapterTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSmsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSmsManagerTest.java
@@ -1,17 +1,24 @@
 package org.robolectric.shadows;
 
 import android.app.PendingIntent;
+import android.os.Build;
 import android.telephony.SmsManager;
 import com.google.android.collect.Lists;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+@Config(sdk = {
+    Build.VERSION_CODES.JELLY_BEAN_MR2,
+    Build.VERSION_CODES.KITKAT,
+    Build.VERSION_CODES.LOLLIPOP })
+
 public class ShadowSmsManagerTest {
   private SmsManager smsManager = SmsManager.getDefault();
   private final String scAddress = "serviceCenterAddress";

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSpannableStringBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSpannableStringBuilderTest.java
@@ -8,7 +8,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowSpannableStringBuilderTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSpannableStringTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSpannableStringTest.java
@@ -10,7 +10,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowSpannableStringTest {
   private static final String TEST_STRING = "Visit us at http://www.foobar.com for more selections";
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSpannedStringTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSpannedStringTest.java
@@ -8,7 +8,7 @@ import org.robolectric.TestRunners;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowSpannedStringTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSslErrorHandlerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSslErrorHandlerTest.java
@@ -10,7 +10,7 @@ import org.robolectric.internal.Shadow;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowSslErrorHandlerTest {
 
   private SslErrorHandler handler;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStatFsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStatFsTest.java
@@ -11,7 +11,7 @@ import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowStatFsTest {
   @Test
   public void shouldRegisterStats() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStateListDrawableTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStateListDrawableTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowStateListDrawableTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStaticLayoutTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStaticLayoutTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowStaticLayoutTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStrictModeTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStrictModeTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowStrictModeTest {
   @Test
   public void setVmPolicyTest() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSurfaceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSurfaceTest.java
@@ -9,7 +9,7 @@ import android.graphics.SurfaceTexture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowSurfaceTest {
   private final SurfaceTexture texture = new SurfaceTexture(0);
   private final Surface surface = new Surface(texture);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSurfaceViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSurfaceViewTest.java
@@ -14,7 +14,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.buildActivity;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowSurfaceViewTest {
 
   private SurfaceHolder.Callback callback1 = new TestCallback();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSyncResultTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSyncResultTest.java
@@ -10,7 +10,7 @@ import static junit.framework.Assert.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowSyncResultTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemClockTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemClockTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowSystemClockTest {
   @Test
   public void shouldAllowForFakingOfTime() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTabActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTabActivityTest.java
@@ -11,7 +11,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTabActivityTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTabHostTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTabHostTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTabHostTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTabSpecTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTabSpecTest.java
@@ -18,7 +18,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTabSpecTest {
   Drawable icon1;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTelephonyManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTelephonyManagerTest.java
@@ -14,7 +14,7 @@ import static org.robolectric.RuntimeEnvironment.*;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.internal.Shadow.newInstanceOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTelephonyManagerTest {
 
   private TelephonyManager manager;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTextPaintTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTextPaintTest.java
@@ -7,7 +7,7 @@ import org.robolectric.TestRunners;
 
 import static junit.framework.Assert.assertEquals;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTextPaintTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTextToSpeechTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTextToSpeechTest.java
@@ -11,7 +11,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTextToSpeechTest {
   private TextToSpeech textToSpeech;
   private Activity activity;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTextUtilsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTextUtilsTest.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTextUtilsTest {
   @Test
   public void testExpandTemplate() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTextViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTextViewTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.verify;
 import static org.robolectric.Robolectric.buildActivity;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTextViewTest {
 
   private static final String INITIAL_TEXT = "initial text";

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
@@ -21,7 +21,7 @@ import org.robolectric.util.TestUtil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.buildActivity;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowThemeTest {
   @Test public void whenExplicitlySetOnActivity_afterSetContentView_activityGetsThemeFromActivityInManifest() throws Exception {
     TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTimePickerDialogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTimePickerDialogTest.java
@@ -9,7 +9,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTimePickerDialogTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTimeTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTimeTest.java
@@ -17,7 +17,7 @@ import org.robolectric.annotation.Config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTimeTest {
   private static final TimeZone DEFAULT_TIMEZONE = TimeZone.getDefault();
   

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowToastTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowToastTest.java
@@ -14,7 +14,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowToastTest {
   @Test
   public void shouldHaveShortDuration() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTouchDelegateTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTouchDelegateTest.java
@@ -12,7 +12,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTouchDelegateTest {
 
   private ShadowTouchDelegate td;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTrafficStatsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTrafficStatsTest.java
@@ -7,7 +7,7 @@ import org.robolectric.TestRunners;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTrafficStatsTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTypedArrayTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTypedArrayTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTypedArrayTest {
   private Context context;
   private Resources resources;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTypefaceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTypefaceTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTypefaceTest {
   private File fontFile;
   @Rule public TemporaryAsset temporaryAsset = new TemporaryAsset();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUriTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUriTest.java
@@ -7,7 +7,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowUriTest {
   @Test
   public void shouldParseUris() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowValueAnimatorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowValueAnimatorTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowValueAnimatorTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowVideoViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowVideoViewTest.java
@@ -12,7 +12,7 @@ import org.robolectric.TestRunners;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.*;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowVideoViewTest {
 
   private VideoView view;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewAnimatorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewAnimatorTest.java
@@ -12,7 +12,7 @@ import org.robolectric.TestRunners;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowViewAnimatorTest {
 
   ViewAnimator viewAnimator;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewConfigurationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewConfigurationTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowViewConfigurationTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewFlipperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewFlipperTest.java
@@ -9,7 +9,7 @@ import org.robolectric.TestRunners;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowViewFlipperTest {
   protected ViewFlipper flipper;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewGroupTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewGroupTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowViewGroupTest {
   private String defaultLineSeparator;
   private ViewGroup root;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.robolectric.Robolectric.buildActivity;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowViewTest {
   private View view;
   private Transcript transcript;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTreeObserverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTreeObserverTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowViewTreeObserverTest {
 
   private ViewTreeObserver viewTreeObserver;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWallpaperManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWallpaperManagerTest.java
@@ -8,7 +8,7 @@ import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowWallpaperManagerTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWebViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWebViewTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowWebViewTest {
 
   private WebView webView;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiConfigurationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiConfigurationTest.java
@@ -9,7 +9,7 @@ import static junit.framework.Assert.assertNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowWifiConfigurationTest {
   @Test
   public void shouldSetTheBitSetsAndWepKeyArrays() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiInfoTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiInfoTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.RuntimeEnvironment.application;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowWifiInfoTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiManagerTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.*;
 import static org.robolectric.RuntimeEnvironment.application;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowWifiManagerTest {
 
   private WifiManager wifiManager;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowManagerGlobalTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowManagerGlobalTest.java
@@ -1,13 +1,21 @@
 package org.robolectric.shadows;
 
+import android.os.Build;
 import android.os.Looper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.MultiApiRobolectricTestRunner;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+@Config(sdk = {
+    Build.VERSION_CODES.JELLY_BEAN_MR1,
+    Build.VERSION_CODES.JELLY_BEAN_MR2,
+    Build.VERSION_CODES.KITKAT,
+    Build.VERSION_CODES.LOLLIPOP })
 public class ShadowWindowManagerGlobalTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowTest.java
@@ -19,7 +19,7 @@ import org.robolectric.util.ActivityController;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowWindowTest {
   @Test
   public void getFlag_shouldReturnWindowFlags() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/VelocityTrackerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/VelocityTrackerTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class VelocityTrackerTest {
   VelocityTracker velocityTracker;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ViewInnerTextTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ViewInnerTextTest.java
@@ -13,7 +13,7 @@ import org.robolectric.TestRunners;
 import static org.junit.Assert.assertEquals;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ViewInnerTextTest {
   private Context context;
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ViewStubTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ViewStubTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.*;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.util.TestUtil.TEST_PACKAGE;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ViewStubTest {
   private Context ctxt;
 


### PR DESCRIPTION
This change uses the MultiApiRobolectricTestRunner to run shadow tests against all supported api versions. Where tests are only compatible since a certain api version they are marked as such using @Config( sdk = {...} ) specifically.

This should protect us from breaking support for previous api versions when adding support for say api 22. There were substantial regressions in api 18 support when support for api 21 was added due to this testing gap.