### PR TITLE
CookieManager: support multiple date formats, respect secure attribute

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/android/webkit/RoboCookieManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/android/webkit/RoboCookieManager.java.vm
@@ -20,6 +20,7 @@ public class RoboCookieManager extends CookieManager {
     private static final String HTTP = "http://";
     private static final String HTTPS = "https://";
     private static final String EXPIRATION_FIELD_NAME = "Expires";
+    private static final String SECURE_ATTR_NAME = "SECURE";
     private final List<Cookie> store = new ArrayList<>();
     private boolean accept;
 
@@ -63,6 +64,11 @@ public class RoboCookieManager extends CookieManager {
 #end
 
     public String getCookie(String url) {
+      // Return null value for empty url
+      if (url == null || url.equals("")) {
+        return null;
+      }
+
       try {
         url = URLDecoder.decode(url, "UTF-8");
       } catch (UnsupportedEncodingException e) {
@@ -185,17 +191,19 @@ public class RoboCookieManager extends CookieManager {
 
       List<String> parsedFields = new ArrayList<>();
       Date expiration = null;
+      boolean isSecure = false;
 
       for (String field : fields) {
         field = field.trim();
         if (field.startsWith(EXPIRATION_FIELD_NAME)) {
           expiration = getExpiration(field);
+        } else if (field.toUpperCase().equals(SECURE_ATTR_NAME)) {
+          isSecure = true;
         } else {
           parsedFields.add(field);
         }
       }
 
-      boolean isSecure = url.startsWith(HTTPS);
       String hostname = getCookieHost(url);
       List<Cookie> cookies = new ArrayList<>();
 
@@ -233,7 +241,14 @@ public class RoboCookieManager extends CookieManager {
         DateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
         return dateFormat.parse(date);
       } catch (ParseException e) {
-        return null;
+        // No-op. Try to parse additional date formats.
+      }
+
+      try {
+        DateFormat dateFormat = new SimpleDateFormat("EEE, dd-MMM-yyyy HH:mm:ss zzz");
+        return dateFormat.parse(date);
+      } catch (ParseException e) {
+        return null; // Was not parsed by any date formatter.
       }
     }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCookieManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCookieManagerTest.java
@@ -191,17 +191,27 @@ public class ShadowCookieManagerTest {
 
   @Test
   public void shouldIgnoreCookiesSetInThePast() {
-    cookieManager.setCookie(url, "name=value; Expires=Wed, 09 Jun 2000 10:18:14 GMT");
+    cookieManager.setCookie(url, "name=value; Expires=Wed, 09-Jun-2000 10:18:14 GMT");
+
+    String url2 = "http://android.com";
+    cookieManager.setCookie(url2, "name2=value2; Expires=Wed, 09 Jun 2000 10:18:14 GMT");
+
     assertThat(cookieManager.getCookie(url)).isNull();
+    assertThat(cookieManager.getCookie(url2)).isNull();
   }
 
   @Test
   public void shouldRespectSecureCookies() {
-    cookieManager.setCookie(httpsUrl, "name1=value1; Expires=Wed, 09 Jun 2020 10:18:14 GMT");
-    cookieManager.setCookie(httpUrl, "name2=value2; Expires=Wed, 09 Jun 2020 10:18:14 GMT");
+    cookieManager.setCookie(httpsUrl, "name1=value1;secure");
+    cookieManager.setCookie(httpUrl, "name2=value2;");
 
     String cookie = cookieManager.getCookie(httpUrl);
     assertThat(cookie.contains("name2=value2")).isTrue();
     assertThat(cookie.contains("name1=value1")).isFalse();
+  }
+
+  @Test
+  public void shouldIgnoreEmptyURLs() {
+    assertThat(cookieManager.getCookie("")).isNull();
   }
 }


### PR DESCRIPTION
Allow both space and '-' separated date formats for cookie expiration. Correctly look at the secure cookie attribute when setting the isSecure boolean. Additionally, do not throw an exception if an empty url is passed to getCookie.

