### PR TITLE
Deploy scripts create and upload shadows-core jars for API 22 and 23

### DIFF
--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -24,3 +24,9 @@ cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P release,android-19 -D ski
 
 echo "Building shadows for API 21..."
 cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P release,android-21 -D skipTests clean deploy
+
+echo "Building shadows for API 22..."
+cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P release,android-22 -D skipTests clean deploy
+
+echo "Building shadows for API 23..."
+cd "$PROJECT"/robolectric-shadows/shadows-core; mvn -P release,android-23 -D skipTests clean deploy

--- a/scripts/deploy-snapshot.sh
+++ b/scripts/deploy-snapshot.sh
@@ -29,6 +29,12 @@ if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ] &
     echo "Building shadows for API 21..."
     cd "$PROJECT"/robolectric-shadows/shadows-core; mvn ${ARGUMENTS} -P snapshot,android-21 clean package
 
+    echo "Building shadows for API 22..."
+    cd "$PROJECT"/robolectric-shadows/shadows-core; mvn ${ARGUMENTS} -P snapshot,android-22 clean package
+
+    echo "Building shadows for API 23..."
+    cd "$PROJECT"/robolectric-shadows/shadows-core; mvn ${ARGUMENTS} -P snapshot,android-23 clean package
+
     echo "Uploading SNAPSHOT..."
     cd "$PROJECT"; mvn ${ARGUMENTS} -P snapshot,android-latest,upload deploy
 fi


### PR DESCRIPTION
I got 3.1-rc1 built and deployed to a staging repository on Sonatype. But when I tried to use API 23 I got a failure - the shadows jar (for 23) was not available.

Turns out the release deploy script (deploy-release.sh) does not build the shadows-core jars for 22 or 23.  So in this PR I updated it to build these jars and upload them.

As far as change to build-snapshot.sh - it was also missing lines for 22 and 23. Maybe not necessary; I am not sure how the snapshot build is actually getting those up to Sonatype, but they are there (https://oss.sonatype.org/content/repositories/snapshots/org/robolectric/shadows-core/3.1-SNAPSHOT/). 

Regardless I updated deploy-snapshot.sh along with deploy-release.sh despite the fact that I don't understand how this stuff works.

I tested the resulting release build via the staging repository on Sonatype and things generally work in terms of dependencies being satisfied. Once I get this changed merged to master I will continue with the process of releasing 3.1 RC1.

Let me know if any of this seems fishy.