### PR TITLE
Add getApplicationIcon(String) to RobolectricPackageManager interface

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
@@ -45,6 +45,8 @@ public interface RobolectricPackageManager {
 
   void addActivityIcon(Intent intent, Drawable d);
 
+  Drawable getApplicationIcon(String packageName) throws PackageManager.NameNotFoundException;
+
   void setApplicationIcon(String packageName, Drawable d);
 
   Intent getLaunchIntentForPackage(String packageName);


### PR DESCRIPTION
`getApplicationIcon(String)` is missing from the `RobolectricPackageManager` interface.