### PR TITLE
Improve RoboExecutorService

### DIFF
--- a/robolectric/src/test/java/org/robolectric/util/concurrent/RoboExecutorServiceTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/concurrent/RoboExecutorServiceTest.java
@@ -12,6 +12,7 @@ import org.robolectric.util.Transcript;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -106,5 +107,28 @@ public class RoboExecutorServiceTest {
 
     transcript.assertNoEventsSoFar();
     assertThat(notExecutedRunnables).hasSize(1);
+  }
+
+  @Test(timeout = 500)
+  public void whenGettingFutureValue_FutureRunnableIsExecuted() throws Exception {
+    Future<String> future = executorService.submit(runnable, "foo");
+
+    assertThat(future.get()).isEqualTo("foo");
+    assertThat(future.isDone()).isTrue();
+  }
+
+  @Test
+  public void whenAwaitingTerminationAfterShutdown_TrueIsReturned() throws InterruptedException {
+    executorService.shutdown();
+
+    assertThat(executorService.awaitTermination(0, TimeUnit.MILLISECONDS)).isTrue();
+  }
+
+  @Test
+  public void whenAwaitingTermination_AllTasksAreRunByDefault() throws Exception {
+    executorService.execute(runnable);
+
+    assertThat(executorService.awaitTermination(500, TimeUnit.MILLISECONDS)).isFalse();
+    transcript.assertNoEventsSoFar();
   }
 }

--- a/robolectric/src/test/java/org/robolectric/util/concurrent/RoboExecutorServiceTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/concurrent/RoboExecutorServiceTest.java
@@ -9,6 +9,7 @@ import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.util.Scheduler;
 import org.robolectric.util.Transcript;
 
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
@@ -74,5 +75,36 @@ public class RoboExecutorServiceTest {
     assertThat(future.isDone()).isTrue();
 
     assertThat(future.get()).isEqualTo("foo");
+  }
+
+  @Test
+  public void byDefault_IsNotShutdown() {
+    assertThat(executorService.isShutdown()).isFalse();
+  }
+
+  @Test
+  public void byDefault_IsNotTerminated() {
+    assertThat(executorService.isTerminated()).isFalse();
+  }
+
+  @Test
+  public void whenShutdownBeforeSubmittedTasksAreExecuted_TaskIsNotInTranscript() {
+    executorService.execute(runnable);
+
+    executorService.shutdown();
+    ShadowApplication.runBackgroundTasks();
+
+    transcript.assertNoEventsSoFar();
+  }
+
+  @Test
+  public void whenShutdownNow_ReturnedListContainsOneRunnable() {
+    executorService.execute(runnable);
+
+    List<Runnable> notExecutedRunnables = executorService.shutdownNow();
+    ShadowApplication.runBackgroundTasks();
+
+    transcript.assertNoEventsSoFar();
+    assertThat(notExecutedRunnables).hasSize(1);
   }
 }


### PR DESCRIPTION
We ran into a lot of leaking threads during test execution because you'd need to always remember to call shutdown() on thread pools, otherwise they leak the threads. Also, for controlling execution, RoboExecutorService seems quite useful. It didn't have everything implemented though. This improves it enough to make it a drop-in replacement for our tests.