### PR TITLE
ResName does not support null values for name, package and type.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/ResName.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/ResName.java
@@ -40,16 +40,19 @@ public class ResName {
     if (packageName.equals("xmlns")) throw new IllegalStateException("\"" + fullyQualifiedName + "\" unexpected");
   }
 
-  public static @NotNull String qualifyResourceName(@NotNull String possiblyQualifiedResourceName, String defaultPackageName, String defaultType) {
+  /**
+   * Returns null if the resource could not be qualified.
+   */
+  public static String qualifyResourceName(@NotNull String possiblyQualifiedResourceName, String defaultPackageName, String defaultType) {
     ResName resName = qualifyResName(possiblyQualifiedResourceName, defaultPackageName, defaultType);
-    return resName.getFullyQualifiedName();
+    return resName != null ? resName.getFullyQualifiedName() : null;
   }
 
-  public static @NotNull ResName qualifyResName(@NotNull String possiblyQualifiedResourceName, ResName defaults) {
+  public static ResName qualifyResName(@NotNull String possiblyQualifiedResourceName, ResName defaults) {
     return qualifyResName(possiblyQualifiedResourceName, defaults.packageName, defaults.type);
   }
 
-  public static @NotNull ResName qualifyResName(@NotNull String possiblyQualifiedResourceName, String defaultPackageName, String defaultType) {
+  public static ResName qualifyResName(@NotNull String possiblyQualifiedResourceName, String defaultPackageName, String defaultType) {
     int indexOfColon = possiblyQualifiedResourceName.indexOf(':');
     int indexOfSlash = possiblyQualifiedResourceName.indexOf('/');
     String type = null;
@@ -69,6 +72,10 @@ public class ResName {
       name = possiblyQualifiedResourceName.substring(indexOfSlash + 1);
     }
 
+    if ((type == null && defaultType == null) || packageName == null && defaultPackageName == null) {
+      return null;
+    }
+
     return new ResName(packageName == null ? defaultPackageName : packageName,
         type == null ? defaultType : type,
         name);
@@ -83,7 +90,11 @@ public class ResName {
       return null;
     }
 
+    // Was not able to fully qualify the resource name
     String fullyQualifiedResourceName = qualifyResourceName(possiblyQualifiedResourceName, contextPackageName, null);
+    if (fullyQualifiedResourceName == null) {
+      return null;
+    }
 
     fullyQualifiedResourceName = fullyQualifiedResourceName.replaceAll("[@+]", "");
     Integer resourceId = resourceIndex.getResourceId(new ResName(fullyQualifiedResourceName));

--- a/robolectric/src/test/java/org/robolectric/res/ResNameTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/ResNameTest.java
@@ -11,6 +11,7 @@ public class ResNameTest {
     assertThat(ResName.qualifyResourceName("some.package:name", "default.package", "deftype")).isEqualTo("some.package:deftype/name");
     assertThat(ResName.qualifyResourceName("type/name", "default.package", "deftype")).isEqualTo("default.package:type/name");
     assertThat(ResName.qualifyResourceName("name", "default.package", "deftype")).isEqualTo("default.package:deftype/name");
+    assertThat(ResName.qualifyResourceName("someRawString", "default.package", null)).isNull();
   }
 
   @Test public void shouldQualifyResNameFromString() throws Exception {


### PR DESCRIPTION
https://github.com/robolectric/robolectric/commit/02af1b119861268b684f42fa0e8f27737015d1e1 exposed a bug where computing the hashcode would blow up with null field values. Turns out that if the application.label is a raw string (permitted) rather than a resource it would  expose this.

This fix handles cases where a non-resource string is passed in and returns null in these cases.