### PR TITLE
Extract code to create and bind an application object.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/DefaultTestLifecycle.java
+++ b/robolectric/src/main/java/org/robolectric/DefaultTestLifecycle.java
@@ -1,16 +1,13 @@
 package org.robolectric;
 
 import android.app.Application;
-import android.content.Intent;
-import android.content.pm.ResolveInfo;
+
 import org.robolectric.annotation.Config;
 import org.robolectric.internal.ClassNameResolver;
-import org.robolectric.manifest.ActivityData;
 import org.robolectric.manifest.AndroidManifest;
-import org.robolectric.res.builder.RobolectricPackageManager;
+import org.robolectric.util.ApplicationTestUtil;
 
 import java.lang.reflect.Method;
-import java.util.Map;
 
 public class DefaultTestLifecycle implements TestLifecycle {
 
@@ -44,7 +41,7 @@ public class DefaultTestLifecycle implements TestLifecycle {
         } catch (ClassNotFoundException e) {
           throw new RuntimeException(e);
         }
-        application = newInstance(applicationClass);
+        application = ApplicationTestUtil.newApplication(applicationClass);
       }
     } else if (appManifest != null && appManifest.getApplicationName() != null) {
       Class<? extends Application> applicationClass = null;
@@ -62,21 +59,11 @@ public class DefaultTestLifecycle implements TestLifecycle {
         }
       }
 
-      application = newInstance(applicationClass);
+      application = ApplicationTestUtil.newApplication(applicationClass);
     } else {
       application = new Application();
     }
 
-    return application;
-  }
-
-  private static Application newInstance(Class<? extends Application> applicationClass) {
-    Application application;
-    try {
-      application = applicationClass.newInstance();
-    } catch (InstantiationException | IllegalAccessException e) {
-      throw new RuntimeException(e);
-    }
     return application;
   }
 

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -25,6 +25,7 @@ import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.builder.DefaultPackageManager;
 import org.robolectric.res.builder.RobolectricPackageManager;
 import org.robolectric.shadows.ShadowLooper;
+import org.robolectric.util.ApplicationTestUtil;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.Scheduler;
 
@@ -142,7 +143,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
       try {
         Context contextImpl = systemContextImpl.createPackageContext(applicationInfo.packageName, Context.CONTEXT_INCLUDE_CODE);
         ReflectionHelpers.setField(activityThreadClass, activityThread, "mInitialApplication", application);
-        ReflectionHelpers.callInstanceMethod(Application.class, application, "attach", ClassParameter.from(Context.class, contextImpl));
+        ApplicationTestUtil.attach(application, contextImpl);
       } catch (PackageManager.NameNotFoundException e) {
         throw new RuntimeException(e);
       }

--- a/robolectric/src/main/java/org/robolectric/util/ApplicationTestUtil.java
+++ b/robolectric/src/main/java/org/robolectric/util/ApplicationTestUtil.java
@@ -1,0 +1,32 @@
+package org.robolectric.util;
+
+import android.app.Application;
+import android.content.Context;
+
+public class ApplicationTestUtil {
+
+  /**
+   * Creates a new {@link Application} and attaches it with a base context obtained from context.
+   */
+  public static <T extends Application> T buildApplication(Class<T> applicationClass, Context context) {
+    T application = newApplication(applicationClass);
+    attach(application, context);
+    return application;
+  }
+
+
+  public static <T extends Application> T newApplication(Class<T> applicationClass) {
+    return ReflectionHelpers.callConstructor(applicationClass);
+  }
+
+  /**
+   * Attaches an application to a base context.
+   * @param application The application to attach.
+   * @param context The context with which to initialize the application, whose base context will
+   *                be attached to the application
+   */
+  public static void attach(Application application, Context context) {
+    ReflectionHelpers.callInstanceMethod(Application.class, application, "attach",
+        ReflectionHelpers.ClassParameter.from(Context.class, context));
+  }
+}


### PR DESCRIPTION
This is helpful for tests that create their own application independent of the one provided by Robolectric.application since the removal of ShadowContextWrapper / ShadowContext more framework code is invoked that requires all contexts to have an attached base context.