### PR TITLE
Cache resource index

### DIFF
--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -8,6 +8,7 @@ import org.junit.runners.model.InitializationError;
 import org.robolectric.annotation.Config;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.PackageResourceLoader;
+import org.robolectric.res.ResourceIndex;
 import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.ResourcePath;
 import org.robolectric.shadows.ShadowView;
@@ -127,8 +128,8 @@ public class RobolectricTestRunnerTest {
         super(testClass);
       }
 
-      @Override public PackageResourceLoader createResourceLoader(ResourcePath resourcePath) {
-        return super.createResourceLoader(resourcePath);
+      @Override public PackageResourceLoader createResourceLoader(ResourcePath resourcePath, ResourceIndex resourceIndex) {
+        return super.createResourceLoader(resourcePath, resourceIndex);
       }
 
       @Override


### PR DESCRIPTION
Creating the resource index is an expensive operation, this patch caches the resource loaders to avoid the need for re-creation between tests.

Recreated branch after rebasing PR #2355