### PR TITLE
Update ShadowAlarmManager.java.vm

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAlarmManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAlarmManager.java.vm
@@ -45,9 +45,12 @@ public class ShadowAlarmManager {
     Intent intent = Shadows.shadowOf(operation).getSavedIntent();
     for (ScheduledAlarm scheduledAlarm : scheduledAlarms) {
       Intent scheduledIntent = Shadows.shadowOf(scheduledAlarm.operation).getSavedIntent();
-      if (scheduledIntent.filterEquals(intent)) {
-        scheduledAlarms.remove(scheduledAlarm);
-        break;
+      long intentTriggerTime = scheduledAlarm.triggerAtTime;
+      if (triggerAtTime == intentTriggerTime) {
+        if (scheduledIntent.filterEquals(intent)) {
+          scheduledAlarms.remove(scheduledAlarm);
+          break;
+        }
       }
     }
     scheduledAlarms.add(new ScheduledAlarm(type, triggerAtTime, interval, operation));


### PR DESCRIPTION
Shadowing of this class is done not really correctly. I was using it for testing the alarms. I had to set up alarms at different time that will start the same BroadcastReceiver. The alarms fire properly one after each other but the ShadowAlarmManager cancels the ones that was scheduled before and shows that only one alarm was scheduled. It happens because the Intent.filterEquals() returns true in this case but it doesn't check if the time is the same.