### PR TITLE
Fix R class resolution

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
@@ -23,7 +23,7 @@ public class RobolectricGradleTestRunner extends RobolectricTestRunner {
   }
 
   @Override
-  protected AndroidManifest getAppManifest(Config config) {
+  protected AndroidManifest getAppManifest(final Config config) {
     if (config.constants() == Void.class) {
       Logger.error("Field 'constants' not specified in @Config annotation");
       Logger.error("This is required when using RobolectricGradleTestRunner!");
@@ -67,7 +67,12 @@ public class RobolectricGradleTestRunner extends RobolectricTestRunner {
     Logger.debug("   Robolectric res directory: " + res.getPath());
     Logger.debug("   Robolectric manifest path: " + manifest.getPath());
     Logger.debug("    Robolectric package name: " + packageName);
-    return new AndroidManifest(manifest, res, assets, packageName);
+    return new AndroidManifest(manifest, res, assets, packageName) {
+      @Override
+      public String getRClassName() throws Exception {
+        return config.constants().getPackage().getName().concat(".R");
+      }
+    };
   }
 
   private static String getType(Config config) {

--- a/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
@@ -102,6 +102,13 @@ public class RobolectricGradleTestRunnerTest {
     runner.getAppManifest(runner.getConfig(NoConstantsTest.class.getMethod("withoutAnnotation")));
   }
 
+  @Test
+  public void rClassShouldBeInTheSamePackageAsBuildConfig() throws Exception {
+    RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(RFileTest.class);
+    AndroidManifest manifest = runner.getAppManifest(runner.getConfig(RFileTest.class.getMethod("withoutAnnotation")));
+    assertThat(manifest.getRClass().getPackage().getName()).isEqualTo("org.robolectric.gradleapp");
+  }
+
   private void delete(File file) {
     final File[] files = file.listFiles();
     if (files != null) {
@@ -140,6 +147,14 @@ public class RobolectricGradleTestRunnerTest {
 
     @Test
     public void withoutAnnotation() throws Exception {
+    }
+  }
+
+  @Ignore
+  @Config(constants = org.robolectric.gradleapp.BuildConfig.class)
+  public static class RFileTest {
+    @Test
+    public void withoutAnnotation() {
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/gradleapp/BuildConfig.java
+++ b/robolectric/src/test/java/org/robolectric/gradleapp/BuildConfig.java
@@ -1,0 +1,7 @@
+package org.robolectric.gradleapp;
+
+public class BuildConfig {
+  public static final String APPLICATION_ID = "org.sandwich.foo";
+  public static final String BUILD_TYPE = "type1";
+  public static final String FLAVOR = "flavor1";
+}


### PR DESCRIPTION
An incorrect assumption is made that R class package is equal to package name defined in the manifest (application id).
Product flavours can get custom application IDs. But R and BuildConfig package name will remain unchanged.