### PR TITLE
Add ABI split support to gradle test runner

### DIFF
--- a/robolectric-annotations/src/main/java/org/robolectric/annotation/Config.java
+++ b/robolectric-annotations/src/main/java/org/robolectric/annotation/Config.java
@@ -76,6 +76,15 @@ public @interface Config {
   String packageName() default "";
 
   /**
+   * The ABI split to use when locating resources and AndroidManifest.xml
+   *
+   * <p>You do not typically have to set this, unless you are utilizing the ABI split feature</p>
+   *
+   * @return The ABI split to test with
+   */
+  String abiSplit() default "";
+
+  /**
    * Qualifiers for the resource resolution, such as "fr-normal-port-hdpi".
    *
    * @return Qualifiers used for resource resolution.
@@ -138,6 +147,7 @@ public @interface Config {
     private final String assetDir;
     private final String buildDir;
     private final String packageName;
+    private final String abiSplit;
     private final Class<?> constants;
     private final Class<?>[] shadows;
     private final String[] instrumentedPackages;
@@ -151,6 +161,7 @@ public @interface Config {
           properties.getProperty("manifest", DEFAULT),
           properties.getProperty("qualifiers", ""),
           properties.getProperty("packageName", ""),
+          properties.getProperty("abiSplit", ""),
           properties.getProperty("resourceDir", Config.DEFAULT_RES_FOLDER),
           properties.getProperty("assetDir", Config.DEFAULT_ASSET_FOLDER),
           properties.getProperty("buildDir", Config.DEFAULT_BUILD_FOLDER),
@@ -201,11 +212,12 @@ public @interface Config {
       return result;
     }
 
-    public Implementation(int[] sdk, String manifest, String qualifiers, String packageName, String resourceDir, String assetDir, String buildDir, Class<?>[] shadows, String[] instrumentedPackages, Class<? extends Application> application, String[] libraries, Class<?> constants) {
+    public Implementation(int[] sdk, String manifest, String qualifiers, String packageName, String abiSplit, String resourceDir, String assetDir, String buildDir, Class<?>[] shadows, String[] instrumentedPackages, Class<? extends Application> application, String[] libraries, Class<?> constants) {
       this.sdk = sdk;
       this.manifest = manifest;
       this.qualifiers = qualifiers;
       this.packageName = packageName;
+      this.abiSplit = abiSplit;
       this.resourceDir = resourceDir;
       this.assetDir = assetDir;
       this.buildDir = buildDir;
@@ -221,6 +233,7 @@ public @interface Config {
       this.manifest = other.manifest();
       this.qualifiers = other.qualifiers();
       this.packageName = other.packageName();
+      this.abiSplit = other.abiSplit();
       this.resourceDir = other.resourceDir();
       this.assetDir = other.assetDir();
       this.buildDir = other.buildDir();
@@ -236,6 +249,7 @@ public @interface Config {
       this.manifest = pick(baseConfig.manifest(), overlayConfig.manifest(), DEFAULT);
       this.qualifiers = pick(baseConfig.qualifiers(), overlayConfig.qualifiers(), "");
       this.packageName = pick(baseConfig.packageName(), overlayConfig.packageName(), "");
+      this.abiSplit = pick(baseConfig.abiSplit(), overlayConfig.abiSplit(), "");
       this.resourceDir = pick(baseConfig.resourceDir(), overlayConfig.resourceDir(), Config.DEFAULT_RES_FOLDER);
       this.assetDir = pick(baseConfig.assetDir(), overlayConfig.assetDir(), Config.DEFAULT_ASSET_FOLDER);
       this.buildDir = pick(baseConfig.buildDir(), overlayConfig.buildDir(), Config.DEFAULT_BUILD_FOLDER);
@@ -295,6 +309,11 @@ public @interface Config {
     @Override
     public String packageName() {
       return packageName;
+    }
+
+    @Override
+    public String abiSplit() {
+      return abiSplit;
     }
 
     @Override

--- a/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
@@ -33,6 +33,7 @@ public class RobolectricGradleTestRunner extends RobolectricTestRunner {
     final String buildOutputDir = getBuildOutputDir(config);
     final String type = getType(config);
     final String flavor = getFlavor(config);
+    final String abiSplit = getAbiSplit(config);
     final String packageName = getPackageName(config);
 
     final FileFsFile res;
@@ -59,9 +60,9 @@ public class RobolectricGradleTestRunner extends RobolectricTestRunner {
     }
 
     if (FileFsFile.from(buildOutputDir, "manifests").exists()) {
-      manifest = FileFsFile.from(buildOutputDir, "manifests", "full", flavor, type, "AndroidManifest.xml");
+      manifest = FileFsFile.from(buildOutputDir, "manifests", "full", flavor, abiSplit, type, "AndroidManifest.xml");
     } else {
-      manifest = FileFsFile.from(buildOutputDir, "bundles", flavor, type, "AndroidManifest.xml");
+      manifest = FileFsFile.from(buildOutputDir, "bundles", flavor, abiSplit, type, "AndroidManifest.xml");
     }
 
     Logger.debug("Robolectric assets directory: " + assets.getPath());
@@ -91,6 +92,14 @@ public class RobolectricGradleTestRunner extends RobolectricTestRunner {
   private static String getFlavor(Config config) {
     try {
       return ReflectionHelpers.getStaticField(config.constants(), "FLAVOR");
+    } catch (Throwable e) {
+      return null;
+    }
+  }
+
+  private static String getAbiSplit(Config config) {
+    try {
+      return config.abiSplit();
     } catch (Throwable e) {
       return null;
     }

--- a/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
+++ b/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
@@ -85,13 +85,13 @@ public class DefaultTestLifecycleTest {
 
   @Test public void shouldLoadConfigApplicationIfSpecified() throws Exception {
     Application application = defaultTestLifecycle.createApplication(null,
-        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(new int[0], "", "", "", "", "", "", new Class[0], new String[0], TestFakeApp.class, new String[0], null));
+        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(new int[0], "", "", "", "", "", "", "", new Class[0], new String[0], TestFakeApp.class, new String[0], null));
     assertThat(application).isExactlyInstanceOf(TestFakeApp.class);
   }
 
   @Test public void shouldLoadConfigInnerClassApplication() throws Exception {
     Application application = defaultTestLifecycle.createApplication(null,
-        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(new int[0], "", "", "", "", "", "", new Class[0], new String[0], TestFakeAppInner.class, new String[0], null));
+        newConfigWith("<application android:name=\"" + "ClassNameToIgnore" + "\"/>"), new Config.Implementation(new int[0], "", "", "", "", "", "", "", new Class[0], new String[0], TestFakeAppInner.class, new String[0], null));
     assertThat(application).isExactlyInstanceOf(TestFakeAppInner.class);
   }
 

--- a/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
@@ -31,7 +31,7 @@ public class ParallelUniverseTest {
   private ParallelUniverse pu;
 
   private static Config getDefaultConfig() {
-    return new Config.Implementation(new int[0], Config.DEFAULT, "", "org.robolectric", "res", "assets", "build", new Class[0], new String[0], Application.class, new String[0], null);
+    return new Config.Implementation(new int[0], Config.DEFAULT, "", "org.robolectric", "", "res", "assets", "build", new Class[0], new String[0], Application.class, new String[0], null);
   }
 
   @Before
@@ -114,7 +114,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromSdkConfig() {
     String givenQualifiers = "";
-    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "res", "assets", "build", new Class[0], new String[0], Application.class, new String[0], null);
+    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "", "res", "assets", "build", new Class[0], new String[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("v18");
     assertThat(getQualifiersFromAppAssetManager()).isEqualTo("v18");
@@ -124,7 +124,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromConfigQualifiers() {
     String givenQualifiers = "land-v17";
-    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "res", "assets", "build", new Class[0], new String[0], Application.class, new String[0], null);
+    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "", "res", "assets", "build", new Class[0], new String[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("land-v17");
     assertThat(getQualifiersFromAppAssetManager()).isEqualTo("land-v17");
@@ -134,7 +134,7 @@ public class ParallelUniverseTest {
   @Test
   public void setUpApplicationState_setsVersionQualifierFromSdkConfigWithOtherQualifiers() {
     String givenQualifiers = "large-land";
-    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "res", "assets", "", "build", new Class[0], new String[0], Application.class, new String[0], null);
+    Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "", "res", "assets", "", "build", new Class[0], new String[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("large-land-v18");
     assertThat(getQualifiersFromAppAssetManager()).isEqualTo("large-land-v18");

--- a/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
@@ -102,6 +102,17 @@ public class RobolectricGradleTestRunnerTest {
   }
 
   @Test
+  public void getAppManifest_withAbiSplitOverride_shouldCreateManifest() throws Exception {
+    final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(AbiSplitTest.class);
+    final AndroidManifest manifest = runner.getAppManifest(runner.getConfig(AbiSplitTest.class.getMethod("withoutAnnotation")));
+
+    assertThat(manifest.getPackageName()).isEqualTo("org.sandwich.foo");
+    assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("build/intermediates/res/flavor1/type1"));
+    assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("build/intermediates/assets/flavor1/type1"));
+    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("build/intermediates/manifests/full/flavor1/armeabi/type1/AndroidManifest.xml"));
+  }
+
+  @Test
   public void getAppManifest_withMergedResources_shouldHaveMergedResPath() throws Exception {
     FileFsFile.from("build", "intermediates", "res", "merged").getFile().mkdirs();
 
@@ -173,6 +184,14 @@ public class RobolectricGradleTestRunnerTest {
   @Config(constants = BuildConfig.class, packageName = "fake.package.name")
   public static class PackageNameTest {
 
+    @Test
+    public void withoutAnnotation() throws Exception {
+    }
+  }
+
+  @Ignore
+  @Config(constants = BuildConfig.class, abiSplit = "armeabi")
+  public static class AbiSplitTest {
     @Test
     public void withoutAnnotation() throws Exception {
     }


### PR DESCRIPTION
### Overview

Android + gradle enables you to specify ABI splits where you can have several APKs that correspond to each ABI you support. When using this option, Robolectric's gradle test runner fails to find the `AndroidManifest.xml` file because it is one directory deeper.

### Proposed Changes

I've added an `abiSplit` option to the Robolectric configuration that allows users to specify which ABI split to use for their tests. This way the test runner can properly locate the necessary files.

I could not have just used a BuildConfig value as the split is determined / processed after compilation.

The test runner could also just detect and take the first directory inside of `manifests/full/flavor/`, but that seems a bit messier.

Fixes #2144