### PR TITLE
Remove wrongly added Test7 from @Config tests

### DIFF
--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -105,16 +105,17 @@ public class RobolectricTestRunnerTest {
             "shadows: org.robolectric.shadows.ShadowView, org.robolectric.shadows.ShadowViewGroup\n" +
             "application: org.robolectric.TestFakeApp\n" +
             "packageName: com.example.test\n" +
-            "libraries: libs/test, libs/test2");
+            "libraries: libs/test, libs/test2\n" +
+            "constants: org.robolectric.RobolectricTestRunnerTest$BuildConfigConstants3");
 
-    assertConfig(configFor(Test7.class, "withoutAnnotation", properties),
+    assertConfig(configFor(Test2.class, "withoutAnnotation", properties),
         new int[] {432}, "--none", TestFakeApp.class, "com.example.test", "from-properties-file", "from/properties/file/res", "from/properties/file/assets", new Class[] {ShadowView.class, ShadowViewGroup.class}, new String[]{"libs/test", "libs/test2"}, BuildConfigConstants3.class);
   }
 
   @Test
   public void withEmptyShadowList_shouldLoadDefaultsFromPropertiesFile() throws Exception {
     Properties properties = properties("shadows:");
-    assertConfig(configFor(Test7.class, "withoutAnnotation", properties), new int[0],  "--default", Application.class, "", "", "res", "assets", new Class[] {}, new String[]{}, BuildConfigConstants3.class);
+    assertConfig(configFor(Test2.class, "withoutAnnotation", properties), new int[0],  "--default", Application.class, "", "", "res", "assets", new Class[] {}, new String[]{}, null);
   }
 
   @Test
@@ -238,11 +239,6 @@ public class RobolectricTestRunnerTest {
   @Ignore
   @Config(qualifiers = "from-class6", shadows = Test6.class, resourceDir = "class6/res", constants = BuildConfigConstants6.class)
   public static class Test6 extends Test5 {
-  }
-
-  @Ignore
-  @Config(constants = BuildConfigConstants3.class)
-  public static class Test7 extends Test2 {
   }
 
   private String stringify(Config config) {


### PR DESCRIPTION
#1707 fixed incorrect overriding behaviour of the constants config property, and also modified the various config overriding tests to include this property. Unfortunately, for the tests for loading the configurations from the properties file, instead of just adding and verifying the constant property in the mock file, it replaced the non-annotated mock class (`Test2`) that was used in the test with a new mock class that had the constants property defined via annotation (`Test7`). This basically invalidated the test, and caused the fixed issue to no longer be covered by it. This pull request fixes that mistake by removing `Test7`, and reverting it's referencing tests to use `Test2`, and also adding the constants property in the mock property file test.