### PR TITLE
Exposes hidden setRssi method in ShadowWifiInfo

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWifiInfo.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWifiInfo.java
@@ -1,15 +1,21 @@
 package org.robolectric.shadows;
 
+import static org.robolectric.internal.Shadow.directlyOn;
+
 import android.net.wifi.WifiInfo;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.HiddenApi;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 /**
  * Shadow for {@link android.net.wifi.WifiInfo}.
  */
 @Implements(WifiInfo.class)
 public class ShadowWifiInfo {
+  @RealObject private WifiInfo realObject;
+
   public static void __staticInitializer__() {
   }
 
@@ -23,5 +29,10 @@ public class ShadowWifiInfo {
   @HiddenApi @Implementation
   public void setMacAddress(String newMacAddress) {
     macAddress = newMacAddress;
+  }
+
+  @HiddenApi @Implementation
+  public void setRssi(int rssi) {
+    directlyOn(realObject, WifiInfo.class, "setRssi", ClassParameter.from(int.class, rssi));
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiInfoTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiInfoTest.java
@@ -24,4 +24,15 @@ public class ShadowWifiInfoTest {
     wifiInfo = wifiManager.getConnectionInfo();
     assertThat(wifiInfo.getMacAddress()).isEqualTo("mac address");
   }
+
+  @Test
+  public void shouldReturnRssi() {
+    WifiManager wifiManager = (WifiManager) application.getSystemService(WIFI_SERVICE);
+    WifiInfo wifiInfo = wifiManager.getConnectionInfo();
+    shadowOf(wifiInfo).setRssi(123);
+
+    wifiManager = (WifiManager) application.getSystemService(WIFI_SERVICE);
+    wifiInfo = wifiManager.getConnectionInfo();
+    assertThat(wifiInfo.getRssi()).isEqualTo(123);
+  }
 }


### PR DESCRIPTION
This allows tests depending on the RSSI value to fake it out. Basically a direct passthrough to the hidden public API setRssi on WifiInfo.