### PR TITLE
Do not instrument #equals/#hashCode for DateFormat$Field

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentingClassLoader.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentingClassLoader.java
@@ -427,7 +427,8 @@ public class InstrumentingClassLoader extends ClassLoader implements Opcodes {
         classNode.methods.add(directCallConstructor);
       }
 
-      if (!isEnum()) {
+      // TODO: Do not override final #equals and #hashCode for all classes
+      if (!isEnum() && !classNode.name.equals("android/icu/text/DateFormat$Field")) {
         instrumentSpecial(foundMethods, "equals", "(Ljava/lang/Object;)Z");
         instrumentSpecial(foundMethods, "hashCode", "()I");
       }


### PR DESCRIPTION
android/icu/text/DateFormat$Field's superclass declares final equals and hashCode methods. Instrumenting these special methods causes class verification errors during instrumentation.

In the long-term, we should check if these methods are declared final on a superclass before attempting to instrument.