### PR TITLE
Use sdk level in RuntimeEnvironment to choose rumtimeadapter instand of sdk_int, fail proof for null viewRootImpl, Making a11y shadows parcelable.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
+++ b/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
@@ -2,6 +2,8 @@ package org.robolectric;
 
 import android.app.Application;
 import android.content.pm.PackageManager;
+
+import org.robolectric.res.ResBundle;
 import org.robolectric.res.builder.RobolectricPackageManager;
 
 public class RuntimeEnvironment {
@@ -40,5 +42,9 @@ public class RuntimeEnvironment {
 
     public static void setQualifiers(String newQualifiers) {
         qualifiers = newQualifiers;
+    }
+
+    public static int getApiLevel() {
+      return ResBundle.getVersionQualifierApiLevel(qualifiers);
     }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAccessibilityEvent.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAccessibilityEvent.java
@@ -45,7 +45,7 @@ public class ShadowAccessibilityEvent {
 
     @Override
     public AccessibilityEvent createFromParcel(Parcel source) {
-      return obtain(orderedInstances.valueAt(source.readInt()).mEvent);
+      return obtain(orderedInstances.get(source.readInt()).mEvent);
     }
 
     @Override
@@ -276,13 +276,13 @@ public class ShadowAccessibilityEvent {
   @Implementation
   public void writeToParcel(Parcel dest, int flags) {
     StrictEqualityEventWrapper wrapper = new StrictEqualityEventWrapper(realAccessibilityEvent);
-    int indexOfWrapper = -1;
+    int keyOfWrapper = -1;
     for (int i = 0; i < orderedInstances.size(); i++) {
       if (orderedInstances.valueAt(i).equals(wrapper)) {
-        indexOfWrapper = i;
+        keyOfWrapper = orderedInstances.keyAt(i);
         break;
       }
     }
-    dest.writeInt(indexOfWrapper);
+    dest.writeInt(keyOfWrapper);
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java.vm
@@ -35,7 +35,7 @@ public class ShadowAccessibilityNodeInfo {
   private static final Map<StrictEqualityNodeWrapper, StackTraceElement[]> obtainedInstances =
       new HashMap<>();
 
-  private static final SparseArray<StrictEqualityNodeWrapper> orderedInstance = new SparseArray<>();
+  private static final SparseArray<StrictEqualityNodeWrapper> orderedInstances = new SparseArray<>();
 
   // Bitmasks for actions
   public static final int UNDEFINED_SELECTION_INDEX = -1;
@@ -45,7 +45,7 @@ public class ShadowAccessibilityNodeInfo {
 
     @Override
     public AccessibilityNodeInfo createFromParcel(Parcel source) {
-      return obtain(orderedInstance.get(source.readInt()).mInfo);
+      return obtain(orderedInstances.valueAt(source.readInt()).mInfo);
     }
 
     @Override
@@ -103,6 +103,10 @@ public class ShadowAccessibilityNodeInfo {
   @RealObject
   private AccessibilityNodeInfo realAccessibilityNodeInfo;
 
+  public void __constructor__() {
+    ReflectionHelpers.setStaticField(AccessibilityNodeInfo.class, "CREATOR", ShadowAccessibilityNodeInfo.CREATOR);
+  }
+
   @Implementation
   public static AccessibilityNodeInfo obtain(AccessibilityNodeInfo info) {
     final ShadowAccessibilityNodeInfo shadowInfo =
@@ -112,9 +116,7 @@ public class ShadowAccessibilityNodeInfo {
     sAllocationCount++;
     StrictEqualityNodeWrapper wrapper = new StrictEqualityNodeWrapper(obtainedInstance);
     obtainedInstances.put(wrapper, Thread.currentThread().getStackTrace());
-    orderedInstance.put(sAllocationCount, wrapper);
-    ReflectionHelpers.setStaticField(
-        AccessibilityNodeInfo.class, "CREATOR", ShadowAccessibilityNodeInfo.CREATOR);    
+    orderedInstances.put(sAllocationCount, wrapper);  
     return obtainedInstance;
   }
 
@@ -143,9 +145,7 @@ public class ShadowAccessibilityNodeInfo {
     sAllocationCount++;
     StrictEqualityNodeWrapper wrapper = new StrictEqualityNodeWrapper(obtainedInstance);
     obtainedInstances.put(wrapper, Thread.currentThread().getStackTrace());
-    orderedInstance.put(sAllocationCount, wrapper);
-    ReflectionHelpers.setStaticField(
-        AccessibilityNodeInfo.class, "CREATOR", ShadowAccessibilityNodeInfo.CREATOR);
+    orderedInstances.put(sAllocationCount, wrapper);
     return obtainedInstance;
   }
 
@@ -186,7 +186,8 @@ public class ShadowAccessibilityNodeInfo {
    */
   public static void resetObtainedInstances() {
     obtainedInstances.clear();
-    orderedInstance.clear();
+    orderedInstances.clear();
+    sAllocationCount = 0;
   }
 
   @Implementation
@@ -207,14 +208,15 @@ public class ShadowAccessibilityNodeInfo {
 
     obtainedInstances.remove(wrapper);
     int keyOfWrapper = -1;
-    for (int i = 0; i < orderedInstance.size(); i++) {
-      int key = orderedInstance.keyAt(i);
-      if (orderedInstance.get(key).equals(wrapper)) {
+    for (int i = 0; i < orderedInstances.size(); i++) {
+      int key = orderedInstances.keyAt(i);
+      if (orderedInstances.get(key).equals(wrapper)) {
         keyOfWrapper = key;
         break;
       }
     }
-    orderedInstance.remove(keyOfWrapper);
+    orderedInstances.remove(keyOfWrapper);
+    sAllocationCount--;
   }
 
   @Implementation
@@ -716,14 +718,13 @@ public class ShadowAccessibilityNodeInfo {
   @Implementation
   public void writeToParcel(Parcel dest, int flags) {
     StrictEqualityNodeWrapper wrapper = new StrictEqualityNodeWrapper(realAccessibilityNodeInfo);
-    int keyofWrapper = -1;
-    for (int i = 0; i < orderedInstance.size(); i++) {
-      int key = orderedInstance.keyAt(i);
-      if (orderedInstance.get(key).equals(wrapper)) {
-         keyofWrapper = key;
-         break;
+    int indexOfWrapper = -1;
+    for (int i = 0; i < orderedInstances.size(); i++) {
+      if (orderedInstances.valueAt(i).equals(wrapper)) {
+        indexOfWrapper = i;
+        break;
       }
     }
-    dest.writeInt(keyofWrapper);
+    dest.writeInt(indexOfWrapper);
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java.vm
@@ -2,8 +2,11 @@ package org.robolectric.shadows;
 
 import android.graphics.Rect;
 import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.text.TextUtils;
 import android.util.Pair;
+import android.util.SparseArray;
 import android.view.View;
 import android.view.accessibility.AccessibilityNodeInfo;
 
@@ -32,8 +35,25 @@ public class ShadowAccessibilityNodeInfo {
   private static final Map<StrictEqualityNodeWrapper, StackTraceElement[]> obtainedInstances =
       new HashMap<>();
 
+  private static final SparseArray<StrictEqualityNodeWrapper> orderedInstance = new SparseArray<>();
+
   // Bitmasks for actions
   public static final int UNDEFINED_SELECTION_INDEX = -1;
+
+  public static final Parcelable.Creator<AccessibilityNodeInfo> CREATOR =
+      new Parcelable.Creator<AccessibilityNodeInfo>() {
+
+    @Override
+    public AccessibilityNodeInfo createFromParcel(Parcel source) {
+      return obtain(orderedInstance.get(source.readInt()).mInfo);
+    }
+
+    @Override
+    public AccessibilityNodeInfo[] newArray(int size) {
+      return new AccessibilityNodeInfo[size];
+    }};
+
+  private static int sAllocationCount = 0;
 
   private static final int CLICKABLE_MASK = 0x00000001;
 
@@ -89,8 +109,12 @@ public class ShadowAccessibilityNodeInfo {
         ((ShadowAccessibilityNodeInfo) ShadowExtractor.extract(info));
     final AccessibilityNodeInfo obtainedInstance = shadowInfo.getClone();
 
-    obtainedInstances.put(
-        new StrictEqualityNodeWrapper(obtainedInstance), Thread.currentThread().getStackTrace());
+    sAllocationCount++;
+    StrictEqualityNodeWrapper wrapper = new StrictEqualityNodeWrapper(obtainedInstance);
+    obtainedInstances.put(wrapper, Thread.currentThread().getStackTrace());
+    orderedInstance.put(sAllocationCount, wrapper);
+    ReflectionHelpers.setStaticField(
+        AccessibilityNodeInfo.class, "CREATOR", ShadowAccessibilityNodeInfo.CREATOR);    
     return obtainedInstance;
   }
 
@@ -116,8 +140,12 @@ public class ShadowAccessibilityNodeInfo {
     shadowObtained.performedActionAndArgsList = new LinkedList<>();
 
     shadowObtained.view = view;
-    obtainedInstances.put(
-        new StrictEqualityNodeWrapper(obtainedInstance), Thread.currentThread().getStackTrace());
+    sAllocationCount++;
+    StrictEqualityNodeWrapper wrapper = new StrictEqualityNodeWrapper(obtainedInstance);
+    obtainedInstances.put(wrapper, Thread.currentThread().getStackTrace());
+    orderedInstance.put(sAllocationCount, wrapper);
+    ReflectionHelpers.setStaticField(
+        AccessibilityNodeInfo.class, "CREATOR", ShadowAccessibilityNodeInfo.CREATOR);
     return obtainedInstance;
   }
 
@@ -158,6 +186,7 @@ public class ShadowAccessibilityNodeInfo {
    */
   public static void resetObtainedInstances() {
     obtainedInstances.clear();
+    orderedInstance.clear();
   }
 
   @Implementation
@@ -177,6 +206,15 @@ public class ShadowAccessibilityNodeInfo {
     }
 
     obtainedInstances.remove(wrapper);
+    int keyOfWrapper = -1;
+    for (int i = 0; i < orderedInstance.size(); i++) {
+      int key = orderedInstance.keyAt(i);
+      if (orderedInstance.get(key).equals(wrapper)) {
+        keyOfWrapper = key;
+        break;
+      }
+    }
+    orderedInstance.remove(keyOfWrapper);
   }
 
   @Implementation
@@ -670,4 +708,22 @@ public class ShadowAccessibilityNodeInfo {
     // Dummy class, this was added in API21
   }
 #end
+  @Implementation
+  public int describeContents() {
+    return 0;
+  }
+
+  @Implementation
+  public void writeToParcel(Parcel dest, int flags) {
+    StrictEqualityNodeWrapper wrapper = new StrictEqualityNodeWrapper(realAccessibilityNodeInfo);
+    int keyofWrapper = -1;
+    for (int i = 0; i < orderedInstance.size(); i++) {
+      int key = orderedInstance.keyAt(i);
+      if (orderedInstance.get(key).equals(wrapper)) {
+         keyofWrapper = key;
+         break;
+      }
+    }
+    dest.writeInt(keyofWrapper);
+  }
 }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java.vm
@@ -45,7 +45,7 @@ public class ShadowAccessibilityNodeInfo {
 
     @Override
     public AccessibilityNodeInfo createFromParcel(Parcel source) {
-      return obtain(orderedInstances.valueAt(source.readInt()).mInfo);
+      return obtain(orderedInstances.get(source.readInt()).mInfo);
     }
 
     @Override
@@ -718,13 +718,13 @@ public class ShadowAccessibilityNodeInfo {
   @Implementation
   public void writeToParcel(Parcel dest, int flags) {
     StrictEqualityNodeWrapper wrapper = new StrictEqualityNodeWrapper(realAccessibilityNodeInfo);
-    int indexOfWrapper = -1;
+    int keyOfWrapper = -1;
     for (int i = 0; i < orderedInstances.size(); i++) {
       if (orderedInstances.valueAt(i).equals(wrapper)) {
-        indexOfWrapper = i;
+        keyOfWrapper = orderedInstances.keyAt(i);
         break;
       }
     }
-    dest.writeInt(indexOfWrapper);
+    dest.writeInt(keyOfWrapper);
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityWindowInfo.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityWindowInfo.java.vm
@@ -1,14 +1,17 @@
 package org.robolectric.shadows;
-
 #if ($api >= 21)
-
 import android.graphics.Rect;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.accessibility.AccessibilityWindowInfo;
 
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.internal.ShadowExtractor;
 import org.robolectric.util.ReflectionHelpers;
+
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Shadow of {@link android.view.accessibility.AccessibilityWindowInfo} that allows a test to set
@@ -16,33 +19,34 @@ import org.robolectric.util.ReflectionHelpers;
  */
 @Implements(AccessibilityWindowInfo.class)
 public class ShadowAccessibilityWindowInfo {
-  private AccessibilityNodeInfo rootNode;
+  private List<AccessibilityWindowInfo> children = null;
 
-  private int type = AccessibilityWindowInfo.TYPE_APPLICATION;
+  private AccessibilityWindowInfo parent = null;
+
+  private AccessibilityNodeInfo rootNode = null;
 
   private Rect boundsInScreen = new Rect();
 
-  private boolean isAccessibilityFocused;
+  private int type = AccessibilityWindowInfo.TYPE_APPLICATION;
 
-  private boolean isActive;
+  private int layer = 0;
 
-  private int id;
+  private int id = 0;
 
-  public void __constructor__() {
+  private boolean isAccessibilityFocused = false;
 
-  }
+  private boolean isActive = false;
+
+  private boolean isFocused = false;
+
+  @RealObject
+  private AccessibilityWindowInfo mRealAccessibilityWindowInfo;
+
+  public void __constructor__() {}
 
   @Implementation
   public static AccessibilityWindowInfo obtain() {
     return ReflectionHelpers.callConstructor(AccessibilityWindowInfo.class);
-  }
-
-  @Implementation
-  public AccessibilityNodeInfo getRoot() {
-    if (rootNode == null) {
-      return null;
-    }
-    return AccessibilityNodeInfo.obtain(rootNode);
   }
 
   @Implementation
@@ -51,13 +55,31 @@ public class ShadowAccessibilityWindowInfo {
   }
 
   @Implementation
-  public void getBoundsInScreen(Rect outBounds) {
-    outBounds.set(boundsInScreen);
+  public int getChildCount() {
+    if (children == null) {
+      return 0;
+    }
+
+    return children.size();
   }
 
   @Implementation
-  public boolean isAccessibilityFocused() {
-    return isAccessibilityFocused;
+  public AccessibilityWindowInfo getChild(int index) {
+    if (children == null) {
+      return null;
+    }
+
+    return children.get(index);
+  }
+
+  @Implementation
+  public AccessibilityWindowInfo getParent() {
+    return parent;
+  }
+
+  @Implementation
+  public AccessibilityNodeInfo getRoot() {
+    return (rootNode == null) ? null : AccessibilityNodeInfo.obtain(rootNode);
   }
 
   @Implementation
@@ -70,19 +92,45 @@ public class ShadowAccessibilityWindowInfo {
     return id;
   }
 
-  public void setRoot(AccessibilityNodeInfo root) {
-    if (rootNode != null) {
-      rootNode.recycle();
+  @Implementation
+  public void getBoundsInScreen(Rect outBounds) {
+    if (boundsInScreen == null) {
+      outBounds.setEmpty();
+    } else {
+      outBounds.set(boundsInScreen);
     }
-    rootNode = AccessibilityNodeInfo.obtain(root);
   }
 
-  public void setType(int t) {
-    type = t;
+  @Implementation
+  public int getLayer() {
+    return layer;
   }
 
-  public void setBoundsInScreen(Rect b) {
-    boundsInScreen.set(b);
+  @Implementation
+  public boolean isFocused() {
+    return isFocused;
+  }
+
+  @Implementation
+  public boolean isAccessibilityFocused() {
+    return isAccessibilityFocused;
+  }
+
+  @Implementation
+  public void recycle() {
+    // This shadow does not track recycling of windows.
+  }
+
+  public void setRoot(AccessibilityNodeInfo root) {
+    rootNode = root;
+  }
+
+  public void setType(int value) {
+    type = value;
+  }
+
+  public void setBoundsInScreen(Rect bounds) {
+    boundsInScreen.set(bounds);
   }
 
   public void setAccessibilityFocused(boolean value) {
@@ -95,6 +143,24 @@ public class ShadowAccessibilityWindowInfo {
 
   public void setId(int value) {
     id = value;
+  }
+
+  public void setLayer(int value) {
+    layer = value;
+  }
+
+  public void setFocused(boolean focused) {
+    isFocused = focused;
+  }
+
+  public void addChild(AccessibilityWindowInfo child) {
+    if (children == null) {
+      children = new LinkedList<>();
+    }
+
+    children.add(child);
+    ((ShadowAccessibilityWindowInfo) ShadowExtractor.extract(child)).parent =
+        mRealAccessibilityWindowInfo;
   }
 }
 #else

--- a/robolectric/pom.xml
+++ b/robolectric/pom.xml
@@ -131,6 +131,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-Xmx2048m -XX:MaxPermSize=1024m</argLine>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/robolectric/src/main/java/org/robolectric/internal/runtime/RuntimeAdapterFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/runtime/RuntimeAdapterFactory.java
@@ -2,18 +2,21 @@ package org.robolectric.internal.runtime;
 
 import android.os.Build;
 
+import org.robolectric.RuntimeEnvironment;
+
 public class RuntimeAdapterFactory {
   public static RuntimeAdapter getInstance() {
-    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN) {
+    int apiLevel = RuntimeEnvironment.getApiLevel();
+    if (apiLevel <= Build.VERSION_CODES.JELLY_BEAN) {
       return new Api16RuntimeAdapter();
-    } else if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+    } else if (apiLevel <= Build.VERSION_CODES.JELLY_BEAN_MR1) {
       return new Api17RuntimeAdapter();
-    } else if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+    } else if (apiLevel <= Build.VERSION_CODES.KITKAT) {
       return new Api19RuntimeAdapter();
-    } else if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP) {
+    } else if (apiLevel <= Build.VERSION_CODES.LOLLIPOP) {
       return new Api21RuntimeAdapter();
     } else {
-      throw new RuntimeException("Could not find AndroidRuntimeAdapter for API level: " + Build.VERSION.SDK_INT);
+      throw new RuntimeException("Could not find AndroidRuntimeAdapter for API level: " + apiLevel);
     }
   }
 }

--- a/robolectric/src/main/java/org/robolectric/util/ActivityController.java
+++ b/robolectric/src/main/java/org/robolectric/util/ActivityController.java
@@ -184,13 +184,18 @@ public class ActivityController<T extends Activity> extends ComponentController<
     });
 
     ViewRootImpl root = component.getWindow().getDecorView().getViewRootImpl();
-    Display display = Shadow.newInstanceOf(Display.class);
-    Rect frame = new Rect();
-    display.getRectSize(frame);
-    Rect insets = new Rect(0, 0, 0, 0);
-    final RuntimeAdapter runtimeAdapter = RuntimeAdapterFactory.getInstance();
-    runtimeAdapter.callViewRootImplDispatchResized(
-        root, frame, insets, insets, insets, insets, insets, true, null);
+    if (root != null) {
+      // If a test pause thread before creating an activity, root will be null as runPaused is waiting
+      // Related to issue #1582
+      Display display = Shadow.newInstanceOf(Display.class);
+      Rect frame = new Rect();
+      display.getRectSize(frame);
+      Rect insets = new Rect(0, 0, 0, 0);
+      final RuntimeAdapter runtimeAdapter = RuntimeAdapterFactory.getInstance();
+      runtimeAdapter.callViewRootImplDispatchResized(
+          root, frame, insets, insets, insets, insets, insets, true, null);
+    }
+
     return this;
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityEventTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityEventTest.java
@@ -1,8 +1,7 @@
 package org.robolectric.shadows;
 
+import android.os.Parcel;
 import android.view.accessibility.AccessibilityEvent;
-import android.view.accessibility.AccessibilityNodeInfo;
-import android.view.accessibility.AccessibilityWindowInfo;
 
 import org.junit.After;
 import org.junit.Before;
@@ -39,6 +38,18 @@ public class ShadowAccessibilityEventTest {
     AccessibilityEvent newEvent = ShadowAccessibilityEvent.obtain(event);
     assertThat(shadow.equals(newEvent)).isEqualTo(true);
     newEvent.recycle();
+  }
+
+  @Test
+  public void shouldWriteAndReadFromParcelCorrectly() {
+    Parcel p = Parcel.obtain();
+    event.setContentDescription("test");
+    event.writeToParcel(p, 0);
+    p.setDataPosition(0);
+    AccessibilityEvent anotherEvent = AccessibilityEvent.CREATOR.createFromParcel(p);
+    assertThat(event).isEqualTo(anotherEvent);
+    event.setContentDescription(null);
+    anotherEvent.recycle();
   }
 
   @After

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityNodeInfoTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityNodeInfoTest.java
@@ -1,7 +1,9 @@
 package org.robolectric.shadows;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
+import android.os.Parcel;
 import android.view.accessibility.AccessibilityNodeInfo;
 
 import org.junit.After;
@@ -28,6 +30,23 @@ public class ShadowAccessibilityNodeInfoTest {
   @Test
   public void shouldHaveObtainedNode() {
     assertThat(ShadowAccessibilityNodeInfo.areThereUnrecycledNodes(false)).isEqualTo(true);
+  }
+
+  @Test
+  public void ShouldHaveClonedCorrectly() {
+    AccessibilityNodeInfo anotherNode = AccessibilityNodeInfo.obtain(node);
+    assertEquals(node, anotherNode);
+  }
+
+  @Test
+  public void shouldWriteAndReadFromParcelCorrectly() {
+    Parcel p = Parcel.obtain();
+    node.setContentDescription("test");
+    node.writeToParcel(p, 0);
+    p.setDataPosition(0);
+    AccessibilityNodeInfo anotherNode = AccessibilityNodeInfo.CREATOR.createFromParcel(p);
+    assertThat(node).isEqualTo(anotherNode);
+    node.setContentDescription(null);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/util/ActivityControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/ActivityControllerTest.java
@@ -16,6 +16,9 @@ import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 import org.robolectric.annotation.Config;
+import org.robolectric.internal.runtime.Api19RuntimeAdapter;
+import org.robolectric.internal.runtime.RuntimeAdapter;
+import org.robolectric.internal.runtime.RuntimeAdapterFactory;
 import org.robolectric.shadows.CoreShadowsAdapter;
 import org.robolectric.shadows.ShadowLooper;
 
@@ -193,6 +196,16 @@ public class ActivityControllerTest {
   public void attach_shouldWorkWithAPI19() {
     MyActivity activity = Robolectric.buildActivity(MyActivity.class).create().get();
     assertThat(activity).isNotNull();
+  }
+
+  @Test
+  @Config(sdk = Build.VERSION_CODES.KITKAT)
+  public void shouldUseCorrectRuntimeAdapter() {
+    ReflectionHelpers.setStaticField(Build.VERSION.class, "SDK_INT", 15);
+    MyActivity activity = Robolectric.buildActivity(MyActivity.class).setup().get();
+    assertThat(activity).isNotNull();
+    RuntimeAdapter adapter = RuntimeAdapterFactory.getInstance();
+    assertThat(adapter.getClass().getName()).isEqualTo(Api19RuntimeAdapter.class.getName());
   }
 
   public static class MyActivity extends Activity {


### PR DESCRIPTION
We have seen users trying to test on android-15 by setting Build.SDK_INT to 15 which is not supported, this is not the right way to define API level so the test can still be compiled without warning/error. This causes api level difference between the android.jar and RuntimeAdapter, which results in runtime errors. 

ActivityController setUp ViewRootImpl of a window in runPause, if a test pause thread before initializing an activity (because of #1582 for instance). ViewRootImpl will be null then we can't call dispatchResized.
@jongerrish Please take a look at the change. 

Making a11y shadows parcelable. 