### PR TITLE
Implement Outline.setConvexPath to avoid 'path must be convex' error.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowOutline.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowOutline.java.vm
@@ -1,0 +1,23 @@
+package org.robolectric.shadows;
+
+#if ($api >= 21)
+import android.graphics.Path;
+import android.graphics.Outline;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Implementation;
+
+/**
+ * Shadow for {@link android.graphics.Outline}.
+ */
+@Implements(Outline.class)
+public class ShadowOutline {
+
+  @Implementation
+  public void setConvexPath(Path convexPath) {
+  }
+}
+#else
+public class ShadowOutline {
+  // Dummy class, this was added in API 21
+}
+#end

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowOutlineTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowOutlineTest.java
@@ -1,0 +1,23 @@
+package org.robolectric.shadows;
+
+import android.graphics.Outline;
+import android.graphics.Path;
+import android.os.Build;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
+
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+@Config(sdk = {
+    Build.VERSION_CODES.LOLLIPOP,
+    Build.VERSION_CODES.LOLLIPOP_MR1
+})
+public class ShadowOutlineTest {
+
+    @Test
+    public void setConvexPath_doesNothing() {
+        final Outline outline = new Outline();
+        outline.setConvexPath(new Path());
+    }
+}


### PR DESCRIPTION
Closes #1810.