### PR TITLE
Qualifiers cleanup

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/ShadowsAdapter.java
+++ b/robolectric-resources/src/main/java/org/robolectric/ShadowsAdapter.java
@@ -2,8 +2,8 @@ package org.robolectric;
 
 import android.app.Activity;
 import android.app.Application;
-import android.content.res.AssetManager;
 import android.content.res.Configuration;
+
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.ResourceLoader;
 import org.robolectric.util.Scheduler;
@@ -31,8 +31,6 @@ public interface ShadowsAdapter {
   void overrideQualifiers(Configuration configuration, String qualifiers);
 
   void bind(Application application, AndroidManifest appManifest, ResourceLoader resourceLoader);
-
-  void setAssetsQualifiers(AssetManager assets, String qualifiers);
 
   ResourceLoader getResourceLoader();
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
@@ -2,9 +2,9 @@ package org.robolectric.shadows;
 
 import android.app.Activity;
 import android.app.Application;
-import android.content.res.AssetManager;
 import android.content.res.Configuration;
 import android.os.Looper;
+
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.ShadowsAdapter;
@@ -85,11 +85,6 @@ public class CoreShadowsAdapter implements ShadowsAdapter {
   @Override
   public void bind(Application application, AndroidManifest appManifest, ResourceLoader resourceLoader) {
     shadowOf(application).bind(appManifest, resourceLoader);
-  }
-
-  @Override
-  public void setAssetsQualifiers(AssetManager assets, String qualifiers) {
-    shadowOf(assets).setQualifiers(qualifiers);
   }
 
   @Override

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -17,11 +17,11 @@ import android.util.TypedValue;
 import android.view.Display;
 
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
-import org.robolectric.annotation.HiddenApi;
 import org.robolectric.fakes.RoboAttributeSet;
 import org.robolectric.res.Attribute;
 import org.robolectric.res.Plural;
@@ -30,8 +30,8 @@ import org.robolectric.res.ResType;
 import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.TypedResource;
 import org.robolectric.res.builder.ResourceParser;
-import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.res.builder.XmlBlock;
+import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import java.io.FileInputStream;
@@ -42,8 +42,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import static org.robolectric.internal.Shadow.directlyOn;
 import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.internal.Shadow.directlyOn;
 
 /**
  * Shadow for {@link android.content.res.Resources}.
@@ -127,7 +127,7 @@ public class ShadowResources {
       if (attrName != null) {
         Attribute attribute = Attribute.find(set, attrName);
         TypedValue typedValue = new TypedValue();
-        Converter.convertAndFill(attribute, typedValue, resourceLoader, shadowAssetManager.getQualifiers(), true);
+        Converter.convertAndFill(attribute, typedValue, resourceLoader, RuntimeEnvironment.getQualifiers(), true);
 
         if (attribute != null && !attribute.isNull()) {
           //noinspection PointlessArithmeticExpression
@@ -165,10 +165,10 @@ public class ShadowResources {
   public String getQuantityString(int id, int quantity) throws Resources.NotFoundException {
     ShadowAssetManager shadowAssetManager = shadowOf(realResources.getAssets());
     ResName resName = shadowAssetManager.getResName(id);
-    Plural plural = shadowAssetManager.getResourceLoader().getPlural(resName, quantity, shadowAssetManager.getQualifiers());
+    Plural plural = shadowAssetManager.getResourceLoader().getPlural(resName, quantity, RuntimeEnvironment.getQualifiers());
     String string = plural.getString();
     TypedResource<?> typedResource = shadowAssetManager.resolve(
-        new TypedResource<>(string, ResType.CHAR_SEQUENCE), shadowAssetManager.getQualifiers(),
+        new TypedResource<>(string, ResType.CHAR_SEQUENCE), RuntimeEnvironment.getQualifiers(),
         new ResName(resName.packageName, "string", resName.name));
     return typedResource == null ? null : typedResource.asString();
   }
@@ -225,7 +225,7 @@ public class ShadowResources {
   public XmlResourceParser loadXmlResourceParser(int id, String type) throws Resources.NotFoundException {
     ShadowAssetManager shadowAssetManager = shadowOf(realResources.getAssets());
     ResName resName = shadowAssetManager.resolveResName(id);
-    XmlBlock block = shadowAssetManager.getResourceLoader().getXml(resName, shadowAssetManager.getQualifiers());
+    XmlBlock block = shadowAssetManager.getResourceLoader().getXml(resName, RuntimeEnvironment.getQualifiers());
     if (block == null) {
       throw new Resources.NotFoundException();
     }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -94,7 +94,7 @@ public final class ShadowAssetManager {
 
   @HiddenApi @Implementation
   public CharSequence getResourceText(int ident) {
-    TypedResource value = getAndResolve(ident, getQualifiers(), true);
+    TypedResource value = getAndResolve(ident, RuntimeEnvironment.getQualifiers(), true);
     if (value == null) return null;
     return (CharSequence) value.getData();
   }
@@ -126,7 +126,7 @@ public final class ShadowAssetManager {
 
   @HiddenApi @Implementation
   public boolean getResourceValue(int ident, int density, TypedValue outValue, boolean resolveRefs) {
-    TypedResource value = getAndResolve(ident, getQualifiers(), resolveRefs);
+    TypedResource value = getAndResolve(ident, RuntimeEnvironment.getQualifiers(), resolveRefs);
     if (value == null) return false;
 
     getConverter(value).fillTypedValue(value.getData(), outValue);
@@ -141,12 +141,12 @@ public final class ShadowAssetManager {
   public CharSequence[] getResourceTextArray(final int id) {
     ResName resName = getResourceLoader().getResourceIndex().getResName(id);
     if (resName == null) throw new Resources.NotFoundException("unknown resource " + id);
-    TypedResource value = getAndResolve(resName, getQualifiers(), true);
+    TypedResource value = getAndResolve(resName, RuntimeEnvironment.getQualifiers(), true);
     if (value == null) return null;
     TypedResource[] items = getConverter(value).getItems(value);
     CharSequence[] charSequences = new CharSequence[items.length];
     for (int i = 0; i < items.length; i++) {
-      TypedResource typedResource = resolve(items[i], getQualifiers(), resName);
+      TypedResource typedResource = resolve(items[i], RuntimeEnvironment.getQualifiers(), resName);
       charSequences[i] = getConverter(typedResource).asCharSequence(typedResource);
     }
     return charSequences;
@@ -179,7 +179,7 @@ public final class ShadowAssetManager {
         attrValue = getOverlayedThemeValue(attrResName, themeStyle, overlayThemeStyles);
       }
       if (attrValue != null) {
-        Converter.convertAndFill(attrValue, outValue, resourceLoader, getQualifiers(), resolveRefs);
+        Converter.convertAndFill(attrValue, outValue, resourceLoader, RuntimeEnvironment.getQualifiers(), resolveRefs);
         return true;
       }
     }
@@ -219,7 +219,7 @@ public final class ShadowAssetManager {
   @HiddenApi @Implementation
   public final InputStream openNonAsset(int cookie, String fileName, int accessMode) throws IOException {
     final ResName resName = qualifyFromNonAssetFileName(fileName);
-    final DrawableNode drawableNode = getResourceLoader().getDrawableNode(resName, getQualifiers());
+    final DrawableNode drawableNode = getResourceLoader().getDrawableNode(resName, RuntimeEnvironment.getQualifiers());
 
     if (drawableNode == null) {
       throw new IOException("Unable to find resource for " + fileName);
@@ -282,12 +282,12 @@ public final class ShadowAssetManager {
   public int[] getArrayIntResource(int arrayRes) {
     ResName resName = getResourceLoader().getResourceIndex().getResName(arrayRes);
     if (resName == null) throw new Resources.NotFoundException("unknown resource " + arrayRes);
-    TypedResource value = getAndResolve(resName, getQualifiers(), true);
+    TypedResource value = getAndResolve(resName, RuntimeEnvironment.getQualifiers(), true);
     if (value == null) return null;
     TypedResource[] items = getConverter(value).getItems(value);
     int[] ints = new int[items.length];
     for (int i = 0; i < items.length; i++) {
-      TypedResource typedResource = resolve(items[i], getQualifiers(), resName);
+      TypedResource typedResource = resolve(items[i], RuntimeEnvironment.getQualifiers(), resName);
       ints[i] = getConverter(typedResource).asInt(typedResource);
     }
     return ints;
@@ -373,10 +373,10 @@ public final class ShadowAssetManager {
   }
 
   Style resolveStyle(Style appTheme, @NotNull ResName themeStyleName) {
-    TypedResource themeStyleResource = resourceLoader.getValue(themeStyleName, getQualifiers());
+    TypedResource themeStyleResource = resourceLoader.getValue(themeStyleName, RuntimeEnvironment.getQualifiers());
     if (themeStyleResource == null) return null;
     StyleData themeStyleData = (StyleData) themeStyleResource.getData();
-    return new StyleResolver(resourceLoader, themeStyleData, appTheme, themeStyleName, getQualifiers());
+    return new StyleResolver(resourceLoader, themeStyleData, appTheme, themeStyleName, RuntimeEnvironment.getQualifiers());
   }
 
   TypedResource getAndResolve(int resId, String qualifiers, boolean resolveRefs) {
@@ -444,14 +444,6 @@ public final class ShadowAssetManager {
 
   public FsFile getAssetsDirectory() {
     return ShadowApplication.getInstance().getAppManifest().getAssetsDirectory();
-  }
-
-  public String getQualifiers() {
-    return RuntimeEnvironment.getQualifiers();
-  }
-
-  public void setQualifiers(String qualifiers) {
-    RuntimeEnvironment.setQualifiers(qualifiers);
   }
 
   private static class Resource {
@@ -794,7 +786,7 @@ public final class ShadowAssetManager {
   }
 
   @NotNull ResName resolveResName(int id) {
-    ResName resName = resolveResName(id, getQualifiers());
+    ResName resName = resolveResName(id, RuntimeEnvironment.getQualifiers());
     return checkResName(id, resName);
   }
 

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -159,7 +159,6 @@ public class ParallelUniverse implements ParallelUniverseInterface {
       ReflectionHelpers.setField(loadedApk, "mApplication", application);
 
       appResources.updateConfiguration(configuration, appResources.getDisplayMetrics());
-      shadowsAdapter.setAssetsQualifiers(appResources.getAssets(), qualifiers);
 
       application.onCreate();
     }

--- a/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
@@ -1,16 +1,14 @@
 package org.robolectric;
 
 import android.app.Application;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.Test;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.InitializationError;
-
-import android.content.res.Resources;
-import android.content.res.Configuration;
-
 import org.robolectric.annotation.Config;
 import org.robolectric.internal.ParallelUniverse;
 import org.robolectric.internal.SdkConfig;
@@ -23,7 +21,9 @@ import java.security.cert.CertificateFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @RunWith(TestRunners.WithDefaults.class)
 public class ParallelUniverseTest {
@@ -117,8 +117,7 @@ public class ParallelUniverseTest {
     Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "", "res", "assets", "build", new Class[0], new String[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("v18");
-    assertThat(getQualifiersFromAppAssetManager()).isEqualTo("v18");
-    assertThat(getQualifiersFromSystemAssetManager()).isEqualTo("v18");
+    assertThat(RuntimeEnvironment.getQualifiers()).isEqualTo("v18");
   }
   
   @Test
@@ -127,8 +126,7 @@ public class ParallelUniverseTest {
     Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "org.robolectric", "", "res", "assets", "build", new Class[0], new String[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("land-v17");
-    assertThat(getQualifiersFromAppAssetManager()).isEqualTo("land-v17");
-    assertThat(getQualifiersFromSystemAssetManager()).isEqualTo("land-v17");
+    assertThat(RuntimeEnvironment.getQualifiers()).isEqualTo("land-v17");
   }
   
   @Test
@@ -137,8 +135,7 @@ public class ParallelUniverseTest {
     Config c = new Config.Implementation(new int[0], Config.DEFAULT, givenQualifiers, "", "res", "assets", "", "build", new Class[0], new String[0], Application.class, new String[0], null);
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), null, null, c);
     assertThat(getQualifiersfromSystemResources()).isEqualTo("large-land-v18");
-    assertThat(getQualifiersFromAppAssetManager()).isEqualTo("large-land-v18");
-    assertThat(getQualifiersFromSystemAssetManager()).isEqualTo("large-land-v18");
+    assertThat(RuntimeEnvironment.getQualifiers()).isEqualTo("large-land-v18");
   }
   
   @Test
@@ -160,13 +157,5 @@ public class ParallelUniverseTest {
     Resources systemResources = Resources.getSystem();
     Configuration configuration = systemResources.getConfiguration();
     return Shadows.shadowOf(configuration).getQualifiers();
-  }
-
-  private String getQualifiersFromAppAssetManager() {
-    return Shadows.shadowOf(RuntimeEnvironment.application.getResources().getAssets()).getQualifiers();
-  }
-
-  private String getQualifiersFromSystemAssetManager() {
-    return Shadows.shadowOf(Resources.getSystem().getAssets()).getQualifiers();
   }
 }

--- a/robolectric/src/test/java/org/robolectric/QualifiersTest.java
+++ b/robolectric/src/test/java/org/robolectric/QualifiersTest.java
@@ -5,7 +5,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.robolectric.Shadows.shadowOf;
 
 @Config(qualifiers = "en")
 @RunWith(TestRunners.WithDefaults.class)
@@ -14,13 +13,13 @@ public class QualifiersTest {
   @Test
   public void shouldGetFromClass() throws Exception {
     String expectedQualifiers = "en" + TestRunners.WithDefaults.SDK_TARGETED_BY_MANIFEST;
-    assertThat(shadowOf(RuntimeEnvironment.application.getAssets()).getQualifiers()).isEqualTo(expectedQualifiers);
+    assertThat(RuntimeEnvironment.getQualifiers()).isEqualTo(expectedQualifiers);
   }
 
   @Test @Config(qualifiers = "fr")
   public void shouldGetFromMethod() throws Exception {
     String expectedQualifiers = "fr" + TestRunners.WithDefaults.SDK_TARGETED_BY_MANIFEST;
-    assertThat(shadowOf(RuntimeEnvironment.application.getAssets()).getQualifiers()).isEqualTo(expectedQualifiers);
+    assertThat(RuntimeEnvironment.getQualifiers()).isEqualTo(expectedQualifiers);
   }
 
   @Test @Config(qualifiers = "de")

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
@@ -2,8 +2,8 @@ package org.robolectric;
 
 import android.app.Application;
 import android.content.res.Resources;
-
 import android.os.Build;
+
 import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -64,7 +64,7 @@ public class RobolectricTestRunnerSelfTest {
   @Config(qualifiers = "fr")
   public void internalBeforeTest_testValuesResQualifiers() {
     String expectedQualifiers = "fr" + TestRunners.WithDefaults.SDK_TARGETED_BY_MANIFEST;
-    assertThat(shadowOf(RuntimeEnvironment.application.getAssets()).getQualifiers()).isEqualTo(expectedQualifiers);
+    assertThat(RuntimeEnvironment.getQualifiers()).isEqualTo(expectedQualifiers);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/res/DrawableResourceLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DrawableResourceLoaderTest.java
@@ -9,21 +9,18 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
 import android.graphics.drawable.NinePatchDrawable;
 
-import com.google.android.apps.common.testing.accessibility.framework.proto.FrameworkProtos;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
-import org.robolectric.shadows.ShadowApplication;
+import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.robolectric.RuntimeEnvironment.application;
-import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.util.TestUtil.TEST_PACKAGE;
 import static org.robolectric.util.TestUtil.assertInstanceOf;
 import static org.robolectric.util.TestUtil.systemResources;
@@ -84,13 +81,12 @@ public class DrawableResourceLoaderTest {
   }
 
   @Test
+  @Config(qualifiers = "xlarge")
   public void testLayerDrawable() {
     Resources resources = RuntimeEnvironment.application.getResources();
     Drawable drawable = resources.getDrawable(R.drawable.rainbow);
     assertThat(drawable).isInstanceOf(LayerDrawable.class);
     assertEquals(8, ((LayerDrawable) drawable).getNumberOfLayers());
-
-    shadowOf(resources.getAssets()).setQualifiers("xlarge");
 
     assertEquals(6, ((LayerDrawable) resources.getDrawable(R.drawable.rainbow)).getNumberOfLayers());
   }

--- a/robolectric/src/test/java/org/robolectric/res/DrawableResourceLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DrawableResourceLoaderTest.java
@@ -82,13 +82,13 @@ public class DrawableResourceLoaderTest {
 
   @Test
   @Config(qualifiers = "xlarge")
-  public void testLayerDrawable() {
-    Resources resources = RuntimeEnvironment.application.getResources();
-    Drawable drawable = resources.getDrawable(R.drawable.rainbow);
-    assertThat(drawable).isInstanceOf(LayerDrawable.class);
-    assertEquals(8, ((LayerDrawable) drawable).getNumberOfLayers());
+  public void testLayerDrawable_xlarge() {
+    assertEquals(6, ((LayerDrawable) RuntimeEnvironment.application.getResources().getDrawable(R.drawable.rainbow)).getNumberOfLayers());
+  }
 
-    assertEquals(6, ((LayerDrawable) resources.getDrawable(R.drawable.rainbow)).getNumberOfLayers());
+  @Test
+  public void testLayerDrawable() {
+    assertEquals(8, ((LayerDrawable) RuntimeEnvironment.application.getResources().getDrawable(R.drawable.rainbow)).getNumberOfLayers());
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 import org.robolectric.util.Strings;
 
 import java.io.ByteArrayInputStream;
@@ -25,7 +26,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.util.TestUtil.joinPath;
 
 @RunWith(TestRunners.MultiApiWithDefaults.class)
@@ -128,9 +128,8 @@ public class ShadowAssetManagerTest {
   }
 
   @Test
+  @Config(qualifiers = "mdpi")
   public void openNonAssetShouldOpenCorrectAssetBasedOnQualifierMdpi() throws IOException {
-    shadowOf(assetManager).setQualifiers("mdpi");
-
     InputStream inputStream = assetManager.openNonAsset(0, "./res/drawable/robolectric.png", 0);
 
     ByteArrayInputStream byteArrayInputStream = (ByteArrayInputStream) inputStream;
@@ -138,9 +137,8 @@ public class ShadowAssetManagerTest {
   }
 
   @Test
+  @Config(qualifiers = "hdpi")
   public void openNonAssetShouldOpenCorrectAssetBasedOnQualifierHdpi() throws IOException {
-    shadowOf(assetManager).setQualifiers("hdpi");
-
     InputStream inputStream = assetManager.openNonAsset(0, "./res/drawable/robolectric.png", 0);
 
     ByteArrayInputStream byteArrayInputStream = (ByteArrayInputStream) inputStream;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLayoutInflaterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLayoutInflaterTest.java
@@ -19,6 +19,7 @@ import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,15 +72,14 @@ public class ShadowLayoutInflaterTest {
 
   @Test @Config(qualifiers = "xlarge-land")
   public void testChoosesLayoutBasedOnSearchPath_choosesFirstFileFoundOnPath() throws Exception {
-//        resourceLoader.setLayoutQualifierSearchPath("xlarge", "land");
-    ViewGroup view = (ViewGroup) inflate("different_screen_sizes", "xlarge-land");
+    ViewGroup view = (ViewGroup) inflate("different_screen_sizes");
     TextView textView = (TextView) view.findViewById(android.R.id.text1);
     assertThat(textView.getText().toString()).isEqualTo("xlarge");
   }
 
   @Test @Config(qualifiers = "doesnotexist-land-xlarge")
   public void testChoosesLayoutBasedOnSearchPath_respectsOrderOfPath() throws Exception {
-    ViewGroup view = (ViewGroup) inflate("different_screen_sizes", "doesnotexist-land-xlarge");
+    ViewGroup view = (ViewGroup) inflate("different_screen_sizes");
     TextView textView = (TextView) view.findViewById(android.R.id.text1);
     assertThat(textView.getText().toString()).isEqualTo("land");
   }
@@ -116,7 +116,7 @@ public class ShadowLayoutInflaterTest {
     ViewGroup view = (ViewGroup) inflate("activity_list_item");
     assertInstanceOf(ImageView.class, view.findViewById(R.id.icon));
 
-    view = (ViewGroup) inflate("android", "activity_list_item", "");
+    view = (ViewGroup) inflate("android", "activity_list_item");
     assertInstanceOf(ImageView.class, view.findViewById(android.R.id.icon));
   }
 
@@ -176,7 +176,7 @@ public class ShadowLayoutInflaterTest {
   public void focusRequest_shouldNotExplodeOnViewRootImpl() throws Exception {
     LinearLayout parent = new LinearLayout(context);
     shadowOf(parent).setMyParent(new StubViewRoot());
-    inflate(context, TEST_PACKAGE, "request_focus", parent, "");
+    inflate(context, TEST_PACKAGE, "request_focus", parent);
   }
 
   @Test
@@ -286,7 +286,7 @@ public class ShadowLayoutInflaterTest {
   @Test
   public void shouldInflateMergeLayoutIntoParent() throws Exception {
     LinearLayout linearLayout = new LinearLayout(context);
-    View innerMerge = inflate(context, TEST_PACKAGE, "inner_merge", linearLayout, "");
+    View innerMerge = inflate(context, TEST_PACKAGE, "inner_merge", linearLayout);
     assertThat(linearLayout.getChildAt(0)).isInstanceOf(TextView.class);
   }
 
@@ -306,10 +306,16 @@ public class ShadowLayoutInflaterTest {
     TestUtil.assertInstanceOf(LinearLayout.class, view);
     assertEquals(view.getId(), R.id.portrait);
     assertSame(context, view.getContext());
+  }
+
+  @Test
+  @Config(qualifiers = "land")
+  public void testMultiOrientation_explicitLandscape() throws Exception {
+    context = buildActivity(Activity.class).create().start().resume().get();
 
     // Confirm explicit "orientation = landscape" works.
     context.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-    view = (ViewGroup) inflate("multi_orientation", "land");
+    ViewGroup view = (ViewGroup) inflate("multi_orientation");
     assertEquals(view.getId(), R.id.landscape);
     TestUtil.assertInstanceOf(LinearLayout.class, view);
   }
@@ -434,13 +440,12 @@ public class ShadowLayoutInflaterTest {
 
   /////////////////////////
 
-  private View inflate(String packageName, String layoutName, String qualifiers) {
-    return inflate(context, packageName, layoutName, null, qualifiers);
+  private View inflate(String packageName, String layoutName) {
+    return inflate(context, packageName, layoutName, null);
   }
 
-  public View inflate(Context context, String packageName, String key, ViewGroup parent, String qualifiers) {
+  private View inflate(Context context, String packageName, String key, ViewGroup parent) {
     ResName resName = new ResName(packageName + ":layout/" + key);
-    shadowOf(context.getAssets()).setQualifiers(qualifiers);
     ResourceLoader resourceLoader = shadowOf(context.getResources().getAssets()).getResourceLoader();
     Integer layoutResId = resourceLoader.getResourceIndex().getResourceId(resName);
     if (layoutResId == null) throw new AssertionError("no such resource " + resName);
@@ -448,11 +453,7 @@ public class ShadowLayoutInflaterTest {
   }
 
   private View inflate(String layoutName) {
-    return inflate(layoutName, "");
-  }
-
-  private View inflate(String layoutName, String qualifiers) {
-    return inflate(TEST_PACKAGE, layoutName, qualifiers);
+    return inflate(TEST_PACKAGE, layoutName);
   }
 
   private Drawable drawable(int id) {


### PR DESCRIPTION
### Overview

ShadowAssetManager + RuntimeEnvironment have redundant qualifier state

### Proposed Changes

Remove ShadowAssetManager's qualifier state in favor of using RuntimeEnvironment.

Update all tests calling RuntimeEnvironment.setQualifiers() to use @Config(qualifiers = ...)