### PR TITLE
Add a more complete set of ShadowRenderNode mutators/accessors.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
@@ -457,26 +457,6 @@ public class ShadowView {
   }
 
   @Implementation
-  public void setScaleX(float scaleX) {
-    this.scaleX = scaleX;
-  }
-
-  @Implementation
-  public float getScaleX() {
-    return scaleX;
-  }
-
-  @Implementation
-  public void setScaleY(float scaleY) {
-    this.scaleY = scaleY;
-  }
-
-  @Implementation
-  public float getScaleY() {
-    return scaleY;
-  }
-
-  @Implementation
   public void setAnimation(final Animation animation) {
     directly().setAnimation(animation);
 

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowRenderNode.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowRenderNode.java.vm
@@ -10,14 +10,77 @@ import org.robolectric.annotation.Implements;
  */
 @Implements(value = RenderNode.class, isInAndroidSdk = false)
 public class ShadowRenderNode {
+  private float alpha = 1f;
+  private float cameraDistance;
+  private boolean clipToOutline;
+  private float elevation;
+  private boolean overlappingRendering;
+  private boolean pivotExplicitlySet;
+  private float pivotX;
+  private float pivotY;
   private float rotation;
   private float rotationX;
   private float rotationY;
+  private float scaleX = 1f;
+  private float scaleY = 1f;
   private float translationX;
   private float translationY;
   private float translationZ;
-  private float pivotX;
-  private float pivotY;
+
+  @Implementation
+  public boolean setAlpha(float alpha) {
+    this.alpha = alpha;
+    return true;
+  }
+
+  @Implementation
+  public float getAlpha() {
+    return alpha;
+  }
+
+  @Implementation
+  public boolean setCameraDistance(float cameraDistance) {
+    this.cameraDistance = cameraDistance;
+    return true;
+  }
+
+  @Implementation
+  public float getCameraDistance() {
+    return cameraDistance;
+  }
+
+  @Implementation
+  public boolean setClipToOutline(boolean clipToOutline) {
+    this.clipToOutline = clipToOutline;
+    return true;
+  }
+
+  @Implementation
+  public boolean getClipToOutline() {
+    return clipToOutline;
+  }
+
+  @Implementation
+  public boolean setElevation(float lift) {
+    elevation = lift;
+    return true;
+  }
+
+  @Implementation
+  public float getElevation() {
+    return elevation;
+  }
+
+  @Implementation
+  public boolean setHasOverlappingRendering(boolean overlappingRendering) {
+    this.overlappingRendering = overlappingRendering;
+    return true;
+  }
+
+  @Implementation
+  public boolean hasOverlappingRendering() {
+    return overlappingRendering;
+  }
 
   @Implementation
   public boolean setRotation(float rotation) {
@@ -50,6 +113,28 @@ public class ShadowRenderNode {
   @Implementation
   public float getRotationY() {
     return rotationY;
+  }
+
+  @Implementation
+  public boolean setScaleX(float scaleX) {
+    this.scaleX = scaleX;
+    return true;
+  }
+
+  @Implementation
+  public float getScaleX() {
+    return scaleX;
+  }
+
+  @Implementation
+  public boolean setScaleY(float scaleY) {
+    this.scaleY = scaleY;
+    return true;
+  }
+
+  @Implementation
+  public float getScaleY() {
+    return scaleY;
   }
 
   @Implementation
@@ -86,8 +171,14 @@ public class ShadowRenderNode {
   }
 
   @Implementation
+  public boolean isPivotExplicitlySet() {
+    return pivotExplicitlySet;
+  }
+
+  @Implementation
   public boolean setPivotX(float pivotX) {
     this.pivotX = pivotX;
+    this.pivotExplicitlySet = true;
     return true;
   }
 
@@ -99,6 +190,7 @@ public class ShadowRenderNode {
   @Implementation
   public boolean setPivotY(float pivotY) {
     this.pivotY = pivotY;
+    this.pivotExplicitlySet = true;
     return true;
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
@@ -8,6 +8,7 @@ import android.graphics.Point;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.ContextMenu;
 import android.view.HapticFeedbackConstants;
@@ -31,6 +32,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 import org.robolectric.annotation.AccessibilityChecks;
+import org.robolectric.annotation.Config;
 import org.robolectric.res.Attribute;
 import org.robolectric.res.ResourceLoader;
 import org.robolectric.util.TestOnClickListener;
@@ -590,24 +592,6 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void setScaleX_shouldSetScaleX() throws Exception {
-    assertThat(shadowOf(view).getScaleX()).isEqualTo(1f);
-    shadowOf(view).setScaleX(2.5f);
-    assertThat(shadowOf(view).getScaleX()).isEqualTo(2.5f);
-    shadowOf(view).setScaleX(0.5f);
-    assertThat(shadowOf(view).getScaleX()).isEqualTo(0.5f);
-  }
-
-  @Test
-  public void setScaleY_shouldSetScaleY() throws Exception {
-    assertThat(shadowOf(view).getScaleX()).isEqualTo(1f);
-    shadowOf(view).setScaleY(2.5f);
-    assertThat(shadowOf(view).getScaleY()).isEqualTo(2.5f);
-    shadowOf(view).setScaleY(0.5f);
-    assertThat(shadowOf(view).getScaleY()).isEqualTo(0.5f);
-  }
-
-  @Test
   public void rotationX() {
     view.setRotationX(10f);
     assertThat(view.getRotationX()).isEqualTo(10f);
@@ -623,6 +607,72 @@ public class ShadowViewTest {
   public void rotation() {
     view.setRotation(30f);
     assertThat(view.getRotation()).isEqualTo(30f);
+  }
+
+  @Test
+  @Config(sdk = { Build.VERSION_CODES.LOLLIPOP })
+  public void cameraDistance() {
+    view.setCameraDistance(100f);
+    assertThat(view.getCameraDistance()).isEqualTo(100f);
+  }
+
+  @Test
+  public void scaleX() {
+    assertThat(view.getScaleX()).isEqualTo(1f);
+    view.setScaleX(0.5f);
+    assertThat(view.getScaleX()).isEqualTo(0.5f);
+  }
+
+  @Test
+  public void scaleY() {
+    assertThat(view.getScaleY()).isEqualTo(1f);
+    view.setScaleY(0.5f);
+    assertThat(view.getScaleY()).isEqualTo(0.5f);
+  }
+
+  @Test
+  public void pivotX() {
+    view.setPivotX(10f);
+    assertThat(view.getPivotX()).isEqualTo(10f);
+  }
+
+  @Test
+  public void pivotY() {
+    view.setPivotY(10f);
+    assertThat(view.getPivotY()).isEqualTo(10f);
+  }
+
+  @Test
+  @Config(sdk = { Build.VERSION_CODES.LOLLIPOP })
+  public void elevation() {
+    view.setElevation(10f);
+    assertThat(view.getElevation()).isEqualTo(10f);
+  }
+
+  @Test
+  public void translationX() {
+    view.setTranslationX(10f);
+    assertThat(view.getTranslationX()).isEqualTo(10f);
+  }
+
+  @Test
+  public void translationY() {
+    view.setTranslationY(10f);
+    assertThat(view.getTranslationY()).isEqualTo(10f);
+  }
+
+  @Test
+  @Config(sdk = { Build.VERSION_CODES.LOLLIPOP })
+  public void translationZ() {
+    view.setTranslationZ(10f);
+    assertThat(view.getTranslationZ()).isEqualTo(10f);
+  }
+
+  @Test
+  @Config(sdk = { Build.VERSION_CODES.LOLLIPOP })
+  public void clipToOutline() {
+    view.setClipToOutline(true);
+    assertThat(view.getClipToOutline()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
These methods are utilized by View in 21+ (and I'm sure elsewhere as
well), so this should fix cases where code sets these properties and
expects to get the values out later. I've added tests for the things
in ShadowViewTest.

While adding those tests, I discovered that ShadowView was stubbing
out set/getScale{X,Y}. Since using the real implementation works fine
(at least with these new Shadow methods), I've removed the
ShadowView implementation.