### PR TITLE
Add a shadow for RenderNodeAnimator.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowRenderNodeAnimator.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowRenderNodeAnimator.java.vm
@@ -1,0 +1,123 @@
+package org.robolectric.shadows;
+
+#if ($api >= 21)
+import android.view.Choreographer;
+import android.view.Choreographer.FrameCallback;
+import android.view.RenderNodeAnimator;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.annotation.Resetter;
+import org.robolectric.util.ReflectionHelpers;
+
+import static org.robolectric.internal.Shadow.directlyOn;
+
+/**
+ * Shadow for {@link android.view.RenderNodeAnimator}.
+ */
+@Implements(value = RenderNodeAnimator.class, isInAndroidSdk = false)
+public class ShadowRenderNodeAnimator {
+  private static final int STATE_FINISHED = 3;
+
+  @RealObject RenderNodeAnimator realObject;
+  private Choreographer choreographer = Choreographer.getInstance();
+  private boolean scheduled = false;
+  private long startTime = -1;
+  private boolean isEnding = false;
+
+  @Resetter
+  public static void reset() {
+    // sAnimationHelper is a static field used for processing delayed animations. Since it registers
+    // callbacks on the Choreographer, this is a problem if not reset between tests (as once the
+    // test is complete, its scheduled callbacks would be removed, but the static object would still
+    // believe it was registered and not re-register for the next test).
+    ReflectionHelpers.setStaticField(
+        RenderNodeAnimator.class, "sAnimationHelper", new ThreadLocal<>());
+  }
+
+#if ($api >= 22)
+  @Implementation
+  public void moveToRunningState() {
+    directlyOn(realObject, RenderNodeAnimator.class, "moveToRunningState");
+    if (!isEnding) {
+      // Only schedule if this wasn't called during an end() call, as Robolectric will run any
+      // Choreographer callbacks synchronously when unpaused (and thus end up running the full
+      // animation even though RenderNodeAnimator just wanted to kick it into STATE_STARTED).
+      schedule();
+    }
+  }
+#else
+  @Implementation
+  public void doStart() {
+    directlyOn(realObject, RenderNodeAnimator.class, "doStart");
+    schedule();
+  }
+
+  @Implementation
+  public void cancel() {
+    directlyOn(realObject, RenderNodeAnimator.class).cancel();
+    int state = ReflectionHelpers.getField(realObject, "mState");
+    if (state != STATE_FINISHED) {
+      // In 21, RenderNodeAnimator only calls nEnd, it doesn't call the Java end method. Thus, it
+      // expects the native code will end up calling onFinished, so we do that here.
+      directlyOn(realObject, RenderNodeAnimator.class, "onFinished");
+    }
+  }
+#end
+
+  @Implementation
+  public void end() {
+    // Set this to true to prevent us from scheduling and running the full animation on the end()
+    // call. This can happen if the animation had not been started yet.
+    isEnding = true;
+    directlyOn(realObject, RenderNodeAnimator.class).end();
+    isEnding = false;
+    unschedule();
+
+    int state = ReflectionHelpers.getField(realObject, "mState");
+    if (state != STATE_FINISHED) {
+      // This means that the RenderNodeAnimator called out to native code to finish the animation,
+      // expecting that it would end up calling onFinished. Since that won't happen in Robolectric,
+      // we call onFinished ourselves.
+      directlyOn(realObject, RenderNodeAnimator.class, "onFinished");
+    }
+  }
+
+  private void schedule() {
+    if (!scheduled) {
+      scheduled = true;
+      choreographer.postFrameCallback(frameCallback);
+    }
+  }
+
+  private void unschedule() {
+    if (scheduled) {
+      choreographer.removeFrameCallback(frameCallback);
+      scheduled = false;
+    }
+  }
+
+  private FrameCallback frameCallback = new FrameCallback() {
+    @Override
+    public void doFrame(long frameTimeNanos) {
+      scheduled = false;
+      if (startTime == -1) {
+        startTime = frameTimeNanos;
+      }
+
+      long duration = realObject.getDuration();
+      long curTime = frameTimeNanos - startTime;
+      if (curTime >= duration) {
+        directlyOn(realObject, RenderNodeAnimator.class, "onFinished");
+      } else {
+        schedule();
+      }
+    }
+  };
+}
+
+#else
+public class ShadowRenderNodeAnimator {
+  // Stub class, does not exist pre-21
+}
+#end

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRenderNodeAnimatorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRenderNodeAnimatorTest.java
@@ -1,0 +1,186 @@
+package org.robolectric.shadows;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.app.Activity;
+import android.os.Build;
+import android.view.View;
+import android.view.ViewAnimationUtils;
+
+import com.google.common.collect.Ordering;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+import org.robolectric.Robolectric;
+import org.robolectric.Shadows;
+import org.robolectric.TestRunners;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+@Config(sdk = {
+  Build.VERSION_CODES.LOLLIPOP,
+  Build.VERSION_CODES.LOLLIPOP_MR1,
+  Build.VERSION_CODES.M,
+})
+public class ShadowRenderNodeAnimatorTest {
+  private Activity activity;
+  private View view;
+  private TestListener listener;
+
+  @Before
+  public void setUp() {
+    activity = Robolectric.setupActivity(Activity.class);
+    view = new View(activity);
+    activity.setContentView(view);
+    listener = new TestListener();
+  }
+
+  @Test
+  public void normal() {
+    Animator animator = ViewAnimationUtils.createCircularReveal(view, 10, 10, 10f, 100f);
+    animator.addListener(listener);
+    animator.start();
+
+    assertThat(listener.startCount).isEqualTo(1);
+    assertThat(listener.endCount).isEqualTo(1);
+  }
+
+  @Test
+  public void canceled() {
+    Animator animator = ViewAnimationUtils.createCircularReveal(view, 10, 10, 10f, 100f);
+    animator.addListener(listener);
+
+    Robolectric.getForegroundThreadScheduler().pause();
+    animator.start();
+    animator.cancel();
+
+    assertThat(listener.startCount).isEqualTo(1);
+    assertThat(listener.cancelCount).isEqualTo(1);
+    assertThat(listener.endCount).isEqualTo(1);
+  }
+
+  @Test
+  public void delayed() {
+    Animator animator = ViewAnimationUtils.createCircularReveal(view, 10, 10, 10f, 100f);
+    animator.setStartDelay(1000);
+    animator.addListener(listener);
+
+    animator.start();
+
+    assertThat(listener.startCount).isEqualTo(1);
+    assertThat(listener.endCount).isEqualTo(1);
+  }
+
+  @Test
+  public void neverStartedCanceled() {
+    Animator animator = ViewAnimationUtils.createCircularReveal(view, 10, 10, 10f, 100f);
+    animator.addListener(listener);
+
+    animator.cancel();
+
+    assertThat(listener.startCount).isEqualTo(0);
+    // This behavior changed between L and L MR1. In older versions, onAnimationCancel and
+    // onAnimationEnd would always be called regardless of whether the animation was started.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+      assertThat(listener.cancelCount).isEqualTo(0);
+      assertThat(listener.endCount).isEqualTo(0);
+    } else {
+      assertThat(listener.cancelCount).isEqualTo(1);
+      assertThat(listener.endCount).isEqualTo(1);
+    }
+  }
+
+  @Test
+  public void neverStartedEnded() {
+    Animator animator = ViewAnimationUtils.createCircularReveal(view, 10, 10, 10f, 100f);
+    animator.addListener(listener);
+
+    animator.end();
+
+    // This behavior changed between L and L MR1. In older versions, onAnimationEnd would always be
+    // called without any guarantee that onAnimationStart had been called first.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+      assertThat(listener.startCount).isEqualTo(1);
+      assertThat(listener.endCount).isEqualTo(1);
+    } else {
+      assertThat(listener.startCount).isEqualTo(0);
+      assertThat(listener.endCount).isEqualTo(1);
+    }
+  }
+
+  @Test
+  public void doubleCanceled() {
+    Animator animator = ViewAnimationUtils.createCircularReveal(view, 10, 10, 10f, 100f);
+    animator.addListener(listener);
+
+    Robolectric.getForegroundThreadScheduler().pause();
+    animator.start();
+    animator.cancel();
+    animator.cancel();
+
+    assertThat(listener.startCount).isEqualTo(1);
+    assertThat(listener.cancelCount).isEqualTo(1);
+    assertThat(listener.endCount).isEqualTo(1);
+  }
+
+  @Test
+  public void doubleEnded() {
+    Animator animator = ViewAnimationUtils.createCircularReveal(view, 10, 10, 10f, 100f);
+    animator.addListener(listener);
+
+    Robolectric.getForegroundThreadScheduler().pause();
+    animator.start();
+    animator.end();
+    animator.end();
+
+    assertThat(listener.startCount).isEqualTo(1);
+    assertThat(listener.endCount).isEqualTo(1);
+  }
+
+  @Test
+  public void delayedAndCanceled() {
+    Animator animator = ViewAnimationUtils.createCircularReveal(view, 10, 10, 10f, 100f);
+    animator.setStartDelay(1000);
+    animator.addListener(listener);
+
+    Robolectric.getForegroundThreadScheduler().pause();
+    animator.start();
+    animator.cancel();
+
+    // This behavior changed between L and L MR1. In older versions, onAnimationStart gets called
+    // *twice* if you cancel a delayed animation before any of its frames run (as both cancel() and
+    // onFinished() implement special behavior for STATE_DELAYED, but the state only gets set to
+    // finished after onFinished()).
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+      assertThat(listener.startCount).isEqualTo(1);
+    } else {
+      assertThat(listener.startCount).isEqualTo(2);
+    }
+    assertThat(listener.cancelCount).isEqualTo(1);
+    assertThat(listener.endCount).isEqualTo(1);
+  }
+
+  private static class TestListener extends AnimatorListenerAdapter {
+    public int startCount;
+    public int cancelCount;
+    public int endCount;
+
+    @Override
+    public void onAnimationStart(Animator animation) {
+      startCount++;
+    }
+
+    @Override
+    public void onAnimationCancel(Animator animation) {
+      cancelCount++;
+    }
+
+    @Override
+    public void onAnimationEnd(Animator animation) {
+      endCount++;
+    }
+  }
+}


### PR DESCRIPTION
RenderNodeAnimator is used by RevealAnimator, which is the Animator
that ViewAnimationUtils creates for circular reveals (21+). Since it
uses native code for actually rendering and timing the animation, it
requires a shadow if we want these animations to actually run/finish.

The shadow implementation here utilizes the Choreographer to time
itself, so it has the same characteristics of other Animators
(ObjectAnimator, ValueAnimator) with regard to testing. The 21 version
of this class had some bugs, unfortunately, but this Shadow reproduces
these faithfully so that tests are accurate.