### PR TITLE
Avoid NPE in ShadowDownloadManager when the query doesn't have any ids.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDownloadManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDownloadManager.java
@@ -45,14 +45,16 @@ public class ShadowDownloadManager {
 
   @Implementation
   public Cursor query(DownloadManager.Query query) {
+    ResultCursor result = new ResultCursor();
     ShadowQuery shadow = Shadows.shadowOf(query);
     long[] ids = shadow.getIds();
 
-    ResultCursor result = new ResultCursor();
-    for (long id : ids) {
-      DownloadManager.Request request = requestMap.get(id);
-      if (request != null) {
-        result.requests.add(request);
+    if (ids != null) {
+      for (long id : ids) {
+        DownloadManager.Request request = requestMap.get(id);
+        if (request != null) {
+          result.requests.add(request);
+        }
       }
     }
     return result;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDownloadManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDownloadManagerTest.java
@@ -133,4 +133,10 @@ public class ShadowDownloadManagerTest {
     assertThat(cursor.getString(cursor.getColumnIndex(DownloadManager.COLUMN_URI))).isEqualTo(uri.toString());
     assertThat(cursor.getString(cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI))).isEqualTo(destination.toString());
   }
+
+  @Test
+  public void query_shouldHandleEmptyIds() {
+    ShadowDownloadManager manager = new ShadowDownloadManager();
+    assertThat(manager.query(new DownloadManager.Query())).isNotNull();
+  }
 }


### PR DESCRIPTION
Closes #1908.