### PR TITLE
Stop exposing ResourceLoader through ShadowContext + subclasses.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
@@ -56,12 +56,12 @@ public class CoreShadowsAdapter implements ShadowsAdapter {
   public void prepareShadowApplicationWithExistingApplication(Application application) {
     ShadowApplication roboShadow = Shadows.shadowOf(RuntimeEnvironment.application);
     ShadowApplication testShadow = Shadows.shadowOf(application);
-    testShadow.bind(roboShadow.getAppManifest(), roboShadow.getResourceLoader());
+    testShadow.bind(roboShadow.getAppManifest(), shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
     testShadow.callAttachBaseContext(RuntimeEnvironment.application.getBaseContext());
   }
 
   @Override
-  public ShadowApplicationAdapter getApplicationAdapter(Activity component) {
+  public ShadowApplicationAdapter getApplicationAdapter(final Activity component) {
     final ShadowApplication shadow = Shadows.shadowOf(component.getApplication());
     return new ShadowApplicationAdapter() {
       public AndroidManifest getAppManifest() {
@@ -69,7 +69,7 @@ public class CoreShadowsAdapter implements ShadowsAdapter {
       }
 
       public ResourceLoader getResourceLoader() {
-        return shadow.getResourceLoader();
+        return shadowOf(component.getAssets()).getResourceLoader();
       }
     };
   }
@@ -111,7 +111,7 @@ public class CoreShadowsAdapter implements ShadowsAdapter {
 
   @Override
   public ResourceLoader getResourceLoader() {
-    return ShadowApplication.getInstance().getResourceLoader();
+    return shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader();
   }
 
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -67,7 +67,6 @@ public class ShadowApplication extends ShadowContextWrapper {
   @RealObject private Application realApplication;
 
   private AndroidManifest appManifest;
-  private ResourceLoader resourceLoader;
   private ContentResolver contentResolver;
   private List<Intent> startedActivities = new ArrayList<>();
   private List<Intent.FilterComparison> startedServices = new ArrayList<>();
@@ -135,9 +134,8 @@ public class ShadowApplication extends ShadowContextWrapper {
    * @param resourceLoader Resource loader.
    */
   public void bind(AndroidManifest appManifest, ResourceLoader resourceLoader) {
-    if (this.resourceLoader != null) throw new RuntimeException("ResourceLoader already set!");
+    ShadowAssetManager.setAppResourceLoader(resourceLoader);
     this.appManifest = appManifest;
-    this.resourceLoader = resourceLoader;
 
     if (appManifest != null) {
       setPackageName(appManifest.getPackageName());
@@ -293,7 +291,7 @@ public class ShadowApplication extends ShadowContextWrapper {
 
   public void setComponentNameAndServiceForBindServiceForIntent(Intent intent, ComponentName name, IBinder service) {
     serviceConnectionDataForIntent.put(new Intent.FilterComparison(intent),
-            new ServiceConnectionDataWrapper(name, service));
+        new ServiceConnectionDataWrapper(name, service));
   }
 
   @Implementation
@@ -423,15 +421,6 @@ public class ShadowApplication extends ShadowContextWrapper {
     } else {
       return stoppedServices.remove(0).getIntent();
     }
-  }
-
-  /**
-   * Non-Android accessor (and a handy way to get a working {@code ResourceLoader}
-   *
-   * @return the {@code ResourceLoader} associated with this Application
-   */
-  public ResourceLoader getResourceLoader() {
-    return resourceLoader;
   }
 
   @Override

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -72,7 +72,7 @@ public class ShadowBitmapFactory {
   }
 
   private static String getResourceName(int id) {
-    return Shadows.shadowOf(RuntimeEnvironment.application).getResourceLoader().getNameForId(id);
+    return Shadows.shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader().getNameForId(id);
   }
 
   @Implementation

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
@@ -44,7 +44,7 @@ abstract public class ShadowContext {
   }
 
   public RoboAttributeSet createAttributeSet(List<Attribute> attributes, Class<? extends View> viewClass) {
-    return new RoboAttributeSet(attributes, getResourceLoader());
+    return new RoboAttributeSet(attributes, shadowOf(realContext.getAssets()).getResourceLoader());
   }
 
   @Implementation
@@ -62,21 +62,12 @@ abstract public class ShadowContext {
     return Environment.getExternalStoragePublicDirectory(type);
   }
 
-  /**
-   * Non-Android accessor.
-   *
-   * @return the {@code ResourceLoader} associated with this {@code Context}
-   */
-  public ResourceLoader getResourceLoader() {
-    return shadowOf((Application) realContext.getApplicationContext()).getResourceLoader();
-  }
-
   public boolean isStrictI18n() {
     return getShadowApplication().isStrictI18n();
   }
 
   public ResName getResName(int resourceId) {
-    return getResourceLoader().getResourceIndex().getResName(resourceId);
+    return shadowOf(realContext.getAssets()).getResourceLoader().getResourceIndex().getResName(resourceId);
   }
 
   public ShadowApplication getShadowApplication() {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
@@ -70,11 +70,6 @@ public class ShadowContextWrapper extends ShadowContext {
     return 0;
   }
 
-  @Override
-  public ResourceLoader getResourceLoader() {
-    return super.getResourceLoader();
-  }
-
   @Implementation
   @Override
   public String getString(int resId) {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreferenceActivity.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreferenceActivity.java
@@ -5,6 +5,7 @@ import android.preference.PreferenceActivity;
 import android.preference.PreferenceScreen;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
 import org.robolectric.res.PreferenceNode;
 import org.robolectric.res.ResName;
 import org.robolectric.shadows.util.PreferenceBuilder;
@@ -20,6 +21,9 @@ public class ShadowPreferenceActivity extends ShadowActivity {
   private PreferenceScreen preferenceScreen;
   private final PreferenceBuilder preferenceBuilder = new PreferenceBuilder();
 
+  @RealObject
+  private PreferenceActivity realOject;
+
   @Implementation
   public void addPreferencesFromResource(int preferencesResId) {
     this.preferencesResId = preferencesResId;
@@ -30,7 +34,7 @@ public class ShadowPreferenceActivity extends ShadowActivity {
   private PreferenceScreen inflatePreferences(int preferencesResId) {
     ResName resName = getResName(preferencesResId);
     String qualifiers = shadowOf(getResources().getConfiguration()).getQualifiers();
-    PreferenceNode preferenceNode = getResourceLoader().getPreferenceNode(resName, qualifiers);
+    PreferenceNode preferenceNode = shadowOf(realOject.getAssets()).getResourceLoader().getPreferenceNode(resName, qualifiers);
     try {
       return (PreferenceScreen) preferenceBuilder.inflate(preferenceNode, realActivity, null);
     } catch (Exception e) {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
@@ -292,7 +292,7 @@ public class ShadowView {
 
   protected void dumpAttributes(PrintStream out) {
     if (realView.getId() > 0) {
-      dumpAttribute(out, "id", shadowOf(realView.getContext()).getResourceLoader().getNameForId(realView.getId()));
+      dumpAttribute(out, "id", shadowOf(realView.getContext().getAssets()).getResourceLoader().getNameForId(realView.getId()));
     }
 
     switch (realView.getVisibility()) {

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowActivity.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowActivity.java.vm
@@ -89,7 +89,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
 
     if (themeRef != null) {
       ResName style = ResName.qualifyResName(themeRef.replace("@", ""), appManifest.getPackageName(), "style");
-      Integer themeRes = shadowApplication.getResourceLoader().getResourceIndex().getResourceId(style);
+      Integer themeRes = shadowOf(getAssets()).getResourceLoader().getResourceIndex().getResourceId(style);
       if (themeRes == null)
         throw new Resources.NotFoundException("no such theme " + style.getFullyQualifiedName());
       realActivity.setTheme(themeRes);

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -55,7 +55,8 @@ public final class ShadowAssetManager {
   public static final int STYLE_CHANGING_CONFIGURATIONS = 4;
   public static final int STYLE_DENSITY = 5;
 
-  private static ResourceLoader systemResources;
+  private static ResourceLoader systemResourceLoader;
+  private static ResourceLoader appResourceLoader;
 
   private Map<$ptrClassBoxed, Resources.Theme> themesById = new LinkedHashMap<>();
   private Map<$ptrClassBoxed, List<OverlayedStyle>> appliedStyles = new HashMap<>();
@@ -66,7 +67,27 @@ public final class ShadowAssetManager {
   AssetManager realObject;
 
   public static void setSystemResources(ResourceLoader systemResources) {
-    ShadowAssetManager.systemResources = systemResources;
+    systemResourceLoader = systemResources;
+  }
+
+  public static void setAppResourceLoader(ResourceLoader resourceLoader) {
+    appResourceLoader = resourceLoader;
+  }
+
+  public ResourceLoader getResourceLoader() {
+    if (resourceLoader == null) {
+      resourceLoader = appResourceLoader;
+    }
+
+    return resourceLoader;
+  }
+
+  @Implementation
+  public static AssetManager getSystem() {
+    AssetManager assetManager = new AssetManager();
+    ShadowAssetManager shadowAssetManager = shadowOf(assetManager);
+    shadowAssetManager.resourceLoader = systemResourceLoader;
+    return assetManager;
   }
 
   @HiddenApi @Implementation
@@ -282,19 +303,18 @@ public final class ShadowAssetManager {
 
   @HiddenApi @Implementation
   public static void applyThemeStyle($ptrClass theme, int styleRes, boolean force) {
-    ResourceLoader resourceLoader = getInstance().getResourceLoader();
     ShadowAssetManager assetManager = shadowOf(getInstance().getAssets());
 
     final Map<$ptrClassBoxed, List<OverlayedStyle>> appliedStyles = assetManager.appliedStyles;
-	
+
     if (!appliedStyles.containsKey(theme)) {
       appliedStyles.put(theme, new LinkedList<OverlayedStyle>());
     }
 
-    ResourceIndex resourceIndex = resourceLoader.getResourceIndex();
+    ResourceIndex resourceIndex = assetManager.getResourceLoader().getResourceIndex();
     ResName resName = resourceIndex.getResName(styleRes);
 
-    Style style = resolveStyle(resourceLoader, null, resName, assetManager.getQualifiers());
+    Style style = resolveStyle(assetManager.getResourceLoader(), null, resName, assetManager.getQualifiers());
 
     List<OverlayedStyle> overlayedStyleList = appliedStyles.get(theme);
     OverlayedStyle styleToAdd = new OverlayedStyle(style, force);
@@ -407,13 +427,6 @@ public final class ShadowAssetManager {
     }
 
     return new Resource(value, resName);
-  }
-
-  public ResourceLoader getResourceLoader() {
-    if (resourceLoader == null) {
-      resourceLoader = ShadowApplication.getInstance().getResourceLoader();
-    }
-    return resourceLoader;
   }
 
   private boolean isReference(TypedResource value) {
@@ -614,14 +627,6 @@ public final class ShadowAssetManager {
           + "}";
     }
 
-  }
-
-  @Implementation
-  public static AssetManager getSystem() {
-    AssetManager assetManager = new AssetManager();
-    ShadowAssetManager shadowAssetManager = shadowOf(assetManager);
-    shadowAssetManager.resourceLoader = systemResources;
-    return assetManager;
   }
 
   List<Attribute> buildAttributes(AttributeSet set, int[] attrs, int defStyleAttr, int themeResourceId, int defStyleRes) {

--- a/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapView.java
+++ b/robolectric-shadows/shadows-maps/src/main/java/org/robolectric/shadows/maps/ShadowMapView.java
@@ -7,25 +7,31 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ZoomButtonsController;
-import com.google.android.maps.*;
+
+import com.google.android.maps.GeoPoint;
+import com.google.android.maps.MapController;
+import com.google.android.maps.MapView;
+import com.google.android.maps.Overlay;
+import com.google.android.maps.Projection;
+
+import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
-import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.internal.ShadowExtractor;
+import org.robolectric.internal.Shadow;
+import org.robolectric.res.Attribute;
 import org.robolectric.shadows.RoboAttributeSet;
-import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowViewGroup;
 import org.robolectric.util.ReflectionHelpers;
-import org.robolectric.res.Attribute;
-import org.robolectric.internal.Shadow;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.robolectric.util.ReflectionHelpers.ClassParameter;
 import static org.robolectric.internal.Shadow.directlyOn;
 import static org.robolectric.internal.Shadow.invokeConstructor;
+import static org.robolectric.shadows.maps.Shadows.shadowOf;
+import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 /**
  * Shadow for {@link com.google.android.maps.MapView}.
@@ -53,7 +59,7 @@ public class ShadowMapView extends ShadowViewGroup {
   @HiddenApi
   public void __constructor__(Context context) {
     setContextOnRealView(context);
-    this.attributeSet = new RoboAttributeSet(new ArrayList<Attribute>(), ShadowApplication.getInstance().getResourceLoader());
+    this.attributeSet = new RoboAttributeSet(new ArrayList<Attribute>(), shadowOf(context.getAssets()).getResourceLoader());
     zoomButtonsController = new ZoomButtonsController(realMapView);
     invokeConstructor(View.class, realView, ClassParameter.from(Context.class, context));
     invokeConstructor(ViewGroup.class, realView, ClassParameter.from(Context.class, context));
@@ -328,9 +334,5 @@ public class ShadowMapView extends ShadowViewGroup {
 
   private void setContextOnRealView(Context context) {
     ReflectionHelpers.setField(realView, "mContext", context);
-  }
-
-  private ShadowMapController shadowOf(MapController mapController) {
-    return (ShadowMapController) ShadowExtractor.extract(mapController);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunnerSelfTest.RunnerForTesting.class)
 public class RobolectricTestRunnerSelfTest {
@@ -34,7 +35,7 @@ public class RobolectricTestRunnerSelfTest {
       .isNotNull()
       .isInstanceOf(MyTestApplication.class);
     assertThat(((MyTestApplication) RuntimeEnvironment.application).onCreateWasCalled).as("onCreate called").isTrue();
-    assertThat(ShadowApplication.getInstance().getResourceLoader()).as("resource loader").isNotNull();
+    assertThat(shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader()).as("resource loader").isNotNull();
   }
 
   @Test
@@ -63,12 +64,12 @@ public class RobolectricTestRunnerSelfTest {
   @Config(qualifiers = "fr")
   public void internalBeforeTest_testValuesResQualifiers() {
     String expectedQualifiers = "fr" + TestRunners.WithDefaults.SDK_TARGETED_BY_MANIFEST;
-    assertThat(Shadows.shadowOf(ShadowApplication.getInstance().getResources().getAssets()).getQualifiers()).isEqualTo(expectedQualifiers);
+    assertThat(shadowOf(RuntimeEnvironment.application.getAssets()).getQualifiers()).isEqualTo(expectedQualifiers);
   }
 
   @Test
   public void internalBeforeTest_resetsValuesResQualifiers() {
-    assertThat(Shadows.shadowOf(ShadowApplication.getInstance().getResources().getConfiguration()).getQualifiers())
+    assertThat(shadowOf(RuntimeEnvironment.application.getResources().getConfiguration()).getQualifiers())
       .isEqualTo("");
   }
 

--- a/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
@@ -46,6 +46,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.robolectric.Robolectric.setupActivity;
+import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE, sdk = 23)
@@ -151,7 +152,7 @@ public class DefaultRobolectricPackageManagerTest {
   @Test
   @Config(manifest = "src/test/resources/TestAndroidManifestForActivitiesWithIntentFilterWithData.xml")
   public void queryIntentActivities_EmptyResultWithNoMatchingImplicitIntents() throws Exception {
-    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), ShadowApplication.getInstance().getResourceLoader());
+    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
     Intent i = new Intent(Intent.ACTION_MAIN, null);
     i.addCategory(Intent.CATEGORY_LAUNCHER);
 
@@ -163,7 +164,7 @@ public class DefaultRobolectricPackageManagerTest {
   @Test
   @Config(manifest = "src/test/resources/TestAndroidManifestForActivitiesWithIntentFilterWithData.xml")
   public void queryIntentActivities_MatchWithImplicitIntents() throws Exception {
-    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), ShadowApplication.getInstance().getResourceLoader());
+    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
     Uri uri = Uri.parse("content://testhost1.com:1/testPath/test.jpeg");
     Intent i = new Intent(Intent.ACTION_VIEW);
     i.addCategory(Intent.CATEGORY_DEFAULT);
@@ -180,7 +181,7 @@ public class DefaultRobolectricPackageManagerTest {
   @Test
   @Config(manifest = "src/test/resources/TestAndroidManifestForActivityAliases.xml")
   public void queryIntentActivities_MatchWithAliasIntents() throws Exception {
-    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), ShadowApplication.getInstance().getResourceLoader());
+    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
     Intent i = new Intent(Intent.ACTION_MAIN);
     i.addCategory(Intent.CATEGORY_LAUNCHER);
 
@@ -334,7 +335,7 @@ public class DefaultRobolectricPackageManagerTest {
   @Config(manifest = "src/test/resources/TestAndroidManifestWithReceivers.xml")
   public void testReceiverInfo() throws Exception {
     ShadowApplication app = ShadowApplication.getInstance();
-    rpm.addManifest(app.getAppManifest(), ShadowApplication.getInstance().getResourceLoader());
+    rpm.addManifest(app.getAppManifest(), shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
     ActivityInfo info = rpm.getReceiverInfo(new ComponentName(app.getApplicationContext(), ".test.ConfigTestReceiver"), PackageManager.GET_META_DATA);
     Bundle meta = info.metaData;
     Object metaValue = meta.get("org.robolectric.metaName1");
@@ -506,7 +507,7 @@ public class DefaultRobolectricPackageManagerTest {
   @Test
   public void shouldAssignTheApplicationNameFromTheManifest() throws Exception {
     AndroidManifest appManifest = newConfigWith("<application android:name=\"org.robolectric.TestApplication\"/>");
-    rpm.addManifest(appManifest, ShadowApplication.getInstance().getResourceLoader());
+    rpm.addManifest(appManifest, shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
     ApplicationInfo applicationInfo = rpm.getApplicationInfo("org.robolectric", 0);
     assertThat(applicationInfo.name).isEqualTo("org.robolectric.TestApplication");
   }
@@ -679,7 +680,7 @@ public class DefaultRobolectricPackageManagerTest {
   @Test
   @Config(manifest = "src/test/resources/TestAndroidManifest.xml")
   public void shouldAssignLabelResFromTheManifest() throws Exception {
-    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), ShadowApplication.getInstance().getResourceLoader());
+    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
     ApplicationInfo applicationInfo = rpm.getApplicationInfo("org.robolectric", 0);
     String appName = ShadowApplication.getInstance().getApplicationContext().getString(applicationInfo.labelRes);
     assertThat(appName).isEqualTo("Testing App");

--- a/robolectric/src/test/java/org/robolectric/res/ResourceLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/ResourceLoaderTest.java
@@ -15,6 +15,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ResourceLoaderTest {
@@ -57,7 +58,7 @@ public class ResourceLoaderTest {
 
   @Test
   public void shouldMakeInternalResourcesAvailable() throws Exception {
-    ResourceLoader resourceLoader = ShadowApplication.getInstance().getResourceLoader();
+    ResourceLoader resourceLoader = shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader();
     ResName internalResource = new ResName("android", "string", "badPin");
     Integer resId = resourceLoader.getResourceIndex().getResourceId(internalResource);
     assertThat(resId).isNotNull();


### PR DESCRIPTION
 Instead callers should access it through ShadowAssetManager.