### PR TITLE
Add ability to set callingPackageName of Activity

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -69,6 +69,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   private boolean mIsTaskRoot = true;
   private Menu optionsMenu;
   private Application testApplication;
+  private ComponentName callingActivity;
 
   public void __constructor__() {
     invokeConstructor(Activity.class, realActivity);
@@ -115,9 +116,13 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
     return getApplication();
   }
 
+  public void setCallingActivity(ComponentName activityName) {
+    callingActivity = activityName;
+  }
+
   @Implementation
   public ComponentName getCallingActivity() {
-    return null;
+    return callingActivity;
   }
 
   @Implementation

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
@@ -7,10 +7,7 @@ import android.app.Application;
 import android.app.Dialog;
 import android.app.Fragment;
 import android.appwidget.AppWidgetProvider;
-import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
-import android.content.SharedPreferences;
+import android.content.*;
 import android.content.pm.ActivityInfo;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteCursor;
@@ -815,6 +812,24 @@ public class ShadowActivityTest {
 
     assertThat(activity.getParentActivityIntent().getComponent().getClassName())
         .isEqualTo(ParentActivity.class.getName());
+  }
+
+  @Test
+  public void getCallingActivity_defaultsToNull() {
+    Activity activity = new Activity();
+
+    assertNull(activity.getCallingActivity());
+  }
+
+  @Test
+  public void getCallingActivity_returnsSetValue() {
+    Activity activity = new Activity();
+    ComponentName componentName = new ComponentName("com.example.package", "SomeActivity");
+
+    ShadowActivity shadowActivity = shadowOf(activity);
+    shadowActivity.setCallingActivity(componentName);
+
+    assertEquals(componentName, activity.getCallingActivity());
   }
 
   /////////////////////////////


### PR DESCRIPTION
This is useful for testing Activities that need to return a result to a caller, but may change their behaviour based on the identity of the calling app.