### PR TITLE
Add a shadow for BitmapRegionDecoder

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowBitmapRegionDecoder.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowBitmapRegionDecoder.java.vm
@@ -1,0 +1,57 @@
+package org.robolectric.shadows;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.BitmapRegionDecoder;
+import android.graphics.Rect;
+
+import android.os.Build;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.util.ReflectionHelpers;
+
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Shadow for {@code android.graphics.BitmapRegionDecoder}.
+ */
+@Implements(BitmapRegionDecoder.class)
+public class ShadowBitmapRegionDecoder {
+  @Implementation
+  public static BitmapRegionDecoder newInstance(byte[] data, int offset, int length, boolean isShareable) throws IOException {
+    return newInstance();
+  }
+
+  @Implementation
+  public static BitmapRegionDecoder newInstance(FileDescriptor fd, boolean isShareable) throws IOException {
+    return newInstance();
+  }
+
+  @Implementation
+  public static BitmapRegionDecoder newInstance(InputStream is, boolean isShareable) throws IOException {
+    return newInstance();
+  }
+
+  @Implementation
+  public static BitmapRegionDecoder newInstance(String pathName, boolean isShareable) throws IOException {
+    return newInstance();
+  }
+
+  @Implementation
+  public Bitmap decodeRegion(Rect rect, BitmapFactory.Options options) {
+    return Bitmap.createBitmap(rect.width(), rect.height(),
+        options.inPreferredConfig != null ? options.inPreferredConfig : Bitmap.Config.ARGB_8888);
+  }
+
+  private static BitmapRegionDecoder newInstance() {
+#if ($api < 21)
+    return ReflectionHelpers.callConstructor(BitmapRegionDecoder.class,
+        new ReflectionHelpers.ClassParameter<>(int.class, 0));
+#else
+      return ReflectionHelpers.callConstructor(BitmapRegionDecoder.class,
+          new ReflectionHelpers.ClassParameter<>(long.class, 0L));
+#end
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapRegionDecoderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapRegionDecoderTest.java
@@ -1,0 +1,55 @@
+package org.robolectric.shadows;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.BitmapRegionDecoder;
+import android.graphics.Rect;
+import org.apache.tools.ant.filters.StringInputStream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.TestRunners;
+
+import java.io.FileDescriptor;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+public class ShadowBitmapRegionDecoderTest {
+  @Test
+  public void testNewInstance() throws IOException {
+    assertThat(BitmapRegionDecoder.newInstance(new byte[] {}, 0, 0, false))
+        .isNotNull();
+    assertThat(BitmapRegionDecoder.newInstance(new FileDescriptor(), false))
+        .isNotNull();
+    assertThat(BitmapRegionDecoder.newInstance(new StringInputStream("test"), false))
+        .isNotNull();
+    assertThat(BitmapRegionDecoder.newInstance("test", false))
+        .isNotNull();
+  }
+
+  @Test
+  public void testDecodeRegionReturnsExpectedSize() throws IOException {
+    BitmapRegionDecoder bitmapRegionDecoder = BitmapRegionDecoder.newInstance("test", false);
+    Bitmap bitmap = bitmapRegionDecoder.decodeRegion(new Rect(10, 20, 110, 220), new BitmapFactory.Options());
+    assertThat(bitmap.getWidth())
+        .isEqualTo(100);
+    assertThat(bitmap.getHeight())
+        .isEqualTo(200);
+  }
+
+  @Test
+  public void testDecodeRegionReturnsExpectedConfig() throws IOException {
+    BitmapRegionDecoder bitmapRegionDecoder = BitmapRegionDecoder.newInstance("test", false);
+
+    BitmapFactory.Options options = new BitmapFactory.Options();
+    assertThat(bitmapRegionDecoder.decodeRegion(new Rect(0, 0, 1, 1), options).getConfig())
+        .isEqualTo(Bitmap.Config.ARGB_8888);
+    options.inPreferredConfig = null;
+    assertThat(bitmapRegionDecoder.decodeRegion(new Rect(0, 0, 1, 1), options).getConfig())
+        .isEqualTo(Bitmap.Config.ARGB_8888);
+    options.inPreferredConfig = Bitmap.Config.RGB_565;
+    assertThat(bitmapRegionDecoder.decodeRegion(new Rect(0, 0, 1, 1), options).getConfig())
+        .isEqualTo(Bitmap.Config.RGB_565);
+  }
+}


### PR DESCRIPTION
### Proposed Changes

This patch adds a simple shadow for BitmapRegionDecoder. The shadow
doesn't attempt to use the underlying bitmap, but implements the
basic functionality of creating new instances and bitmaps of the
required size.