### PR TITLE
Update the FragmentController to support customized view ID as the

### DIFF
--- a/robolectric/src/main/java/org/robolectric/util/FragmentController.java
+++ b/robolectric/src/main/java/org/robolectric/util/FragmentController.java
@@ -37,15 +37,25 @@ public class FragmentController<F extends Fragment> extends ComponentController<
     return this;
   }
 
-  public FragmentController<F> create(final Bundle bundle) {
+  /**
+   * Creates the activity with {@link Bundle} and adds the fragment to the view with ID {@code contentViewId}.
+   */
+  public FragmentController<F> create(final int contentViewId, final Bundle bundle) {
     shadowMainLooper.runPaused(new Runnable() {
       @Override
       public void run() {
         if (!attached) attach();
-        activityController.create(bundle).get().getFragmentManager().beginTransaction().add(1, fragment).commit();
+        activityController.create(bundle).get().getFragmentManager().beginTransaction().add(contentViewId, fragment).commit();
       }
     });
     return this;
+  }
+
+  /**
+   * Creates the activity with {@link Bundle} and adds the fragment to it. Note that the fragment will be added to the view with ID 1.
+   */
+  public FragmentController<F> create(Bundle bundle) {
+    return create(1, bundle);
   }
 
   @Override

--- a/robolectric/src/test/java/org/robolectric/util/FragmentControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/FragmentControllerTest.java
@@ -19,6 +19,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class FragmentControllerTest {
+
+  private static final int VIEW_ID_CUSTOMIZED_LOGIN_ACTIVITY = 123;
+
   @Test
   public void initialNotAttached() {
     final LoginFragment fragment = new LoginFragment();
@@ -43,6 +46,18 @@ public class FragmentControllerTest {
   public void attachedAfterCreate() {
     final LoginFragment fragment = new LoginFragment();
     FragmentController.of(fragment).create();
+
+    assertThat(fragment.getView()).isNotNull();
+    assertThat(fragment.getActivity()).isNotNull();
+    assertThat(fragment.isAdded()).isTrue();
+    assertThat(fragment.isResumed()).isFalse();
+    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+  }
+
+  @Test
+  public void attachedAfterCreate_customizedViewId() {
+    final LoginFragment fragment = new LoginFragment();
+    FragmentController.of(fragment, CustomizedViewIdLoginActivity.class).create(VIEW_ID_CUSTOMIZED_LOGIN_ACTIVITY, null);
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();
@@ -144,6 +159,17 @@ public class FragmentControllerTest {
       super.onCreate(savedInstanceState);
       LinearLayout view = new LinearLayout(this);
       view.setId(1);
+
+      setContentView(view);
+    }
+  }
+
+  private static class CustomizedViewIdLoginActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      LinearLayout view = new LinearLayout(this);
+      view.setId(VIEW_ID_CUSTOMIZED_LOGIN_ACTIVITY);
 
       setContentView(view);
     }


### PR DESCRIPTION
Update the FragmentController to support customized view ID as the behavior of adding the fragment was changed in commit 2ab0c4af618ddb03b9cced522c3ee8eb13560c23.