### PR TITLE
Fix ShadowPendingIntent.equals

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
@@ -13,6 +13,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
 import org.robolectric.fakes.RoboIntentSender;
+import org.robolectric.internal.ShadowExtractor;
 import org.robolectric.util.ReflectionHelpers;
 
 import java.util.ArrayList;
@@ -131,9 +132,14 @@ public class ShadowPendingIntent {
   @Implementation
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (o == null || !(getClass() == o.getClass() || PendingIntent.class == o.getClass())) return false;
 
-    ShadowPendingIntent that = (ShadowPendingIntent) o;
+    ShadowPendingIntent that;
+    if (o instanceof PendingIntent) {
+      that = (ShadowPendingIntent) ShadowExtractor.extract(o);
+    } else {
+      that = (ShadowPendingIntent) o;
+    }
 
     if (savedContext != null) {
       String packageName = savedContext.getPackageName();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPendingIntentTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPendingIntentTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.internal.ShadowExtractor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
@@ -198,5 +199,33 @@ public class ShadowPendingIntentTest {
 
     assertThat(saved).isNotNull();
     assertThat(intent).isEqualTo(shadowOf(saved).getSavedIntent());
+  }
+
+  @Test
+  public void equals_sameRealInstance_shouldReturnTrue() {
+    Intent intent = new Intent();
+
+    PendingIntent pendingIntent = PendingIntent.getBroadcast(RuntimeEnvironment.application, 0, intent, 0);
+
+    assertThat(pendingIntent).isEqualTo(pendingIntent);
+  }
+
+  @Test
+  public void equals_sameShadowInstance_shouldReturnTrue() {
+    Intent intent = new Intent();
+
+    PendingIntent pendingIntent = PendingIntent.getBroadcast(RuntimeEnvironment.application, 0, intent, 0);
+    ShadowPendingIntent shadowPendingIntent = (ShadowPendingIntent) ShadowExtractor.extract(pendingIntent);
+
+    assertThat(shadowPendingIntent).isEqualTo(shadowPendingIntent);
+  }
+
+  @Test
+  public void equals_differentClass_shouldReturnFalse() {
+    Intent intent = new Intent();
+
+    PendingIntent pendingIntent = PendingIntent.getBroadcast(RuntimeEnvironment.application, 0, intent, 0);
+
+    assertThat(pendingIntent).isNotEqualTo("A String");
   }
 }


### PR DESCRIPTION
### Overview

Fix a small bug in the implementation of ShadowPendingIntent.equals
### Proposed Changes

This method previously returned false if the other object wasn't an
instance of ShadowPendingIntent. This meant that comparing any two
PendingIntents (or even comparing a PendingIntent to itself!) would
always return false.
