### PR TITLE
Make ShadowApplication.registerReceiverWithContext protected

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -638,7 +638,7 @@ public class ShadowApplication extends ShadowContextWrapper {
     return registerReceiverWithContext(receiver, filter, broadcastPermission, scheduler, realApplication);
   }
 
-  Intent registerReceiverWithContext(BroadcastReceiver receiver, IntentFilter filter, String broadcastPermission, Handler scheduler, Context context) {
+  protected Intent registerReceiverWithContext(BroadcastReceiver receiver, IntentFilter filter, String broadcastPermission, Handler scheduler, Context context) {
     if (receiver != null) {
       registeredReceivers.add(new Wrapper(receiver, filter, context, broadcastPermission, scheduler));
     }


### PR DESCRIPTION
registerReceiverWithContext is used in ShadowApplication and by
ShadowContextWrapper. Setting it to protected makes sure custom shadow
can override the method to make behavior consistent.
