### PR TITLE
Implement getAllNetworks() and getNetworkInfo(Network) in ShadowConnectivityManager.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowConnectivityManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowConnectivityManager.java.vm
@@ -5,8 +5,10 @@ import android.net.NetworkInfo;
 
 #if ($api >= 21)
 import android.net.NetworkRequest;
+import android.net.Network;
 #end
 
+import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.HiddenApi;
@@ -22,6 +24,12 @@ import java.util.Set;
 @Implements(ConnectivityManager.class)
 public class ShadowConnectivityManager {
 
+#if ($api >= 21)
+  // Package-private for tests.
+  static final int NET_ID_WIFI = 1;
+  static final int NET_ID_MOBILE = 2;
+#end
+
   private NetworkInfo activeNetwork;
   private boolean backgroundDataSetting;
   private int networkPreference = ConnectivityManager.DEFAULT_NETWORK_PREFERENCE;
@@ -29,16 +37,27 @@ public class ShadowConnectivityManager {
 
 #if ($api >= 21)
   private HashSet<ConnectivityManager.NetworkCallback> networkCallbacks = new HashSet<>();
+  private final Map<Integer, Network> netIdToNetwork = new HashMap<>();
+  private final Map<Integer, NetworkInfo> netIdToNetworkInfo = new HashMap<>();
 #end
 
   public ShadowConnectivityManager() {
-    NetworkInfo wifi = ShadowNetworkInfo.newInstance(NetworkInfo.DetailedState.DISCONNECTED, ConnectivityManager.TYPE_WIFI, 0, true, false);
+    NetworkInfo wifi = ShadowNetworkInfo.newInstance(NetworkInfo.DetailedState.DISCONNECTED,
+        ConnectivityManager.TYPE_WIFI, 0, true, false);
     networkTypeToNetworkInfo.put(ConnectivityManager.TYPE_WIFI, wifi);
 
-    NetworkInfo mobile = ShadowNetworkInfo.newInstance(NetworkInfo.DetailedState.CONNECTED, ConnectivityManager.TYPE_MOBILE, ConnectivityManager.TYPE_MOBILE_MMS, true, true);
+    NetworkInfo mobile = ShadowNetworkInfo.newInstance(NetworkInfo.DetailedState.CONNECTED,
+        ConnectivityManager.TYPE_MOBILE, ConnectivityManager.TYPE_MOBILE_MMS, true, true);
     networkTypeToNetworkInfo.put(ConnectivityManager.TYPE_MOBILE, mobile);
 
     this.activeNetwork = mobile;
+
+#if ($api >= 21)
+    netIdToNetwork.put(NET_ID_WIFI, ShadowNetwork.newInstance(NET_ID_WIFI));
+    netIdToNetwork.put(NET_ID_MOBILE, ShadowNetwork.newInstance(NET_ID_MOBILE));
+    netIdToNetworkInfo.put(NET_ID_WIFI, wifi);
+    netIdToNetworkInfo.put(NET_ID_MOBILE, mobile);
+#end
   }
 
 #if ($api >= 21)
@@ -76,6 +95,19 @@ public class ShadowConnectivityManager {
   public NetworkInfo getNetworkInfo(int networkType) {
     return networkTypeToNetworkInfo.get(networkType);
   }
+
+#if ($api >= 21)
+  @Implementation
+  public NetworkInfo getNetworkInfo(Network network) {
+    ShadowNetwork shadowNetwork = Shadows.shadowOf(network);
+    return netIdToNetworkInfo.get(shadowNetwork.getNetId());
+  }
+
+  @Implementation
+  public Network[] getAllNetworks() {
+    return netIdToNetwork.values().toArray(new Network[netIdToNetwork.size()]);
+  }
+#end
 
   @Implementation
   public boolean getBackgroundDataSetting() {
@@ -122,4 +154,38 @@ public class ShadowConnectivityManager {
       networkTypeToNetworkInfo.clear();
     }
   }
+
+#if ($api >= 21)
+  /**
+   * Adds new {@code network} to the list of all {@link android.net.Network}s.
+   *
+   * @param network The network.
+   * @param networkInfo The network info paired with the {@link android.net.Network}.
+   */
+  public void addNetwork(Network network, NetworkInfo networkInfo) {
+    ShadowNetwork shadowNetwork = Shadows.shadowOf(network);
+    int netId = shadowNetwork.getNetId();
+    netIdToNetwork.put(netId, network);
+    netIdToNetworkInfo.put(netId, networkInfo);
+  }
+
+  /**
+   * Removes the {@code network} from the list of all {@link android.net.Network}s.
+   * @param network The network.
+   */
+  public void removeNetwork(Network network) {
+    ShadowNetwork shadowNetwork = Shadows.shadowOf(network);
+    int netId = shadowNetwork.getNetId();
+    netIdToNetwork.remove(netId);
+    netIdToNetworkInfo.remove(netId);
+  }
+
+  /**
+   * Clears the list of all {@link android.net.Network}s.
+   */
+  public void clearAllNetworks() {
+    netIdToNetwork.clear();
+    netIdToNetworkInfo.clear();
+  }
+#end
 }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowNetwork.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowNetwork.java.vm
@@ -1,0 +1,45 @@
+package org.robolectric.shadows;
+
+#if ($api >= 21)
+import android.net.Network;
+
+import org.robolectric.annotation.Implements;
+import org.robolectric.internal.Shadow;
+
+/**
+ * Shadow for {@code android.net.Network}.
+ */
+@Implements(Network.class)
+public class ShadowNetwork {
+  private int netId;
+
+  /**
+   * Creates new instance of {@link Network}, because its constructor is hidden.
+   *
+   * @param netId The netId.
+   * @return The Network instance.
+   */
+  public static Network newInstance(int netId) {
+    Network network = Shadow.newInstance(Network.class, new Class[]{int.class}, new Object[]{netId});
+    return network;
+  }
+
+  public void __constructor__(int netId) {
+    this.netId = netId;
+  }
+
+  /**
+   * Allows to get the stored netId.
+   *
+   * @return The netId.
+   */
+  public int getNetId() {
+    return netId;
+  }
+}
+
+#else
+public class ShadowNetwork {
+  // Stub class, does not exist pre-21
+}
+#end

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
@@ -5,11 +5,13 @@ import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkInfo;
 import android.net.NetworkRequest;
+import android.os.Build;
 import android.telephony.TelephonyManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
 import org.robolectric.annotation.Config;
 
@@ -55,6 +57,35 @@ public class ShadowConnectivityManagerTest {
     assertThat(mobile.getDetailedState()).isEqualTo(NetworkInfo.DetailedState.CONNECTED);
   }
 
+  @Test @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
+  public void getNetworkInfo_shouldReturnSomeForAllNetworks() throws Exception {
+    Network[] allNetworks = connectivityManager.getAllNetworks();
+    for (Network network: allNetworks) {
+      NetworkInfo networkInfo = connectivityManager.getNetworkInfo(network);
+      assertThat(networkInfo).isNotNull();
+    }
+  }
+
+  @Test @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
+  public void getNetworkInfo_shouldReturnAddedNetwork() throws Exception {
+    Network vpnNetwork = ShadowNetwork.newInstance(123);
+    NetworkInfo vpnNetworkInfo = ShadowNetworkInfo.newInstance(NetworkInfo.DetailedState.CONNECTED,
+        ConnectivityManager.TYPE_VPN, 0, true, true);
+    shadowConnectivityManager.addNetwork(vpnNetwork, vpnNetworkInfo);
+
+    NetworkInfo returnedNetworkInfo = connectivityManager.getNetworkInfo(vpnNetwork);
+    assertThat(returnedNetworkInfo).isSameAs(vpnNetworkInfo);
+  }
+
+  @Test @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
+  public void getNetworkInfo_shouldNotReturnRemovedNetwork() throws Exception {
+    Network wifiNetwork = ShadowNetwork.newInstance(ShadowConnectivityManager.NET_ID_WIFI);
+    shadowConnectivityManager.removeNetwork(wifiNetwork);
+
+    NetworkInfo returnedNetworkInfo = connectivityManager.getNetworkInfo(wifiNetwork);
+    assertThat(returnedNetworkInfo).isNull();
+  }
+
   @Test
   public void setConnectionType_shouldReturnTypeCorrectly() {
     shadowOfActiveNetworkInfo.setConnectionType(ConnectivityManager.TYPE_MOBILE);
@@ -76,8 +107,7 @@ public class ShadowConnectivityManagerTest {
     shadowConnectivityManager.setActiveNetworkInfo(null);
     assertThat(connectivityManager.getActiveNetworkInfo()).isNull();
     shadowConnectivityManager.setActiveNetworkInfo(ShadowNetworkInfo.newInstance(null,
-        ConnectivityManager.TYPE_MOBILE_HIPRI,
-        TelephonyManager.NETWORK_TYPE_EDGE, true, false));
+        ConnectivityManager.TYPE_MOBILE_HIPRI, TelephonyManager.NETWORK_TYPE_EDGE, true, false));
 
     NetworkInfo info = connectivityManager.getActiveNetworkInfo();
 
@@ -97,6 +127,53 @@ public class ShadowConnectivityManagerTest {
     assertThat(connectivityManager.getAllNetworkInfo()).isEmpty();
   }
 
+  @Test @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
+  public void getAllNetworks_shouldReturnAllNetworks() throws Exception {
+    Network[] networks = connectivityManager.getAllNetworks();
+    assertThat(networks).hasSize(2);
+  }
+
+  @Test @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
+  public void getAllNetworks_shouldReturnNoNetworksWhenCleared() throws Exception {
+    shadowConnectivityManager.clearAllNetworks();
+    Network[] networks = connectivityManager.getAllNetworks();
+    assertThat(networks).isEmpty();
+  }
+
+  @Test @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
+  public void getAllNetworks_shouldReturnAddedNetworks() throws Exception {
+    // Let's start clear.
+    shadowConnectivityManager.clearAllNetworks();
+
+    // Add a "VPN network".
+    Network vpnNetwork = ShadowNetwork.newInstance(123);
+    NetworkInfo vpnNetworkInfo = ShadowNetworkInfo.newInstance(NetworkInfo.DetailedState.CONNECTED,
+        ConnectivityManager.TYPE_VPN, 0, true, true);
+    shadowConnectivityManager.addNetwork(vpnNetwork, vpnNetworkInfo);
+
+    Network[] networks = connectivityManager.getAllNetworks();
+    assertThat(networks).hasSize(1);
+
+    Network returnedNetwork = networks[0];
+    assertThat(returnedNetwork).isSameAs(vpnNetwork);
+
+    NetworkInfo returnedNetworkInfo = connectivityManager.getNetworkInfo(returnedNetwork);
+    assertThat(returnedNetworkInfo).isSameAs(vpnNetworkInfo);
+  }
+
+  @Test @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
+  public void getAllNetworks_shouldNotReturnRemovedNetworks() throws Exception {
+    Network wifiNetwork = ShadowNetwork.newInstance(ShadowConnectivityManager.NET_ID_WIFI);
+    shadowConnectivityManager.removeNetwork(wifiNetwork);
+
+    Network[] networks = connectivityManager.getAllNetworks();
+    assertThat(networks).hasSize(1);
+
+    Network returnedNetwork = networks[0];
+    ShadowNetwork shadowReturnedNetwork = Shadows.shadowOf(returnedNetwork);
+    assertThat(shadowReturnedNetwork.getNetId()).isNotEqualTo(ShadowConnectivityManager.NET_ID_WIFI);
+  }
+
   @Test
   public void getNetworkPreference_shouldGetDefaultValue() throws Exception {
     assertThat(connectivityManager.getNetworkPreference()).isEqualTo(ConnectivityManager.DEFAULT_NETWORK_PREFERENCE);
@@ -110,7 +187,7 @@ public class ShadowConnectivityManagerTest {
     assertThat(connectivityManager.getNetworkPreference()).isEqualTo(ConnectivityManager.TYPE_WIFI);
   }
 
-  @Test @Config(sdk = 21)
+  @Test @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
   public void getNetworkCallbacks_shouldHaveEmptyDefault() throws Exception {
     assertEquals(0, shadowConnectivityManager.getNetworkCallbacks().size());
   }
@@ -124,7 +201,7 @@ public class ShadowConnectivityManagerTest {
     };
   }
 
-  @Test @Config(sdk = 21)
+  @Test @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
   public void registerCallback_shouldAddCallback() throws Exception {
     NetworkRequest.Builder builder = new NetworkRequest.Builder();
     ConnectivityManager.NetworkCallback callback = createSimpleCallback();
@@ -132,7 +209,7 @@ public class ShadowConnectivityManagerTest {
     assertEquals(1, shadowConnectivityManager.getNetworkCallbacks().size());
   }
 
-  @Test @Config(sdk = 21)
+  @Test @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
   public void unregisterCallback_shouldRemoveCallbacks() throws Exception {
     NetworkRequest.Builder builder = new NetworkRequest.Builder();
     // Add two different callbacks.

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNetworkTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNetworkTest.java
@@ -1,0 +1,25 @@
+package org.robolectric.shadows;
+
+import android.net.Network;
+import android.os.Build;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Shadows;
+import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+@Config(sdk = Build.VERSION_CODES.LOLLIPOP)
+public class ShadowNetworkTest {
+  @Test
+  public void getNetId_shouldReturnConstructorNetId() {
+    final int netId = 123;
+
+    Network network = ShadowNetwork.newInstance(netId);
+    ShadowNetwork shadowNetwork = Shadows.shadowOf(network);
+    assertThat(shadowNetwork.getNetId()).isEqualTo(netId);
+  }
+}


### PR DESCRIPTION
This required also shadowing of the Network class.
It's also possible to add your own Network to the list returned by getAllNetworks(), as well as remove one or clear all of them.
Couple of tests for the new functionality were added as well.