### PR TITLE
Restore ShadowImageView.getImageResourceId()

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowImageView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowImageView.java
@@ -1,0 +1,21 @@
+package org.robolectric.shadows;
+
+import android.widget.ImageView;
+
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.util.ReflectionHelpers;
+
+/**
+ * Shadow for {@link android.widget.ImageView}.
+ */
+@Implements(ImageView.class)
+public class ShadowImageView extends ShadowView {
+
+  @RealObject
+  private ImageView realImageView;
+
+  public int getImageResourceId() {
+    return ReflectionHelpers.getField(realImageView, "mResource");
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowImageViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowImageViewTest.java
@@ -1,0 +1,31 @@
+package org.robolectric.shadows;
+
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.widget.ImageView;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.R;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.TestRunners;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+public class ShadowImageViewTest {
+
+  @Test
+  public void getDrawableResourceId_shouldWorkWhenTheDrawableWasCreatedFromAResource() throws Exception {
+
+    Resources resources = RuntimeEnvironment.application.getResources();
+    Bitmap bitmap = BitmapFactory.decodeResource(resources, R.drawable.an_image);
+    ImageView imageView = new ImageView(RuntimeEnvironment.application);
+    imageView.setImageBitmap(bitmap);
+
+    imageView.setImageResource(R.drawable.an_image);
+    assertThat(shadowOf(imageView).getImageResourceId()).isEqualTo(R.drawable.an_image);
+  }
+}


### PR DESCRIPTION
Based on comment from @mpost on https://github.com/robolectric/robolectric/pull/2265 - it seems this method is still required. Actually it is still used fairly often here, my mistake originally in saying that it wasn't.

This re-implementation just provides the ability to expose the real android code rather than reimplementing anything.