### PR TITLE
Fix tests failing for ShadowDateUtils since the beginning of 2016

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDateUtilsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDateUtilsTest.java
@@ -47,7 +47,7 @@ public class ShadowDateUtilsTest {
       Build.VERSION_CODES.JELLY_BEAN_MR2,
       Build.VERSION_CODES.KITKAT,
       Build.VERSION_CODES.LOLLIPOP })
-  public void formatDateTime_withPastYear_works() {
+  public void formatDateTime_withPastYear() {
       String actual = DateUtils.formatDateTime(RuntimeEnvironment.application, 1420099200000L, DateUtils.FORMAT_NUMERIC_DATE);
       assertThat(actual).isEqualTo("1/1/2015");
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDateUtilsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDateUtilsTest.java
@@ -2,11 +2,15 @@ package org.robolectric.shadows;
 
 import android.os.Build;
 import android.text.format.DateUtils;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 import org.robolectric.annotation.Config;
+
+import java.util.Calendar;
+import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,8 +21,10 @@ public class ShadowDateUtilsTest {
   @Config(sdk = {
       Build.VERSION_CODES.KITKAT,
       Build.VERSION_CODES.LOLLIPOP })
-  public void formatDateTime_worksSinceKitKat() {
-    String actual = DateUtils.formatDateTime(RuntimeEnvironment.application, 1420099200000L, DateUtils.FORMAT_NUMERIC_DATE);
+  public void formatDateTime_withCurrentYear_worksSinceKitKat() {
+    final long millisAtStartOfYear = getMillisAtStartOfYear();
+
+    String actual = DateUtils.formatDateTime(RuntimeEnvironment.application, millisAtStartOfYear, DateUtils.FORMAT_NUMERIC_DATE);
     assertThat(actual).isEqualTo("1/1");
   }
 
@@ -26,10 +32,24 @@ public class ShadowDateUtilsTest {
   @Config(sdk = {
       Build.VERSION_CODES.JELLY_BEAN,
       Build.VERSION_CODES.JELLY_BEAN_MR1,
-      Build.VERSION_CODES.JELLY_BEAN_MR2 })
-  public void formatDateTime_worksPreKitKat() {
-    String actual = DateUtils.formatDateTime(RuntimeEnvironment.application, 1420099200000L, DateUtils.FORMAT_NUMERIC_DATE);
-    assertThat(actual).isEqualTo("1/1/2015");
+      Build.VERSION_CODES.JELLY_BEAN_MR2})
+  public void formatDateTime_withCurrentYear_worksPreKitKat() {
+    final long millisAtStartOfYear = getMillisAtStartOfYear();
+
+    String actual = DateUtils.formatDateTime(RuntimeEnvironment.application, millisAtStartOfYear, DateUtils.FORMAT_NUMERIC_DATE);
+    assertThat(actual).isEqualTo("1/1/2016");
+  }
+
+  @Test
+  @Config(sdk = {
+      Build.VERSION_CODES.JELLY_BEAN,
+      Build.VERSION_CODES.JELLY_BEAN_MR1,
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP })
+  public void formatDateTime_withPastYear_works() {
+      String actual = DateUtils.formatDateTime(RuntimeEnvironment.application, 1420099200000L, DateUtils.FORMAT_NUMERIC_DATE);
+      assertThat(actual).isEqualTo("1/1/2015");
   }
 
   @Test
@@ -40,5 +60,14 @@ public class ShadowDateUtilsTest {
     assertThat(DateUtils.isToday(today)).isTrue();
     assertThat(DateUtils.isToday(today + (86400 * 1000)  /* 24 hours */)).isFalse();
     assertThat(DateUtils.isToday(today + (86400 * 10000) /* 240 hours */)).isFalse();
+  }
+
+  private long getMillisAtStartOfYear() {
+    Calendar calendar = Calendar.getInstance();
+    final int currentYear = calendar.get(Calendar.YEAR);
+    calendar.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
+    calendar.set(currentYear, Calendar.JANUARY, 1, 0, 0, 0);
+
+    return calendar.getTimeInMillis();
   }
 }


### PR DESCRIPTION
On KitKat and above, Android is formatting dates in the form "1/1" instead of "1/1/2016" for example, but only for the current year. For past years, the format is always "1/1/2015".
This appears to happen in DateIntervalFormat.toSkeleton() where the date format is constructed.

Fixes #2194