### PR TITLE
ShadowTypedArrayTest should use public Android APIs to create a TypedArray

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -105,12 +105,6 @@ public class ShadowResources {
     }
 
     List<Attribute> attributes = shadowOf(realResources.getAssets()).buildAttributes(set, attrs, defStyleAttr, themeResourceId, defStyleRes);
-    TypedArray typedArray = createTypedArray(attributes, attrs);
-    shadowOf(typedArray).positionDescription = set.getPositionDescription();
-    return typedArray;
-  }
-
-  public TypedArray createTypedArray(List<Attribute> set, int[] attrs) {
     ShadowAssetManager shadowAssetManager = shadowOf(realResources.getAssets());
     ResourceLoader resourceLoader = shadowAssetManager.getResourceLoader();
 
@@ -125,7 +119,7 @@ public class ShadowResources {
       int attr = attrs[i];
       ResName attrName = resourceLoader.getResourceIndex().getResName(attr);
       if (attrName != null) {
-        Attribute attribute = Attribute.find(set, attrName);
+        Attribute attribute = Attribute.find(attributes, attrName);
         TypedValue typedValue = new TypedValue();
         Converter.convertAndFill(attribute, typedValue, resourceLoader, RuntimeEnvironment.getQualifiers(), true);
 
@@ -147,7 +141,9 @@ public class ShadowResources {
 
     indices[0] = nextIndex;
 
-    return ShadowTypedArray.create(realResources, attrs, data, indices, nextIndex, stringData);
+    TypedArray typedArray = ShadowTypedArray.create(realResources, attrs, data, indices, nextIndex, stringData);
+    shadowOf(typedArray).positionDescription = set.getPositionDescription();
+    return typedArray;
   }
 
   @Implementation

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTypedArrayTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTypedArrayTest.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.drawable.ColorDrawable;
+import android.util.AttributeSet;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,6 +14,7 @@ import org.robolectric.R;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.fakes.RoboAttributeSet;
 import org.robolectric.res.Attribute;
 import org.robolectric.util.TestUtil;
 
@@ -26,12 +29,10 @@ import static org.robolectric.Shadows.shadowOf;
 @RunWith(TestRunners.MultiApiWithDefaults.class)
 public class ShadowTypedArrayTest {
   private Context context;
-  private Resources resources;
 
   @Before
   public void setUp() throws Exception {
-    context = Robolectric.buildActivity(Activity.class).create().get();
-    resources = RuntimeEnvironment.application.getResources();
+    context = RuntimeEnvironment.application;
   }
 
   @Test
@@ -51,8 +52,8 @@ public class ShadowTypedArrayTest {
 
   @Test
   public void getInt_withFlags_shouldReturnValue() throws Exception {
-    TypedArray typedArray = shadowOf(resources).createTypedArray(
-        asList(new Attribute("android:attr/gravity", "top|left", TestUtil.TEST_PACKAGE)),
+    TypedArray typedArray = context.obtainStyledAttributes(
+        RoboAttributeSet.create(context, new Attribute("android:attr/gravity", "top|left", TestUtil.TEST_PACKAGE)),
         new int[]{android.R.attr.gravity});
     assertThat(typedArray.getInt(0, -1)).isEqualTo(0x33);
   }
@@ -64,8 +65,8 @@ public class ShadowTypedArrayTest {
 
   @Test
   public void getResourceId_shouldReturnActualValue() throws Exception {
-    TypedArray typedArray = shadowOf(resources).createTypedArray(
-        asList(new Attribute("android:attr/id", "@+id/snippet_text", TestUtil.TEST_PACKAGE)),
+    TypedArray typedArray = context.obtainStyledAttributes(
+        RoboAttributeSet.create(context, new Attribute("android:attr/id", "@+id/snippet_text", TestUtil.TEST_PACKAGE)),
         new int[]{android.R.attr.id});
     assertThat(typedArray.getResourceId(0, -1)).isEqualTo(R.id.snippet_text);
   }
@@ -77,8 +78,8 @@ public class ShadowTypedArrayTest {
 
   @Test
   public void getFraction_shouldReturnGivenValue() throws Exception {
-    TypedArray typedArray = shadowOf(resources).createTypedArray(
-        asList(new Attribute(TestUtil.SYSTEM_PACKAGE + ":attr/width", "50%", TestUtil.SYSTEM_PACKAGE)),
+    TypedArray typedArray = context.obtainStyledAttributes(
+        RoboAttributeSet.create(context, new Attribute(TestUtil.SYSTEM_PACKAGE + ":attr/width", "50%", TestUtil.SYSTEM_PACKAGE)),
         new int[]{android.R.attr.width});
     assertThat(typedArray.getFraction(0, 100, 1, -1)).isEqualTo(50f);
   }
@@ -90,60 +91,60 @@ public class ShadowTypedArrayTest {
 
   @Test
   public void getDimension_shouldReturnGivenValue() throws Exception {
-    TypedArray typedArray = shadowOf(resources).createTypedArray(
-        asList(new Attribute(TestUtil.SYSTEM_PACKAGE + ":attr/width", "50dp", TestUtil.SYSTEM_PACKAGE)),
+    TypedArray typedArray = context.obtainStyledAttributes(
+        RoboAttributeSet.create(context, new Attribute(TestUtil.SYSTEM_PACKAGE + ":attr/width", "50dp", TestUtil.SYSTEM_PACKAGE)),
         new int[]{android.R.attr.width});
     assertThat(typedArray.getDimension(0, -1)).isEqualTo(50f);
   }
 
   @Test
   public void getDrawable_withExplicitColorValue_shouldReturnColorDrawable() throws Exception {
-    TypedArray typedArray = shadowOf(resources).createTypedArray(
-        asList(new Attribute("android:attr/background", "#ff777777", TestUtil.TEST_PACKAGE)),
+    TypedArray typedArray = context.obtainStyledAttributes(
+        RoboAttributeSet.create(context, new Attribute("android:attr/background", "#ff777777", TestUtil.TEST_PACKAGE)),
         new int[]{android.R.attr.background});
     assertThat(typedArray.getDrawable(0)).isEqualTo(new ColorDrawable(0xff777777));
   }
 
   @Test
   public void getTextArray_whenNoSuchAttribute_shouldReturnNull() throws Exception {
-    TypedArray typedArray = shadowOf(resources).createTypedArray(
-        asList(new Attribute(TestUtil.TEST_PACKAGE + ":attr/keycode", "@array/greetings", TestUtil.TEST_PACKAGE)),
+    TypedArray typedArray = context.obtainStyledAttributes(
+        RoboAttributeSet.create(context, new Attribute(TestUtil.TEST_PACKAGE + ":attr/keycode", "@array/greetings", TestUtil.TEST_PACKAGE)),
         new int[]{R.attr.items});
     assertNull(typedArray.getTextArray(0));
   }
 
   @Test
   public void getTextArray_shouldReturnValues() throws Exception {
-    TypedArray typedArray = shadowOf(resources).createTypedArray(
-        asList(new Attribute(TestUtil.TEST_PACKAGE + ":attr/responses", "@array/greetings", TestUtil.TEST_PACKAGE)),
+    TypedArray typedArray = context.obtainStyledAttributes(
+        RoboAttributeSet.create(context, new Attribute(TestUtil.TEST_PACKAGE + ":attr/responses", "@array/greetings", TestUtil.TEST_PACKAGE)),
         new int[]{R.attr.responses});
     assertThat(typedArray.getTextArray(0)).containsExactly("hola", "Hello");
   }
 
   @Test public void hasValue_withValue() throws Exception {
-    TypedArray typedArray = shadowOf(resources).createTypedArray(
-        asList(new Attribute(TestUtil.TEST_PACKAGE + ":attr/responses", "@array/greetings", TestUtil.TEST_PACKAGE)),
+    TypedArray typedArray = context.obtainStyledAttributes(
+        RoboAttributeSet.create(context, new Attribute(TestUtil.TEST_PACKAGE + ":attr/responses", "@array/greetings", TestUtil.TEST_PACKAGE)),
         new int[]{R.attr.responses});
     assertThat(typedArray.hasValue(0)).isTrue();
   }
 
   @Test public void hasValue_withoutValue() throws Exception {
-    TypedArray typedArray = shadowOf(resources).createTypedArray(
-        Arrays.<Attribute>asList(),
+    TypedArray typedArray = context.obtainStyledAttributes(
+        null,
         new int[]{R.attr.items});
     assertThat(typedArray.hasValue(0)).isFalse();
   }
 
   @Test public void hasValue_withNullValue() throws Exception {
-    TypedArray typedArray = shadowOf(resources).createTypedArray(
-        asList(new Attribute(TestUtil.TEST_PACKAGE + ":attr/items", "@null", TestUtil.TEST_PACKAGE)),
+    TypedArray typedArray = context.obtainStyledAttributes(
+        RoboAttributeSet.create(context, new Attribute(TestUtil.TEST_PACKAGE + ":attr/items", "@null", TestUtil.TEST_PACKAGE)),
         new int[]{R.attr.items});
     assertThat(typedArray.hasValue(0)).isFalse();
   }
 
   @Test public void shouldEnumeratePresentValues() throws Exception {
-    TypedArray typedArray = shadowOf(resources).createTypedArray(
-        asList(
+    TypedArray typedArray = context.obtainStyledAttributes(
+        RoboAttributeSet.create(context, 
             new Attribute(TestUtil.TEST_PACKAGE + ":attr/responses", "@array/greetings", TestUtil.TEST_PACKAGE),
             new Attribute(TestUtil.TEST_PACKAGE + ":attr/aspectRatio", "1", TestUtil.TEST_PACKAGE)
         ),


### PR DESCRIPTION
### Overview

ShadowTypedArrayTest uses an exposed method on ShadowResources to create a TypedArray.

### Proposed Changes

We should prefer testing using the Android public APIs. This change switches the test to use Context.obtainStyledAttributes() instead.

This allows us to make ShadowResources.createTypedArray() private and inlined where we can refactor the implementation without needing to change tests.