### PR TITLE
Fixed not setting properties on @Config

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
@@ -11,7 +11,7 @@ import org.robolectric.util.ReflectionHelpers;
  * Test runner customized for running unit tests either through the Gradle CLI or
  * Android Studio. The runner uses the build type and build flavor to compute the
  * resource, asset, and AndroidManifest paths.
- *
+ * <p/>
  * This test runner requires that you set the 'constants' field on the @Config
  * annotation (or the org.robolectric.Config.properties file) for your tests.
  */
@@ -39,24 +39,36 @@ public class RobolectricGradleTestRunner extends RobolectricTestRunner {
     final FileFsFile manifest;
 
     // res/merged added in Android Gradle plugin 1.3-beta1
-    if (FileFsFile.from(BUILD_OUTPUT, "res", "merged").exists()) {
-      res = FileFsFile.from(BUILD_OUTPUT, "res", "merged", flavor, type);
-    } else if (FileFsFile.from(BUILD_OUTPUT, "res").exists()) {
-      res = FileFsFile.from(BUILD_OUTPUT, "res", flavor, type);
+    if (Config.DEFAULT_RES_FOLDER.equals(config.resourceDir())) {
+      if (FileFsFile.from(BUILD_OUTPUT, "res", "merged").exists()) {
+        res = FileFsFile.from(BUILD_OUTPUT, "res", "merged", flavor, type);
+      } else if (FileFsFile.from(BUILD_OUTPUT, "res").exists()) {
+        res = FileFsFile.from(BUILD_OUTPUT, "res", flavor, type);
+      } else {
+        res = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "res");
+      }
     } else {
-      res = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "res");
+      res = FileFsFile.from(config.resourceDir());
     }
 
-    if (FileFsFile.from(BUILD_OUTPUT, "assets").exists()) {
-      assets = FileFsFile.from(BUILD_OUTPUT, "assets", flavor, type);
+    if (Config.DEFAULT_ASSET_FOLDER.equals(config.assetDir())) {
+      if (FileFsFile.from(BUILD_OUTPUT, "assets").exists()) {
+        assets = FileFsFile.from(BUILD_OUTPUT, "assets", flavor, type);
+      } else {
+        assets = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "assets");
+      }
     } else {
-      assets = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "assets");
+      assets = FileFsFile.from(config.assetDir());
     }
 
-    if (FileFsFile.from(BUILD_OUTPUT, "manifests").exists()) {
-      manifest = FileFsFile.from(BUILD_OUTPUT, "manifests", "full", flavor, type, "AndroidManifest.xml");
+    if (config.manifest().equals(Config.DEFAULT)) {
+      if (FileFsFile.from(BUILD_OUTPUT, "manifests").exists()) {
+        manifest = FileFsFile.from(BUILD_OUTPUT, "manifests", "full", flavor, type, "AndroidManifest.xml");
+      } else {
+        manifest = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "AndroidManifest.xml");
+      }
     } else {
-      manifest = FileFsFile.from(BUILD_OUTPUT, "bundles", flavor, type, "AndroidManifest.xml");
+      manifest = FileFsFile.from(config.manifest());
     }
 
     Logger.debug("Robolectric assets directory: " + assets.getPath());

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -2,6 +2,7 @@ package org.robolectric;
 
 import android.app.Application;
 import android.os.Build;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
 import org.junit.AfterClass;
@@ -516,17 +517,20 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
       super(testClass);
     }
 
-    @Override protected Object createTest() throws Exception {
+    @Override
+    protected Object createTest() throws Exception {
       Object test = super.createTest();
       testLifecycle.prepareTest(test);
       return test;
     }
 
-    @Override public Statement classBlock(RunNotifier notifier) {
+    @Override
+    public Statement classBlock(RunNotifier notifier) {
       return super.classBlock(notifier);
     }
 
-    @Override public Statement methodBlock(FrameworkMethod method) {
+    @Override
+    public Statement methodBlock(FrameworkMethod method) {
       return super.methodBlock(method);
     }
   }
@@ -539,7 +543,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
     private final List<FsFile> libraryDirs;
 
     public ManifestIdentifier(FsFile manifestFile, FsFile resDir, FsFile assetDir, String packageName,
-        List<FsFile> libraryDirs) {
+                              List<FsFile> libraryDirs) {
       this.manifestFile = manifestFile;
       this.resDir = resDir;
       this.assetDir = assetDir;
@@ -555,10 +559,10 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
       ManifestIdentifier that = (ManifestIdentifier) o;
 
       return assetDir.equals(that.assetDir)
-          && libraryDirs.equals(that.libraryDirs)
-          && manifestFile.equals(that.manifestFile)
-          && resDir.equals(that.resDir)
-          && ((packageName == null && that.packageName == null) || (packageName != null && packageName.equals(that.packageName)));
+              && libraryDirs.equals(that.libraryDirs)
+              && manifestFile.equals(that.manifestFile)
+              && resDir.equals(that.resDir)
+              && ((packageName == null && that.packageName == null) || (packageName != null && packageName.equals(that.packageName)));
     }
 
     @Override
@@ -574,12 +578,12 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
 
   private static <A extends Annotation> A defaultsFor(Class<A> annotation) {
     return annotation.cast(
-        Proxy.newProxyInstance(annotation.getClassLoader(), new Class[] { annotation },
-            new InvocationHandler() {
-              public Object invoke(Object proxy, @NotNull Method method, Object[] args)
-                  throws Throwable {
-                return method.getDefaultValue();
-              }
-            }));
+            Proxy.newProxyInstance(annotation.getClassLoader(), new Class[]{annotation},
+                    new InvocationHandler() {
+                      public Object invoke(Object proxy, @NotNull Method method, Object[] args)
+                              throws Throwable {
+                        return method.getDefaultValue();
+                      }
+                    }));
   }
 }

--- a/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
@@ -33,7 +33,7 @@ public class RobolectricGradleTestRunnerTest {
   private static String convertPath(String path) {
     return path.replace('/', File.separatorChar);
   }
-  
+
   @Test
   public void getAppManifest_forApplications_shouldCreateManifest() throws Exception {
     final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(ConstantsTest.class);
@@ -96,6 +96,17 @@ public class RobolectricGradleTestRunnerTest {
   }
 
   @Test
+  public void getAppManifest_withChangedResourceDir() throws Exception {
+    final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(ConfigParansTest.class);
+    final AndroidManifest manifest = runner.getAppManifest(runner.getConfig(ConfigParansTest.class.getMethod("withoutAnnotation")));
+
+    assertThat(manifest.getPackageName()).isEqualTo("fake.package.name");
+    assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("fake/assets/dir"));
+    assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("src/test/res"));
+    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("fake/manifest/file.xml"));
+  }
+
+  @Test
   public void getAppManifest_shouldThrowException_whenConstantsNotSpecified() throws Exception {
     final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(NoConstantsTest.class);
     exception.expect(RuntimeException.class);
@@ -120,7 +131,8 @@ public class RobolectricGradleTestRunnerTest {
     public void withoutAnnotation() throws Exception {
     }
 
-    @Test @Config(constants = BuildConfigOverride.class)
+    @Test
+    @Config(constants = BuildConfigOverride.class)
     public void withOverrideAnnotation() throws Exception {
     }
   }
@@ -137,6 +149,15 @@ public class RobolectricGradleTestRunnerTest {
   @Ignore
   @Config(constants = BuildConfig.class, packageName = "fake.package.name")
   public static class PackageNameTest {
+
+    @Test
+    public void withoutAnnotation() throws Exception {
+    }
+  }
+
+  @Ignore
+  @Config(constants = BuildConfig.class, resourceDir = "src/test/res", packageName = "fake.package.name", assetDir = "fake/assets/dir", manifest = "fake/manifest/file.xml")
+  public static class ConfigParansTest {
 
     @Test
     public void withoutAnnotation() throws Exception {


### PR DESCRIPTION
When using RobolectricGradleTestRunner, assets directory, resource directory and manifest file weren't able to be configured with @Config. This pull request makes possible to override such configurations.