### PR TITLE
Automatically attach base context to Activities / Services

### DIFF
--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -1,9 +1,11 @@
 package org.robolectric;
 
 import android.app.Activity;
+import android.app.Fragment;
 import android.app.Service;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.util.ActivityController;
+import org.robolectric.util.FragmentController;
 import org.robolectric.util.Scheduler;
 import org.robolectric.util.ServiceController;
 import org.robolectric.internal.ShadowProvider;
@@ -44,19 +46,27 @@ public class Robolectric {
   }
 
   public static <T extends Service> ServiceController<T> buildService(Class<T> serviceClass) {
-    return ServiceController.of(getShadowsAdapter(), serviceClass);
+    return ServiceController.of(getShadowsAdapter(), serviceClass).attach();
   }
 
   public static <T extends Service> T setupService(Class<T> serviceClass) {
-    return ServiceController.of(getShadowsAdapter(), serviceClass).attach().create().get();
+    return buildService(serviceClass).create().get();
   }
 
   public static <T extends Activity> ActivityController<T> buildActivity(Class<T> activityClass) {
-    return ActivityController.of(getShadowsAdapter(), activityClass);
+    return ActivityController.of(getShadowsAdapter(), activityClass).attach();
   }
 
   public static <T extends Activity> T setupActivity(Class<T> activityClass) {
-    return ActivityController.of(getShadowsAdapter(), activityClass).setup().get();
+    return buildActivity(activityClass).setup().get();
+  }
+
+  public static <T extends Fragment> FragmentController<T> buildFragment(Class<T> fragmentClass) {
+    return FragmentController.of(fragmentClass);
+  }
+
+  public static <T extends Fragment> FragmentController<T> buildFragment(Class<T> fragmentClass, Class<? extends Activity> activityClass) {
+    return FragmentController.of(fragmentClass, activityClass);
   }
 
   /**

--- a/robolectric/src/main/java/org/robolectric/util/ActivityController.java
+++ b/robolectric/src/main/java/org/robolectric/util/ActivityController.java
@@ -43,19 +43,22 @@ public class ActivityController<T extends Activity> extends ComponentController<
   }
 
   public ActivityController<T> attach() {
-    Context baseContext = RuntimeEnvironment.application.getBaseContext();
+    if (!attached) {
+      Context baseContext = RuntimeEnvironment.application.getBaseContext();
 
-    final String title = getActivityTitle();
-    final ClassLoader cl = baseContext.getClassLoader();
-    final ActivityInfo info = getActivityInfo(RuntimeEnvironment.application);
-    final Class<?> threadClass = getActivityThreadClass(cl);
-    final Class<?> nonConfigurationClass = getNonConfigurationClass(cl);
+      final String title = getActivityTitle();
+      final ClassLoader cl = baseContext.getClassLoader();
+      final ActivityInfo info = getActivityInfo(RuntimeEnvironment.application);
+      final Class<?> threadClass = getActivityThreadClass(cl);
+      final Class<?> nonConfigurationClass = getNonConfigurationClass(cl);
 
-    final RuntimeAdapter runtimeAdapter = RuntimeAdapterFactory.getInstance();
-    runtimeAdapter.callActivityAttach(component, baseContext, threadClass, RuntimeEnvironment.application, getIntent(), info, title, nonConfigurationClass);
+      final RuntimeAdapter runtimeAdapter = RuntimeAdapterFactory.getInstance();
+      runtimeAdapter.callActivityAttach(component, baseContext, threadClass, RuntimeEnvironment.application, getIntent(), info, title, nonConfigurationClass);
 
-    shadowReference.setThemeFromManifest();
-    attached = true;
+      shadowReference.setThemeFromManifest();
+      attached = true;
+    }
+
     return this;
   }
 
@@ -117,7 +120,7 @@ public class ActivityController<T extends Activity> extends ComponentController<
     shadowMainLooper.runPaused(new Runnable() {
       @Override
       public void run() {
-        if (!attached) attach();
+        attach();
         ReflectionHelpers.callInstanceMethod(Activity.class, component, "performCreate", ClassParameter.from(Bundle.class, bundle));
       }
     });

--- a/robolectric/src/main/java/org/robolectric/util/FragmentController.java
+++ b/robolectric/src/main/java/org/robolectric/util/FragmentController.java
@@ -31,6 +31,18 @@ public class FragmentController<F extends Fragment> extends ComponentController<
     return new FragmentController<>(Robolectric.getShadowsAdapter(), fragment, activityClass);
   }
 
+  public static <F extends Fragment> FragmentController<F> of(Class<F> fragmentClass) {
+    return new FragmentController<>(Robolectric.getShadowsAdapter(),
+        ReflectionHelpers.callConstructor(fragmentClass),
+        FragmentControllerActivity.class);
+  }
+
+  public static <F extends Fragment> FragmentController<F> of(Class<F> fragmentClass, Class<? extends Activity> activityClass) {
+    return new FragmentController<>(Robolectric.getShadowsAdapter(),
+        ReflectionHelpers.callConstructor(fragmentClass),
+        activityClass);
+  }
+
   @Override
   public FragmentController<F> attach() {
     activityController.attach();

--- a/robolectric/src/main/java/org/robolectric/util/FragmentTestUtil.java
+++ b/robolectric/src/main/java/org/robolectric/util/FragmentTestUtil.java
@@ -8,6 +8,10 @@ import android.app.FragmentManager;
 import android.os.Bundle;
 import android.widget.LinearLayout;
 
+/**
+ * @deprecated Please use {@link Robolectric#buildFragment(Class)} or {@link Robolectric#buildFragment(Class, Class)}
+ */
+@Deprecated
 public final class FragmentTestUtil {
   
   public static void startFragment(Fragment fragment) {

--- a/scripts/install-dependencies.rb
+++ b/scripts/install-dependencies.rb
@@ -45,7 +45,7 @@ end
 
 def install_jar(group_id, artifact_id, version, archive, &block)
   unless File.exists?(archive)
-    puts "#{group_id}:#{artifact_id} not found!"
+    puts "#{group_id}:#{artifact_id}:#{version} #{archive} not found!"
     puts "Make sure that the 'Android Support Repository' and 'Google Repository' is up to date in the SDK manager."
     exit 1
   end
@@ -78,7 +78,7 @@ def install_map(group_id, artifact_id, api, revision)
   path = "#{dir}/libs/maps.jar"
 
   unless File.exists?(path)
-    puts "#{group_id}:#{artifact_id} not found!"
+    puts "#{group_id}:#{artifact_id}:#{revision} #{path} not found!"
     puts "Make sure that 'Google APIs' is up to date in the SDK manager for API #{api}."
     exit 1
   end


### PR DESCRIPTION
Call attach in Robolectric.buildActivity or buildService. This should be done by Robolectric rather than by the user since it is not part of the public lifecycle, also, since the excessive shadowing code was removed from ShadowContextWrapper / ShadowContext the framework requires it for many operations.

Add Robolectric.buildFragment() convenience methods to match buildActivity/buildService which are cleaner to use than the controller directly.

Add better failure messages to build-dependencies.db