### PR TITLE
Add ability to switch main thread & get JUnit timeouts working

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
+++ b/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
@@ -6,49 +6,94 @@ import android.content.pm.PackageManager;
 import org.robolectric.res.builder.RobolectricPackageManager;
 
 public class RuntimeEnvironment {
-    public static Application application;
+  public static Application application;
 
-    private static String qualifiers;
-    private static Object activityThread;
-    private static RobolectricPackageManager packageManager;
-    private static int apiLevel;
+  private volatile static Thread mainThread = Thread.currentThread();
+  private static String qualifiers;
+  private static Object activityThread;
+  private static RobolectricPackageManager packageManager;
+  private static int apiLevel;
 
-    public static Object getActivityThread() {
-        return activityThread;
+  /**
+   * Tests if the given thread is currently set as the main thread.
+   *
+   * @param thread the thread to test.
+   * @return <tt>true</tt> if the specified thread is the main thread, <tt>false</tt> otherwise.
+   * @see #isMainThread()
+   */
+  public static boolean isMainThread(Thread thread) {
+    return thread == mainThread;
+  }
+
+  /**
+   * Tests if the current thread is currently set as the main thread.
+   *
+   * @return <tt>true</tt> if the current thread is the main thread, <tt>false</tt> otherwise.
+   */
+  public static boolean isMainThread() {
+    return isMainThread(Thread.currentThread());
+  }
+
+  /**
+   * Retrieves the main thread. The main thread is the thread to which the main looper is attached.
+   * Defaults to the thread that initialises the <tt>RuntimeEnvironment</tt> class.
+   *
+   * @return The main thread.
+   * @see #setMainThread(Thread)
+   * @see #isMainThread()
+   */
+  public static Thread getMainThread() {
+    return mainThread;
+  }
+
+  /**
+   * Sets the main thread. The main thread is the thread to which the main looper is attached.
+   * Defaults to the thread that initialises the <tt>RuntimeEnvironment</tt> class.
+   *
+   * @param newMainThread the new main thread.
+   * @see #setMainThread(Thread)
+   * @see #isMainThread()
+   */
+  public static void setMainThread(Thread newMainThread) {
+    mainThread = newMainThread;
+  }
+
+  public static Object getActivityThread() {
+    return activityThread;
+  }
+
+  public static void setActivityThread(Object newActivityThread) {
+    activityThread = newActivityThread;
+  }
+
+  public static PackageManager getPackageManager() {
+    return (PackageManager) packageManager;
+  }
+
+  public static RobolectricPackageManager getRobolectricPackageManager() {
+    return packageManager;
+  }
+
+  public static void setRobolectricPackageManager(RobolectricPackageManager newPackageManager) {
+    if (packageManager != null) {
+      packageManager.reset();
     }
+    packageManager = newPackageManager;
+  }
 
-    public static void setActivityThread(Object newActivityThread) {
-        activityThread = newActivityThread;
-    }
+  public static String getQualifiers() {
+    return qualifiers;
+  }
 
-    public static PackageManager getPackageManager() {
-        return (PackageManager) packageManager;
-    }
+  public static void setQualifiers(String newQualifiers) {
+    qualifiers = newQualifiers;
+  }
 
-    public static RobolectricPackageManager getRobolectricPackageManager() {
-        return packageManager;
-    }
+  public static void setApiLevel(int level) {
+    apiLevel = level;
+  }
 
-    public static void setRobolectricPackageManager(RobolectricPackageManager newPackageManager) {
-      if (packageManager != null) {
-        packageManager.reset();
-      }
-      packageManager = newPackageManager;
-    }
-
-    public static String getQualifiers() {
-        return qualifiers;
-    }
-
-    public static void setQualifiers(String newQualifiers) {
-        qualifiers = newQualifiers;
-    }
-
-    public static void setApiLevel(int level) {
-        apiLevel = level;
-    }
-
-    public static int getApiLevel() {
-        return apiLevel;
-    }
+  public static int getApiLevel() {
+    return apiLevel;
+  }
 }

--- a/robolectric-resources/src/test/java/org/robolectric/RuntimeEnvironmentTest.java
+++ b/robolectric-resources/src/test/java/org/robolectric/RuntimeEnvironmentTest.java
@@ -1,0 +1,72 @@
+package org.robolectric;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RuntimeEnvironmentTest {
+  @Test
+  public void setMainThread_forCurrentThread() {
+    RuntimeEnvironment.setMainThread(Thread.currentThread());
+    assertThat(RuntimeEnvironment.getMainThread()).isSameAs(Thread.currentThread());
+  }
+
+  @Test
+  public void setMainThread_forNewThread() {
+    Thread t = new Thread();
+    RuntimeEnvironment.setMainThread(t);
+    assertThat(RuntimeEnvironment.getMainThread()).isSameAs(t);
+  }
+
+  @Test
+  public void isMainThread_forNewThread_withoutSwitch() throws InterruptedException {
+    final AtomicBoolean res = new AtomicBoolean();
+    final CountDownLatch finished = new CountDownLatch(1);
+    Thread t = new Thread() {
+      @Override
+      public void run() {
+        res.set(RuntimeEnvironment.isMainThread());
+        finished.countDown();
+      }
+    };
+    RuntimeEnvironment.setMainThread(Thread.currentThread());
+    t.start();
+    if (!finished.await(1000, MILLISECONDS)) {
+      throw new InterruptedException("Thread " + t + " didn't finish timely");
+    }
+    assertThat(RuntimeEnvironment.isMainThread()).as("testThread").isTrue();
+    assertThat(res.get()).as("thread t").isFalse();
+  }
+
+  @Test
+  public void isMainThread_forNewThread_withSwitch() throws InterruptedException {
+    final AtomicBoolean res = new AtomicBoolean();
+    final CountDownLatch finished = new CountDownLatch(1);
+    Thread t = new Thread() {
+      @Override
+      public void run() {
+        res.set(RuntimeEnvironment.isMainThread());
+        finished.countDown();
+      }
+    };
+    RuntimeEnvironment.setMainThread(t);
+    t.start();
+    if (!finished.await(1000, MILLISECONDS)) {
+      throw new InterruptedException("Thread " + t + " didn't finish timely");
+    }
+    assertThat(RuntimeEnvironment.isMainThread()).as("testThread").isFalse();
+    assertThat(res.get()).as("thread t").isTrue();
+  }
+
+  @Test
+  public void isMainThread_withArg_forNewThread_withSwitch() throws InterruptedException {
+    Thread t = new Thread();
+    RuntimeEnvironment.setMainThread(t);
+    assertThat(RuntimeEnvironment.isMainThread(t)).isTrue();
+  }
+}

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
@@ -31,6 +31,7 @@ public class ShadowMessageQueue {
   @RealObject
   private MessageQueue realQueue;
 
+  private Scheduler scheduler = new Scheduler();
 #if ($api >= 21)
 #set($recycle = "recycleUnchecked")
 #else
@@ -68,6 +69,10 @@ public class ShadowMessageQueue {
     return false;
   }
 
+  public Scheduler getScheduler() {
+    return scheduler;
+  }
+
   public Message getHead() {
     return getField(realQueue, "mMessages");
   }
@@ -78,13 +83,13 @@ public class ShadowMessageQueue {
 
   public void reset() {
     setHead(null);
+    scheduler = new Scheduler();
   }
   
   @Implementation
   public boolean enqueueMessage(final Message msg, long when) {
     final boolean retval = directlyOn(realQueue, MessageQueue.class, "enqueueMessage", from(Message.class, msg), from(long.class, when));
     if (retval) {
-      final Scheduler scheduler = shadowOf(msg.getTarget().getLooper()).getScheduler();
       final Runnable callback = new Runnable() {
         @Override
         public void run() {

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -41,6 +41,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
 
   @Override
   public void resetStaticState(Config config) {
+    RuntimeEnvironment.setMainThread(Thread.currentThread());
     Robolectric.reset();
 
     if (!loggingInitialized) {
@@ -67,6 +68,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
   @Override
   public void setUpApplicationState(Method method, TestLifecycle testLifecycle, ResourceLoader systemResourceLoader, AndroidManifest appManifest, Config config) {
     RuntimeEnvironment.application = null;
+    RuntimeEnvironment.setMainThread(Thread.currentThread());
     RuntimeEnvironment.setRobolectricPackageManager(new DefaultPackageManager(shadowsAdapter));
     RuntimeEnvironment.getRobolectricPackageManager().addPackage(DEFAULT_PACKAGE_NAME);
     ResourceLoader resourceLoader;
@@ -94,6 +96,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
 
     Class<?> activityThreadClass = ReflectionHelpers.loadClass(getClass().getClassLoader(), shadowsAdapter.getShadowActivityThreadClassName());
     // Looper needs to be prepared before the activity thread is created
+//    if (Looper.getMainLooper() == null) {
     if (Looper.myLooper() == null) {
       Looper.prepareMainLooper();
     }
@@ -145,6 +148,16 @@ public class ParallelUniverse implements ParallelUniverseInterface {
       RuntimeEnvironment.application = application;
       application.onCreate();
     }
+  }
+
+  @Override
+  public Thread getMainThread() {
+    return RuntimeEnvironment.getMainThread();
+  }
+
+  @Override
+  public void setMainThread(Thread newMainThread) {
+    RuntimeEnvironment.setMainThread(newMainThread);
   }
 
   @Override

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverseInterface.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverseInterface.java
@@ -11,9 +11,14 @@ public interface ParallelUniverseInterface {
 
   void setUpApplicationState(Method method, TestLifecycle testLifecycle, ResourceLoader systemResourceLoader, AndroidManifest appManifest, Config config);
 
+  Thread getMainThread();
+
+  void setMainThread(Thread newMainThread);
+
   void tearDownApplication();
 
   Object getCurrentApplication();
 
   void setSdkConfig(SdkConfig sdkConfig);
+
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
@@ -6,7 +6,6 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -205,7 +204,6 @@ public class ShadowLooperTest {
     assertThat(test.hasContinued).as("hasContinued:after").isTrue();
   }
  
-  @Ignore("Not yet implemented (ref #1407)") 
   @Test(timeout = 1000)
   public void whenTestHarnessUsesDifferentThread_shouldStillHaveMainLooper() {
     assertThat(Looper.myLooper()).isNotNull();
@@ -248,8 +246,27 @@ public class ShadowLooperTest {
 
   @Test
   public void getMainLooperReturnsNonNullOnMainThreadWhenRobolectricApplicationIsNull() {
-      RuntimeEnvironment.application = null;
-      assertThat(Looper.getMainLooper()).isNotNull();
+    RuntimeEnvironment.application = null;
+    assertThat(Looper.getMainLooper()).isNotNull();
+  }
+
+  @Test
+  public void myLooper_returnsMainLooper_ifMainThreadIsSwitched() throws InterruptedException {
+    final AtomicReference<Looper> myLooper = new AtomicReference<>();
+    Thread t = new Thread(testName.getMethodName()) {
+      @Override
+      public void run() {
+        myLooper.set(Looper.myLooper());
+      }
+    };
+    RuntimeEnvironment.setMainThread(t);
+    t.start();
+    try {
+      t.join(1000);
+      assertThat(myLooper.get()).isSameAs(Looper.getMainLooper());
+    } finally {
+      RuntimeEnvironment.setMainThread(Thread.currentThread());
+    }
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
@@ -6,7 +6,6 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
 
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -200,10 +199,10 @@ public class ShadowLooperTest {
   @Test
   public void resetThreadLoopers_shouldQuitAllNonMainLoopers() throws InterruptedException {
     QuitThread test = getQuitThread();
-    assertThat(test.hasContinued).isFalse();
+    assertThat(test.hasContinued).as("hasContinued:before").isFalse();
     ShadowLooper.resetThreadLoopers();
     test.join(5000);
-    assertThat(test.hasContinued).isTrue();
+    assertThat(test.hasContinued).as("hasContinued:after").isTrue();
   }
  
   @Ignore("Not yet implemented (ref #1407)") 


### PR DESCRIPTION
Added ability to change the thread that is associated with the main looper. This feature was added primarily to facilitate solving #1407 - the timeout feature causes the test to run on a different thread from what the rest of the `ParallelUniverse` setup code runs, which means that if you call `myLooper()` you don't get the main looper as you would without the timeout. Using the switch thread feature, I was able to add a hook in the test runner so that the main thread would be switched to the current thread (whatever that thread happens to be) just before the test method was invoked, so that the test thread would again be linked to the main looper.

There may be other use cases for the switch main thread feature, though I can't think of any at present.

Of slightly less importance, I also fixed the indentation of `RuntimeEnvironment` to bring it into line with the Robolectric 2-char standard.