### PR TITLE
Remove unneeded startActivity() method from ShadowActivity

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -426,16 +426,6 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public void startActivity(Intent intent) {
-    startActivityForResult(intent, -1);
-  }
-
-  @Implementation
-  public void startActivity(Intent intent, Bundle options) {
-    startActivityForResult(intent, -1, options);
-  }
-
-  @Implementation
   public void startActivityForResult(Intent intent, int requestCode) {
     intentRequestCodeMap.put(new Intent.FilterComparison(intent), requestCode);
     startedActivitiesForResults.add(new IntentForResult(intent, requestCode));


### PR DESCRIPTION
`startActivity()` merely delegates to `startActivityForResult()`, so there is no point in having it shadowed as well. This fixes the issue of overridden `startActivityForResult()` not being triggered by calls to `startActivity()`, as happens in the framework.