### PR TITLE
Change TestLifecycle.createApplication() to TestLifecycle.getApplicationClass()

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenuItem.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenuItem.java
@@ -7,6 +7,8 @@ import android.view.ContextMenu;
 import android.view.MenuItem;
 import android.view.SubMenu;
 import android.view.View;
+
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowApplication;
 
 /**
@@ -97,7 +99,7 @@ public class RoboMenuItem implements MenuItem {
 
   @Override
   public MenuItem setIcon(int iconRes) {
-    this.icon = iconRes == 0 ? null : ShadowApplication.getInstance().getResources().getDrawable(iconRes);
+    this.icon = iconRes == 0 ? null : RuntimeEnvironment.application.getResources().getDrawable(iconRes);
     return this;
   }
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -121,11 +121,11 @@ public class ShadowApplication extends ShadowContextWrapper {
   }
 
   public static void setDisplayMetricsDensity(float densityMultiplier) {
-    shadowOf(getInstance().getResources()).setDensity(densityMultiplier);
+    shadowOf(RuntimeEnvironment.application.getResources()).setDensity(densityMultiplier);
   }
 
   public static void setDefaultDisplay(Display display) {
-    shadowOf(getInstance().getResources()).setDisplay(display);
+    shadowOf(RuntimeEnvironment.application.getResources()).setDisplay(display);
   }
 
   /**

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreferenceActivity.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreferenceActivity.java
@@ -5,6 +5,7 @@ import android.preference.PreferenceActivity;
 import android.preference.PreferenceScreen;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
 import org.robolectric.res.PreferenceNode;
 import org.robolectric.res.ResName;
 import org.robolectric.shadows.util.PreferenceBuilder;
@@ -20,16 +21,20 @@ public class ShadowPreferenceActivity extends ShadowActivity {
   private PreferenceScreen preferenceScreen;
   private final PreferenceBuilder preferenceBuilder = new PreferenceBuilder();
 
+  @RealObject
+  private PreferenceActivity realObject;
+
   @Implementation
   public void addPreferencesFromResource(int preferencesResId) {
     this.preferencesResId = preferencesResId;
     preferenceScreen = inflatePreferences(preferencesResId);
-    ((PreferenceActivity)realActivity).setPreferenceScreen(preferenceScreen);
+    realObject.setPreferenceScreen(preferenceScreen);
   }
 
   private PreferenceScreen inflatePreferences(int preferencesResId) {
     ResName resName = getResName(preferencesResId);
-    String qualifiers = shadowOf(getResources().getConfiguration()).getQualifiers();
+    String qualifiers = shadowOf(realObject.getResources().getConfiguration()).getQualifiers();
+
     PreferenceNode preferenceNode = getResourceLoader().getPreferenceNode(resName, qualifiers);
     try {
       return (PreferenceScreen) preferenceBuilder.inflate(preferenceNode, realActivity, null);

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
@@ -5,6 +5,8 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.FileUtils;
 import android.os.Handler;

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -1,6 +1,5 @@
 package org.robolectric;
 
-import android.app.Application;
 import android.os.Build;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
@@ -59,7 +58,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
   private static ShadowMap mainShadowMap;
 
   private InstrumentingClassLoaderFactory instrumentingClassLoaderFactory;
-  private TestLifecycle<Application> testLifecycle;
+  private TestLifecycle testLifecycle;
   private DependencyResolver dependencyResolver;
 
   static {

--- a/robolectric/src/main/java/org/robolectric/TestLifecycle.java
+++ b/robolectric/src/main/java/org/robolectric/TestLifecycle.java
@@ -5,8 +5,8 @@ import org.robolectric.manifest.AndroidManifest;
 
 import java.lang.reflect.Method;
 
-public interface TestLifecycle<T> {
-  T createApplication(Method method, AndroidManifest appManifest, Config config);
+public interface TestLifecycle {
+  Class getApplicationClass(Method method, AndroidManifest appManifest, Config config);
 
   void beforeTest(Method method);
 

--- a/robolectric/src/main/java/org/robolectric/util/ActivityController.java
+++ b/robolectric/src/main/java/org/robolectric/util/ActivityController.java
@@ -15,13 +15,13 @@ import android.view.ViewRootImpl;
 
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.ShadowsAdapter;
+import org.robolectric.ShadowsAdapter.ShadowActivityAdapter;
+import org.robolectric.ShadowsAdapter.ShadowApplicationAdapter;
 import org.robolectric.internal.Shadow;
 import org.robolectric.internal.runtime.RuntimeAdapter;
 import org.robolectric.internal.runtime.RuntimeAdapterFactory;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.ResName;
-import org.robolectric.ShadowsAdapter.ShadowActivityAdapter;
-import org.robolectric.ShadowsAdapter.ShadowApplicationAdapter;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 public class ActivityController<T extends Activity> extends ComponentController<ActivityController<T>, T> {
@@ -110,7 +110,7 @@ public class ActivityController<T extends Activity> extends ComponentController<
         }
 
         /* Get the resource ID, use the activity to look up the actual string */
-        title = component.getString(labelRes);
+        title = RuntimeEnvironment.application.getString(labelRes);
       } else {
         title = labelRef; /* Label isn't an identifier, use it directly as the title */
       }

--- a/robolectric/src/test/java/org/robolectric/RobolectricTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTest.java
@@ -103,15 +103,15 @@ public class RobolectricTest {
 
   @Test
   public void shouldUseSetDensityForContexts() throws Exception {
-    assertThat(new Activity().getResources().getDisplayMetrics().density).isEqualTo(1.0f);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().density).isEqualTo(1.0f);
     ShadowApplication.setDisplayMetricsDensity(1.5f);
-    assertThat(new Activity().getResources().getDisplayMetrics().density).isEqualTo(1.5f);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().density).isEqualTo(1.5f);
   }
 
   @Test
   public void shouldUseSetDisplayForContexts() throws Exception {
-    assertThat(new Activity().getResources().getDisplayMetrics().widthPixels).isEqualTo(480);
-    assertThat(new Activity().getResources().getDisplayMetrics().heightPixels).isEqualTo(800);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().widthPixels).isEqualTo(480);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().heightPixels).isEqualTo(800);
 
     Display display = Shadow.newInstanceOf(Display.class);
     ShadowDisplay shadowDisplay = Shadows.shadowOf(display);
@@ -119,8 +119,8 @@ public class RobolectricTest {
     shadowDisplay.setHeight(200);
     ShadowApplication.setDefaultDisplay(display);
 
-    assertThat(new Activity().getResources().getDisplayMetrics().widthPixels).isEqualTo(100);
-    assertThat(new Activity().getResources().getDisplayMetrics().heightPixels).isEqualTo(200);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().widthPixels).isEqualTo(100);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().heightPixels).isEqualTo(200);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
@@ -63,12 +63,12 @@ public class RobolectricTestRunnerSelfTest {
   @Config(qualifiers = "fr")
   public void internalBeforeTest_testValuesResQualifiers() {
     String expectedQualifiers = "fr" + TestRunners.WithDefaults.SDK_TARGETED_BY_MANIFEST;
-    assertThat(Shadows.shadowOf(ShadowApplication.getInstance().getResources().getAssets()).getQualifiers()).isEqualTo(expectedQualifiers);
+    assertThat(Shadows.shadowOf(RuntimeEnvironment.application.getResources().getAssets()).getQualifiers()).isEqualTo(expectedQualifiers);
   }
 
   @Test
   public void internalBeforeTest_resetsValuesResQualifiers() {
-    assertThat(Shadows.shadowOf(ShadowApplication.getInstance().getResources().getConfiguration()).getQualifiers())
+    assertThat(Shadows.shadowOf(RuntimeEnvironment.application.getResources().getConfiguration()).getQualifiers())
       .isEqualTo("");
   }
 
@@ -126,8 +126,8 @@ public class RobolectricTestRunnerSelfTest {
     }
 
     public static class MyTestLifecycle extends DefaultTestLifecycle {
-      @Override public Application createApplication(Method method, AndroidManifest appManifest, Config config) {
-        return new MyTestApplication();
+      @Override public Class getApplicationClass(Method method, AndroidManifest appManifest, Config config) {
+        return MyTestApplication.class;
       }
     }
   }

--- a/robolectric/src/test/java/org/robolectric/TestRunnerSequenceTest.java
+++ b/robolectric/src/test/java/org/robolectric/TestRunnerSequenceTest.java
@@ -31,7 +31,7 @@ public class TestRunnerSequenceTest {
         "configureShadows",
 //                "resetStaticState", // no longer an overridable hook
 //                "setupApplicationState", // no longer an overridable hook
-        "createApplication",
+        "getApplicationClass",
         "application.onCreate",
         "beforeTest",
         "application.beforeTest",
@@ -53,7 +53,7 @@ public class TestRunnerSequenceTest {
     }));
     StateHolder.transcript.assertEventsSoFar(
         "configureShadows",
-        "createApplication",
+        "getApplicationClass",
         "application.onCreate",
         "beforeTest",
         "application.beforeTest",
@@ -121,9 +121,9 @@ public class TestRunnerSequenceTest {
   }
 
   public static class MyTestLifecycle extends DefaultTestLifecycle {
-    @Override public Application createApplication(Method method, AndroidManifest appManifest, Config config) {
-      StateHolder.transcript.add("createApplication");
-      return new MyApplication();
+    @Override public Class getApplicationClass(Method method, AndroidManifest appManifest, Config config) {
+      StateHolder.transcript.add("getApplicationClass");
+      return MyApplication.class;
     }
 
     @Override public void beforeTest(Method method) {
@@ -141,7 +141,7 @@ public class TestRunnerSequenceTest {
       super.afterTest(method);
     }
 
-    private static class MyApplication extends Application implements TestLifecycleApplication {
+    public static class MyApplication extends Application implements TestLifecycleApplication {
       @Override public void onCreate() {
         StateHolder.transcript.add("application.onCreate");
       }

--- a/robolectric/src/test/java/org/robolectric/fakes/RoboMenuTest.java
+++ b/robolectric/src/test/java/org/robolectric/fakes/RoboMenuTest.java
@@ -3,14 +3,19 @@ package org.robolectric.fakes;
 import android.app.Activity;
 import android.content.Intent;
 import android.view.MenuItem;
+
+import com.google.android.apps.common.testing.accessibility.framework.proto.FrameworkProtos;
+
 import junit.framework.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
 import org.robolectric.fakes.RoboMenu;
 import org.robolectric.fakes.RoboMenuItem;
 import org.robolectric.shadows.ShadowActivity;
+import org.robolectric.shadows.ShadowApplication;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -21,7 +26,7 @@ public class RoboMenuTest {
 
   @Test
   public void addAndRemoveMenuItems() {
-    RoboMenu menu = new RoboMenu(new MyActivity());
+    RoboMenu menu = new RoboMenu(RuntimeEnvironment.application);
     menu.add(9, 10, 0, org.robolectric.R.string.ok);
 
     RoboMenuItem item = (RoboMenuItem) menu.findItem(10);
@@ -37,7 +42,7 @@ public class RoboMenuTest {
 
   @Test
   public void addSubMenu() {
-    RoboMenu menu = new RoboMenu(new MyActivity());
+    RoboMenu menu = new RoboMenu(RuntimeEnvironment.application);
     menu.addSubMenu(9, 10, 0, org.robolectric.R.string.ok);
 
     RoboMenuItem item = (RoboMenuItem) menu.findItem(10);
@@ -48,29 +53,25 @@ public class RoboMenuTest {
 
   @Test
   public void clickWithIntent() {
-    MyActivity activity = new MyActivity();
-
-    RoboMenu menu = new RoboMenu(activity);
+    RoboMenu menu = new RoboMenu(RuntimeEnvironment.application);
     menu.add(0, 10, 0, org.robolectric.R.string.ok);
 
     RoboMenuItem item = (RoboMenuItem) menu.findItem(10);
     Assert.assertNull(item.getIntent());
 
-    Intent intent = new Intent(activity, MyActivity.class);
+    Intent intent = new Intent(RuntimeEnvironment.application, Activity.class);
     item.setIntent(intent);
     item.click();
 
     Assert.assertNotNull(item);
 
-    ShadowActivity shadowActivity = Shadows.shadowOf(activity);
-    Intent startedIntent = shadowActivity.getNextStartedActivity();
+    Intent startedIntent = ShadowApplication.getInstance().getNextStartedActivity();
     assertNotNull(startedIntent);
   }
 
   @Test
   public void add_AddsItemsInOrder() {
-    MyActivity activity = new MyActivity();
-    RoboMenu menu = new RoboMenu(activity);
+    RoboMenu menu = new RoboMenu(RuntimeEnvironment.application);
     menu.add(0, 0, 1, "greeting");
     menu.add(0, 0, 0, "hell0");
     menu.add(0, 0, 0, "hello");
@@ -81,13 +82,5 @@ public class RoboMenuTest {
     assertEquals("hello", item.getTitle());
     item = menu.getItem(2);
     assertEquals("greeting", item.getTitle());
-  }
-
-  private static class MyActivity extends Activity {
-
-    @Override
-    protected void onDestroy() {
-      super.onDestroy();
-    }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/CustomRobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/CustomRobolectricTestRunnerTest.java
@@ -109,8 +109,8 @@ public class CustomRobolectricTestRunnerTest {
   }
 
   public static class X extends DefaultTestLifecycle {
-    @Override public Application createApplication(Method method, AndroidManifest appManifest, Config config) {
-      return new MyApplication();
+    @Override public Class getApplicationClass(Method method, AndroidManifest appManifest, Config config) {
+      return MyApplication.class;
     }
   }
 
@@ -172,8 +172,8 @@ public class CustomRobolectricTestRunnerTest {
         afterTestMethod = method;
       }
 
-      @Override public Application createApplication(Method method, AndroidManifest appManifest, Config config) {
-        return new CustomApplication();
+      @Override public Class getApplicationClass(Method method, AndroidManifest appManifest, Config config) {
+        return CustomApplication.class;
       }
     }
   }

--- a/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
@@ -367,15 +367,15 @@ public class DefaultRobolectricPackageManagerTest {
 
     metaValue = meta.get("org.robolectric.metaBooleanFromRes");
     assertTrue(Boolean.class.isInstance(metaValue));
-    assertEquals(app.getResources().getBoolean(R.bool.false_bool_value), metaValue);
+    assertEquals(RuntimeEnvironment.application.getResources().getBoolean(R.bool.false_bool_value), metaValue);
 
     metaValue = meta.get("org.robolectric.metaIntFromRes");
     assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(app.getResources().getInteger(R.integer.test_integer1), metaValue);
+    assertEquals(RuntimeEnvironment.application.getResources().getInteger(R.integer.test_integer1), metaValue);
 
     metaValue = meta.get("org.robolectric.metaColorFromRes");
     assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(app.getResources().getColor(R.color.clear), metaValue);
+    assertEquals(RuntimeEnvironment.application.getResources().getColor(R.color.clear), metaValue);
 
     metaValue = meta.get("org.robolectric.metaStringFromRes");
     assertTrue(String.class.isInstance(metaValue));
@@ -568,15 +568,15 @@ public class DefaultRobolectricPackageManagerTest {
 
     metaValue = meta.get("org.robolectric.metaBooleanFromRes");
     assertTrue(Boolean.class.isInstance(metaValue));
-    assertEquals(app.getResources().getBoolean(R.bool.false_bool_value), metaValue);
+    assertEquals(RuntimeEnvironment.application.getResources().getBoolean(R.bool.false_bool_value), metaValue);
 
     metaValue = meta.get("org.robolectric.metaIntFromRes");
     assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(app.getResources().getInteger(R.integer.test_integer1), metaValue);
+    assertEquals(RuntimeEnvironment.application.getResources().getInteger(R.integer.test_integer1), metaValue);
 
     metaValue = meta.get("org.robolectric.metaColorFromRes");
     assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(app.getResources().getColor(R.color.clear), metaValue);
+    assertEquals(RuntimeEnvironment.application.getResources().getColor(R.color.clear), metaValue);
 
     metaValue = meta.get("org.robolectric.metaStringFromRes");
     assertTrue(String.class.isInstance(metaValue));

--- a/robolectric/src/test/java/org/robolectric/res/DrawableResourceLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DrawableResourceLoaderTest.java
@@ -59,7 +59,7 @@ public class DrawableResourceLoaderTest {
 
   @Test
   public void testGetDrawable_rainbow() throws Exception {
-    assertNotNull(ShadowApplication.getInstance().getResources().getDrawable(R.drawable.rainbow));
+    assertNotNull(RuntimeEnvironment.application.getResources().getDrawable(R.drawable.rainbow));
   }
 
   @Test
@@ -82,7 +82,7 @@ public class DrawableResourceLoaderTest {
 
   @Test
   public void testLayerDrawable() {
-    Resources resources = ShadowApplication.getInstance().getResources();
+    Resources resources = RuntimeEnvironment.application.getResources();
     Drawable drawable = resources.getDrawable(R.drawable.rainbow);
     assertThat(drawable).isInstanceOf(LayerDrawable.class);
     assertEquals(8, ((LayerDrawable) drawable).getNumberOfLayers());

--- a/robolectric/src/test/java/org/robolectric/res/ResourceLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/ResourceLoaderTest.java
@@ -52,7 +52,7 @@ public class ResourceLoaderTest {
     View view = LayoutInflater.from(RuntimeEnvironment.application).inflate(R.layout.different_screen_sizes, null);
     TextView textView = (TextView) view.findViewById(android.R.id.text1);
     assertThat(textView.getText().toString()).isEqualTo("default");
-    Shadows.shadowOf(ShadowApplication.getInstance().getResources().getConfiguration()).overrideQualifiers("land"); // testing if this pollutes the other test
+    Shadows.shadowOf(RuntimeEnvironment.application.getResources().getConfiguration()).overrideQualifiers("land"); // testing if this pollutes the other test
   }
 
   @Test
@@ -70,6 +70,4 @@ public class ResourceLoaderTest {
 
     assertThat(RuntimeEnvironment.application.getResources().getString(resId)).isEqualTo("The old PIN you typed isn't correct.");
   }
-
-  private static class TestPreferenceActivity extends PreferenceActivity { }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
@@ -1,27 +1,14 @@
 package org.robolectric.shadows;
 
-import static android.content.pm.PackageManager.PERMISSION_DENIED;
-import static android.content.pm.PackageManager.PERMISSION_GRANTED;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.robolectric.Shadows.shadowOf;
-
 import android.app.Activity;
 import android.app.Application;
 import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
-import android.content.ContextWrapper;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
-import android.content.res.Resources;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.IInterface;
@@ -37,9 +24,6 @@ import android.widget.PopupWindow;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.DefaultTestLifecycle;
-import org.robolectric.R;
-import org.robolectric.RoboSettings;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
@@ -48,14 +32,9 @@ import org.robolectric.annotation.Config;
 import org.robolectric.fakes.RoboSensorManager;
 import org.robolectric.fakes.RoboVibrator;
 import org.robolectric.manifest.AndroidManifest;
-import org.robolectric.res.EmptyResourceLoader;
 import org.robolectric.res.Fs;
 import org.robolectric.res.ResName;
-import org.robolectric.res.ResType;
 import org.robolectric.res.ResourceExtractor;
-import org.robolectric.res.ResourceIndex;
-import org.robolectric.res.ResourceLoader;
-import org.robolectric.res.TypedResource;
 import org.robolectric.test.TemporaryFolder;
 import org.robolectric.util.Scheduler;
 import org.robolectric.util.TestBroadcastReceiver;
@@ -64,6 +43,16 @@ import java.io.File;
 import java.io.FileDescriptor;
 import java.io.IOException;
 import java.util.List;
+
+import static android.content.pm.PackageManager.PERMISSION_DENIED;
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowApplicationTest {
@@ -484,24 +473,9 @@ public class ShadowApplicationTest {
   }
 
   @Test
-  public void shouldRememberResourcesAfterLazilyLoading() throws Exception {
-    Application application = new DefaultTestLifecycle().createApplication(null, newConfigWith("com.wacka.wa", ""), null);
-    assertSame(application.getResources(), application.getResources());
-  }
-
-  @Test
-  public void shouldBeAbleToResetResources() throws Exception {
-    Application application = new DefaultTestLifecycle().createApplication(null,
-        newConfigWith("com.wacka.wa", ""), null);
-    Resources res = application.getResources();
-    shadowOf(application).resetResources();
-    assertFalse(res == application.getResources());
-  }
-
-  @Test
   public void checkPermission_shouldTrackGrantedAndDeniedPermissions() throws Exception {
-    Application application = new DefaultTestLifecycle().createApplication(null,
-        newConfigWith("com.wacka.wa", ""), null);
+    Application application = RuntimeEnvironment.application;
+
     shadowOf(application).grantPermissions("foo", "bar");
     shadowOf(application).denyPermissions("foo", "qux");
     assertThat(application.checkPermission("foo", -1, -1)).isEqualTo(PERMISSION_DENIED);
@@ -512,8 +486,7 @@ public class ShadowApplicationTest {
 
   @Test
   public void startActivity_whenActivityCheckingEnabled_checksPackageManagerResolveInfo() throws Exception {
-    Application application = new DefaultTestLifecycle().createApplication(null,
-        newConfigWith("com.wacka.wa", ""), null);
+    Application application = RuntimeEnvironment.application;
     shadowOf(application).checkActivities(true);
 
     String action = "com.does.not.exist.android.app.v2.mobile";

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
@@ -685,8 +685,6 @@ public class ShadowContentResolverTest {
 
   @Test
   public void getProvider_shouldNotReturnAnyProviderWhenManifestIsNull() {
-    Application application = new DefaultTestLifecycle().createApplication(null, null, null);
-    ReflectionHelpers.callInstanceMethod(application, "attach", ReflectionHelpers.ClassParameter.from(Context.class, RuntimeEnvironment.application.getBaseContext()));
     assertThat(ShadowContentResolver.getProvider(Uri.parse("content://"))).isNull();
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
+import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
@@ -33,7 +34,7 @@ public class ShadowResourcesTest {
 
   @Before
   public void setup() throws Exception {
-    resources = new Activity().getResources();
+    resources = RuntimeEnvironment.application.getResources();
   }
 
   @Test
@@ -276,7 +277,7 @@ public class ShadowResourcesTest {
 
   @Test
   public void testGetNinePatchDrawable() {
-    assertThat(ShadowApplication.getInstance().getResources().getDrawable(R.drawable.nine_patch_drawable)).isInstanceOf(NinePatchDrawable.class);
+    assertThat(RuntimeEnvironment.application.getResources().getDrawable(R.drawable.nine_patch_drawable)).isInstanceOf(NinePatchDrawable.class);
   }
 
   @Test(expected = Resources.NotFoundException.class)
@@ -306,19 +307,19 @@ public class ShadowResourcesTest {
 
   @Test
   public void testDensity() {
-    Activity activity = new Activity();
+    Activity activity = Robolectric.setupActivity(Activity.class);
     assertThat(activity.getResources().getDisplayMetrics().density).isEqualTo(1f);
 
     shadowOf(activity.getResources()).setDensity(1.5f);
     assertThat(activity.getResources().getDisplayMetrics().density).isEqualTo(1.5f);
 
-    Activity anotherActivity = new Activity();
+    Activity anotherActivity = Robolectric.setupActivity(Activity.class);
     assertThat(anotherActivity.getResources().getDisplayMetrics().density).isEqualTo(1.5f);
   }
 
   @Test
   public void displayMetricsShouldNotHaveLotsOfZeros() throws Exception {
-    Activity activity = new Activity();
+    Activity activity = Robolectric.setupActivity(Activity.class);
     assertThat(activity.getResources().getDisplayMetrics().heightPixels).isEqualTo(800);
     assertThat(activity.getResources().getDisplayMetrics().widthPixels).isEqualTo(480);
   }
@@ -335,7 +336,7 @@ public class ShadowResourcesTest {
 
   @Test
   public void applicationResourcesShouldHaveBothSystemAndLocalValues() throws Exception {
-    Activity activity = new Activity();
+    Activity activity = Robolectric.setupActivity(Activity.class);
     assertThat(activity.getResources().getString(android.R.string.copy)).isEqualTo("Copy");
     assertThat(activity.getResources().getString(R.string.copy)).isEqualTo("Local Copy");
   }
@@ -472,7 +473,7 @@ public class ShadowResourcesTest {
 
   @Test
   public void subClassInitializedOK() {
-    SubClassResources subClassResources = new SubClassResources(ShadowApplication.getInstance().getResources());
+    SubClassResources subClassResources = new SubClassResources(RuntimeEnvironment.application.getResources());
     assertThat(subClassResources.openRawResource(R.raw.raw_resource)).isNotNull();
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
@@ -7,9 +7,11 @@ import android.os.Bundle;
 import android.util.TypedValue;
 import android.view.View;
 import android.widget.Button;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
+import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
 import org.robolectric.res.ResName;
@@ -42,35 +44,35 @@ public class ShadowThemeTest {
   }
 
   @Test public void whenSetOnActivityInManifest_activityGetsThemeFromActivityInManifest() throws Exception {
-    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
+    TestActivity activity = Robolectric.setupActivity(TestActivityWithAnotherTheme.class);
     Button theButton = (Button) activity.findViewById(R.id.button);
     ColorDrawable background = (ColorDrawable) theButton.getBackground();
     assertThat(background.getColor()).isEqualTo(0xffff0000);
   }
 
   @Test public void whenNotSetOnActivityInManifest_activityGetsThemeFromApplicationInManifest() throws Exception {
-    TestActivity activity = buildActivity(TestActivity.class).create().get();
+    TestActivity activity = Robolectric.setupActivity(TestActivity.class);
     Button theButton = (Button) activity.findViewById(R.id.button);
     ColorDrawable background = (ColorDrawable) theButton.getBackground();
     assertThat(background.getColor()).isEqualTo(0xff00ff00);
   }
 
   @Test public void shouldResolveReferencesThatStartWithAQuestionMark() throws Exception {
-    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
+    TestActivity activity = Robolectric.setupActivity(TestActivityWithAnotherTheme.class);
     Button theButton = (Button) activity.findViewById(R.id.button);
     assertThat(theButton.getMinWidth()).isEqualTo(42); // via AnotherTheme.Button -> logoWidth and logoHeight
 //        assertThat(theButton.getMinHeight()).isEqualTo(42); todo 2.0-cleanup
   }
 
   @Test public void shouldLookUpStylesFromStyleResId() throws Exception {
-    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
+    TestActivity activity = Robolectric.setupActivity(TestActivityWithAnotherTheme.class);
     TypedArray a = activity.obtainStyledAttributes(null, R.styleable.CustomView, 0, R.style.MyCustomView);
     boolean enabled = a.getBoolean(R.styleable.CustomView_aspectRatioEnabled, false);
     assertThat(enabled).isTrue();
   }
 
   @Test public void shouldApplyStylesFromResourceReference() throws Exception {
-    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
+    TestActivity activity = Robolectric.setupActivity(TestActivityWithAnotherTheme.class);
     TypedArray a = activity.obtainStyledAttributes(null, R.styleable.CustomView, 0, R.attr.animalStyle);
     int animalStyleId = a.getResourceId(R.styleable.CustomView_animalStyle, 0);
     assertThat(animalStyleId).isEqualTo(R.style.Gastropod);
@@ -78,7 +80,7 @@ public class ShadowThemeTest {
   }
 
   @Test public void shouldApplyStylesFromAttributeReference() throws Exception {
-    TestActivity activity = buildActivity(TestActivityWithAThirdTheme.class).create().get();
+    TestActivity activity = Robolectric.setupActivity(TestActivityWithAThirdTheme.class);
     TypedArray a = activity.obtainStyledAttributes(null, R.styleable.CustomView, 0, R.attr.animalStyle);
     int animalStyleId = a.getResourceId(R.styleable.CustomView_animalStyle, 0);
     assertThat(animalStyleId).isEqualTo(R.style.Gastropod);
@@ -86,7 +88,7 @@ public class ShadowThemeTest {
   }
 
   @Test public void shouldGetValuesFromAttributeReference() throws Exception {
-    TestActivity activity = buildActivity(TestActivityWithAThirdTheme.class).create().get();
+    TestActivity activity = Robolectric.setupActivity(TestActivityWithAThirdTheme.class);
 
     TypedValue value1 = new TypedValue();
     TypedValue value2 = new TypedValue();
@@ -101,7 +103,7 @@ public class ShadowThemeTest {
   }
 
   @Test public void shouldInheritThemeValuesFromImplicitParents() throws Exception {
-    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
+    TestActivity activity = Robolectric.setupActivity(TestActivityWithAnotherTheme.class);
     ResourceLoader resourceLoader = Shadows.shadowOf(activity.getResources().getAssets()).getResourceLoader();
     Style style = ShadowAssetManager.resolveStyle(resourceLoader,
         null,
@@ -111,7 +113,7 @@ public class ShadowThemeTest {
   }
 
   @Test public void whenAThemeHasExplicitlyEmptyParentAttr_shouldHaveNoParent() throws Exception {
-    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
+    TestActivity activity = Robolectric.setupActivity(TestActivityWithAnotherTheme.class);
     ResourceLoader resourceLoader = Shadows.shadowOf(activity.getResources().getAssets()).getResourceLoader();
     Style style = ShadowAssetManager.resolveStyle(resourceLoader,
         null,
@@ -121,7 +123,7 @@ public class ShadowThemeTest {
 
 
   @Test public void shouldApplyParentStylesFromAttrs() throws Exception {
-    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
+    TestActivity activity = Robolectric.setupActivity(TestActivityWithAnotherTheme.class);
     ResourceLoader resourceLoader = Shadows.shadowOf(activity.getResources().getAssets()).getResourceLoader();
     Style theme = ShadowAssetManager.resolveStyle(resourceLoader, null,
         new ResName(TestUtil.TEST_PACKAGE, "style", "Theme.AnotherTheme"), "");
@@ -153,7 +155,7 @@ public class ShadowThemeTest {
   }
 
   @Test public void shouldApplyFromStyleAttribute() throws Exception {
-    TestWithStyleAttrActivity activity = buildActivity(TestWithStyleAttrActivity.class).create().get();
+    TestWithStyleAttrActivity activity = Robolectric.setupActivity(TestWithStyleAttrActivity.class);
     View button = activity.findViewById(R.id.button);
     assertThat(button.getLayoutParams().width).isEqualTo(42); // comes via style attr
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewConfigurationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewConfigurationTest.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.view.ViewConfiguration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 
@@ -17,7 +18,7 @@ public class ShadowViewConfigurationTest {
 
   @Test
   public void methodsShouldReturnAndroidConstants() {
-    Activity context = new Activity();
+    Activity context = Robolectric.setupActivity(Activity.class);
     ViewConfiguration viewConfiguration = ViewConfiguration.get(context);
 
     assertEquals(10, ViewConfiguration.getScrollBarSize());
@@ -54,7 +55,7 @@ public class ShadowViewConfigurationTest {
 
   @Test
   public void methodsShouldReturnScaledAndroidConstantsDependingOnPixelDensity() {
-    Activity context = new Activity();
+    Activity context = Robolectric.setupActivity(Activity.class);
     shadowOf(context.getResources()).setDensity(1.5f);
     ViewConfiguration viewConfiguration = ViewConfiguration.get(context);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowTest.java
@@ -67,7 +67,7 @@ public class ShadowWindowTest {
 
   @Test
   public void getProgressBar_returnsTheProgressBar() {
-    Activity activity = Robolectric.buildActivity(TestActivity.class).create().get();
+    Activity activity = Robolectric.setupActivity(TestActivity.class);
 
     ProgressBar progress = shadowOf(activity.getWindow()).getProgressBar();
 


### PR DESCRIPTION
This allows us to use the Android Framework Instrumentation class to create and bind the application for us rather than doing it ourselves via reflection in ParallelUniverse.

Also switch usages of ShadowApplication.getResources() to Application.getResources()