### PR TITLE
Push down some shadowing code from ShadowResources to ShadowAssetManager

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -156,32 +156,6 @@ public class ShadowResources {
   }
 
   @Implementation
-  public String getResourceName(int resId) throws Resources.NotFoundException {
-    return shadowOf(realResources.getAssets()).getResName(resId).getFullyQualifiedName();
-  }
-
-  @Implementation
-  public String getResourcePackageName(int resId) throws Resources.NotFoundException {
-    return shadowOf(realResources.getAssets()).getResName(resId).packageName;
-  }
-
-  @Implementation
-  public String getResourceTypeName(int resId) throws Resources.NotFoundException {
-    return shadowOf(realResources.getAssets()).getResName(resId).type;
-  }
-
-  @Implementation
-  public String getResourceEntryName(int resId) throws Resources.NotFoundException {
-    return shadowOf(realResources.getAssets()).getResName(resId).name;
-  }
-
-  @Implementation
-  public CharSequence getText(int id) throws Resources.NotFoundException {
-    CharSequence text = directlyOn(realResources, Resources.class).getText(id);
-    return text.toString();
-  }
-
-  @Implementation
   public String getQuantityString(int id, int quantity, Object... formatArgs) throws Resources.NotFoundException {
     String raw = getQuantityString(id, quantity);
     return String.format(Locale.ENGLISH, raw, formatArgs);

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -805,6 +805,26 @@ public final class ShadowAssetManager {
     return resName;
   }
 
+  @Implementation
+  public String getResourceName(int resid) {
+    return getResName(resid).getFullyQualifiedName();
+  }
+
+  @Implementation
+  public String getResourcePackageName(int resid) {
+    return getResName(resid).packageName;
+  }
+
+  @Implementation
+  public String getResourceTypeName(int resid) {
+    return getResName(resid).type;
+  }
+
+  @Implementation
+  public String getResourceEntryName(int resid) {
+   return getResName(resid).name;
+  }
+
   @Resetter
   public static void reset() {
     systemResourceLoader = null;


### PR DESCRIPTION
Move getResourceName(), getResourcePackageName(), getResourceTypeName(), getResourceEntryName() from ShadowResources down to ShadowAssetManager as a step towards removing ShadowResources and prefering more real framework code. Also remove redundant getText() which simply calls AssetManager.getText()