### PR TITLE
Migrate off method that Guava 20 will remove

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -535,7 +535,7 @@ public class ShadowApplication extends ShadowContextWrapper {
                                                              ListenableFuture<BroadcastResultHolder> oldResult,
                                                              final AtomicBoolean abort) {
     final Handler scheduler = (wrapper.scheduler != null) ? wrapper.scheduler : this.mainHandler;
-    return Futures.transform(oldResult, new AsyncFunction<BroadcastResultHolder, BroadcastResultHolder>() {
+    return Futures.transformAsync(oldResult, new AsyncFunction<BroadcastResultHolder, BroadcastResultHolder>() {
       @Override
       public ListenableFuture<BroadcastResultHolder> apply(BroadcastResultHolder broadcastResultHolder) throws Exception {
         final BroadcastReceiver.PendingResult result = ShadowBroadcastPendingResult.create(


### PR DESCRIPTION
http://google.github.io/guava/releases/19.0/api/docs/com/google/common/util/concurrent/Futures.html#transform%28com%2Egoogle%2Ecommon%2Eutil%2Econcurrent%2EListenableFuture%2C%20com%2Egoogle%2Ecommon%2Eutil%2Econcurrent%2EAsyncFunction%2C%20java%2Eutil%2Econcurrent%2EExecutor%29

This CL migrates to the method's new name. The new version was introduced in Guava 19.0, which Robolectric already uses:
https://github.com/robolectric/robolectric/blob/569259de2c8d76898e3ab916475cf63fd86f0f47/pom.xml#L112