### PR TITLE
Load both android.R and com.android.internal.R from the aosp jars.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
@@ -210,7 +210,12 @@ public class InstrumentationConfiguration {
       return name.contains("Test");
     }
 
-    if (name.matches("com\\.android\\.internal\\.R(\\$.*)?")) return true;
+    // Both internal and public R class must be loaded from the same classloader since they only
+    // have stable ID's within a given API version.
+    if (name.matches("com\\.android\\.internal\\.R(\\$.*)?") ||
+        name.matches("android\\.R(\\$.*)?")) {
+      return true;
+    }
 
     // Android SDK code almost universally refers to com.android.internal.R, except
     // when refering to android.R.stylable, as in HorizontalScrollView. arghgh.


### PR DESCRIPTION
If android.R is loaded from the system classloader it will get the values for the latest SDK in the android.jar. It must load them both from the aosp jars to ensure the same stable ids between both classes.