### PR TITLE
Shadow context wrapper cleanup

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenuItem.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenuItem.java
@@ -7,6 +7,8 @@ import android.view.ContextMenu;
 import android.view.MenuItem;
 import android.view.SubMenu;
 import android.view.View;
+
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowApplication;
 
 /**
@@ -97,7 +99,7 @@ public class RoboMenuItem implements MenuItem {
 
   @Override
   public MenuItem setIcon(int iconRes) {
-    this.icon = iconRes == 0 ? null : ShadowApplication.getInstance().getResources().getDrawable(iconRes);
+    this.icon = iconRes == 0 ? null : RuntimeEnvironment.application.getResources().getDrawable(iconRes);
     return this;
   }
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
@@ -69,7 +69,7 @@ public class CoreShadowsAdapter implements ShadowsAdapter {
       }
 
       public ResourceLoader getResourceLoader() {
-        return shadowOf(component.getAssets()).getResourceLoader();
+        return shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader();
       }
     };
   }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -86,8 +86,6 @@ public class ShadowApplication extends ShadowContextWrapper {
   private ShadowDialog latestDialog;
   private ShadowPopupMenu latestPopupMenu;
   private Object bluetoothAdapter = newInstanceOf("android.bluetooth.BluetoothAdapter");
-  private Resources resources;
-  private AssetManager assetManager;
   private Set<String> grantedPermissions = new HashSet<>();
 
   private Map<Intent.FilterComparison, ServiceConnectionDataWrapper> serviceConnectionDataForIntent = new HashMap<>();
@@ -120,11 +118,11 @@ public class ShadowApplication extends ShadowContextWrapper {
   }
 
   public static void setDisplayMetricsDensity(float densityMultiplier) {
-    shadowOf(getInstance().getResources()).setDensity(densityMultiplier);
+    shadowOf(RuntimeEnvironment.application.getResources()).setDensity(densityMultiplier);
   }
 
   public static void setDefaultDisplay(Display display) {
-    shadowOf(getInstance().getResources()).setDisplay(display);
+    shadowOf(RuntimeEnvironment.application.getResources()).setDisplay(display);
   }
 
   /**
@@ -192,32 +190,6 @@ public class ShadowApplication extends ShadowContextWrapper {
   @Implementation
   public Context getApplicationContext() {
     return realApplication;
-  }
-
-  @Override
-  @Implementation
-  public AssetManager getAssets() {
-    if (assetManager == null) {
-      assetManager = new AssetManager();
-    }
-    return assetManager;
-  }
-
-  @Override
-  @Implementation
-  public Resources getResources() {
-    if (resources == null) {
-      resources = new Resources(realApplication.getAssets(), null, new Configuration());
-    }
-    return resources;
-  }
-
-  /**
-   * Reset (set to null) resources instance, so they will be reloaded next time they are
-   * {@link #getResources gotten}
-   */
-  public void resetResources(){
-    resources = null;
   }
 
   @Implementation

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
@@ -29,11 +29,6 @@ abstract public class ShadowContext {
   private ShadowApplication shadowApplication;
 
   @Implementation
-  public String getString(int resId) {
-    return realContext.getResources().getString(resId);
-  }
-
-  @Implementation
   public CharSequence getText(int resId) {
     return realContext.getResources().getText(resId);
   }
@@ -45,11 +40,6 @@ abstract public class ShadowContext {
 
   public RoboAttributeSet createAttributeSet(List<Attribute> attributes, Class<? extends View> viewClass) {
     return new RoboAttributeSet(attributes, shadowOf(realContext.getAssets()).getResourceLoader());
-  }
-
-  @Implementation
-  public Resources getResources() {
-    throw new RuntimeException("you should override me in a subclass!");
   }
 
   @Implementation

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
@@ -28,16 +28,6 @@ abstract public class ShadowContext {
   @RealObject private Context realContext;
   private ShadowApplication shadowApplication;
 
-  @Implementation
-  public CharSequence getText(int resId) {
-    return realContext.getResources().getText(resId);
-  }
-
-  @Implementation
-  public String getString(int resId, Object... formatArgs) {
-    return realContext.getResources().getString(resId, formatArgs);
-  }
-
   public RoboAttributeSet createAttributeSet(List<Attribute> attributes, Class<? extends View> viewClass) {
     return new RoboAttributeSet(attributes, shadowOf(realContext.getAssets()).getResourceLoader());
   }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
@@ -72,12 +72,6 @@ public class ShadowContextWrapper extends ShadowContext {
 
   @Implementation
   @Override
-  public String getString(int resId) {
-    return super.getString(resId);
-  }
-
-  @Implementation
-  @Override
   public String getString(int resId, Object... formatArgs) {
     return super.getString(resId, formatArgs);
   }
@@ -98,11 +92,6 @@ public class ShadowContextWrapper extends ShadowContext {
   @Override
   public File getExternalFilesDir(String type) {
     return super.getExternalFilesDir(type);
-  }
-
-  @Implementation
-  public Resources getResources() {
-    return getApplicationContext().getResources();
   }
 
   @Implementation
@@ -217,11 +206,6 @@ public class ShadowContextWrapper extends ShadowContext {
     }
 
     return sharedPreferencesMap.get(name);
-  }
-
-  @Implementation
-  public AssetManager getAssets() {
-    return getResources().getAssets();
   }
 
   /**

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
@@ -72,18 +72,6 @@ public class ShadowContextWrapper extends ShadowContext {
 
   @Implementation
   @Override
-  public String getString(int resId, Object... formatArgs) {
-    return super.getString(resId, formatArgs);
-  }
-
-  @Implementation
-  @Override
-  public CharSequence getText(int resId) {
-    return super.getText(resId);
-  }
-
-  @Implementation
-  @Override
   public File getExternalCacheDir() {
     return super.getExternalCacheDir();
   }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreferenceActivity.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPreferenceActivity.java
@@ -33,7 +33,7 @@ public class ShadowPreferenceActivity extends ShadowActivity {
 
   private PreferenceScreen inflatePreferences(int preferencesResId) {
     ResName resName = getResName(preferencesResId);
-    String qualifiers = shadowOf(getResources().getConfiguration()).getQualifiers();
+    String qualifiers = shadowOf(realOject.getResources().getConfiguration()).getQualifiers();
     PreferenceNode preferenceNode = shadowOf(realOject.getAssets()).getResourceLoader().getPreferenceNode(resName, qualifiers);
     try {
       return (PreferenceScreen) preferenceBuilder.inflate(preferenceNode, realActivity, null);

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -64,6 +64,7 @@ public class ShadowResources {
     for (LongSparseArray<?> sparseArray : resettableArrays) {
       sparseArray.clear();
     }
+    system = null;
   }
 
   private static List<LongSparseArray<?>> obtainResettableArrays() {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowToast.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowToast.java
@@ -51,7 +51,7 @@ public class ShadowToast {
 
   @Implementation
   public void setText(int resId) {
-    this.text = shadowOf(RuntimeEnvironment.application).getString(resId);
+    this.text = RuntimeEnvironment.application.getString(resId);
   }
 
   @Implementation

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowActivity.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowActivity.java.vm
@@ -89,7 +89,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
 
     if (themeRef != null) {
       ResName style = ResName.qualifyResName(themeRef.replace("@", ""), appManifest.getPackageName(), "style");
-      Integer themeRes = shadowOf(getAssets()).getResourceLoader().getResourceIndex().getResourceId(style);
+      Integer themeRes = shadowOf(realActivity.getAssets()).getResourceLoader().getResourceIndex().getResourceId(style);
       if (themeRes == null)
         throw new Resources.NotFoundException("no such theme " + style.getFullyQualifiedName());
       realActivity.setTheme(themeRes);

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -303,7 +303,7 @@ public final class ShadowAssetManager {
 
   @HiddenApi @Implementation
   public static void applyThemeStyle($ptrClass theme, int styleRes, boolean force) {
-    ShadowAssetManager assetManager = shadowOf(getInstance().getAssets());
+    ShadowAssetManager assetManager = shadowOf(RuntimeEnvironment.application.getAssets());
 
     final Map<$ptrClassBoxed, List<OverlayedStyle>> appliedStyles = assetManager.appliedStyles;
 

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -39,6 +39,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.robolectric.annotation.Resetter;
+
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.shadows.ShadowApplication.getInstance;
 
@@ -801,5 +803,11 @@ public final class ShadowAssetManager {
       throw new Resources.NotFoundException("Unable to find resource ID #0x" + Integer.toHexString(id));
     }
     return resName;
+  }
+
+  @Resetter
+  public static void reset() {
+    systemResourceLoader = null;
+    appResourceLoader = null;
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowResourceManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowResourceManager.java.vm
@@ -1,0 +1,23 @@
+package org.robolectric.shadows;
+
+#if ($api >= 19)
+
+import android.app.ResourcesManager;
+
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
+import org.robolectric.util.ReflectionHelpers;
+
+@Implements(value = ResourcesManager.class, isInAndroidSdk = false)
+public class ShadowResourceManager {
+
+  @Resetter
+  public static void reset() {
+    ReflectionHelpers.setStaticField(ResourcesManager.class, "sResourcesManager", null);
+  }
+}
+#else
+public class ShadowResourceManager {
+  // Dummy class, this was added in API19
+}
+#end

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -136,9 +136,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
         // todo: make this cleaner...
         shadowsAdapter.setPackageName(application, applicationInfo.packageName);
       }
-      Resources appResources = application.getResources();
-      ReflectionHelpers.setField(loadedApk, "mResources", appResources);
-      ReflectionHelpers.setField(loadedApk, "mApplication", application);
+
       try {
         Context contextImpl = systemContextImpl.createPackageContext(applicationInfo.packageName, Context.CONTEXT_INCLUDE_CODE);
         ReflectionHelpers.setField(activityThreadClass, activityThread, "mInitialApplication", application);
@@ -146,6 +144,10 @@ public class ParallelUniverse implements ParallelUniverseInterface {
       } catch (PackageManager.NameNotFoundException e) {
         throw new RuntimeException(e);
       }
+
+      Resources appResources = application.getResources();
+      ReflectionHelpers.setField(loadedApk, "mResources", appResources);
+      ReflectionHelpers.setField(loadedApk, "mApplication", application);
 
       appResources.updateConfiguration(configuration, appResources.getDisplayMetrics());
       shadowsAdapter.setAssetsQualifiers(appResources.getAssets(), qualifiers);

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -99,7 +99,6 @@ public class ParallelUniverse implements ParallelUniverseInterface {
 
     Class<?> activityThreadClass = ReflectionHelpers.loadClass(getClass().getClassLoader(), shadowsAdapter.getShadowActivityThreadClassName());
     // Looper needs to be prepared before the activity thread is created
-//    if (Looper.getMainLooper() == null) {
     if (Looper.myLooper() == null) {
       Looper.prepareMainLooper();
     }

--- a/robolectric/src/main/java/org/robolectric/util/ActivityController.java
+++ b/robolectric/src/main/java/org/robolectric/util/ActivityController.java
@@ -110,7 +110,7 @@ public class ActivityController<T extends Activity> extends ComponentController<
         }
 
         /* Get the resource ID, use the activity to look up the actual string */
-        title = component.getString(labelRes);
+        title = RuntimeEnvironment.application.getString(labelRes);
       } else {
         title = labelRef; /* Label isn't an identifier, use it directly as the title */
       }

--- a/robolectric/src/test/java/org/robolectric/RobolectricTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTest.java
@@ -103,15 +103,15 @@ public class RobolectricTest {
 
   @Test
   public void shouldUseSetDensityForContexts() throws Exception {
-    assertThat(new Activity().getResources().getDisplayMetrics().density).isEqualTo(1.0f);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().density).isEqualTo(1.0f);
     ShadowApplication.setDisplayMetricsDensity(1.5f);
-    assertThat(new Activity().getResources().getDisplayMetrics().density).isEqualTo(1.5f);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().density).isEqualTo(1.5f);
   }
 
   @Test
   public void shouldUseSetDisplayForContexts() throws Exception {
-    assertThat(new Activity().getResources().getDisplayMetrics().widthPixels).isEqualTo(480);
-    assertThat(new Activity().getResources().getDisplayMetrics().heightPixels).isEqualTo(800);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().widthPixels).isEqualTo(480);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().heightPixels).isEqualTo(800);
 
     Display display = Shadow.newInstanceOf(Display.class);
     ShadowDisplay shadowDisplay = Shadows.shadowOf(display);
@@ -119,8 +119,8 @@ public class RobolectricTest {
     shadowDisplay.setHeight(200);
     ShadowApplication.setDefaultDisplay(display);
 
-    assertThat(new Activity().getResources().getDisplayMetrics().widthPixels).isEqualTo(100);
-    assertThat(new Activity().getResources().getDisplayMetrics().heightPixels).isEqualTo(200);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().widthPixels).isEqualTo(100);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().heightPixels).isEqualTo(200);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/fakes/RoboMenuTest.java
+++ b/robolectric/src/test/java/org/robolectric/fakes/RoboMenuTest.java
@@ -6,11 +6,13 @@ import android.view.MenuItem;
 import junit.framework.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
 import org.robolectric.fakes.RoboMenu;
 import org.robolectric.fakes.RoboMenuItem;
 import org.robolectric.shadows.ShadowActivity;
+import org.robolectric.shadows.ShadowApplication;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -21,7 +23,7 @@ public class RoboMenuTest {
 
   @Test
   public void addAndRemoveMenuItems() {
-    RoboMenu menu = new RoboMenu(new MyActivity());
+    RoboMenu menu = new RoboMenu(RuntimeEnvironment.application);
     menu.add(9, 10, 0, org.robolectric.R.string.ok);
 
     RoboMenuItem item = (RoboMenuItem) menu.findItem(10);
@@ -37,7 +39,7 @@ public class RoboMenuTest {
 
   @Test
   public void addSubMenu() {
-    RoboMenu menu = new RoboMenu(new MyActivity());
+    RoboMenu menu = new RoboMenu(RuntimeEnvironment.application);
     menu.addSubMenu(9, 10, 0, org.robolectric.R.string.ok);
 
     RoboMenuItem item = (RoboMenuItem) menu.findItem(10);
@@ -48,29 +50,25 @@ public class RoboMenuTest {
 
   @Test
   public void clickWithIntent() {
-    MyActivity activity = new MyActivity();
-
-    RoboMenu menu = new RoboMenu(activity);
+    RoboMenu menu = new RoboMenu(RuntimeEnvironment.application);
     menu.add(0, 10, 0, org.robolectric.R.string.ok);
 
     RoboMenuItem item = (RoboMenuItem) menu.findItem(10);
     Assert.assertNull(item.getIntent());
 
-    Intent intent = new Intent(activity, MyActivity.class);
+    Intent intent = new Intent(RuntimeEnvironment.application, Activity.class);
     item.setIntent(intent);
     item.click();
 
     Assert.assertNotNull(item);
 
-    ShadowActivity shadowActivity = Shadows.shadowOf(activity);
-    Intent startedIntent = shadowActivity.getNextStartedActivity();
+    Intent startedIntent = ShadowApplication.getInstance().getNextStartedActivity();
     assertNotNull(startedIntent);
   }
 
   @Test
   public void add_AddsItemsInOrder() {
-    MyActivity activity = new MyActivity();
-    RoboMenu menu = new RoboMenu(activity);
+    RoboMenu menu = new RoboMenu(RuntimeEnvironment.application);
     menu.add(0, 0, 1, "greeting");
     menu.add(0, 0, 0, "hell0");
     menu.add(0, 0, 0, "hello");
@@ -81,13 +79,5 @@ public class RoboMenuTest {
     assertEquals("hello", item.getTitle());
     item = menu.getItem(2);
     assertEquals("greeting", item.getTitle());
-  }
-
-  private static class MyActivity extends Activity {
-
-    @Override
-    protected void onDestroy() {
-      super.onDestroy();
-    }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
@@ -534,7 +534,6 @@ public class DefaultRobolectricPackageManagerTest {
   @Config(manifest = "src/test/resources/TestAndroidManifestWithAppMetaData.xml")
   public void shouldAssignTheAppMetaDataFromTheManifest() throws Exception {
     ShadowApplication app = ShadowApplication.getInstance();
-    String appName = app.getString(R.string.app_name);
     String packageName = app.getAppManifest().getPackageName();
     ApplicationInfo info = app.getPackageManager().getApplicationInfo(packageName, 0);
     Bundle meta = info.metaData;
@@ -581,11 +580,11 @@ public class DefaultRobolectricPackageManagerTest {
 
     metaValue = meta.get("org.robolectric.metaStringFromRes");
     assertTrue(String.class.isInstance(metaValue));
-    assertEquals(app.getString(R.string.app_name), metaValue);
+    assertEquals(RuntimeEnvironment.application.getString(R.string.app_name), metaValue);
 
     metaValue = meta.get("org.robolectric.metaStringOfIntFromRes");
     assertTrue(String.class.isInstance(metaValue));
-    assertEquals(app.getString(R.string.str_int), metaValue);
+    assertEquals(RuntimeEnvironment.application.getString(R.string.str_int), metaValue);
 
     metaValue = meta.get("org.robolectric.metaStringRes");
     assertTrue(Integer.class.isInstance(metaValue));

--- a/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
@@ -368,23 +368,23 @@ public class DefaultRobolectricPackageManagerTest {
 
     metaValue = meta.get("org.robolectric.metaBooleanFromRes");
     assertTrue(Boolean.class.isInstance(metaValue));
-    assertEquals(app.getResources().getBoolean(R.bool.false_bool_value), metaValue);
+    assertEquals(RuntimeEnvironment.application.getResources().getBoolean(R.bool.false_bool_value), metaValue);
 
     metaValue = meta.get("org.robolectric.metaIntFromRes");
     assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(app.getResources().getInteger(R.integer.test_integer1), metaValue);
+    assertEquals(RuntimeEnvironment.application.getResources().getInteger(R.integer.test_integer1), metaValue);
 
     metaValue = meta.get("org.robolectric.metaColorFromRes");
     assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(app.getResources().getColor(R.color.clear), metaValue);
+    assertEquals(RuntimeEnvironment.application.getResources().getColor(R.color.clear), metaValue);
 
     metaValue = meta.get("org.robolectric.metaStringFromRes");
     assertTrue(String.class.isInstance(metaValue));
-    assertEquals(app.getString(R.string.app_name), metaValue);
+    assertEquals(RuntimeEnvironment.application.getString(R.string.app_name), metaValue);
 
     metaValue = meta.get("org.robolectric.metaStringOfIntFromRes");
     assertTrue(String.class.isInstance(metaValue));
-    assertEquals(app.getString(R.string.str_int), metaValue);
+    assertEquals(RuntimeEnvironment.application.getString(R.string.str_int), metaValue);
 
     metaValue = meta.get("org.robolectric.metaStringRes");
     assertTrue(Integer.class.isInstance(metaValue));
@@ -569,15 +569,15 @@ public class DefaultRobolectricPackageManagerTest {
 
     metaValue = meta.get("org.robolectric.metaBooleanFromRes");
     assertTrue(Boolean.class.isInstance(metaValue));
-    assertEquals(app.getResources().getBoolean(R.bool.false_bool_value), metaValue);
+    assertEquals(RuntimeEnvironment.application.getResources().getBoolean(R.bool.false_bool_value), metaValue);
 
     metaValue = meta.get("org.robolectric.metaIntFromRes");
     assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(app.getResources().getInteger(R.integer.test_integer1), metaValue);
+    assertEquals(RuntimeEnvironment.application.getResources().getInteger(R.integer.test_integer1), metaValue);
 
     metaValue = meta.get("org.robolectric.metaColorFromRes");
     assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(app.getResources().getColor(R.color.clear), metaValue);
+    assertEquals(RuntimeEnvironment.application.getResources().getColor(R.color.clear), metaValue);
 
     metaValue = meta.get("org.robolectric.metaStringFromRes");
     assertTrue(String.class.isInstance(metaValue));

--- a/robolectric/src/test/java/org/robolectric/res/DrawableResourceLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DrawableResourceLoaderTest.java
@@ -8,6 +8,9 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
 import android.graphics.drawable.NinePatchDrawable;
+
+import com.google.android.apps.common.testing.accessibility.framework.proto.FrameworkProtos;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,7 +62,7 @@ public class DrawableResourceLoaderTest {
 
   @Test
   public void testGetDrawable_rainbow() throws Exception {
-    assertNotNull(ShadowApplication.getInstance().getResources().getDrawable(R.drawable.rainbow));
+    assertNotNull(RuntimeEnvironment.application.getResources().getDrawable(R.drawable.rainbow));
   }
 
   @Test
@@ -82,7 +85,7 @@ public class DrawableResourceLoaderTest {
 
   @Test
   public void testLayerDrawable() {
-    Resources resources = ShadowApplication.getInstance().getResources();
+    Resources resources = RuntimeEnvironment.application.getResources();
     Drawable drawable = resources.getDrawable(R.drawable.rainbow);
     assertThat(drawable).isInstanceOf(LayerDrawable.class);
     assertEquals(8, ((LayerDrawable) drawable).getNumberOfLayers());

--- a/robolectric/src/test/java/org/robolectric/res/ResourceLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/ResourceLoaderTest.java
@@ -53,7 +53,7 @@ public class ResourceLoaderTest {
     View view = LayoutInflater.from(RuntimeEnvironment.application).inflate(R.layout.different_screen_sizes, null);
     TextView textView = (TextView) view.findViewById(android.R.id.text1);
     assertThat(textView.getText().toString()).isEqualTo("default");
-    Shadows.shadowOf(ShadowApplication.getInstance().getResources().getConfiguration()).overrideQualifiers("land"); // testing if this pollutes the other test
+    Shadows.shadowOf(RuntimeEnvironment.application.getResources().getConfiguration()).overrideQualifiers("land"); // testing if this pollutes the other test
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
@@ -422,7 +422,7 @@ public class ShadowActivityTest {
 
   @Test
   public void retrieveIdOfResource() {
-    Activity activity = new Activity();
+    Activity activity = Robolectric.setupActivity(Activity.class);
 
     int id1 = R.string.hello;
     String string = activity.getString(id1);
@@ -437,7 +437,7 @@ public class ShadowActivityTest {
 
   @Test
   public void retrieveIdOfNonExistingResource() {
-    Activity activity = new Activity();
+    Activity activity = Robolectric.setupActivity(Activity.class);
 
     int id = activity.getResources().getIdentifier("just_alot_of_crap", "string", "org.robolectric");
     assertThat(id).isEqualTo(0);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
@@ -485,17 +485,7 @@ public class ShadowApplicationTest {
 
   @Test
   public void shouldRememberResourcesAfterLazilyLoading() throws Exception {
-    Application application = new DefaultTestLifecycle().createApplication(null, newConfigWith("com.wacka.wa", ""), null);
-    assertSame(application.getResources(), application.getResources());
-  }
-
-  @Test
-  public void shouldBeAbleToResetResources() throws Exception {
-    Application application = new DefaultTestLifecycle().createApplication(null,
-        newConfigWith("com.wacka.wa", ""), null);
-    Resources res = application.getResources();
-    shadowOf(application).resetResources();
-    assertFalse(res == application.getResources());
+    assertSame(RuntimeEnvironment.application.getResources(), RuntimeEnvironment.application.getResources());
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
@@ -1,14 +1,5 @@
 package org.robolectric.shadows;
 
-import static android.content.pm.PackageManager.PERMISSION_DENIED;
-import static android.content.pm.PackageManager.PERMISSION_GRANTED;
-import static junit.framework.Assert.assertEquals;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.robolectric.Robolectric.buildActivity;
-import static org.robolectric.Shadows.shadowOf;
-
 import android.app.Activity;
 import android.app.Application;
 import android.appwidget.AppWidgetProvider;
@@ -25,7 +16,9 @@ import android.os.HandlerThread;
 import android.os.Looper;
 import android.view.LayoutInflater;
 import android.view.View;
+
 import com.google.common.util.concurrent.SettableFuture;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,6 +31,15 @@ import org.robolectric.util.Transcript;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static android.content.pm.PackageManager.PERMISSION_DENIED;
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Robolectric.buildActivity;
+import static org.robolectric.Shadows.shadowOf;
+
 @RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowContextWrapperTest {
   public Transcript transcript;
@@ -45,7 +47,7 @@ public class ShadowContextWrapperTest {
 
   @Before public void setUp() throws Exception {
     transcript = new Transcript();
-    contextWrapper = new ContextWrapper(new Activity());
+    contextWrapper = new ContextWrapper(RuntimeEnvironment.application);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -1,16 +1,26 @@
 package org.robolectric.shadows;
 
 import android.app.Activity;
-import android.content.res.*;
-import android.graphics.drawable.*;
+import android.content.res.ColorStateList;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.content.res.XmlResourceParser;
+import android.graphics.drawable.AnimationDrawable;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.NinePatchDrawable;
 import android.os.Build;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
+
 import org.assertj.core.data.Offset;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
+import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
@@ -33,7 +43,7 @@ public class ShadowResourcesTest {
 
   @Before
   public void setup() throws Exception {
-    resources = new Activity().getResources();
+    resources = RuntimeEnvironment.application.getResources();
   }
 
   @Test
@@ -276,7 +286,7 @@ public class ShadowResourcesTest {
 
   @Test
   public void testGetNinePatchDrawable() {
-    assertThat(ShadowApplication.getInstance().getResources().getDrawable(R.drawable.nine_patch_drawable)).isInstanceOf(NinePatchDrawable.class);
+    assertThat(resources.getDrawable(R.drawable.nine_patch_drawable)).isInstanceOf(NinePatchDrawable.class);
   }
 
   @Test(expected = Resources.NotFoundException.class)
@@ -306,21 +316,19 @@ public class ShadowResourcesTest {
 
   @Test
   public void testDensity() {
-    Activity activity = new Activity();
-    assertThat(activity.getResources().getDisplayMetrics().density).isEqualTo(1f);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().density).isEqualTo(1f);
 
-    shadowOf(activity.getResources()).setDensity(1.5f);
+    shadowOf(RuntimeEnvironment.application.getResources()).setDensity(1.5f);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().density).isEqualTo(1.5f);
+
+    Activity activity = Robolectric.setupActivity(Activity.class);
     assertThat(activity.getResources().getDisplayMetrics().density).isEqualTo(1.5f);
-
-    Activity anotherActivity = new Activity();
-    assertThat(anotherActivity.getResources().getDisplayMetrics().density).isEqualTo(1.5f);
   }
 
   @Test
   public void displayMetricsShouldNotHaveLotsOfZeros() throws Exception {
-    Activity activity = new Activity();
-    assertThat(activity.getResources().getDisplayMetrics().heightPixels).isEqualTo(800);
-    assertThat(activity.getResources().getDisplayMetrics().widthPixels).isEqualTo(480);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().heightPixels).isEqualTo(800);
+    assertThat(RuntimeEnvironment.application.getResources().getDisplayMetrics().widthPixels).isEqualTo(480);
   }
 
   @Test
@@ -335,9 +343,8 @@ public class ShadowResourcesTest {
 
   @Test
   public void applicationResourcesShouldHaveBothSystemAndLocalValues() throws Exception {
-    Activity activity = new Activity();
-    assertThat(activity.getResources().getString(android.R.string.copy)).isEqualTo("Copy");
-    assertThat(activity.getResources().getString(R.string.copy)).isEqualTo("Local Copy");
+    assertThat(RuntimeEnvironment.application.getResources().getString(android.R.string.copy)).isEqualTo("Copy");
+    assertThat(RuntimeEnvironment.application.getResources().getString(R.string.copy)).isEqualTo("Local Copy");
   }
 
   @Test
@@ -472,7 +479,7 @@ public class ShadowResourcesTest {
 
   @Test
   public void subClassInitializedOK() {
-    SubClassResources subClassResources = new SubClassResources(ShadowApplication.getInstance().getResources());
+    SubClassResources subClassResources = new SubClassResources(RuntimeEnvironment.application.getResources());
     assertThat(subClassResources.openRawResource(R.raw.raw_resource)).isNotNull();
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewConfigurationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewConfigurationTest.java
@@ -17,8 +17,7 @@ public class ShadowViewConfigurationTest {
 
   @Test
   public void methodsShouldReturnAndroidConstants() {
-    Activity context = new Activity();
-    ViewConfiguration viewConfiguration = ViewConfiguration.get(context);
+    ViewConfiguration viewConfiguration = ViewConfiguration.get(RuntimeEnvironment.application);
 
     assertEquals(10, ViewConfiguration.getScrollBarSize());
     assertEquals(250, ViewConfiguration.getScrollBarFadeDuration());
@@ -39,7 +38,7 @@ public class ShadowViewConfigurationTest {
     assertEquals(500, ViewConfiguration.getGlobalActionKeyTimeout());
     assertEquals(0.015f, ViewConfiguration.getScrollFriction());
 
-    assertEquals(1f, context.getResources().getDisplayMetrics().density);
+    assertEquals(1f, RuntimeEnvironment.application.getResources().getDisplayMetrics().density);
 
     assertEquals(10, viewConfiguration.getScaledScrollBarSize());
     assertEquals(12, viewConfiguration.getScaledFadingEdgeLength());
@@ -54,9 +53,8 @@ public class ShadowViewConfigurationTest {
 
   @Test
   public void methodsShouldReturnScaledAndroidConstantsDependingOnPixelDensity() {
-    Activity context = new Activity();
-    shadowOf(context.getResources()).setDensity(1.5f);
-    ViewConfiguration viewConfiguration = ViewConfiguration.get(context);
+    shadowOf(RuntimeEnvironment.application.getResources()).setDensity(1.5f);
+    ViewConfiguration viewConfiguration = ViewConfiguration.get(RuntimeEnvironment.application);
 
     assertEquals(15, viewConfiguration.getScaledScrollBarSize());
     assertEquals(18, viewConfiguration.getScaledFadingEdgeLength());


### PR DESCRIPTION
Remove getAssets(), getResources(), getText(), getString(int) and getString(int, Object..) from ShadowContext and subclasses.

We should use framework code instead. It is suspected that the excessive shadowing here is causing:-

#2315