### PR TITLE
Make ShadowAssetManager.resolveStyle() non-static

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -160,7 +160,7 @@ public final class ShadowAssetManager {
     ResName themeStyleName = resourceIndex.getResName(styleResourceId);
     if (themeStyleName == null) return false; // is this right?
 
-    Style themeStyle = resolveStyle(resourceLoader, null, themeStyleName, getQualifiers());
+    Style themeStyle = resolveStyle(null, themeStyleName);
 
     //// Load the theme attribute for the default style attributes. E.g., attr/buttonStyle
     //ResName defStyleName = getResourceLoader().getResourceIndex().getResName(ident);
@@ -168,7 +168,7 @@ public final class ShadowAssetManager {
     //// Load the style for the default style attribute. E.g. "@style/Widget.Robolectric.Button";
     //String defStyleNameValue = themeStyle.getAttrValue(defStyleName);
     //ResName defStyleResName = new ResName(defStyleName.packageName, "style", defStyleName.name);
-    //Style style = resolveStyle(resourceLoader, defStyleResName, getQualifiers());
+    //Style style = resolveStyle(resourceLoader, defStyleResName);
     if (themeStyle != null) {
       List<OverlayedStyle> overlayThemeStyles = getOverlayThemeStyles(styleResourceId);
       Attribute attrValue = getOverlayedThemeValue(resName, themeStyle, overlayThemeStyles);
@@ -314,7 +314,7 @@ public final class ShadowAssetManager {
     ResourceIndex resourceIndex = assetManager.getResourceLoader().getResourceIndex();
     ResName resName = resourceIndex.getResName(styleRes);
 
-    Style style = resolveStyle(assetManager.getResourceLoader(), null, resName, assetManager.getQualifiers());
+    Style style = assetManager.resolveStyle(null, resName);
 
     List<OverlayedStyle> overlayedStyleList = appliedStyles.get(theme);
     OverlayedStyle styleToAdd = new OverlayedStyle(style, force);
@@ -370,11 +370,11 @@ public final class ShadowAssetManager {
     return themesById.get(internalThemeId);
   }
 
-  static Style resolveStyle(ResourceLoader resourceLoader, Style appTheme, @NotNull ResName themeStyleName, String qualifiers) {
-    TypedResource themeStyleResource = resourceLoader.getValue(themeStyleName, qualifiers);
+  Style resolveStyle(Style appTheme, @NotNull ResName themeStyleName) {
+    TypedResource themeStyleResource = resourceLoader.getValue(themeStyleName, getQualifiers());
     if (themeStyleResource == null) return null;
     StyleData themeStyleData = (StyleData) themeStyleResource.getData();
-    return new StyleResolver(resourceLoader, themeStyleData, appTheme, themeStyleName, qualifiers);
+    return new StyleResolver(resourceLoader, themeStyleData, appTheme, themeStyleName, getQualifiers());
   }
 
   TypedResource getAndResolve(int resId, String qualifiers, boolean resolveRefs) {
@@ -649,7 +649,7 @@ public final class ShadowAssetManager {
     if (themeResourceId != 0) {
       // Load the style for the theme we represent. E.g. "@style/Theme.Robolectric"
       ResName themeStyleName = getResName(themeResourceId);
-      theme = ShadowAssetManager.resolveStyle(resourceLoader, null, themeStyleName, getQualifiers());
+      theme = resolveStyle(null, themeStyleName);
 
       if (defStyleAttr != 0) {
         // Load the theme attribute for the default style attributes. E.g., attr/buttonStyle
@@ -668,7 +668,7 @@ public final class ShadowAssetManager {
 
           if (defStyleAttribute.isResourceReference()) {
             ResName defStyleResName = defStyleAttribute.getResourceReference();
-            defStyleFromAttr = ShadowAssetManager.resolveStyle(resourceLoader, theme, defStyleResName, getQualifiers());
+            defStyleFromAttr = resolveStyle(theme, defStyleResName);
           }
         }
       }
@@ -685,7 +685,7 @@ public final class ShadowAssetManager {
           styleAttributeResName = attrValue.getStyleReference();
         }
       }
-      styleAttrStyle = ShadowAssetManager.resolveStyle(resourceLoader, theme, styleAttributeResName, getQualifiers());
+      styleAttrStyle = resolveStyle(theme, styleAttributeResName);
     }
 
     if (defStyleRes != 0) {
@@ -700,7 +700,7 @@ public final class ShadowAssetManager {
           }
         }
       }
-      defStyleFromRes = ShadowAssetManager.resolveStyle(resourceLoader, theme, resName, getQualifiers());
+      defStyleFromRes = resolveStyle(theme, resName);
     }
 
     List<Attribute> attributes = new ArrayList<>();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
@@ -10,7 +10,7 @@ import android.widget.Button;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
-import org.robolectric.Shadows;
+import org.robolectric.Robolectric;
 import org.robolectric.TestRunners;
 import org.robolectric.res.ResName;
 import org.robolectric.res.ResourceLoader;
@@ -20,6 +20,7 @@ import org.robolectric.util.TestUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.buildActivity;
+import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowThemeTest {
@@ -101,32 +102,30 @@ public class ShadowThemeTest {
   }
 
   @Test public void shouldInheritThemeValuesFromImplicitParents() throws Exception {
-    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
-    ResourceLoader resourceLoader = Shadows.shadowOf(activity.getResources().getAssets()).getResourceLoader();
-    Style style = ShadowAssetManager.resolveStyle(resourceLoader,
+    TestActivity activity = Robolectric.setupActivity(TestActivityWithAnotherTheme.class);
+    Style style = shadowOf(activity.getAssets()).resolveStyle(
         null,
-        new ResName(TestUtil.TEST_PACKAGE, "style", "Widget.AnotherTheme.Button.Blarf"), "");
+        new ResName(TestUtil.TEST_PACKAGE, "style", "Widget.AnotherTheme.Button.Blarf"));
     assertThat(style.getAttrValue(new ResName("android", "attr", "background")).value)
         .isEqualTo("#ffff0000");
   }
 
   @Test public void whenAThemeHasExplicitlyEmptyParentAttr_shouldHaveNoParent() throws Exception {
-    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
-    ResourceLoader resourceLoader = Shadows.shadowOf(activity.getResources().getAssets()).getResourceLoader();
-    Style style = ShadowAssetManager.resolveStyle(resourceLoader,
+    TestActivity activity = Robolectric.setupActivity(TestActivityWithAnotherTheme.class);
+    Style style = shadowOf(activity.getAssets()).resolveStyle(
         null,
-        new ResName(TestUtil.TEST_PACKAGE, "style", "Theme.MyTheme"), "");
+        new ResName(TestUtil.TEST_PACKAGE, "style", "Theme.MyTheme"));
     assertThat(style.getAttrValue(new ResName("android", "attr", "background"))).isNull();
   }
 
 
   @Test public void shouldApplyParentStylesFromAttrs() throws Exception {
-    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
-    ResourceLoader resourceLoader = Shadows.shadowOf(activity.getResources().getAssets()).getResourceLoader();
-    Style theme = ShadowAssetManager.resolveStyle(resourceLoader, null,
-        new ResName(TestUtil.TEST_PACKAGE, "style", "Theme.AnotherTheme"), "");
-    Style style = ShadowAssetManager.resolveStyle(resourceLoader, theme,
-        new ResName(TestUtil.TEST_PACKAGE, "style", "IndirectButtonStyle"), "");
+    TestActivity activity = Robolectric.setupActivity(TestActivityWithAnotherTheme.class);
+    ShadowAssetManager shadowAssetManager = shadowOf(activity.getAssets());
+    Style theme = shadowAssetManager.resolveStyle(null,
+        new ResName(TestUtil.TEST_PACKAGE, "style", "Theme.AnotherTheme"));
+    Style style = shadowAssetManager.resolveStyle(theme,
+        new ResName(TestUtil.TEST_PACKAGE, "style", "IndirectButtonStyle"));
     assertThat(style.getAttrValue(new ResName("android", "attr", "background")).value)
         .isEqualTo("#ffff0000");
   }


### PR DESCRIPTION
Limits the scope of exposing the ResourceLoader and qualifiers.