### PR TITLE
Capture Application.registerActivityLifecycleCallbacks

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
@@ -37,6 +37,7 @@ import org.robolectric.res.ResName;
 import org.robolectric.res.ResourceExtractor;
 import org.robolectric.test.TemporaryFolder;
 import org.robolectric.util.Scheduler;
+import org.robolectric.util.TestActivityLifecycleCallbacks;
 import org.robolectric.util.TestBroadcastReceiver;
 
 import java.io.File;
@@ -588,6 +589,28 @@ public class ShadowApplicationTest {
 
     PopupWindow latestPopupWindow = ShadowApplication.getInstance().getLatestPopupWindow();
     assertThat(latestPopupWindow).isSameAs(pw);
+  }
+
+  @Test
+  public void activityLifecycleCallbacks_shouldBeRegistered() {
+    TestActivityLifecycleCallbacks callbacks = new TestActivityLifecycleCallbacks();
+    RuntimeEnvironment.application.registerActivityLifecycleCallbacks(callbacks);
+
+    List<Application.ActivityLifecycleCallbacks> callbacksList =
+        shadowOf(RuntimeEnvironment.application).getActivityLifecycleCallbacks();
+    assertTrue(callbacksList.size() == 1);
+    assertEquals(callbacks, callbacksList.get(0));
+  }
+
+  @Test
+  public void activityLifecycleCallbacks_shouldBeUnregistered() {
+    TestActivityLifecycleCallbacks callbacks = new TestActivityLifecycleCallbacks();
+    RuntimeEnvironment.application.registerActivityLifecycleCallbacks(callbacks);
+    RuntimeEnvironment.application.unregisterActivityLifecycleCallbacks(callbacks);
+
+    List<Application.ActivityLifecycleCallbacks> callbacksList =
+        shadowOf(RuntimeEnvironment.application).getActivityLifecycleCallbacks();
+    assertTrue(callbacksList.size() == 0);
   }
 
   /////////////////////////////

--- a/robolectric/src/test/java/org/robolectric/util/TestActivityLifecycleCallbacks.java
+++ b/robolectric/src/test/java/org/robolectric/util/TestActivityLifecycleCallbacks.java
@@ -1,0 +1,48 @@
+package org.robolectric.util;
+
+import android.app.Application;
+
+public class TestActivityLifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
+  public boolean created = false;
+  public boolean started = false;
+  public boolean resumed = false;
+  public boolean paused = false;
+  public boolean stopped = false;
+  public boolean saved = false;
+  public boolean destroyed = false;
+
+  @Override
+  public void onActivityCreated(android.app.Activity activity, android.os.Bundle bundle) {
+    created = true;
+  }
+
+  @Override
+  public void onActivityStarted(android.app.Activity activity) {
+    started = true;
+  }
+
+  @Override
+  public void onActivityResumed(android.app.Activity activity) {
+    resumed = true;
+  }
+
+  @Override
+  public void onActivityPaused(android.app.Activity activity) {
+    paused = true;
+  }
+
+  @Override
+  public void onActivityStopped(android.app.Activity activity) {
+    stopped = true;
+  }
+
+  @Override
+  public void onActivitySaveInstanceState(android.app.Activity activity, android.os.Bundle bundle) {
+    saved = true;
+  }
+
+  @Override
+  public void onActivityDestroyed(android.app.Activity activity) {
+    destroyed = true;
+  }
+}


### PR DESCRIPTION
### Overview

### Proposed Changes

Application does not expose the list of registered `ActivityLifecycleCallbacks`. This patch intercepts `registerActivityLifecycleCallbacks` and `unregisterActivityLifecycleCallbacks` to implement `getActivityLifecycleCallbacks` in `ShadowApplication`.