### PR TITLE
Make Maven repo url and id configurable

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/RoboSettings.java
+++ b/robolectric-resources/src/main/java/org/robolectric/RoboSettings.java
@@ -5,10 +5,30 @@ package org.robolectric;
  */
 public class RoboSettings {
 
+  private static String mavenRepositoryId;
+  private static String mavenRepositoryUrl;
   private static boolean useGlobalScheduler;
 
   static {
+    mavenRepositoryId = System.getProperty("robolectric.dependency.repo.id", "sonatype");
+    mavenRepositoryUrl = System.getProperty("robolectric.dependency.repo.url", "https://oss.sonatype.org/content/groups/public/");
     useGlobalScheduler = Boolean.getBoolean("robolectric.scheduling.global");
+  }
+
+  public static String getMavenRepositoryId() {
+    return mavenRepositoryId;
+  }
+
+  public static void setMavenRepositoryId(String mavenRepositoryId) {
+    RoboSettings.mavenRepositoryId = mavenRepositoryId;
+  }
+
+  public static String getMavenRepositoryUrl() {
+    return mavenRepositoryUrl;
+  }
+
+  public static void setMavenRepositoryUrl(String mavenRepositoryUrl) {
+    RoboSettings.mavenRepositoryUrl = mavenRepositoryUrl;
   }
 
   public static boolean isUseGlobalScheduler() {

--- a/robolectric-resources/src/test/java/org/robolectric/RoboSettingsTest.java
+++ b/robolectric-resources/src/test/java/org/robolectric/RoboSettingsTest.java
@@ -1,0 +1,61 @@
+package org.robolectric;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RoboSettingsTest {
+
+  private String originalMavenRepositoryId;
+  private String originalMavenRepositoryUrl;
+  private boolean originalUseGlobalScheduler;
+
+  @Before
+  public void setUp() {
+    originalMavenRepositoryId = RoboSettings.getMavenRepositoryId();
+    originalMavenRepositoryUrl = RoboSettings.getMavenRepositoryUrl();
+    originalUseGlobalScheduler = RoboSettings.isUseGlobalScheduler();
+  }
+
+  @After
+  public void tearDown() {
+    RoboSettings.setMavenRepositoryId(originalMavenRepositoryId);
+    RoboSettings.setMavenRepositoryUrl(originalMavenRepositoryUrl);
+    RoboSettings.setUseGlobalScheduler(originalUseGlobalScheduler);
+  }
+
+  @Test
+  public void getMavenRepositoryId_defaultSonatype() {
+    assertEquals("sonatype", RoboSettings.getMavenRepositoryId());
+  }
+
+  @Test
+  public void setMavenRepositoryId() {
+    RoboSettings.setMavenRepositoryId("testRepo");
+    assertEquals("testRepo", RoboSettings.getMavenRepositoryId());
+  }
+
+  @Test
+  public void getMavenRepositoryUrl_defaultSonatype() {
+    assertEquals("https://oss.sonatype.org/content/groups/public/", RoboSettings.getMavenRepositoryUrl());
+  }
+
+  @Test
+  public void setMavenRepositoryUrl() {
+    RoboSettings.setMavenRepositoryUrl("http://local");
+    assertEquals("http://local", RoboSettings.getMavenRepositoryUrl());
+  }
+
+  @Test
+  public void isUseGlobalScheduler_defaultFalse() {
+    assertFalse(RoboSettings.isUseGlobalScheduler());
+  }
+
+  @Test
+  public void setUseGlobalScheduler() {
+    RoboSettings.setUseGlobalScheduler(true);
+    assertTrue(RoboSettings.isUseGlobalScheduler());
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
@@ -4,6 +4,7 @@ import org.apache.maven.artifact.ant.DependenciesTask;
 import org.apache.maven.artifact.ant.RemoteRepository;
 import org.apache.maven.model.Dependency;
 import org.apache.tools.ant.Project;
+import org.robolectric.RoboSettings;
 import org.robolectric.util.Util;
 
 import java.net.MalformedURLException;
@@ -16,8 +17,7 @@ public class MavenDependencyResolver implements DependencyResolver {
   private final String repositoryId;
 
   public MavenDependencyResolver() {
-    this(System.getProperty("robolectric.dependency.repo.url", "https://oss.sonatype.org/content/groups/public/"),
-        System.getProperty("robolectric.dependency.repo.id", "sonatype"));
+    this(RoboSettings.getMavenRepositoryUrl(), RoboSettings.getMavenRepositoryId());
   }
 
   public MavenDependencyResolver(String repositoryUrl, String repositoryId) {

--- a/robolectric/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
@@ -16,7 +16,8 @@ public class MavenDependencyResolver implements DependencyResolver {
   private final String repositoryId;
 
   public MavenDependencyResolver() {
-    this("https://oss.sonatype.org/content/groups/public/", "sonatype");
+    this(System.getProperty("robolectric.dependency.repo.url", "https://oss.sonatype.org/content/groups/public/"),
+        System.getProperty("robolectric.dependency.repo.id", "sonatype"));
   }
 
   public MavenDependencyResolver(String repositoryUrl, String repositoryId) {
@@ -32,10 +33,10 @@ public class MavenDependencyResolver implements DependencyResolver {
   public URL[] getLocalArtifactUrls(DependencyJar... dependencies) {
     DependenciesTask dependenciesTask = new DependenciesTask();
     configureMaven(dependenciesTask);
-    RemoteRepository sonatypeRepository = new RemoteRepository();
-    sonatypeRepository.setUrl(repositoryUrl);
-    sonatypeRepository.setId(repositoryId);
-    dependenciesTask.addConfiguredRemoteRepository(sonatypeRepository);
+    RemoteRepository remoteRepository = new RemoteRepository();
+    remoteRepository.setUrl(repositoryUrl);
+    remoteRepository.setId(repositoryId);
+    dependenciesTask.addConfiguredRemoteRepository(remoteRepository);
     dependenciesTask.setProject(project);
     for (DependencyJar dependencyJar : dependencies) {
       Dependency dependency = new Dependency();


### PR DESCRIPTION
We use an internal maven repository (Artifactory), so at the moment we have to do some Gradle hackery to download the Test Runner dependency jars from Artifactory and then we use the [`robolectric.offline`](http://codeblast.com/2015/05/13/using-robolectric-in-offline-mode/) mode...

May I propose using system properties to specify the repo URL and ID for more flexibility, similar to the `robolectric.offline` and `robolectric.dependency.dir` properties?

Then in our `build.gradle`, we could override the Maven repo URL using:

	android {
		testOptions {
	        unitTests.all {
	            systemProperty 'robolectric.dependency.repo.url', 'https://artifactory/repo'
	            systemProperty 'robolectric.dependency.repo.id', 'local'
	        }
	    }
	}

I realize that Jake's change #2025 already helps a bit with this by making it possible to specify a different URL and ID when creating the `MavenDependencyResolver`, however we're not using a custom test runner, so it would be great to change this via configuration...

I'll update `configuring.md` in `robolectric/robolectric.github.io` with more details.
