### PR TITLE
Fix crash with hashCode() of PorterDuffColorFilter

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPorterDuffColorFilter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPorterDuffColorFilter.java
@@ -28,6 +28,11 @@ public class ShadowPorterDuffColorFilter {
     this.mode = mode;
   }
 
+  @Implementation
+  public int hashCode() {
+    return 31 * mode.hashCode() + color;
+  }
+
   /**
    * Non-Android accessor.
    *

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPorterDuffColorFilterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPorterDuffColorFilterTest.java
@@ -36,4 +36,20 @@ public class ShadowPorterDuffColorFilterTest {
     filter.setMode(PorterDuff.Mode.DST_IN);
     assertThat(filter.getMode()).isEqualTo(PorterDuff.Mode.DST_IN);
   }
+
+  @Test
+  public void hashCode_returnsDifferentValuesForDifferentModes() {
+    PorterDuffColorFilter addFilter = new PorterDuffColorFilter(Color.RED, PorterDuff.Mode.ADD);
+    PorterDuffColorFilter dstFilter = new PorterDuffColorFilter(Color.RED, PorterDuff.Mode.DST);
+
+    assertThat(addFilter.hashCode()).isNotEqualTo(dstFilter.hashCode());
+  }
+
+  @Test
+  public void hashCode_returnsDifferentValuesForDifferentColors() {
+    PorterDuffColorFilter blueFilter = new PorterDuffColorFilter(Color.BLUE, PorterDuff.Mode.ADD);
+    PorterDuffColorFilter redFilter = new PorterDuffColorFilter(Color.RED, PorterDuff.Mode.ADD);
+
+    assertThat(blueFilter.hashCode()).isNotEqualTo(redFilter.hashCode());
+  }
 }


### PR DESCRIPTION
Because the shadow does not invoke the real constructor, mode was null.

Credits go to @holmari for this.