### PR TITLE
ResourcePath / ResourceExtractor interface is convoluted cleanup.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -504,7 +504,7 @@ public class AndroidManifest {
 
   public ResourcePath getResourcePath() {
     validate();
-    return new ResourcePath(getRClass(), getPackageName(), resDirectory, assetsDirectory);
+    return new ResourcePath(getPackageName(), resDirectory, assetsDirectory, getRClass());
   }
 
   public List<ResourcePath> getIncludedResourcePaths() {

--- a/robolectric-resources/src/main/java/org/robolectric/res/RawResourceLoader.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/RawResourceLoader.java
@@ -8,8 +8,10 @@ public class RawResourceLoader {
   }
 
   public void loadTo(ResBundle<FsFile> rawResourceFiles) {
-    if (resourcePath.rawDir != null) {
-      FsFile[] files = resourcePath.rawDir.listFiles();
+    FsFile rawDir = resourcePath.resourceBase.join("raw");
+
+    if (rawDir != null) {
+      FsFile[] files = rawDir.listFiles();
       if (files != null) {
         for (FsFile file : files) {
           String fileBaseName = file.getBaseName();

--- a/robolectric-resources/src/main/java/org/robolectric/res/ResourcePath.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/ResourcePath.java
@@ -1,19 +1,18 @@
 package org.robolectric.res;
 
+import java.util.Arrays;
+
 public class ResourcePath {
-  public final Class<?> rClass;
   public final String packageName;
   public final FsFile resourceBase;
   public final FsFile assetsDir;
-  public final FsFile rawDir;
+  public Class<?>[] rClasses;
 
-  public ResourcePath(Class<?> rClass, String packageName, FsFile resourceBase, FsFile assetsDir) {
-    this.rClass = rClass;
+  public ResourcePath(String packageName, FsFile resourceBase, FsFile assetsDir, Class<?>... rClasses) {
     this.packageName = packageName;
     this.resourceBase = resourceBase;
     this.assetsDir = assetsDir;
-    FsFile rawDir = resourceBase.join("raw");
-    this.rawDir = rawDir.exists() ? rawDir : null;
+    this.rClasses = rClasses;
   }
 
   public String getPackageName() {
@@ -34,22 +33,18 @@ public class ResourcePath {
 
     if (!assetsDir.equals(that.assetsDir)) return false;
     if (!packageName.equals(that.packageName)) return false;
-    if (!(rClass == null ? that.rClass == null : rClass.equals(that.rClass))) return false;
-    if (!(rawDir == null ? that.rawDir == null : rawDir.equals(that.rawDir))) return false;
     if (!resourceBase.equals(that.resourceBase)) return false;
 
-    return true;
+    return Arrays.equals(rClasses, that.rClasses);
   }
 
   @Override
   public int hashCode() {
-    int result = rClass != null ? rClass.hashCode() : 0;
-    result = 31 * result + packageName.hashCode();
+    int result = 31 * packageName.hashCode();
     result = 31 * result + resourceBase.hashCode();
     result = 31 * result + assetsDir.hashCode();
-    if (rawDir != null) {
-      result = 31 * result + rawDir.hashCode();
-    }
+
+    result = 31 * result + Arrays.hashCode(rClasses);
     return result;
   }
 }

--- a/robolectric/src/test/java/org/robolectric/res/RawResourceLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/RawResourceLoaderTest.java
@@ -3,20 +3,21 @@ package org.robolectric.res;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.robolectric.R;
-import org.robolectric.TestRunners;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.util.TestUtil.TEST_RESOURCE_PATH;
 import static org.robolectric.util.TestUtil.testResources;
 
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(JUnit4.class)
 public class RawResourceLoaderTest {
 
   private ResourceExtractor resourceIndex;
   private ResBundle<FsFile> rawResourceFiles;
 
-  @Before public void setUp() throws Exception {
+  @Before
+  public void setUp() throws Exception {
     resourceIndex = new ResourceExtractor(testResources());
     rawResourceFiles = new ResBundle<>();
     RawResourceLoader rawResourceLoader = new RawResourceLoader(TEST_RESOURCE_PATH);
@@ -26,12 +27,12 @@ public class RawResourceLoaderTest {
   @Test
   public void shouldReturnRawResourcesWithExtensions() throws Exception {
     FsFile f = rawResourceFiles.get(resourceIndex.getResName(R.raw.raw_resource), "");
-    assertThat(f).isEqualTo(TEST_RESOURCE_PATH.rawDir.join("raw_resource.txt"));
+    assertThat(f).isEqualTo(TEST_RESOURCE_PATH.resourceBase.join("raw").join("raw_resource.txt"));
   }
 
   @Test
   public void shouldReturnRawResourcesWithoutExtensions() throws Exception {
     FsFile f = rawResourceFiles.get(resourceIndex.getResName(R.raw.raw_no_ext), "");
-    assertThat(f).isEqualTo(TEST_RESOURCE_PATH.rawDir.join("raw_no_ext"));
+    assertThat(f).isEqualTo(TEST_RESOURCE_PATH.resourceBase.join("raw").join("raw_no_ext"));
   }
 }

--- a/robolectric/src/test/java/org/robolectric/res/builder/XmlBlockLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/builder/XmlBlockLoaderTest.java
@@ -1,14 +1,14 @@
 package org.robolectric.res.builder;
 
 import android.content.res.XmlResourceParser;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.robolectric.R;
-import org.robolectric.TestRunners;
 import org.robolectric.res.DocumentLoader;
-import org.robolectric.res.MergedResourceIndex;
 import org.robolectric.res.ResBundle;
 import org.robolectric.res.ResName;
 import org.robolectric.res.ResourceExtractor;
@@ -20,14 +20,18 @@ import org.w3c.dom.Document;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,25 +52,22 @@ import static org.robolectric.util.TestUtil.testResources;
  *
  * @author msama (michele@swiftkey.net)
  */
-@RunWith(TestRunners.WithDefaults.class)
+@RunWith(JUnit4.class)
 public class XmlBlockLoaderTest {
 
   public static final String XMLNS_NS = "http://www.w3.org/2000/xmlns/";
-  private XmlBlockLoader xmlBlockLoader;
-  private XmlBlock xmlBlock;
   private XmlResourceParserImpl parser;
-  private ResBundle<XmlBlock> resBundle;
   private ResourceIndex resourceIndex;
 
   @Before
   public void setUp() throws Exception {
-    resBundle = new ResBundle<>();
-    xmlBlockLoader = new XmlBlockLoader(resBundle, "xml");
+    ResBundle<XmlBlock> resBundle = new ResBundle<>();
+    XmlBlockLoader xmlBlockLoader = new XmlBlockLoader(resBundle, "xml");
     new DocumentLoader(testResources()).load("xml", xmlBlockLoader);
 
     ResName resName = new ResName(TEST_PACKAGE, "xml", "preferences");
-    xmlBlock = resBundle.get(resName, "");
-    resourceIndex = new MergedResourceIndex(new ResourceExtractor(testResources()), new ResourceExtractor());
+    XmlBlock xmlBlock = resBundle.get(resName, "");
+    resourceIndex = new ResourceExtractor(testResources());
     parser = (XmlResourceParserImpl) ResourceParser.from(xmlBlock, TEST_PACKAGE, resourceIndex);
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
@@ -606,13 +606,6 @@ public class ShadowApplicationTest {
     return new AndroidManifest(Fs.newFile(f), null, null);
   }
 
-  private static class ImperviousResourceExtractor extends ResourceExtractor {
-    @Override
-    public ResName getResName(int resourceId) {
-      return new ResName("", "", "");
-    }
-  }
-
   private static class EmptyServiceConnection implements ServiceConnection {
     @Override
     public void onServiceConnected(ComponentName name, IBinder service) {}

--- a/robolectric/src/test/java/org/robolectric/util/TestUtil.java
+++ b/robolectric/src/test/java/org/robolectric/util/TestUtil.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class TestUtil {
   private static ResourcePath SYSTEM_RESOURCE_PATH;
-  public static final ResourcePath TEST_RESOURCE_PATH = new ResourcePath(R.class, R.class.getPackage().getName(), resourceFile("res"), resourceFile("assets"));
+  public static final ResourcePath TEST_RESOURCE_PATH = new ResourcePath(R.class.getPackage().getName(), resourceFile("res"), resourceFile("assets"), R.class);
   public static final String SYSTEM_PACKAGE = android.R.class.getPackage().getName();
   public static final String TEST_PACKAGE = R.class.getPackage().getName();
   public static final String TEST_PACKAGE_NS = Attribute.ANDROID_RES_NS_PREFIX + R.class.getPackage().getName();
@@ -87,28 +87,28 @@ public abstract class TestUtil {
   }
 
   public static ResourcePath lib1Resources() {
-    return new ResourcePath(org.robolectric.lib1.R.class, "org.robolectric.lib1", resourceFile("lib1/res"), resourceFile("lib1/assets"));
+    return new ResourcePath("org.robolectric.lib1", resourceFile("lib1/res"), resourceFile("lib1/assets"), org.robolectric.lib1.R.class);
   }
 
   public static ResourcePath lib2Resources() {
-    return new ResourcePath(org.robolectric.lib2.R.class, "org.robolectric.lib2", resourceFile("lib2/res"), resourceFile("lib2/assets"));
+    return new ResourcePath("org.robolectric.lib2", resourceFile("lib2/res"), resourceFile("lib2/assets"), org.robolectric.lib2.R.class);
   }
 
   public static ResourcePath lib3Resources() {
-    return new ResourcePath(org.robolectric.lib3.R.class, "org.robolectric.lib3", resourceFile("lib3/res"), resourceFile("lib3/assets"));
+    return new ResourcePath("org.robolectric.lib3", resourceFile("lib3/res"), resourceFile("lib3/assets"), org.robolectric.lib3.R.class);
   }
 
   public static ResourcePath systemResources() {
     if (SYSTEM_RESOURCE_PATH == null) {
       SdkConfig sdkConfig = new SdkConfig(SdkConfig.FALLBACK_SDK_VERSION);
       Fs fs = Fs.fromJar(new MavenDependencyResolver().getLocalArtifactUrl(sdkConfig.getAndroidSdkDependency()));
-      SYSTEM_RESOURCE_PATH = new ResourcePath(android.R.class, "android", fs.join("res"), fs.join("assets"));
+      SYSTEM_RESOURCE_PATH = new ResourcePath("android", fs.join("res"), fs.join("assets"), android.R.class);
     }
     return SYSTEM_RESOURCE_PATH;
   }
 
   public static ResourcePath gradleAppResources() {
-    return new ResourcePath(org.robolectric.gradleapp.R.class, "org.robolectric.gradleapp", resourceFile("gradle/res/layoutFlavor/menuBuildType"), resourceFile("gradle/assets/layoutFlavor/menuBuildType"));
+    return new ResourcePath("org.robolectric.gradleapp", resourceFile("gradle/res/layoutFlavor/menuBuildType"), resourceFile("gradle/assets/layoutFlavor/menuBuildType"), org.robolectric.gradleapp.R.class);
   }
 
   public static AndroidManifest newConfig(String androidManifestFile) {


### PR DESCRIPTION
### Overview

ResourcePath / ResourceExtractor interface is convoluted.

### Proposed Changes

Simplified ResourceExtractor
1) Remove redundant two constructors and make all usages use the single ResourcePath constructor.
2) Removed unused ResourceRemapper, R files should never have any id clashes internally as they are generated by AAPT.
3) Remove unused getPackageName() + getProcessedRFile() methods.

Simplify ResourcePath
1) Move raw directory to the only place it is accessed - RawResourceLoader.
2) Remove unused equals + hashCode methods - instances are never stored in a collection.

Switched two tests to JUnit4 runner, Robolectric framework tests do not need to use Robolectric test runner which is much slower.
