### PR TITLE
MessageQueue - cache method and field lookups

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
@@ -4,6 +4,10 @@ import android.os.Handler;
 import android.os.Message;
 import android.os.MessageQueue;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import javax.annotation.Generated;
 
 import org.robolectric.annotation.HiddenApi;
@@ -27,8 +31,6 @@ import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 @Generated("org.robolectric.shadows.ShadowMessageQueue.java.vm")
 @Implements(MessageQueue.class)
 public class ShadowMessageQueue {
-  @RealObject
-  private MessageQueue realQueue;
 
 #if ($api >= 21)
 #set($ptrClass = "long")
@@ -38,7 +40,30 @@ public class ShadowMessageQueue {
 #set($recycle = "recycle")
 #end
 
-#set($Integer = 0)
+  // Cache fields & methods that are invoked reflectively.
+  // Saves having to look them up on every request.
+  private static final Field messagesField;
+  private static final Method enqueueMethod;
+  private static final Method markInUseMethod;
+  private static final Method recycleMethod;
+
+  static {
+    try {
+      messagesField = MessageQueue.class.getDeclaredField("mMessages");
+      messagesField.setAccessible(true);
+      enqueueMethod = MessageQueue.class.getDeclaredMethod(directMethodName("enqueueMessage"), Message.class, long.class);
+      enqueueMethod.setAccessible(true);
+      markInUseMethod = Message.class.getDeclaredMethod("markInUse");
+      markInUseMethod.setAccessible(true);
+      recycleMethod = Message.class.getDeclaredMethod("$recycle");
+      recycleMethod.setAccessible(true);
+    } catch (ReflectiveOperationException e) {
+	  throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  @RealObject
+  private MessageQueue realQueue;
 
   // Stub out the native peer - scheduling
   // is handled by the Scheduler class which is user-driven
@@ -72,11 +97,21 @@ public class ShadowMessageQueue {
   }
 
   public Message getHead() {
-    return getField(realQueue, "mMessages");
+    try {
+      return (Message)messagesField.get(realQueue);
+    } catch (IllegalAccessException e) {
+      // This should never happen
+      throw new RuntimeException(e);
+    }
   }
   
   public void setHead(Message msg) {
-    setField(realQueue, "mMessages", msg);
+    try {
+      messagesField.set(realQueue, msg);
+    } catch (IllegalAccessException e) {
+      // This should never happen
+      throw new RuntimeException(e);
+    }
   }
 
   public void reset() {
@@ -85,7 +120,7 @@ public class ShadowMessageQueue {
   
   @Implementation
   public boolean enqueueMessage(final Message msg, long when) {
-    final boolean retval = directlyOn(realQueue, MessageQueue.class, "enqueueMessage", from(Message.class, msg), from(long.class, when));
+    final boolean retval = callInstanceMethod(realQueue, enqueueMethod, msg, when);
     if (retval) {
       final Scheduler scheduler = shadowOf(msg.getTarget().getLooper()).getScheduler();
       final Runnable callback = new Runnable() {
@@ -134,9 +169,9 @@ public class ShadowMessageQueue {
     // If target is null it means the message has been removed
     // from the queue prior to being dispatched by the scheduler.
     if (target != null) {
-      callInstanceMethod(msg, "markInUse");
+      callInstanceMethod(msg, markInUseMethod);
       target.dispatchMessage(msg);
-      callInstanceMethod(msg, "$recycle");
+      callInstanceMethod(msg, recycleMethod);
     }
   }
 }

--- a/robolectric-utils/src/main/java/org/robolectric/util/ReflectionHelpers.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/ReflectionHelpers.java
@@ -140,7 +140,37 @@ public class ReflectionHelpers {
   }
 
   /**
-   * Reflectively call an instance method on an object.
+   * Reflectively call an instance method on an object. The method object is assumed
+   * to have already had {@link Method#setAccessible(boolean) setAccessible(true)}
+   * called on it if necessary - this allows for optimizations where the same method
+   * object may be repeatedly invoked.
+   *
+   * @param instance Target object.
+   * @param method The method to call.
+   * @param parameters Array of parameters.
+   * @param <R> The return type.
+   * @return The return value of the method.
+   */
+  @SuppressWarnings("unchecked")
+  public static <R> R callInstanceMethod(Object instance, Method method, Object... parameters) {
+    try {
+      return (R) method.invoke(instance, parameters);
+    } catch (InvocationTargetException e) {
+      if (e.getTargetException() instanceof RuntimeException) {
+        throw (RuntimeException) e.getTargetException();
+      }
+      if (e.getTargetException() instanceof Error) {
+        throw (Error) e.getTargetException();
+      }
+      throw new RuntimeException(e.getTargetException());
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Reflectively call an instance method on an object. The method is specified
+   * as a String and setAccessible(true) is called before calling it.
    *
    * @param instance Target object.
    * @param methodName The method name to call.
@@ -185,6 +215,7 @@ public class ReflectionHelpers {
    * @param <R> The return type.
    * @return The return value of the method.
    */
+  @SuppressWarnings("unchecked")
   public static <R> R callInstanceMethod(Class<?> cl, final Object instance, final String methodName, ClassParameter<?>... classParameters) {
     try {
       final Class<?>[] classes = ClassParameter.getClasses(classParameters);

--- a/robolectric-utils/src/test/java/org/robolectric/util/ReflectionHelpersTest.java
+++ b/robolectric-utils/src/test/java/org/robolectric/util/ReflectionHelpersTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -114,6 +115,15 @@ public class ReflectionHelpersTest {
   public void callInstanceMethodReflectively_whenMultipleSignaturesExistForAMethodName_callsMethodWithCorrectSignature() {
     ExampleDescendant example = new ExampleDescendant();
     assertThat(ReflectionHelpers.callInstanceMethod(example, "returnNumber", ClassParameter.from(int.class, 5)))
+      .isEqualTo(5);
+  }
+
+  @Test
+  public void callInstanceMethod_viaMethodInstance_callsMethod() throws NoSuchMethodException {
+    ExampleDescendant example = new ExampleDescendant();
+    Method method = ExampleDescendant.class.getDeclaredMethod("returnNumber", int.class);
+    method.setAccessible(true);
+    assertThat(ReflectionHelpers.callInstanceMethod(example, method, 5))
       .isEqualTo(5);
   }
 


### PR DESCRIPTION
Save having to do the method/field lookup & set accessibility on every method invocation by caching & reusing the appropriate method & field objects. Haven't benchmarked it but should improve performance a little.