### PR TITLE
Fix for Powermock integration

### DIFF
--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/SupportFragmentControllerTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/SupportFragmentControllerTest.java
@@ -151,7 +151,7 @@ public class SupportFragmentControllerTest {
     assertThat(fragment.isVisible()).isTrue();
   }
 
-  private static class LoginFragment extends Fragment {
+  public static class LoginFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
       return inflater.inflate(R.layout.fragment_contents, container, false);

--- a/robolectric/pom.xml
+++ b/robolectric/pom.xml
@@ -26,6 +26,42 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.6.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4-common</artifactId>
+      <version>1.6.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4-rule</artifactId>
+      <version>1.6.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-classloading-xstream</artifactId>
+      <version>1.6.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>1.6.4</version>
       <scope>test</scope>
     </dependency>
 
@@ -43,6 +79,12 @@
     <dependency>
       <groupId>org.robolectric</groupId>
       <artifactId>robolectric-utils</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>xmlpull</groupId>
+      <artifactId>xmlpull</artifactId>
+      <version>1.1.3.1</version>
     </dependency>
 
     <dependency>

--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
@@ -12,8 +12,13 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.annotation.internal.Instrument;
-import org.robolectric.internal.*;
+import org.robolectric.internal.ParallelUniverseInterface;
+import org.robolectric.internal.SdkConfig;
+import org.robolectric.internal.SdkEnvironment;
+import org.robolectric.internal.ShadowProvider;
+import org.robolectric.internal.ShadowedObject;
 import org.robolectric.internal.dependency.DependencyJar;
+import org.robolectric.internal.dependency.DependencyResolver;
 import org.robolectric.internal.fakes.RoboCharsets;
 import org.robolectric.internal.fakes.RoboExtendedResponseCache;
 import org.robolectric.internal.fakes.RoboResponseSource;
@@ -24,7 +29,16 @@ import org.robolectric.res.builder.XmlBlock;
 import org.robolectric.util.TempDirectory;
 import org.robolectric.util.Transcript;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
 
 /**
  * Configuration rules for {@link org.robolectric.internal.bytecode.InstrumentingClassLoader}.
@@ -123,6 +137,7 @@ public class InstrumentationConfiguration {
           DoNotInstrument.class,
           Config.class,
           Transcript.class,
+          DependencyResolver.class,
           DirectObjectMarker.class,
           DependencyJar.class,
           ParallelUniverseInterface.class,
@@ -141,7 +156,9 @@ public class InstrumentationConfiguration {
           "org.specs2",  // allows for android projects with mixed scala\java tests to be
           "scala.",      //  run with Maven Surefire (see the RoboSpecs project on github)
           "kotlin.",
-          "com.almworks.sqlite4java" // Fix #958: SQLite native library must be loaded once.
+          "com.almworks.sqlite4java", // Fix #958: SQLite native library must be loaded once.
+          "org.mockito",
+          "org.powermock"
       ));
       classNameTranslations.put("java.net.ExtendedResponseCache", RoboExtendedResponseCache.class.getName());
       classNameTranslations.put("java.net.ResponseSource", RoboResponseSource.class.getName());

--- a/robolectric/src/test/java/org/mockito/configuration/MockitoConfiguration.java
+++ b/robolectric/src/test/java/org/mockito/configuration/MockitoConfiguration.java
@@ -1,0 +1,9 @@
+package org.mockito.configuration;
+
+public class MockitoConfiguration extends DefaultMockitoConfiguration {
+
+    @Override
+    public boolean enableClassCache() {
+        return false;
+    }
+}

--- a/robolectric/src/test/java/org/robolectric/PowerMockTest.java
+++ b/robolectric/src/test/java/org/robolectric/PowerMockTest.java
@@ -1,0 +1,35 @@
+package org.robolectric;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*", "org.apache.tools.*"})
+@PrepareForTest(PowerMockTest.TestStaticClass.class)
+public class PowerMockTest {
+
+    @Rule
+    public PowerMockRule rule = new PowerMockRule();
+
+    @Test
+    public void powermock_shouldMockStaticMethods() {
+        PowerMockito.mockStatic(TestStaticClass.class);
+        Mockito.when(TestStaticClass.staticMethod()).thenReturn("hello mock");
+
+        assertThat(TestStaticClass.staticMethod().equals("hello mock"));
+    }
+
+    static class TestStaticClass {
+        public static String staticMethod() {
+            return "";
+        }
+    }
+}

--- a/robolectric/src/test/java/org/robolectric/util/FragmentControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/FragmentControllerTest.java
@@ -148,7 +148,7 @@ public class FragmentControllerTest {
     assertThat(fragment.isVisible()).isTrue();
   }
 
-  private static class LoginFragment extends Fragment {
+  public static class LoginFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
       return inflater.inflate(R.layout.fragment_contents, container, false);


### PR DESCRIPTION
Follow-up for https://github.com/robolectric/robolectric/pull/2213. Should fix https://github.com/robolectric/robolectric/issues/2208 and probably, https://github.com/robolectric/robolectric/issues/2153. 

I implemented a simple integration test to make sure Powermock isn't broken later. Although, I'm not very familiar with Maven, so there might be a better way of specifying the dependencies.

