### PR TITLE
Implement shadow for BitmapFactory.decodeFileDescriptor

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmap.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmap.java
@@ -11,6 +11,7 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.res.ResName;
 import org.robolectric.util.ReflectionHelpers;
 
+import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -34,6 +35,7 @@ public class ShadowBitmap {
   int createdFromResId = -1;
   String createdFromPath;
   InputStream createdFromStream;
+  FileDescriptor createdFromFileDescriptor;
   byte[] createdFromBytes;
   private Bitmap createdFromBitmap;
   private int createdFromX = -1;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -7,26 +7,27 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.net.Uri;
 import android.util.TypedValue;
-import java.util.Iterator;
-import javax.imageio.ImageReader;
-import javax.imageio.stream.ImageInputStream;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
+import org.robolectric.internal.Shadow;
+import org.robolectric.util.Join;
 import org.robolectric.util.NamedStream;
 import org.robolectric.util.ReflectionHelpers;
-import org.robolectric.util.Join;
-import org.robolectric.internal.Shadow;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.CRC32;
@@ -85,6 +86,14 @@ public class ShadowBitmapFactory {
     Bitmap bitmap = create("file:" + pathName, options);
     ShadowBitmap shadowBitmap = Shadows.shadowOf(bitmap);
     shadowBitmap.createdFromPath = pathName;
+    return bitmap;
+  }
+
+  @Implementation
+  public static Bitmap decodeFileDescriptor(FileDescriptor fd, Rect outPadding, BitmapFactory.Options opts) {
+    Bitmap bitmap = create("fd:" + fd, opts);
+    ShadowBitmap shadowBitmap = Shadows.shadowOf(bitmap);
+    shadowBitmap.createdFromFileDescriptor = fd;
     return bitmap;
   }
 
@@ -183,6 +192,10 @@ public class ShadowBitmapFactory {
 
   public static void provideWidthAndHeightHints(String file, int width, int height) {
     widthAndHeightMap.put("file:" + file, new Point(width, height));
+  }
+
+  public static void provideWidthAndHeightHints(FileDescriptor fd, int width, int height) {
+    widthAndHeightMap.put("fd:" + fd, new Point(width, height));
   }
 
   private static String stringify(BitmapFactory.Options options) {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapFactoryTest.java
@@ -10,12 +10,17 @@ import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.shadows.util.DataSource;
 
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
 import java.io.InputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.shadows.util.DataSource.toDataSource;
 
 @RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowBitmapFactoryTest {
@@ -141,6 +146,28 @@ public class ShadowBitmapFactoryTest {
     assertEquals("Bitmap for content:/path", shadowOf(bitmap).getDescription());
     assertEquals(123, bitmap.getWidth());
     assertEquals(456, bitmap.getHeight());
+  }
+
+  @Test
+  public void decodeFileDescriptor_shouldGetWidthAndHeightFromHints() throws Exception {
+    File tmpFile = File.createTempFile("BitmapFactoryTest", null);
+    try {
+      tmpFile.deleteOnExit();
+      FileInputStream is = new FileInputStream(tmpFile);
+      try {
+        FileDescriptor fd = is.getFD();
+        ShadowBitmapFactory.provideWidthAndHeightHints(fd, 123, 456);
+
+        Bitmap bitmap = BitmapFactory.decodeFileDescriptor(fd);
+        assertEquals("Bitmap for fd:" + fd, shadowOf(bitmap).getDescription());
+        assertEquals(123, bitmap.getWidth());
+        assertEquals(456, bitmap.getHeight());
+      } finally {
+        is.close();
+      }
+    } finally {
+      tmpFile.delete();
+    }
   }
 
   @Test


### PR DESCRIPTION
### Proposed Changes

Add a shadow for the decodeFileDescriptor method, following the pattern of the rest of the decode methods.