### PR TITLE
Synchronize the plan cache in ShadowWrangler

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
@@ -44,12 +44,13 @@ public class ShadowWrangler implements ClassHandler {
   private static final MethodHandle NO_SHADOW_HANDLE = constant(Object.class, NO_SHADOW);
   private final ShadowMap shadowMap;
   private final Map<Class, MetaShadow> metaShadowMap = new HashMap<>();
-  private final Map<String, Plan> planCache = new LinkedHashMap<String, Plan>() {
-    @Override
-    protected boolean removeEldestEntry(Map.Entry<String, Plan> eldest) {
-      return size() > 500;
-    }
-  };
+  private final Map<String, Plan> planCache =
+      Collections.synchronizedMap(new LinkedHashMap<String, Plan>() {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, Plan> eldest) {
+          return size() > 500;
+        }
+      });
   private final Map<Class, ShadowConfig> shadowConfigCache = new ConcurrentHashMap<>();
   private final ClassValue<ShadowConfig> shadowConfigs = new ClassValue<ShadowConfig>() {
     @Override protected ShadowConfig computeValue(Class<?> type) {
@@ -126,8 +127,11 @@ public class ShadowWrangler implements ClassHandler {
 
   @Override
   public Plan methodInvoked(String signature, boolean isStatic, Class<?> theClass) {
-    if (planCache.containsKey(signature)) return planCache.get(signature);
-    Plan plan = calculatePlan(signature, isStatic, theClass);
+    Plan plan = planCache.get(signature);
+    if (plan != null) {
+      return plan;
+    }
+    plan = calculatePlan(signature, isStatic, theClass);
     planCache.put(signature, plan);
     return plan;
   }


### PR DESCRIPTION
### Overview

### Proposed Changes

The plan cache in ShadowWrangler is used concurrently when running
tests under gradle. Adding and removing plans from the cache
occasionally incurs in a race condition that causes test flakiness.

Twitter uses a custom version of OpenJdk that makes this issue
particularly noticeable, since it nulls out an entry's links when
it gets removed. In this case, the race condition causes and NPE.
In the general case, the map uses entries that are already removed.

I fixed by making the map synchronized and replacing containsKey/get
with a single call to get and a null check. I considered making the
method synchronized, but it felt wasteful to run plan calculation
within a synchronized block. The only downside of this is that the
occasional plan may get calculated twice.