### PR TITLE
Saving apiLevel in RuntimeEnvironment

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
+++ b/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
@@ -3,7 +3,6 @@ package org.robolectric;
 import android.app.Application;
 import android.content.pm.PackageManager;
 
-import org.robolectric.res.ResBundle;
 import org.robolectric.res.builder.RobolectricPackageManager;
 
 public class RuntimeEnvironment {
@@ -12,6 +11,7 @@ public class RuntimeEnvironment {
     private static String qualifiers;
     private static Object activityThread;
     private static RobolectricPackageManager packageManager;
+    private static int apiLevel;
 
     public static Object getActivityThread() {
         return activityThread;
@@ -44,7 +44,11 @@ public class RuntimeEnvironment {
         qualifiers = newQualifiers;
     }
 
+    public static void setApiLevel(int level) {
+        apiLevel = level;
+    }
+
     public static int getApiLevel() {
-      return ResBundle.getVersionQualifierApiLevel(qualifiers);
+        return apiLevel;
     }
 }

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -88,6 +88,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
     shadowsAdapter.overrideQualifiers(configuration, qualifiers);
     systemResources.updateConfiguration(configuration, systemResources.getDisplayMetrics());
     RuntimeEnvironment.setQualifiers(qualifiers);
+    RuntimeEnvironment.setApiLevel(sdkConfig.getApiLevel());
 
     Class<?> contextImplClass = ReflectionHelpers.loadClass(getClass().getClassLoader(), shadowsAdapter.getShadowContextImplClassName());
 


### PR DESCRIPTION
This is to prevent test failures due to users setting SDK_INT or version qualifer with Reflection/Config to apis Robolectric doesn't support.