### PR TITLE
Rely on RuntimeEnvironment.application to fetch resources in a fake.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenu.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenu.java
@@ -20,10 +20,6 @@ public class RoboMenu implements Menu {
   private List<MenuItem> menuItems = new ArrayList<>();
   private Context context;
 
-  public RoboMenu() {
-    this(null);
-  }
-
   public RoboMenu(Context context) {
     this.context = context;
   }
@@ -40,7 +36,7 @@ public class RoboMenu implements Menu {
 
   @Override
   public MenuItem add(int groupId, int itemId, int order, CharSequence title) {
-    RoboMenuItem menuItem = new RoboMenuItem();
+    RoboMenuItem menuItem = new RoboMenuItem(context);
     menuItem.setOrder(order);
     menuItems.add(menuItem);
     menuItem.setGroupId(groupId);
@@ -57,8 +53,8 @@ public class RoboMenu implements Menu {
 
   @Override
   public SubMenu addSubMenu(CharSequence title) {
-    RoboSubMenu tsm = new RoboSubMenu();
-    RoboMenuItem menuItem = new RoboMenuItem();
+    RoboSubMenu tsm = new RoboSubMenu(context);
+    RoboMenuItem menuItem = new RoboMenuItem(context);
     menuItems.add(menuItem);
     menuItem.setTitle(title);
     menuItem.setSubMenu(tsm);
@@ -67,8 +63,8 @@ public class RoboMenu implements Menu {
 
   @Override
   public SubMenu addSubMenu(int titleRes) {
-    RoboSubMenu tsm = new RoboSubMenu();
-    RoboMenuItem menuItem = new RoboMenuItem();
+    RoboSubMenu tsm = new RoboSubMenu(context);
+    RoboMenuItem menuItem = new RoboMenuItem(context);
     menuItems.add(menuItem);
     menuItem.setTitle(titleRes);
     menuItem.setSubMenu(tsm);
@@ -77,8 +73,8 @@ public class RoboMenu implements Menu {
 
   @Override
   public SubMenu addSubMenu(int groupId, int itemId, int order, CharSequence title) {
-    RoboSubMenu tsm = new RoboSubMenu();
-    RoboMenuItem menuItem = new RoboMenuItem();
+    RoboSubMenu tsm = new RoboSubMenu(context);
+    RoboMenuItem menuItem = new RoboMenuItem(context);
     menuItems.add(menuItem);
     menuItem.setGroupId(groupId);
     menuItem.setItemId(itemId);
@@ -89,8 +85,8 @@ public class RoboMenu implements Menu {
 
   @Override
   public SubMenu addSubMenu(int groupId, int itemId, int order, int titleRes) {
-    RoboSubMenu tsm = new RoboSubMenu();
-    RoboMenuItem menuItem = new RoboMenuItem();
+    RoboSubMenu tsm = new RoboSubMenu(context);
+    RoboMenuItem menuItem = new RoboMenuItem(context);
     menuItems.add(menuItem);
     menuItem.setGroupId(groupId);
     menuItem.setItemId(itemId);
@@ -214,3 +210,4 @@ public class RoboMenu implements Menu {
     }
   }
 }
+

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenuItem.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenuItem.java
@@ -1,5 +1,6 @@
 package org.robolectric.fakes;
 
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
 import android.view.ActionProvider;
@@ -7,9 +8,6 @@ import android.view.ContextMenu;
 import android.view.MenuItem;
 import android.view.SubMenu;
 import android.view.View;
-
-import org.robolectric.RuntimeEnvironment;
-import org.robolectric.shadows.ShadowApplication;
 
 /**
  * Robolectric implementation of {@link android.view.MenuItem}.
@@ -30,8 +28,10 @@ public class RoboMenuItem implements MenuItem {
   private View actionView;
   private OnActionExpandListener actionExpandListener;
   private int order;
+  private Context context;
 
-  public RoboMenuItem() {
+  public RoboMenuItem(Context context) {
+    this.context = context;
   }
 
   public RoboMenuItem(int itemId) {
@@ -99,7 +99,7 @@ public class RoboMenuItem implements MenuItem {
 
   @Override
   public MenuItem setIcon(int iconRes) {
-    this.icon = iconRes == 0 ? null : RuntimeEnvironment.application.getResources().getDrawable(iconRes);
+    this.icon = iconRes == 0 ? null : context.getResources().getDrawable(iconRes);
     return this;
   }
 
@@ -217,7 +217,7 @@ public class RoboMenuItem implements MenuItem {
     if (enabled && menuItemClickListener != null) {
       menuItemClickListener.onMenuItemClick(this);
     } else if (enabled && intent != null) {
-      ShadowApplication.getInstance().startActivity(intent);
+      context.startActivity(intent);
     }
   }
 
@@ -295,3 +295,4 @@ public class RoboMenuItem implements MenuItem {
     return this;
   }
 }
+

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboSubMenu.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboSubMenu.java
@@ -1,5 +1,6 @@
 package org.robolectric.fakes;
 
+import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.view.MenuItem;
 import android.view.SubMenu;
@@ -9,6 +10,10 @@ import android.view.View;
  * Robolectric implementation of {@link android.view.SubMenu}.
  */
 public class RoboSubMenu extends RoboMenu implements SubMenu {
+
+  public RoboSubMenu(Context context) {
+    super(context);
+  }
 
   @Override
   public SubMenu setHeaderTitle(int titleRes) {
@@ -54,3 +59,4 @@ public class RoboSubMenu extends RoboMenu implements SubMenu {
     return null;
   }
 }
+

--- a/robolectric/src/test/java/org/robolectric/fakes/RoboMenuItemTest.java
+++ b/robolectric/src/test/java/org/robolectric/fakes/RoboMenuItemTest.java
@@ -20,7 +20,7 @@ public class RoboMenuItemTest {
 
   @Before
   public void setUp() throws Exception {
-    item = new RoboMenuItem();
+    item = new RoboMenuItem(RuntimeEnvironment.application);
     listener =  new TestOnActionExpandListener();
     item.setOnActionExpandListener(listener);
   }


### PR DESCRIPTION
### Overview
Prior to this change, usage of this API resulted in a NullPointerException.
The root cause of this was that the provided context to RoboMenu was not passed onto RoboSubMenu. First attempt to fix, was to pass the context along, but after reviewing RoboSubMenuItem, I decided it'd be better to stick with a simpler approach.
  
### Proposed Changes
Explicitly pass in a Context to RoboMenu/RoboSubMenu,RoboSubMenuItem