### PR TITLE
Support instrumentedPackages and auto-instrument shadows in @Config

### DIFF
--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/Config.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/Config.java
@@ -103,6 +103,13 @@ public @interface Config {
    * @return A list of additional shadow classes to enable.
    */
   Class<?>[] shadows() default {};
+  
+  /**
+   * A list of instrumented packages, in addition to those that are already instrumented.
+   * 
+   * @return A list of additional instrumented packages.
+   */
+  String[] instrumentedPackages() default {};
 
   /**
    * A list of folders containing Android Libraries on which this project depends.
@@ -120,6 +127,7 @@ public @interface Config {
     private final String packageName;
     private final Class<?> constants;
     private final Class<?>[] shadows;
+    private final String[] instrumentedPackages;
     private final Class<? extends Application> application;
     private final String[] libraries;
 
@@ -133,6 +141,7 @@ public @interface Config {
           properties.getProperty("resourceDir", Config.DEFAULT_RES_FOLDER),
           properties.getProperty("assetDir", Config.DEFAULT_ASSET_FOLDER),
           parseClasses(properties.getProperty("shadows", "")),
+          parseStringArrayProperty(properties.getProperty("instrumentedPackages", "")),
           parseApplication(properties.getProperty("application", "android.app.Application")),
           parseStringArrayProperty(properties.getProperty("libraries", "")),
           parseClass(properties.getProperty("constants", ""))
@@ -178,7 +187,7 @@ public @interface Config {
       return result;
     }
 
-    public Implementation(int[] sdk, String manifest, String qualifiers, String packageName, String resourceDir, String assetDir, Class<?>[] shadows, Class<? extends Application> application, String[] libraries, Class<?> constants) {
+    public Implementation(int[] sdk, String manifest, String qualifiers, String packageName, String resourceDir, String assetDir, Class<?>[] shadows, String[] instrumentedPackages, Class<? extends Application> application, String[] libraries, Class<?> constants) {
       this.sdk = sdk;
       this.manifest = manifest;
       this.qualifiers = qualifiers;
@@ -186,6 +195,7 @@ public @interface Config {
       this.resourceDir = resourceDir;
       this.assetDir = assetDir;
       this.shadows = shadows;
+      this.instrumentedPackages = instrumentedPackages;
       this.application = application;
       this.libraries = libraries;
       this.constants = constants;
@@ -200,6 +210,7 @@ public @interface Config {
       this.assetDir = other.assetDir();
       this.constants = other.constants();
       this.shadows = other.shadows();
+      this.instrumentedPackages = other.instrumentedPackages();
       this.application = other.application();
       this.libraries = other.libraries();
     }
@@ -218,6 +229,11 @@ public @interface Config {
       shadows.addAll(Arrays.asList(overlayConfig.shadows()));
       this.shadows = shadows.toArray(new Class[shadows.size()]);
 
+      Set<String> instrumentedPackages = new HashSet<>();
+      instrumentedPackages.addAll(Arrays.asList(baseConfig.instrumentedPackages()));
+      instrumentedPackages.addAll(Arrays.asList(overlayConfig.instrumentedPackages()));
+      this.instrumentedPackages = instrumentedPackages.toArray(new String[instrumentedPackages.size()]);
+      
       this.application = pick(baseConfig.application(), overlayConfig.application(), Application.class);
 
       Set<String> libraries = new HashSet<>();
@@ -279,6 +295,11 @@ public @interface Config {
       return shadows;
     }
 
+    @Override
+    public String[] instrumentedPackages() {
+      return instrumentedPackages;
+    }
+    
     @Override
     public String[] libraries() {
       return libraries;

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -57,7 +57,6 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
   private static final Map<Pair<AndroidManifest, SdkConfig>, ResourceLoader> resourceLoadersByManifestAndConfig = new HashMap<>();
   private static final Map<ManifestIdentifier, AndroidManifest> appManifestsByFile = new HashMap<>();
   private static ShadowMap mainShadowMap;
-  private InstrumentingClassLoaderFactory instrumentingClassLoaderFactory;
   private TestLifecycle<Application> testLifecycle;
   private DependencyResolver dependencyResolver;
 
@@ -128,8 +127,8 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
     return new AndroidManifest(manifestFile, resDir, assetDir, packageName);
   }
 
-  public InstrumentationConfiguration createClassLoaderConfig() {
-    return InstrumentationConfiguration.newBuilder().build();
+  public InstrumentationConfiguration createClassLoaderConfig(Config config) {
+    return InstrumentationConfiguration.newBuilder().withConfig(config).build();
   }
 
   protected Class<? extends TestLifecycle> getTestLifecycleClass() {
@@ -181,9 +180,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
       eachNotifier.fireTestStarted();
       try {
         AndroidManifest appManifest = getAppManifest(config);
-        if (instrumentingClassLoaderFactory == null) {
-          instrumentingClassLoaderFactory = new InstrumentingClassLoaderFactory(createClassLoaderConfig(), getJarResolver());
-        }
+        InstrumentingClassLoaderFactory instrumentingClassLoaderFactory = new InstrumentingClassLoaderFactory(createClassLoaderConfig(config), getJarResolver());
         SdkEnvironment sdkEnvironment = instrumentingClassLoaderFactory.getSdkEnvironment(new SdkConfig(pickSdkVersion(config, appManifest)));
         methodBlock(method, config, appManifest, sdkEnvironment).evaluate();
       } catch (AssumptionViolatedException e) {

--- a/robolectric/src/main/java/org/robolectric/internal/InstrumentingClassLoaderFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/InstrumentingClassLoaderFactory.java
@@ -11,8 +11,11 @@ import java.util.Map;
 
 public class InstrumentingClassLoaderFactory {
 
+  // We need to cache class loader more than the number of supported APIs as different tests may have different configurations.
+  private static final int CACHE_SIZE_FACTOR = 5;
+
   // Typical test suites will use a single test runner, therefore have a maximum of one SdkEnvironment per API level.
-  private static final int CACHE_SIZE = SdkConfig.getSupportedApis().size();
+  private static final int CACHE_SIZE = SdkConfig.getSupportedApis().size() * CACHE_SIZE_FACTOR;
 
   // Simple LRU Cache. SdkEnvironments are unique across InstrumentingClassloaderConfig and SdkConfig
   private static final LinkedHashMap<Pair<InstrumentationConfiguration, SdkConfig>, SdkEnvironment> sdkToEnvironment = new LinkedHashMap<Pair<InstrumentationConfiguration, SdkConfig>, SdkEnvironment>() {

--- a/robolectric/src/main/java/org/robolectric/internal/InstrumentingClassLoaderFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/InstrumentingClassLoaderFactory.java
@@ -11,10 +11,10 @@ import java.util.Map;
 
 public class InstrumentingClassLoaderFactory {
 
-  // We need to cache class loader more than the number of supported APIs as different tests may have different configurations.
-  private static final int CACHE_SIZE_FACTOR = 5;
+  /** The factor for cache size. See {@link #CACHE_SIZE} for details. */
+  private static final int CACHE_SIZE_FACTOR = 3;
 
-  // Typical test suites will use a single test runner, therefore have a maximum of one SdkEnvironment per API level.
+  /** We need to set the cache size of class loaders more than the number of supported APIs as different tests may have different configurations. */
   private static final int CACHE_SIZE = SdkConfig.getSupportedApis().size() * CACHE_SIZE_FACTOR;
 
   // Simple LRU Cache. SdkEnvironments are unique across InstrumentingClassloaderConfig and SdkConfig

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
@@ -25,6 +25,10 @@ import org.robolectric.res.builder.XmlBlock;
 import org.robolectric.util.TempDirectory;
 import org.robolectric.util.Transcript;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -86,7 +90,7 @@ public class InstrumentationConfiguration {
       this.classesToNotInstrument.add(className);
       return this;
     }
-    
+
     public Builder withConfig(Config config) {
       for (Class<?> clazz : config.shadows()) {
         Implements annotation = clazz.getAnnotation(Implements.class);
@@ -185,22 +189,24 @@ public class InstrumentationConfiguration {
     return new Builder();
   }
 
-  private final List<String> instrumentedPackages = new ArrayList<>();
-  private final HashSet<String> instrumentedClasses = new HashSet<>();
-  private final HashSet<String> classesToNotInstrument = new HashSet<>();
-  private final Map<String, String> classNameTranslations = new HashMap<>();
-  private final HashSet<MethodRef> interceptedMethods = new HashSet<>();
-  private final Set<String> classesToNotAquire = new HashSet<>();
-  private final Set<String> packagesToNotAquire = new HashSet<>();
+  private final List<String> instrumentedPackages;
+  private final Set<String> instrumentedClasses;
+  private final Set<String> classesToNotInstrument;
+  private final Map<String, String> classNameTranslations;
+  private final Set<MethodRef> interceptedMethods;
+  private final Set<String> classesToNotAquire;
+  private final Set<String> packagesToNotAquire;
+  private int cachedHashCode;
 
   private InstrumentationConfiguration(Map<String, String> classNameTranslations, Collection<MethodRef> interceptedMethods, Collection<String> instrumentedPackages, Collection<String> instrumentedClasses, Collection<String> classesToNotAquire, Collection<String> packagesToNotAquire, Collection<String> classesToNotInstrument) {
-    this.classNameTranslations.putAll(classNameTranslations);
-    this.interceptedMethods.addAll(interceptedMethods);
-    this.instrumentedPackages.addAll(instrumentedPackages);
-    this.instrumentedClasses.addAll(instrumentedClasses);
-    this.classesToNotAquire.addAll(classesToNotAquire);
-    this.packagesToNotAquire.addAll(packagesToNotAquire);
-    this.classesToNotInstrument.addAll(classesToNotInstrument);
+    this.classNameTranslations = ImmutableMap.copyOf(classNameTranslations);
+    this.interceptedMethods = ImmutableSet.copyOf(interceptedMethods);
+    this.instrumentedPackages = ImmutableList.copyOf(instrumentedPackages);
+    this.instrumentedClasses = ImmutableSet.copyOf(instrumentedClasses);
+    this.classesToNotAquire = ImmutableSet.copyOf(classesToNotAquire);
+    this.packagesToNotAquire = ImmutableSet.copyOf(packagesToNotAquire);
+    this.classesToNotInstrument = ImmutableSet.copyOf(classesToNotInstrument);
+    this.cachedHashCode = 0;
   }
 
   /**
@@ -301,11 +307,16 @@ public class InstrumentationConfiguration {
 
   @Override
   public int hashCode() {
+    if (cachedHashCode != 0) {
+      return cachedHashCode;
+    }
+
     int result = instrumentedPackages.hashCode();
     result = 31 * result + instrumentedClasses.hashCode();
     result = 31 * result + classNameTranslations.hashCode();
     result = 31 * result + interceptedMethods.hashCode();
     result = 31 * result + classesToNotAquire.hashCode();
+    cachedHashCode = result;
     return result;
   }
 

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
@@ -86,6 +86,28 @@ public class InstrumentationConfiguration {
       this.classesToNotInstrument.add(className);
       return this;
     }
+    
+    public Builder withConfig(Config config) {
+      for (Class<?> clazz : config.shadows()) {
+        Implements annotation = clazz.getAnnotation(Implements.class);
+        if (annotation == null) {
+          throw new IllegalArgumentException(clazz + " is not annotated with @Implements");
+        }
+
+        String className = annotation.className();
+        if (className.isEmpty()) {
+          className = annotation.value().getName();
+        }
+
+        if (!className.isEmpty()) {
+          addInstrumentedClass(className);
+        }
+      }
+      for (String packageName : config.instrumentedPackages()) {
+        addInstrumentedPackage(packageName);
+      }
+      return this;
+    }
 
     public InstrumentationConfiguration build() {
       interceptedMethods.addAll(Arrays.asList(

--- a/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
+++ b/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
@@ -85,13 +85,13 @@ public class DefaultTestLifecycleTest {
 
   @Test public void shouldLoadConfigApplicationIfSpecified() throws Exception {
     Application application = defaultTestLifecycle.createApplication(null,
-        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(new int[0], "", "", "", "", "", new Class[0], TestFakeApp.class, new String[0], null));
+        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(new int[0], "", "", "", "", "", new Class[0], new String[0], TestFakeApp.class, new String[0], null));
     assertThat(application).isExactlyInstanceOf(TestFakeApp.class);
   }
 
   @Test public void shouldLoadConfigInnerClassApplication() throws Exception {
     Application application = defaultTestLifecycle.createApplication(null,
-        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(new int[0], "", "", "", "", "", new Class[0], TestFakeAppInner.class, new String[0], null));
+        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(new int[0], "", "", "", "", "", new Class[0], new String[0], TestFakeAppInner.class, new String[0], null));
     assertThat(application).isExactlyInstanceOf(TestFakeAppInner.class);
   }
 

--- a/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
@@ -31,7 +31,7 @@ public class ParallelUniverseTest {
   private ParallelUniverse pu;
 
   private static Config getDefaultConfig() {
-    return new Config.Implementation(new int[0], Config.DEFAULT, "", "org.robolectric", "res", "assets", new Class[0], Application.class, new String[0], null);
+    return new Config.Implementation(new int[0], Config.DEFAULT, "", "org.robolectric", "res", "assets", new Class[0], new String[0], Application.class, new String[0], null);
   }
 
   @Before
@@ -114,7 +114,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromSdkConfig() {
     String givenQualifiers = "";
-    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "res", "assets", new Class[0], Application.class, new String[0], null);
+    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "res", "assets", new Class[0], new String[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("v18");
     assertThat(getQualifiersFromAppAssetManager()).isEqualTo("v18");
@@ -124,7 +124,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromConfigQualifiers() {
     String givenQualifiers = "land-v17";
-    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "res", "assets", new Class[0], Application.class, new String[0], null);
+    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "res", "assets", new Class[0], new String[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("land-v17");
     assertThat(getQualifiersFromAppAssetManager()).isEqualTo("land-v17");
@@ -134,7 +134,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromSdkConfigWithOtherQualifiers() {
     String givenQualifiers = "large-land";
-    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "res", "assets", "", new Class[0], Application.class, new String[0], null);
+    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "res", "assets", "", new Class[0], new String[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("large-land-v18");
     assertThat(getQualifiersFromAppAssetManager()).isEqualTo("large-land-v18");

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -25,73 +25,73 @@ public class RobolectricTestRunnerTest {
   @Test
   public void whenClassHasConfigAnnotation_getConfig_shouldMergeClassAndMethodConfig() throws Exception {
     assertConfig(configFor(Test1.class, "withoutAnnotation"),
-        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-test", "test/res", "test/assets", new Class[]{Test1.class}, new String[]{"libs/test"}, BuildConfigConstants.class);
+        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-test", "test/res", "test/assets", new Class[]{Test1.class}, new String[]{"com.example.test1"}, new String[]{"libs/test"}, BuildConfigConstants.class);
 
     assertConfig(configFor(Test1.class, "withDefaultsAnnotation"),
-        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-test", "test/res", "test/assets", new Class[]{Test1.class}, new String[]{"libs/test"}, BuildConfigConstants.class);
+        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-test", "test/res", "test/assets", new Class[]{Test1.class}, new String[]{"com.example.test1"}, new String[]{"libs/test"}, BuildConfigConstants.class);
 
     assertConfig(configFor(Test1.class, "withOverrideAnnotation"),
-        new int[] {9}, "furf", TestApplication.class, "com.example.method", "from-method", "method/res", "method/assets", new Class[]{Test1.class, Test2.class}, new String[]{"libs/method", "libs/test"}, BuildConfigConstants2.class);
+        new int[] {9}, "furf", TestApplication.class, "com.example.method", "from-method", "method/res", "method/assets", new Class[]{Test1.class, Test2.class}, new String[]{"com.example.test1", "com.example.method1"}, new String[]{"libs/method", "libs/test"}, BuildConfigConstants2.class);
   }
 
   @Test
   public void whenClassDoesntHaveConfigAnnotation_getConfig_shouldUseMethodConfig() throws Exception {
     assertConfig(configFor(Test2.class, "withoutAnnotation"),
-        new int[0], "--default", Application.class, "", "", "res", "assets", new Class[]{}, new String[]{}, Void.class);
+        new int[0], "--default", Application.class, "", "", "res", "assets", new Class[]{}, new String[]{}, new String[]{}, Void.class);
 
     assertConfig(configFor(Test2.class, "withDefaultsAnnotation"),
-        new int[0], "--default", Application.class, "", "", "res", "assets", new Class[]{}, new String[]{}, Void.class);
+        new int[0], "--default", Application.class, "", "", "res", "assets", new Class[]{}, new String[]{}, new String[]{}, Void.class);
 
     assertConfig(configFor(Test2.class, "withOverrideAnnotation"),
-        new int[] {9}, "furf", TestFakeApp.class, "com.example.method", "from-method", "method/res", "method/assets", new Class[]{Test1.class}, new String[]{"libs/method"}, BuildConfigConstants.class);
+        new int[] {9}, "furf", TestFakeApp.class, "com.example.method", "from-method", "method/res", "method/assets", new Class[]{Test1.class}, new String[]{"com.example.method2"}, new String[]{"libs/method"}, BuildConfigConstants.class);
   }
 
   @Test
   public void whenClassDoesntHaveConfigAnnotation_getConfig_shouldMergeParentClassAndMethodConfig() throws Exception {
     assertConfig(configFor(Test5.class, "withoutAnnotation"),
-        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-test", "test/res", "test/assets", new Class[]{Test1.class}, new String[]{"libs/test"}, BuildConfigConstants.class);
+        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-test", "test/res", "test/assets", new Class[]{Test1.class}, new String[]{"com.example.test1"}, new String[]{"libs/test"}, BuildConfigConstants.class);
 
     assertConfig(configFor(Test5.class, "withDefaultsAnnotation"),
-        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-test", "test/res", "test/assets", new Class[]{Test1.class}, new String[]{"libs/test"}, BuildConfigConstants.class);
+        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-test", "test/res", "test/assets", new Class[]{Test1.class}, new String[]{"com.example.test1"}, new String[]{"libs/test"}, BuildConfigConstants.class);
 
     assertConfig(configFor(Test5.class, "withOverrideAnnotation"),
-        new int[] {14}, "foo", TestFakeApp.class, "com.example.test", "from-method5", "test/res", "method5/assets", new Class[]{Test1.class, Test5.class}, new String[]{"libs/test"}, BuildConfigConstants5.class);
+        new int[] {14}, "foo", TestFakeApp.class, "com.example.test", "from-method5", "test/res", "method5/assets", new Class[]{Test1.class, Test5.class}, new String[]{"com.example.test1", "com.example.method5"}, new String[]{"libs/test"}, BuildConfigConstants5.class);
   }
 
   @Test
   public void whenClassAndParentClassHaveConfigAnnotation_getConfig_shouldMergeParentClassAndMethodConfig() throws Exception {
     assertConfig(configFor(Test6.class, "withoutAnnotation"),
-        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-class6", "class6/res", "test/assets", new Class[]{Test1.class, Test6.class}, new String[]{"libs/test"}, BuildConfigConstants6.class);
+        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-class6", "class6/res", "test/assets", new Class[]{Test1.class, Test6.class}, new String[]{"com.example.test1", "com.example.test6"}, new String[]{"libs/test"}, BuildConfigConstants6.class);
 
     assertConfig(configFor(Test6.class, "withDefaultsAnnotation"),
-        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-class6", "class6/res", "test/assets", new Class[]{Test1.class, Test6.class}, new String[]{"libs/test"}, BuildConfigConstants6.class);
+        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-class6", "class6/res", "test/assets", new Class[]{Test1.class, Test6.class}, new String[]{"com.example.test1", "com.example.test6"}, new String[]{"libs/test"}, BuildConfigConstants6.class);
 
     assertConfig(configFor(Test6.class, "withOverrideAnnotation"),
-        new int[] {14}, "foo", TestFakeApp.class, "com.example.test", "from-method5", "class6/res", "method5/assets", new Class[]{Test1.class, Test5.class, Test6.class}, new String[]{"libs/test"}, BuildConfigConstants5.class);
+        new int[] {14}, "foo", TestFakeApp.class, "com.example.test", "from-method5", "class6/res", "method5/assets", new Class[]{Test1.class, Test5.class, Test6.class}, new String[]{"com.example.test1", "com.example.method5", "com.example.test6"}, new String[]{"libs/test"}, BuildConfigConstants5.class);
   }
 
   @Test
   public void whenClassAndSubclassHaveConfigAnnotation_getConfig_shouldMergeClassSubclassAndMethodConfig() throws Exception {
     assertConfig(configFor(Test3.class, "withoutAnnotation"),
-        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-subclass", "test/res", "test/assets", new Class[]{Test1.class}, new String[]{"libs/test"}, BuildConfigConstants.class);
+        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-subclass", "test/res", "test/assets", new Class[]{Test1.class}, new String[]{"com.example.test1"}, new String[]{"libs/test"}, BuildConfigConstants.class);
 
     assertConfig(configFor(Test3.class, "withDefaultsAnnotation"),
-        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-subclass", "test/res", "test/assets", new Class[]{Test1.class}, new String[]{"libs/test"}, BuildConfigConstants.class);
+        new int[] {1}, "foo", TestFakeApp.class, "com.example.test", "from-subclass", "test/res", "test/assets", new Class[]{Test1.class}, new String[]{"com.example.test1"}, new String[]{"libs/test"}, BuildConfigConstants.class);
 
     assertConfig(configFor(Test3.class, "withOverrideAnnotation"),
-        new int[] {9},"furf", TestApplication.class, "com.example.method", "from-method", "method/res", "method/assets", new Class[]{Test1.class, Test2.class}, new String[]{"libs/method", "libs/test"}, BuildConfigConstants2.class);
+        new int[] {9},"furf", TestApplication.class, "com.example.method", "from-method", "method/res", "method/assets", new Class[]{Test1.class, Test2.class}, new String[]{"com.example.test1", "com.example.method1"}, new String[]{"libs/method", "libs/test"}, BuildConfigConstants2.class);
   }
 
   @Test
   public void whenClassDoesntHaveConfigAnnotationButSubclassDoes_getConfig_shouldMergeSubclassAndMethodConfig() throws Exception {
     assertConfig(configFor(Test4.class, "withoutAnnotation"),
-        new int[0],  "--default", Application.class, "", "from-subclass", "res", "assets", new Class[]{}, new String[]{}, Void.class);
+        new int[0],  "--default", Application.class, "", "from-subclass", "res", "assets", new Class[]{}, new String[]{}, new String[]{}, Void.class);
 
     assertConfig(configFor(Test4.class, "withDefaultsAnnotation"),
-        new int[0],  "--default", Application.class, "", "from-subclass", "res", "assets", new Class[]{}, new String[]{}, Void.class);
+        new int[0],  "--default", Application.class, "", "from-subclass", "res", "assets", new Class[]{}, new String[]{}, new String[]{}, Void.class);
 
     assertConfig(configFor(Test4.class, "withOverrideAnnotation"),
-        new int[] {9}, "furf", TestFakeApp.class, "com.example.method", "from-method", "method/res", "method/assets", new Class[]{Test1.class}, new String[]{"libs/method"}, BuildConfigConstants.class);
+        new int[] {9}, "furf", TestFakeApp.class, "com.example.method", "from-method", "method/res", "method/assets", new Class[]{Test1.class}, new String[]{"com.example.method2"}, new String[]{"libs/method"}, BuildConfigConstants.class);
   }
 
   @Test
@@ -105,17 +105,18 @@ public class RobolectricTestRunnerTest {
             "shadows: org.robolectric.shadows.ShadowView, org.robolectric.shadows.ShadowViewGroup\n" +
             "application: org.robolectric.TestFakeApp\n" +
             "packageName: com.example.test\n" +
+            "instrumentedPackages: com.example.test1, com.example.test2\n" +
             "libraries: libs/test, libs/test2\n" +
             "constants: org.robolectric.RobolectricTestRunnerTest$BuildConfigConstants3");
 
     assertConfig(configFor(Test2.class, "withoutAnnotation", properties),
-        new int[] {432}, "--none", TestFakeApp.class, "com.example.test", "from-properties-file", "from/properties/file/res", "from/properties/file/assets", new Class[] {ShadowView.class, ShadowViewGroup.class}, new String[]{"libs/test", "libs/test2"}, BuildConfigConstants3.class);
+        new int[] {432}, "--none", TestFakeApp.class, "com.example.test", "from-properties-file", "from/properties/file/res", "from/properties/file/assets", new Class[] {ShadowView.class, ShadowViewGroup.class}, new String[]{"com.example.test1", "com.example.test2"}, new String[]{"libs/test", "libs/test2"}, BuildConfigConstants3.class);
   }
 
   @Test
   public void withEmptyShadowList_shouldLoadDefaultsFromPropertiesFile() throws Exception {
     Properties properties = properties("shadows:");
-    assertConfig(configFor(Test2.class, "withoutAnnotation", properties), new int[0],  "--default", Application.class, "", "", "res", "assets", new Class[] {}, new String[]{}, null);
+    assertConfig(configFor(Test2.class, "withoutAnnotation", properties), new int[0],  "--default", Application.class, "", "", "res", "assets", new Class[] {}, new String[]{}, new String[]{}, null);
   }
 
   @Test
@@ -162,12 +163,12 @@ public class RobolectricTestRunnerTest {
     return new RobolectricTestRunner(testClass).getConfig(info);
   }
 
-  private void assertConfig(Config config, int[] sdk, String manifest, Class<? extends Application> application, String packageName, String qualifiers, String resourceDir, String assetsDir, Class<?>[] shadows, String[] libraries, Class<?> constants) {
-    assertThat(stringify(config)).isEqualTo(stringify(sdk, manifest, application, packageName, qualifiers, resourceDir, assetsDir, shadows, libraries, constants));
+  private void assertConfig(Config config, int[] sdk, String manifest, Class<? extends Application> application, String packageName, String qualifiers, String resourceDir, String assetsDir, Class<?>[] shadows, String[] instrumentedPackages, String[] libraries, Class<?> constants) {
+    assertThat(stringify(config)).isEqualTo(stringify(sdk, manifest, application, packageName, qualifiers, resourceDir, assetsDir, shadows, instrumentedPackages, libraries, constants));
   }
 
   @Ignore
-  @Config(sdk = 1, manifest = "foo", application = TestFakeApp.class, packageName = "com.example.test", shadows = Test1.class, libraries = "libs/test", qualifiers = "from-test", resourceDir = "test/res", assetDir = "test/assets", constants = BuildConfigConstants.class)
+  @Config(sdk = 1, manifest = "foo", application = TestFakeApp.class, packageName = "com.example.test", shadows = Test1.class, instrumentedPackages = "com.example.test1", libraries = "libs/test", qualifiers = "from-test", resourceDir = "test/res", assetDir = "test/assets", constants = BuildConfigConstants.class)
   public static class Test1 {
     @Test
     public void withoutAnnotation() throws Exception {
@@ -179,7 +180,7 @@ public class RobolectricTestRunnerTest {
     }
 
     @Test
-    @Config(sdk = 9, manifest = "furf", application = TestApplication.class, packageName = "com.example.method", shadows = Test2.class, libraries = "libs/method", qualifiers = "from-method", resourceDir = "method/res", assetDir = "method/assets", constants = BuildConfigConstants2.class)
+    @Config(sdk = 9, manifest = "furf", application = TestApplication.class, packageName = "com.example.method", shadows = Test2.class, instrumentedPackages = "com.example.method1", libraries = "libs/method", qualifiers = "from-method", resourceDir = "method/res", assetDir = "method/assets", constants = BuildConfigConstants2.class)
     public void withOverrideAnnotation() throws Exception {
     }
   }
@@ -196,7 +197,7 @@ public class RobolectricTestRunnerTest {
     }
 
     @Test
-    @Config(sdk = 9, manifest = "furf", application = TestFakeApp.class, packageName = "com.example.method", shadows = Test1.class, libraries = "libs/method", qualifiers = "from-method", resourceDir = "method/res", assetDir = "method/assets", constants = BuildConfigConstants.class)
+    @Config(sdk = 9, manifest = "furf", application = TestFakeApp.class, packageName = "com.example.method", shadows = Test1.class, instrumentedPackages = "com.example.method2", libraries = "libs/method", qualifiers = "from-method", resourceDir = "method/res", assetDir = "method/assets", constants = BuildConfigConstants.class)
     public void withOverrideAnnotation() throws Exception {
     }
   }
@@ -213,17 +214,20 @@ public class RobolectricTestRunnerTest {
 
   @Ignore
   public static class Test5 extends Test1 {
+    @Override
     @Test
     public void withoutAnnotation() throws Exception {
     }
 
+    @Override
     @Test
     @Config
     public void withDefaultsAnnotation() throws Exception {
     }
 
+    @Override
     @Test
-    @Config(sdk = 14, shadows = Test5.class, qualifiers = "from-method5", assetDir = "method5/assets", constants = BuildConfigConstants5.class)
+    @Config(sdk = 14, shadows = Test5.class, instrumentedPackages = "com.example.method5", packageName = "com.example.test", qualifiers = "from-method5", assetDir = "method5/assets", constants = BuildConfigConstants5.class)
     public void withOverrideAnnotation() throws Exception {
     }
   }
@@ -237,7 +241,7 @@ public class RobolectricTestRunnerTest {
 
 
   @Ignore
-  @Config(qualifiers = "from-class6", shadows = Test6.class, resourceDir = "class6/res", constants = BuildConfigConstants6.class)
+  @Config(qualifiers = "from-class6", shadows = Test6.class, instrumentedPackages = "com.example.test6", resourceDir = "class6/res", constants = BuildConfigConstants6.class)
   public static class Test6 extends Test5 {
   }
 
@@ -250,12 +254,13 @@ public class RobolectricTestRunnerTest {
     String resourceDir = config.resourceDir();
     String assetsDir = config.assetDir();
     Class<?>[] shadows = config.shadows();
+    String[] instrumentedPackages = config.instrumentedPackages();
     String[] libraries = config.libraries();
     Class<?> constants = config.constants();
-    return stringify(sdk, manifest, application, packageName, qualifiers, resourceDir, assetsDir, shadows, libraries, constants);
+    return stringify(sdk, manifest, application, packageName, qualifiers, resourceDir, assetsDir, shadows, instrumentedPackages, libraries, constants);
   }
 
-  private String stringify(int[] sdk, String manifest, Class<? extends Application> application, String packageName, String qualifiers, String resourceDir, String assetsDir, Class<?>[] shadows, String[] libraries, Class<?> constants) {
+  private String stringify(int[] sdk, String manifest, Class<? extends Application> application, String packageName, String qualifiers, String resourceDir, String assetsDir, Class<?>[] shadows, String[] instrumentedPackages, String[] libraries, Class<?> constants) {
       String[] stringClasses = new String[shadows.length];
       for (int i = 0; i < stringClasses.length; i++) {
           stringClasses[i] = shadows[i].toString();
@@ -266,6 +271,9 @@ public class RobolectricTestRunnerTest {
       String[] sortedLibraries = libraries.clone();
       Arrays.sort(sortedLibraries);
 
+      String[] sortedInstrumentedPackages = instrumentedPackages.clone();
+      Arrays.sort(sortedInstrumentedPackages);
+
       return "sdk=" + Arrays.toString(sdk) + "\n" +
         "manifest=" + manifest + "\n" +
         "application=" + application + "\n" +
@@ -274,6 +282,7 @@ public class RobolectricTestRunnerTest {
         "resourceDir=" + resourceDir + "\n" +
         "assetDir=" + assetsDir + "\n" +
         "shadows=" + Arrays.toString(stringClasses) + "\n" +
+        "instrumentedPackages" + Arrays.toString(sortedInstrumentedPackages) + "\n" +
         "libraries=" + Arrays.toString(sortedLibraries) + "\n" +
         "constants=" + constants;
   }

--- a/robolectric/src/test/java/org/robolectric/TestRunnerSequenceTest.java
+++ b/robolectric/src/test/java/org/robolectric/TestRunnerSequenceTest.java
@@ -99,7 +99,7 @@ public class TestRunnerSequenceTest {
       super(testClass);
     }
 
-    @Override public InstrumentationConfiguration createClassLoaderConfig() {
+    @Override public InstrumentationConfiguration createClassLoaderConfig(Config config) {
       return InstrumentationConfiguration.newBuilder()
           .doNotAquireClass(StateHolder.class.getName())
           .build();

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/AndroidTranslatorClassInstrumentedTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/AndroidTranslatorClassInstrumentedTest.java
@@ -5,7 +5,6 @@ import android.graphics.Paint;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.TestRunners;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -49,18 +48,6 @@ public class AndroidTranslatorClassInstrumentedTest {
     CustomPaint customPaint = new CustomPaint();
     assertThat(customPaint.getColor()).isEqualTo(10);
     assertThat(customPaint.getColorName()).isEqualTo("rainbow");
-  }
-
-  /*
-   * Test "foreign class" not getting its methods shadowed when it's
-   * not in the InstrumentingClassLoader CustomClassNames arrayList
-   */
-  @Test
-  @Config(shadows = {ShadowCustomXmasPaint.class, ShadowPaintForTests.class})
-  public void testCustomMethodNotShadowed() throws Exception {
-    CustomXmasPaint customXmasPaint = new CustomXmasPaint();
-    assertThat(customXmasPaint.getColor()).isEqualTo(999);
-    assertThat(customXmasPaint.getColorName()).isEqualTo("XMAS");
   }
 
   @Instrument
@@ -114,6 +101,7 @@ public class AndroidTranslatorClassInstrumentedTest {
   @Implements(CustomPaint.class)
   public static class ShadowCustomPaint extends ShadowPaintForTests {
 
+    @Override
     @Implementation
     public int getColor() {
       return 10;
@@ -122,33 +110,6 @@ public class AndroidTranslatorClassInstrumentedTest {
     @Implementation
     public String getColorName() {
       return "rainbow";
-    }
-  }
-
-  @SuppressWarnings({"UnusedDeclaration"})
-  public static class CustomXmasPaint extends Paint {
-
-    @Override
-    public int getColor() {
-      return 999;
-    }
-
-    public String getColorName() {
-      return "XMAS";
-    }
-  }
-
-  @Implements(CustomXmasPaint.class)
-  public static class ShadowCustomXmasPaint extends ShadowPaintForTests {
-
-    @Implementation
-    public int getColor() {
-      return -999;
-    }
-
-    @Implementation
-    public String getColorName() {
-      return "XMAS Color Test";
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/CustomRobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/CustomRobolectricTestRunnerTest.java
@@ -143,7 +143,7 @@ public class CustomRobolectricTestRunnerTest {
       super(testClass);
     }
 
-    @Override public InstrumentationConfiguration createClassLoaderConfig() {
+    @Override public InstrumentationConfiguration createClassLoaderConfig(Config config) {
       return InstrumentationConfiguration.newBuilder()
           .doNotAquireClass(CustomRobolectricTestRunnerTest.class.getName())
           .build();


### PR DESCRIPTION
Currently it's a bit weird to declare shadows in @Config because the shadows are not automatically instrumented. The problem can be solved by reading the "shadows" attribute in @Config in the test runner and adding the shadowed classes to instrumented classes list.

This change also adds a new attribute to @Config so we can add the information of instrumented packages to @Config.