### PR TITLE
Fixed malformed POM that maven was complaining about

### DIFF
--- a/robolectric-shadows/shadows-core/pom.xml
+++ b/robolectric-shadows/shadows-core/pom.xml
@@ -453,31 +453,31 @@
                 <configuration>
                   <artifacts>
                     <artifact>
-                      <file>dist/shadows-core-${version}-16.jar</file>
+                      <file>dist/shadows-core-${project.version}-16.jar</file>
                       <type>jar</type>
                       <classifier>16</classifier>
                     </artifact>
 
                     <artifact>
-                      <file>dist/shadows-core-${version}-17.jar</file>
+                      <file>dist/shadows-core-${project.version}-17.jar</file>
                       <type>jar</type>
                       <classifier>17</classifier>
                     </artifact>
 
                     <artifact>
-                      <file>dist/shadows-core-${version}-18.jar</file>
+                      <file>dist/shadows-core-${project.version}-18.jar</file>
                       <type>jar</type>
                       <classifier>18</classifier>
                     </artifact>
 
                     <artifact>
-                      <file>dist/shadows-core-${version}-19.jar</file>
+                      <file>dist/shadows-core-${project.version}-19.jar</file>
                       <type>jar</type>
                       <classifier>19</classifier>
                     </artifact>
 
                     <artifact>
-                      <file>dist/shadows-core-${version}-21.jar</file>
+                      <file>dist/shadows-core-${project.version}-21.jar</file>
                       <type>jar</type>
                       <classifier>21</classifier>
                     </artifact>


### PR DESCRIPTION
Cleans up some warnings when maven builds the shadows-core variants.