### PR TITLE
Remove redundant dependencies.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/InstrumentingClassLoaderFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/InstrumentingClassLoaderFactory.java
@@ -2,6 +2,7 @@ package org.robolectric.internal;
 
 import org.robolectric.internal.bytecode.InstrumentationConfiguration;
 import org.robolectric.internal.bytecode.InstrumentingClassLoader;
+import org.robolectric.internal.dependency.DependencyJar;
 import org.robolectric.internal.dependency.DependencyResolver;
 import org.robolectric.util.Pair;
 
@@ -39,7 +40,10 @@ public class InstrumentingClassLoaderFactory {
 
     SdkEnvironment sdkEnvironment = sdkToEnvironment.get(key);
     if (sdkEnvironment == null) {
-      URL[] urls = dependencyResolver.getLocalArtifactUrls(sdkConfig.getSdkClasspathDependencies());
+      URL[] urls = dependencyResolver.getLocalArtifactUrls(
+          sdkConfig.getAndroidSdkDependency(),
+          sdkConfig.getCoreShadowsDependency());
+
       ClassLoader robolectricClassLoader = new InstrumentingClassLoader(instrumentationConfig, urls);
       sdkEnvironment = new SdkEnvironment(sdkConfig, robolectricClassLoader);
       sdkToEnvironment.put(key, sdkEnvironment);

--- a/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
@@ -50,17 +50,12 @@ public class SdkConfig {
     return apiLevel;
   }
 
-  public DependencyJar getSystemResourceDependency() {
+  public DependencyJar getAndroidSdkDependency() {
     return createDependency("org.robolectric", "android-all", artifactVersionString, null);
   }
 
-  public DependencyJar[] getSdkClasspathDependencies() {
-    return new DependencyJar[] {
-        createDependency("org.robolectric", "android-all", artifactVersionString, null),
-        createDependency("org.robolectric", "shadows-core", ROBOLECTRIC_VERSION, Integer.toString(apiLevel)),
-        createDependency("org.json", "json", "20080701", null),
-        createDependency("org.ccil.cowan.tagsoup", "tagsoup", "1.2", null)
-    };
+  public DependencyJar getCoreShadowsDependency() {
+    return createDependency("org.robolectric", "shadows-core", ROBOLECTRIC_VERSION, Integer.toString(apiLevel));
   }
 
   @Override

--- a/robolectric/src/main/java/org/robolectric/internal/SdkEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SdkEnvironment.java
@@ -28,7 +28,7 @@ public class SdkEnvironment {
   }
 
   public PackageResourceLoader createSystemResourceLoader(DependencyResolver dependencyResolver) {
-    Fs systemResFs = Fs.fromJar(dependencyResolver.getLocalArtifactUrl(sdkConfig.getSystemResourceDependency()));
+    Fs systemResFs = Fs.fromJar(dependencyResolver.getLocalArtifactUrl(sdkConfig.getAndroidSdkDependency()));
     ResourceExtractor resourceExtractor;
     try {
       resourceExtractor = new ResourceExtractor(getRobolectricClassLoader().loadClass("com.android.internal.R"), getRobolectricClassLoader().loadClass("android.R"));

--- a/robolectric/src/test/java/org/robolectric/util/TestUtil.java
+++ b/robolectric/src/test/java/org/robolectric/util/TestUtil.java
@@ -101,7 +101,7 @@ public abstract class TestUtil {
   public static ResourcePath systemResources() {
     if (SYSTEM_RESOURCE_PATH == null) {
       SdkConfig sdkConfig = new SdkConfig(SdkConfig.FALLBACK_SDK_VERSION);
-      Fs fs = Fs.fromJar(new MavenDependencyResolver().getLocalArtifactUrl(sdkConfig.getSystemResourceDependency()));
+      Fs fs = Fs.fromJar(new MavenDependencyResolver().getLocalArtifactUrl(sdkConfig.getAndroidSdkDependency()));
       SYSTEM_RESOURCE_PATH = new ResourcePath(android.R.class, "android", fs.join("res"), fs.join("assets"));
     }
     return SYSTEM_RESOURCE_PATH;


### PR DESCRIPTION
json and tagsoup classes now are included in the android-all jars.

Fixes https://github.com/robolectric/robolectric/issues/2332