### PR TITLE
Adds missing getActivity to ShadowPendingIntent

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
@@ -43,6 +43,11 @@ public class ShadowPendingIntent {
   }
 
   @Implementation
+  public static PendingIntent getActivity(Context context, int requestCode, Intent intent, int flags, Bundle options) {
+    return create(context, new Intent[] {intent}, true, false, false, requestCode, flags);
+  }
+
+  @Implementation
   public static PendingIntent getActivities(Context context, int requestCode, Intent[] intents, int flags) {
     return create(context, intents, true, false, false, requestCode, flags);
   }


### PR DESCRIPTION
### Overview

### Proposed Changes

PendingIntent.getActivity that takes an options bundle was missing.
See:
http://developer.android.com/reference/android/app/PendingIntent.html#getActivity(android.content.Context, int, android.content.Intent, int, android.os.Bundle)