### PR TITLE
Make ShadowDialog#getOnCancelListener work again

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDialog.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowDialog.java
@@ -96,6 +96,12 @@ public class ShadowDialog {
     return onCancelListener;
   }
 
+  @Implementation
+  public void setOnCancelListener(DialogInterface.OnCancelListener listener) {
+    this.onCancelListener = listener;
+    directlyOn(realDialog, Dialog.class).setOnCancelListener(listener);
+  }
+
   public boolean hasBeenDismissed() {
     return hasBeenDismissed;
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDialogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDialogTest.java
@@ -7,6 +7,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.TextView;
+import junit.framework.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
@@ -16,12 +17,11 @@ import org.robolectric.TestRunners;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.Transcript;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.util.TestUtil.assertInstanceOf;
 
 @RunWith(TestRunners.MultiApiWithDefaults.class)
@@ -74,7 +74,7 @@ public class ShadowDialogTest {
   @Test
   public void shouldSetCancelable() {
     Dialog dialog = new Dialog(RuntimeEnvironment.application);
-    ShadowDialog shadow = Shadows.shadowOf(dialog);
+    ShadowDialog shadow = shadowOf(dialog);
 
     dialog.setCancelable(false);
     assertThat(shadow.isCancelable()).isFalse();
@@ -90,7 +90,7 @@ public class ShadowDialogTest {
   @Test
   public void shouldDefaultCancelableToTrueAsTheSDKDoes() throws Exception {
     Dialog dialog = new Dialog(RuntimeEnvironment.application);
-    ShadowDialog shadow = Shadows.shadowOf(dialog);
+    ShadowDialog shadow = shadowOf(dialog);
 
     assertThat(shadow.isCancelable()).isTrue();
   }
@@ -179,6 +179,19 @@ public class ShadowDialogTest {
   public void show_shouldWorkWithAPI19() {
     Dialog dialog = new Dialog(RuntimeEnvironment.application);
     dialog.show();
+  }
+
+  @Test
+  public void canSetAndGetOnCancelListener() {
+    Dialog dialog = new Dialog(RuntimeEnvironment.application);
+    DialogInterface.OnCancelListener onCancelListener = new DialogInterface.OnCancelListener() {
+      @Override
+      public void onCancel(DialogInterface dialog) {
+
+      }
+    };
+    dialog.setOnCancelListener(onCancelListener);
+    assertSame(onCancelListener, shadowOf(dialog).getOnCancelListener());
   }
 
   private static class TestDialog extends Dialog {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDialogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDialogTest.java
@@ -191,7 +191,7 @@ public class ShadowDialogTest {
       }
     };
     dialog.setOnCancelListener(onCancelListener);
-    assertSame(onCancelListener, shadowOf(dialog).getOnCancelListener());
+    assertThat(onCancelListener).isSameAs(shadowOf(dialog).getOnCancelListener());
   }
 
   private static class TestDialog extends Dialog {


### PR DESCRIPTION
We added an @Implementation setOnCancelListener in ShadowDialog.java. We're not 100% sure that the directlyOn() line should be there, and we weren't sure how to write a test for that line.

Thanks,
Rick & Tom