### PR TITLE
Fix for NPE when calling Context.createPackageContext()

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
@@ -86,7 +86,7 @@ public class CoreShadowsAdapter implements ShadowsAdapter {
 
   @Override
   public void setSystemResources(ResourceLoader systemResourceLoader) {
-    ShadowResources.setSystemResources(systemResourceLoader);
+    ShadowAssetManager.setSystemResources(systemResourceLoader);
   }
 
   @Override

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -200,7 +200,7 @@ public class ShadowApplication extends ShadowContextWrapper {
   @Implementation
   public AssetManager getAssets() {
     if (assetManager == null) {
-      assetManager = ShadowAssetManager.bind(newInstanceOf(AssetManager.class), appManifest, resourceLoader);
+      assetManager = new AssetManager();
     }
     return assetManager;
   }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.ArrayList;
 import org.jetbrains.annotations.NotNull;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.RealObject;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -52,19 +53,18 @@ public final class ShadowAssetManager {
   public static final int STYLE_CHANGING_CONFIGURATIONS = 4;
   public static final int STYLE_DENSITY = 5;
 
-  private String qualifiers = "";
+  private static ResourceLoader systemResources;
+
   private Map<$ptrClassBoxed, Resources.Theme> themesById = new LinkedHashMap<>();
   private Map<$ptrClassBoxed, List<OverlayedStyle>> appliedStyles = new HashMap<>();
   private int nextInternalThemeId = 1000;
-  private AndroidManifest appManifest;
   private ResourceLoader resourceLoader;
 
-  static AssetManager bind(AssetManager assetManager, AndroidManifest androidManifest, ResourceLoader resourceLoader) {
-    ShadowAssetManager shadowAssetManager = shadowOf(assetManager);
-    if (shadowAssetManager.appManifest != null) throw new RuntimeException("ResourceLoader already set!");
-    shadowAssetManager.appManifest = androidManifest;
-    shadowAssetManager.resourceLoader = resourceLoader;
-    return assetManager;
+  @RealObject
+  AssetManager realObject;
+
+  public static void setSystemResources(ResourceLoader systemResources) {
+    ShadowAssetManager.systemResources = systemResources;
   }
 
   @HiddenApi @Implementation
@@ -92,7 +92,7 @@ public final class ShadowAssetManager {
 
   @HiddenApi @Implementation
   public int getResourceIdentifier(String name, String defType, String defPackage) {
-    ResourceIndex resourceIndex = resourceLoader.getResourceIndex();
+    ResourceIndex resourceIndex = getResourceLoader().getResourceIndex();
     ResName resName = ResName.qualifyResName(name, defPackage, defType);
     Integer resourceId = resourceIndex.getResourceId(resName);
     if (resourceId == null) return 0;
@@ -114,7 +114,7 @@ public final class ShadowAssetManager {
 
   @HiddenApi @Implementation
   public CharSequence[] getResourceTextArray(final int id) {
-    ResName resName = resourceLoader.getResourceIndex().getResName(id);
+    ResName resName = getResourceLoader().getResourceIndex().getResName(id);
     if (resName == null) throw new Resources.NotFoundException("unknown resource " + id);
     TypedResource value = getAndResolve(resName, getQualifiers(), true);
     if (value == null) return null;
@@ -129,7 +129,7 @@ public final class ShadowAssetManager {
 
   @HiddenApi @Implementation
   public boolean getThemeValue($ptrClass theme, int ident, TypedValue outValue, boolean resolveRefs) {
-    ResourceIndex resourceIndex = resourceLoader.getResourceIndex();
+    ResourceIndex resourceIndex = getResourceLoader().getResourceIndex();
     ResName resName = resourceIndex.getResName(ident);
     Resources.Theme theTheme = getThemeByInternalId(theme);
     // Load the style for the theme we represent. E.g. "@style/Theme.Robolectric"
@@ -140,7 +140,7 @@ public final class ShadowAssetManager {
     Style themeStyle = resolveStyle(resourceLoader, null, themeStyleName, getQualifiers());
 
     //// Load the theme attribute for the default style attributes. E.g., attr/buttonStyle
-    //ResName defStyleName = resourceLoader.getResourceIndex().getResName(ident);
+    //ResName defStyleName = getResourceLoader().getResourceIndex().getResName(ident);
     //
     //// Load the style for the default style attribute. E.g. "@style/Widget.Robolectric.Button";
     //String defStyleNameValue = themeStyle.getAttrValue(defStyleName);
@@ -167,24 +167,24 @@ public final class ShadowAssetManager {
 
   @Implementation
   public final InputStream open(String fileName) throws IOException {
-    return appManifest.getAssetsDirectory().join(fileName).getInputStream();
+    return ShadowApplication.getInstance().getAppManifest().getAssetsDirectory().join(fileName).getInputStream();
   }
 
   @Implementation
   public final InputStream open(String fileName, int accessMode) throws IOException {
-    return appManifest.getAssetsDirectory().join(fileName).getInputStream();
+    return ShadowApplication.getInstance().getAppManifest().getAssetsDirectory().join(fileName).getInputStream();
   }
 
   @Implementation
   public final AssetFileDescriptor openFd(String fileName) throws IOException {
-    File file = new File(appManifest.getAssetsDirectory().join(fileName).getPath());
+    File file = new File(ShadowApplication.getInstance().getAppManifest().getAssetsDirectory().join(fileName).getPath());
     ParcelFileDescriptor parcelFileDescriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
     return new AssetFileDescriptor(parcelFileDescriptor, 0, file.length());
   }
 
   @Implementation
   public final String[] list(String path) throws IOException {
-    FsFile file = appManifest.getAssetsDirectory().join(path);
+    FsFile file = ShadowApplication.getInstance().getAppManifest().getAssetsDirectory().join(path);
     if (file.isDirectory()) {
       return file.listFileNames();
     }
@@ -194,7 +194,7 @@ public final class ShadowAssetManager {
   @HiddenApi @Implementation
   public final InputStream openNonAsset(int cookie, String fileName, int accessMode) throws IOException {
     final ResName resName = qualifyFromNonAssetFileName(fileName);
-    final DrawableNode drawableNode = resourceLoader.getDrawableNode(resName, getQualifiers());
+    final DrawableNode drawableNode = getResourceLoader().getDrawableNode(resName, getQualifiers());
 
     if (drawableNode == null) {
       throw new IOException("Unable to find resource for " + fileName);
@@ -212,7 +212,7 @@ public final class ShadowAssetManager {
       // Must remove "jar:" prefix, or else qualifyFromFilePath fails on Windows
       return ResName.qualifyFromFilePath("android", fileName.replaceFirst("jar:", ""));
     } else {
-      return ResName.qualifyFromFilePath(appManifest.getPackageName(), fileName);
+      return ResName.qualifyFromFilePath(ShadowApplication.getInstance().getAppManifest().getPackageName(), fileName);
     }
   }
 
@@ -255,7 +255,7 @@ public final class ShadowAssetManager {
 
   @HiddenApi @Implementation
   public int[] getArrayIntResource(int arrayRes) {
-    ResName resName = resourceLoader.getResourceIndex().getResName(arrayRes);
+    ResName resName = getResourceLoader().getResourceIndex().getResName(arrayRes);
     if (resName == null) throw new Resources.NotFoundException("unknown resource " + arrayRes);
     TypedResource value = getAndResolve(resName, getQualifiers(), true);
     if (value == null) return null;
@@ -356,20 +356,20 @@ public final class ShadowAssetManager {
   }
 
   TypedResource getAndResolve(int resId, String qualifiers, boolean resolveRefs) {
-    ResName resName = resourceLoader.getResourceIndex().getResName(resId);
+    ResName resName = getResourceLoader().getResourceIndex().getResName(resId);
     if (resName == null) throw new Resources.NotFoundException("unknown resource " + resId);
     return getAndResolve(resName, qualifiers, resolveRefs);
   }
 
   TypedResource getAndResolve(@NotNull ResName resName, String qualifiers, boolean resolveRefs) {
-    TypedResource value = resourceLoader.getValue(resName, qualifiers);
+    TypedResource value = getResourceLoader().getValue(resName, qualifiers);
     if (resolveRefs) {
       value = resolve(value, qualifiers, resName);
     }
 
     // todo: make the drawable loader put stuff into the normal spot...
     if (value == null && DrawableResourceLoader.isStillHandledHere(resName)) {
-      DrawableNode drawableNode = resourceLoader.getDrawableNode(resName, qualifiers);
+      DrawableNode drawableNode = getResourceLoader().getDrawableNode(resName, qualifiers);
       return new TypedResource<FsFile>(drawableNode.getFsFile(), ResType.FILE);
     }
 
@@ -386,9 +386,9 @@ public final class ShadowAssetManager {
   }
 
   ResName resolveResName(int resId, String qualifiers) {
-    ResName resName = resourceLoader.getResourceIndex().getResName(resId);
+    ResName resName = getResourceLoader().getResourceIndex().getResName(resId);
     if (resName == null) return null;
-    TypedResource value = resourceLoader.getValue(resName, qualifiers);
+    TypedResource value = getResourceLoader().getValue(resName, qualifiers);
     return resolveResource(value, qualifiers, resName).resName;
   }
 
@@ -400,11 +400,18 @@ public final class ShadowAssetManager {
       } else {
         String refStr = s.substring(1).replace("+", "");
         resName = ResName.qualifyResName(refStr, resName);
-        value = resourceLoader.getValue(resName, qualifiers);
+        value = getResourceLoader().getValue(resName, qualifiers);
       }
     }
 
     return new Resource(value, resName);
+  }
+
+  ResourceLoader getResourceLoader() {
+    if (resourceLoader == null) {
+      resourceLoader = ShadowApplication.getInstance().getResourceLoader();
+    }
+    return resourceLoader;
   }
 
   private boolean isReference(TypedResource value) {
@@ -419,7 +426,7 @@ public final class ShadowAssetManager {
   }
 
   public FsFile getAssetsDirectory() {
-    return appManifest.getAssetsDirectory();
+    return ShadowApplication.getInstance().getAppManifest().getAssetsDirectory();
   }
 
   public String getQualifiers() {
@@ -607,4 +614,11 @@ public final class ShadowAssetManager {
 
   }
 
+  @Implementation
+  public static AssetManager getSystem() {
+    AssetManager assetManager = new AssetManager();
+    ShadowAssetManager shadowAssetManager = shadowOf(assetManager);
+    shadowAssetManager.resourceLoader = systemResources;
+    return assetManager;
+  }
 }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
@@ -206,4 +206,9 @@ public class ShadowContextImpl extends ShadowContext {
   public void sendBroadcast(Intent intent) {
     realObject.getApplicationContext().sendBroadcast(intent);
   }
+
+  @Implementation
+  public ClassLoader getClassLoader() {
+    return this.getClass().getClassLoader();
+  }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
@@ -76,36 +76,6 @@ public class ShadowApplicationTest {
   }
 
   @Test
-  public void shouldBeBindableToAResourceLoader() throws Exception {
-    ResourceLoader resourceLoader1 = new EmptyResourceLoader() {
-      @Override public TypedResource getValue(ResName resName, String qualifiers) {
-        return new TypedResource("title from resourceLoader1", ResType.CHAR_SEQUENCE);
-      }
-
-      @Override public ResourceIndex getResourceIndex() {
-        return new ImperviousResourceExtractor();
-      }
-    };
-    ResourceLoader resourceLoader2 = new EmptyResourceLoader() {
-      @Override public TypedResource getValue(ResName resName, String qualifiers) {
-        return new TypedResource("title from resourceLoader2", ResType.CHAR_SEQUENCE);
-      }
-
-      @Override public ResourceIndex getResourceIndex() {
-        return new ImperviousResourceExtractor();
-      }
-    };
-
-    final Application app1 = new Application();
-    final Application app2 = new Application();
-    shadowOf(app1).bind(null, resourceLoader1);
-    shadowOf(app2).bind(null, resourceLoader2);
-
-    assertEquals("title from resourceLoader1", new ContextWrapper(app1).getResources().getString(R.string.howdy));
-    assertEquals("title from resourceLoader2", new ContextWrapper(app2).getResources().getString(R.string.howdy));
-  }
-
-  @Test
   public void shouldProvideServices() throws Exception {
     checkSystemService(Context.ACTIVITY_SERVICE, android.app.ActivityManager.class);
     checkSystemService(Context.POWER_SERVICE, android.os.PowerManager.class);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextImplTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextImplTest.java
@@ -7,9 +7,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.os.Build;
+import android.view.LayoutInflater;
+import android.widget.FrameLayout;
+import android.widget.RemoteViews;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.R;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestApplication;
 import org.robolectric.TestRunners;
@@ -71,5 +75,20 @@ public class ShadowContextImplTest {
     assertThat(ShadowApplication.getInstance().getNextStartedService().getComponent().getClassName()).isEqualTo("ServiceIntent");
   }
 
+  @Test
+  public void createPackageContext() throws Exception {
+    Context packageContext = context.createPackageContext(RuntimeEnvironment.application.getPackageName(), 0);
+
+    LayoutInflater inflater = (LayoutInflater) RuntimeEnvironment.application.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+    inflater.cloneInContext(packageContext);
+
+    inflater.inflate(R.layout.remote_views, new FrameLayout(RuntimeEnvironment.application), false);
+  }
+
+  @Test
+  public void createPackageContextRemoteViews() throws Exception {
+    RemoteViews remoteViews = new RemoteViews(RuntimeEnvironment.application.getPackageName(), R.layout.remote_views);
+    remoteViews.apply(RuntimeEnvironment.application, new FrameLayout(RuntimeEnvironment.application));
+  }
 }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,7 +12,6 @@ import org.robolectric.TestRunners;
 import org.robolectric.res.Attribute;
 import org.robolectric.res.PackageResourceLoader;
 import org.robolectric.res.ResourceLoader;
-import org.robolectric.util.TestUtil;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -242,7 +242,6 @@ public class ShadowContextTest {
   @Test
   public void obtainStyledAttributes_shouldExtractAttributesFromAttributeSet() throws Exception {
     ResourceLoader resourceLoader = new PackageResourceLoader(TEST_RESOURCE_PATH);
-    TestUtil.createResourcesFor(resourceLoader);
 
     RoboAttributeSet roboAttributeSet = new RoboAttributeSet(asList(
         new Attribute(TEST_PACKAGE + ":attr/itemType", "ungulate", TEST_PACKAGE),

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPreferenceGroupTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPreferenceGroupTest.java
@@ -2,17 +2,17 @@ package org.robolectric.shadows;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.res.Resources;
 import android.preference.Preference;
 import android.preference.PreferenceGroup;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.TestRunners;
 import org.robolectric.res.Attribute;
-import org.robolectric.util.TestUtil;
+import org.robolectric.res.EmptyResourceLoader;
 
 import java.util.ArrayList;
 
@@ -32,8 +32,7 @@ public class ShadowPreferenceGroupTest {
   @Before
   public void setUp() throws Exception {
     activity = buildActivity(Activity.class).create().get();
-    Resources resources = TestUtil.emptyResources();
-    attrs = new RoboAttributeSet(new ArrayList<Attribute>(), shadowOf(resources).getResourceLoader());
+    attrs = new RoboAttributeSet(new ArrayList<Attribute>(), new EmptyResourceLoader());
 
     group = new TestPreferenceGroup(activity, attrs);
     shadow = shadowOf(group);

--- a/robolectric/src/test/java/org/robolectric/util/TestUtil.java
+++ b/robolectric/src/test/java/org/robolectric/util/TestUtil.java
@@ -1,17 +1,13 @@
 package org.robolectric.util;
 
-import android.content.res.Resources;
-import org.robolectric.manifest.AndroidManifest;
-import org.robolectric.internal.dependency.MavenDependencyResolver;
 import org.robolectric.R;
 import org.robolectric.internal.SdkConfig;
+import org.robolectric.internal.dependency.MavenDependencyResolver;
+import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.Attribute;
-import org.robolectric.res.EmptyResourceLoader;
 import org.robolectric.res.Fs;
 import org.robolectric.res.FsFile;
-import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.ResourcePath;
-import org.robolectric.shadows.ShadowResources;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -141,17 +137,5 @@ public abstract class TestUtil {
       file = new File(file, part);
     }
     return file.getPath();
-  }
-
-  public static String joinCanonicalPath(String... parts) throws IOException {
-    return new File(joinPath(parts)).getCanonicalPath();
-  }
-
-  public static Resources createResourcesFor(ResourceLoader resourceLoader) {
-    return ShadowResources.createFor(resourceLoader);
-  }
-
-  public static Resources emptyResources() {
-    return ShadowResources.createFor(new EmptyResourceLoader());
   }
 }


### PR DESCRIPTION
This was exposed when ShadowRemoteViews was removed.

Pushes resource loader down into package manager.
Removes unused TestUtil methods.