### PR TITLE
Add a fragment controller to facilitate testing of fragments.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/util/FragmentController.java
+++ b/robolectric/src/main/java/org/robolectric/util/FragmentController.java
@@ -1,0 +1,61 @@
+package org.robolectric.util;
+
+import android.app.Activity;
+import android.app.Fragment;
+import android.os.Bundle;
+import android.widget.LinearLayout;
+import org.robolectric.Robolectric;
+
+/**
+ * Controller class for driving fragment lifecycles, similar to {@link org.robolectric.util.ActivityController}. Only
+ * necessary if more complex lifecycle management is needed, otherwise {@link org.robolectric.util.FragmentTestUtil}
+ * should be sufficient.
+ */
+public class FragmentController {
+  private final Fragment fragment;
+  private final ActivityController<? extends Activity> activityController;
+
+  private FragmentController(Fragment fragment, Class<? extends Activity> activityClass) {
+    this.fragment = fragment;
+    this.activityController = Robolectric.buildActivity(activityClass);
+  }
+
+  public static FragmentController of(Fragment fragment) {
+    return new FragmentController(fragment, FragmentControllerActivity.class);
+  }
+
+  public static FragmentController of(Fragment fragment, Class<? extends Activity> activityClass) {
+    return new FragmentController(fragment, activityClass);
+  }
+
+  public FragmentController start() {
+    activityController.create().start().get().getFragmentManager().beginTransaction().add(fragment, null).commit();
+    return this;
+  }
+
+  public FragmentController resume() {
+    activityController.resume();
+    return this;
+  }
+
+  public FragmentController pause() {
+    activityController.pause();
+    return this;
+  }
+
+  public FragmentController stop() {
+    activityController.stop();
+    return this;
+  }
+
+  private static class FragmentControllerActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      LinearLayout view = new LinearLayout(this);
+      view.setId(1);
+
+      setContentView(view);
+    }
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/util/FragmentControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/FragmentControllerTest.java
@@ -39,9 +39,9 @@ public class FragmentControllerTest {
   }
 
   @Test
-  public void attachedAfterStart() {
+  public void attachedAfterCreate() {
     final LoginFragment fragment = new LoginFragment();
-    FragmentController.of(fragment).start();
+    FragmentController.of(fragment).create();
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();
@@ -51,9 +51,9 @@ public class FragmentControllerTest {
   }
 
   @Test
-  public void attachedAfterStart_customActivity() {
+  public void attachedAfterCreate_customActivity() {
     final LoginFragment fragment = new LoginFragment();
-    FragmentController.of(fragment, LoginActivity.class).start();
+    FragmentController.of(fragment, LoginActivity.class).create();
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();
@@ -66,7 +66,7 @@ public class FragmentControllerTest {
   @Test
   public void isResumed() {
     final LoginFragment fragment = new LoginFragment();
-    FragmentController.of(fragment, LoginActivity.class).start().resume();
+    FragmentController.of(fragment, LoginActivity.class).create().start().resume();
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();
@@ -77,7 +77,7 @@ public class FragmentControllerTest {
   @Test
   public void isPaused() {
     final LoginFragment fragment = spy(new LoginFragment());
-    FragmentController.of(fragment, LoginActivity.class).start().resume().pause();
+    FragmentController.of(fragment, LoginActivity.class).create().start().resume().pause();
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();
@@ -91,7 +91,7 @@ public class FragmentControllerTest {
   @Test
   public void isStopped() {
     final LoginFragment fragment = spy(new LoginFragment());
-    FragmentController.of(fragment, LoginActivity.class).start().resume().pause().stop();
+    FragmentController.of(fragment, LoginActivity.class).create().start().resume().pause().stop();
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();

--- a/robolectric/src/test/java/org/robolectric/util/FragmentControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/FragmentControllerTest.java
@@ -1,0 +1,124 @@
+package org.robolectric.util;
+
+import android.app.Activity;
+import android.app.Fragment;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.R;
+import org.robolectric.TestRunners;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(TestRunners.WithDefaults.class)
+public class FragmentControllerTest {
+  @Test
+  public void initialNotAttached() {
+    final LoginFragment fragment = new LoginFragment();
+    FragmentController.of(fragment);
+
+    assertThat(fragment.getView()).isNull();
+    assertThat(fragment.getActivity()).isNull();
+    assertThat(fragment.isAdded()).isFalse();
+  }
+
+  @Test
+  public void initialNotAttached_customActivity() {
+    final LoginFragment fragment = new LoginFragment();
+    FragmentController.of(fragment, LoginActivity.class);
+
+    assertThat(fragment.getView()).isNull();
+    assertThat(fragment.getActivity()).isNull();
+    assertThat(fragment.isAdded()).isFalse();
+  }
+
+  @Test
+  public void attachedAfterStart() {
+    final LoginFragment fragment = new LoginFragment();
+    FragmentController.of(fragment).start();
+
+    assertThat(fragment.getView()).isNotNull();
+    assertThat(fragment.getActivity()).isNotNull();
+    assertThat(fragment.isAdded()).isTrue();
+    assertThat(fragment.isResumed()).isFalse();
+    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+  }
+
+  @Test
+  public void attachedAfterStart_customActivity() {
+    final LoginFragment fragment = new LoginFragment();
+    FragmentController.of(fragment, LoginActivity.class).start();
+
+    assertThat(fragment.getView()).isNotNull();
+    assertThat(fragment.getActivity()).isNotNull();
+    assertThat(fragment.getActivity()).isInstanceOf(LoginActivity.class);
+    assertThat(fragment.isAdded()).isTrue();
+    assertThat(fragment.isResumed()).isFalse();
+    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+  }
+
+  @Test
+  public void isResumed() {
+    final LoginFragment fragment = new LoginFragment();
+    FragmentController.of(fragment, LoginActivity.class).start().resume();
+
+    assertThat(fragment.getView()).isNotNull();
+    assertThat(fragment.getActivity()).isNotNull();
+    assertThat(fragment.isAdded()).isTrue();
+    assertThat(fragment.isResumed()).isTrue();
+  }
+
+  @Test
+  public void isPaused() {
+    final LoginFragment fragment = spy(new LoginFragment());
+    FragmentController.of(fragment, LoginActivity.class).start().resume().pause();
+
+    assertThat(fragment.getView()).isNotNull();
+    assertThat(fragment.getActivity()).isNotNull();
+    assertThat(fragment.isAdded()).isTrue();
+    assertThat(fragment.isResumed()).isFalse();
+
+    verify(fragment).onResume();
+    verify(fragment).onPause();
+  }
+
+  @Test
+  public void isStopped() {
+    final LoginFragment fragment = spy(new LoginFragment());
+    FragmentController.of(fragment, LoginActivity.class).start().resume().pause().stop();
+
+    assertThat(fragment.getView()).isNotNull();
+    assertThat(fragment.getActivity()).isNotNull();
+    assertThat(fragment.isAdded()).isTrue();
+    assertThat(fragment.isResumed()).isFalse();
+
+    verify(fragment).onStart();
+    verify(fragment).onResume();
+    verify(fragment).onPause();
+    verify(fragment).onStop();
+  }
+
+  private static class LoginFragment extends Fragment {
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+      return inflater.inflate(R.layout.fragment_contents, container, false);
+    }
+  }
+
+  private static class LoginActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      LinearLayout view = new LinearLayout(this);
+      view.setId(1);
+
+      setContentView(view);
+    }
+  }
+}


### PR DESCRIPTION
This class makes it possible to test fragment lifecycles without
needing to first create an activity controller, attach the fragment,
and drive the lifecycle indirectly via the activity controller.