### PR TITLE
Don't create a new Paint object when creating paint history event objects

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCanvas.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCanvas.java
@@ -306,7 +306,7 @@ public class ShadowCanvas {
 
     private LinePaintHistoryEvent(
         float startX, float startY, float stopX, float stopY, Paint paint) {
-      this.paint = new Paint(paint);
+      this.paint = paint;
       this.paint.setColor(paint.getColor());
       this.paint.setStrokeWidth(paint.getStrokeWidth());
       this.startX = startX;
@@ -322,7 +322,7 @@ public class ShadowCanvas {
 
     private OvalPaintHistoryEvent(RectF oval, Paint paint) {
       this.oval = new RectF(oval);
-      this.paint = new Paint(paint);
+      this.paint = paint;
       this.paint.setColor(paint.getColor());
       this.paint.setStrokeWidth(paint.getStrokeWidth());
     }
@@ -339,7 +339,7 @@ public class ShadowCanvas {
     private RectPaintHistoryEvent(
         float left, float top, float right, float bottom, Paint paint){
       this.rect = new RectF(left, top, right, bottom);
-      this.paint = new Paint(paint);
+      this.paint = paint;
       this.paint.setColor(paint.getColor());
       this.paint.setStrokeWidth(paint.getStrokeWidth());
       this.paint.setTextSize(paint.getTextSize());


### PR DESCRIPTION
Creating a new Paint object looses the information that the ShadowPaint object had.
This was working properly for CirclePaintHistoryEvent, adjusting the other events to do the same.