### PR TITLE
Add Robolectric.buildContextWrapper()

### DIFF
--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -3,15 +3,18 @@ package org.robolectric;
 import android.app.Activity;
 import android.app.Fragment;
 import android.app.Service;
+import android.content.Context;
+import android.content.ContextWrapper;
 import android.content.Intent;
 
+import org.robolectric.internal.ShadowProvider;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.util.ActivityController;
 import org.robolectric.util.FragmentController;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
 import org.robolectric.util.Scheduler;
 import org.robolectric.util.ServiceController;
-import org.robolectric.internal.ShadowProvider;
 
 import java.util.ServiceLoader;
 
@@ -46,6 +49,17 @@ public class Robolectric {
       }
     }
     return shadowsAdapter;
+  }
+
+  /**
+   * Creates an instance of a {@link ContextWrapper} subclass and attaches it to the environments base context.
+   * @param contextWrapperClass ContextWrapper implementation class.
+   * @param constructorArgs constructor arguments.
+   */
+  public static <T extends ContextWrapper> T buildContextWrapper(Class<T> contextWrapperClass, ClassParameter<?>... constructorArgs) {
+    T instance = ReflectionHelpers.callConstructor(contextWrapperClass, constructorArgs);
+    ReflectionHelpers.callInstanceMethod(contextWrapperClass, instance, "attachBaseContext", ClassParameter.from(Context.class, RuntimeEnvironment.application.getBaseContext()));
+    return instance;
   }
 
   public static <T extends Service> ServiceController<T> buildService(Class<T> serviceClass) {

--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -58,7 +58,7 @@ public class Robolectric {
    */
   public static <T extends ContextWrapper> T buildContextWrapper(Class<T> contextWrapperClass, ClassParameter<?>... constructorArgs) {
     T instance = ReflectionHelpers.callConstructor(contextWrapperClass, constructorArgs);
-    ReflectionHelpers.callInstanceMethod(contextWrapperClass, instance, "attachBaseContext", ClassParameter.from(Context.class, RuntimeEnvironment.application.getBaseContext()));
+    ReflectionHelpers.callInstanceMethod(ContextWrapper.class, instance, "attachBaseContext", ClassParameter.from(Context.class, RuntimeEnvironment.application.getBaseContext()));
     return instance;
   }
 

--- a/robolectric/src/test/java/org/robolectric/RobolectricTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTest.java
@@ -3,6 +3,7 @@ package org.robolectric;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
@@ -17,15 +18,16 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.internal.Shadow;
+import org.robolectric.internal.ShadowProvider;
 import org.robolectric.res.builder.RobolectricPackageManager;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowDisplay;
 import org.robolectric.shadows.ShadowLooper;
 import org.robolectric.shadows.ShadowView;
 import org.robolectric.shadows.StubViewRoot;
-import org.robolectric.internal.Shadow;
-import org.robolectric.internal.ShadowProvider;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
 import org.robolectric.util.TestOnClickListener;
 
 import java.io.ByteArrayOutputStream;
@@ -38,7 +40,8 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.WithDefaults.class)
@@ -237,5 +240,27 @@ public class RobolectricTest {
     public boolean isVisible() {
       return getWindow().getDecorView().getWindowToken() != null;
     }
+  }
+
+  @Test
+  public void testBuildContextWrapper() {
+    MyContextWrapper contextWrapper = Robolectric.buildContextWrapper(MyContextWrapper.class, ClassParameter.from(String.class, "A String"));
+    assertThat(contextWrapper.getBaseContext()).isNotNull();
+    assertThat(contextWrapper.someText).isEqualTo("A String");
+  }
+
+  private static class MyContextWrapper extends ContextWrapper {
+
+    String someText;
+
+    public MyContextWrapper() {
+      super(null);
+    }
+
+    public MyContextWrapper(String someText) {
+      this();
+      this.someText = someText;
+    }
+
   }
 }


### PR DESCRIPTION
### Overview

Since we ripped out a fake implementation code in ShadowContextWrapper, real Android requires an attached base context for any components that call through or up to ContextWrapper.

### Proposed Changes

This change makes it easier for tests testing subclasses of ContextWrapper by instantiating the class and wiring up the base context. Also supports passing constructor arguments.