### PR TITLE
Fix ptr type for CursorWindow and SQLiteConnection

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowCursorWindow.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowCursorWindow.java.vm
@@ -28,7 +28,7 @@ public class ShadowCursorWindow {
   private static final WindowData WINDOW_DATA = new WindowData();
 
   @Implementation
-  public static long nativeCreate(String name, int cursorWindowSize) {
+  public static $ptrClass nativeCreate(String name, int cursorWindowSize) {
     return WINDOW_DATA.create(name, cursorWindowSize);
   }
 

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSQLiteConnection.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowSQLiteConnection.java.vm
@@ -57,13 +57,13 @@ public class ShadowSQLiteConnection {
   }
 
   @Implementation
-  public static long nativeOpen(String path, int openFlags, String label, boolean enableTrace, boolean enableProfile) {
+  public static $ptrClass nativeOpen(String path, int openFlags, String label, boolean enableTrace, boolean enableProfile) {
     SQLiteLibraryLoader.load();
     return CONNECTIONS.open(path);
   }
 
   @Implementation
-  public static long nativePrepareStatement($ptrClass connectionPtr, String sql) {
+  public static $ptrClass nativePrepareStatement($ptrClass connectionPtr, String sql) {
     final String newSql = convertSQLWithLocalizedUnicodeCollator(sql);
     return CONNECTIONS.prepareStatement(connectionPtr, newSql);
   }


### PR DESCRIPTION
These changed from int -> long in API 21 but we always return them as `long`. See for example `nativePrepareStatement ` in https://android.googlesource.com/platform/frameworks/base/+/c00df6d52eb5f473e6e1a50fef8f17d8e712bc78/core/java/android/database/sqlite/SQLiteConnection.java.

