### PR TITLE
Make @Config @Inherited

### DIFF
--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/Config.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/Config.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -18,6 +19,7 @@ import java.util.Set;
  * Configuration settings that can be used on a per-class or per-test basis.
  */
 @Documented
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface Config {


### PR DESCRIPTION
### Overview

### Proposed Changes

org.junit.runner.RunWith is @Inherited, and JUnit runs tests that are inherited from a superclass, so it makes sense for @Config to be @Inherited as well. It's one less thing to have to duplicate across all concrete subclasses of an abstract test class.