### PR TITLE
Change Scheduler.unPause() so that it doesn't freewheel

### DIFF
--- a/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
@@ -51,7 +51,7 @@ public class Scheduler {
    */
   public synchronized void unPause() {
     paused = false;
-    advanceToLastPostedRunnable();
+    advanceBy(0);
   }
 
   /**

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
@@ -378,7 +378,7 @@ public class ShadowHandlerTest {
     Message newMsg = handler.obtainMessage(123);
     assertThat(newMsg).as("new message").isSameAs(msg);
     handler.sendMessageDelayed(newMsg, 400);
-    ShadowLooper.unPauseMainLooper();
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
     // Original implementation had a bug which caused reused messages to still
     // be invoked at their original post time.
     assertThat(runAt).as("handledAt").containsExactly(startTime + 400L);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
@@ -299,7 +299,7 @@ public class ShadowViewTest {
     ShadowView shadowView = shadowOf(view);
     assertFalse(shadowView.wasInvalidated());
 
-    ShadowLooper.unPauseMainLooper();
+    ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
     assertTrue(shadowView.wasInvalidated());
   }
 

--- a/robolectric/src/test/java/org/robolectric/util/SchedulerTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/SchedulerTest.java
@@ -22,6 +22,18 @@ public class SchedulerTest {
   }
 
   @Test
+  public void unPause_shouldRunPendingTasks() {
+    scheduler.postDelayed(new AddToTranscript("one"), 0);
+    scheduler.postDelayed(new AddToTranscript("two"), 0);
+    scheduler.postDelayed(new AddToTranscript("three"), 1000);
+    transcript.assertNoEventsSoFar();
+    final long time = scheduler.getCurrentTime();
+    scheduler.unPause();
+    transcript.assertEventsSoFar("one", "two");
+    assertThat(scheduler.getCurrentTime()).as("time").isEqualTo(time);
+  }
+  
+  @Test
   public void advanceTo_shouldAdvanceTimeEvenIfThereIsNoWork() throws Exception {
     scheduler.advanceTo(1000);
     assertThat(scheduler.getCurrentTime()).isEqualTo(1000);


### PR DESCRIPTION
This is part of #1879 (specifically, 6a of the points listed in the OP). For consistency reasons, `Scheduler.unPause()` should not call `advanceToLastPostedRunnable()` but should call `advanceBy(0)`.

I have submitted it early in the piece compared with other issues because I thought it might be a quick workaround for a spate of issues that have recently popped up (possibly including #1888, #1889, #1877).

I had to fix two tests within Robolectric's own test suite as a result of this change. I am hoping that this is an indication that the effect will not be too drastic on the installed code base.

@jongerrish, are you in a position to give this change a try and see what impact it has on your existing tests?