### PR TITLE
Small ShadowApplication cleanups

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContext.java
@@ -22,7 +22,6 @@ import static org.robolectric.Shadows.shadowOf;
 @Implements(Context.class)
 abstract public class ShadowContext {
   @RealObject private Context realContext;
-  private ShadowApplication shadowApplication;
 
   @Implementation
   public File getExternalCacheDir() {
@@ -45,16 +44,8 @@ abstract public class ShadowContext {
     return shadowOf(realContext.getAssets()).getResourceLoader();
   }
 
-  public boolean isStrictI18n() {
-    return getShadowApplication().isStrictI18n();
-  }
-
   public ResName getResName(int resourceId) {
     return shadowOf(realContext.getAssets()).getResourceLoader().getResourceIndex().getResName(resourceId);
-  }
-
-  public ShadowApplication getShadowApplication() {
-    return shadowApplication;
   }
 
   public void callAttachBaseContext(Context context) {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
@@ -11,17 +11,14 @@ import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
-import android.content.res.AssetManager;
-import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Handler;
-import android.os.Looper;
+
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.res.ResourceLoader;
 import org.robolectric.fakes.RoboSharedPreferences;
 
 import java.io.File;
@@ -120,7 +117,7 @@ public class ShadowContextWrapper extends ShadowContext {
 
   @Implementation
   public int checkPermission(String permission, int pid, int uid) {
-    return getShadowApplication().checkPermission(permission, pid, uid);
+    return ShadowApplication.getInstance().checkPermission(permission, pid, uid);
   }
 
   @Implementation
@@ -190,7 +187,7 @@ public class ShadowContextWrapper extends ShadowContext {
   @Implementation
   public SharedPreferences getSharedPreferences(String name, int mode) {
     if (!sharedPreferencesMap.containsKey(name)) {
-      sharedPreferencesMap.put(name, new RoboSharedPreferences(getShadowApplication().getSharedPreferenceMap(), name, mode));
+      sharedPreferencesMap.put(name, new RoboSharedPreferences(ShadowApplication.getInstance().getSharedPreferenceMap(), name, mode));
     }
 
     return sharedPreferencesMap.get(name);
@@ -212,7 +209,7 @@ public class ShadowContextWrapper extends ShadowContext {
    * @return the next started {@code Intent} for an activity
    */
   public Intent getNextStartedActivity() {
-    return getShadowApplication().getNextStartedActivity();
+    return ShadowApplication.getInstance().getNextStartedActivity();
   }
 
   /**
@@ -222,7 +219,7 @@ public class ShadowContextWrapper extends ShadowContext {
    * @return the next started {@code Intent} for an activity
    */
   public Intent peekNextStartedActivity() {
-    return getShadowApplication().peekNextStartedActivity();
+    return ShadowApplication.getInstance().peekNextStartedActivity();
   }
 
   /**
@@ -232,7 +229,7 @@ public class ShadowContextWrapper extends ShadowContext {
    * @return the next started {@code Intent} for a service
    */
   public Intent getNextStartedService() {
-    return getShadowApplication().getNextStartedService();
+    return ShadowApplication.getInstance().getNextStartedService();
   }
 
   /**
@@ -240,7 +237,7 @@ public class ShadowContextWrapper extends ShadowContext {
    * service intents.
    */
   public void clearStartedServices() {
-    getShadowApplication().clearStartedServices();
+    ShadowApplication.getInstance().clearStartedServices();
   }
 
   /**
@@ -249,7 +246,7 @@ public class ShadowContextWrapper extends ShadowContext {
    * @return the next started {@code Intent} for a service
    */
   public Intent peekNextStartedService() {
-    return getShadowApplication().peekNextStartedService();
+    return ShadowApplication.getInstance().peekNextStartedService();
   }
 
   /**
@@ -259,38 +256,24 @@ public class ShadowContextWrapper extends ShadowContext {
    * @return {@code Intent} for the next service requested to be stopped
    */
   public Intent getNextStoppedService() {
-    return getShadowApplication().getNextStoppedService();
-  }
-
-  @Implementation
-  public Looper getMainLooper() {
-    return getShadowApplication().getMainLooper();
-  }
-
-  public ShadowApplication getShadowApplication() {
-    return ((ShadowApplication) Shadows.shadowOf(getApplicationContext()));
+    return ShadowApplication.getInstance().getNextStoppedService();
   }
 
   @Implementation
   public boolean bindService(Intent intent, final ServiceConnection serviceConnection, int i) {
-    return getShadowApplication().bindService(intent, serviceConnection, i);
+    return ShadowApplication.getInstance().bindService(intent, serviceConnection, i);
   }
 
   @Implementation
   public void unbindService(final ServiceConnection serviceConnection) {
-    getShadowApplication().unbindService(serviceConnection);
-  }
-
-  @Implementation
-  public boolean isRestricted() {
-    return false;
+    ShadowApplication.getInstance().unbindService(serviceConnection);
   }
 
   public void grantPermissions(String... permissionNames) {
-    getShadowApplication().grantPermissions(permissionNames);
+    ShadowApplication.getInstance().grantPermissions(permissionNames);
   }
 
   public void denyPermissions(String... permissionNames) {
-    getShadowApplication().denyPermissions(permissionNames);
+    ShadowApplication.getInstance().denyPermissions(permissionNames);
   }
 }

--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManager.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManager.java
@@ -12,6 +12,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.internal.ShadowExtractor;
 import org.robolectric.shadows.Provider;
+import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowContext;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
@@ -30,7 +31,7 @@ public class ShadowLocalBroadcastManager {
 
   @Implementation
   public static LocalBroadcastManager getInstance(final Context context) {
-    return shadowOf(context).getShadowApplication().getSingleton(LocalBroadcastManager.class, new Provider<LocalBroadcastManager>() {
+    return ShadowApplication.getInstance().getSingleton(LocalBroadcastManager.class, new Provider<LocalBroadcastManager>() {
       @Override
       public LocalBroadcastManager get() {
         return ReflectionHelpers.callConstructor(LocalBroadcastManager.class, ClassParameter.from(Context.class, context));

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
@@ -73,11 +73,6 @@ public class RobolectricTestRunnerSelfTest {
       .isEqualTo("");
   }
 
-  @Test
-  public void internalBeforeTest_doesNotSetI18nStrictModeFromSystemIfPropertyAbsent() {
-    assertThat(ShadowApplication.getInstance().isStrictI18n()).isFalse();
-  }
-
   @Before
   public void clearOrder() {
     onTerminateCalledFromMain = null;


### PR DESCRIPTION
Remove unused ShadowApplication.isStrictI18n(). 
getMainLooper() from real Application rather than maintain our own copy.
Remove ShadowContext.getShadowApplication() convenience method (Use ShadowApplication.getInstance() instead.