### PR TITLE
Fix for Powermock integration

### DIFF
--- a/robolectric/pom.xml
+++ b/robolectric/pom.xml
@@ -26,6 +26,42 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.6.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4-common</artifactId>
+      <version>1.6.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4-rule</artifactId>
+      <version>1.6.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-classloading-xstream</artifactId>
+      <version>1.6.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>1.6.4</version>
       <scope>test</scope>
     </dependency>
 
@@ -43,6 +79,12 @@
     <dependency>
       <groupId>org.robolectric</groupId>
       <artifactId>robolectric-utils</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>xmlpull</groupId>
+      <artifactId>xmlpull</artifactId>
+      <version>1.1.3.1</version>
     </dependency>
 
     <dependency>

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
@@ -3,6 +3,7 @@ package org.robolectric.internal.bytecode;
 import android.R;
 import org.robolectric.internal.ShadowedObject;
 import org.robolectric.internal.ShadowProvider;
+import org.robolectric.internal.dependency.DependencyResolver;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.internal.dependency.DependencyJar;
 import org.robolectric.RobolectricTestRunner;
@@ -152,6 +153,7 @@ public class InstrumentationConfiguration {
           DoNotInstrument.class,
           Config.class,
           Transcript.class,
+          DependencyResolver.class,
           DirectObjectMarker.class,
           DependencyJar.class,
           ParallelUniverseInterface.class,
@@ -170,7 +172,8 @@ public class InstrumentationConfiguration {
           "org.specs2",  // allows for android projects with mixed scala\java tests to be
           "scala.",      //  run with Maven Surefire (see the RoboSpecs project on github)
           "kotlin.",
-          "com.almworks.sqlite4java" // Fix #958: SQLite native library must be loaded once.
+          "com.almworks.sqlite4java", // Fix #958: SQLite native library must be loaded once.
+          "org.powermock"
       ));
       classNameTranslations.put("java.net.ExtendedResponseCache", RoboExtendedResponseCache.class.getName());
       classNameTranslations.put("java.net.ResponseSource", RoboResponseSource.class.getName());

--- a/robolectric/src/test/java/org/robolectric/PowerMockTest.java
+++ b/robolectric/src/test/java/org/robolectric/PowerMockTest.java
@@ -1,0 +1,37 @@
+package org.robolectric;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.robolectric.annotation.Config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MultiApiRobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*", "org.apache.tools.*"})
+@PrepareForTest(PowerMockTest.TestStaticClass.class)
+public class PowerMockTest {
+
+    @Rule
+    public PowerMockRule rule = new PowerMockRule();
+
+    @Test
+    public void powermock_shouldMockStaticMethods() {
+        PowerMockito.mockStatic(TestStaticClass.class);
+        Mockito.when(TestStaticClass.staticMethod()).thenReturn("hello mock");
+
+        assertThat(TestStaticClass.staticMethod().equals("hello mock"));
+    }
+
+    static class TestStaticClass {
+        public static String staticMethod() {
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
Fixes the issue I raised earlier: https://github.com/robolectric/robolectric/issues/2208 and will hopefully fix https://github.com/robolectric/robolectric/issues/2153. Basically, the tests using Powermock were failing with

		com.thoughtworks.xstream.converters.ConversionException: Cannot convert type org.robolectric.internal.dependency.CachedDependencyResolver to type org.robolectric.internal.dependency.DependencyResolver
		---- Debugging information ----
		class               : org.robolectric.MultiApiRobolectricTestRunner$TestRunnerForApiVersion
		required-type       : org.robolectric.MultiApiRobolectricTestRunner$TestRunnerForApiVersion
		converter-type      : com.thoughtworks.xstream.converters.reflection.ReflectionConverter
		path                : /org.powermock.modules.junit4.rule.PowerMockStatement$1/outer-class/fNext/this$1/outer-class/dependencyResolver
		line number         : 250
		class[1]            : org.robolectric.MultiApiRobolectricTestRunner$TestRunnerForApiVersion$1
		class[2]            : org.robolectric.RobolectricTestRunner$HelperTestRunner$1
		class[3]            : org.powermock.modules.junit4.rule.PowerMockStatement
		class[4]            : org.powermock.modules.junit4.rule.PowerMockStatement$1
		version             : not available
		-------------------------------

			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.doUnmarshal(AbstractReflectionConverter.java:439)
			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.unmarshal(AbstractReflectionConverter.java:263)
			at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72)
			at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:65)
			at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66)
			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.unmarshallField(AbstractReflectionConverter.java:480)
			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.doUnmarshal(AbstractReflectionConverter.java:412)
			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.unmarshal(AbstractReflectionConverter.java:263)
			at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72)
			at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:65)
			at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66)
			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.unmarshallField(AbstractReflectionConverter.java:480)
			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.doUnmarshal(AbstractReflectionConverter.java:412)
			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.unmarshal(AbstractReflectionConverter.java:263)
			at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72)
			at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:65)
			at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66)
			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.unmarshallField(AbstractReflectionConverter.java:480)
			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.doUnmarshal(AbstractReflectionConverter.java:412)
			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.unmarshal(AbstractReflectionConverter.java:263)
			at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72)
			at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:65)
			at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66)
			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.unmarshallField(AbstractReflectionConverter.java:480)
			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.doUnmarshal(AbstractReflectionConverter.java:412)
			at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.unmarshal(AbstractReflectionConverter.java:263)
			at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72)
			at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:65)
			at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66)
			at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:50)
			at com.thoughtworks.xstream.core.TreeUnmarshaller.start(TreeUnmarshaller.java:134)
			at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.unmarshal(AbstractTreeMarshallingStrategy.java:32)
			at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1206)
			at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1190)
			at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1061)
			at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1052)
			at org.powermock.classloading.DeepCloner.clone(DeepCloner.java:54)
			at org.powermock.classloading.ClassloaderExecutor.execute(ClassloaderExecutor.java:89)
			at org.powermock.classloading.ClassloaderExecutor.execute(ClassloaderExecutor.java:78)
			at org.powermock.modules.junit4.rule.PowerMockStatement.evaluate(PowerMockRule.java:57)
			at org.robolectric.RobolectricTestRunner$2.evaluate(RobolectricTestRunner.java:255)
			at org.robolectric.RobolectricTestRunner.runChild(RobolectricTestRunner.java:185)
			at org.robolectric.RobolectricTestRunner.runChild(RobolectricTestRunner.java:54)
			at org.junit.runners.ParentRunner$3.run(ParentRunner.java:193)
			at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:52)
			at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:191)
			at org.junit.runners.ParentRunner.access$000(ParentRunner.java:42)
			at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:184)
			at org.robolectric.RobolectricTestRunner$1.evaluate(RobolectricTestRunner.java:151)
			at org.junit.runners.ParentRunner.run(ParentRunner.java:236)
			at org.junit.runners.Suite.runChild(Suite.java:128)
			at org.junit.runners.Suite.runChild(Suite.java:24)
			at org.junit.runners.ParentRunner$3.run(ParentRunner.java:193)
			at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:52)
			at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:191)
			at org.junit.runners.ParentRunner.access$000(ParentRunner.java:42)
			at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:184)
			at org.junit.runners.ParentRunner.run(ParentRunner.java:236)
			at org.junit.runner.JUnitCore.run(JUnitCore.java:157)
			at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:117)
			at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:234)
			at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:74)
			at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
			at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
			at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
			at java.lang.reflect.Method.invoke(Method.java:497)
			at com.intellij.rt.execution.application.AppMain.main(AppMain.java:144)

I feel like the PR is unfinished anyway since I left some mess in the `pom.xml` file which has to be fixed, and would be nice if someone clarified some internal stuff, so please respond to the comments :)