### PR TITLE
Improved Looper realism

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -54,7 +54,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Shadow for {@link android.app.Application}.
  */
-@SuppressWarnings({"UnusedDeclaration"})
 @Implements(Application.class)
 public class ShadowApplication extends ShadowContextWrapper {
   @RealObject private Application realApplication;
@@ -70,7 +69,7 @@ public class ShadowApplication extends ShadowContextWrapper {
   private List<ServiceConnection> unboundServiceConnections = new ArrayList<>();
   private List<Wrapper> registeredReceivers = new ArrayList<>();
   private Map<String, Intent> stickyIntents = new LinkedHashMap<>();
-  private Looper mainLooper = ShadowLooper.myLooper();
+  private Looper mainLooper = Looper.myLooper();
   private Handler mainHandler = new Handler(mainLooper);
   private Scheduler backgroundScheduler = new Scheduler();
   private Map<String, Map<String, Object>> sharedPreferenceMap = new HashMap<>();

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -6,6 +6,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.os.Looper;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.robolectric.Robolectric;
@@ -91,6 +92,10 @@ public class ParallelUniverse implements ParallelUniverseInterface {
     Class<?> contextImplClass = ReflectionHelpers.loadClass(getClass().getClassLoader(), shadowsAdapter.getShadowContextImplClassName());
 
     Class<?> activityThreadClass = ReflectionHelpers.loadClass(getClass().getClassLoader(), shadowsAdapter.getShadowActivityThreadClassName());
+    // Looper needs to be prepared before the activity thread is created
+    if (Looper.myLooper() == null) {
+      Looper.prepareMainLooper();
+    }
     Object activityThread = ReflectionHelpers.newInstance(activityThreadClass);
     RuntimeEnvironment.setActivityThread(activityThread);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
@@ -367,7 +367,7 @@ public class ShadowHandlerTest {
     Handler handler = new Handler() {
       @Override
       public void handleMessage(Message msg) {
-        runAt.add(shadowOf(ShadowLooper.myLooper()).getScheduler().getCurrentTime());
+        runAt.add(shadowOf(Looper.myLooper()).getScheduler().getCurrentTime());
       }
     };
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
@@ -51,10 +51,6 @@ public class ShadowLooperTest {
       super(testName.getMethodName());
     }
     
-//    public QuitThread(String name) {
-//      super(name);
-//    }
-    
     @Override
     public void run() {
       Looper.prepare();
@@ -183,22 +179,6 @@ public class ShadowLooperTest {
     assertThat(test.hasContinued).as("afterJoin").isTrue();
   }
 
-//  @Test
-//  public void threadShouldContinue_whenLooperResets() throws InterruptedException {
-//    QuitThread test = new QuitThread();
-//    test.start();
-//    synchronized(test) {
-//      // Set a timeout as a defense against unforseen failure that prevents
-//      // notify() getting called
-//      test.wait(5000);
-//    }
-//    assertThat(test.looper).isNotNull();
-//    assertThat(test.hasContinued).isFalse();
-//    test.sLooper.reset();
-//    test.join(5000);
-//    assertThat(test.hasContinued).isTrue();
-//  }
-//
   @Test
   public void shouldResetQueue_whenLooperIsReset() {
     HandlerThread ht = getHandlerThread();
@@ -226,7 +206,7 @@ public class ShadowLooperTest {
     assertThat(test.hasContinued).isTrue();
   }
  
-  @Ignore("Not yet implemented") 
+  @Ignore("Not yet implemented (ref #1407)") 
   @Test(timeout = 1000)
   public void whenTestHarnessUsesDifferentThread_shouldStillHaveMainLooper() {
     assertThat(Looper.myLooper()).isNotNull();
@@ -250,7 +230,8 @@ public class ShadowLooperTest {
     assertThat(ex.get()).isInstanceOf(IllegalStateException.class);
   }
   
-  @Test public void soStaticRefsToLoopersInAppWorksAcrossTests_shouldRetainSameLooperForMainThreadBetweenResetsButGiveItAFreshScheduler() throws Exception {
+  @Test
+  public void soStaticRefsToLoopersInAppWorksAcrossTests_shouldRetainSameLooperForMainThreadBetweenResetsButGiveItAFreshScheduler() throws Exception {
     Looper mainLooper = Looper.getMainLooper();
     Scheduler scheduler = shadowOf(mainLooper).getScheduler();
     shadowOf(mainLooper).quit = true;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowValueAnimatorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowValueAnimatorTest.java
@@ -1,6 +1,8 @@
 package org.robolectric.shadows;
 
 import android.animation.ValueAnimator;
+import android.os.Looper;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -22,6 +24,7 @@ public class ShadowValueAnimatorTest {
 
     ShadowChoreographer.setFrameInterval(100 * TimeUtils.NANOS_PER_MS);
 
+    
     final ValueAnimator animator = ValueAnimator.ofInt(0, 10);
     animator.setDuration(1000);
     animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
@@ -46,17 +49,27 @@ public class ShadowValueAnimatorTest {
     assertThat(animator.getRepeatCount()).isEqualTo(1);
   }
 
-  @Test(timeout = 1000)
-  public void test_WhenInfiniteAnimationIsPlayed_AnimationIsOnlyPlayedOnce() {
+  @Test
+// It would be nice if timeout worked properly; however internally JUnit sets
+// up a separate thread when timeout is used, which violates some assumptions
+// that the rest of Robolectric makes about the test thread being invariant.
+//  @Test(timeout = 1000)
+  public void test_WhenInfiniteAnimationIsPlayed_AnimationIsOnlyPlayedOnce() throws InterruptedException {
     ShadowChoreographer.setFrameInterval(100 * TimeUtils.NANOS_PER_MS);
-
     final ValueAnimator animator = ValueAnimator.ofInt(0, 10);
     animator.setDuration(200);
     animator.setRepeatCount(ValueAnimator.INFINITE);
 
     animator.start();
 
-    Robolectric.flushForegroundThreadScheduler();
+    Thread flush = new Thread("test_WhenInfiniteAnimationIsPlayed_AnimationIsOnlyPlayedOnce") {
+      @Override
+      public void run() {
+        Robolectric.flushForegroundThreadScheduler();
+      }
+    };
+    flush.start();
+    flush.join(1000);
     assertThat(animator.isRunning()).isFalse();
   }
 }


### PR DESCRIPTION
Apart from some general tidy-ups, this PR does a few things:

* The biggest change came about because I noticed during my testing & auditing that there is no mechanism to close background loopers at the end of a test. I put some code into `RobolectricTestRunner` to dump the active threads at the end of each test, and I found that at the end of a full test suite run there were dozens of looper threads in `Object.wait()`. These threads were never exiting and hence never releasing their associated loopers and their resources. I suspect that this is the real source of the memory leak that the `SoftThreadLocal` in `ShadowLooper` was attempting to solve. This PR fixes `ShadowLooper.resetThreadLoopers()` to make sure that `quit()` is called on all background loopers. By the end of the full test suite they've all exited.
* Facilitating the above, I replaced the `SoftThreadLocal` with a `WeakHashMap` so that it is possible to see what a thread's looper is from another thread. This also allowed me to implement a utility function that will give you the looper for a given thread. It is also now possible (though yet implemented) for one thread to initialise another thread's looper, which might simplify some test scenarios.
* Having solved the memory leak issue (fingers crossed!) I was emboldened to remove some of the shadowing and use more real Android. In particular, I noted that our shadow implementation of `myLooper()` would implicitly do a `prepare()` for the thread too, whereas in Android calling `myLooper()` without first calling `prepare()` would result in a runtime exception. However fixing this issue also made me run into #1407 with `ShadowValueAnimatorTest` which I had to work around (I'll comment more on what I discovered against that issue).
* There are no longer any references to `ShadowApplication` from within `ShadowLooper`, making `ShadowLooper` better encapsulated & decoupled from `ShadowApplication`. This has no immediate effect but was a prerequisite to my attempt to implement a master scheduler - I was running into a chicken-and-egg problem when trying to initialise the main looper and its main scheduler. This also means that you can call `getMainLooper()` before the `ShadowApplication` is set up and while `RuntimeEnvironment.application` is still null, and you'll still get the main looper (used to throw an NPE in this case, which meant that background threads would occasionally be stillborn).