### PR TITLE
ShadowAlarmManager fix

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAlarmManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAlarmManager.java.vm
@@ -45,9 +45,12 @@ public class ShadowAlarmManager {
     Intent intent = Shadows.shadowOf(operation).getSavedIntent();
     for (ScheduledAlarm scheduledAlarm : scheduledAlarms) {
       Intent scheduledIntent = Shadows.shadowOf(scheduledAlarm.operation).getSavedIntent();
-      if (scheduledIntent.filterEquals(intent)) {
-        scheduledAlarms.remove(scheduledAlarm);
-        break;
+      long intentTriggerTime = scheduledAlarm.triggerAtTime;
+      if (triggerAtTime == intentTriggerTime) {
+        if (scheduledIntent.filterEquals(intent)) {
+          scheduledAlarms.remove(scheduledAlarm);
+          break;
+        }
       }
     }
     scheduledAlarms.add(new ScheduledAlarm(type, triggerAtTime, interval, operation));

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
@@ -70,6 +70,16 @@ public class ShadowAlarmManagerTest {
   }
   
   @Test
+  public void setShouldNotReplaceAlarmsScheduledOnDifferentTime() {
+    Intent intent = new Intent(activity, activity.getClass());
+    long firstAtMillis = 1;
+    long secondAtMillis = 2;
+    alarmManager.set(AlarmManager.ELAPSED_REALTIME, firstAtMillis, PendingIntent.getActivity(activity, 0, intent, 0));
+    alarmManager.set(AlarmManager.ELAPSED_REALTIME, secondAtMillis, PendingIntent.getActivity(activity, 0, intent, 0));
+    assertEquals(2, shadowAlarmManager.getScheduledAlarms().size());
+  }
+
+  @Test
   public void setRepeatingShouldReplaceDuplicates() {
     alarmManager.setRepeating(AlarmManager.ELAPSED_REALTIME, 0, AlarmManager.INTERVAL_HOUR, PendingIntent.getActivity(activity, 0, new Intent(activity, activity.getClass()), 0));
     alarmManager.setRepeating(AlarmManager.ELAPSED_REALTIME, 0, AlarmManager.INTERVAL_HOUR, PendingIntent.getActivity(activity, 0, new Intent(activity, activity.getClass()), 0));


### PR DESCRIPTION
Shadowing of this class is done not really correctly. I was using it for testing the alarms. I had to set up alarms at different time that will start the same BroadcastReceiver. The alarms fire properly one after each other but the ShadowAlarmManager cancels the ones that was scheduled before and shows that only one alarm was scheduled. It happens because the Intent.filterEquals() returns true in this case but it doesn't check if the time is the same.