### PR TITLE
Fix ShadowImageView.getImageResourceId() and restore ShadowImageView.getImageBitmap()

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowImageView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowImageView.java
@@ -1,10 +1,13 @@
 package org.robolectric.shadows;
 
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
 import android.widget.ImageView;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.util.ReflectionHelpers;
+
+import static org.robolectric.Shadows.shadowOf;
 
 /**
  * Shadow for {@link android.widget.ImageView}.
@@ -15,7 +18,21 @@ public class ShadowImageView extends ShadowView {
   @RealObject
   private ImageView realImageView;
 
+  /**
+   * @deprecated Prefer shadowOf(realImageView.getDrawable()).getCreatedFromResId()
+   * - this method will be removed in the future.
+   */
+  @Deprecated
   public int getImageResourceId() {
-    return ReflectionHelpers.getField(realImageView, "mResource");
+    return shadowOf(realImageView.getDrawable()).getCreatedFromResId();
+  }
+
+  /**
+   * @deprecated Prefer ((BitmapDrawable)ImageView.getDrawable()).getBitmap() - this method will
+   * be removed in the future.
+   */
+  @Deprecated
+  public Bitmap getImageBitmap() {
+    return ((BitmapDrawable)realImageView.getDrawable()).getBitmap();
   }
 }


### PR DESCRIPTION
These missing methods caused a small number of breakages in our code base. Restoring them to a minimal (non-invasive) implementation and marking as @Deprecated since there are alternative ways to get these values. We should remove these at some point though.