### PR TITLE
Demote cross dependency links in javadocs that cannot be resolved

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
+++ b/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
@@ -105,8 +105,8 @@ public class RuntimeEnvironment {
    * the background scheduler and for all other {@link android.os.Looper Looper}s
    * @return The current master scheduler.
    * @see #setMasterScheduler(Scheduler)
-   * @see Robolectric#getForegroundThreadScheduler
-   * @see Robolectric#getBackgroundThreadScheduler
+   * see org.robolectric.Robolectric#getForegroundThreadScheduler()
+   * see org.robolectric.Robolectric#getBackgroundThreadScheduler()
    */
   public static Scheduler getMasterScheduler() {
     return masterScheduler;
@@ -118,8 +118,8 @@ public class RuntimeEnvironment {
    * Changing the master scheduler during a test will have unpredictable results.
    * @param masterScheduler the new master scheduler.
    * @see #getMasterScheduler()
-   * @see Robolectric#getForegroundThreadScheduler()
-   * @see Robolectric#getBackgroundThreadScheduler()
+   * see org.robolectric.Robolectric#getForegroundThreadScheduler()
+   * see org.robolectric.Robolectric#getBackgroundThreadScheduler()
    */
   public static void setMasterScheduler(Scheduler masterScheduler) {
     RuntimeEnvironment.masterScheduler = masterScheduler;

--- a/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
@@ -12,9 +12,9 @@ import static org.robolectric.util.Scheduler.IdleState.*;
 /**
  * Class that manages a queue of Runnables that are scheduled to run now (or at some time in
  * the future). Runnables that are scheduled to run on the UI thread (tasks, animations, etc)
- * eventually get routed to a Scheduler instance. If
- * {@link org.robolectric.RoboSettings#isUseMasterScheduler()} is <tt>true</tt>, then there will
- * only be one instance of this class which is used by all components in the test.
+ * eventually get routed to a Scheduler instance. If org.robolectric.RoboSettings#isUseGlobalScheduler()
+ * is <tt>true</tt>, then there will only be one instance of this class which is used by all components
+ * in the test.
  * 
  * The execution of a scheduler can be in one of three states:
  * <ul><li>paused ({@link #pause()}): if paused, then no posted events will be run unless the Scheduler


### PR DESCRIPTION
This should fix javadoc errors that are preventing the snapshot deploy from Travis.