### PR TITLE
Modified the resolution of resource folders to a local context

### DIFF
--- a/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
@@ -14,20 +14,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RobolectricGradleTestRunnerTest {
   @Rule
   public ExpectedException exception = ExpectedException.none();
+  private final static String TEST_SUBJECT_LOCATION = RobolectricGradleTestRunner.class.getProtectionDomain().getCodeSource().getLocation().getFile();
 
   @Before
   public void setup() {
-    FileFsFile.from("build", "intermediates", "res").getFile().mkdirs();
-    FileFsFile.from("build", "intermediates", "assets").getFile().mkdirs();
-    FileFsFile.from("build", "intermediates", "manifests").getFile().mkdirs();
+    FileFsFile.from(TEST_SUBJECT_LOCATION, "res").getFile().mkdirs();
+    FileFsFile.from(TEST_SUBJECT_LOCATION, "assets").getFile().mkdirs();
+    FileFsFile.from(TEST_SUBJECT_LOCATION, "manifests").getFile().mkdirs();
   }
 
   @After
   public void teardown() throws IOException {
-    delete(FileFsFile.from("build", "intermediates", "res").getFile());
-    delete(FileFsFile.from("build", "intermediates", "assets").getFile());
-    delete(FileFsFile.from("build", "intermediates", "manifests").getFile());
-    delete(FileFsFile.from("build", "intermediates", "res", "merged").getFile());
+    delete(FileFsFile.from(TEST_SUBJECT_LOCATION, "res").getFile());
+    delete(FileFsFile.from(TEST_SUBJECT_LOCATION, "assets").getFile());
+    delete(FileFsFile.from(TEST_SUBJECT_LOCATION, "manifests").getFile());
+    delete(FileFsFile.from(TEST_SUBJECT_LOCATION, "res", "merged").getFile());
+    delete(FileFsFile.from(TEST_SUBJECT_LOCATION, "bundles").getFile());
   }
 
   private static String convertPath(String path) {
@@ -40,24 +42,25 @@ public class RobolectricGradleTestRunnerTest {
     final AndroidManifest manifest = runner.getAppManifest(runner.getConfig(ConstantsTest.class.getMethod("withoutAnnotation")));
 
     assertThat(manifest.getPackageName()).isEqualTo("org.sandwich.foo");
-    assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("build/intermediates/res/flavor1/type1"));
-    assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("build/intermediates/assets/flavor1/type1"));
-    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("build/intermediates/manifests/full/flavor1/type1/AndroidManifest.xml"));
+    assertThat(manifest.getResDirectory().getPath()).endsWith(convertPath("/res/flavor1/type1"));
+    assertThat(manifest.getAssetsDirectory().getPath()).endsWith(convertPath("/assets/flavor1/type1"));
+    assertThat(manifest.getAndroidManifestFile().getPath()).endsWith(convertPath("/manifests/full/flavor1/type1/AndroidManifest.xml"));
   }
 
   @Test
   public void getAppManifest_forLibraries_shouldCreateManifest() throws Exception {
-    delete(FileFsFile.from("build", "intermediates", "res").getFile());
-    delete(FileFsFile.from("build", "intermediates", "assets").getFile());
-    delete(FileFsFile.from("build", "intermediates", "manifests").getFile());
+    delete(FileFsFile.from(TEST_SUBJECT_LOCATION, "res").getFile());
+    delete(FileFsFile.from(TEST_SUBJECT_LOCATION, "assets").getFile());
+    delete(FileFsFile.from(TEST_SUBJECT_LOCATION, "manifests").getFile());
+    FileFsFile.from(TEST_SUBJECT_LOCATION, "bundles").getFile().mkdirs();
 
     final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(ConstantsTest.class);
     final AndroidManifest manifest = runner.getAppManifest(runner.getConfig(ConstantsTest.class.getMethod("withoutAnnotation")));
 
     assertThat(manifest.getPackageName()).isEqualTo("org.sandwich.foo");
-    assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("build/intermediates/bundles/flavor1/type1/res"));
-    assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("build/intermediates/bundles/flavor1/type1/assets"));
-    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("build/intermediates/bundles/flavor1/type1/AndroidManifest.xml"));
+    assertThat(manifest.getResDirectory().getPath()).endsWith(convertPath("/flavor1/type1/res"));
+    assertThat(manifest.getAssetsDirectory().getPath()).endsWith(convertPath("/flavor1/type1/assets"));
+    assertThat(manifest.getAndroidManifestFile().getPath()).endsWith(convertPath("/flavor1/type1/AndroidManifest.xml"));
   }
 
   @Test
@@ -66,9 +69,9 @@ public class RobolectricGradleTestRunnerTest {
     final AndroidManifest manifest = runner.getAppManifest(runner.getConfig(ConstantsTest.class.getMethod("withOverrideAnnotation")));
 
     assertThat(manifest.getPackageName()).isEqualTo("org.sandwich.bar");
-    assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("build/intermediates/res/flavor2/type2"));
-    assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("build/intermediates/assets/flavor2/type2"));
-    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("build/intermediates/manifests/full/flavor2/type2/AndroidManifest.xml"));
+    assertThat(manifest.getResDirectory().getPath()).endsWith(convertPath("/res/flavor2/type2"));
+    assertThat(manifest.getAssetsDirectory().getPath()).endsWith(convertPath("/assets/flavor2/type2"));
+    assertThat(manifest.getAndroidManifestFile().getPath()).endsWith(convertPath("/manifests/full/flavor2/type2/AndroidManifest.xml"));
   }
 
   @Test
@@ -77,22 +80,22 @@ public class RobolectricGradleTestRunnerTest {
     final AndroidManifest manifest = runner.getAppManifest(runner.getConfig(PackageNameTest.class.getMethod("withoutAnnotation")));
 
     assertThat(manifest.getPackageName()).isEqualTo("fake.package.name");
-    assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("build/intermediates/res/flavor1/type1"));
-    assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("build/intermediates/assets/flavor1/type1"));
-    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("build/intermediates/manifests/full/flavor1/type1/AndroidManifest.xml"));
+    assertThat(manifest.getResDirectory().getPath()).endsWith(convertPath("/res/flavor1/type1"));
+    assertThat(manifest.getAssetsDirectory().getPath()).endsWith(convertPath("/assets/flavor1/type1"));
+    assertThat(manifest.getAndroidManifestFile().getPath()).endsWith(convertPath("/manifests/full/flavor1/type1/AndroidManifest.xml"));
   }
 
   @Test
   public void getAppManifest_withMergedResources_shouldHaveMergedResPath() throws Exception {
-    FileFsFile.from("build", "intermediates", "res", "merged").getFile().mkdirs();
+    FileFsFile.from(TEST_SUBJECT_LOCATION, "res", "merged").getFile().mkdirs();
 
     final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(PackageNameTest.class);
     final AndroidManifest manifest = runner.getAppManifest(runner.getConfig(PackageNameTest.class.getMethod("withoutAnnotation")));
 
     assertThat(manifest.getPackageName()).isEqualTo("fake.package.name");
-    assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("build/intermediates/res/merged/flavor1/type1"));
-    assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("build/intermediates/assets/flavor1/type1"));
-    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("build/intermediates/manifests/full/flavor1/type1/AndroidManifest.xml"));
+    assertThat(manifest.getResDirectory().getPath()).endsWith(convertPath("/res/merged/flavor1/type1"));
+    assertThat(manifest.getAssetsDirectory().getPath()).endsWith(convertPath("/assets/flavor1/type1"));
+    assertThat(manifest.getAndroidManifestFile().getPath()).endsWith(convertPath("/manifests/full/flavor1/type1/AndroidManifest.xml"));
   }
 
   @Test


### PR DESCRIPTION
As mentioned in [Running-tests-in-Android-Studio] [1] there is a bug with Mac where the working directory of the test configuration has to be set up manually. This is a problem when using TDD when you have to often switch from different tests, so it can be a bit of a nuisance.

With this PR I have changed the way that the location of the resources are located in the `getAppManifest(Config)` method inside `RobolectricGradleTestRunner`. This relies on the location of the generated source to figure out where the resources are (potentially a more resilient method)

I've only tested this on Mac (both AS and command line) and it seems to work ok.

Also, I may raise it as a feature request but maybe makes sense to move the gradle specific classes to a separate repository so they can be updated independently from the main project.

[1]: https://github.com/robolectric/robolectric/wiki/Running-tests-in-Android-Studio