### PR TITLE
Optional global scheduler

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/RoboSettings.java
+++ b/robolectric-resources/src/main/java/org/robolectric/RoboSettings.java
@@ -1,0 +1,21 @@
+package org.robolectric;
+
+/**
+ * Class that encapsulates reading global configuration options from the Java system properties file.
+ */
+public class RoboSettings {
+
+  private static boolean useGlobalScheduler;
+
+  static {
+    useGlobalScheduler = Boolean.getBoolean("robolectric.scheduling.global");
+  }
+
+  public static boolean isUseGlobalScheduler() {
+    return useGlobalScheduler;
+  }
+
+  public static void setUseGlobalScheduler(boolean useGlobalScheduler) {
+    RoboSettings.useGlobalScheduler = useGlobalScheduler;
+  }
+}

--- a/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
+++ b/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.pm.PackageManager;
 
 import org.robolectric.res.builder.RobolectricPackageManager;
+import org.robolectric.util.Scheduler;
 
 public class RuntimeEnvironment {
   public static Application application;
@@ -13,6 +14,7 @@ public class RuntimeEnvironment {
   private static Object activityThread;
   private static RobolectricPackageManager packageManager;
   private static int apiLevel;
+  private static Scheduler masterScheduler;
 
   /**
    * Tests if the given thread is currently set as the main thread.
@@ -95,5 +97,31 @@ public class RuntimeEnvironment {
 
   public static int getApiLevel() {
     return apiLevel;
+  }
+
+  /**
+   * Retrieves the current master scheduler. This scheduler is always used by the main
+   * {@link android.os.Looper Looper}, and if the global scheduler option is set it is also used for
+   * the background scheduler and for all other {@link android.os.Looper Looper}s
+   * @return The current master scheduler.
+   * @see #setMasterScheduler(Scheduler)
+   * @see Robolectric#getForegroundThreadScheduler
+   * @see Robolectric#getBackgroundThreadScheduler
+   */
+  public static Scheduler getMasterScheduler() {
+    return masterScheduler;
+  }
+
+  /**
+   * Sets the current master scheduler. See {@link #getMasterScheduler()} for details.
+   * Note that this method is primarily intended to be called by the Robolectric core setup code.
+   * Changing the master scheduler during a test will have unpredictable results.
+   * @param masterScheduler the new master scheduler.
+   * @see #getMasterScheduler()
+   * @see Robolectric#getForegroundThreadScheduler()
+   * @see Robolectric#getBackgroundThreadScheduler()
+   */
+  public static void setMasterScheduler(Scheduler masterScheduler) {
+    RuntimeEnvironment.masterScheduler = masterScheduler;
   }
 }

--- a/robolectric-resources/src/test/java/org/robolectric/RuntimeEnvironmentTest.java
+++ b/robolectric-resources/src/test/java/org/robolectric/RuntimeEnvironmentTest.java
@@ -1,6 +1,7 @@
 package org.robolectric;
 
 import org.junit.Test;
+import org.robolectric.util.Scheduler;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -68,5 +69,12 @@ public class RuntimeEnvironmentTest {
     Thread t = new Thread();
     RuntimeEnvironment.setMainThread(t);
     assertThat(RuntimeEnvironment.isMainThread(t)).isTrue();
+  }
+
+  @Test
+  public void getSetMasterScheduler() {
+    Scheduler s = new Scheduler();
+    RuntimeEnvironment.setMasterScheduler(s);
+    assertThat(RuntimeEnvironment.getMasterScheduler()).isSameAs(s);
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -29,6 +29,8 @@ import android.view.LayoutInflater;
 import android.widget.ListPopupWindow;
 import android.widget.PopupWindow;
 import android.widget.Toast;
+
+import org.robolectric.RoboSettings;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
@@ -71,7 +73,7 @@ public class ShadowApplication extends ShadowContextWrapper {
   private Map<String, Intent> stickyIntents = new LinkedHashMap<>();
   private Looper mainLooper = Looper.myLooper();
   private Handler mainHandler = new Handler(mainLooper);
-  private Scheduler backgroundScheduler = Boolean.getBoolean("robolectric.scheduling.advanced") ? getForegroundThreadScheduler() : new Scheduler();
+  private Scheduler backgroundScheduler = RoboSettings.isUseGlobalScheduler() ? getForegroundThreadScheduler() : new Scheduler();
   private Map<String, Map<String, Object>> sharedPreferenceMap = new HashMap<>();
   private ArrayList<Toast> shownToasts = new ArrayList<>();
   private PowerManager.WakeLock latestWakeLock;
@@ -170,7 +172,7 @@ public class ShadowApplication extends ShadowContextWrapper {
    * @return  Foreground scheduler.
    */
   public Scheduler getForegroundThreadScheduler() {
-    return ShadowLooper.getShadowMainLooper().getScheduler();
+    return RuntimeEnvironment.getMasterScheduler();
   }
 
   /**

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -71,7 +71,7 @@ public class ShadowApplication extends ShadowContextWrapper {
   private Map<String, Intent> stickyIntents = new LinkedHashMap<>();
   private Looper mainLooper = Looper.myLooper();
   private Handler mainHandler = new Handler(mainLooper);
-  private Scheduler backgroundScheduler = new Scheduler();
+  private Scheduler backgroundScheduler = Boolean.getBoolean("robolectric.scheduling.advanced") ? getForegroundThreadScheduler() : new Scheduler();
   private Map<String, Map<String, Object>> sharedPreferenceMap = new HashMap<>();
   private ArrayList<Toast> shownToasts = new ArrayList<>();
   private PowerManager.WakeLock latestWakeLock;
@@ -170,7 +170,7 @@ public class ShadowApplication extends ShadowContextWrapper {
    * @return  Foreground scheduler.
    */
   public Scheduler getForegroundThreadScheduler() {
-    return shadowOf(Looper.getMainLooper()).getScheduler();
+    return ShadowLooper.getShadowMainLooper().getScheduler();
   }
 
   /**

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
@@ -6,6 +6,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 
+import org.robolectric.RoboSettings;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -309,10 +311,10 @@ public class ShadowLooper {
 
   public void resetScheduler() {
     ShadowMessageQueue sQueue = shadowOf(realObject.getQueue());
-    if (this == getShadowMainLooper() || !Boolean.getBoolean("robolectric.scheduling.advanced")) {
-      sQueue.setScheduler(new Scheduler());
+    if (this == getShadowMainLooper() || RoboSettings.isUseGlobalScheduler()) {
+      sQueue.setScheduler(RuntimeEnvironment.getMasterScheduler());
     } else {
-      sQueue.setScheduler(getShadowMainLooper().getScheduler());
+      sQueue.setScheduler(new Scheduler());
     }
   }
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
@@ -72,6 +72,7 @@ public class ShadowLooper {
     } else {
       loopingLoopers.put(Thread.currentThread(), realObject);
     }
+    resetScheduler();
   }
 
   @Implementation
@@ -306,11 +307,22 @@ public class ShadowLooper {
     return wasPaused;
   }
 
+  public void resetScheduler() {
+    ShadowMessageQueue sQueue = shadowOf(realObject.getQueue());
+    if (this == getShadowMainLooper() || !Boolean.getBoolean("robolectric.scheduling.advanced")) {
+      sQueue.setScheduler(new Scheduler());
+    } else {
+      sQueue.setScheduler(getShadowMainLooper().getScheduler());
+    }
+  }
+
   /**
    * Causes all enqueued tasks to be discarded, and pause state to be reset
    */
   public void reset() {
     shadowOf(realObject.getQueue()).reset();
+    resetScheduler();
+
     quit = false;
   }
 

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowMessageQueue.java.vm
@@ -28,10 +28,12 @@ import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
  */
 @Implements(MessageQueue.class)
 public class ShadowMessageQueue {
+
   @RealObject
   private MessageQueue realQueue;
 
-  private Scheduler scheduler = new Scheduler();
+  private Scheduler scheduler;
+
 #if ($api >= 21)
 #set($recycle = "recycleUnchecked")
 #else
@@ -73,17 +75,20 @@ public class ShadowMessageQueue {
     return scheduler;
   }
 
+  public void setScheduler(Scheduler scheduler) {
+    this.scheduler = scheduler;
+  }
+
   public Message getHead() {
     return getField(realQueue, "mMessages");
   }
-  
+
   public void setHead(Message msg) {
     setField(realQueue, "mMessages", msg);
   }
 
   public void reset() {
     setHead(null);
-    scheduler = new Scheduler();
   }
   
   @Implementation

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -20,7 +20,9 @@ import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.ResBundle;
 import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.builder.DefaultPackageManager;
+import org.robolectric.shadows.ShadowLooper;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.Scheduler;
 
 import java.lang.reflect.Method;
 import java.security.Security;
@@ -68,6 +70,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
   @Override
   public void setUpApplicationState(Method method, TestLifecycle testLifecycle, ResourceLoader systemResourceLoader, AndroidManifest appManifest, Config config) {
     RuntimeEnvironment.application = null;
+    RuntimeEnvironment.setMasterScheduler(new Scheduler());
     RuntimeEnvironment.setMainThread(Thread.currentThread());
     RuntimeEnvironment.setRobolectricPackageManager(new DefaultPackageManager(shadowsAdapter));
     RuntimeEnvironment.getRobolectricPackageManager().addPackage(DEFAULT_PACKAGE_NAME);
@@ -100,6 +103,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
     if (Looper.myLooper() == null) {
       Looper.prepareMainLooper();
     }
+    ShadowLooper.getShadowMainLooper().resetScheduler();
     Object activityThread = ReflectionHelpers.newInstance(activityThreadClass);
     RuntimeEnvironment.setActivityThread(activityThread);
 

--- a/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
@@ -15,6 +15,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.internal.ParallelUniverse;
 import org.robolectric.internal.SdkConfig;
 import org.robolectric.res.builder.RobolectricPackageManager;
+import org.robolectric.shadows.ShadowApplication;
 
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -36,6 +37,27 @@ public class ParallelUniverseTest {
   public void setUp() throws InitializationError {
     pu = new ParallelUniverse(new RobolectricTestRunner(ParallelUniverseTest.class));
     pu.setSdkConfig(new SdkConfig(18));
+  }
+
+  @Test
+  public void setUpApplicationState_setsBackgroundScheduler_toBeSameAsForeground_whenAdvancedScheduling() {
+    System.setProperty("robolectric.scheduling.advanced", "true");
+    try {
+      pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, getDefaultConfig());
+      final ShadowApplication shadowApplication = Shadows.shadowOf(RuntimeEnvironment.application);
+      assertThat(shadowApplication.getBackgroundThreadScheduler())
+          .isSameAs(shadowApplication.getForegroundThreadScheduler());
+    } finally {
+      System.getProperties().remove("robolectric.scheduling.advanced");
+    }
+  }
+
+  @Test
+  public void setUpApplicationState_setsBackgroundScheduler_toBeDifferentToForeground_byDefault() {
+    pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, getDefaultConfig());
+    final ShadowApplication shadowApplication = Shadows.shadowOf(RuntimeEnvironment.application);
+    assertThat(shadowApplication.getBackgroundThreadScheduler())
+        .isNotSameAs(shadowApplication.getForegroundThreadScheduler());
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.DefaultTestLifecycle;
 import org.robolectric.R;
+import org.robolectric.RoboSettings;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
@@ -52,6 +53,7 @@ import org.robolectric.res.ResourceIndex;
 import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.TypedResource;
 import org.robolectric.test.TemporaryFolder;
+import org.robolectric.util.Scheduler;
 import org.robolectric.util.TestBroadcastReceiver;
 
 import java.io.File;
@@ -594,6 +596,30 @@ public class ShadowApplicationTest {
     final ShadowApplication shadowApplication = Shadows.shadowOf(RuntimeEnvironment.application);
     assertThat(shadowApplication.getForegroundThreadScheduler()).isSameAs(Robolectric.getForegroundThreadScheduler());
     assertThat(shadowApplication.getBackgroundThreadScheduler()).isSameAs(Robolectric.getBackgroundThreadScheduler());
+  }
+
+  @Test
+  public void getForegroundThreadScheduler_shouldMatchRuntimeEnvironment() {
+    Scheduler s = new Scheduler();
+    RuntimeEnvironment.setMasterScheduler(s);
+    final ShadowApplication shadowApplication = Shadows.shadowOf(RuntimeEnvironment.application);
+    assertThat(shadowApplication.getForegroundThreadScheduler()).isSameAs(s);
+  }
+
+  @Test
+  public void getBackgroundThreadScheduler_shouldDifferFromRuntimeEnvironment_byDefault() {
+    Scheduler s = new Scheduler();
+    RuntimeEnvironment.setMasterScheduler(s);
+    final ShadowApplication shadowApplication = Shadows.shadowOf(RuntimeEnvironment.application);
+    assertThat(shadowApplication.getBackgroundThreadScheduler()).isNotSameAs(RuntimeEnvironment.getMasterScheduler());
+  }
+
+  @Test
+  public void getBackgroundThreadScheduler_shouldDifferFromRuntimeEnvironment_withAdvancedScheduling() {
+    Scheduler s = new Scheduler();
+    RuntimeEnvironment.setMasterScheduler(s);
+    final ShadowApplication shadowApplication = Shadows.shadowOf(RuntimeEnvironment.application);
+    assertThat(shadowApplication.getBackgroundThreadScheduler()).isNotSameAs(s);
   }
 
   /////////////////////////////

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.TestRunners;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.Scheduler;
 import org.robolectric.util.TestRunnable;
 import org.robolectric.util.Transcript;
 
@@ -81,6 +82,8 @@ public class ShadowHandlerTest {
 
     Looper looper2 = newLooper(true);
     ShadowLooper.pauseLooper(looper2);
+    // Make sure looper has a different scheduler to the first
+    shadowOf(looper2.getQueue()).setScheduler(new Scheduler());
 
     Handler handler1 = new Handler(looper1);
     handler1.post(new Say("first thing"));

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageQueueTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageQueueTest.java
@@ -215,11 +215,4 @@ public class ShadowMessageQueueTest {
     assertThat(handler.hasMessages(1234)).as("after-1234").isFalse();
     assertThat(handler.hasMessages(5678)).as("after-5678").isFalse();
   }
-
-  @Test
-  public void reset_shouldSetNewScheduler() {
-    Scheduler old = shadowQueue.getScheduler();
-    shadowOf(looper).reset();
-    assertThat(shadowQueue.getScheduler()).isNotSameAs(old);
-  }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageQueueTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMessageQueueTest.java
@@ -116,7 +116,7 @@ public class ShadowMessageQueueTest {
         from(Handler.class, handler),
         from(int.class, what),
         from(Object.class, token)
-        );    
+    );
   }
   
   
@@ -219,7 +219,7 @@ public class ShadowMessageQueueTest {
   @Test
   public void reset_shouldSetNewScheduler() {
     Scheduler old = shadowQueue.getScheduler();
-    shadowQueue.reset();
+    shadowOf(looper).reset();
     assertThat(shadowQueue.getScheduler()).isNotSameAs(old);
   }
-  }
+}


### PR DESCRIPTION
This is an implementation of #1879, point 3. It sets up a single global scheduler to use for all `Looper`s and for the background thread scheduler.

Because this change has the greatest potential to be non-compatible, I have made it optional and off by default. Those who want to take advantage of the single global scheduler will have to set the Java system property `robolectric.scheduling.advanced` to `true`, in any of the usual ways.

I'm hoping to get some feedback on this arrangement (@erd, @jongerrish, or anyone else with an interest in the scheduling code), in particular:
* On or off by default? Perhaps this can depend on the results of @jongerrish' testing - if turning it on breaks at most few tests, perhaps we can set it on by default.
* Naming of the property? I'm thinking that instead of a generic name like "advanced", I could make it `robolectric.scheduling.globalScheduler` or something similar.
* This is not the first time I've thought it would be useful to have a system-wide config option like this. Is there a standard way of implementing such system-wide config items that I should be doing instead of (or maybe even as well as) using a system property? Do we want to blow out the `@Config` annotation with config items like these, for example?