### PR TITLE
Add unit tests for MavenDependencyResolver

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
@@ -30,7 +30,7 @@ public class MavenDependencyResolver implements DependencyResolver {
    */
   @Override
   public URL[] getLocalArtifactUrls(DependencyJar... dependencies) {
-    DependenciesTask dependenciesTask = new DependenciesTask();
+    DependenciesTask dependenciesTask = createDependenciesTask();
     configureMaven(dependenciesTask);
     RemoteRepository sonatypeRepository = new RemoteRepository();
     sonatypeRepository.setUrl(repositoryUrl);
@@ -78,6 +78,10 @@ public class MavenDependencyResolver implements DependencyResolver {
       key += ":" + dependency.getClassifier();
     }
     return key;
+  }
+
+  protected DependenciesTask createDependenciesTask() {
+    return new DependenciesTask();
   }
 
   protected void configureMaven(DependenciesTask dependenciesTask) {

--- a/robolectric/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
@@ -1,0 +1,150 @@
+package org.robolectric.internal.dependency;
+
+import org.apache.maven.artifact.ant.DependenciesTask;
+import org.apache.maven.artifact.ant.RemoteRepository;
+import org.apache.maven.model.Dependency;
+import org.apache.tools.ant.Project;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.URL;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class MavenDependencyResolverTest {
+
+  private static final String REPOSITORY_URL = "https://default-repo";
+
+  private static final String REPOSITORY_ID = "remote";
+
+  private DependenciesTask dependenciesTask;
+
+  private Project project;
+
+  @Before
+  public void setUp() {
+    dependenciesTask = spy(new DependenciesTask());
+    doNothing().when(dependenciesTask).execute();
+    doAnswer(new Answer() {
+      @Override
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+        invocationOnMock.callRealMethod();
+        Object[] args = invocationOnMock.getArguments();
+        project = (Project) args[0];
+        project.setProperty("group1:artifact1:jar", "path1");
+        project.setProperty("group2:artifact2:jar", "path2");
+        project.setProperty("group3:artifact3:jar:classifier3", "path3");
+        return null;
+      }
+    }).when(dependenciesTask).setProject(any(Project.class));
+  }
+
+  @Test
+  public void getLocalArtifactUrl_shouldAddConfiguredRemoteRepository() {
+    DependencyResolver dependencyResolver = createResolver();
+    DependencyJar dependencyJar = new DependencyJar("group1", "artifact1", "", null);
+
+    dependencyResolver.getLocalArtifactUrl(dependencyJar);
+
+    List<RemoteRepository> repositories = dependenciesTask.getRemoteRepositories();
+
+    assertEquals(1, repositories.size());
+    RemoteRepository remoteRepository = repositories.get(0);
+    assertEquals(REPOSITORY_URL, remoteRepository.getUrl());
+    assertEquals(REPOSITORY_ID, remoteRepository.getId());
+  }
+
+  @Test
+  public void getLocalArtifactUrl_shouldAddDependencyToDependenciesTask() {
+    DependencyResolver dependencyResolver = createResolver();
+    DependencyJar dependencyJar = new DependencyJar("group1", "artifact1", "3", null);
+
+    dependencyResolver.getLocalArtifactUrl(dependencyJar);
+
+    List<Dependency> dependencies = dependenciesTask.getDependencies();
+
+    assertEquals(1, dependencies.size());
+    Dependency dependency = dependencies.get(0);
+    assertEquals("group1", dependency.getGroupId());
+    assertEquals("artifact1", dependency.getArtifactId());
+    assertEquals("3", dependency.getVersion());
+    assertEquals("jar", dependency.getType());
+    assertNull(dependency.getClassifier());
+  }
+
+  @Test
+  public void getLocalArtifactUrl_shouldExecuteDependenciesTask() {
+    DependencyResolver dependencyResolver = createResolver();
+    DependencyJar dependencyJar = new DependencyJar("group1", "artifact1", "", null);
+
+    dependencyResolver.getLocalArtifactUrl(dependencyJar);
+
+    verify(dependenciesTask).execute();
+  }
+
+  @Test
+  public void getLocalArtifactUrl_shouldReturnCorrectUrlForArtifactKey() {
+    DependencyResolver dependencyResolver = createResolver();
+    DependencyJar dependencyJar = new DependencyJar("group1", "artifact1", "", null);
+
+    URL url = dependencyResolver.getLocalArtifactUrl(dependencyJar);
+
+    assertEquals("file:/path1", url.toExternalForm());
+  }
+
+  @Test
+  public void getLocalArtifactUrl_shouldReturnCorrectUrlForArtifactKeyWithClassifier() {
+    DependencyResolver dependencyResolver = createResolver();
+    DependencyJar dependencyJar = new DependencyJar("group3", "artifact3", "", "classifier3");
+
+    URL url = dependencyResolver.getLocalArtifactUrl(dependencyJar);
+
+    assertEquals("file:/path3", url.toExternalForm());
+  }
+
+  @Test
+  public void getLocalArtifactUrls_shouldReturnEmptyArrayIfNoDependencyJarProvided() {
+    DependencyResolver dependencyResolver = createResolver();
+
+    URL[] urls = dependencyResolver.getLocalArtifactUrls();
+
+    assertEquals(0, urls.length);
+  }
+
+  @Test
+  public void getLocalArtifactUrls_shouldReturnURLsForEachDependencyJar() {
+    DependencyResolver dependencyResolver = createResolver();
+    DependencyJar dependencyJar1 = new DependencyJar("group1", "artifact1", "", null);
+    DependencyJar dependencyJar2 = new DependencyJar("group2", "artifact2", "", null);
+
+    URL[] urls = dependencyResolver.getLocalArtifactUrls(dependencyJar1, dependencyJar2);
+
+    assertEquals(2, urls.length);
+    assertEquals("file:/path1", urls[0].toExternalForm());
+    assertEquals("file:/path2", urls[1].toExternalForm());
+  }
+
+  @Test
+  public void getLocalArtifactUrls_shouldAddEachDependencyToDependenciesTask() {
+    DependencyResolver dependencyResolver = createResolver();
+    DependencyJar dependencyJar1 = new DependencyJar("group1", "artifact1", "", null);
+    DependencyJar dependencyJar2 = new DependencyJar("group2", "artifact2", "", null);
+
+    dependencyResolver.getLocalArtifactUrls(dependencyJar1, dependencyJar2);
+
+    verify(dependenciesTask, times(2)).addDependency(any(Dependency.class));
+  }
+
+  private DependencyResolver createResolver() {
+    return new MavenDependencyResolver(REPOSITORY_URL, REPOSITORY_ID) {
+      @Override
+      protected DependenciesTask createDependenciesTask() {
+        return dependenciesTask;
+      }
+    };
+  }
+}


### PR DESCRIPTION
If you're OK with the small change in MavenDependencyResolver, then we can add some tests for it. If this kind test is considered useful, then I'd be glad to do more similar changes for LocalDependencyResolver etc.

I thought it might be useful to add tests since I've also uploaded another PR for a small change without tests in the same class (#2079).