### PR TITLE
Fix flaky NPE when one of the passed intents was changed.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -46,7 +46,7 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
     this.shadowsAdapter = shadowsAdapter;
   }
 
-  private static class IntentComparator implements Comparator<Intent> {
+  static class IntentComparator implements Comparator<Intent> {
 
     @Override
     public int compare(Intent i1, Intent i2) {
@@ -59,8 +59,8 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
       if (action1 == null && action2 != null) return -1;
       if (action1 != null && action2 == null) return 1;
       if (action1 != null && action2 != null) {
-        if (!i1.getAction().equals(i2.getAction())) {
-          return i1.getAction().compareTo(i2.getAction());
+        if (!action1.equals(action2)) {
+          return action1.compareTo(action2);
         }
       }
       Uri data1 = i1.getData();

--- a/robolectric/src/test/java/org/robolectric/res/builder/DefaultPackageManagerIntentComparatorTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/builder/DefaultPackageManagerIntentComparatorTest.java
@@ -1,0 +1,40 @@
+package org.robolectric.res.builder;
+
+import android.content.Intent;
+import org.junit.Test;
+import org.assertj.core.api.Assertions;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DefaultPackageManagerIntentComparatorTest {
+
+  @Test
+  public void validCompareResult() {
+    final DefaultPackageManager.IntentComparator intentComparator = new DefaultPackageManager.IntentComparator();
+
+    Assertions.assertThat(intentComparator.compare(null, null)).isEqualTo(0);
+    Assertions.assertThat(intentComparator.compare(new Intent(), null)).isEqualTo(1);
+    Assertions.assertThat(intentComparator.compare(null, new Intent())).isEqualTo(-1);
+
+    Intent intent1 = new Intent();
+    Intent intent2 = new Intent();
+
+    Assertions.assertThat(intentComparator.compare(intent1, intent2)).isEqualTo(0);
+  }
+
+  @Test
+  public void canSustainConcurrentModification() {
+    final DefaultPackageManager.IntentComparator intentComparator = new DefaultPackageManager.IntentComparator();
+
+    Intent mockedIntent1 = mock(Intent.class);
+    when(mockedIntent1.getAction()).thenReturn("actionstring0", null);
+
+    Intent mockedIntent2 = mock(Intent.class);
+    when(mockedIntent2.getAction()).thenReturn("actionstring1", null);
+
+    Assertions.assertThat(intentComparator.compare(mockedIntent1, mockedIntent2)).isEqualTo(-1);
+  }
+
+}


### PR DESCRIPTION
Sometimes when we run a lot of tests (about 4k) on our CI we have Robolectric crashed with stacktrace like this:
```
Caused by: java.lang.NullPointerException
    at org.robolectric.res.builder.DefaultPackageManager$IntentComparator.compare(DefaultPackageManager.java:63)
    at org.robolectric.res.builder.DefaultPackageManager$IntentComparator.compare(DefaultPackageManager.java:49)
    at java.util.TreeMap.put(TreeMap.java:552)
    at org.robolectric.res.builder.DefaultPackageManager.findOrCreateInfoList(DefaultPackageManager.java:527)
    at org.robolectric.res.builder.DefaultPackageManager.addResolveInfoForIntent(DefaultPackageManager.java:250)
    at org.robolectric.DefaultTestLifecycle.addManifestActivitiesToPackageManager(DefaultTestLifecycle.java:94)
    at org.robolectric.DefaultTestLifecycle.createApplication(DefaultTestLifecycle.java:70)
    at org.robolectric.DefaultTestLifecycle.createApplication(DefaultTestLifecycle.java:15)
    at org.robolectric.internal.ParallelUniverse.setUpApplicationState(ParallelUniverse.java:102)
    at org.robolectric.RobolectricTestRunner.setUpApplicationState(RobolectricTestRunner.java:421)
    at org.robolectric.RobolectricTestRunner$2.evaluate(RobolectricTestRunner.java:234)
```
It looks like if intent is modified while `compare` method being executed we crash with no glory.
