### PR TITLE
Reduce synchronicity of Scheduler to eliminate deadlock

### DIFF
--- a/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
@@ -55,11 +55,11 @@ public class Scheduler {
   }
 
   /** Time for this scheduler, measured in nanoseconds. */
-  private long currentTime = 100000000;
+  private volatile long currentTime = 100000000;
   private boolean isExecutingRunnable = false;
   private final Thread associatedThread = Thread.currentThread();
   private final List<ScheduledRunnable> runnables = new ArrayList<>();
-  private IdleState idleState = UNPAUSED;
+  private volatile IdleState idleState = UNPAUSED;
 
   /**
    * Retrieves the current idling state of this <tt>Scheduler</tt>.
@@ -67,7 +67,7 @@ public class Scheduler {
    * @see #setIdleState(IdleState)
    * @see #isPaused()
    */
-  public synchronized IdleState getIdleState() {
+  public IdleState getIdleState() {
     return idleState;
   }
 
@@ -99,7 +99,7 @@ public class Scheduler {
    * @return  Current time of this scheduler in milliseconds.
    * @see #getCurrentTime(TimeUnit)
    */
-  public synchronized long getCurrentTime() {
+  public long getCurrentTime() {
     return getCurrentTime(MILLISECONDS);
   }
 
@@ -110,7 +110,7 @@ public class Scheduler {
    * @return  Current time in the given time units.
    * @see #getCurrentTime()
    */
-  public synchronized long getCurrentTime(TimeUnit units) {
+  public long getCurrentTime(TimeUnit units) {
     return units.convert(currentTime, NANOSECONDS);
   }
 
@@ -139,7 +139,7 @@ public class Scheduler {
    *
    * @return  <tt>true</tt> if it is paused.
    */
-  public synchronized boolean isPaused() {
+  public boolean isPaused() {
     return idleState == PAUSED;
   }
 


### PR DESCRIPTION
In playing with the scheduling code I have made some changes to allow some limited multi-threading support within Robolectric. Because the master/foreground `Scheduler` is globally accessible and backs the `SystemClock` functions, yet doesn't allow concurrent access, so if a background thread tries to access the time while the foreground thread is dispatching an event on the `Scheduler`, deadlock results (see #2115, #1043). 

It is a curiosity to me that the `Scheduler` class has any synchronization at all if Robolectric historically hasn't officially support any multi-threading, however rather than simply remove all the synchronization I have taken baby steps and removed it on all of the read-only/idempotent methods. This should fix the common problem of a bg thread trying to fetch the system time (eg #2115).