### PR TITLE
Nanosecond Scheduler and SystemClock fixes

### DIFF
--- a/robolectric-utils/src/test/java/org/robolectric/util/SchedulerTest.java
+++ b/robolectric-utils/src/test/java/org/robolectric/util/SchedulerTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.concurrent.TimeUnit.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.util.Scheduler.IdleState.*;
 
@@ -18,7 +19,65 @@ public class SchedulerTest {
   @Before
   public void setUp() throws Exception {
     scheduler.pause();
-    startTime = scheduler.getCurrentTime();
+    startTime = scheduler.getCurrentTime(NANOSECONDS);
+  }
+
+  @Test
+  public void postDelayed_worksWithDifferentTimeUnits() {
+    Runnable r = new AddToTranscript("dummy");
+    scheduler.postDelayed(r, 12, NANOSECONDS);
+    scheduler.advanceToNextPostedRunnable();
+    startTime += 12;
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("nano step").isEqualTo(startTime);
+    scheduler.postDelayed(r, 12, MICROSECONDS);
+    scheduler.advanceToNextPostedRunnable();
+    startTime += 12000;
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("micro step").isEqualTo(startTime);
+    scheduler.postDelayed(r, 12, MILLISECONDS);
+    scheduler.advanceToNextPostedRunnable();
+    startTime += 12000000;
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("milli step").isEqualTo(startTime);
+    scheduler.postDelayed(r, 12, SECONDS);
+    scheduler.advanceToNextPostedRunnable();
+    startTime += 12000000000L;
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("full step").isEqualTo(startTime);
+  }
+
+  @Test
+  public void getCurrentTime_worksWithDifferentTimeUnits() {
+    scheduler.advanceTo(1234);
+    assertThat(scheduler.getCurrentTime(MILLISECONDS)).as("millis").isEqualTo(1234);
+    assertThat(scheduler.getCurrentTime(MICROSECONDS)).as("micros").isEqualTo(1234000);
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("nanos").isEqualTo(1234000000);
+    assertThat(scheduler.getCurrentTime(SECONDS)).as("seconds").isEqualTo(1);
+  }
+
+  @Test
+  public void advanceTo_worksWithDifferentTimeUnits() {
+    scheduler.advanceTo(1234567, NANOSECONDS);
+    assertThat(scheduler.getCurrentTime()).as("millis").isEqualTo(1);
+    scheduler.advanceTo(1234123, MICROSECONDS);
+    assertThat(scheduler.getCurrentTime()).as("micros").isEqualTo(1234);
+    scheduler.advanceTo(5678, MILLISECONDS);
+    assertThat(scheduler.getCurrentTime()).as("millis").isEqualTo(5678);
+    scheduler.advanceTo(1234, SECONDS);
+    assertThat(scheduler.getCurrentTime()).as("millis").isEqualTo(1234000);
+  }
+
+  @Test
+  public void advanceBy_worksWithDifferentTimeUnits() {
+    scheduler.advanceBy(12, NANOSECONDS);
+    startTime += 12;
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("nano step").isEqualTo(startTime);
+    scheduler.advanceBy(12, MICROSECONDS);
+    startTime += 12000;
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("micro step").isEqualTo(startTime);
+    scheduler.advanceBy(12, MILLISECONDS);
+    startTime += 12000000;
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("milli step").isEqualTo(startTime);
+    scheduler.advanceBy(12, SECONDS);
+    startTime += 12000000000L;
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("full step").isEqualTo(startTime);
   }
 
   @Test
@@ -69,10 +128,9 @@ public class SchedulerTest {
     scheduler.postDelayed(new AddToTranscript("two"), 0);
     scheduler.postDelayed(new AddToTranscript("three"), 1000);
     transcript.assertNoEventsSoFar();
-    final long time = scheduler.getCurrentTime();
     scheduler.setIdleState(UNPAUSED);
     transcript.assertEventsSoFar("one", "two");
-    assertThat(scheduler.getCurrentTime()).as("time").isEqualTo(time);
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("time").isEqualTo(startTime);
   }
 
   @Test
@@ -81,10 +139,10 @@ public class SchedulerTest {
     scheduler.postDelayed(new AddToTranscript("two"), 0);
     scheduler.postDelayed(new AddToTranscript("three"), 1000);
     transcript.assertNoEventsSoFar();
-    final long time = scheduler.getCurrentTime();
     scheduler.setIdleState(CONSTANT_IDLE);
     transcript.assertEventsSoFar("one", "two", "three");
-    assertThat(scheduler.getCurrentTime()).as("time").isEqualTo(time + 1000);
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("time")
+        .isEqualTo(startTime + MILLISECONDS.toNanos(1000));
   }
 
   @Test
@@ -93,10 +151,9 @@ public class SchedulerTest {
     scheduler.postDelayed(new AddToTranscript("two"), 0);
     scheduler.postDelayed(new AddToTranscript("three"), 1000);
     transcript.assertNoEventsSoFar();
-    final long time = scheduler.getCurrentTime();
     scheduler.unPause();
     transcript.assertEventsSoFar("one", "two");
-    assertThat(scheduler.getCurrentTime()).as("time").isEqualTo(time);
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("time").isEqualTo(startTime);
   }
 
   @Test
@@ -106,10 +163,10 @@ public class SchedulerTest {
     scheduler.postDelayed(new AddToTranscript("two"), 0);
     scheduler.postDelayed(new AddToTranscript("three"), 1000);
     transcript.assertNoEventsSoFar();
-    final long time = scheduler.getCurrentTime();
     scheduler.idleConstantly(true);
     transcript.assertEventsSoFar("one", "two", "three");
-    assertThat(scheduler.getCurrentTime()).as("time").isEqualTo(time + 1000);
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("time")
+        .isEqualTo(startTime + MILLISECONDS.toNanos(1000));
   }
 
   @Test
@@ -166,7 +223,7 @@ public class SchedulerTest {
     scheduler.setIdleState(CONSTANT_IDLE);
     scheduler.postDelayed(new AddToTranscript("one"), 1000);
 
-    assertThat(scheduler.getCurrentTime()).isEqualTo(1000 + startTime);
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).isEqualTo(startTime + MILLISECONDS.toNanos(1000));
   }
   
   @Test
@@ -393,7 +450,8 @@ public class SchedulerTest {
     scheduler.advanceToLastPostedRunnable();
     assertThat(order).as("order:after").containsExactly(1, 2, 3);
     assertThat(scheduler.size()).as("size:after").isEqualTo(0);    
-    assertThat(scheduler.getCurrentTime()).as("time:after").isEqualTo(1 + startTime);
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("time:after")
+        .isEqualTo(startTime + MILLISECONDS.toNanos(1));
   }
 
   @Test
@@ -416,7 +474,8 @@ public class SchedulerTest {
 
     assertThat(order).as("order").containsExactly(1, 2, 3);
     assertThat(scheduler.size()).as("size").isEqualTo(0);
-    assertThat(scheduler.getCurrentTime()).as("time").isEqualTo(1 + startTime);
+    assertThat(scheduler.getCurrentTime(NANOSECONDS)).as("time")
+        .isEqualTo(startTime + MILLISECONDS.toNanos(1));
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemClockTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemClockTest.java
@@ -1,11 +1,19 @@
 package org.robolectric.shadows;
 
+import android.os.Build;
 import android.os.SystemClock;
+
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.internal.Shadow;
 import org.robolectric.internal.bytecode.RobolectricInternals;
+import org.robolectric.util.Scheduler;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
@@ -13,38 +21,83 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowSystemClockTest {
+
+  private Scheduler scheduler;
+
+  @Before
+  public void setUp() {
+    scheduler = RuntimeEnvironment.getMasterScheduler();
+  }
+
   @Test
-  public void shouldAllowForFakingOfTime() throws Exception {
-    assertThat(SystemClock.uptimeMillis()).isNotEqualTo(1000);
-    Robolectric.getForegroundThreadScheduler().advanceTo(1000);
-    assertThat(SystemClock.uptimeMillis()).isEqualTo(1000);
+  public void uptimeClock_shouldFollowMasterScheduler() {
+    assertThat(SystemClock.uptimeMillis()).as("before").isNotEqualTo(1000);
+    scheduler.advanceTo(200003333, TimeUnit.NANOSECONDS);
+    assertThat(SystemClock.uptimeMillis()).as("millis").isEqualTo(200);
+    assertThat(ShadowSystemClock.nanoTime()).as("nanos").isEqualTo(200003333);
+    assertThat(SystemClock.elapsedRealtime()).as("elapsedRealTime").isEqualTo(200);
+    if (Build.VERSION.SDK_INT > 16) {
+      assertThat(SystemClock.elapsedRealtimeNanos()).as("elapsedRealTimeNanos").isEqualTo(200003333);
+    }
   }
 
   @Test
   public void sleep() {
-    Robolectric.getForegroundThreadScheduler().advanceTo(1000);
+    scheduler.advanceTo(1000);
     SystemClock.sleep(34);
     assertThat(SystemClock.uptimeMillis()).isEqualTo(1034);
   }
   
   @Test
-  public void testSetCurrentTime() {
-    Robolectric.getForegroundThreadScheduler().advanceTo(1000);
-    assertThat(ShadowSystemClock.now()).isEqualTo(1000);
-    assertTrue(SystemClock.setCurrentTimeMillis(1034));
-    assertThat(ShadowSystemClock.now()).isEqualTo(1034);
-    assertFalse(SystemClock.setCurrentTimeMillis(1000));
-    assertThat(ShadowSystemClock.now()).isEqualTo(1034);
+  public void wallClock_tracksSystemClock() {
+    final long startTime = scheduler.getCurrentTime(TimeUnit.NANOSECONDS);
+    ShadowSystemClock.setCurrentTime(1034100100, TimeUnit.NANOSECONDS);
+    scheduler.advanceBy(100100100, TimeUnit.NANOSECONDS);
+    assertThat(scheduler.getCurrentTime(TimeUnit.NANOSECONDS)).as("systemTime").isEqualTo(startTime + 100100100);
+    assertThat(ShadowSystemClock.currentTimeMillis()).as("milliWall").isEqualTo(1134);
+    assertThat(SystemClock.currentTimeMicro()).as("microWall").isEqualTo(1134200);
+    assertThat(ShadowSystemClock.currentTimeNanos()).as("nanoWall").isEqualTo(1134200200);
   }
-  
+
+  @Test
+  public void reset_setsCurrentTimeOffset_backToZero() {
+    SystemClock.setCurrentTimeMillis(1234567);
+    assertThat(ShadowSystemClock.currentTimeMillis()).as("beforeMillis").isNotEqualTo(SystemClock.uptimeMillis());
+    assertThat(ShadowSystemClock.currentTimeMicro())
+        .as("beforeMicros").isNotEqualTo(scheduler.getCurrentTime(TimeUnit.MICROSECONDS));
+    assertThat(ShadowSystemClock.currentTimeNanos())
+        .as("beforeNanos").isNotEqualTo(scheduler.getCurrentTime(TimeUnit.NANOSECONDS));
+    ShadowSystemClock.reset();
+    assertThat(ShadowSystemClock.currentTimeMillis()).as("afterMillis").isEqualTo(SystemClock.uptimeMillis());
+    assertThat(ShadowSystemClock.currentTimeMicro())
+        .as("afterMicros").isEqualTo(scheduler.getCurrentTime(TimeUnit.MICROSECONDS));
+    assertThat(ShadowSystemClock.currentTimeNanos())
+        .as("afterNanos").isEqualTo(scheduler.getCurrentTime(TimeUnit.NANOSECONDS));
+  }
+
+  @Test
+  public void setCurrentTimeMillis_adjustsWallClock_butNotUptimeClock() {
+    scheduler.advanceTo(1000100100, TimeUnit.NANOSECONDS);
+    assertThat(SystemClock.uptimeMillis()).as("milliSystem:before").isEqualTo(1000);
+    assertThat(ShadowSystemClock.currentTimeNanos()).as("nanoWall:before").isEqualTo(1000100100);
+    assertThat(SystemClock.currentTimeMicro()).as("microWall:before").isEqualTo(1000100);
+    assertThat(ShadowSystemClock.currentTimeMillis()).as("milliWall:before").isEqualTo(1000);
+
+    assertThat(ShadowSystemClock.setCurrentTimeMillis(1034)).as("setTime").isTrue();
+    assertThat(SystemClock.uptimeMillis()).as("milliSystem:after").isEqualTo(1000);
+    assertThat(ShadowSystemClock.currentTimeNanos()).as("nanoWall:after").isEqualTo(1034000000);
+    assertThat(SystemClock.currentTimeMicro()).as("microWall:after").isEqualTo(1034000);
+    assertThat(ShadowSystemClock.currentTimeMillis()).as("milliWall:after").isEqualTo(1034);
+  }
+
   @Test
   public void shouldInterceptSystemTimeCalls() throws Throwable {
-    ShadowSystemClock.setNanoTime(3141592L);
+    scheduler.advanceTo(314159265L, TimeUnit.NANOSECONDS);
     long systemNanoTime = (Long) RobolectricInternals.intercept(
         "java/lang/System/nanoTime()J", null, null, getClass());
-    assertThat(systemNanoTime).isEqualTo(3141592L);
+    assertThat(systemNanoTime).as("nanoTime").isEqualTo(314159265L);
     long systemMilliTime = (Long) RobolectricInternals.intercept(
         "java/lang/System/currentTimeMillis()J", null, null, getClass());
-    assertThat(systemMilliTime).isEqualTo(3L);
+    assertThat(systemMilliTime).as("currentTimeMillis").isEqualTo(314L);
   }
 }


### PR DESCRIPTION
This PR implements point 2 of #1879. It rationalises the `ShadowSystemClock` implementation to slave all of its time measures from the same source (the master scheduler). This keeps the various time measures consistent with each other, and fixes several inconsistencies that I noticed in the current implementation.

Because some of the time measures require nanosecond precision, the Scheduler class has also been enhanced so that it uses nanosecond precision under-the-hood. For backwards compatibility the existing methods still accept/return milliseconds, and a separate set of methods were implemented to enable the scheduler to be manipulated using other time units.

This is the last of the three major fixes proposed in #1879 (there are still a few more minor ones that I hope to get to soon). I'll be eager to try these out and hopeful that they will help with (among other possibilities) being able to rely more on real Android code for the animation code, solving some of the outstanding issues there.