### PR TITLE
Improve handling of ordered and async broadcasts

### DIFF
--- a/robolectric-shadows/shadows-core/pom.xml
+++ b/robolectric-shadows/shadows-core/pom.xml
@@ -54,6 +54,12 @@
       <version>53.1</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>16.0.1</version>
+    </dependency>
+
     <!-- SQLite Dependencies -->
     <dependency>
       <groupId>com.almworks.sqlite4java</groupId>

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBroadcastReceiver.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBroadcastReceiver.java
@@ -34,5 +34,10 @@ public class ShadowBroadcastReceiver {
   public void onReceive(Context context, Intent intent, AtomicBoolean abort) {
     this.abort = abort;
     onReceive(context, intent);
+    // If the underlying receiver has called goAsync(), we should not finish the pending result yet - they'll do that
+    // for us.
+    if (receiver.getPendingResult() != null) {
+      receiver.getPendingResult().finish();
+    }
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
@@ -131,6 +131,13 @@ public class ShadowContextWrapper extends ShadowContext {
   }
 
   @Implementation
+  public void sendOrderedBroadcast(Intent intent, String receiverPermission, BroadcastReceiver resultReceiver,
+                                   Handler scheduler, int initialCode, String initialData, Bundle initialExtras) {
+    getApplicationContext().sendOrderedBroadcast(intent, receiverPermission, resultReceiver, scheduler, initialCode,
+            initialData, initialExtras);
+  }
+
+  @Implementation
   public void sendStickyBroadcast(Intent intent) {
     getApplicationContext().sendStickyBroadcast(intent);
   }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowBroadcastPendingResult.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowBroadcastPendingResult.java.vm
@@ -1,0 +1,63 @@
+package org.robolectric.shadows;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+
+@Implements(BroadcastReceiver.PendingResult.class)
+public final class ShadowBroadcastPendingResult {
+    @RealObject BroadcastReceiver.PendingResult pendingResult;
+
+    static BroadcastReceiver.PendingResult create(int resultCode, String resultData, Bundle resultExtras, boolean ordered) {
+#if ($api < 17)
+      return new BroadcastReceiver.PendingResult(
+                    resultCode,
+                    resultData,
+                    resultExtras,
+                    0 /* type */,
+                    ordered,
+                    false /*sticky*/,
+                    null /* ibinder token */);
+#elseif ($api < 23)
+      return new BroadcastReceiver.PendingResult(
+              resultCode,
+              resultData,
+              resultExtras,
+              0 /* type */,
+              ordered,
+              false /*sticky*/,
+              null /* ibinder token */,
+              0 /* userid */);
+
+#else
+      return new BroadcastReceiver.PendingResult(
+                    resultCode,
+                    resultData,
+                    resultExtras,
+                    0 /* type */,
+                    ordered,
+                    false /*sticky*/,
+                    null /* ibinder token */,
+                    0 /* userid */,
+                    0 /* flags */);
+#end
+    }
+
+    private final SettableFuture<BroadcastReceiver.PendingResult> finished = SettableFuture.create();
+
+    @Implementation
+    public final void finish() {
+      Preconditions.checkState(finished.set(pendingResult), "Broadcast already finished");
+    }
+
+    public ListenableFuture<BroadcastReceiver.PendingResult> getFuture() {
+      return finished;
+    }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
@@ -38,7 +38,7 @@ import org.robolectric.util.Transcript;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowContextWrapperTest {
   public Transcript transcript;
   private ContextWrapper contextWrapper;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
@@ -1,5 +1,14 @@
 package org.robolectric.shadows;
 
+import static android.content.pm.PackageManager.PERMISSION_DENIED;
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Robolectric.buildActivity;
+import static org.robolectric.Shadows.shadowOf;
+
 import android.app.Activity;
 import android.app.Application;
 import android.appwidget.AppWidgetProvider;
@@ -16,26 +25,20 @@ import android.os.HandlerThread;
 import android.os.Looper;
 import android.view.LayoutInflater;
 import android.view.View;
+import com.google.common.util.concurrent.SettableFuture;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
+import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 import org.robolectric.util.Transcript;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static android.content.pm.PackageManager.PERMISSION_DENIED;
-import static android.content.pm.PackageManager.PERMISSION_GRANTED;
-import static junit.framework.Assert.assertEquals;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.robolectric.Robolectric.buildActivity;
-import static org.robolectric.Shadows.shadowOf;
-
-@RunWith(TestRunners.MultiApiWithDefaults.class)
+@RunWith(TestRunners.WithDefaults.class)
 public class ShadowContextWrapperTest {
   public Transcript transcript;
   private ContextWrapper contextWrapper;
@@ -117,6 +120,79 @@ public class ShadowContextWrapperTest {
     assertThat(shadowOf(handler.getLooper()).getScheduler().size()).isEqualTo(0);
 
     transcript.assertEventsSoFar("Larry notified of foo");
+  }
+
+  @Test
+  public void sendOrderedBroadcast_shouldReturnValues() throws Exception {
+    String action = "test";
+
+    IntentFilter lowFilter = new IntentFilter(action);
+    lowFilter.setPriority(1);
+    BroadcastReceiver lowReceiver = broadcastReceiver("Low");
+    contextWrapper.registerReceiver(lowReceiver, lowFilter);
+
+    IntentFilter highFilter = new IntentFilter(action);
+    highFilter.setPriority(2);
+    BroadcastReceiver highReceiver = broadcastReceiver("High");
+    contextWrapper.registerReceiver(highReceiver, highFilter);
+
+    final FooReceiver resultReceiver = new FooReceiver();
+    contextWrapper.sendOrderedBroadcast(new Intent(action), null, resultReceiver, null, 1, "initial", null);
+    transcript.assertEventsSoFar("High notified of test", "Low notified of test");
+    assertThat(resultReceiver.resultCode).isEqualTo(1);
+  }
+
+  private static final class FooReceiver extends BroadcastReceiver {
+    private int resultCode;
+    private SettableFuture<Void> settableFuture = SettableFuture.create();
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      resultCode = getResultCode();
+      settableFuture.set(null);
+    }
+  }
+
+  @Test
+  public void sendOrderedBroadcast_shouldExecuteSerially() {
+    String action = "test";
+    AtomicReference<BroadcastReceiver.PendingResult> midResult = new AtomicReference<>();
+
+    IntentFilter lowFilter = new IntentFilter(action);
+    lowFilter.setPriority(1);
+    BroadcastReceiver lowReceiver = broadcastReceiver("Low");
+    contextWrapper.registerReceiver(lowReceiver, lowFilter);
+
+    IntentFilter midFilter = new IntentFilter(action);
+    midFilter.setPriority(2);
+    AsyncReceiver midReceiver = new AsyncReceiver(midResult);
+    contextWrapper.registerReceiver(midReceiver, midFilter);
+
+    IntentFilter highFilter = new IntentFilter(action);
+    highFilter.setPriority(3);
+    BroadcastReceiver highReceiver = broadcastReceiver("High");
+    contextWrapper.registerReceiver(highReceiver, highFilter);
+
+    contextWrapper.sendOrderedBroadcast(new Intent(action), null);
+    transcript.assertEventsSoFar("High notified of test", "Mid notified of test");
+    assertThat(midResult.get()).isNotNull();
+    midResult.get().finish();
+    Robolectric.flushForegroundThreadScheduler();
+    transcript.assertEventsSoFar("Low notified of test");
+  }
+
+  private class AsyncReceiver extends BroadcastReceiver {
+    private final AtomicReference<PendingResult> reference;
+
+    private AsyncReceiver(AtomicReference<PendingResult> reference) {
+      this.reference = reference;
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      reference.set(goAsync());
+      transcript.add("Mid notified of " + intent.getAction());
+    }
   }
 
   @Test


### PR DESCRIPTION
In fixing the attached issues, I had to change around the
implementation of ordered broadcasts. This fixed a few other issues -
ordered broadcasts sent to receivers with custom schedulers now execute
serially, and they propagate results along with them.

Fixes #2112
Fixes #1973