### PR TITLE
Remove hardcoded year 2016

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDateUtilsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDateUtilsTest.java
@@ -34,10 +34,12 @@ public class ShadowDateUtilsTest {
       Build.VERSION_CODES.JELLY_BEAN_MR1,
       Build.VERSION_CODES.JELLY_BEAN_MR2})
   public void formatDateTime_withCurrentYear_worksPreKitKat() {
+    Calendar calendar = Calendar.getInstance();
+    final int currentYear = calendar.get(Calendar.YEAR);
     final long millisAtStartOfYear = getMillisAtStartOfYear();
 
     String actual = DateUtils.formatDateTime(RuntimeEnvironment.application, millisAtStartOfYear, DateUtils.FORMAT_NUMERIC_DATE);
-    assertThat(actual).isEqualTo("1/1/2016");
+    assertThat(actual).isEqualTo("1/1/" + currentYear);
   }
 
   @Test


### PR DESCRIPTION
Get the actual current year so this test doesn't fail in 2017. 
I overlooked this yesterday when merging.
Thanks!