### PR TITLE
Attach ContentProvider's info before creation, set authority field

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
@@ -10,6 +10,7 @@ import android.content.ContentValues;
 import android.content.IContentProvider;
 import android.content.OperationApplicationException;
 import android.content.PeriodicSync;
+import android.content.pm.ProviderInfo;
 import android.content.res.AssetFileDescriptor;
 import android.database.ContentObserver;
 import android.database.Cursor;
@@ -573,6 +574,9 @@ public class ShadowContentResolver {
   private static ContentProvider createAndInitialize(ContentProviderData providerData) {
     try {
       ContentProvider provider = (ContentProvider) Class.forName(providerData.getClassName()).newInstance();
+      ProviderInfo providerInfo = new ProviderInfo();
+      providerInfo.authority = providerData.getAuthority();
+      provider.attachInfo(RuntimeEnvironment.application, providerInfo);
       provider.onCreate();
       return provider;
     } catch (InstantiationException | ClassNotFoundException | IllegalAccessException e) {


### PR DESCRIPTION
### Overview

While testing data loading flow, we get exceptions like 

```
Caused by: java.lang.SecurityException: The authority of the uri content://com.yandex.mail.data/content/account/folders/1 does not match the one of the contentProvider: null
    at android.content.ContentProvider.validateIncomingUri(ContentProvider.java:1795)
    at android.content.ContentProvider.access$000(ContentProvider.java:90)
    at android.content.ContentProvider$Transport.query(ContentProvider.java:202)
    at android.content.ContentResolver.query(ContentResolver.java:478)
    at android.content.CursorLoader.loadInBackground(CursorLoader.java:64)
    at android.content.CursorLoader.loadInBackground(CursorLoader.java:42)
    at org.robolectric.shadows.ShadowAsyncTaskLoader$BackgroundWorker.call(ShadowAsyncTaskLoader.java:54)
    at org.robolectric.util.SimpleFuture.run(SimpleFuture.java:56)
    ... 45 more
```

### Proposed Changes

Attaching `ContentProvider`'s info resolves this issue.
