### PR TITLE
Enable in-memory SQLite databases

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowContextImpl.java.vm
@@ -40,6 +40,11 @@ import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
  */
 @Implements(className = ShadowContextImpl.CLASS_NAME)
 public class ShadowContextImpl {
+  /**
+   * Special path used by in-memory databases (from android.database.sqlite.SQLiteDatabaseConfiguration).
+   */
+  public static final String SQLITE_IN_MEMORY_PATH = ":memory:";
+
   public static final String CLASS_NAME = "android.app.ContextImpl";
   private static final Map<String, String> SYSTEM_SERVICE_MAP = new HashMap<>();
   private final Map<String, RoboSharedPreferences> roboSharedPreferencesMap = new HashMap<>();
@@ -103,7 +108,9 @@ public class ShadowContextImpl {
     File dir;
     File f = new File(name);
 
-    if (f.isAbsolute()) {
+    if (SQLITE_IN_MEMORY_PATH.equals(name)) {
+      return f;
+    } else if (f.isAbsolute()) {
       dir = f.getParentFile();
     } else {
       dir = directlyOn(realObject, "android.app.ContextImpl", "getDatabasesDir");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextImplTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextImplTest.java
@@ -90,5 +90,11 @@ public class ShadowContextImplTest {
     RemoteViews remoteViews = new RemoteViews(RuntimeEnvironment.application.getPackageName(), R.layout.remote_views);
     remoteViews.apply(RuntimeEnvironment.application, new FrameLayout(RuntimeEnvironment.application));
   }
+
+  @Test
+  public void validateInMemoryDatabasePath() {
+    assertThat(context.getDatabasePath(ShadowContextImpl.SQLITE_IN_MEMORY_PATH).getPath())
+        .isEqualTo(ShadowContextImpl.SQLITE_IN_MEMORY_PATH);
+  }
 }
 


### PR DESCRIPTION
### Overview

### Proposed Changes

SQLite creates an in-memory database when the database path is ":memory:". Twitter runs hundreds of database unit tests, and we have measured speedups of up to 5x in certain server configurations when switching to using in-memory databases.

This patch updates the database file path validation to act as a passthrough for ":memory:". `ContextImpl.openOrCreateDatabase` just calls `getPath()` on this file to pass it into `SQLiteDatabase.openDatabase`.