### PR TITLE
Allow shadows to exist outside of org.robolectric.shadows

### DIFF
--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/RobolectricModel.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/RobolectricModel.java
@@ -22,6 +22,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementVisitor;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
@@ -35,6 +36,7 @@ import javax.lang.model.util.SimpleTypeVisitor6;
 import javax.lang.model.util.Types;
 
 import com.google.common.base.Equivalence;
+import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.HashMultimap;
@@ -272,6 +274,8 @@ public class RobolectricModel {
     }
 
     // Other imports that the generated class needs
+    imports.add("java.util.Map");
+    imports.add("java.util.HashMap");
     imports.add("javax.annotation.Generated");
     imports.add("org.robolectric.internal.ShadowExtractor");
     imports.add("org.robolectric.internal.ShadowProvider");
@@ -291,6 +295,10 @@ public class RobolectricModel {
 
   public Set<String> getImports() {
     return imports;
+  }
+
+  public Map<TypeElement, TypeElement> getAllShadowTypes() {
+    return shadowTypes;
   }
 
   public Map<TypeElement, TypeElement> getResetterShadowTypes() {

--- a/robolectric-processor/src/test/resources/mock-source/org/robolectric/internal/ShadowProvider.java
+++ b/robolectric-processor/src/test/resources/mock-source/org/robolectric/internal/ShadowProvider.java
@@ -1,6 +1,12 @@
 package org.robolectric.internal;
 
+import java.util.Map;
+
 public interface ShadowProvider {
 
   void reset();
+
+  String[] getProvidedPackageNames();
+
+  Map<String, String> getShadowMap();
 }

--- a/robolectric-processor/src/test/resources/org/robolectric/Robolectric_Anything.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/Robolectric_Anything.java
@@ -1,5 +1,7 @@
 package org.robolectric;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Generated;
 
 import org.robolectric.annotation.processing.objects.AnyObject;
@@ -12,6 +14,12 @@ import org.robolectric.internal.ShadowProvider;
 @Generated("org.robolectric.annotation.processing.RobolectricProcessor")
 @SuppressWarnings({"unchecked","deprecation"})
 public class Shadows implements ShadowProvider {
+  private static final Map<String, String> SHADOW_MAP = new HashMap<>(2);
+
+  static {
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.AnyObject", "org.robolectric.annotation.processing.shadows.ShadowAnything");
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
+  }
 
   public static ShadowAnything shadowOf(AnyObject actual) {
     return (ShadowAnything) ShadowExtractor.extract(actual);
@@ -26,6 +34,12 @@ public class Shadows implements ShadowProvider {
     ShadowDummy.resetter_method();
   }
 
+  @Override
+  public Map<String, String> getShadowMap() {
+    return SHADOW_MAP;
+  }
+
+  @Override
   public String[] getProvidedPackageNames() {
     return new String[] {"org.robolectric.annotation.processing.objects"};
   }

--- a/robolectric-processor/src/test/resources/org/robolectric/Robolectric_ClassNameOnly.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/Robolectric_ClassNameOnly.java
@@ -1,5 +1,7 @@
 package org.robolectric;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Generated;
 
 import org.robolectric.annotation.processing.objects.AnyObject;
@@ -12,6 +14,12 @@ import org.robolectric.internal.ShadowProvider;
 @Generated("org.robolectric.annotation.processing.RobolectricProcessor")
 @SuppressWarnings({"unchecked","deprecation"})
 public class Shadows implements ShadowProvider {
+  private static final Map<String, String> SHADOW_MAP = new HashMap<>(2);
+
+  static {
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.AnyObject", "org.robolectric.annotation.processing.shadows.ShadowClassNameOnly");
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
+  }
 
   public static ShadowClassNameOnly shadowOf(AnyObject actual) {
     return (ShadowClassNameOnly) ShadowExtractor.extract(actual);
@@ -26,6 +34,12 @@ public class Shadows implements ShadowProvider {
     ShadowDummy.resetter_method();
   }
 
+  @Override
+  public Map<String, String> getShadowMap() {
+    return SHADOW_MAP;
+  }
+
+  @Override
   public String[] getProvidedPackageNames() {
     return new String[] {"org.robolectric.annotation.processing.objects"};
   }

--- a/robolectric-processor/src/test/resources/org/robolectric/Robolectric_HiddenClasses.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/Robolectric_HiddenClasses.java
@@ -1,5 +1,7 @@
 package org.robolectric;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Generated;
 
 import org.robolectric.annotation.processing.objects.Dummy;
@@ -16,6 +18,16 @@ import org.robolectric.internal.ShadowProvider;
 @Generated("org.robolectric.annotation.processing.RobolectricProcessor")
 @SuppressWarnings({"unchecked","deprecation"})
 public class Shadows implements ShadowProvider {
+  private static final Map<String, String> SHADOW_MAP = new HashMap<>(6);
+
+  static {
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.OuterDummy2", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy2");
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.OuterDummy2.InnerPackage", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy2$ShadowInnerPackage");
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.OuterDummy2.InnerPrivate", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy2$ShadowInnerPrivate");
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.OuterDummy2.InnerProtected", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy2$ShadowInnerProtected");
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Private", "org.robolectric.annotation.processing.shadows.ShadowPrivate");
+  }
 
   public static ShadowDummy shadowOf(Dummy actual) {
     return (ShadowDummy) ShadowExtractor.extract(actual);
@@ -30,6 +42,12 @@ public class Shadows implements ShadowProvider {
     ShadowPrivate.resetMethod();
   }
 
+  @Override
+  public Map<String, String> getShadowMap() {
+    return SHADOW_MAP;
+  }
+
+  @Override
   public String[] getProvidedPackageNames() {
     return new String[] {"org.robolectric.annotation.processing.objects"};
   }

--- a/robolectric-processor/src/test/resources/org/robolectric/Robolectric_InnerClassCollision.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/Robolectric_InnerClassCollision.java
@@ -1,5 +1,7 @@
 package org.robolectric;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Generated;
 
 import org.robolectric.annotation.processing.objects.Dummy;
@@ -16,6 +18,16 @@ import org.robolectric.internal.ShadowProvider;
 @Generated("org.robolectric.annotation.processing.RobolectricProcessor")
 @SuppressWarnings({"unchecked","deprecation"})
 public class Shadows implements ShadowProvider {
+  private static final Map<String, String> SHADOW_MAP = new HashMap<>(6);
+
+  static {
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.OuterDummy", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy");
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.OuterDummy.InnerDummy", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy$ShadowInnerDummy");
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.UniqueDummy", "org.robolectric.annotation.processing.shadows.ShadowUniqueDummy");
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.UniqueDummy.InnerDummy", "org.robolectric.annotation.processing.shadows.ShadowUniqueDummy$ShadowInnerDummy");
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.UniqueDummy.UniqueInnerDummy", "org.robolectric.annotation.processing.shadows.ShadowUniqueDummy$ShadowUniqueInnerDummy");
+  }
 
   public static ShadowDummy shadowOf(Dummy actual) {
     return (ShadowDummy) ShadowExtractor.extract(actual);
@@ -45,6 +57,12 @@ public class Shadows implements ShadowProvider {
     ShadowDummy.resetter_method();
   }
 
+  @Override
+  public Map<String, String> getShadowMap() {
+    return SHADOW_MAP;
+  }
+
+  @Override
   public String[] getProvidedPackageNames() {
     return new String[]{"org.robolectric.annotation.processing.objects"};
   }

--- a/robolectric-processor/src/test/resources/org/robolectric/Robolectric_NoExcludedTypes.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/Robolectric_NoExcludedTypes.java
@@ -1,5 +1,7 @@
 package org.robolectric;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Generated;
 
 import org.robolectric.internal.ShadowExtractor;
@@ -11,10 +13,21 @@ import org.robolectric.internal.ShadowProvider;
 @Generated("org.robolectric.annotation.processing.RobolectricProcessor")
 @SuppressWarnings({"unchecked","deprecation"})
 public class Shadows implements ShadowProvider {
+  private static final Map<String, String> SHADOW_MAP = new HashMap<>(1);
+
+  static {
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowExcludedFromAndroidSdk");
+  }
 
   public void reset() {
   }
 
+  @Override
+  public Map<String, String> getShadowMap() {
+    return SHADOW_MAP;
+  }
+
+  @Override
   public String[] getProvidedPackageNames() {
     return new String[] {};
   }

--- a/robolectric-processor/src/test/resources/org/robolectric/Robolectric_Parameterized.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/Robolectric_Parameterized.java
@@ -1,5 +1,7 @@
 package org.robolectric;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Generated;
 
 import org.robolectric.annotation.processing.objects.Dummy;
@@ -12,6 +14,12 @@ import org.robolectric.internal.ShadowProvider;
 @Generated("org.robolectric.annotation.processing.RobolectricProcessor")
 @SuppressWarnings({"unchecked","deprecation"})
 public class Shadows implements ShadowProvider {
+  private static final Map<String, String> SHADOW_MAP = new HashMap<>(2);
+
+  static {
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
+    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.ParameterizedDummy", "org.robolectric.annotation.processing.shadows.ShadowParameterizedDummy");
+  }
 
   public static ShadowDummy shadowOf(Dummy actual) {
     return (ShadowDummy) ShadowExtractor.extract(actual);
@@ -25,6 +33,12 @@ public class Shadows implements ShadowProvider {
     ShadowDummy.resetter_method();
   }
 
+  @Override
+  public Map<String, String> getShadowMap() {
+    return SHADOW_MAP;
+  }
+
+  @Override
   public String[] getProvidedPackageNames() {
     return new String[] {"org.robolectric.annotation.processing.objects"};
   }

--- a/robolectric-utils/src/main/java/org/robolectric/internal/ShadowProvider.java
+++ b/robolectric-utils/src/main/java/org/robolectric/internal/ShadowProvider.java
@@ -1,5 +1,7 @@
 package org.robolectric.internal;
 
+import java.util.Map;
+
 /**
  * Interface implemented by packages that provide shadows to Robolectric.
  */
@@ -16,4 +18,11 @@ public interface ShadowProvider {
    * @return  Array of Java package names.
    */
   String[] getProvidedPackageNames();
+
+  /**
+   * Return the mapping of class name to shadow name.
+   *
+   * @return  Shadow mapping.
+   */
+  Map<String, String> getShadowMap();
 }

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -171,7 +171,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
 
   @Override
   protected void runChild(FrameworkMethod method, RunNotifier notifier) {
-    Description description= describeChild(method);
+    Description description = describeChild(method);
     EachTestNotifier eachNotifier = new EachTestNotifier(notifier, description);
 
     final Config config = getConfig(method.getMethod());
@@ -204,6 +204,11 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
     return new Statement() {
       @Override
       public void evaluate() throws Throwable {
+        // Configure shadows *BEFORE* setting the ClassLoader. This is necessary because
+        // creating the ShadowMap loads all ShadowProviders via ServiceLoader and this is
+        // not available once we install the Robolectric class loader.
+        configureShadows(sdkEnvironment, config);
+
         Thread.currentThread().setContextClassLoader(sdkEnvironment.getRobolectricClassLoader());
 
         Class bootstrappedTestClass = sdkEnvironment.bootstrappedClass(getTestClass().getJavaClass());
@@ -216,8 +221,6 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
         } catch (NoSuchMethodException e) {
           throw new RuntimeException(e);
         }
-
-        configureShadows(sdkEnvironment, config);
 
         ParallelUniverseInterface parallelUniverseInterface = getHooksInterface(sdkEnvironment);
         try {

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowConfig.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowConfig.java
@@ -1,5 +1,7 @@
 package org.robolectric.internal.bytecode;
 
+import org.robolectric.annotation.Implements;
+
 public class ShadowConfig {
   public final String shadowClassName;
   public final boolean callThroughByDefault;
@@ -7,10 +9,14 @@ public class ShadowConfig {
   public final boolean looseSignatures;
 
   ShadowConfig(String shadowClassName, boolean callThroughByDefault, boolean inheritImplementationMethods, boolean looseSignatures) {
-    this.callThroughByDefault = callThroughByDefault;
     this.shadowClassName = shadowClassName;
+    this.callThroughByDefault = callThroughByDefault;
     this.inheritImplementationMethods = inheritImplementationMethods;
     this.looseSignatures = looseSignatures;
+  }
+
+  ShadowConfig(String shadowClassName, Implements annotation) {
+    this(shadowClassName, annotation.callThroughByDefault(), annotation.inheritImplementationMethods(), annotation.looseSignatures());
   }
 
   @Override

--- a/robolectric/src/test/java/org/robolectric/RobolectricTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTest.java
@@ -33,6 +33,7 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
@@ -161,6 +162,11 @@ public class RobolectricTest {
 
     @Override
     public String[] getProvidedPackageNames() {
+      return null;
+    }
+
+    @Override
+    public Map<String, String> getShadowMap() {
       return null;
     }
   }


### PR DESCRIPTION
Instead of assuming shadows live in the org.robolectric.shadows package,
use the annotation processor to generate a mapping of android class name
to shadow name (for each ShadowProvider) and use this mapping when
looking up shadow configuration.

Closes #1897.