### PR TITLE
Fixed an overflow bug in ScheduledRunnable.compareTo()

### DIFF
--- a/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
@@ -398,7 +398,7 @@ public class Scheduler {
 
     @Override
     public int compareTo(ScheduledRunnable runnable) {
-      return (int) (scheduledTime - runnable.scheduledTime);
+      return Long.compare(scheduledTime, runnable.scheduledTime);
     }
 
     @Override

--- a/robolectric-utils/src/test/java/org/robolectric/util/SchedulerTest.java
+++ b/robolectric-utils/src/test/java/org/robolectric/util/SchedulerTest.java
@@ -503,6 +503,24 @@ public class SchedulerTest {
     assertThat(runnablesThatWereRun).containsExactly(1, 2);
   }
 
+  @Test
+  public void scheduledRunnableCompareTo_handlesLargeDifferences() {
+    // Found an overflow bug in the original implementation of compareTo() when casting diff to int -
+    // if the diff is > INT_MAX the result of casing to INT will be negative, which results in it
+    // sorting the opposite of what we want.
+    // ScheduledRunnable is private; cannot create directly. Test indirectly using postDelayed().
+    TestRunnable r1 = new TestRunnable();
+    TestRunnable r2 = new TestRunnable();
+    scheduler.postDelayed(r1, 100);
+    scheduler.postDelayed(r2, 60, SECONDS); // Difference between 60s and 100ms in nanos is > INT_MAX
+
+    scheduler.runOneTask();
+    assertThat(r1.wasRun).as("first task run first").isTrue();
+    assertThat(r2.wasRun).as("second task not run yet").isFalse();
+    scheduler.runOneTask();
+    assertThat(r2.wasRun).as("second task run second").isTrue();
+  }
+
   private class AddToTranscript implements Runnable {
     private String event;
 


### PR DESCRIPTION
`ScheduledRunnable.compareTo()` was naively implemented as:

````
return (int)(scheduledTime - other.scheduledTime)
````
For large differences (> `INT_MAX`), the cast to `int` would overflow and could result in a sign inversion. This sign inversion messes up the sorting, which messes up the operation of the scheduler.

It seems that this bug may have always been here, but the shift to a nanosecond timebase (#2063) has made it more likely to manifest - one only has to specify an interval of more than 2.1s or so to overflow an `int` counter if the interval is measured in nanoseconds.