### PR TITLE
Set Build.Version.RELEASE and Build.Version.INCREMENTAL

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSystemProperties.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSystemProperties.java
@@ -18,6 +18,8 @@ public class ShadowSystemProperties {
   private static final Set<String> alreadyWarned = new HashSet<>();
 
   static {
+    VALUES.put("ro.build.version.release", "2.2");
+    VALUES.put("ro.build.version.incremental", "0");
     VALUES.put("ro.build.version.sdk", 8);
     VALUES.put("ro.build.date.utc", 1277708400000L);  // Jun 28, 2010
     VALUES.put("ro.debuggable", 0);

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -244,7 +244,11 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
             parallelUniverseInterface.setSdkConfig(sdkEnvironment.getSdkConfig());
 
             int sdkVersion = pickSdkVersion(config, appManifest);
-            ReflectionHelpers.setStaticField(sdkEnvironment.bootstrappedClass(Build.VERSION.class), "SDK_INT", sdkVersion);
+            ReflectionHelpers.setStaticField(sdkEnvironment.bootstrappedClass(Build.VERSION.class),
+                "SDK_INT", sdkVersion);
+            SdkConfig sdkConfig = new SdkConfig(sdkVersion);
+            ReflectionHelpers.setStaticField(sdkEnvironment.bootstrappedClass(Build.VERSION.class),
+                "RELEASE", sdkConfig.getAndroidVersion());
 
             ResourceLoader systemResourceLoader = sdkEnvironment.getSystemResourceLoader(getJarResolver());
             setUpApplicationState(bootstrappedMethod, parallelUniverseInterface, systemResourceLoader, appManifest, config);

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
@@ -3,6 +3,7 @@ package org.robolectric;
 import android.app.Application;
 import android.content.res.Resources;
 
+import android.os.Build;
 import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -14,7 +15,6 @@ import org.mockito.stubbing.Answer;
 import org.robolectric.annotation.Config;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.builder.RobolectricPackageManager;
-import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.util.ReflectionHelpers;
 
 import java.lang.reflect.Method;
@@ -55,9 +55,9 @@ public class RobolectricTestRunnerSelfTest {
 
   @Test
   public void setStaticValue_shouldIgnoreFinalModifier() {
-    ReflectionHelpers.setStaticField(android.os.Build.class, "MODEL", "expected value");
+    ReflectionHelpers.setStaticField(Build.class, "MODEL", "expected value");
 
-    assertThat(android.os.Build.MODEL).isEqualTo("expected value");
+    assertThat(Build.MODEL).isEqualTo("expected value");
   }
 
   @Test
@@ -98,6 +98,14 @@ public class RobolectricTestRunnerSelfTest {
     assertThat(RuntimeEnvironment.isMainThread()).isTrue();
   }
 
+  @Test
+  @Config(sdk = Build.VERSION_CODES.KITKAT)
+  public void testVersionConfiguration() {
+    assertThat(Build.VERSION.SDK_INT)
+        .isEqualTo(Build.VERSION_CODES.KITKAT);
+    assertThat(Build.VERSION.RELEASE)
+        .isEqualTo("4.4_r1");
+  }
 
   @AfterClass
   public static void resetStaticState_shouldBeCalled_afterAppTearDown() {


### PR DESCRIPTION
### Proposed Changes

This patch sets RELEASE and INCREMENTAL to non-null values when running Robolectric. I chose an arbitrary value for INCREMENTAL, and I'm setting release to a release number that matches the SDK,
using the release names in SdkConfig.