### PR TITLE
ResName optimization

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/ResName.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/ResName.java
@@ -99,10 +99,6 @@ public class ResName {
     return new ResName(packageName, type, name);
   }
 
-  public ResName qualify(String string) {
-    return new ResName(qualifyResourceName(string.replace("@", ""), packageName, null));
-  }
-
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/robolectric-resources/src/main/java/org/robolectric/res/ResName.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/ResName.java
@@ -16,10 +16,14 @@ public class ResName {
   public final @NotNull String type;
   public final @NotNull String name;
 
+  public final int hashCode;
+
   public ResName(@NotNull String packageName, @NotNull String type, @NotNull String name) {
     this.packageName = packageName;
     this.type = type;
     this.name = name.indexOf('.') != -1 ? name.replace('.', '_').trim() : name.trim();
+
+    hashCode = computeHashCode();
   }
 
   public ResName(@NotNull String fullyQualifiedName) {
@@ -32,6 +36,7 @@ public class ResName {
     String nameStr = matcher.group(NAME);
     name = nameStr.indexOf('.') != -1 ? nameStr.replace('.', '_') : nameStr;
 
+    hashCode = computeHashCode();
     if (packageName.equals("xmlns")) throw new IllegalStateException("\"" + fullyQualifiedName + "\" unexpected");
   }
 
@@ -105,6 +110,8 @@ public class ResName {
 
     ResName resName = (ResName) o;
 
+    if (hashCode() != resName.hashCode()) return false;
+
     if (!packageName.equals(resName.packageName)) return false;
     if (!type.equals(resName.type)) return false;
     if (!name.equals(resName.name)) return false;
@@ -114,10 +121,7 @@ public class ResName {
 
   @Override
   public int hashCode() {
-    int result = packageName.hashCode();
-    result = 31 * result + type.hashCode();
-    result = 31 * result + name.hashCode();
-    return result;
+    return hashCode;
   }
 
   @Override
@@ -142,5 +146,12 @@ public class ResName {
     if (!type.equals(expectedType)) {
       throw new RuntimeException("expected " + getFullyQualifiedName() + " to be a " + expectedType + ", is a " + type);
     }
+  }
+
+  private int computeHashCode() {
+    int result = packageName.hashCode();
+    result = 31 * result + type.hashCode();
+    result = 31 * result + name.hashCode();
+    return result;
   }
 }


### PR DESCRIPTION
JProfiler says that we call ResName.equals() millions of times when running just 700 tests. I didn't look at the root cause (in ShadowResources) yet, but this straightforward change speeds up test execution by 25% when running 10000 tests.