### PR TITLE
Update Javadocs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.1</version>
           <configuration>
-            <quiet>true</quiet>
+            <excludePackageNames>org.robolectric.res:org.robolectric.manifest:org.robolectric.internal:org.robolectric.annotation.internal:org.robolectric.annotation.processing:android:com.google</excludePackageNames>
           </configuration>
         </plugin>
 

--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/HiddenApi.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/HiddenApi.java
@@ -1,10 +1,16 @@
 package org.robolectric.annotation;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
  * Indicates that the annotated method is hidden in the public Android API.
  */
-@java.lang.annotation.Documented
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@java.lang.annotation.Target({java.lang.annotation.ElementType.METHOD})
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
 public @interface HiddenApi {
 }

--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/Implementation.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/Implementation.java
@@ -1,11 +1,17 @@
 package org.robolectric.annotation;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
- * Indicates that a method declaration is intended to Shadow a method with the same signature on the associated
- * Android class.
+ * Indicates that a method declaration is intended to Shadow a method with the same signature
+ * on the associated Android class.
  */
-@java.lang.annotation.Documented
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@java.lang.annotation.Target({java.lang.annotation.ElementType.METHOD})
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
 public @interface Implementation {
 }

--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/Implements.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/Implements.java
@@ -1,13 +1,20 @@
 package org.robolectric.annotation;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
- * Indicates that a class declaration is intended to Shadow an Android class declaration. The Robolectric runtime
- * searches classes with this annotation for methods with the {@link Implementation} annotation and calls them in
- * place of the methods on the Android class.
+ * Indicates that a class declaration is intended to Shadow an Android class declaration.
+ * The Robolectric runtime searches classes with this annotation for methods with the
+ * {@link Implementation} annotation and calls them in place of the methods on the Android
+ * class.
  */
-@java.lang.annotation.Documented
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@java.lang.annotation.Target({java.lang.annotation.ElementType.TYPE})
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
 public @interface Implements {
 
   /**

--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/RealObject.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/RealObject.java
@@ -1,10 +1,16 @@
 package org.robolectric.annotation;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
  * Shadow fields annotated @RealObject will have the real instance injected.
  */
-@java.lang.annotation.Documented
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@java.lang.annotation.Target({java.lang.annotation.ElementType.FIELD})
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
 public @interface RealObject {
 }

--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/Resetter.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/Resetter.java
@@ -1,10 +1,16 @@
 package org.robolectric.annotation;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
  * Indicates that the annotated method is used to reset static state in a shadow.
  */
-@java.lang.annotation.Documented
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@java.lang.annotation.Target({java.lang.annotation.ElementType.METHOD})
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
 public @interface Resetter {
 }

--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/internal/DoNotInstrument.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/internal/DoNotInstrument.java
@@ -1,10 +1,16 @@
 package org.robolectric.annotation.internal;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
  * Indicates that a class should not be stripped/instrumented under any circumstances.
  */
-@java.lang.annotation.Documented
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@java.lang.annotation.Target({java.lang.annotation.ElementType.TYPE})
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
 public @interface DoNotInstrument {
 }

--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/internal/Instrument.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/internal/Instrument.java
@@ -1,10 +1,16 @@
 package org.robolectric.annotation.internal;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
  * Indicates that a class should always be instrumented regardless of its package.
  */
-@java.lang.annotation.Documented
-@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@java.lang.annotation.Target({java.lang.annotation.ElementType.TYPE})
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
 public @interface Instrument {
 }

--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/package-info.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package containing Robolectric annotations.
+ */
+package org.robolectric.annotation;

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/Generator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/Generator.java
@@ -1,5 +1,8 @@
 package org.robolectric.annotation.processing.generator;
 
+/**
+ * Base class for code generators.
+ */
 public abstract class Generator {
   protected static final String GEN_CLASS = "Shadows";
 

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/package-info.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Classes used to generate code.
+ */
+package org.robolectric.annotation.processing.generator;

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/package-info.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Robolectric annotation processor.
+ *
+ * <p>
+ * Annotation processor used to generate `shadowOf` methods and other metadata needed by
+ * shadow packages, as well as perform compile-time checking of constraints that are
+ * implied by Robolectric's annotations.
+ * </p>
+ */
+package org.robolectric.annotation.processing;

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/FoundOnImplementsValidator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/FoundOnImplementsValidator.java
@@ -9,6 +9,9 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 
+/**
+ * Validator that checks usages of {@link org.robolectric.annotation.Implements}.
+ */
 public abstract class FoundOnImplementsValidator extends Validator {
 
   protected AnnotationMirror imp;

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementationValidator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementationValidator.java
@@ -6,6 +6,9 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 
+/**
+ * Validator that checks usages of {@link org.robolectric.annotation.Implementation}.
+ */
 public class ImplementationValidator extends FoundOnImplementsValidator {
   public ImplementationValidator(RobolectricModel model, ProcessingEnvironment env) {
     super(model, env, "org.robolectric.annotation.Implementation");

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementsValidator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementsValidator.java
@@ -13,6 +13,9 @@ import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic.Kind;
 
+/**
+ * Validator that checks usages of {@link org.robolectric.annotation.Implements}.
+ */
 public class ImplementsValidator extends Validator {
 
   public static final String IMPLEMENTS_CLASS = "org.robolectric.annotation.Implements";

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/RealObjectValidator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/RealObjectValidator.java
@@ -14,6 +14,9 @@ import javax.lang.model.type.TypeVisitor;
 import javax.lang.model.util.SimpleTypeVisitor6;
 import javax.tools.Diagnostic.Kind;
 
+/**
+ * Validator that checks usages of {@link org.robolectric.annotation.RealObject}.
+ */
 public class RealObjectValidator extends FoundOnImplementsValidator {
 
   public RealObjectValidator(RobolectricModel model, ProcessingEnvironment env) {

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/ResetterValidator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/ResetterValidator.java
@@ -11,6 +11,9 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 
+/**
+ * Validator that checks usages of {@link org.robolectric.annotation.Resetter}.
+ */
 public class ResetterValidator extends FoundOnImplementsValidator {
   public ResetterValidator(RobolectricModel model, ProcessingEnvironment env) {
     super(model, env, "org.robolectric.annotation.Resetter");

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/Validator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/Validator.java
@@ -18,7 +18,10 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
 
-public class Validator implements ElementVisitor<Void, Element> {
+/**
+ * Base class for validators.
+ */
+public abstract class Validator implements ElementVisitor<Void, Element> {
   final protected RobolectricModel model;
   final protected Elements elements;
   final protected Types types;

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/package-info.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Classes used to perform compile-time checking of shadows.
+ */
+package org.robolectric.annotation.processing.validator;

--- a/robolectric-resources/src/main/java/org/robolectric/shadows/RoboAttributeSet.java
+++ b/robolectric-resources/src/main/java/org/robolectric/shadows/RoboAttributeSet.java
@@ -13,6 +13,9 @@ import org.robolectric.res.TypedResource;
 
 import java.util.List;
 
+/**
+ * Robolectric implementation of {@link android.util.AttributeSet}.
+ */
 public class RoboAttributeSet implements AttributeSet {
   private final List<Attribute> attributes;
   private final ResourceLoader resourceLoader;

--- a/robolectric-resources/src/main/java/org/robolectric/shadows/RoboLayoutInflater.java
+++ b/robolectric-resources/src/main/java/org/robolectric/shadows/RoboLayoutInflater.java
@@ -5,6 +5,9 @@ import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
 
+/**
+ * Robolectric implementation of {@link android.view.LayoutInflater}.
+ */
 public class RoboLayoutInflater extends LayoutInflater {
   private static final String[] sClassPrefixList = {
       "android.widget.",

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboCursor.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboCursor.java
@@ -6,6 +6,9 @@ import android.net.Uri;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Robolectric implementation of {@link android.database.Cursor}.
+ */
 public class RoboCursor extends BaseCursor {
   public Uri uri;
   public String[] projection;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboIntentSender.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboIntentSender.java
@@ -4,6 +4,9 @@ import android.content.IIntentSender;
 import android.content.Intent;
 import android.content.IntentSender;
 
+/**
+ * Robolectric implementation of {@link android.content.IntentSender}.
+ */
 public class RoboIntentSender extends IntentSender {
   public Intent intent;
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenu.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenu.java
@@ -13,6 +13,9 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+/**
+ * Robolectric implementation of {@link android.view.Menu}.
+ */
 public class RoboMenu implements Menu {
   private List<MenuItem> menuItems = new ArrayList<>();
   private Context context;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenuItem.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenuItem.java
@@ -9,6 +9,9 @@ import android.view.SubMenu;
 import android.view.View;
 import org.robolectric.shadows.ShadowApplication;
 
+/**
+ * Robolectric implementation of {@link android.view.MenuItem}.
+ */
 public class RoboMenuItem implements MenuItem {
   private int itemId;
   private int groupId;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboSharedPreferences.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboSharedPreferences.java
@@ -9,8 +9,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Robolectric implementation of {@link android.content.SharedPreferences}.
+ */
 public class RoboSharedPreferences implements SharedPreferences {
-
   public Map<String, Map<String, Object>> content;
   protected String filename;
   public int mode;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboSubMenu.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboSubMenu.java
@@ -5,6 +5,9 @@ import android.view.MenuItem;
 import android.view.SubMenu;
 import android.view.View;
 
+/**
+ * Robolectric implementation of {@link android.view.SubMenu}.
+ */
 public class RoboSubMenu extends RoboMenu implements SubMenu {
 
   @Override

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/package-info.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package containing fake implementations of Android classes.
+ */
+package org.robolectric.fakes;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
@@ -15,7 +15,7 @@ import org.robolectric.util.Scheduler;
 import static org.robolectric.Shadows.shadowOf;
 
 /**
- * This is the interface between the Robolectric runtime and the robolectric-shadows module.
+ * Interface between the Robolectric runtime and the shadows-core module.
  */
 public class CoreShadowsAdapter implements ShadowsAdapter {
   @Override

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAbsListView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAbsListView.java
@@ -4,6 +4,9 @@ import android.widget.AbsListView;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.widget.AbsListView}.
+ */
 @Implements(AbsListView.class)
 public class ShadowAbsListView extends ShadowAdapterView {
   private AbsListView.OnScrollListener onScrollListener;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAbsSeekBar.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAbsSeekBar.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.widget.AbsSeekBar;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.widget.AbsSeekBar}.
+ */
 @Implements(AbsSeekBar.class)
 public class ShadowAbsSeekBar extends ShadowProgressBar {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAbsSpinner.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAbsSpinner.java
@@ -9,6 +9,9 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.widget.AbsSpinner}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(AbsSpinner.class)
 public class ShadowAbsSpinner extends ShadowAdapterView {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAbsoluteLayout.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAbsoluteLayout.java
@@ -4,9 +4,16 @@ import android.widget.AbsoluteLayout;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
+/**
+ * Shadow for {@link android.widget.AbsoluteLayout}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(AbsoluteLayout.class)
 public class ShadowAbsoluteLayout extends ShadowViewGroup {
+
+  /**
+   * Shadow for {@link android.widget.AbsoluteLayout.LayoutParams}.
+   */
   @Implements(AbsoluteLayout.LayoutParams.class)
   public static class ShadowLayoutParams extends ShadowViewGroup.ShadowLayoutParams {
     @RealObject

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAbstractCursor.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAbstractCursor.java
@@ -6,6 +6,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
 
+/**
+ * Shadow for {@link android.database.AbstractCursor}.
+ */
 @Implements(AbstractCursor.class)
 public class ShadowAbstractCursor {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -32,6 +32,9 @@ import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.internal.Shadow.directlyOn;
 import static org.robolectric.internal.Shadow.invokeConstructor;
 
+/**
+ * Shadow for {@link android.app.Activity}.
+ */
 @Implements(Activity.class)
 public class ShadowActivity extends ShadowContextThemeWrapper {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivityGroup.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivityGroup.java
@@ -5,6 +5,9 @@ import android.app.ActivityGroup;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.app.ActivityGroup}.
+ */
 @Implements(ActivityGroup.class)
 public class ShadowActivityGroup extends ShadowActivity {
   private Activity currentActivity;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Shadow for the Android {@code ActivityManager} class.
+ * Shadow for {@link android.app.ActivityManager}.
  */
 @Implements(ActivityManager.class)
 public class ShadowActivityManager {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivityManagerNative.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivityManagerNative.java
@@ -6,6 +6,9 @@ import android.app.RobolectricActivityManager;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.app.ActivityManagerNative}.
+ */
 @Implements(value = ActivityManagerNative.class, isInAndroidSdk = false)
 public class ShadowActivityManagerNative {
   private static final RobolectricActivityManager activityManager = new RobolectricActivityManager();

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
@@ -12,6 +12,9 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
+/**
+ * Shadow for {@link android.app.ActivityThread}.
+ */
 @Implements(value = ActivityThread.class, isInAndroidSdk = false)
 public class ShadowActivityThread {
   public static final String CLASS_NAME = "android.app.ActivityThread";

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAdapterView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAdapterView.java
@@ -13,6 +13,9 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
 import static org.robolectric.internal.Shadow.directlyOn;
 import static org.robolectric.Shadows.shadowOf;
 
+/**
+ * Shadow for {@link android.widget.AdapterView}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(AdapterView.class)
 public class ShadowAdapterView<T extends Adapter> extends ShadowViewGroup {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAddress.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAddress.java
@@ -4,7 +4,9 @@ import android.location.Address;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
-
+/**
+ * Shadow for {@link android.location.Address}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Address.class)
 public class ShadowAddress {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAlertController.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAlertController.java
@@ -13,6 +13,9 @@ import java.lang.reflect.InvocationTargetException;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link com.android.internal.app.AlertController}.
+ */
 @Implements(value = AlertController.class, isInAndroidSdk = false)
 public class ShadowAlertController {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAlertDialog.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAlertDialog.java
@@ -16,6 +16,9 @@ import org.robolectric.util.ReflectionHelpers;
 
 import static org.robolectric.Shadows.shadowOf;
 
+/**
+ * Shadow for {@link android.app.AlertDialog}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(AlertDialog.class)
 public class ShadowAlertDialog extends ShadowDialog {
@@ -125,7 +128,7 @@ public class ShadowAlertDialog extends ShadowDialog {
   }
 
   /**
-   * Shadows the {@code android.app.AlertDialog.Builder} class.
+   * Shadow for {@code android.app.AlertDialog.Builder}.
    */
   @Implements(AlertDialog.Builder.class)
   public static class ShadowBuilder {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAndroidBidi.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAndroidBidi.java
@@ -4,6 +4,9 @@ import android.text.Layout;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@code android.text.AndroidBidi}.
+ */
 @Implements(className = "android.text.AndroidBidi")
 public class ShadowAndroidBidi {
   @Implementation

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAndroidHttpClient.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAndroidHttpClient.java
@@ -20,6 +20,9 @@ import org.robolectric.util.ReflectionHelpers;
 
 import java.io.IOException;
 
+/**
+ * Shadow for {@link android.net.http.AndroidHttpClient}.
+ */
 @Implements(AndroidHttpClient.class)
 public class ShadowAndroidHttpClient {
   @RealObject private AndroidHttpClient client;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAnimationBridge.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAnimationBridge.java
@@ -6,6 +6,9 @@ import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
+/**
+ * Bridge between shadows and {@link android.view.animation.Animation}.
+ */
 @DoNotInstrument
 public class ShadowAnimationBridge {
   private Animation realAnimation;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAnimationUtils.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAnimationUtils.java
@@ -11,6 +11,9 @@ import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.view.animation.AnimationUtils}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(AnimationUtils.class)
 public class ShadowAnimationUtils {
@@ -27,5 +30,4 @@ public class ShadowAnimationUtils {
     Shadows.shadowOf(layoutAnim).setLoadedFromResourceId(id);
     return layoutAnim;
   }
-
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAppWidgetHost.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAppWidgetHost.java
@@ -9,6 +9,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
+/**
+ * Shadow for {@link android.appwidget.AppWidgetHost}.
+ */
 @Implements(AppWidgetHost.class)
 public class ShadowAppWidgetHost {
   @RealObject

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAppWidgetHostView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAppWidgetHostView.java
@@ -6,6 +6,9 @@ import android.appwidget.AppWidgetProviderInfo;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.appwidget.AppWidgetHost}.
+ */
 @Implements(AppWidgetHostView.class)
 public class ShadowAppWidgetHostView extends ShadowFrameLayout {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAppWidgetManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAppWidgetManager.java
@@ -22,6 +22,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Shadow for {@link android.appwidget.AppWidgetManager}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(AppWidgetManager.class)
 public class ShadowAppWidgetManager {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -52,7 +52,7 @@ import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.internal.Shadow.newInstanceOf;
 
 /**
- * Shadows the {@code android.app.Application} class.
+ * Shadow for {@link android.app.Application}.
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Application.class)

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowArrayAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowArrayAdapter.java
@@ -5,7 +5,10 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
 
-@SuppressWarnings( { "UnusedDeclaration" })
+/**
+ * Shadow for {@link android.widget.ArrayAdapter}.
+ */
+@SuppressWarnings("UnusedDeclaration")
 @Implements(ArrayAdapter.class)
 public class ShadowArrayAdapter<T> extends ShadowBaseAdapter {
   @RealObject private ArrayAdapter<T> realArrayAdapter;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAsyncTask.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAsyncTask.java
@@ -13,6 +13,9 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+/**
+ * Shadow for {@link android.os.AsyncTask}.
+ */
 @Implements(AsyncTask.class)
 public class ShadowAsyncTask<Params, Progress, Result> {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAsyncTaskBridge.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAsyncTaskBridge.java
@@ -6,7 +6,7 @@ import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 /**
- * This must be placed in the same package as the underlying AsyncTask because it calls protected methods.
+ * Bridge between shadows and {@link android.os.AsyncTask}.
  */
 @DoNotInstrument
 public class ShadowAsyncTaskBridge<Params, Progress, Result> {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAudioEffect.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAudioEffect.java
@@ -9,6 +9,9 @@ import org.robolectric.annotation.Resetter;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * Shadow for {@link android.media.audiofx.AudioEffect}.
+ */
 @Implements(AudioEffect.class)
 public class ShadowAudioEffect {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
@@ -6,6 +6,9 @@ import org.robolectric.annotation.Implements;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Shadow for {@link android.media.AudioManager}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(AudioManager.class)
 public class ShadowAudioManager {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBaseAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBaseAdapter.java
@@ -7,6 +7,9 @@ import org.robolectric.annotation.RealObject;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.widget.BaseAdapter}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(BaseAdapter.class)
 public class ShadowBaseAdapter {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBinder.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBinder.java
@@ -9,6 +9,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
 
+/**
+ * Shadow for {@link android.os.Binder}.
+ */
 @Implements(Binder.class)
 public class ShadowBinder {
   @RealObject

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBinderBridge.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBinderBridge.java
@@ -7,6 +7,9 @@ import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
+/**
+ * Bridge between shadow and {@link android.os.Binder}.
+ */
 @DoNotInstrument
 public class ShadowBinderBridge {
   private Binder realBinder;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmap.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmap.java
@@ -15,6 +15,9 @@ import java.io.OutputStream;
 
 import static org.robolectric.Shadows.shadowOf;
 
+/**
+ * Shadow for {@link android.graphics.Bitmap}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Bitmap.class)
 public class ShadowBitmap {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapDrawable.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapDrawable.java
@@ -15,6 +15,9 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.graphics.drawable.BitmapDrawable}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(BitmapDrawable.class)
 public class ShadowBitmapDrawable extends ShadowDrawable {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -34,6 +34,9 @@ import java.util.zip.Checksum;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.graphics.BitmapFactory}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(BitmapFactory.class)
 public class ShadowBitmapFactory {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapShader.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapShader.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.graphics.BitmapShader;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.graphics.BitmapShader}.
+ */
 @Implements(BitmapShader.class)
 public class ShadowBitmapShader {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBluetoothDevice.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBluetoothDevice.java
@@ -4,6 +4,9 @@ import android.bluetooth.BluetoothDevice;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.bluetooth.BluetoothDevice}.
+ */
 @Implements(BluetoothDevice.class)
 public class ShadowBluetoothDevice {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBroadcastReceiver.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBroadcastReceiver.java
@@ -9,6 +9,9 @@ import org.robolectric.annotation.RealObject;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * Shadow for {@link android.content.BroadcastReceiver}.
+ */
 @Implements(BroadcastReceiver.class)
 public class ShadowBroadcastReceiver {
   @RealObject BroadcastReceiver receiver;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBundle.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBundle.java
@@ -8,7 +8,9 @@ import org.robolectric.util.ReflectionHelpers;
 
 import java.util.Map;
 
-
+/**
+ * Shadow for {@link android.os.Bundle}.
+ */
 @Implements(Bundle.class)
 public class ShadowBundle {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCamera.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCamera.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import static org.robolectric.internal.Shadow.*;
 
 /**
- * Shadows the Android {@code Camera} class.
+ * Shadow for {@link android.hardware.Camera}.
  */
 @Implements(Camera.class)
 public class ShadowCamera {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCanvas.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCanvas.java
@@ -18,12 +18,11 @@ import java.util.List;
 import static org.robolectric.Shadows.shadowOf;
 
 /**
- * Shadows the {@code android.graphics.Canvas} class.
+ * Shadow for {@link android.graphics.Canvas}.
  *
- * <p>
- * Broken.
- * This implementation is very specific to the application for which it was developed.
- * Todo: Reimplement. Consider using the same strategy of collecting a history of draw events and providing methods for writing queries based on type, number, and order of events.
+ * <p> Broken. This implementation is very specific to the application for which it was developed.
+ * Todo: Reimplement. Consider using the same strategy of collecting a history of draw events
+ * and providing methods for writing queries based on type, number, and order of events.</p>
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Canvas.class)

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowChoreographer.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowChoreographer.java
@@ -12,9 +12,11 @@ import org.robolectric.util.SoftThreadLocal;
 import org.robolectric.util.TimeUtils;
 
 /**
- * Shadow Choreographer implementation. This class maintains its own concept of the current time aimed
- * at making animations work correctly. Time starts out at 0 and advances by "frameInterval" every time
- * {@link getFrameTimeNanos} is called.
+ * Shadow for {@link android.view.Choreographer}.
+ *
+ * <p>This class maintains its own concept of the current time aimed at making animations
+ * work correctly. Time starts out at 0 and advances by "frameInterval" every time
+ * {@link android.view.Choreographer#getFrameTimeNanos} is called.</p>
  */
 @Implements(Choreographer.class)
 public class ShadowChoreographer {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowColor.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowColor.java
@@ -1,13 +1,12 @@
 package org.robolectric.shadows;
 
 import android.graphics.Color;
-import org.robolectric.Shadows;
-import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Implementation;
 
-import org.robolectric.internal.Shadow;
-import org.robolectric.util.ReflectionHelpers;
-
+/**
+ * Shadow for {@link android.graphics.Color}.
+ */
 @Implements(Color.class)
 public class ShadowColor {
   /**
@@ -17,8 +16,9 @@ public class ShadowColor {
    * with a small adjustment to the representation of the hue.</p>
    *
    * <p>{@link java.awt.Color} represents hue as 0..1 (where 1 == 100% == 360 degrees),
-   * while {@link android.graphics.Color} represents hue as 0..360 degrees. The correct hue can be calculated
-   * by multiplying with 360.</p>
+   * while {@link android.graphics.Color} represents hue as 0..360 degrees. The correct hue
+   * can be calculated by multiplying with 360.</p>
+   *
    * @param red Red component
    * @param green Green component
    * @param blue Blue component

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowColorMatrix.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowColorMatrix.java
@@ -10,6 +10,9 @@ import org.robolectric.util.Join;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Shadow for {@link android.graphics.ColorMatrix}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(ColorMatrix.class)
 public class ShadowColorMatrix {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowColorMatrixColorFilter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowColorMatrixColorFilter.java
@@ -5,6 +5,9 @@ import android.graphics.ColorMatrixColorFilter;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.graphics.ColorMatrixColorFilter}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(ColorMatrixColorFilter.class)
 public class ShadowColorMatrixColorFilter {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCompoundButton.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCompoundButton.java
@@ -9,6 +9,9 @@ import org.robolectric.annotation.RealObject;
 import static org.robolectric.internal.Shadow.*;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.*;
 
+/**
+ * Shadow for {@link android.widget.CompoundButton}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(CompoundButton.class)
 public class ShadowCompoundButton extends ShadowTextView {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowConfiguration.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowConfiguration.java
@@ -8,6 +8,9 @@ import org.robolectric.annotation.RealObject;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.content.res.Configuration}.
+ */
 @Implements(Configuration.class)
 public class ShadowConfiguration {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentObserver.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentObserver.java
@@ -6,7 +6,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
-
+/**
+ * Shadow for {@link android.database.ContentObserver}.
+ */
 @Implements(ContentObserver.class)
 public class ShadowContentObserver {
 
@@ -14,13 +16,12 @@ public class ShadowContentObserver {
   private ContentObserver realObserver;
 
   @Implementation
-  public void dispatchChange( boolean selfChange, Uri uri ) {
+  public void dispatchChange(boolean selfChange, Uri uri) {
     realObserver.onChange(selfChange, uri);
   }
 
   @Implementation
-  public void dispatchChange( boolean selfChange ) {
+  public void dispatchChange(boolean selfChange) {
     realObserver.onChange(selfChange);
   }
-
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentProvider.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentProvider.java
@@ -6,6 +6,9 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.content.ContentProvider}.
+ */
 @Implements(ContentProvider.class)
 public class ShadowContentProvider {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentProviderClient.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentProviderClient.java
@@ -15,21 +15,23 @@ import android.os.Bundle;
 import android.os.CancellationSignal;
 import android.os.ParcelFileDescriptor;
 import android.os.RemoteException;
+
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
+
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.content.ContentProviderClient}.
+ */
 @Implements(ContentProviderClient.class)
 public class ShadowContentProviderClient {
-
-  private ContentProvider provider;
   private boolean stable;
+  private boolean released;
+  private ContentProvider provider;
 
-  private boolean released = false;
-
-  public void __constructor__(ContentResolver contentResolver, IContentProvider contentProvider,
-      boolean stable) {
+  public void __constructor__(ContentResolver contentResolver, IContentProvider contentProvider, boolean stable) {
     this.stable = stable;
   }
 
@@ -50,13 +52,13 @@ public class ShadowContentProviderClient {
 
   @Implementation
   public Cursor query(Uri url, String[] projection, String selection, String[] selectionArgs,
-      String sortOrder) throws RemoteException {
+                      String sortOrder) throws RemoteException {
     return provider.query(url, projection, selection, selectionArgs, sortOrder);
   }
 
   @Implementation
   public Cursor query(Uri url, String[] projection, String selection, String[] selectionArgs,
-      String sortOrder, CancellationSignal cancellationSignal) throws RemoteException {
+                      String sortOrder, CancellationSignal cancellationSignal) throws RemoteException {
     return provider.query(url, projection, selection, selectionArgs, sortOrder, cancellationSignal);
   }
 
@@ -96,7 +98,7 @@ public class ShadowContentProviderClient {
 
   @Implementation
   public final AssetFileDescriptor openTypedAssetFileDescriptor(Uri uri,
-      String mimeType, Bundle opts) throws RemoteException, FileNotFoundException {
+                                                                String mimeType, Bundle opts) throws RemoteException, FileNotFoundException {
     return provider.openTypedAssetFile(uri, mimeType, opts);
   }
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentProviderOperation.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentProviderOperation.java
@@ -11,11 +11,10 @@ import org.robolectric.util.ReflectionHelpers;
 import java.util.Map;
 
 /**
- * Shadow for {@link ContentProviderOperation}. Gives access to operation internal properties.
+ * Shadow for {@link android.content.ContentProviderOperation}.
  */
 @Implements(ContentProviderOperation.class)
 public class ShadowContentProviderOperation {
-
   public final static int TYPE_INSERT = 1;
   public final static int TYPE_UPDATE = 2;
   public final static int TYPE_DELETE = 3;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentProviderResult.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentProviderResult.java
@@ -7,6 +7,9 @@ import org.robolectric.annotation.RealObject;
 
 import java.lang.reflect.Field;
 
+/**
+ * Shadow for {@link android.content.ContentProviderResult}.
+ */
 @Implements(ContentProviderResult.class)
 public class ShadowContentProviderResult {
   @RealObject ContentProviderResult realResult;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
@@ -40,6 +40,9 @@ import java.util.concurrent.CopyOnWriteArraySet;
 
 import static org.robolectric.Shadows.shadowOf;
 
+/**
+ * Shadow for {@link android.content.ContentResolver}.
+ */
 @Implements(ContentResolver.class)
 public class ShadowContentResolver {
   private int nextDatabaseIdForInserts;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentUris.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentUris.java
@@ -5,6 +5,9 @@ import android.net.Uri;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.content.ContentUris}.
+ */
 @Implements(ContentUris.class)
 public class ShadowContentUris {
 
@@ -22,5 +25,4 @@ public class ShadowContentUris {
     if (path == null) return -1;
     return Long.parseLong(path);
   }
-
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
@@ -20,7 +20,7 @@ import java.util.List;
 import static org.robolectric.Shadows.shadowOf;
 
 /**
- * Calls through to the {@code resourceLoader} to actually load resources.
+ * Shadow for {@link android.content.Context}.
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Context.class)

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextThemeWrapper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextThemeWrapper.java
@@ -5,6 +5,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
 
+/**
+ * Shadow for {@link android.view.ContextThemeWrapper}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(ContextThemeWrapper.class)
 public class ShadowContextThemeWrapper extends ShadowContextWrapper {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
@@ -29,6 +29,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Shadow for {@link android.content.ContextWrapper}.
+ */
 @Implements(ContextWrapper.class)
 public class ShadowContextWrapper extends ShadowContext {
   private final Map<String, RoboSharedPreferences> sharedPreferencesMap = new HashMap<>();

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCookieManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCookieManager.java
@@ -25,7 +25,7 @@ import org.robolectric.annotation.Resetter;
 import org.robolectric.util.ReflectionHelpers;
 
 /**
- * Shadows the {@code android.webkit.CookieManager} class.
+ * Shadow for {@code android.webkit.CookieManager}.
  */
 @Implements(CookieManager.class)
 public class ShadowCookieManager {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCookieSyncManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCookieSyncManager.java
@@ -7,7 +7,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.internal.Shadow;
 
 /**
- * Shadows the {@code android.webkit.CookieSyncManager} class.
+ * Shadow for {@code android.webkit.CookieSyncManager}.
  */
 @Implements(CookieSyncManager.class)
 public class ShadowCookieSyncManager extends ShadowWebSyncManager {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCornerPathEffect.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCornerPathEffect.java
@@ -6,6 +6,9 @@ import org.robolectric.annotation.Implements;
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(CornerPathEffect.class)
 
+/**
+ * Shadow for {@link android.graphics.CornerPathEffect}.
+ */
 public class ShadowCornerPathEffect {
   private float radius;
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCountDownTimer.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCountDownTimer.java
@@ -5,9 +5,11 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
+/**
+ * Shadow for {@link android.os.CountDownTimer}.
+ */
 @Implements(CountDownTimer.class)
 public class ShadowCountDownTimer {
-
   private boolean started;
   private long countDownInterval;
   private long millisInFuture;
@@ -26,12 +28,10 @@ public class ShadowCountDownTimer {
     return countDownTimer;
   }
 
-
   @Implementation
   public final void cancel() {
     started = false;
   }
-
 
   public void invokeTick(long millisUntilFinished) {
     countDownTimer.onTick(millisUntilFinished);

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCursorAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCursorAdapter.java
@@ -38,9 +38,7 @@ import static android.widget.CursorAdapter.FLAG_AUTO_REQUERY;
 import static android.widget.CursorAdapter.FLAG_REGISTER_CONTENT_OBSERVER;
 
 /**
- * Adapter that exposes data from a {@link android.database.Cursor Cursor} to a
- * {@link android.widget.ListView ListView} widget. The Cursor must include
- * a column named "_id" or this class will not work.
+ * Shadow for {@link android.widget.CursorAdapter}.
  */
 @Implements(CursorAdapter.class)
 public class ShadowCursorAdapter extends ShadowBaseAdapter {
@@ -224,7 +222,6 @@ public class ShadowCursorAdapter extends ShadowBaseAdapter {
 
   protected void onContentChangedInternal() {
     if (mAutoRequery && mCursor != null && !mCursor.isClosed()) {
-      if (Config.LOGV) Log.v("Cursor", "Auto requerying " + mCursor + " due to update");
       mDataValid = mCursor.requery();
     }
   }
@@ -258,5 +255,4 @@ public class ShadowCursorAdapter extends ShadowBaseAdapter {
       realCursorAdapter.notifyDataSetInvalidated();
     }
   }
-
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDashPathEffect.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDashPathEffect.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.graphics.DashPathEffect;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.graphics.DashPathEffect}.
+ */
 @Implements(DashPathEffect.class)
 public class ShadowDashPathEffect {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDateFormat.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDateFormat.java
@@ -7,6 +7,9 @@ import org.robolectric.annotation.Implements;
 
 import java.util.Locale;
 
+/**
+ * Shadow for {@link android.text.format.DateFormat}.
+ */
 @Implements(DateFormat.class)
 public class ShadowDateFormat {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDatePickerDialog.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDatePickerDialog.java
@@ -8,6 +8,9 @@ import org.robolectric.annotation.RealObject;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter;
 import static org.robolectric.internal.Shadow.invokeConstructor;
 
+/**
+ * Shadow for {@link android.app.DatePickerDialog}.
+ */
 @Implements(DatePickerDialog.class)
 public class ShadowDatePickerDialog extends ShadowAlertDialog {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDebug.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDebug.java
@@ -4,6 +4,9 @@ import android.os.Debug;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.os.Debug}.
+ */
 @Implements(Debug.class)
 public class ShadowDebug {
   @Implementation

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDialog.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDialog.java
@@ -22,6 +22,9 @@ import java.util.List;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.app.Dialog}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Dialog.class)
 public class ShadowDialog {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDownloadManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDownloadManager.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Shadows Androids DownloadManager
+ * Shadow for {@link android.app.DownloadManager}.
  */
 @Implements(DownloadManager.class)
 public class ShadowDownloadManager {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDrawable.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDrawable.java
@@ -23,6 +23,9 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import static org.robolectric.Shadows.shadowOf;
 
+/**
+ * Shadow for {@link android.graphics.drawable.Drawable}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Drawable.class)
 public class ShadowDrawable {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowEdgeEffect.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowEdgeEffect.java
@@ -2,6 +2,9 @@ package org.robolectric.shadows;
 
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.widget.EdgeEffect}.
+ */
 @Implements(className = "android.widget.EdgeEffect")
 public class ShadowEdgeEffect {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowExifInterface.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowExifInterface.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.media.ExifInterface;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.media.ExifInterface}.
+ */
 @Implements(value = ExifInterface.class, callThroughByDefault = false)
 public class ShadowExifInterface {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowExpandableListView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowExpandableListView.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.widget.ExpandableListView;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.widget.ExpandableListView}.
+ */
 @Implements(ExpandableListView.class)
 public class ShadowExpandableListView extends ShadowListView {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowFilter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowFilter.java
@@ -7,6 +7,9 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
+/**
+ * Shadow for {@link android.widget.Filter}.
+ */
 @Implements(Filter.class)
 public class ShadowFilter {
   @RealObject private Filter realObject;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowFloatMath.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowFloatMath.java
@@ -20,6 +20,9 @@ import android.util.FloatMath;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.util.FloatMath}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(FloatMath.class)
 public class ShadowFloatMath {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowFrameLayout.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowFrameLayout.java
@@ -4,7 +4,7 @@ import android.widget.FrameLayout;
 import org.robolectric.annotation.Implements;
 
 /**
- * Shadow for {@link FrameLayout} that simulates its implementation.
+ * Shadow for {@link android.widget.FrameLayout}.
  */
 @SuppressWarnings("UnusedDeclaration")
 @Implements(FrameLayout.class)

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowGestureDetector.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowGestureDetector.java
@@ -13,6 +13,9 @@ import static android.view.GestureDetector.OnDoubleTapListener;
 import static org.robolectric.internal.Shadow.directlyOn;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
+/**
+ * Shadow for {@link android.view.GestureDetector}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(GestureDetector.class)
 public class ShadowGestureDetector {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowGradientDrawable.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowGradientDrawable.java
@@ -7,6 +7,9 @@ import org.robolectric.annotation.RealObject;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.graphics.drawable.GradientDrawable}.
+ */
 @Implements(GradientDrawable.class)
 public class ShadowGradientDrawable extends ShadowDrawable {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowHttpResponseCache.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowHttpResponseCache.java
@@ -14,6 +14,9 @@ import java.util.Map;
 
 import static org.robolectric.internal.Shadow.newInstanceOf;
 
+/**
+ * Shadow for {@link android.net.http.HttpResponseCache}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(value = HttpResponseCache.class, callThroughByDefault = false)
 public class ShadowHttpResponseCache {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowImageView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowImageView.java
@@ -10,6 +10,9 @@ import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.widget.ImageView}.
+ */
 @Implements(ImageView.class)
 public class ShadowImageView extends ShadowView {
   private Drawable imageDrawable;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowInputDevice.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowInputDevice.java
@@ -6,6 +6,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.internal.Shadow;
 
+/**
+ * Shadow for {@link android.view.InputDevice}.
+ */
 @Implements(InputDevice.class)
 public class ShadowInputDevice {
   private String deviceName;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowInputEvent.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowInputEvent.java
@@ -5,6 +5,9 @@ import android.view.InputEvent;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.view.InputEvent}.
+ */
 @Implements(InputEvent.class)
 public class ShadowInputEvent {
   protected InputDevice device;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowInputMethodManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowInputMethodManager.java
@@ -9,6 +9,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.internal.Shadow;
 
+/**
+ * Shadow for {@link android.view.inputmethod.InputMethodManager}.
+ */
 @Implements(value = InputMethodManager.class, callThroughByDefault = false)
 public class ShadowInputMethodManager {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntent.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntent.java
@@ -26,6 +26,9 @@ import java.util.Set;
 import static android.content.Intent.*;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter;
 
+/**
+ * Shadow for {@link android.content.Intent}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Intent.class)
 public class ShadowIntent {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntentFilter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntentFilter.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Shadow of {@code IntentFilter} implemented with a {@link java.util.List}
+ * Shadow for {@link android.content.IntentFilter}.
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(IntentFilter.class)

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntentSender.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntentSender.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.content.IntentSender;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.content.IntentSender}.
+ */
 @Implements(IntentSender.class)
 public class ShadowIntentSender {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntentService.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntentService.java
@@ -8,6 +8,9 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.app.IntentService}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(IntentService.class)
 public class ShadowIntentService extends ShadowService {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowJsPromptResult.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowJsPromptResult.java
@@ -5,6 +5,9 @@ import org.robolectric.annotation.Implements;
 
 import static org.robolectric.internal.Shadow.newInstanceOf;
 
+/**
+ * Shadow for {@link android.webkit.JsPromptResult}.
+ */
 @Implements(JsPromptResult.class)
 public class ShadowJsPromptResult extends ShadowJsResult{
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowJsResult.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowJsResult.java
@@ -4,6 +4,9 @@ import android.webkit.JsResult;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.webkit.JsResult}.
+ */
 @Implements(JsResult.class)
 public class ShadowJsResult {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowKeyCharacterMap.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowKeyCharacterMap.java
@@ -5,6 +5,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.util.ReflectionHelpers;
 
+/**
+ * Shadow for {@link android.view.KeyCharacterMap}.
+ */
 @Implements(KeyCharacterMap.class)
 public class ShadowKeyCharacterMap {
   @Implementation

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowKeyguardManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowKeyguardManager.java
@@ -7,7 +7,7 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.internal.Shadow;
 
 /**
- * Shadows the {@code android.app.KeyguardManager} class.
+ * Shadow for {@link android.app.KeyguardManager}.
  */
 @Implements(KeyguardManager.class)
 public class ShadowKeyguardManager {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLayoutAnimationController.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLayoutAnimationController.java
@@ -4,6 +4,9 @@ import android.view.animation.LayoutAnimationController;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
+/**
+ * Shadow for {@link android.view.animation.LayoutAnimationController}.
+ */
 @Implements(LayoutAnimationController.class)
 public class ShadowLayoutAnimationController {
   @RealObject

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLinearGradient.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLinearGradient.java
@@ -4,6 +4,9 @@ import android.graphics.LinearGradient;
 import android.graphics.Shader;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.graphics.LinearGradient}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(LinearGradient.class)
 public class ShadowLinearGradient {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLinearLayout.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLinearLayout.java
@@ -5,7 +5,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
 
-
+/**
+ * Shadow for {@link android.widget.LinearLayout}.
+ */
 @Implements(LinearLayout.class)
 public class ShadowLinearLayout extends ShadowViewGroup {
   @RealObject LinearLayout realObject;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLinkMovementMethod.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLinkMovementMethod.java
@@ -5,6 +5,9 @@ import android.text.method.MovementMethod;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.text.method.LinkMovementMethod}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(LinkMovementMethod.class)
 public class ShadowLinkMovementMethod {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowListPopupWindow.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowListPopupWindow.java
@@ -10,6 +10,9 @@ import org.robolectric.annotation.RealObject;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.widget.ListPopupWindow}.
+ */
 @Implements(ListPopupWindow.class)
 public class ShadowListPopupWindow {
   

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowListView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowListView.java
@@ -9,6 +9,9 @@ import org.robolectric.annotation.RealObject;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Shadow for {@link android.widget.ListView}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(ListView.class)
 public class ShadowListView extends ShadowAbsListView {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLocalActivityManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLocalActivityManager.java
@@ -4,25 +4,8 @@ import android.app.LocalActivityManager;
 import org.robolectric.annotation.Implements;
 
 /**
- *
+ * Shadow for {@link android.app.LocalActivityManager}.
  */
 @Implements(LocalActivityManager.class)
 public class ShadowLocalActivityManager {
-
-  //@Implementation
-  //public Window startActivity(String id, Intent intent) {
-  //  try {
-  //    final String clazz = intent.getComponent().getClassName();
-  //    final Class<? extends Activity> aClass = (Class<? extends Activity>) Class.forName(clazz);
-  //    final Constructor<? extends Activity> ctor = aClass.getConstructor();
-  //    Activity activity = ctor.newInstance();
-  //    final Method onCreateMethod = aClass.getDeclaredMethod("onCreate", Bundle.class);
-  //    onCreateMethod.setAccessible(true);
-  //    onCreateMethod.invoke(activity, (Bundle) null);
-  //    return activity.getWindow();
-  //  } catch (Exception e) {
-  //    throw new RuntimeException("Unable to create class", e);
-  //  }
-  //}
-
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLocation.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLocation.java
@@ -8,8 +8,7 @@ import org.robolectric.annotation.HiddenApi;
 import org.robolectric.internal.ShadowExtractor;
 
 /**
- * Shadow of {@code Location} that treats it primarily as a data-holder
- * todo: support Location's static utility methods
+ * Shadow for {@link android.location.Location}.
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Location.class)

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLocationManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLocationManager.java
@@ -23,8 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Shadow of {@code LocationManager} that provides for the simulation of different location providers being enabled and
- * disabled.
+ * Shadow for {@link android.location.LocationManager}.
  */
 @Implements(LocationManager.class)
 public class ShadowLocationManager {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLog.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLog.java
@@ -13,6 +13,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Shadow for {@link android.util.Log}.
+ */
 @Implements(Log.class)
 public class ShadowLog {
   private static final int extraLogLength = "l/: \n".length();

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
@@ -15,9 +15,9 @@ import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 /**
- * Shadow for {@code Looper} that enqueues posted {@link Runnable}s to be run (on this thread) later. {@code Runnable}s
- * that are scheduled to run immediately can be triggered by calling {@link #idle()}
- * todo: provide better support for advancing the clock and running queued tasks
+ * Shadow for {@link android.os.Looper} that enqueues posted {@link Runnable}s to be run
+ * (on this thread) later. {@code Runnable}s that are scheduled to run immediately can be
+ * triggered by calling {@link #idle()}.
  *
  * @see ShadowMessageQueue
  */
@@ -164,8 +164,7 @@ public class ShadowLooper {
    * Runs any immediately runnable tasks previously queued on the UI thread,
    * e.g. by {@link android.app.Activity#runOnUiThread(Runnable)} or {@link android.os.AsyncTask#onPostExecute(Object)}.
    *
-   * <p>
-   * Note: calling this method does not pause or un-pause the scheduler.
+   * <p>Note: calling this method does not pause or un-pause the scheduler.</p>
    */
   public static void runUiThreadTasks() {
     ShadowApplication.getInstance().getForegroundThreadScheduler().advanceBy(0);

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMatrix.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMatrix.java
@@ -14,6 +14,9 @@ import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.graphics.Matrix}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Matrix.class)
 public class ShadowMatrix {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaMetadataRetriever.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaMetadataRetriever.java
@@ -14,6 +14,9 @@ import org.robolectric.shadows.util.DataSource;
 
 import static org.robolectric.shadows.util.DataSource.toDataSource;
 
+/**
+ * Shadow for {@link android.media.MediaMetadataRetriever}.
+ */
 @Implements(MediaMetadataRetriever.class)
 public class ShadowMediaMetadataRetriever {
   private DataSource dataSource;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
@@ -30,7 +30,7 @@ import static org.robolectric.shadows.ShadowMediaPlayer.State.*;
 import static org.robolectric.shadows.util.DataSource.toDataSource;
 
 /**
- * Shadows the Android {@code MediaPlayer} class.
+ * Shadow for {@link android.media.MediaPlayer}.
  * 
  * Automated testing of media playback can be a difficult thing - especially
  * testing that your code properly handles asynchronous errors and events. This

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaRecorder.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaRecorder.java
@@ -7,7 +7,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /**
- * Shadows the {@code MediaRecorder} class.
+ * Shadow for {@link android.media.MediaRecorder}.
  */
 @Implements(MediaRecorder.class)
 public class ShadowMediaRecorder {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaRouter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaRouter.java
@@ -5,6 +5,9 @@ import android.media.MediaRouter;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.media.MediaRouter}.
+ */
 @Implements(MediaRouter.class)
 public class ShadowMediaRouter {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaScannerConnection.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaScannerConnection.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.media.MediaScannerConnection;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.media.MediaScannerConnection}.
+ */
 @Implements(MediaScannerConnection.class)
 public class ShadowMediaScannerConnection {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaStore.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaStore.java
@@ -8,13 +8,19 @@ import android.provider.MediaStore;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.provider.MediaStore}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(MediaStore.class)
 public class ShadowMediaStore {
+
   @Implements(MediaStore.Images.class)
   public static class ShadowImages {
+
     @Implements(MediaStore.Images.Media.class)
     public static class ShadowMedia {
+
       @Implementation
       public static Bitmap getBitmap(ContentResolver cr, Uri url) {
         return ShadowBitmapFactory.create(url.toString());

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMessenger.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMessenger.java
@@ -7,9 +7,11 @@ import android.os.RemoteException;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.os.Messenger}.
+ */
 @Implements(Messenger.class)
 public class ShadowMessenger {
-
   private Handler handler;
 
   public void __constructor__(Handler handler) {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMimeTypeMap.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMimeTypeMap.java
@@ -12,33 +12,31 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Shadow for {@code MimeTypeMap} that allows custom extension to mimetype mapping to be set up by tests.
+ * Shadow for {@link android.webkit.MimeTypeMap}.
  */
 @Implements(MimeTypeMap.class)
 public class ShadowMimeTypeMap {
-
-  Map<String, String> extensionToMimeTypeMap = new HashMap<>();
-  Map<String, String> mimeTypeToExtensionMap = new HashMap<>();
-
-  static MimeTypeMap sSingleton = null;
-  static Object sSingletonLock = new Object();
+  private final Map<String, String> extensionToMimeTypeMap = new HashMap<>();
+  private final Map<String, String> mimeTypeToExtensionMap = new HashMap<>();
+  private static MimeTypeMap singleton = null;
+  private static final Object singletonLock = new Object();
 
   @Implementation
   public static MimeTypeMap getSingleton() {
-    if (sSingleton == null) {
-      synchronized (sSingletonLock) {
-        if (sSingleton == null) {
-          sSingleton = Shadow.newInstanceOf(MimeTypeMap.class);
+    if (singleton == null) {
+      synchronized (singletonLock) {
+        if (singleton == null) {
+          singleton = Shadow.newInstanceOf(MimeTypeMap.class);
         }
       }
     }
 
-    return sSingleton;
+    return singleton;
   }
 
   @Resetter
   public static void reset() {
-    if (sSingleton != null) {
+    if (singleton != null) {
       Shadows.shadowOf(getSingleton()).clearMappings();
     }
   }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMotionEvent.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMotionEvent.java
@@ -9,8 +9,7 @@ import org.robolectric.annotation.RealObject;
 import java.lang.reflect.Constructor;
 
 /**
- * Shadow for {@code MotionEvent} that uses reflection to create {@code MotionEvent} objects, which cannot otherwise
- * be constructed.
+ * Shadow for {@link android.view.MotionEvent}.
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(MotionEvent.class)

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNetworkInfo.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNetworkInfo.java
@@ -7,7 +7,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.internal.Shadow;
 
 /**
- * Shadow of {@code NetworkInfo} which is used by ShadowConnectivityManager.
+ * Shadow for {@code android.net.NetworkInfo}.
  */
 @Implements(NetworkInfo.class)
 public class ShadowNetworkInfo {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNfcAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNfcAdapter.java
@@ -10,6 +10,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
 
+/**
+ * Shadow for {@link android.nfc.NfcAdapter}.
+ */
 @Implements(NfcAdapter.class)
 public class ShadowNfcAdapter {
   @RealObject NfcAdapter nfcAdapter;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNinePatch.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNinePatch.java
@@ -4,6 +4,9 @@ import android.graphics.NinePatch;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.graphics.NinePatch}.
+ */
 @Implements(NinePatch.class)
 public class ShadowNinePatch {
   @Implementation

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -10,10 +10,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Shadow for {@link android.app.NotificationManager}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(NotificationManager.class)
 public class ShadowNotificationManager {
-
   private Map<Key, Notification> notifications = new HashMap<>();
 
   @Implementation

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNumberPicker.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNumberPicker.java
@@ -7,6 +7,9 @@ import org.robolectric.annotation.RealObject;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.widget.NumberPicker}.
+ */
 @Implements(value = NumberPicker.class)
 public class ShadowNumberPicker extends ShadowLinearLayout {
   @RealObject

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowObjectAnimator.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowObjectAnimator.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.animation.ObjectAnimator;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.animation.ObjectAnimator}.
+ */
 @Implements(ObjectAnimator.class)
 public class ShadowObjectAnimator extends ShadowValueAnimator {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowOverScroller.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowOverScroller.java
@@ -7,6 +7,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.util.Scheduler;
 
+/**
+ * Shadow for {@link android.widget.OverScroller}.
+ */
 @Implements(OverScroller.class)
 public class ShadowOverScroller {
   private int startX;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPaint.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPaint.java
@@ -12,8 +12,7 @@ import org.robolectric.internal.Shadow;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 /**
- * Shadow of {@code Paint} that has some extra accessors so that tests can tell whether a {@code Paint} object was
- * created with the expected parameters.
+ * Shadow for {@link android.graphics.Paint}.
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Paint.class)

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowParcelFileDescriptor.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowParcelFileDescriptor.java
@@ -12,6 +12,9 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.reflect.Constructor;
 
+/**
+ * Shadow for {@link android.os.ParcelFileDescriptor}.
+ */
 @Implements(ParcelFileDescriptor.class)
 public class ShadowParcelFileDescriptor {
   private RandomAccessFile file;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPath.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPath.java
@@ -12,8 +12,9 @@ import static org.robolectric.shadows.ShadowPath.Point.Type.LINE_TO;
 import static org.robolectric.shadows.ShadowPath.Point.Type.MOVE_TO;
 
 /**
- * Shadow of {@code Path} that contains a simplified implementation of the original class that only supports
- * straight-line {@code Path}s.
+ * Shadow for {@code android.graphics.Path}.
+ *
+ * <p>The shadow only supports straight-line paths.</p>
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Path.class)

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Shadow of {@code PendingIntent} that creates and sends {@code Intent}s appropriately.
+ * Shadow for {@code android.app.PendingIntent}.
  */
 @Implements(PendingIntent.class)
 public class ShadowPendingIntent {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPhoneWindow.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPhoneWindow.java
@@ -10,6 +10,9 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link com.android.internal.policy.impl.PhoneWindow}.
+ */
 @Implements(value = PhoneWindow.class, isInAndroidSdk = false)
 public class ShadowPhoneWindow extends ShadowWindow {
   @SuppressWarnings("UnusedDeclaration")

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPopupMenu.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPopupMenu.java
@@ -10,6 +10,9 @@ import org.robolectric.annotation.RealObject;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.widget.PopupMenu}.
+ */
 @Implements(PopupMenu.class)
 public class ShadowPopupMenu {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPopupWindow.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPopupWindow.java
@@ -15,6 +15,9 @@ import org.robolectric.annotation.RealObject;
 
 import static org.robolectric.Shadows.shadowOf;
 
+/**
+ * Shadow for {@link android.widget.PopupWindow}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(PopupWindow.class)
 public class ShadowPopupWindow {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPorterDuffColorFilter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPorterDuffColorFilter.java
@@ -5,6 +5,9 @@ import android.graphics.PorterDuffColorFilter;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.graphics.PorterDuffColorFilter}.
+ */
 @Implements(PorterDuffColorFilter.class)
 public class ShadowPorterDuffColorFilter {
   private int color;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreference.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreference.java
@@ -7,6 +7,9 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.internal.Shadow;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
+/**
+ * Shadow for {@link android.preference.Preference}.
+ */
 @Implements(Preference.class)
 public class ShadowPreference {
   @RealObject private Preference realPreference;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreferenceActivity.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreferenceActivity.java
@@ -11,6 +11,9 @@ import org.robolectric.shadows.util.PreferenceBuilder;
 
 import static org.robolectric.Shadows.shadowOf;
 
+/**
+ * Shadow for {@link android.preference.PreferenceActivity}.
+ */
 @Implements(PreferenceActivity.class)
 public class ShadowPreferenceActivity extends ShadowActivity {
   private int preferencesResId = -1;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreferenceManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreferenceManager.java
@@ -6,12 +6,14 @@ import android.preference.PreferenceManager;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.preference.PreferenceManager}.
+ */
 @Implements(PreferenceManager.class)
 public class ShadowPreferenceManager {
 
   @Implementation
   public static SharedPreferences getDefaultSharedPreferences(Context context) {
-    ShadowApplication shadowApplication = ShadowApplication.getInstance();
-    return shadowApplication.getSharedPreferences("__default__", Context.MODE_PRIVATE);
+    return ShadowApplication.getInstance().getSharedPreferences("__default__", Context.MODE_PRIVATE);
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowProcess.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowProcess.java
@@ -5,7 +5,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
 
 /**
- * Shadows the {@code android.os.Process} class.
+ * Shadow for {@link android.os.Process}.
  */
 @Implements(android.os.Process.class)
 public class ShadowProcess {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowProgressBar.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowProgressBar.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.widget.ProgressBar;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.widget.ProgressBar}.
+ */
 @Implements(ProgressBar.class)
 public class ShadowProgressBar extends ShadowView {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowProgressDialog.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowProgressDialog.java
@@ -1,10 +1,11 @@
 package org.robolectric.shadows;
 
-
 import android.app.ProgressDialog;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.app.ProgressDialog}.
+ */
 @Implements(ProgressDialog.class)
 public class ShadowProgressDialog extends ShadowAlertDialog {
-
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowRegion.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowRegion.java
@@ -5,6 +5,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.HiddenApi;
 
+/**
+ * Shadow for {@link android.graphics.Region}.
+ */
 @Implements(Region.class)
 public class ShadowRegion {
   public static int nextId = 1;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowRelativeLayout.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowRelativeLayout.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.widget.RelativeLayout;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.widget.RelativeLayout}.
+ */
 @Implements(RelativeLayout.class)
 public class ShadowRelativeLayout extends ShadowViewGroup {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowRemoteCallbackList.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowRemoteCallbackList.java
@@ -9,6 +9,9 @@ import org.robolectric.annotation.Implements;
 
 import java.util.HashMap;
 
+/**
+ * Shadow for {@link android.os.RemoteCallbackList}.
+ */
 @Implements(RemoteCallbackList.class)
 public class ShadowRemoteCallbackList<E extends IInterface> {
   private HashMap<IBinder, Callback> callbacks = new HashMap<>();

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowRemoteViews.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowRemoteViews.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Shadow for {@code RemoteViews} that simulates its implementation.
+ * Shadow for {@link android.widget.RemoteViews}.
  */
 @Implements(RemoteViews.class)
 public class ShadowRemoteViews {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResolveInfo.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResolveInfo.java
@@ -8,9 +8,11 @@ import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.content.pm.ResolveInfo}.
+ */
 @Implements(ResolveInfo.class)
 public class ShadowResolveInfo {
-
   private String label;
 
   /**

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResourceCursorAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResourceCursorAdapter.java
@@ -10,8 +10,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /**
- * An easy adapter that creates views defined in an XML file. You can specify
- * the XML file that defines the appearance of the views.
+ * Shadow for {@link android.widget.ResourceCursorAdapter}.
  */
 @Implements(ResourceCursorAdapter.class)
 public class ShadowResourceCursorAdapter extends ShadowCursorAdapter {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -49,7 +49,7 @@ import static org.robolectric.internal.Shadow.directlyOn;
 import static org.robolectric.Shadows.shadowOf;
 
 /**
- * Shadow of {@code Resources} that simulates the loading of resources
+ * Shadow for {@link android.content.res.Resources}.
  */
 @Implements(Resources.class)
 public class ShadowResources {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResultReceiver.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResultReceiver.java
@@ -6,16 +6,19 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
+/**
+ * Shadow for {@link android.os.ResultReceiver}.
+ */
 @Implements(ResultReceiver.class)
 public class ShadowResultReceiver {
-  // TODO: Use handler to make asynchronous
-
   @RealObject private ResultReceiver realResultReceiver;
 
   @Implementation
   public void send(int resultCode, android.os.Bundle resultData) {
-    ReflectionHelpers.callInstanceMethod(realResultReceiver, "onReceiveResult", new ReflectionHelpers.ClassParameter(Integer.TYPE, resultCode),
-        new ReflectionHelpers.ClassParameter(Bundle.class, resultData));
+    ReflectionHelpers.callInstanceMethod(realResultReceiver, "onReceiveResult",
+        ClassParameter.from(Integer.TYPE, resultCode),
+        ClassParameter.from(Bundle.class, resultData));
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowScaleGestureDetector.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowScaleGestureDetector.java
@@ -6,6 +6,9 @@ import android.view.ScaleGestureDetector;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.view.ScaleGestureDetector}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(ScaleGestureDetector.class)
 public class ShadowScaleGestureDetector {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowScanResult.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowScanResult.java
@@ -6,6 +6,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.internal.Shadow;
 
+/**
+ * Shadow for {@link android.net.wifi.ScanResult}.
+ */
 @Implements(ScanResult.class)
 public class ShadowScanResult {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowScrollView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowScrollView.java
@@ -4,8 +4,12 @@ import android.widget.ScrollView;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.widget.ScrollView}.
+ */
 @Implements(ScrollView.class)
 public class ShadowScrollView extends ShadowFrameLayout {
+
   @Implementation
   public void smoothScrollTo(int x, int y) {
     scrollTo(x, y);

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowScroller.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowScroller.java
@@ -4,6 +4,9 @@ import android.widget.Scroller;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.widget.Scroller}.
+ */
 @Implements(Scroller.class)
 public class ShadowScroller {
   private int startX;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSearchManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSearchManager.java
@@ -6,6 +6,9 @@ import android.content.ComponentName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.app.SearchManager}.
+ */
 @Implements(SearchManager.class)
 public class ShadowSearchManager {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSeekBar.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSeekBar.java
@@ -6,6 +6,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.internal.Shadow;
 
+/**
+ * Shadow for {@link android.widget.SeekBar}.
+ */
 @Implements(SeekBar.class)
 public class ShadowSeekBar extends ShadowAbsSeekBar {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
@@ -12,14 +12,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Shadow for {@link android.hardware.SensorManager}.
+ */
 @Implements(SensorManager.class)
 public class ShadowSensorManager {
-
-  private ArrayList<SensorEventListener> listeners = new ArrayList<>();
-
   public boolean forceListenersToFail = false;
-
   private final Map<Integer, Sensor> sensorMap = new HashMap<>();
+  private final ArrayList<SensorEventListener> listeners = new ArrayList<>();
 
   /**
    * Provide a Sensor for the indicated sensor type.
@@ -37,13 +37,12 @@ public class ShadowSensorManager {
 
   @Implementation
   public boolean registerListener(SensorEventListener listener, Sensor sensor, int rate) {
-
-    if(forceListenersToFail)
+    if (forceListenersToFail) {
       return false;
-
-    if(!listeners.contains(listener))
+    }
+    if (!listeners.contains(listener)) {
       listeners.add(listener);
-
+    }
     return true;
   }
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowService.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowService.java
@@ -13,6 +13,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
+/**
+ * Shadow for {@link android.app.Service}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Service.class)
 public class ShadowService extends ShadowContextWrapper {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowServiceManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowServiceManager.java
@@ -3,27 +3,37 @@ package org.robolectric.shadows;
 import android.os.IBinder;
 import android.os.RemoteException;
 import android.os.ServiceManager;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 import java.util.Map;
 
+/**
+ * Shadow for {@link android.os.ServiceManager}.
+ */
 @Implements(value = ServiceManager.class, isInAndroidSdk = false)
 public class ShadowServiceManager {
+
+  @Implementation
   public static IBinder getService(String name) {
     return null;
   }
 
+  @Implementation
   public static void addService(String name, IBinder service) {
   }
 
+  @Implementation
   public static IBinder checkService(String name) {
     return null;
   }
 
+  @Implementation
   public static String[] listServices() throws RemoteException {
     return null;
   }
 
+  @Implementation
   public static void initServiceCache(Map<String, IBinder> cache) {
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSimpleCursorAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSimpleCursorAdapter.java
@@ -30,6 +30,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
+/**
+ * Shadow for {@link android.widget.SimpleCursorAdapter}.
+ */
 @Implements(SimpleCursorAdapter.class)
 public class ShadowSimpleCursorAdapter extends ShadowResourceCursorAdapter {
   @RealObject private SimpleCursorAdapter realSimpleCursorAdapter;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSocketTagger.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSocketTagger.java
@@ -7,6 +7,9 @@ import org.robolectric.annotation.Implements;
 import java.net.Socket;
 import java.net.SocketException;
 
+/**
+ * Shadow for {@link dalvik.system.SocketTagger}.
+ */
 @Implements(value = SocketTagger.class, isInAndroidSdk = false)
 public class ShadowSocketTagger {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSpannableStringBuilder.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSpannableStringBuilder.java
@@ -5,17 +5,15 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
+/**
+ * Shadow for {@link android.text.SpannableStringBuilder}.
+ */
 @Implements(SpannableStringBuilder.class)
 public class ShadowSpannableStringBuilder {
   @RealObject SpannableStringBuilder realSpannableStringBuilder;
 
-  // this sucks because while ssb.equals(equivalentString) is true, equivalentString.equals(ssb) is not! sorry. [xw]
   @Implementation @Override public boolean equals(Object obj) {
-    if (obj == null) {
-      return false;
-    }
-    // todo: we should check that the spans match too...
-    return realSpannableStringBuilder.toString().equals(obj.toString());
+    return obj != null && realSpannableStringBuilder.toString().equals(obj.toString());
   }
 
   @Implementation @Override public int hashCode() {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSpellChecker.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSpellChecker.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.widget.SpellChecker;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.widget.SpellChecker}.
+ */
 @Implements(value = SpellChecker.class, callThroughByDefault = false, isInAndroidSdk = false)
 public class ShadowSpellChecker {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSslErrorHandler.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSslErrorHandler.java
@@ -4,6 +4,9 @@ import android.webkit.SslErrorHandler;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.webkit.SslErrorHandler}.
+ */
 @Implements(SslErrorHandler.class)
 public class ShadowSslErrorHandler extends ShadowHandler {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowStateListDrawable.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowStateListDrawable.java
@@ -16,11 +16,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Shadow for {@link android.graphics.drawable.StateListDrawable}.
+ */
 @Implements(StateListDrawable.class)
 public class ShadowStateListDrawable extends ShadowDrawable {
-
-  private Map<Integer, Integer> stateToResource = new HashMap<>();
-  private Map<List<Integer>, Drawable> stateToDrawable = new HashMap<>();
+  private final Map<Integer, Integer> stateToResource = new HashMap<>();
+  private final Map<List<Integer>, Drawable> stateToDrawable = new HashMap<>();
 
   public void addState(int stateId, int resId) {
     stateToResource.put(stateId, resId);
@@ -37,7 +39,6 @@ public class ShadowStateListDrawable extends ShadowDrawable {
 
   @Implementation
   public void inflate(Resources r, XmlPullParser parser, AttributeSet attrs) throws XmlPullParserException, IOException {
-    // todo 2.0-cleanup
   }
 
   /**

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowStrictMode.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowStrictMode.java
@@ -4,11 +4,14 @@ import android.os.StrictMode;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.os.StrictMode}.
+ */
 @Implements(StrictMode.class)
 public class ShadowStrictMode {
+
   @Implementation
   public static void setVmPolicy(StrictMode.VmPolicy p) {
-    // Just ignore VM policy setting.
-    // Results in a NPE otherwise.
+    // Prevent Robolectric from calling through
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSurface.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSurface.java
@@ -4,6 +4,9 @@ import android.view.Surface;
 import android.graphics.SurfaceTexture;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.view.Surface}.
+ */
 @Implements(Surface.class)
 public class ShadowSurface {
   private SurfaceTexture surfaceTexture;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSurfaceView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSurfaceView.java
@@ -11,11 +11,13 @@ import org.robolectric.annotation.Implements;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * Shadow for {@link android.view.SurfaceView}.
+ */
 @Implements(SurfaceView.class)
 @SuppressWarnings({"UnusedDeclaration"})
 public class ShadowSurfaceView extends ShadowView {
-
-  private FakeSurfaceHolder fakeSurfaceHolder = new FakeSurfaceHolder();
+  private final FakeSurfaceHolder fakeSurfaceHolder = new FakeSurfaceHolder();
 
   @Implementation
   public void onAttachedToWindow() {
@@ -31,14 +33,13 @@ public class ShadowSurfaceView extends ShadowView {
   }
 
   /**
-   * Fake version of {@link SurfaceHolder} that gives access to the stored callbacks,
-   * so they can be called by tests.
+   * Robolectric implementation of {@link android.view.SurfaceHolder}.
    */
   public static class FakeSurfaceHolder implements SurfaceHolder {
+    private final Set<Callback> callbacks = new HashSet<>();
 
-    final private Set<Callback> callbacks = new HashSet<>();
-
-    @Override public void addCallback(Callback callback) {
+    @Override
+    public void addCallback(Callback callback) {
       callbacks.add(callback);
     }
 
@@ -46,45 +47,57 @@ public class ShadowSurfaceView extends ShadowView {
       return callbacks;
     }
 
-    @Override public void removeCallback(Callback callback) {
+    @Override
+    public void removeCallback(Callback callback) {
       callbacks.remove(callback);
     }
 
-    @Override public boolean isCreating() {
+    @Override
+    public boolean isCreating() {
       return false;
     }
 
-    @Override public void setType(int i) {
+    @Override
+    public void setType(int i) {
     }
 
-    @Override public void setFixedSize(int i, int i1) {
+    @Override
+    public void setFixedSize(int i, int i1) {
     }
 
-    @Override public void setSizeFromLayout() {
+    @Override
+    public void setSizeFromLayout() {
     }
 
-    @Override public void setFormat(int i) {
+    @Override
+    public void setFormat(int i) {
     }
 
-    @Override public void setKeepScreenOn(boolean b) {
+    @Override
+    public void setKeepScreenOn(boolean b) {
     }
 
-    @Override public Canvas lockCanvas() {
+    @Override
+    public Canvas lockCanvas() {
       return null;
     }
 
-    @Override public Canvas lockCanvas(Rect rect) {
+    @Override
+    public Canvas lockCanvas(Rect rect) {
       return null;
     }
 
-    @Override public void unlockCanvasAndPost(Canvas canvas) {
+    @Override
+    public void unlockCanvasAndPost(Canvas canvas) {
     }
 
-    @Override public Rect getSurfaceFrame() {
+    @Override
+    public Rect getSurfaceFrame() {
       return null;
     }
 
-    @Override public Surface getSurface() {
+    @Override
+    public Surface getSurface() {
       return null;
     }
   }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
@@ -6,9 +6,11 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.HiddenApi;
 
 /**
- * The concept of current time is base on the current time of the UI Scheduler for consistency with previous
- * implementations. This is not ideal, since both schedulers (background and foreground), can see different
- * values for the current time.
+ * Shadow for {@link android.os.SystemClock}.
+ *
+ * <p>The concept of current time is base on the current time of the UI Scheduler for
+ * consistency with previous implementations. This is not ideal, since both schedulers
+ * (background and foreground), can see different values for the current time.</p>
  */
 @Implements(SystemClock.class)
 public class ShadowSystemClock {
@@ -17,15 +19,15 @@ public class ShadowSystemClock {
   private static final int MILLIS_PER_NANO = 1000000;
 
   static long now() {
-    if(ShadowApplication.getInstance() == null) {
-        return 0;
+    if (ShadowApplication.getInstance() == null) {
+      return 0;
     }
     return ShadowApplication.getInstance().getForegroundThreadScheduler().getCurrentTime();
   }
 
   @Implementation
   public static void sleep(long millis) {
-    if(ShadowApplication.getInstance() == null) {
+    if (ShadowApplication.getInstance() == null) {
       return;
     }
 
@@ -35,7 +37,7 @@ public class ShadowSystemClock {
 
   @Implementation
   public static boolean setCurrentTimeMillis(long millis) {
-    if(ShadowApplication.getInstance() == null) {
+    if (ShadowApplication.getInstance() == null) {
       return false;
     }
 
@@ -46,7 +48,7 @@ public class ShadowSystemClock {
     ShadowApplication.getInstance().getForegroundThreadScheduler().advanceTo(millis);
     return true;
   }
-  
+
   @Implementation
   public static long uptimeMillis() {
     return now() - bootedAt;
@@ -62,16 +64,18 @@ public class ShadowSystemClock {
     return uptimeMillis();
   }
 
-  @HiddenApi @Implementation
+  @HiddenApi
+  @Implementation
   public static long currentThreadTimeMicro() {
     return uptimeMillis() * 1000;
   }
 
-  @HiddenApi @Implementation
+  @HiddenApi
+  @Implementation
   public static long currentTimeMicro() {
     return now() * 1000;
   }
-  
+
   /**
    * Implements {@link System#currentTimeMillis} through ShadowWrangler.
    *

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSystemProperties.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSystemProperties.java
@@ -9,6 +9,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Shadow for {@link android.os.SystemProperties}.
+ */
 @Implements(value = SystemProperties.class, isInAndroidSdk = false)
 public class ShadowSystemProperties {
   private static final Map<String, Object> VALUES = new HashMap<>();

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTabActivity.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTabActivity.java
@@ -7,12 +7,15 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
+/**
+ * Shadow for {@link android.app.TabActivity}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(TabActivity.class)
 public class ShadowTabActivity extends ShadowActivityGroup {
+  @RealObject private TabActivity realTabActivity;
+  private TabHost tabhost;
 
-  @RealObject TabActivity realTabActivity;
-  TabHost tabhost;
   @Implementation
   public TabHost getTabHost() {
     if (tabhost==null) {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTabHost.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTabHost.java
@@ -18,6 +18,9 @@ import org.robolectric.internal.Shadow;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Shadow for {@link android.widget.TabHost}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(TabHost.class)
 public class ShadowTabHost extends ShadowFrameLayout {
@@ -26,7 +29,7 @@ public class ShadowTabHost extends ShadowFrameLayout {
   private int currentTab = -1;
 
   @RealObject
-  TabHost realObject;
+  private TabHost realObject;
 
   @Implementation
   public android.widget.TabHost.TabSpec newTabSpec(java.lang.String tag) {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTabWidget.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTabWidget.java
@@ -5,8 +5,12 @@ import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.widget.TabWidget}.
+ */
 @Implements(TabWidget.class)
 public class ShadowTabWidget extends ShadowLinearLayout {
+
   @HiddenApi @Implementation
   public void initTabWidget() {
   }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
@@ -5,9 +5,11 @@ import android.telephony.TelephonyManager;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.telephony.PhoneStateListener}.
+ */
 @Implements(TelephonyManager.class)
 public class ShadowTelephonyManager {
-
   private PhoneStateListener listener;
   private int eventFlags;
   private String deviceId;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTextPaint.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTextPaint.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.text.TextPaint;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.text.TextPaint}.
+ */
 @Implements(TextPaint.class)
 public class ShadowTextPaint extends ShadowPaint {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTextToSpeech.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTextToSpeech.java
@@ -6,6 +6,9 @@ import java.util.HashMap;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.speech.tts.TextToSpeech}.
+ */
 @Implements(TextToSpeech.class)
 public class ShadowTextToSpeech {
   private Context context;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTextView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTextView.java
@@ -23,6 +23,9 @@ import java.util.Locale;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.widget.TextView}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(TextView.class)
 public class ShadowTextView extends ShadowView {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTimePickerDialog.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTimePickerDialog.java
@@ -8,6 +8,9 @@ import org.robolectric.internal.Shadow;
 
 import static org.robolectric.util.ReflectionHelpers.ClassParameter;
 
+/**
+ * Shadow for {@link android.app.TimePickerDialog}.
+ */
 @Implements(value = TimePickerDialog.class, inheritImplementationMethods = true)
 public class ShadowTimePickerDialog extends ShadowAlertDialog {
   @RealObject

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowToast.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowToast.java
@@ -14,7 +14,7 @@ import java.util.List;
 import static org.robolectric.Shadows.shadowOf;
 
 /**
- * Shadow of {@code Toast} that tracks {@code Toast} requests. Hear hear! (*clink*)
+ * Shadow for {@link android.widget.Toast}.
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Toast.class)

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTouchDelegate.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTouchDelegate.java
@@ -6,12 +6,12 @@ import android.view.View;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
+/**
+ * Shadow for {@link android.view.TouchDelegate}.
+ */
 @Implements(TouchDelegate.class)
 public class ShadowTouchDelegate {
-
-  @RealObject
-  TouchDelegate realObject;
-
+  @RealObject private TouchDelegate realObject;
   private Rect bounds;
   private View delegateView;
 
@@ -27,5 +27,4 @@ public class ShadowTouchDelegate {
   public View getDelegateView() {
     return this.delegateView;
   }
-
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTrafficStats.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTrafficStats.java
@@ -4,89 +4,139 @@ import android.net.TrafficStats;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
-@SuppressWarnings("unused")
+/**
+ * Shadow for {@link android.net.TrafficStats}.
+ */
 @Implements(TrafficStats.class)
 public class ShadowTrafficStats {
 
   @Implementation
-  public static void setThreadStatsTag(int tag) { }
+  public static void setThreadStatsTag(int tag) {
+  }
 
   @Implementation
-  public static int getThreadStatsTag() { return TrafficStats.UNSUPPORTED; }
+  public static int getThreadStatsTag() {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static void clearThreadStatsTag() { }
+  public static void clearThreadStatsTag() {
+  }
 
   @Implementation
-  public static void tagSocket(java.net.Socket socket) throws java.net.SocketException { }
+  public static void tagSocket(java.net.Socket socket) throws java.net.SocketException {
+  }
 
   @Implementation
-  public static void untagSocket(java.net.Socket socket) throws java.net.SocketException { }
+  public static void untagSocket(java.net.Socket socket) throws java.net.SocketException {
+  }
 
   @Implementation
-  public static void incrementOperationCount(int operationCount) { }
+  public static void incrementOperationCount(int operationCount) {
+  }
 
   @Implementation
-  public static void incrementOperationCount(int tag, int operationCount) { }
+  public static void incrementOperationCount(int tag, int operationCount) {
+  }
 
   @Implementation
-  public static long getMobileTxPackets() { return TrafficStats.UNSUPPORTED; }
+  public static long getMobileTxPackets() {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getMobileRxPackets() { return TrafficStats.UNSUPPORTED; }
+  public static long getMobileRxPackets() {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getMobileTxBytes() { return TrafficStats.UNSUPPORTED; }
+  public static long getMobileTxBytes() {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getMobileRxBytes() { return TrafficStats.UNSUPPORTED; }
+  public static long getMobileRxBytes() {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getTotalTxPackets() { return TrafficStats.UNSUPPORTED; }
+  public static long getTotalTxPackets() {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getTotalRxPackets() { return TrafficStats.UNSUPPORTED; }
+  public static long getTotalRxPackets() {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getTotalTxBytes() { return TrafficStats.UNSUPPORTED; }
+  public static long getTotalTxBytes() {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getTotalRxBytes() { return TrafficStats.UNSUPPORTED; }
+  public static long getTotalRxBytes() {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getUidTxBytes(int i) { return TrafficStats.UNSUPPORTED; }
+  public static long getUidTxBytes(int i) {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getUidRxBytes(int i) { return TrafficStats.UNSUPPORTED; }
+  public static long getUidRxBytes(int i) {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getUidTxPackets(int i) { return TrafficStats.UNSUPPORTED; }
+  public static long getUidTxPackets(int i) {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getUidRxPackets(int i) { return TrafficStats.UNSUPPORTED; }
+  public static long getUidRxPackets(int i) {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getUidTcpTxBytes(int i) { return TrafficStats.UNSUPPORTED; }
+  public static long getUidTcpTxBytes(int i) {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getUidTcpRxBytes(int i) { return TrafficStats.UNSUPPORTED; }
+  public static long getUidTcpRxBytes(int i) {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getUidUdpTxBytes(int i) { return TrafficStats.UNSUPPORTED; }
+  public static long getUidUdpTxBytes(int i) {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getUidUdpRxBytes(int i) { return TrafficStats.UNSUPPORTED; }
+  public static long getUidUdpRxBytes(int i) {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getUidTcpTxSegments(int i) { return TrafficStats.UNSUPPORTED; }
+  public static long getUidTcpTxSegments(int i) {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getUidTcpRxSegments(int i) { return TrafficStats.UNSUPPORTED; }
+  public static long getUidTcpRxSegments(int i) {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getUidUdpTxPackets(int i) { return TrafficStats.UNSUPPORTED; }
+  public static long getUidUdpTxPackets(int i) {
+    return TrafficStats.UNSUPPORTED;
+  }
 
   @Implementation
-  public static long getUidUdpRxPackets(int i) { return TrafficStats.UNSUPPORTED; }
+  public static long getUidUdpRxPackets(int i) {
+    return TrafficStats.UNSUPPORTED;
+  }
 }
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTypedArray.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowTypedArray.java
@@ -8,7 +8,11 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
+/**
+ * Shadow for {@link android.content.res.TypedArray}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(TypedArray.class)
 public class ShadowTypedArray {
@@ -17,9 +21,11 @@ public class ShadowTypedArray {
   public String positionDescription;
 
   public static TypedArray create(Resources realResources, int[] attrs, int[] data, int[] indices, int len, CharSequence[] stringData) {
-    TypedArray typedArray = ReflectionHelpers.callConstructor(TypedArray.class, new ReflectionHelpers.ClassParameter(Resources.class, realResources),
-        new ReflectionHelpers.ClassParameter(int[].class, data), new ReflectionHelpers.ClassParameter(int[].class, indices),
-        new ReflectionHelpers.ClassParameter(int.class, len));
+    TypedArray typedArray = ReflectionHelpers.callConstructor(TypedArray.class,
+        ClassParameter.from(Resources.class, realResources),
+        ClassParameter.from(int[].class, data),
+        ClassParameter.from(int[].class, indices),
+        ClassParameter.from(int.class, len));
     Shadows.shadowOf(typedArray).stringData = stringData;
     return typedArray;
   }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowVMRuntime.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowVMRuntime.java
@@ -6,6 +6,9 @@ import org.robolectric.annotation.Implements;
 
 import java.lang.reflect.Array;
 
+/**
+ * Shadow for {@link dalvik.system.VMRuntime}.
+ */
 @Implements(value = VMRuntime.class, isInAndroidSdk = false)
 public class ShadowVMRuntime {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowValueAnimator.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowValueAnimator.java
@@ -10,6 +10,9 @@ import org.robolectric.util.ReflectionHelpers;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.animation.ValueAnimator}.
+ */
 @Implements(ValueAnimator.class)
 public class ShadowValueAnimator {
 
@@ -44,6 +47,8 @@ public class ShadowValueAnimator {
   /**
    * Returns the value that was set as the repeat count. This is otherwise the same
    * as getRepeatCount(), except when the count was set to infinite.
+   *
+   * @return Repeat count.
    */
   public int getActualRepeatCount() {
     return actualRepeatCount;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowVelocityTracker.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowVelocityTracker.java
@@ -1,6 +1,5 @@
 package org.robolectric.shadows;
 
-
 import android.util.SparseArray;
 import android.view.MotionEvent;
 import android.view.VelocityTracker;
@@ -8,6 +7,9 @@ import android.view.VelocityTracker;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.view.VelocityTracker}.
+ */
 @Implements(VelocityTracker.class)
 public class ShadowVelocityTracker {
   private static final int ACTIVE_POINTER_ID = -1;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowVideoView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowVideoView.java
@@ -6,10 +6,12 @@ import android.widget.VideoView;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.widget.VideoView}.
+ */
 @Implements(VideoView.class)
 @SuppressWarnings({"UnusedDeclaration"})
 public class ShadowVideoView extends ShadowSurfaceView {
-
   private MediaPlayer.OnCompletionListener completionListner;
   private MediaPlayer.OnErrorListener errorListener;
   private MediaPlayer.OnPreparedListener preparedListener;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
@@ -33,12 +33,7 @@ import static org.robolectric.internal.Shadow.directlyOn;
 import static org.robolectric.internal.Shadow.invokeConstructor;
 
 /**
- * Shadow implementation of {@code View} that simulates the behavior of this
- * class.
- *
- * <p>
- * Supports listeners, focusability (but not focus order), resource loading,
- * visibility, onclick, tags, and tracks the size and shape of the view.
+ * Shadow for {@link android.view.View}.
  */
 @Implements(View.class)
 public class ShadowView {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowViewAnimator.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowViewAnimator.java
@@ -7,7 +7,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /**
- * Shadow of {@link android.widget.ViewAnimator}
+ * Shadow for {@link android.widget.ViewAnimator}.
  */
 @Implements(ViewAnimator.class)
 public class ShadowViewAnimator extends ShadowFrameLayout {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowViewConfiguration.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowViewConfiguration.java
@@ -29,6 +29,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.internal.Shadow;
 
+/**
+ * Shadow for {@link android.view.ViewConfiguration}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(ViewConfiguration.class)
 public class ShadowViewConfiguration {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowViewGroup.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowViewGroup.java
@@ -10,14 +10,14 @@ import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import java.io.PrintStream;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
 /**
- * Shadow for {@code ViewGroup} that simulates its implementation
+ * Shadow for {@link android.view.ViewGroup}.
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(ViewGroup.class)
@@ -33,17 +33,17 @@ public class ShadowViewGroup extends ShadowView {
   public void addView(final View child, final int index, final ViewGroup.LayoutParams params) {
     Shadows.shadowOf(Looper.getMainLooper()).runPaused(new Runnable() {
       @Override public void run() {
-        directlyOn(realViewGroup, ViewGroup.class, "addView", new ReflectionHelpers.ClassParameter(View.class, child),
-            new ReflectionHelpers.ClassParameter(int.class, index), new ReflectionHelpers.ClassParameter(ViewGroup.LayoutParams.class, params));
+        directlyOn(realViewGroup, ViewGroup.class, "addView",
+            ClassParameter.from(View.class, child),
+            ClassParameter.from(int.class, index),
+            ClassParameter.from(ViewGroup.LayoutParams.class, params));
       }
     });
   }
 
   /**
-   * Returns a string representation of this {@code ViewGroup} by concatenating all of the strings contained in all
-   * of the descendants of this {@code ViewGroup}.
-   * <p>
-   * Robolectric extension.
+   * Returns a string representation of this {@code ViewGroup} by concatenating all of the
+   * strings contained in all of the descendants of this {@code ViewGroup}.
    */
   @Override
   public String innerText() {
@@ -126,7 +126,9 @@ public class ShadowViewGroup extends ShadowView {
     return false;
   }
 
-  // todo: remove?
+  /**
+   * Shadow for {@link android.view.ViewGroup.LayoutParams}.
+   */
   @SuppressWarnings({"UnusedDeclaration"})
   @Implements(ViewGroup.LayoutParams.class)
   public static class ShadowLayoutParams {
@@ -142,9 +144,8 @@ public class ShadowViewGroup extends ShadowView {
     }
   }
 
-  // todo: remove?
   /**
-   * Shadow for {@link android.view.ViewGroup.MarginLayoutParams} that simulates its implementation.
+   * Shadow for {@link android.view.ViewGroup.MarginLayoutParams}.
    */
   @SuppressWarnings("UnusedDeclaration")
   @Implements(ViewGroup.MarginLayoutParams.class)

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowViewRootImpl.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowViewRootImpl.java
@@ -5,6 +5,9 @@ import android.view.ViewRootImpl;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.view.ViewRootImpl}.
+ */
 @Implements(value = ViewRootImpl.class, isInAndroidSdk = false)
 public class ShadowViewRootImpl {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowViewTreeObserver.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowViewTreeObserver.java
@@ -7,11 +7,13 @@ import org.robolectric.annotation.Implements;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Shadow for {@link android.view.ViewTreeObserver}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(ViewTreeObserver.class)
 public class ShadowViewTreeObserver {
-
-  private ArrayList<ViewTreeObserver.OnGlobalLayoutListener> globalLayoutListeners = new ArrayList<>();
+  private final ArrayList<ViewTreeObserver.OnGlobalLayoutListener> globalLayoutListeners = new ArrayList<>();
 
   @Implementation
   public void addOnGlobalLayoutListener(ViewTreeObserver.OnGlobalLayoutListener listener) {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWallpaperManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWallpaperManager.java
@@ -9,15 +9,18 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.internal.Shadow;
 
+/**
+ * Shadow for {@link android.app.WallpaperManager}.
+ */
 @Implements(WallpaperManager.class)
 public class ShadowWallpaperManager {
 
-    @Implementation
-    public static WallpaperManager getInstance(Context context) {
-        return Shadow.newInstanceOf(WallpaperManager.class);
-    }
+  @Implementation
+  public static WallpaperManager getInstance(Context context) {
+    return Shadow.newInstanceOf(WallpaperManager.class);
+  }
 
-    @Implementation
-    public void sendWallpaperCommand(IBinder windowToken, String action, int x, int y, int z, Bundle extras) {
-    }
+  @Implementation
+  public void sendWallpaperCommand(IBinder windowToken, String action, int x, int y, int z, Bundle extras) {
+  }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWebSyncManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWebSyncManager.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@code android.webkit.WebSyncManager}.
+ */
 @Implements(className = "android.webkit.WebSyncManager")
 public class ShadowWebSyncManager {
   protected boolean synced = false;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWebViewDatabase.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWebViewDatabase.java
@@ -6,6 +6,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.internal.Shadow;
 
+/**
+ * Shadow for {@link android.webkit.WebViewDatabase}.
+ */
 @Implements(value = WebViewDatabase.class, callThroughByDefault = false)
 public class ShadowWebViewDatabase {
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWifiConfiguration.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWifiConfiguration.java
@@ -6,9 +6,12 @@ import org.robolectric.annotation.RealObject;
 
 import java.util.BitSet;
 
+/**
+ * Shadow for {@link android.net.wifi.WifiConfiguration}.
+ */
 @Implements(WifiConfiguration.class)
 public class ShadowWifiConfiguration {
-  @RealObject WifiConfiguration realObject;
+  @RealObject private WifiConfiguration realObject;
 
   public void __constructor__() {
     realObject.networkId = -1;
@@ -29,7 +32,7 @@ public class ShadowWifiConfiguration {
 //        }
   }
 
-  public WifiConfiguration copy(){
+  public WifiConfiguration copy() {
     WifiConfiguration config = new WifiConfiguration();
     config.networkId = realObject.networkId;
     config.SSID = realObject.SSID;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWifiInfo.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWifiInfo.java
@@ -5,6 +5,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.HiddenApi;
 
+/**
+ * Shadow for {@link android.net.wifi.WifiInfo}.
+ */
 @Implements(WifiInfo.class)
 public class ShadowWifiInfo {
   public static void __staticInitializer__() {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
@@ -15,6 +15,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Shadow for {@link android.net.wifi.WifiManager}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(WifiManager.class)
 public class ShadowWifiManager {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWindow.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWindow.java
@@ -10,10 +10,11 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
-import java.lang.reflect.Constructor;
-
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.view.Window}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Window.class)
 public class ShadowWindow {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWindowManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWindowManager.java
@@ -3,6 +3,9 @@ package org.robolectric.shadows;
 import android.view.WindowManager;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.view.WindowManager}.
+ */
 @Implements(WindowManager.class)
 public class ShadowWindowManager {
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWindowManagerImpl.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWindowManagerImpl.java
@@ -13,6 +13,9 @@ import java.util.List;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.view.WindowManagerImpl}.
+ */
 @Implements(value = WindowManagerImpl.class, isInAndroidSdk = false)
 public class ShadowWindowManagerImpl extends ShadowWindowManager {
   public static final String WINDOW_MANAGER_IMPL_CLASS_NAME = "android.view.WindowManagerImpl";
@@ -24,7 +27,8 @@ public class ShadowWindowManagerImpl extends ShadowWindowManager {
   public void addView(View view, android.view.ViewGroup.LayoutParams layoutParams) {
     views.add(view);
     directlyOn(realObject, WINDOW_MANAGER_IMPL_CLASS_NAME, "addView",
-        ClassParameter.from(View.class, view), ClassParameter.from(ViewGroup.LayoutParams.class, layoutParams));
+        ClassParameter.from(View.class, view),
+        ClassParameter.from(ViewGroup.LayoutParams.class, layoutParams));
   }
 
   @Implementation

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowZoomButtonsController.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowZoomButtonsController.java
@@ -6,8 +6,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /**
- * Shadow of {@code ZoomButtonsController} that allows simulated clicking of the zoom button controls to trigger
- * events on the registered listener.
+ * Shadow for {@link android.widget.ZoomButtonsController}.
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(ZoomButtonsController.class)

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/package-info.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package containing shadow classes for the Android SDK.
+ */
+package org.robolectric.shadows;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/util/package-info.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package containing shadow related utility classes.
+ */
+package org.robolectric.shadows.util;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/util/concurrent/package-info.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/util/concurrent/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package containing concurrency related utility classes.
+ */
+package org.robolectric.util.concurrent;

--- a/robolectric-shadows/shadows-core/src/main/resources/android/app/RobolectricActivityManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/android/app/RobolectricActivityManager.java.vm
@@ -46,6 +46,9 @@ import com.android.internal.app.IVoiceInteractor;
 
 import java.util.List;
 
+/**
+ * Robolectric implementation of {@link android.app.ActivityManager}.
+ */
 public class RobolectricActivityManager implements IActivityManager {
 
 #if ($api >= 15 && $api < 17)

--- a/robolectric-shadows/shadows-core/src/main/resources/android/hardware/display/RoboDisplayManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/android/hardware/display/RoboDisplayManager.java.vm
@@ -10,6 +10,9 @@ import android.os.RemoteException;
 import android.view.DisplayInfo;
 import android.view.Surface;
 
+/**
+ * Robolectric implementation of {@link android.hardware.display.IDisplayManager}.
+ */
 public class RoboDisplayManager implements IDisplayManager {
 
 #if ($api >= 21)

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/fakes/BaseCursor.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/fakes/BaseCursor.java.vm
@@ -8,6 +8,9 @@ import android.database.DataSetObserver;
 import android.net.Uri;
 import android.os.Bundle;
 
+/**
+ * Robolectric implementation of {@link android.database.Cursor}.
+ */
 public class BaseCursor implements Cursor {
   @Override
   public int getCount() {

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/fakes/RoboSensorManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/fakes/RoboSensorManager.java.vm
@@ -11,6 +11,9 @@ import android.os.Handler;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Robolectric implementation of {@link android.hardware.SensorManager}.
+ */
 public class RoboSensorManager extends SensorManager {
 
   @Override

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/fakes/RoboVibrator.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/fakes/RoboVibrator.java.vm
@@ -8,6 +8,9 @@ import android.media.AudioAttributes;
 
 import org.robolectric.annotation.internal.DoNotInstrument;
 
+/**
+ * Robolectric implementation of {@link android.os.Vibrator}.
+ */
 @DoNotInstrument
 public class RoboVibrator extends Vibrator {
   private boolean vibrating;

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/fakes/RoboWebSettings.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/fakes/RoboWebSettings.java.vm
@@ -3,7 +3,7 @@ package org.robolectric.fakes;
 import android.webkit.WebSettings;
 
 /**
- * Concrete implementation of the abstract WebSettings class.
+ * Robolectric implementation of {@link android.webkit.WebSettings}.
  */
 public class RoboWebSettings extends WebSettings {
   private boolean allowContentAccess = true;

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityManager.java.vm
@@ -21,6 +21,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.List;
 
+/**
+ * Shadow for {@link android.view.accessibility.AccessibilityManager}.
+ */
 @Implements(AccessibilityManager.class)
 public class ShadowAccessibilityManager {
 

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccountManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccountManager.java.vm
@@ -30,7 +30,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Shadow implementation for the Android {@code AccountManager} class.
+ * Shadow for {@link android.accounts.AccountManager}.
  */
 @Implements(AccountManager.class)
 public class ShadowAccountManager {
@@ -416,6 +416,7 @@ public class ShadowAccountManager {
    * Non-android accessor.
    *
    * @param account User account.
+   * @param previousName Previous account name.
    */
   public void setPreviousAccountName(Account account, String previousName) {
     previousNames.put(account, previousName);
@@ -426,5 +427,4 @@ public class ShadowAccountManager {
     return previousNames.get(account);
   }
 #end
-
 }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAlarmManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAlarmManager.java.vm
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Shadows the {@code android.app.AlarmManager} class.
+ * Shadow for {@link android.app.AlarmManager}.
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(AlarmManager.class)

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -37,6 +37,9 @@ import org.robolectric.util.Strings;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.shadows.ShadowApplication.getInstance;
 
+/**
+ * Shadow for {@link android.content.res.AssetManager}.
+ */
 @Implements(AssetManager.class)
 public final class ShadowAssetManager {
   public static final int STYLE_NUM_ENTRIES = 6;

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowBackgroundThread.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowBackgroundThread.java.vm
@@ -9,6 +9,9 @@ import org.robolectric.annotation.Resetter;
 import org.robolectric.internal.Shadow;
 import org.robolectric.util.ReflectionHelpers;
 
+/**
+ * Shadow for {@link com.android.internal.os.BackgroundThread}.
+ */
 @Implements(value = BackgroundThread.class, isInAndroidSdk = false, inheritImplementationMethods = true)
 public class ShadowBackgroundThread {
 

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowBluetoothAdapter.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowBluetoothAdapter.java.vm
@@ -13,6 +13,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+/**
+ * Shadow for {@link android.bluetooth.BluetoothAdapter}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(BluetoothAdapter.class)
 public class ShadowBluetoothAdapter {

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowClipboardManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowClipboardManager.java.vm
@@ -13,6 +13,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.content.ClipboardManager}.
+ */
 @SuppressWarnings("UnusedDeclaration")
 @Implements(ClipboardManager.class)
 public class ShadowClipboardManager {

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowConnectivityManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowConnectivityManager.java.vm
@@ -16,6 +16,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Shadow for {@link android.net.ConnectivityManager}.
+ */
 @Implements(ConnectivityManager.class)
 public class ShadowConnectivityManager {
 

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
@@ -23,6 +23,9 @@ import static org.robolectric.internal.Shadow.directlyOn;
 import static org.robolectric.internal.Shadow.newInstanceOf;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
+/**
+ * Shadow for {@code android.content.ContextImpl}.
+ */
 @Implements(className = ShadowContextImpl.CLASS_NAME)
 public class ShadowContextImpl extends ShadowContext {
   public static final String CLASS_NAME = "android.app.ContextImpl";

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowCursorWindow.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowCursorWindow.java.vm
@@ -20,7 +20,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Generated;
 
-@Generated("org.robolectric.shadows.ShadowCursorWindow.java.vm")
+/**
+ * Shadow for {@link android.database.CursorWindow}.
+ */
 @Implements(value = CursorWindow.class)
 public class ShadowCursorWindow {
   private static final WindowData WINDOW_DATA = new WindowData();

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowCursorWrapper.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowCursorWrapper.java.vm
@@ -11,6 +11,9 @@ import android.os.Bundle;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.database.CursorWrapper}.
+ */
 @Implements(CursorWrapper.class)
 public class ShadowCursorWrapper implements Cursor {
   private Cursor wrappedCursor;

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowDateIntervalFormat.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowDateIntervalFormat.java.vm
@@ -11,6 +11,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.internal.Shadow;
 
+/**
+ * Shadow for {@link libcore.icu.DateIntervalFormat}.
+ */
 @Implements(value = DateIntervalFormat.class, isInAndroidSdk = false)
 public class ShadowDateIntervalFormat {
 

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowDisplay.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowDisplay.java.vm
@@ -14,7 +14,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /**
- * A shadow for Display with some reasonable defaults
+ * Shadow for {@link android.view.Display}.
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(value = Display.class)

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowDisplayManagerGlobal.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowDisplayManagerGlobal.java.vm
@@ -10,6 +10,9 @@ import org.robolectric.internal.Shadow;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
+/**
+ * Shadow for {@link android.hardware.display.DisplayManagerGlobal}.
+ */
 @Implements(value = DisplayManagerGlobal.class, isInAndroidSdk = false)
 public class ShadowDisplayManagerGlobal {
   private static final RoboDisplayManager displayManager = new RoboDisplayManager();

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowEnvironment.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowEnvironment.java.vm
@@ -12,6 +12,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.util.TempDirectory;
 
+/**
+ * Shadow for {@link android.os.Environment}.
+ */
 @Implements(Environment.class)
 public class ShadowEnvironment {
   private static String externalStorageState = Environment.MEDIA_REMOVED;

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowICU.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowICU.java.vm
@@ -5,6 +5,9 @@ import org.robolectric.annotation.Implements;
 
 import java.util.Locale;
 
+/**
+ * Shadow for {@link libcore.icu.ICU}.
+ */
 @Implements(value = libcore.icu.ICU.class, isInAndroidSdk = false)
 public class ShadowICU {
 

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowLocaleData.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowLocaleData.java.vm
@@ -8,13 +8,15 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.internal.Shadow;
 
 /**
- * Setup locale data for Robolectric. We fill in values for en_US regardless of the default locale set in the JVM.
+ * Shadow for {@link libcore.icu.LocaleData}.
+ *
+ * <p>This class only supports en_US regardless of the default locale set in the JVM.</p>
  */
 @Implements(value = LocaleData.class, isInAndroidSdk = false)
 public class ShadowLocaleData {
   public static final String REAL_CLASS_NAME = "libcore.icu.LocaleData";
 
-  @Implementation // API 21 - Return type changed
+  @Implementation
   public static LocaleData get(Locale locale) {
     LocaleData localeData = (LocaleData) Shadow.newInstanceOf(REAL_CLASS_NAME);
     if (locale == null) {
@@ -96,6 +98,5 @@ public class ShadowLocaleData {
     localeData.integerPattern = "\u0023,\u0023\u00230";
     localeData.currencyPattern = "\u00A4\u0023,\u0023\u00230.00;(\u00A4\u0023,\u0023\u00230.00)";
     localeData.percentPattern = "\u0023,\u0023\u00230%";
-
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMemoryMappedFile.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMemoryMappedFile.java.vm
@@ -18,9 +18,11 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 /**
- * Shadow for MemoryMappedFile. This is used by Android to load and parse time zone information.
- * Robolectric emulates this functionality by proxying to a time zone database file packaged into
- * the android-all jar.
+ * Shadow for {@link libcore.io.MemoryMappedFile}.
+ *
+ * <p>This is used by Android to load and parse time zone information. Robolectric emulates
+ * this functionality by proxying to a time zone database file packaged into the android-all
+ * jar.</p>
  */
 @Implements(value = MemoryMappedFile.class, isInAndroidSdk = false)
 public class ShadowMemoryMappedFile {

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessage.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessage.java.vm
@@ -18,9 +18,8 @@ import static org.robolectric.internal.Shadow.*;
 import static org.robolectric.util.ReflectionHelpers.*;
 
 /**
- * Shadow for Message that removes the message from its corresponding scheduler.
+ * Shadow for {@link android.os.Message}.
  */
-@Generated("org.robolectric.shadows.ShadowMessage.java.vm")
 @Implements(Message.class)
 public class ShadowMessage {
   @RealObject

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
@@ -18,27 +18,24 @@ import static org.robolectric.util.ReflectionHelpers.*;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 /**
- * Shadow for MessageQueue that puts {@link Message}s into the scheduler queue instead of sending them to be handled on a
- * separate thread. {@link Message}s that are scheduled to be dispatched can be triggered by calling
- * {@link ShadowLooper#idleMainLooper}.
+ * Shadow for {@link android.os.MessageQueue}.
+ *
+ * <p>This class puts {@link android.os.Message}s into the scheduler queue instead of sending
+ * them to be handled on a separate thread. {@link android.os.Message}s that are scheduled to
+ * be dispatched can be triggered by calling {@link ShadowLooper#idleMainLooper}.</p>
  * 
  * @see ShadowLooper
  */
-@Generated("org.robolectric.shadows.ShadowMessageQueue.java.vm")
 @Implements(MessageQueue.class)
 public class ShadowMessageQueue {
   @RealObject
   private MessageQueue realQueue;
 
 #if ($api >= 21)
-#set($ptrClass = "long")
 #set($recycle = "recycleUnchecked")
 #else
-#set($ptrClass = "int")
 #set($recycle = "recycle")
 #end
-
-#set($Integer = 0)
 
   // Stub out the native peer - scheduling
   // is handled by the Scheduler class which is user-driven

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowNotification.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowNotification.java.vm
@@ -16,6 +16,9 @@ import java.util.ArrayList;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.app.Notification}.
+ */
 @Implements(Notification.class)
 public class ShadowNotification {
 #if ($api >= 18)

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowParcel.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowParcel.java.vm
@@ -18,6 +18,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Shadow for {@link android.os.Parcel}.
+ */
 @Implements(Parcel.class)
 @SuppressWarnings("unchecked")
 public class ShadowParcel {

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowPowerManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowPowerManager.java.vm
@@ -12,7 +12,7 @@ import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.shadows.ShadowApplication.getInstance;
 
 /**
- * Shadows the {@code android.os.PowerManager} class.
+ * Shadow for {@link android.os.PowerManager}.
  */
 @Implements(PowerManager.class)
 public class ShadowPowerManager {

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowRenderNode.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowRenderNode.java.vm
@@ -5,6 +5,9 @@ import android.view.RenderNode;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.view.RenderNode}.
+ */
 @Implements(value = RenderNode.class, isInAndroidSdk = false)
 public class ShadowRenderNode {
   private float translationX;

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSQLiteConnection.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSQLiteConnection.java.vm
@@ -30,7 +30,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Generated;
 
-@Generated("org.robolectric.shadows.ShadowSQLiteConnection.java.vm")
+/**
+ * Shadow for {@link android.database.sqlite.SQLiteConnection}.
+ */
 @Implements(value = android.database.sqlite.SQLiteConnection.class, isInAndroidSdk = false)
 public class ShadowSQLiteConnection {
 

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSettings.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSettings.java.vm
@@ -11,8 +11,7 @@ import java.util.Map;
 import java.util.WeakHashMap;
 
 /**
- * Shadow of {@code Settings} that allows the status of various System and Secure settings to be simulated, changed and
- * queried.
+ * Shadow for {@link android.provider.Settings}.
  */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Settings.class)

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSmsManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSmsManager.java.vm
@@ -10,6 +10,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.internal.Shadow;
 
+/**
+ * Shadow for {@link android.telephony.SmsManager}.
+ */
 @Implements(SmsManager.class)
 public class ShadowSmsManager {
   @RealObject

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowStatFs.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowStatFs.java.vm
@@ -9,6 +9,9 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Shadow for {@link android.os.StatFs}.
+ */
 @Implements(StatFs.class)
 public class ShadowStatFs {
   public static final int BLOCK_SIZE = 4096;

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowStaticLayout.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowStaticLayout.java.vm
@@ -5,6 +5,9 @@ import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.text.StaticLayout}.
+ */
 @Implements(StaticLayout.class)
 public class ShadowStaticLayout {
 

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowTime.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowTime.java.vm
@@ -16,6 +16,9 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.TimeZone;
 
+/**
+ * Shadow for {@link android.text.format.Time}.
+ */
 @Implements(Time.class)
 public class ShadowTime {
   @RealObject

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowTypeface.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowTypeface.java.vm
@@ -26,10 +26,11 @@ import java.util.Map;
 
 import static org.robolectric.Shadows.shadowOf;
 
-@Generated("org.robolectric.shadows.ShadowTypeface.java.vm")
+/**
+ * Shadow for {@link android.graphics.Typeface}.
+ */
 @Implements(Typeface.class)
 public class ShadowTypeface {
-
   private static Map<$ptrClassBoxed, FontDesc> FONTS = new HashMap<>();
   private static $ptrClass nextFontId = 1;
   private FontDesc description;

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowWebView.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowWebView.java.vm
@@ -17,6 +17,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Shadow for {@link android.webkit.WebView}.
+ */
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(value = WebView.class, inheritImplementationMethods = true)
 public class ShadowWebView extends ShadowAbsoluteLayout {

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowWindowManagerGlobal.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowWindowManagerGlobal.java.vm
@@ -6,6 +6,9 @@ import android.view.WindowManagerGlobal;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.view.WindowManagerGlobal}.
+ */
 @Implements(value = WindowManagerGlobal.class, isInAndroidSdk = false)
 public class ShadowWindowManagerGlobal {
 

--- a/robolectric-shadows/shadows-httpclient/pom.xml
+++ b/robolectric-shadows/shadows-httpclient/pom.xml
@@ -74,7 +74,7 @@
             <sourceDirectory>target/generated-shadows</sourceDirectory>
           </additionalSourceDirectories>
           <outputDirectory>target/generated-sources</outputDirectory>
-          <compilerArguments>-source ${maven.compiler.source} -target ${maven.compiler.target} -Aorg.robolectric.annotation.processing.shadowPackage=org.robolectric.httpclient</compilerArguments>
+          <compilerArguments>-source ${maven.compiler.source} -target ${maven.compiler.target} -Aorg.robolectric.annotation.processing.shadowPackage=org.robolectric.shadows.httpclient</compilerArguments>
         </configuration>
         <executions>
           <execution>

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/DefaultRequestDirector.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/DefaultRequestDirector.java
@@ -26,7 +26,7 @@
  * <http://www.apache.org/>.
  *
  */
-package org.robolectric.tester.org.apache.http.impl.client;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttp.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttp.java
@@ -1,11 +1,8 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.Header;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
-import org.robolectric.tester.org.apache.http.FakeHttpLayer;
-import org.robolectric.tester.org.apache.http.HttpRequestInfo;
-import org.robolectric.tester.org.apache.http.RequestMatcher;
 
 import java.util.List;
 

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttp.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttp.java
@@ -6,6 +6,9 @@ import org.apache.http.HttpResponse;
 
 import java.util.List;
 
+/**
+ * Collection of static methods used interact with HTTP requests / responses.
+ */
 public class FakeHttp {
   private static FakeHttpLayer instance = new FakeHttpLayer();
 

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttpLayer.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttpLayer.java
@@ -1,4 +1,4 @@
-package org.robolectric.tester.org.apache.http;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -12,7 +12,6 @@ import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
-import org.robolectric.shadows.HttpResponseGenerator;
 
 import java.io.IOException;
 import java.net.URI;

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttpLayer.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttpLayer.java
@@ -156,7 +156,7 @@ public class FakeHttpLayer {
    *
    * If you are just using mocked http calls, you should not even notice this method here.
    *
-   * @param requestInfo
+   * @param requestInfo Request info object to add.
    */
   public void addRequestInfo(HttpRequestInfo requestInfo) {
     httpRequestInfos.add(requestInfo);

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpEntityStub.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpEntityStub.java
@@ -1,4 +1,4 @@
-package org.robolectric.tester.org.apache.http;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpRedirect.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpRedirect.java
@@ -26,7 +26,7 @@
  * <http://www.apache.org/>.
  *
  */
-package org.robolectric.tester.org.apache.http.impl.client;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.client.methods.HttpGet;

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpRequestInfo.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpRequestInfo.java
@@ -1,4 +1,4 @@
-package org.robolectric.tester.org.apache.http;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpResponseGenerator.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpResponseGenerator.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpResponseStub.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpResponseStub.java
@@ -1,4 +1,4 @@
-package org.robolectric.tester.org.apache.http;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.Header;
 import org.apache.http.HeaderIterator;

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/ParamsParser.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/ParamsParser.java
@@ -1,4 +1,4 @@
-package org.robolectric.tester.org.apache.http;
+package org.robolectric.shadows.httpclient;
 
 import android.net.Uri;
 import org.apache.http.HttpEntity;

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/RequestMatcher.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/RequestMatcher.java
@@ -1,4 +1,4 @@
-package org.robolectric.tester.org.apache.http;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.HttpRequest;
 

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -26,7 +26,6 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
-import org.robolectric.tester.org.apache.http.HttpRequestInfo;
 import org.robolectric.util.Util;
 
 import java.io.ByteArrayInputStream;
@@ -53,7 +52,7 @@ public class ShadowDefaultRequestDirector {
   protected UserTokenHandler userTokenHandler;
   protected HttpParams httpParams;
 
-  org.robolectric.tester.org.apache.http.impl.client.DefaultRequestDirector redirector;
+  org.robolectric.shadows.httpclient.DefaultRequestDirector redirector;
 
   public void __constructor__(
       Log log,
@@ -84,7 +83,7 @@ public class ShadowDefaultRequestDirector {
     this.httpParams = params;
 
     try {
-      redirector = new org.robolectric.tester.org.apache.http.impl.client.DefaultRequestDirector(
+      redirector = new org.robolectric.shadows.httpclient.DefaultRequestDirector(
           log,
           requestExec,
           conman,
@@ -135,7 +134,7 @@ public class ShadowDefaultRequestDirector {
 
   /**
    * @param index The index
-   * @deprecated Use {@link org.robolectric.shadows.FakeHttp#getSentHttpRequestInfo(int)} instead.)
+   * @deprecated Use {@link FakeHttp#getSentHttpRequestInfo(int)} instead.)
    * @return HttpRequest
    */
   @Deprecated
@@ -154,7 +153,7 @@ public class ShadowDefaultRequestDirector {
 
   /**
    * @param index The index
-   * @deprecated Use {@link org.robolectric.shadows.FakeHttp#getSentHttpRequest(int)} instead.)
+   * @deprecated Use {@link FakeHttp#getSentHttpRequest(int)} instead.)
    * @return HttpRequestInfo
    */
   @Deprecated

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/StatusLineStub.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/StatusLineStub.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/TestHttpResponse.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/TestHttpResponse.java
@@ -1,4 +1,4 @@
-package org.robolectric.tester.org.apache.http;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.Header;
 import org.apache.http.HeaderIterator;
@@ -8,7 +8,6 @@ import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpParams;
-import org.robolectric.shadows.StatusLineStub;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/package-info.java
+++ b/robolectric-shadows/shadows-httpclient/src/main/java/org/robolectric/shadows/httpclient/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Shadows for Apache HTTP Client.
+ *
+ * <p>To use this in your project, add the artifact {@code org.robolectric:shadows-httpclient}
+ * to your project. These shadows are only provided for legacy compatibility. They are no
+ * longer actively maintained and will be removed in a future release.</p>
+ */
+@Deprecated
+package org.robolectric.shadows.httpclient;

--- a/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/AndroidHttpClientTest.java
+++ b/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/AndroidHttpClientTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.httpclient;
 
 import android.net.http.AndroidHttpClient;
 import org.apache.http.HttpResponse;

--- a/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/FakeHttpLayerTest.java
+++ b/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/FakeHttpLayerTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.tester.org.apache.http.impl;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpGet;
@@ -9,7 +9,7 @@ import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
 import org.junit.Before;
 import org.junit.Test;
-import org.robolectric.tester.org.apache.http.FakeHttpLayer;
+import org.robolectric.shadows.httpclient.FakeHttpLayer;
 
 import java.io.IOException;
 

--- a/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/FakeHttpTest.java
+++ b/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/FakeHttpTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
@@ -8,6 +8,7 @@ import org.apache.http.impl.client.DefaultRequestDirector;
 import org.apache.http.protocol.HttpContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.shadows.httpclient.FakeHttp;
 import org.robolectric.util.TestRunnerWithManifest;
 
 import java.io.IOException;

--- a/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/ParamsParserTest.java
+++ b/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/ParamsParserTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.tester.org.apache.http.impl;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
@@ -6,7 +6,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
 import org.junit.Test;
-import org.robolectric.tester.org.apache.http.ParamsParser;
+import org.robolectric.shadows.httpclient.ParamsParser;
 
 import java.util.Map;
 

--- a/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirectorTest.java
+++ b/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirectorTest.java
@@ -19,11 +19,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.shadows.httpclient.FakeHttp;
-import org.robolectric.shadows.httpclient.HttpResponseGenerator;
-import org.robolectric.shadows.httpclient.FakeHttpLayer;
-import org.robolectric.shadows.httpclient.RequestMatcher;
-import org.robolectric.shadows.httpclient.TestHttpResponse;
 import org.robolectric.util.Strings;
 import org.robolectric.util.TestRunnerWithManifest;
 
@@ -36,7 +31,7 @@ import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
-import static org.robolectric.httpclient.Shadows.shadowOf;
+import static org.robolectric.shadows.httpclient.Shadows.shadowOf;
 
 @RunWith(TestRunnerWithManifest.class)
 public class ShadowDefaultRequestDirectorTest {

--- a/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirectorTest.java
+++ b/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirectorTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.httpclient;
 
 import junit.framework.Assert;
 import org.apache.http.HttpRequest;
@@ -19,9 +19,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.tester.org.apache.http.FakeHttpLayer;
-import org.robolectric.tester.org.apache.http.RequestMatcher;
-import org.robolectric.tester.org.apache.http.TestHttpResponse;
+import org.robolectric.shadows.httpclient.FakeHttp;
+import org.robolectric.shadows.httpclient.HttpResponseGenerator;
+import org.robolectric.shadows.httpclient.FakeHttpLayer;
+import org.robolectric.shadows.httpclient.RequestMatcher;
+import org.robolectric.shadows.httpclient.TestHttpResponse;
 import org.robolectric.util.Strings;
 import org.robolectric.util.TestRunnerWithManifest;
 

--- a/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/TestHttpResponseTest.java
+++ b/robolectric-shadows/shadows-httpclient/src/test/java/org/robolectric/shadows/httpclient/TestHttpResponseTest.java
@@ -1,11 +1,11 @@
-package org.robolectric.tester.org.apache.http.impl;
+package org.robolectric.shadows.httpclient;
 
 import org.apache.http.Header;
 import org.apache.http.HeaderIterator;
 import org.apache.http.HttpResponse;
 import org.apache.http.message.BasicHeader;
 import org.junit.Test;
-import org.robolectric.tester.org.apache.http.TestHttpResponse;
+import org.robolectric.shadows.httpclient.TestHttpResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/robolectric-shadows/shadows-maps/pom.xml
+++ b/robolectric-shadows/shadows-maps/pom.xml
@@ -82,7 +82,7 @@
             <sourceDirectory>target/generated-shadows</sourceDirectory>
           </additionalSourceDirectories>
           <outputDirectory>target/generated-sources</outputDirectory>
-          <compilerArguments>-source ${maven.compiler.source} -target ${maven.compiler.target} -Aorg.robolectric.annotation.processing.shadowPackage=org.robolectric.maps</compilerArguments>
+          <compilerArguments>-source ${maven.compiler.source} -target ${maven.compiler.target} -Aorg.robolectric.annotation.processing.shadowPackage=org.robolectric.shadows.maps</compilerArguments>
         </configuration>
         <executions>
           <execution>

--- a/robolectric-shadows/shadows-maps/src/main/java/com/google/android/maps/ShadowItemizedOverlayBridge.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/com/google/android/maps/ShadowItemizedOverlayBridge.java
@@ -2,6 +2,9 @@ package com.google.android.maps;
 
 import org.robolectric.annotation.internal.DoNotInstrument;
 
+/**
+ * Bridge between Robolectric and {@link com.google.android.maps.OverlayItem}.
+ */
 @DoNotInstrument
 public class ShadowItemizedOverlayBridge<Item extends OverlayItem> {
   private ItemizedOverlay<Item> itemizedObject;

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowGeoPoint.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowGeoPoint.java
@@ -5,6 +5,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.internal.ShadowExtractor;
 
+/**
+ * Shadow for {@link com.google.android.maps.GeoPoint}.
+ */
 @Implements(GeoPoint.class)
 public class ShadowGeoPoint {
   private int lat;

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowGeoPoint.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowGeoPoint.java
@@ -1,11 +1,9 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.maps;
 
 import com.google.android.maps.GeoPoint;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.internal.ShadowExtractor;
-
-import static org.robolectric.shadows.ShadowMapView.fromE6;
 
 @Implements(GeoPoint.class)
 public class ShadowGeoPoint {
@@ -53,8 +51,8 @@ public class ShadowGeoPoint {
   @Override @Implementation
   public String toString() {
     return "ShadowGeoPoint{" +
-        "lat=" + fromE6(lat) +
-        ", lng=" + fromE6(lng) +
+        "lat=" + ShadowMapView.fromE6(lat) +
+        ", lng=" + ShadowMapView.fromE6(lng) +
         '}';
   }
 

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowGeocoder.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowGeocoder.java
@@ -11,6 +11,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+/**
+ * Shadow for {@link android.location.Geocoder}.
+ */
 @Implements(Geocoder.class)
 public class ShadowGeocoder {
   private String addressLine1;

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowGeocoder.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowGeocoder.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.maps;
 
 import android.location.Address;
 import android.location.Geocoder;

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowItemizedOverlay.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowItemizedOverlay.java
@@ -10,6 +10,9 @@ import org.robolectric.annotation.RealObject;
 
 import java.util.ArrayList;
 
+/**
+ * Shadow for {@link com.google.android.maps.ItemizedOverlay}.
+ */
 @Implements(ItemizedOverlay.class)
 public class ShadowItemizedOverlay<Item extends OverlayItem> {
   private boolean isPopulated;

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowItemizedOverlay.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowItemizedOverlay.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.maps;
 
 import android.graphics.drawable.Drawable;
 import com.google.android.maps.ItemizedOverlay;

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapActivity.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapActivity.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.maps;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import com.google.android.maps.MapActivity;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowActivity;
 
 @Implements(MapActivity.class)
 public class ShadowMapActivity extends ShadowActivity {

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapActivity.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapActivity.java
@@ -10,6 +10,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowActivity;
 
+/**
+ * Shadow for {@link com.google.android.maps.MapActivity}.
+ */
 @Implements(MapActivity.class)
 public class ShadowMapActivity extends ShadowActivity {
   private ConnectivityBroadcastReceiver connectivityBroadcastReceiver = new ConnectivityBroadcastReceiver();

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapController.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapController.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.maps;
 
 import com.google.android.maps.GeoPoint;
 import com.google.android.maps.MapController;

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapController.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapController.java
@@ -5,6 +5,9 @@ import com.google.android.maps.MapController;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link com.google.android.maps.MapController}.
+ */
 @Implements(MapController.class)
 public class ShadowMapController {
   private ShadowMapView shadowMapView;

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapView.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapView.java
@@ -27,6 +27,9 @@ import static org.robolectric.util.ReflectionHelpers.ClassParameter;
 import static org.robolectric.internal.Shadow.directlyOn;
 import static org.robolectric.internal.Shadow.invokeConstructor;
 
+/**
+ * Shadow for {@link com.google.android.maps.MapView}.
+ */
 @Implements(MapView.class)
 public class ShadowMapView extends ShadowViewGroup {
   @SuppressWarnings("UnusedDeclaration") @RealObject

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapView.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapView.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.maps;
 
 import android.content.Context;
 import android.graphics.Point;
@@ -13,6 +13,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.internal.ShadowExtractor;
+import org.robolectric.shadows.RoboAttributeSet;
+import org.robolectric.shadows.ShadowApplication;
+import org.robolectric.shadows.ShadowViewGroup;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.res.Attribute;
 import org.robolectric.internal.Shadow;

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowOverlayItem.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowOverlayItem.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.maps;
 
 import com.google.android.maps.GeoPoint;
 import com.google.android.maps.OverlayItem;

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowOverlayItem.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowOverlayItem.java
@@ -7,6 +7,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.internal.ShadowExtractor;
 import org.robolectric.util.Strings;
 
+/**
+ * Shadow for {@link com.google.android.maps.OverlayItem}.
+ */
 @Implements(OverlayItem.class)
 public class ShadowOverlayItem {
   private GeoPoint geoPoint;

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/package-info.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Shadows for Google Maps.
+ *
+ * <p>To use this in your project, add the artifact {@code org.robolectric:shadows-maps}
+ * to your project.</p>
+ */
+package org.robolectric.shadows.maps;

--- a/robolectric-shadows/shadows-maps/src/test/java/org/robolectric/shadows/maps/ShadowGeocoderTest.java
+++ b/robolectric-shadows/shadows-maps/src/test/java/org/robolectric/shadows/maps/ShadowGeocoderTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.maps;
 
 import android.app.Activity;
 import android.location.Address;

--- a/robolectric-shadows/shadows-maps/src/test/java/org/robolectric/shadows/maps/ShadowItemizedOverlayTest.java
+++ b/robolectric-shadows/shadows-maps/src/test/java/org/robolectric/shadows/maps/ShadowItemizedOverlayTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.maps;
 
 import com.google.android.maps.GeoPoint;
 import com.google.android.maps.ItemizedOverlay;

--- a/robolectric-shadows/shadows-maps/src/test/java/org/robolectric/shadows/maps/ShadowMapActivityTest.java
+++ b/robolectric-shadows/shadows-maps/src/test/java/org/robolectric/shadows/maps/ShadowMapActivityTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.maps;
 
 import android.os.Bundle;
 import com.google.android.maps.MapActivity;

--- a/robolectric-shadows/shadows-maps/src/test/java/org/robolectric/shadows/maps/ShadowMapViewTest.java
+++ b/robolectric-shadows/shadows-maps/src/test/java/org/robolectric/shadows/maps/ShadowMapViewTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.maps;
 
 import android.app.Activity;
 import android.graphics.Point;
@@ -18,7 +18,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.util.TestRunnerWithManifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.robolectric.shadows.ShadowMapView.toE6;
+import static org.robolectric.shadows.maps.ShadowMapView.toE6;
 
 @RunWith(TestRunnerWithManifest.class)
 public class ShadowMapViewTest {

--- a/robolectric-shadows/shadows-multidex/pom.xml
+++ b/robolectric-shadows/shadows-multidex/pom.xml
@@ -57,7 +57,7 @@
             <sourceDirectory>target/generated-shadows</sourceDirectory>
           </additionalSourceDirectories>
           <outputDirectory>target/generated-sources</outputDirectory>
-          <compilerArguments>-source ${maven.compiler.source} -target ${maven.compiler.target} -Aorg.robolectric.annotation.processing.shadowPackage=org.robolectric.multidex</compilerArguments>
+          <compilerArguments>-source ${maven.compiler.source} -target ${maven.compiler.target} -Aorg.robolectric.annotation.processing.shadowPackage=org.robolectric.shadows.multidex</compilerArguments>
         </configuration>
         <executions>
           <execution>

--- a/robolectric-shadows/shadows-multidex/src/main/java/org/robolectric/shadows/multidex/ShadowMultiDex.java
+++ b/robolectric-shadows/shadows-multidex/src/main/java/org/robolectric/shadows/multidex/ShadowMultiDex.java
@@ -6,10 +6,11 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Implementation;
 
 /**
- * Shadow for {@link MultiDex}.
+ * Shadow for {@link android.support.multidex.MultiDex}.
  */
 @Implements(MultiDex.class)
 public class ShadowMultiDex {
+
   @Implementation
   public static void install(Context context) {
     // Do nothing since with Robolectric nothing is dexed.

--- a/robolectric-shadows/shadows-multidex/src/main/java/org/robolectric/shadows/multidex/ShadowMultiDex.java
+++ b/robolectric-shadows/shadows-multidex/src/main/java/org/robolectric/shadows/multidex/ShadowMultiDex.java
@@ -1,11 +1,13 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.multidex;
 
 import android.content.Context;
 import android.support.multidex.MultiDex;
-
-import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Implementation;
 
+/**
+ * Shadow for {@link MultiDex}.
+ */
 @Implements(MultiDex.class)
 public class ShadowMultiDex {
   @Implementation

--- a/robolectric-shadows/shadows-multidex/src/main/java/org/robolectric/shadows/multidex/package-info.java
+++ b/robolectric-shadows/shadows-multidex/src/main/java/org/robolectric/shadows/multidex/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Shadows for the Android Multidex Library.
+ *
+ * <p>To use this in your project, add the artifact {@code org.robolectric:shadows-multidex}
+ * to your project.</p>
+ */
+package org.robolectric.shadows.multidex;

--- a/robolectric-shadows/shadows-play-services/pom.xml
+++ b/robolectric-shadows/shadows-play-services/pom.xml
@@ -71,7 +71,7 @@
             <sourceDirectory>target/generated-shadows</sourceDirectory>
           </additionalSourceDirectories>
           <outputDirectory>target/generated-sources</outputDirectory>
-          <compilerArguments>-source ${maven.compiler.source} -target ${maven.compiler.target} -Aorg.robolectric.annotation.processing.shadowPackage=org.robolectric.gms</compilerArguments>
+          <compilerArguments>-source ${maven.compiler.source} -target ${maven.compiler.target} -Aorg.robolectric.annotation.processing.shadowPackage=org.robolectric.shadows.gms</compilerArguments>
         </configuration>
         <executions>
           <execution>

--- a/robolectric-shadows/shadows-play-services/src/main/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtil.java
+++ b/robolectric-shadows/shadows-play-services/src/main/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtil.java
@@ -1,11 +1,14 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.gms;
 
 import android.content.Context;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Implementation;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
-import org.robolectric.annotation.Implementation;
-import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link GooglePlayServicesUtil}
+ */
 @Implements(GooglePlayServicesUtil.class)
 public class ShadowGooglePlayServicesUtil {
   private static int availabilityCode = ConnectionResult.SERVICE_MISSING;

--- a/robolectric-shadows/shadows-play-services/src/main/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtil.java
+++ b/robolectric-shadows/shadows-play-services/src/main/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtil.java
@@ -7,7 +7,7 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 
 /**
- * Shadow for {@link GooglePlayServicesUtil}
+ * Shadow for {@link com.google.android.gms.common.GooglePlayServicesUtil}.
  */
 @Implements(GooglePlayServicesUtil.class)
 public class ShadowGooglePlayServicesUtil {

--- a/robolectric-shadows/shadows-play-services/src/main/java/org/robolectric/shadows/gms/package-info.java
+++ b/robolectric-shadows/shadows-play-services/src/main/java/org/robolectric/shadows/gms/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Shadows for the Google Play Services Library.
+ *
+ * <p>To use this in your project, add the artifact {@code org.robolectric:shadows-play-services}
+ * to your project.</p>
+ */
+package org.robolectric.shadows.gms;

--- a/robolectric-shadows/shadows-play-services/src/test/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtilTest.java
+++ b/robolectric-shadows/shadows-play-services/src/test/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtilTest.java
@@ -1,13 +1,12 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.gms;
 
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GooglePlayServicesUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.RobolectricTestRunner;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GooglePlayServicesUtil;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(RobolectricTestRunner.class)

--- a/robolectric-shadows/shadows-support-v4/pom.xml
+++ b/robolectric-shadows/shadows-support-v4/pom.xml
@@ -82,7 +82,7 @@
             <sourceDirectory>target/generated-shadows</sourceDirectory>
           </additionalSourceDirectories>
           <outputDirectory>target/generated-sources</outputDirectory>
-          <compilerArguments>-source ${maven.compiler.source} -target ${maven.compiler.target} -Aorg.robolectric.annotation.processing.shadowPackage=org.robolectric.support.v4</compilerArguments>
+          <compilerArguments>-source ${maven.compiler.source} -target ${maven.compiler.target} -Aorg.robolectric.annotation.processing.shadowPackage=org.robolectric.shadows.support.v4</compilerArguments>
         </configuration>
         <executions>
           <execution>

--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowAsyncTaskLoader.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowAsyncTaskLoader.java
@@ -10,7 +10,7 @@ import android.support.v4.content.AsyncTaskLoader;
 import java.util.concurrent.Callable;
 
 /**
- * Shadow AsyncTaskLoader from the support library.
+ * Shadow for {@link android.support.v4.content.AsyncTaskLoader}.
  */
 @Implements(AsyncTaskLoader.class)
 public class ShadowAsyncTaskLoader<D> {

--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowAsyncTaskLoader.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowAsyncTaskLoader.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.support.v4;
 
 import android.content.Context;
 import org.robolectric.Robolectric;

--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowCursorLoader.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowCursorLoader.java
@@ -4,6 +4,9 @@ import android.database.Cursor;
 import android.support.v4.content.CursorLoader;
 import org.robolectric.annotation.Implements;
 
+/**
+ * Shadow for {@link android.support.v4.content.CursorLoader}.
+ */
 @Implements(CursorLoader.class)
 public class ShadowCursorLoader extends ShadowAsyncTaskLoader<Cursor> {
 }

--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowCursorLoader.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowCursorLoader.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.support.v4;
 
 import android.database.Cursor;
 import android.support.v4.content.CursorLoader;

--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowDrawerLayout.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowDrawerLayout.java
@@ -1,9 +1,10 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.support.v4;
 
 import android.support.v4.widget.DrawerLayout;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Implementation;
+import org.robolectric.shadows.ShadowViewGroup;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 

--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowDrawerLayout.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowDrawerLayout.java
@@ -8,11 +8,13 @@ import org.robolectric.shadows.ShadowViewGroup;
 
 import static org.robolectric.internal.Shadow.directlyOn;
 
+/**
+ * Shadow for {@link android.support.v4.widget.DrawerLayout}.
+ */
 @Implements(DrawerLayout.class)
 public class ShadowDrawerLayout extends ShadowViewGroup {
-  private DrawerLayout.DrawerListener drawerListener;
-
   @RealObject private DrawerLayout realDrawerLayout;
+  private DrawerLayout.DrawerListener drawerListener;
 
   @Implementation
   public void setDrawerListener(DrawerLayout.DrawerListener drawerListener) {

--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManager.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManager.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.support.v4;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -11,6 +11,8 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.internal.ShadowExtractor;
+import org.robolectric.shadows.Provider;
+import org.robolectric.shadows.ShadowContext;
 import org.robolectric.util.ReflectionHelpers;
 
 import java.util.ArrayList;

--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManager.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManager.java
@@ -14,23 +14,26 @@ import org.robolectric.internal.ShadowExtractor;
 import org.robolectric.shadows.Provider;
 import org.robolectric.shadows.ShadowContext;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * Shadow for {@link android.support.v4.content.LocalBroadcastManager}.
+ */
 @Implements(LocalBroadcastManager.class)
 public class ShadowLocalBroadcastManager {
-
-  final List<Intent> sentBroadcastIntents = new ArrayList<>();
-  final List<Wrapper> registeredReceivers = new ArrayList<>();
+  private final List<Intent> sentBroadcastIntents = new ArrayList<>();
+  private final List<Wrapper> registeredReceivers = new ArrayList<>();
 
   @Implementation
   public static LocalBroadcastManager getInstance(final Context context) {
     return shadowOf(context).getShadowApplication().getSingleton(LocalBroadcastManager.class, new Provider<LocalBroadcastManager>() {
       @Override
       public LocalBroadcastManager get() {
-        return ReflectionHelpers.callConstructor(LocalBroadcastManager.class, new ReflectionHelpers.ClassParameter(Context.class, context));
+        return ReflectionHelpers.callConstructor(LocalBroadcastManager.class, ClassParameter.from(Context.class, context));
       }
     });
   }

--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/SupportFragmentTestUtil.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/SupportFragmentTestUtil.java
@@ -1,4 +1,4 @@
-package org.robolectric.util;
+package org.robolectric.shadows.support.v4;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;

--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/SupportFragmentTestUtil.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/SupportFragmentTestUtil.java
@@ -7,6 +7,9 @@ import android.support.v4.app.FragmentManager;
 import android.widget.LinearLayout;
 import org.robolectric.Robolectric;
 
+/**
+ * Utilities for creating Fragments for testing.
+ */
 public class SupportFragmentTestUtil {
 
   public static void startFragment(Fragment fragment) {
@@ -18,7 +21,6 @@ public class SupportFragmentTestUtil {
     buildSupportFragmentManager(fragmentActivityClass)
         .beginTransaction().add(fragment, null).commit();
   }
-
 
   public static void startVisibleFragment(Fragment fragment) {
     buildSupportFragmentManager(FragmentUtilActivity.class)

--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/package-info.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Shadows for the Android Support Library.
+ *
+ * <p>To use this in your project, add the artifact {@code org.robolectric:shadows-support-v4}
+ * to your project.</p>
+ */
+package org.robolectric.shadows.support.v4;

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowAsyncTaskLoaderTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowAsyncTaskLoaderTest.java
@@ -1,7 +1,7 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.support.v4;
 
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowCursorLoaderTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowCursorLoaderTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.support.v4;
 
 import android.app.Activity;
 import android.net.Uri;

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowDialogFragmentTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowDialogFragmentTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.support.v4;
 
 import android.app.Activity;
 import android.app.Dialog;
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
 import org.robolectric.internal.ShadowExtractor;
+import org.robolectric.shadows.ShadowDialog;
 import org.robolectric.util.TestRunnerWithManifest;
 import org.robolectric.util.Transcript;
 

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowDrawerLayoutTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowDrawerLayoutTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.support.v4;
 
 import android.app.Activity;
 import android.support.v4.widget.DrawerLayout;
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.internal.ShadowExtractor;
+import org.robolectric.shadows.support.v4.ShadowDrawerLayout;
 import org.robolectric.util.TestRunnerWithManifest;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowLoaderTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowLoaderTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.support.v4;
 
 import android.support.v4.content.Loader;
 import org.junit.Before;

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManagerTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManagerTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.support.v4;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.internal.ShadowExtractor;
+import org.robolectric.shadows.support.v4.ShadowLocalBroadcastManager;
 import org.robolectric.util.TestRunnerWithManifest;
 import org.robolectric.util.Transcript;
 

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowPagerAdapterTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowPagerAdapterTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.support.v4;
 
 import android.database.DataSetObserver;
 import android.support.v4.view.PagerAdapter;

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowViewPagerTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowViewPagerTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.shadows;
+package org.robolectric.shadows.support.v4;
 
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/SupportFragmentTestUtilTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/SupportFragmentTestUtilTest.java
@@ -1,4 +1,4 @@
-package org.robolectric.util;
+package org.robolectric.shadows.support.v4;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -10,10 +10,11 @@ import android.widget.LinearLayout;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
+import org.robolectric.util.TestRunnerWithManifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.robolectric.util.SupportFragmentTestUtil.startFragment;
-import static org.robolectric.util.SupportFragmentTestUtil.startVisibleFragment;
+import static org.robolectric.shadows.support.v4.SupportFragmentTestUtil.startFragment;
+import static org.robolectric.shadows.support.v4.SupportFragmentTestUtil.startVisibleFragment;
 
 @RunWith(TestRunnerWithManifest.class)
 public class SupportFragmentTestUtilTest {

--- a/robolectric-utils/src/main/java/org/robolectric/util/Function.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Function.java
@@ -1,8 +1,8 @@
 package org.robolectric.util;
 
 /**
- *
+ * Interface defining a function object.
  */
 public interface Function<R, T> {
-  public R call(Class<?> theClass, T value, Object[] params);
+  R call(Class<?> theClass, T value, Object[] params);
 }

--- a/robolectric-utils/src/main/java/org/robolectric/util/Join.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Join.java
@@ -2,6 +2,9 @@ package org.robolectric.util;
 
 import java.util.Collection;
 
+/**
+ * Utility class used to join strings together with a delimiter.
+ */
 public class Join {
   public static String join(String delimiter, Collection collection) {
     String del = "";

--- a/robolectric-utils/src/main/java/org/robolectric/util/Logger.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Logger.java
@@ -1,8 +1,11 @@
 package org.robolectric.util;
 
 /**
- * Logger for Robolectric. For now, it simply prints messages to stdout. Logging
- * can be enabled by setting the property: robolectric.logging.enabled = true.
+ * Logger for Robolectric. For now, it simply prints messages to stdout.
+ *
+ * <p>
+ * Logging can be enabled by setting the property: {@code robolectric.logging.enabled = true}.
+ * </p>
  */
 public class Logger {
   private static final String LOGGING_ENABLED = "robolectric.logging.enabled";

--- a/robolectric-utils/src/main/java/org/robolectric/util/NamedStream.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/NamedStream.java
@@ -1,4 +1,7 @@
 package org.robolectric.util;
 
+/**
+ * Marker interface for {@link java.io.InputStream} that need special handling.
+ */
 public interface NamedStream {
 }

--- a/robolectric-utils/src/main/java/org/robolectric/util/Pair.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Pair.java
@@ -16,6 +16,12 @@ package org.robolectric.util;
  * limitations under the License.
  */
 
+/**
+ * Container to ease passing around a tuple of two objects.
+ *
+ * @param <F> First type.
+ * @param <S> Second type.
+ */
 public class Pair<F, S> {
   public final F first;
   public final S second;

--- a/robolectric-utils/src/main/java/org/robolectric/util/ReflectionHelpers.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/ReflectionHelpers.java
@@ -254,6 +254,10 @@ public class ReflectionHelpers {
 
   /**
    * Create a new instance of a class
+   *
+   * @param cl The class object.
+   * @param <T> The class type.
+   * @return New class instance.
    */
   public static <T> T newInstance(Class<T> cl) {
     try {
@@ -319,10 +323,15 @@ public class ReflectionHelpers {
     modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
   }
 
-  private static interface InsideTraversal<R> {
-    public R run(Class<?> traversalClass) throws Exception;
+  private interface InsideTraversal<R> {
+    R run(Class<?> traversalClass) throws Exception;
   }
 
+  /**
+   * Typed parameter used with reflective method calls.
+   *
+   * @param <V> The value of the method parameter.
+   */
   public static class ClassParameter<V> {
     public final Class<? extends V> clazz;
     public final V val;
@@ -363,6 +372,11 @@ public class ReflectionHelpers {
     }
   }
 
+  /**
+   * String parameter used with reflective method calls.
+   *
+   * @param <V> The value of the method parameter.
+   */
   public static class StringParameter<V> {
     public final String className;
     public final V val;

--- a/robolectric-utils/src/main/java/org/robolectric/util/SimpleFuture.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/SimpleFuture.java
@@ -4,14 +4,18 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 
-public class SimpleFuture<Result> {
-
-  private boolean cancelled;
+/**
+ * A Future represents the result of an asynchronous computation.
+ *
+ * @param <T> The result type returned by this Future's get method.
+ */
+public class SimpleFuture<T> {
+  private T result;
   private boolean hasRun;
-  private Callable<Result> callable;
-  private Result result;
+  private boolean cancelled;
+  private final Callable<T> callable;
 
-  public SimpleFuture(Callable<Result> callable) {
+  public SimpleFuture(Callable<T> callable) {
     this.callable = callable;
   }
 
@@ -28,7 +32,7 @@ public class SimpleFuture<Result> {
     return cancelled;
   }
 
-  public synchronized Result get() throws InterruptedException {
+  public synchronized T get() throws InterruptedException {
     if (cancelled) {
       throw new CancellationException();
     } else {
@@ -37,7 +41,7 @@ public class SimpleFuture<Result> {
     }
   }
 
-  public synchronized Result get(long timeout, TimeUnit unit) throws InterruptedException {
+  public synchronized T get(long timeout, TimeUnit unit) throws InterruptedException {
     if (cancelled) {
       throw new CancellationException();
     } else {
@@ -61,6 +65,5 @@ public class SimpleFuture<Result> {
   }
 
   protected void done() {
-
   }
 }

--- a/robolectric-utils/src/main/java/org/robolectric/util/SoftThreadLocal.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/SoftThreadLocal.java
@@ -2,6 +2,11 @@ package org.robolectric.util;
 
 import java.lang.ref.SoftReference;
 
+/**
+ * Soft reference to a {@code java.lang.ThreadLocal}.
+ *
+ * @param <T> The referent to track.
+ */
 public abstract class SoftThreadLocal<T> {
   private final ThreadLocal<SoftReference<T>> threadLocal = new ThreadLocal<SoftReference<T>>() {
     protected SoftReference<T> initialValue() {

--- a/robolectric-utils/src/main/java/org/robolectric/util/Strftime.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Strftime.java
@@ -5,18 +5,21 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
+/**
+ * An implementation of the Unix strftime with some glibc extensions.
+ */
 public class Strftime {
+
   /**
-   * An implementation of the Unix strftime with some glibc extensions.
+   * Format a date string.
    *
    * @param format The format in strftime syntax.
+   * @param date The date to format.
+   * @param locale The locale to use for formatting.
+   * @param zone The timezone to use for formatting.
    * @return The formatted datetime.
    */
-  static public String format(
-      final String format,
-      final Date date,
-      final Locale locale,
-      final TimeZone timeZone) {
+  public static String format(String format, final Date date, Locale locale, TimeZone zone) {
     StringBuffer buffer = new StringBuffer();
 
     class Formatter {
@@ -42,7 +45,7 @@ public class Strftime {
       }
     }
 
-    Formatter formatter = new Formatter(date, locale, timeZone);
+    Formatter formatter = new Formatter(date, locale, zone);
 
     Boolean inside = false;
 

--- a/robolectric-utils/src/main/java/org/robolectric/util/Strings.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Strings.java
@@ -3,6 +3,9 @@ package org.robolectric.util;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * Utility methods for dealing with strings.
+ */
 public class Strings {
 
   public static String fromStream(InputStream inputStream) throws IOException {

--- a/robolectric-utils/src/main/java/org/robolectric/util/TimeUtils.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/TimeUtils.java
@@ -1,5 +1,8 @@
 package org.robolectric.util;
 
+/**
+ * Utility methods for dealing with time.
+ */
 public class TimeUtils {
   public static final long NANOS_PER_MS = 1000000;
 }

--- a/robolectric-utils/src/main/java/org/robolectric/util/Transcript.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Transcript.java
@@ -6,6 +6,9 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Test helper used to record events and assert on the order in which they happen.
+ */
 public class Transcript {
   private List<String> events = new ArrayList<>();
 

--- a/robolectric-utils/src/main/java/org/robolectric/util/Util.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Util.java
@@ -10,6 +10,9 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Generic collection of utility methods.
+ */
 public class Util {
   public static void copy(InputStream in, OutputStream out) throws IOException {
     byte[] buffer = new byte[8196];
@@ -24,17 +27,16 @@ public class Util {
   }
 
   /**
-   * This method consumes an inputstream, returning its content then closing
-   * it.
+   * This method consumes an input stream and returns its content.
+   *
+   * @param is The input stream to read from.
+   * @return The bytes read from the stream.
+   * @throws IOException Error reading from stream.
    */
-  public static byte[] readBytes(InputStream inputStream) throws IOException {
-    try {
-      ByteArrayOutputStream byteArrayOutputStream =
-              new ByteArrayOutputStream(inputStream.available());
-      copy(inputStream, byteArrayOutputStream);
-      return byteArrayOutputStream.toByteArray();
-    } finally {
-      inputStream.close();
+  public static byte[] readBytes(InputStream is) throws IOException {
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream(is.available())) {
+      copy(is, bos);
+      return bos.toByteArray();
     }
   }
 

--- a/robolectric-utils/src/main/java/org/robolectric/util/package-info.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package containing general utility classes.
+ */
+package org.robolectric.util;

--- a/robolectric/src/main/java/org/robolectric/package-info.java
+++ b/robolectric/src/main/java/org/robolectric/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package containing main Robolectric classes.
+ */
+package org.robolectric;


### PR DESCRIPTION
This also moves add-on shadows into their own package underneath org.robolectric.shadows,
so it's easier to understand what add-ons contain which classes.