### PR TITLE
[Fix for #2049] Use ConcurrentHashMap instead of Hashmap for shadow config cache management

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
@@ -11,6 +11,7 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import java.lang.reflect.*;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ShadowWrangler implements ClassHandler {
   public static final Function<Object, Object> DO_NOTHING_HANDLER = new Function<Object, Object>() {
@@ -37,7 +38,7 @@ public class ShadowWrangler implements ClassHandler {
       return size() > 500;
     }
   };
-  private final Map<Class, ShadowConfig> shadowConfigCache = new HashMap<>();
+  private final Map<Class, ShadowConfig> shadowConfigCache = new ConcurrentHashMap<>();
   public static final HashMap<String, Object> PRIMITIVE_RETURN_VALUES = new HashMap<>();
 
   static {


### PR DESCRIPTION
We have like 1 out of 3  builds failing because of this issue, tests gets frozen on ShadowWrangler.getShadowConfig method accessing cache map, as this method can be called from multiple threads, it's seems just a concurrency problem with the HashMap.

After replacing shadowConfigCache HashMap by a ConcurrentHashMap, we are not able to reproduce the problem anymore.

Check related issue for more details --> https://github.com/robolectric/robolectric/issues/2049

Thanks in advance.