### PR TITLE
Set Build.Version.RELEASE and Build.Version.INCREMENTAL

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSystemProperties.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSystemProperties.java
@@ -18,6 +18,8 @@ public class ShadowSystemProperties {
   private static final Set<String> alreadyWarned = new HashSet<>();
 
   static {
+    VALUES.put("ro.build.version.release", "2.2");
+    VALUES.put("ro.build.version.incremental", "0");
     VALUES.put("ro.build.version.sdk", 8);
     VALUES.put("ro.build.date.utc", 1277708400000L);  // Jun 28, 2010
     VALUES.put("ro.debuggable", 0);


### PR DESCRIPTION
### Proposed Changes

This patch sets `RELEASE` and `INCREMENTAL` to non-null values when running Robolectric. I chose two somewhat arbitrary values; in particular, I chose "2.2" for the version string to keep it in
sync with `SDK_INT`.

It would be cool if the values depended on the selected SDK though. I guess it's a matter of making the shadow API-dependent?