### PR TITLE
Fix ResName parsing so we can handle case where slash precedes semicolon

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/ResName.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/ResName.java
@@ -47,13 +47,26 @@ public class ResName {
   public static @NotNull ResName qualifyResName(@NotNull String possiblyQualifiedResourceName, String defaultPackageName, String defaultType) {
     int indexOfColon = possiblyQualifiedResourceName.indexOf(':');
     int indexOfSlash = possiblyQualifiedResourceName.indexOf('/');
-    String packageName = indexOfColon == -1 ? null : possiblyQualifiedResourceName.substring(0, indexOfColon);
-    String type = indexOfSlash == -1 ? null : possiblyQualifiedResourceName.substring(indexOfColon == -1 ? 0 : indexOfColon + 1, indexOfSlash);
-    int indexBeforeName = indexOfColon > indexOfSlash ? indexOfColon : indexOfSlash;
+    String type = null;
+    String packageName = null;
+    String name = possiblyQualifiedResourceName;
+    if (indexOfColon > indexOfSlash) {
+      if (indexOfSlash > 0) {
+        type = possiblyQualifiedResourceName.substring(0, indexOfSlash);
+      }
+      packageName = possiblyQualifiedResourceName.substring(indexOfSlash + 1, indexOfColon);
+      name =  possiblyQualifiedResourceName.substring(indexOfColon + 1);
+    } else if (indexOfSlash > indexOfColon) {
+      if (indexOfColon > 0) {
+        packageName = possiblyQualifiedResourceName.substring(0, indexOfColon);
+      }
+      type = possiblyQualifiedResourceName.substring(indexOfColon + 1, indexOfSlash);
+      name = possiblyQualifiedResourceName.substring(indexOfSlash + 1);
+    }
 
     return new ResName(packageName == null ? defaultPackageName : packageName,
         type == null ? defaultType : type,
-        possiblyQualifiedResourceName.substring(indexBeforeName + 1));
+        name);
   }
 
   public static Integer getResourceId(ResourceIndex resourceIndex, String possiblyQualifiedResourceName, String contextPackageName) {

--- a/robolectric/src/test/java/org/robolectric/res/ResNameTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/ResNameTest.java
@@ -13,6 +13,19 @@ public class ResNameTest {
     assertThat(ResName.qualifyResourceName("name", "default.package", "deftype")).isEqualTo("default.package:deftype/name");
   }
 
+  @Test public void shouldQualifyResNameFromString() throws Exception {
+    assertThat(ResName.qualifyResName("some.package:type/name", "default_package", "default_type"))
+        .isEqualTo(new ResName("some.package", "type", "name"));
+    assertThat(ResName.qualifyResName("some.package:name", "default_package", "default_type"))
+        .isEqualTo(new ResName("some.package", "default_type", "name"));
+    assertThat(ResName.qualifyResName("type/name", "default_package", "default_type"))
+        .isEqualTo(new ResName("default_package", "type", "name"));
+    assertThat(ResName.qualifyResName("name", "default_package", "default_type"))
+        .isEqualTo(new ResName("default_package", "default_type", "name"));
+    assertThat(ResName.qualifyResName("type/package:name", "default_package", "default_type"))
+        .isEqualTo(new ResName("package", "type", "name"));
+  }
+
   @Test
   public void qualifyFromFilePathShouldExtractResourceTypeAndNameFromUnqualifiedPath() {
     final ResName actual = ResName.qualifyFromFilePath("some.package", "./res/drawable/icon.png");


### PR DESCRIPTION
Before this commit, ResName#qualifyRename assumed that semicolon always appears
before slash (if both exist), but it's not always the case. 

In fact, AlertDialog in appcompat seems to have following style, which caused #1736

> style="?attr/android:windowTitleStyle"
 
https://chromium.googlesource.com/android_tools/+/7200281446186c7192cb02f54dc2b38e02d705e5/sdk/extras/android/support/v7/appcompat/res/layout/abc_alert_dialog_material.xml