### PR TITLE
Remove ShadowResources.{getResourceLoader(),getQualifiers(),getResNam…

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -409,7 +409,7 @@ public final class ShadowAssetManager {
     return new Resource(value, resName);
   }
 
-  ResourceLoader getResourceLoader() {
+  public ResourceLoader getResourceLoader() {
     if (resourceLoader == null) {
       resourceLoader = ShadowApplication.getInstance().getResourceLoader();
     }

--- a/robolectric/src/test/java/org/robolectric/res/RoboAttributeSetTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/RoboAttributeSetTest.java
@@ -26,7 +26,7 @@ public class RoboAttributeSetTest {
   @Before
   public void setUp() throws Exception {
     resources = RuntimeEnvironment.application.getResources();
-    resourceLoader = shadowOf(resources).getResourceLoader();
+    resourceLoader = shadowOf(resources.getAssets()).getResourceLoader();
   }
 
   @Test
@@ -158,7 +158,7 @@ public class RoboAttributeSetTest {
   @Test
   public void getAttributeIntValue_shouldReturnValueFromAttribute() throws Exception {
     roboAttributeSet = new RoboAttributeSet(asList(new Attribute(TEST_PACKAGE + ":attr/sugarinessPercent", "100", TEST_PACKAGE)),
-        shadowOf(resources).getResourceLoader());
+        shadowOf(resources.getAssets()).getResourceLoader());
     assertThat(roboAttributeSet.getAttributeIntValue(TEST_PACKAGE_NS, "sugarinessPercent", 0)).isEqualTo(100);
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowEditTextTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowEditTextTest.java
@@ -33,7 +33,7 @@ public class ShadowEditTextTest {
   public void setup() {
     List<Attribute> attributes = new ArrayList<>();
     attributes.add(new Attribute("android:attr/maxLength", "5", R.class.getPackage().getName()));
-    RoboAttributeSet attributeSet = new RoboAttributeSet(attributes, shadowOf(application.getResources()).getResourceLoader());
+    RoboAttributeSet attributeSet = new RoboAttributeSet(attributes, shadowOf(application.getResources().getAssets()).getResourceLoader());
     editText = new EditText(application, attributeSet);
   }
 
@@ -120,7 +120,7 @@ public class ShadowEditTextTest {
 
   private AttributeSet attributeSetWithMaxLength(int maxLength) {
     Resources resources = RuntimeEnvironment.application.getResources();
-    ResourceLoader resourceLoader = shadowOf(resources).getResourceLoader();
+    ResourceLoader resourceLoader = shadowOf(resources.getAssets()).getResourceLoader();
     return new RoboAttributeSet(
         asList(new Attribute(new ResName("android", "attr", "maxLength"), maxLength + "", "android")),
         resourceLoader);
@@ -128,7 +128,7 @@ public class ShadowEditTextTest {
 
   private AttributeSet attributeSetWithoutMaxLength() {
     Resources resources = RuntimeEnvironment.application.getResources();
-    ResourceLoader resourceLoader = shadowOf(resources).getResourceLoader();
+    ResourceLoader resourceLoader = shadowOf(resources.getAssets()).getResourceLoader();
     return new RoboAttributeSet(Arrays.<Attribute>asList(),
         resourceLoader);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLayoutInflaterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLayoutInflaterTest.java
@@ -441,7 +441,7 @@ public class ShadowLayoutInflaterTest {
   public View inflate(Context context, String packageName, String key, ViewGroup parent, String qualifiers) {
     ResName resName = new ResName(packageName + ":layout/" + key);
     shadowOf(context.getAssets()).setQualifiers(qualifiers);
-    ResourceLoader resourceLoader = shadowOf(context.getResources()).getResourceLoader();
+    ResourceLoader resourceLoader = shadowOf(context.getResources().getAssets()).getResourceLoader();
     Integer layoutResId = resourceLoader.getResourceIndex().getResourceId(resName);
     if (layoutResId == null) throw new AssertionError("no such resource " + resName);
     return LayoutInflater.from(context).inflate(layoutResId, parent);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowProgressBarTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowProgressBarTest.java
@@ -27,7 +27,7 @@ public class ShadowProgressBarTest {
         new Attribute(new ResName(TestUtil.SYSTEM_PACKAGE, "attr", "max"), "100", TestUtil.TEST_PACKAGE),
         new Attribute(new ResName(TestUtil.SYSTEM_PACKAGE, "attr", "indeterminate"), "false", TestUtil.TEST_PACKAGE),
         new Attribute(new ResName(TestUtil.SYSTEM_PACKAGE, "attr", "indeterminateOnly"), "false", TestUtil.TEST_PACKAGE)
-    ), shadowOf(application.getResources()).getResourceLoader());
+    ), shadowOf(application.getResources().getAssets()).getResourceLoader());
 
     progressBar = new ProgressBar(application, attrs);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
@@ -102,7 +102,7 @@ public class ShadowThemeTest {
 
   @Test public void shouldInheritThemeValuesFromImplicitParents() throws Exception {
     TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
-    ResourceLoader resourceLoader = Shadows.shadowOf(activity.getResources()).getResourceLoader();
+    ResourceLoader resourceLoader = Shadows.shadowOf(activity.getResources().getAssets()).getResourceLoader();
     Style style = ShadowAssetManager.resolveStyle(resourceLoader,
         null,
         new ResName(TestUtil.TEST_PACKAGE, "style", "Widget.AnotherTheme.Button.Blarf"), "");
@@ -112,7 +112,7 @@ public class ShadowThemeTest {
 
   @Test public void whenAThemeHasExplicitlyEmptyParentAttr_shouldHaveNoParent() throws Exception {
     TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
-    ResourceLoader resourceLoader = Shadows.shadowOf(activity.getResources()).getResourceLoader();
+    ResourceLoader resourceLoader = Shadows.shadowOf(activity.getResources().getAssets()).getResourceLoader();
     Style style = ShadowAssetManager.resolveStyle(resourceLoader,
         null,
         new ResName(TestUtil.TEST_PACKAGE, "style", "Theme.MyTheme"), "");
@@ -122,7 +122,7 @@ public class ShadowThemeTest {
 
   @Test public void shouldApplyParentStylesFromAttrs() throws Exception {
     TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
-    ResourceLoader resourceLoader = Shadows.shadowOf(activity.getResources()).getResourceLoader();
+    ResourceLoader resourceLoader = Shadows.shadowOf(activity.getResources().getAssets()).getResourceLoader();
     Style theme = ShadowAssetManager.resolveStyle(resourceLoader, null,
         new ResName(TestUtil.TEST_PACKAGE, "style", "Theme.AnotherTheme"), "");
     Style style = ShadowAssetManager.resolveStyle(resourceLoader, theme,

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
@@ -67,7 +67,7 @@ public class ShadowViewTest {
     transcript = new Transcript();
     view = new View(RuntimeEnvironment.application);
     resources = RuntimeEnvironment.application.getResources();
-    resourceLoader = shadowOf(resources).getResourceLoader();
+    resourceLoader = shadowOf(resources.getAssets()).getResourceLoader();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ViewStubTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ViewStubTest.java
@@ -56,7 +56,7 @@ public class ViewStubTest {
   @Test
   public void shouldApplyAttributes() throws Exception {
     Resources resources = RuntimeEnvironment.application.getResources();
-    ResourceLoader resourceLoader = shadowOf(resources).getResourceLoader();
+    ResourceLoader resourceLoader = shadowOf(resources.getAssets()).getResourceLoader();
 
     ViewStub viewStub = new ViewStub(ctxt,
         new RoboAttributeSet(asList(


### PR DESCRIPTION
…e()} prefer to obtain these directly from the ShadowAssetManager.

The goal is to remove as much shadow code from resources as possible, pushing down resource resolution to the AssetManager.