### PR TITLE
MultiApiRobolectricTestRunner should just not create the child test case

### DIFF
--- a/robolectric/src/main/java/org/robolectric/MultiApiRobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/MultiApiRobolectricTestRunner.java
@@ -19,36 +19,6 @@ import java.util.List;
  */
 public class MultiApiRobolectricTestRunner extends Suite {
 
-  public static final int[] JELLY_BEAN_UP = {
-      Build.VERSION_CODES.JELLY_BEAN,
-      Build.VERSION_CODES.JELLY_BEAN_MR1,
-      Build.VERSION_CODES.JELLY_BEAN_MR2,
-      Build.VERSION_CODES.KITKAT,
-      Build.VERSION_CODES.LOLLIPOP
-  };
-
-  public static final int[] JELLY_BEAN_MR1_UP = {
-      Build.VERSION_CODES.JELLY_BEAN_MR1,
-      Build.VERSION_CODES.JELLY_BEAN_MR2,
-      Build.VERSION_CODES.KITKAT,
-      Build.VERSION_CODES.LOLLIPOP
-  };
-
-  public static final int[] JELLY_BEAN_MR2_UP = {
-      Build.VERSION_CODES.JELLY_BEAN_MR2,
-      Build.VERSION_CODES.KITKAT,
-      Build.VERSION_CODES.LOLLIPOP
-  };
-
-  public static final int[] KIT_KAT_UP = {
-      Build.VERSION_CODES.KITKAT,
-      Build.VERSION_CODES.LOLLIPOP
-  };
-
-  public static final int[] LOLLIPOP_UP = {
-      Build.VERSION_CODES.LOLLIPOP
-  };
-
   protected static class TestRunnerForApiVersion extends RobolectricTestRunner {
 
     private final String name;
@@ -80,11 +50,8 @@ public class MultiApiRobolectricTestRunner extends Suite {
       return "TestClassRunnerForParameters " + name;
     }
 
-    protected boolean shouldIgnore(FrameworkMethod method, Config config) {
-      return super.shouldIgnore(method, config) || !shouldRunApiVersion(config);
-    }
-
-    private boolean shouldRunApiVersion(Config config) {
+    @Override
+    protected boolean shouldRunApiVersion(Config config) {
       if (config.sdk().length == 0) {
         return true;
       }
@@ -130,6 +97,7 @@ public class MultiApiRobolectricTestRunner extends Suite {
     super(klass, Collections.<Runner>emptyList());
 
     for (Integer integer : SdkConfig.getSupportedApis()) {
+
       runners.add(createTestRunner(integer));
 
     }

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -177,7 +177,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
     final Config config = getConfig(method.getMethod());
     if (shouldIgnore(method, config)) {
       eachNotifier.fireTestIgnored();
-    } else {
+    } else if(shouldRunApiVersion(config)) {
       eachNotifier.fireTestStarted();
       try {
         AndroidManifest appManifest = getAppManifest(config);
@@ -194,6 +194,10 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
         eachNotifier.fireTestFinished();
       }
     }
+  }
+
+  protected boolean shouldRunApiVersion(Config config) {
+    return true;
   }
 
   protected boolean shouldIgnore(FrameworkMethod method, Config config) {

--- a/robolectric/src/test/java/org/robolectric/MultiApiRobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/MultiApiRobolectricTestRunnerTest.java
@@ -65,9 +65,8 @@ public class MultiApiRobolectricTestRunnerTest {
     runNotifier.addListener(runListener);
     runner.run(runNotifier);
 
-    // The test should be ignored on all but the single API runner that corresponds to its
-    // @Config value
-    verify(runListener, times(4)).testIgnored(any(Description.class));
+    verify(runListener, never()).testIgnored(any(Description.class));
+    // Since test method should only be run once
     verify(runListener, times(1)).testFinished(any(Description.class));
   }
 
@@ -82,9 +81,8 @@ public class MultiApiRobolectricTestRunnerTest {
     runNotifier.addListener(runListener);
     runner.run(runNotifier);
 
-    // Each one of the five methods should be ignored for all runners except the one for the
-    // corresponding API level
-    verify(runListener, times(20)).testIgnored(any(Description.class));
+    verify(runListener, never()).testIgnored(any(Description.class));
+    // Each of the 5 methods should be run once only each
     verify(runListener, times(5)).testFinished(any(Description.class));
   }
 


### PR DESCRIPTION
Rather than create it and mark @Ignore for unsupported API versions which seems strange to have a bunch of @Ignored tests for this reason.