### PR TITLE
Allow override of build dir via config property.

### DIFF
--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/Config.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/Config.java
@@ -27,6 +27,7 @@ public @interface Config {
   String DEFAULT = "--default";
   String DEFAULT_RES_FOLDER = "res";
   String DEFAULT_ASSET_FOLDER = "assets";
+  String DEFAULT_BUILD_FOLDER = "build";
 
   /**
    * The Android SDK level to emulate. If not specified, Robolectric defaults to API 16.
@@ -100,6 +101,15 @@ public @interface Config {
   String assetDir() default DEFAULT_ASSET_FOLDER;
 
   /**
+   * The directory where application files are created during the application build process.
+   *
+   * <p>If not specified, Robolectric defaults to {@code build}.</p>
+   *
+   * @return Android build directory.
+   */
+  String buildDir() default DEFAULT_BUILD_FOLDER;
+
+  /**
    * A list of shadow classes to enable, in addition to those that are already present.
    *
    * @return A list of additional shadow classes to enable.
@@ -126,6 +136,7 @@ public @interface Config {
     private final String qualifiers;
     private final String resourceDir;
     private final String assetDir;
+    private final String buildDir;
     private final String packageName;
     private final Class<?> constants;
     private final Class<?>[] shadows;
@@ -142,6 +153,7 @@ public @interface Config {
           properties.getProperty("packageName", ""),
           properties.getProperty("resourceDir", Config.DEFAULT_RES_FOLDER),
           properties.getProperty("assetDir", Config.DEFAULT_ASSET_FOLDER),
+          properties.getProperty("buildDir", Config.DEFAULT_BUILD_FOLDER),
           parseClasses(properties.getProperty("shadows", "")),
           parseStringArrayProperty(properties.getProperty("instrumentedPackages", "")),
           parseApplication(properties.getProperty("application", "android.app.Application")),
@@ -189,13 +201,14 @@ public @interface Config {
       return result;
     }
 
-    public Implementation(int[] sdk, String manifest, String qualifiers, String packageName, String resourceDir, String assetDir, Class<?>[] shadows, String[] instrumentedPackages, Class<? extends Application> application, String[] libraries, Class<?> constants) {
+    public Implementation(int[] sdk, String manifest, String qualifiers, String packageName, String resourceDir, String assetDir, String buildDir, Class<?>[] shadows, String[] instrumentedPackages, Class<? extends Application> application, String[] libraries, Class<?> constants) {
       this.sdk = sdk;
       this.manifest = manifest;
       this.qualifiers = qualifiers;
       this.packageName = packageName;
       this.resourceDir = resourceDir;
       this.assetDir = assetDir;
+      this.buildDir = buildDir;
       this.shadows = shadows;
       this.instrumentedPackages = instrumentedPackages;
       this.application = application;
@@ -210,6 +223,7 @@ public @interface Config {
       this.packageName = other.packageName();
       this.resourceDir = other.resourceDir();
       this.assetDir = other.assetDir();
+      this.buildDir = other.buildDir();
       this.constants = other.constants();
       this.shadows = other.shadows();
       this.instrumentedPackages = other.instrumentedPackages();
@@ -224,6 +238,7 @@ public @interface Config {
       this.packageName = pick(baseConfig.packageName(), overlayConfig.packageName(), "");
       this.resourceDir = pick(baseConfig.resourceDir(), overlayConfig.resourceDir(), Config.DEFAULT_RES_FOLDER);
       this.assetDir = pick(baseConfig.assetDir(), overlayConfig.assetDir(), Config.DEFAULT_ASSET_FOLDER);
+      this.buildDir = pick(baseConfig.buildDir(), overlayConfig.buildDir(), Config.DEFAULT_BUILD_FOLDER);
       this.constants = pick(baseConfig.constants(), overlayConfig.constants(), Void.class);
 
       Set<Class<?>> shadows = new HashSet<>();
@@ -290,6 +305,11 @@ public @interface Config {
     @Override
     public String assetDir() {
       return assetDir;
+    }
+
+    @Override
+    public String buildDir() {
+      return buildDir;
     }
 
     @Override

--- a/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
+++ b/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
@@ -85,13 +85,13 @@ public class DefaultTestLifecycleTest {
 
   @Test public void shouldLoadConfigApplicationIfSpecified() throws Exception {
     Application application = defaultTestLifecycle.createApplication(null,
-        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(new int[0], "", "", "", "", "", new Class[0], new String[0], TestFakeApp.class, new String[0], null));
+        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(new int[0], "", "", "", "", "", "", new Class[0], new String[0], TestFakeApp.class, new String[0], null));
     assertThat(application).isExactlyInstanceOf(TestFakeApp.class);
   }
 
   @Test public void shouldLoadConfigInnerClassApplication() throws Exception {
     Application application = defaultTestLifecycle.createApplication(null,
-        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(new int[0], "", "", "", "", "", new Class[0], new String[0], TestFakeAppInner.class, new String[0], null));
+        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(new int[0], "", "", "", "", "", "", new Class[0], new String[0], TestFakeAppInner.class, new String[0], null));
     assertThat(application).isExactlyInstanceOf(TestFakeAppInner.class);
   }
 

--- a/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
@@ -31,7 +31,7 @@ public class ParallelUniverseTest {
   private ParallelUniverse pu;
 
   private static Config getDefaultConfig() {
-    return new Config.Implementation(new int[0], Config.DEFAULT, "", "org.robolectric", "res", "assets", new Class[0], new String[0], Application.class, new String[0], null);
+    return new Config.Implementation(new int[0], Config.DEFAULT, "", "org.robolectric", "res", "assets", "build", new Class[0], new String[0], Application.class, new String[0], null);
   }
 
   @Before
@@ -114,7 +114,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromSdkConfig() {
     String givenQualifiers = "";
-    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "res", "assets", new Class[0], new String[0], Application.class, new String[0], null);
+    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "res", "assets", "build", new Class[0], new String[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("v18");
     assertThat(getQualifiersFromAppAssetManager()).isEqualTo("v18");
@@ -124,7 +124,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromConfigQualifiers() {
     String givenQualifiers = "land-v17";
-    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "res", "assets", new Class[0], new String[0], Application.class, new String[0], null);
+    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "res", "assets", "build", new Class[0], new String[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("land-v17");
     assertThat(getQualifiersFromAppAssetManager()).isEqualTo("land-v17");
@@ -134,7 +134,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromSdkConfigWithOtherQualifiers() {
     String givenQualifiers = "large-land";
-    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "res", "assets", "", new Class[0], new String[0], Application.class, new String[0], null);
+    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "res", "assets", "", "build", new Class[0], new String[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("large-land-v18");
     assertThat(getQualifiersFromAppAssetManager()).isEqualTo("large-land-v18");

--- a/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
@@ -20,6 +20,10 @@ public class RobolectricGradleTestRunnerTest {
     FileFsFile.from("build", "intermediates", "res").getFile().mkdirs();
     FileFsFile.from("build", "intermediates", "assets").getFile().mkdirs();
     FileFsFile.from("build", "intermediates", "manifests").getFile().mkdirs();
+
+    FileFsFile.from("custom_build", "intermediates", "res").getFile().mkdirs();
+    FileFsFile.from("custom_build", "intermediates", "assets").getFile().mkdirs();
+    FileFsFile.from("custom_build", "intermediates", "manifests").getFile().mkdirs();
   }
 
   @After
@@ -28,6 +32,10 @@ public class RobolectricGradleTestRunnerTest {
     delete(FileFsFile.from("build", "intermediates", "assets").getFile());
     delete(FileFsFile.from("build", "intermediates", "manifests").getFile());
     delete(FileFsFile.from("build", "intermediates", "res", "merged").getFile());
+
+    delete(FileFsFile.from("custom_build", "intermediates", "res").getFile());
+    delete(FileFsFile.from("custom_build", "intermediates", "assets").getFile());
+    delete(FileFsFile.from("custom_build", "intermediates", "manifests").getFile());
   }
 
   private static String convertPath(String path) {
@@ -69,6 +77,17 @@ public class RobolectricGradleTestRunnerTest {
     assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("build/intermediates/res/flavor2/type2"));
     assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("build/intermediates/assets/flavor2/type2"));
     assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("build/intermediates/manifests/full/flavor2/type2/AndroidManifest.xml"));
+  }
+
+  @Test
+  public void getAppManifest_withBuildDirOverride_shouldCreateManifest() throws Exception {
+    final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(BuildDirTest.class);
+    final AndroidManifest manifest = runner.getAppManifest(runner.getConfig(BuildDirTest.class.getMethod("withoutAnnotation")));
+
+    assertThat(manifest.getPackageName()).isEqualTo("org.sandwich.foo");
+    assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("custom_build/intermediates/res/flavor1/type1"));
+    assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("custom_build/intermediates/assets/flavor1/type1"));
+    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("custom_build/intermediates/manifests/full/flavor1/type1/AndroidManifest.xml"));
   }
 
   @Test
@@ -135,6 +154,15 @@ public class RobolectricGradleTestRunnerTest {
   @Ignore
   @Config
   public static class NoConstantsTest {
+
+    @Test
+    public void withoutAnnotation() throws Exception {
+    }
+  }
+
+  @Ignore
+  @Config(constants = BuildConfig.class, buildDir = "custom_build")
+  public static class BuildDirTest {
 
     @Test
     public void withoutAnnotation() throws Exception {


### PR DESCRIPTION
### Overview

Using gradle, we have switched the android app output build folder:

```
//changing the build output folder, so gradle can co-exist with another system...
allprojects {
    buildDir = 'gen_build'
}
```
The app builds and runs as expected, but when running our Robolectric tests we receive an error that the `AndroidManifest.xml` can not be found.

This is due to `RobolectricGradleTestRunner` currently being hard coded via a private static variable to only check the `build/intermediates` output location for the `AndroidManifest.xml` file.

### Proposed Changes

This change adds the ability to set the base build directory via a new config property. In doing this one can choose to set a custom build directory via the `@Config` or `robolectric.properties` conventions that are already in place.

