### PR TITLE
Bug fix for shadowA11yNodeInfo

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java.vm
@@ -41,6 +41,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import static org.robolectric.Shadows.shadowOf;
 /**
  * Shadow of {@link android.view.accessibility.AccessibilityNodeInfo} that allows a test to set
  * properties that are locked in the original class. It also keeps track of calls to
@@ -170,6 +171,8 @@ public class ShadowAccessibilityNodeInfo {
   private int maxTextLength; //21
 
   private CharSequence error; //21
+  
+  private AccessibilityWindowInfo accessibilityWindowInfo;
 #end
 #if ($api >= 22)
   private AccessibilityNodeInfo traversalAfter; //22
@@ -178,6 +181,8 @@ public class ShadowAccessibilityNodeInfo {
 #end
 
   private OnPerformActionListener actionListener;
+  
+  private boolean visitedWhenCheckingChildren = false;
 
   @RealObject
   private AccessibilityNodeInfo realAccessibilityNodeInfo;
@@ -903,6 +908,15 @@ public class ShadowAccessibilityNodeInfo {
 
 #if ($api >= 21)
   @Implementation
+  public AccessibilityWindowInfo getWindow() {
+    return accessibilityWindowInfo;
+  }
+
+  public void setAccessibilityWindowInfo(AccessibilityWindowInfo info) {
+    accessibilityWindowInfo = info;
+  }
+
+  @Implementation
   public List<AccessibilityAction> getActionList() {
     if (actionsArray == null) {
       return Collections.emptyList();
@@ -928,6 +942,31 @@ public class ShadowAccessibilityNodeInfo {
       : true;
   }
 
+  private boolean childrenEqualityCheck(
+      ShadowAccessibilityNodeInfo otherShadow,
+      LinkedList<ShadowAccessibilityNodeInfo> visitedNodes) {
+    if (children.size() != otherShadow.children.size()) {
+      return false;
+    }
+    boolean childrenEquality = true;
+    for (int i = 0; i < children.size(); i++) {
+      ShadowAccessibilityNodeInfo childShadow =
+          (ShadowAccessibilityNodeInfo) ShadowExtractor.extract(children.get(i));
+      if (!childShadow.visitedWhenCheckingChildren) {
+        ShadowAccessibilityNodeInfo otherChildShadow =
+            (ShadowAccessibilityNodeInfo) ShadowExtractor.extract(otherShadow.children.get(i));
+        visitedNodes.add(childShadow);
+        childShadow.visitedWhenCheckingChildren = true;
+        if (!childShadow.equals(otherShadow.children.get(i))) {
+           childrenEquality = false;
+           break;
+        }
+        childrenEquality = childShadow.childrenEqualityCheck(otherChildShadow, visitedNodes);
+      }
+    }
+    return childrenEquality;
+  }
+
   /**
    * Equality check based on reference equality for mParent and mView and
    * value equality for other fields.
@@ -947,20 +986,37 @@ public class ShadowAccessibilityNodeInfo {
     if (children == null) {
       areEqual &= (otherShadow.children == null);
     } else {
-      areEqual &= (otherShadow.children != null) && children.equals(otherShadow.children);
+      LinkedList<ShadowAccessibilityNodeInfo> visitedNodes = new LinkedList<>();
+      areEqual &=
+          (otherShadow.children != null) && childrenEqualityCheck(otherShadow, visitedNodes);
+      if (!shadowOf(parent).visitedWhenCheckingChildren) {
+        areEqual &= (
+            parent == null
+                ? otherShadow.parent == null : shadowOf(parent).equals(otherShadow.parent));
+      }
+      while (!visitedNodes.isEmpty()) {
+        ShadowAccessibilityNodeInfo visitedNode = visitedNodes.remove();
+        visitedNode.visitedWhenCheckingChildren = false;
+      }
     }
-    areEqual &= (parent == otherShadow.parent);
-
     areEqual &= (propertyFlags == otherShadow.propertyFlags);
 
 #if ($api >= 21)
     boolean actionsArrayEquality = false;
     if (actionsArray == null && otherShadow.actionsArray == null) {
       actionsArrayEquality = true;
+    } else if (actionsArray == null || otherShadow.actionsArray == null) {
+      actionsArrayEquality = false;
     } else {
       actionsArrayEquality = actionsArray.equals(otherShadow.actionsArray);
     }
     areEqual &= actionsArrayEquality;
+    if (accessibilityWindowInfo == null) {
+      areEqual &= (otherShadow.accessibilityWindowInfo == null);
+    } else {
+      areEqual &= (otherShadow.accessibilityWindowInfo != null) 
+                      && accessibilityWindowInfo.equals(otherShadow.accessibilityWindowInfo);
+    }
 #else
     areEqual &= (actionsMask == otherShadow.actionsMask);
 #end

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityWindowInfo.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAccessibilityWindowInfo.java.vm
@@ -130,8 +130,8 @@ public class ShadowAccessibilityWindowInfo {
     }
 
     final AccessibilityWindowInfo window = (AccessibilityWindowInfo) object;
-    final AccessibilityWindowInfo otherShadow =
-        (AccessibilityWindowInfo) ShadowExtractor.extract(window);
+    final ShadowAccessibilityWindowInfo otherShadow =
+        (ShadowAccessibilityWindowInfo) ShadowExtractor.extract(window);
 
     boolean areEqual = (type == otherShadow.getType());
     areEqual &= (parent == otherShadow.getParent());

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDateUtilsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDateUtilsTest.java
@@ -34,10 +34,12 @@ public class ShadowDateUtilsTest {
       Build.VERSION_CODES.JELLY_BEAN_MR1,
       Build.VERSION_CODES.JELLY_BEAN_MR2})
   public void formatDateTime_withCurrentYear_worksPreKitKat() {
+    Calendar calendar = Calendar.getInstance();
+    final int currentYear = calendar.get(Calendar.YEAR);
     final long millisAtStartOfYear = getMillisAtStartOfYear();
 
     String actual = DateUtils.formatDateTime(RuntimeEnvironment.application, millisAtStartOfYear, DateUtils.FORMAT_NUMERIC_DATE);
-    assertThat(actual).isEqualTo("1/1/2016");
+    assertThat(actual).isEqualTo("1/1/" + currentYear);
   }
 
   @Test


### PR DESCRIPTION
Fixing the following issues for the shadw:
Issue 1
The shadow class is missing getWindow(). I added:

Issue 2: In equals(), checking actionsArray does actions.equals without verifying that actionsArray isn't null.

Issue 3: In equals(), the list of children is checked, which calls .equals on all children. If there is a loop in the children, an infinite loop results. Added a DFS comparison with visited flag to avoid infinite loops.

Tests are also added to make sure they are working correctly now.

Also fixed a syntax error in ShadowAccessibilityWindowInfo.