### PR TITLE
[Issue #2028] add null check for requestedPermissions 

### DIFF
--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -678,7 +678,7 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
   @Override
   public int checkPermission(String permName, String pkgName) {
     PackageInfo permissionsInfo = packageInfos.get(pkgName);
-    if (permissionsInfo == null) {
+    if (permissionsInfo == null || permissionsInfo.requestedPermissions == null) {
       return PackageManager.PERMISSION_DENIED;
     }
     for (String permission : permissionsInfo.requestedPermissions) {


### PR DESCRIPTION
Fixes: https://github.com/robolectric/robolectric/issues/2028

Add in null check for requestedPermissions in DefaultPackageManager.checkPermission()

Tests run and tested in my own local code where error was occurring and seems to resolve issue. 