### PR TITLE
Adds getStatSize() support to ShadowParcelFileDescriptor.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowParcelFileDescriptor.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowParcelFileDescriptor.java
@@ -42,6 +42,15 @@ public class ShadowParcelFileDescriptor {
   }
 
   @Implementation
+  public long getStatSize() {
+    try {
+      return file.length();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Implementation
   public void close() throws IOException {
     file.close();
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelFileDescriptorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelFileDescriptorTest.java
@@ -55,6 +55,26 @@ public class ShadowParcelFileDescriptorTest {
   }
 
   @Test
+  public void testStatSize_emptyFile() throws Exception {
+    ParcelFileDescriptor pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_WRITE);
+    assertThat(pfd).isNotNull();
+    assertThat(pfd.getFileDescriptor().valid()).isTrue();
+    assertThat(pfd.getStatSize()).isEqualTo(0);
+    pfd.close();
+  }
+
+  @Test
+  public void testStatSize_writtenFile() throws Exception {
+    ParcelFileDescriptor pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_WRITE);
+    assertThat(pfd).isNotNull();
+    assertThat(pfd.getFileDescriptor().valid()).isTrue();
+    FileOutputStream os = new FileOutputStream(pfd.getFileDescriptor());
+    os.write(5);
+    assertThat(pfd.getStatSize()).isEqualTo(1);  // One byte.
+    os.close();
+  }
+
+  @Test
   public void testCloses() throws Exception {
     ParcelFileDescriptor pfd = ParcelFileDescriptor.open(file, -1);
     pfd.close();


### PR DESCRIPTION
Tested: install-robolectric.sh. Verified that tests fail
before the change and pass afterward.