### PR TITLE
SupportFragmentController now supports custom view IDs

### DIFF
--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/SupportFragmentController.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/SupportFragmentController.java
@@ -20,7 +20,7 @@ public class SupportFragmentController<F extends Fragment> extends ComponentCont
   private final F fragment;
   private final ActivityController<? extends FragmentActivity> activityController;
 
-  private SupportFragmentController(ShadowsAdapter shadowsAdapter, F fragment, Class<? extends FragmentActivity> activityClass) {
+  protected SupportFragmentController(ShadowsAdapter shadowsAdapter, F fragment, Class<? extends FragmentActivity> activityClass) {
     super(shadowsAdapter, fragment);
     this.fragment = fragment;
     this.activityController = Robolectric.buildActivity(activityClass);
@@ -40,15 +40,25 @@ public class SupportFragmentController<F extends Fragment> extends ComponentCont
     return this;
   }
 
-  public SupportFragmentController<F> create(final Bundle bundle) {
+  /**
+   * Creates the activity with {@link Bundle} and adds the fragment to the view with ID {@code contentViewId}.
+   */
+  public SupportFragmentController<F> create(final int contentViewId, final Bundle bundle) {
     shadowMainLooper.runPaused(new Runnable() {
       @Override
       public void run() {
         if (!attached) attach();
-        activityController.create(bundle).get().getSupportFragmentManager().beginTransaction().add(1, fragment).commit();
+        activityController.create(bundle).get().getSupportFragmentManager().beginTransaction().add(contentViewId, fragment).commit();
       }
     });
     return this;
+  }
+
+  /**
+   * Creates the activity with {@link Bundle} and adds the fragment to it. Note that the fragment will be added to the view with ID 1.
+   */
+  public SupportFragmentController<F> create(final Bundle bundle) {
+    return create(1, bundle);
   }
 
   @Override

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/SupportFragmentControllerTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/SupportFragmentControllerTest.java
@@ -8,7 +8,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
@@ -20,6 +19,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(TestRunnerWithManifest.class)
 public class SupportFragmentControllerTest {
+
+  private static final int VIEW_ID_CUSTOMIZED_LOGIN_ACTIVITY = 123;
+
   @Test
   public void initialNotAttached() {
     final LoginFragment fragment = new LoginFragment();
@@ -59,6 +61,26 @@ public class SupportFragmentControllerTest {
     assertThat(fragment.getActivity()).isInstanceOf(LoginActivity.class);
     assertThat(fragment.isAdded()).isTrue();
     assertThat(fragment.isResumed()).isFalse();
+  }
+
+  @Test
+  public void attachedAfterCreate_customizedViewId() {
+    final LoginFragment fragment = new LoginFragment();
+    SupportFragmentController.of(fragment, CustomizedViewIdLoginActivity.class).create(VIEW_ID_CUSTOMIZED_LOGIN_ACTIVITY, null).start();
+
+    assertThat(fragment.getView()).isNotNull();
+    assertThat(fragment.getActivity()).isNotNull();
+    assertThat(fragment.isAdded()).isTrue();
+    assertThat(fragment.isResumed()).isFalse();
+    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+  }
+
+  @Test
+  public void hasViewAfterStart() {
+    final LoginFragment fragment = new LoginFragment();
+    SupportFragmentController.of(fragment).create().start();
+
+    assertThat(fragment.getView()).isNotNull();
   }
 
   @Test
@@ -142,6 +164,17 @@ public class SupportFragmentControllerTest {
       super.onCreate(savedInstanceState);
       LinearLayout view = new LinearLayout(this);
       view.setId(1);
+
+      setContentView(view);
+    }
+  }
+
+  private static class CustomizedViewIdLoginActivity extends FragmentActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      LinearLayout view = new LinearLayout(this);
+      view.setId(VIEW_ID_CUSTOMIZED_LOGIN_ACTIVITY);
 
       setContentView(view);
     }

--- a/robolectric/src/main/java/org/robolectric/util/FragmentController.java
+++ b/robolectric/src/main/java/org/robolectric/util/FragmentController.java
@@ -17,7 +17,7 @@ public class FragmentController<F extends Fragment> extends ComponentController<
   private final F fragment;
   private final ActivityController<? extends Activity> activityController;
 
-  private FragmentController(ShadowsAdapter shadowsAdapter, F fragment, Class<? extends Activity> activityClass) {
+  protected FragmentController(ShadowsAdapter shadowsAdapter, F fragment, Class<? extends Activity> activityClass) {
     super(shadowsAdapter, fragment);
     this.fragment = fragment;
     this.activityController = Robolectric.buildActivity(activityClass);

--- a/robolectric/src/test/java/org/robolectric/util/FragmentControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/FragmentControllerTest.java
@@ -139,7 +139,9 @@ public class FragmentControllerTest {
     final LoginFragment fragment = new LoginFragment();
     final FragmentController<LoginFragment> controller = FragmentController.of(fragment, LoginActivity.class);
 
-    controller.create().start().resume();
+    controller.create();
+    assertThat(controller.get().getView()).isNotNull();
+    controller.start().resume();
     assertThat(fragment.isVisible()).isFalse();
 
     controller.visible();


### PR DESCRIPTION
Follow-up for https://github.com/robolectric/robolectric/pull/2190

Note, however, that the test `SupportFragmentController.attachedAfterCreate_customizedViewId` is slightly different from `FragmentController.attachedAfterCreate_customizedViewId`: I had to call `.start()` as well, otherwise `getView()` returned null. I did some digging in the fragment manager and apparently, `FragmentManager` from the support library gets in the "Actitivity created" state only after `Activity.onStart`, whereas normal `FragmentManager` does that after `Activity.onCreate`.

I am not sure why there is such a discrepancy, but that's how it works, same behavior reproduces on real devices; even `getSupportFragmentManager().findFragmentById` returns `null` if you call it in between `onCreate` and `onStart`. So I also added a test `hasViewAfterStart` because before, there were no calls for `getView()` in `SupportFragmentControllerTest` at all.

Also, I relaxed the visibility for `FragmentController`s constructor to protected, since it makes experimenting with it in real tests easier, you can just extend and implement whatever helper methods you want (or some hacks to make your stuff work before it is fixed in the master Robolectric branch).