### PR TITLE
Fix for missing shadows that should be generated even on API levels they are not defined.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java.vm
@@ -665,5 +665,9 @@ public class ShadowAccessibilityNodeInfo {
       return label;
     }
   }
+#else
+  public static final class ShadowAccessibilityAction {
+    // Dummy class, this was added in API21
+  }
 #end
 }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityWindowInfo.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityWindowInfo.java.vm
@@ -1,5 +1,6 @@
-#if ($api >= 21)
 package org.robolectric.shadows;
+
+#if ($api >= 21)
 
 import android.graphics.Rect;
 import android.view.accessibility.AccessibilityNodeInfo;
@@ -96,4 +97,9 @@ public class ShadowAccessibilityWindowInfo {
     id = value;
   }
 }
+#else
+public class ShadowAccessibilityWindowInfo {
+  // Dummy class, this was added in API21
+}
 #end
+


### PR DESCRIPTION
This results in the following compilation errors

XXXXXXXX error: cannot access AccessibilityWindowInfo
    ShadowCountDownTimer shadowTimer = Shadows.shadowOf(timeLimit.getTimer());

XXXXXXXX  error: cannot access AccessibilityAction
    ShadowCountDownTimer shadowTimer = Shadows.shadowOf(timeLimit.getTimer());