### PR TITLE
Adding shadow for `readParcelCreator` to overcome JDK7 field access issue

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelTest.java
@@ -393,6 +393,42 @@ public class ShadowParcelTest {
   }
 
   @Test
+  public void testParcelableWithPackageProtected() throws Exception {
+    TestParcelablePackage normal = new TestParcelablePackage(23);
+
+    parcel.writeParcelable(normal, 0);
+    parcel.setDataPosition(0);
+
+    TestParcelablePackage rehydrated = parcel.readParcelable(TestParcelablePackage.class.getClassLoader());
+
+    assertEquals(normal.contents, rehydrated.contents);
+  }
+
+  @Test
+  public void testParcelableWithBase() throws Exception {
+    TestParcelableImpl normal = new TestParcelableImpl(23);
+
+    parcel.writeParcelable(normal, 0);
+    parcel.setDataPosition(0);
+
+    TestParcelableImpl rehydrated = parcel.readParcelable(TestParcelableImpl.class.getClassLoader());
+
+    assertEquals(normal.contents, rehydrated.contents);
+  }
+
+  @Test
+  public void testParcelableWithPublicClass() throws Exception {
+    TestParcelable normal = new TestParcelable(23);
+
+    parcel.writeParcelable(normal, 0);
+    parcel.setDataPosition(0);
+
+    TestParcelable rehydrated = parcel.readParcelable(TestParcelable.class.getClassLoader());
+
+    assertEquals(normal.contents, rehydrated.contents);
+  }
+
+  @Test
   public void testReadAndWriteStringList() throws Exception {
     ArrayList<String> original = new ArrayList<>();
     List<String> rehydrated = new ArrayList<>();

--- a/robolectric/src/test/java/org/robolectric/shadows/TestParcelableBase.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/TestParcelableBase.java
@@ -1,0 +1,16 @@
+package org.robolectric.shadows;
+
+import android.os.Parcelable;
+
+abstract class TestParcelableBase implements Parcelable {
+  int contents;
+
+  protected TestParcelableBase(int contents) {
+    this.contents = contents;
+  }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/TestParcelableImpl.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/TestParcelableImpl.java
@@ -1,0 +1,33 @@
+package org.robolectric.shadows;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+class TestParcelableImpl extends TestParcelableBase implements Parcelable {
+
+  public TestParcelableImpl(int contents) {
+    super(contents);
+  }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  public static final Creator<TestParcelableImpl> CREATOR =
+      new Creator<TestParcelableImpl>() {
+        @Override
+        public TestParcelableImpl createFromParcel(Parcel source) {
+          return new TestParcelableImpl(source.readInt());
+        }
+
+        @Override
+        public TestParcelableImpl[] newArray(int size) {
+          return new TestParcelableImpl[0];
+        }
+      };
+  @Override
+  public void writeToParcel(Parcel dest, int flags) {
+    dest.writeInt(contents);
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/TestParcelablePackage.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/TestParcelablePackage.java
@@ -1,0 +1,36 @@
+package org.robolectric.shadows;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+class TestParcelablePackage implements Parcelable {
+  int contents;
+
+  public TestParcelablePackage(int contents) {
+    this.contents = contents;
+  }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  public static final CreatorImpl CREATOR = new CreatorImpl();
+
+  @Override
+  public void writeToParcel(Parcel dest, int flags) {
+    dest.writeInt(contents);
+  }
+
+  public static class CreatorImpl implements Creator<TestParcelablePackage> {
+    @Override
+    public TestParcelablePackage createFromParcel(Parcel source) {
+      return new TestParcelablePackage(source.readInt());
+    }
+
+    @Override
+    public TestParcelablePackage[] newArray(int size) {
+      return new TestParcelablePackage[size];
+    }
+  }
+}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcel.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcel.java
@@ -1,10 +1,12 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.KITKAT_WATCH;
+import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static org.robolectric.RuntimeEnvironment.castNativePtr;
 
 import android.os.Parcel;
+import android.os.Parcelable;
 import android.text.TextUtils;
 import android.util.Pair;
 import java.io.ByteArrayInputStream;
@@ -12,6 +14,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -29,6 +32,38 @@ public class ShadowParcel {
   @RealObject private Parcel realObject;
   private static final Map<Long, ByteBuffer> NATIVE_PTR_TO_PARCEL = new LinkedHashMap<>();
   private static long nextNativePtr = 1; // this needs to start above 0, which is a magic number to Parcel
+
+  @Implementation(maxSdk = JELLY_BEAN_MR1) @SuppressWarnings("TypeParameterUnusedInFormals")
+  public <T extends Parcelable> T readParcelable(ClassLoader loader) throws IllegalAccessException, NoSuchFieldException, ClassNotFoundException {
+    Parcelable.Creator<?> creator = readParcelableCreator(loader);
+    if (creator == null) {
+      return null;
+    }
+
+    if (creator instanceof Parcelable.ClassLoaderCreator<?>) {
+      Parcelable.ClassLoaderCreator<?> classLoaderCreator = (Parcelable.ClassLoaderCreator<?>) creator;
+      return (T) classLoaderCreator.createFromParcel(realObject, loader);
+    }
+    return (T) creator.createFromParcel(realObject);
+  }
+
+  @Implementation @HiddenApi
+  public Parcelable.Creator<?> readParcelableCreator(ClassLoader loader) throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
+    //note: calling `readString` will also consume the string, and increment the data-pointer.
+    //which is exactly what we need, since we do not call the real `readParcelableCreator`.
+    final String name = realObject.readString();
+    if (name == null) return null;
+
+    ClassLoader parcelableClassLoader = (loader == null ? getClass().getClassLoader() : loader);
+    Class<?> parcelableClass = Class.forName(name, false /* initialize */, parcelableClassLoader);
+    Field field = parcelableClass.getField("CREATOR");
+    //this is a fix for JDK8<->Android VM incompatibility:
+    //Apparently, JDK will not allow access to a public field if its
+    //class is not visible (private or package-private) from the call-site.
+    field.setAccessible(true);
+
+    return (Parcelable.Creator<?>) field.get(null/*static method does not have an instance*/);
+  }
 
   @Implementation
   public void writeByteArray(byte[] b, int offset, int len) {


### PR DESCRIPTION
This is related to https://github.com/robolectric/robolectric/issues/2398
