### PR TITLE
Simplify ShadowAssetManager creation

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
+++ b/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
@@ -3,6 +3,7 @@ package org.robolectric;
 import android.app.Application;
 import android.content.pm.PackageManager;
 
+import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.builder.RobolectricPackageManager;
 import org.robolectric.util.Scheduler;
 
@@ -15,6 +16,8 @@ public class RuntimeEnvironment {
   private static RobolectricPackageManager packageManager;
   private static int apiLevel;
   private static Scheduler masterScheduler;
+  private static ResourceLoader systemResourceLoader;
+  private static ResourceLoader appResourceLoader;
 
   /**
    * Tests if the given thread is currently set as the main thread.
@@ -123,5 +126,21 @@ public class RuntimeEnvironment {
    */
   public static void setMasterScheduler(Scheduler masterScheduler) {
     RuntimeEnvironment.masterScheduler = masterScheduler;
+  }
+
+  public static void setSystemResourceLoader(ResourceLoader systemResourceLoader) {
+    RuntimeEnvironment.systemResourceLoader = systemResourceLoader;
+  }
+
+  public static void setAppResourceLoader(ResourceLoader appResourceLoader) {
+    RuntimeEnvironment.appResourceLoader = appResourceLoader;
+  }
+
+  public static ResourceLoader getSystemResourceLoader() {
+    return systemResourceLoader;
+  }
+
+  public static ResourceLoader getAppResourceLoader() {
+    return appResourceLoader;
   }
 }

--- a/robolectric-resources/src/main/java/org/robolectric/ShadowsAdapter.java
+++ b/robolectric-resources/src/main/java/org/robolectric/ShadowsAdapter.java
@@ -5,7 +5,6 @@ import android.app.Application;
 import android.content.res.Configuration;
 
 import org.robolectric.manifest.AndroidManifest;
-import org.robolectric.res.ResourceLoader;
 import org.robolectric.util.Scheduler;
 
 /**
@@ -26,13 +25,9 @@ public interface ShadowsAdapter {
 
   String getShadowContextImplClassName();
 
-  void setSystemResources(ResourceLoader systemResourceLoader);
-
   void overrideQualifiers(Configuration configuration, String qualifiers);
 
-  void bind(Application application, AndroidManifest appManifest, ResourceLoader resourceLoader);
-
-  ResourceLoader getResourceLoader();
+  void bind(Application application, AndroidManifest appManifest);
 
   interface ShadowActivityAdapter {
 
@@ -45,7 +40,5 @@ public interface ShadowsAdapter {
 
   interface ShadowApplicationAdapter {
     AndroidManifest getAppManifest();
-
-    ResourceLoader getResourceLoader();
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/CoreShadowsAdapter.java
@@ -5,11 +5,9 @@ import android.app.Application;
 import android.content.res.Configuration;
 import android.os.Looper;
 
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.ShadowsAdapter;
 import org.robolectric.manifest.AndroidManifest;
-import org.robolectric.res.ResourceLoader;
 import org.robolectric.util.Scheduler;
 
 import static org.robolectric.Shadows.shadowOf;
@@ -55,10 +53,6 @@ public class CoreShadowsAdapter implements ShadowsAdapter {
       public AndroidManifest getAppManifest() {
         return ShadowApplication.getInstance().getAppManifest();
       }
-
-      public ResourceLoader getResourceLoader() {
-        return shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader();
-      }
     };
   }
 
@@ -73,23 +67,12 @@ public class CoreShadowsAdapter implements ShadowsAdapter {
   }
 
   @Override
-  public void setSystemResources(ResourceLoader systemResourceLoader) {
-    ShadowAssetManager.setSystemResources(systemResourceLoader);
-  }
-
-  @Override
   public void overrideQualifiers(Configuration configuration, String qualifiers) {
     shadowOf(configuration).overrideQualifiers(qualifiers);
   }
 
   @Override
-  public void bind(Application application, AndroidManifest appManifest, ResourceLoader resourceLoader) {
-    shadowOf(application).bind(appManifest, resourceLoader);
+  public void bind(Application application, AndroidManifest appManifest) {
+    shadowOf(application).bind(appManifest);
   }
-
-  @Override
-  public ResourceLoader getResourceLoader() {
-    return shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader();
-  }
-
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -35,7 +35,6 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.internal.ShadowExtractor;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.manifest.BroadcastReceiverData;
-import org.robolectric.res.ResourceLoader;
 import org.robolectric.util.Scheduler;
 
 import java.util.ArrayList;
@@ -121,14 +120,7 @@ public class ShadowApplication extends ShadowContextWrapper {
     shadowOf(RuntimeEnvironment.application.getResources()).setDisplay(display);
   }
 
-  /**
-   * Associates a {@code ResourceLoader} with an {@code Application} instance.
-   *
-   * @param appManifest Android manifest.
-   * @param resourceLoader Resource loader.
-   */
-  public void bind(AndroidManifest appManifest, ResourceLoader resourceLoader) {
-    ShadowAssetManager.setAppResourceLoader(resourceLoader);
+  public void bind(AndroidManifest appManifest) {
     this.appManifest = appManifest;
 
     if (appManifest != null) {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -237,14 +237,6 @@ public class ShadowResources {
     return loadXmlResourceParser(id, type);
   }
 
-  /**
-   * Deprecated. Instead call through {@link ShadowAssetManager#getResourceLoader()};
-   */
-  @Deprecated
-  public ResourceLoader getResourceLoader() {
-    return shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader();
-  }
-
   @Implements(Resources.Theme.class)
   public static class ShadowTheme {
     @RealObject Resources.Theme realTheme;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
@@ -292,7 +292,7 @@ public class ShadowView {
 
   protected void dumpAttributes(PrintStream out) {
     if (realView.getId() > 0) {
-      dumpAttribute(out, "id", shadowOf(realView.getContext().getAssets()).getResourceLoader().getNameForId(realView.getId()));
+      dumpAttribute(out, "id", realView.getContext().getResources().getResourceName(realView.getId()));
     }
 
     switch (realView.getVisibility()) {

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -57,9 +57,6 @@ public final class ShadowAssetManager {
   public static final int STYLE_CHANGING_CONFIGURATIONS = 4;
   public static final int STYLE_DENSITY = 5;
 
-  private static ResourceLoader systemResourceLoader;
-  private static ResourceLoader appResourceLoader;
-
   private Map<$ptrClassBoxed, Resources.Theme> themesById = new LinkedHashMap<>();
   private Map<$ptrClassBoxed, List<OverlayedStyle>> appliedStyles = new HashMap<>();
   private int nextInternalThemeId = 1000;
@@ -68,28 +65,16 @@ public final class ShadowAssetManager {
   @RealObject
   AssetManager realObject;
 
-  public static void setSystemResources(ResourceLoader systemResources) {
-    systemResourceLoader = systemResources;
-  }
-
-  public static void setAppResourceLoader(ResourceLoader resourceLoader) {
-    appResourceLoader = resourceLoader;
-  }
-
   public ResourceLoader getResourceLoader() {
-    if (resourceLoader == null) {
-      resourceLoader = appResourceLoader;
-    }
-
     return resourceLoader;
   }
 
-  @Implementation
-  public static AssetManager getSystem() {
-    AssetManager assetManager = new AssetManager();
-    ShadowAssetManager shadowAssetManager = shadowOf(assetManager);
-    shadowAssetManager.resourceLoader = systemResourceLoader;
-    return assetManager;
+  public void __constructor__() {
+    resourceLoader = RuntimeEnvironment.getAppResourceLoader();
+  }
+
+  public void __constructor__(boolean isSystem) {
+    resourceLoader = isSystem ? RuntimeEnvironment.getSystemResourceLoader() : RuntimeEnvironment.getAppResourceLoader();
   }
 
   @HiddenApi @Implementation
@@ -442,10 +427,6 @@ public final class ShadowAssetManager {
     return false;
   }
 
-  public FsFile getAssetsDirectory() {
-    return ShadowApplication.getInstance().getAppManifest().getAssetsDirectory();
-  }
-
   private static class Resource {
     public final ResName resName;
     public final TypedResource<?> value;
@@ -632,8 +613,6 @@ public final class ShadowAssetManager {
      * 3. The default style specified by defStyleAttr and defStyleRes
      * 4. The base values in this theme.
      */
-    ResourceLoader resourceLoader = getResourceLoader();
-
     Style defStyleFromAttr = null;
     Style defStyleFromRes = null;
     Style styleAttrStyle = null;
@@ -815,11 +794,5 @@ public final class ShadowAssetManager {
   @Implementation
   public String getResourceEntryName(int resid) {
    return getResName(resid).name;
-  }
-
-  @Resetter
-  public static void reset() {
-    systemResourceLoader = null;
-    appResourceLoader = null;
   }
 }

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -95,11 +95,13 @@ public class ParallelUniverse implements ParallelUniverseInterface {
       resourceLoader = systemResourceLoader;
     }
 
+    RuntimeEnvironment.setSystemResourceLoader(systemResourceLoader);
+    RuntimeEnvironment.setAppResourceLoader(resourceLoader);
+
     if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
       Security.insertProviderAt(new BouncyCastleProvider(), 1);
     }
 
-    shadowsAdapter.setSystemResources(systemResourceLoader);
     String qualifiers = addVersionQualifierToQualifiers(config.qualifiers());
     Resources systemResources = Resources.getSystem();
     Configuration configuration = systemResources.getConfiguration();
@@ -128,7 +130,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
     RuntimeEnvironment.application = application;
 
     if (application != null) {
-      shadowsAdapter.bind(application, appManifest, resourceLoader);
+      shadowsAdapter.bind(application, appManifest);
 
       ApplicationInfo applicationInfo;
       try {

--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -174,7 +174,6 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
     if (activityData != null) {
       activityInfo.parentActivityName = activityData.getParentActivityName();
       activityInfo.metaData = metaDataToBundle(activityData.getMetaData().getValueMap());
-      ResourceIndex resourceIndex = shadowsAdapter.getResourceLoader().getResourceIndex();
       String themeRef;
 
       // Based on ShadowActivity
@@ -185,7 +184,7 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
       }
       if (themeRef != null) {
         ResName style = ResName.qualifyResName(themeRef.replace("@", ""), packageName, "style");
-        activityInfo.theme = resourceIndex.getResourceId(style);
+        activityInfo.theme = RuntimeEnvironment.getAppResourceLoader().getResourceIndex().getResourceId(style);
       }
     }
     activityInfo.applicationInfo = getApplicationInfo(packageName, flags);

--- a/robolectric/src/main/java/org/robolectric/util/ActivityController.java
+++ b/robolectric/src/main/java/org/robolectric/util/ActivityController.java
@@ -109,7 +109,7 @@ public class ActivityController<T extends Activity> extends ComponentController<
       if (labelRef.startsWith("@")) {
         /* Label refers to a string value, get the resource identifier */
         ResName style = ResName.qualifyResName(labelRef.replace("@", ""), appManifest.getPackageName(), "string");
-        Integer labelRes = shadowApplicationAdapter.getResourceLoader().getResourceIndex().getResourceId(style);
+        Integer labelRes = RuntimeEnvironment.getAppResourceLoader().getResourceIndex().getResourceId(style);
 
         /* If we couldn't determine the resource ID, throw it up */
         if (labelRes == null) {

--- a/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
+++ b/robolectric/src/test/java/org/robolectric/DefaultTestLifecycleTest.java
@@ -60,7 +60,7 @@ public class DefaultTestLifecycleTest {
   public void shouldRegisterReceiversFromTheManifest() throws Exception {
     AndroidManifest appManifest = newConfig("TestAndroidManifestWithReceivers.xml");
     Application application = defaultTestLifecycle.createApplication(null, appManifest, null);
-    shadowOf(application).bind(appManifest, null);
+    shadowOf(application).bind(appManifest);
 
     List<ShadowApplication.Wrapper> receivers = shadowOf(application).getRegisteredReceivers();
     assertThat(receivers.size()).isEqualTo(5);

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
@@ -35,7 +35,7 @@ public class RobolectricTestRunnerSelfTest {
       .isNotNull()
       .isInstanceOf(MyTestApplication.class);
     assertThat(((MyTestApplication) RuntimeEnvironment.application).onCreateWasCalled).as("onCreate called").isTrue();
-    assertThat(shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader()).as("resource loader").isNotNull();
+    assertThat(RuntimeEnvironment.getAppResourceLoader()).as("Application resource loader").isNotNull();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DefaultRobolectricPackageManagerTest.java
@@ -152,7 +152,7 @@ public class DefaultRobolectricPackageManagerTest {
   @Test
   @Config(manifest = "src/test/resources/TestAndroidManifestForActivitiesWithIntentFilterWithData.xml")
   public void queryIntentActivities_EmptyResultWithNoMatchingImplicitIntents() throws Exception {
-    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
+    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), RuntimeEnvironment.getAppResourceLoader());
     Intent i = new Intent(Intent.ACTION_MAIN, null);
     i.addCategory(Intent.CATEGORY_LAUNCHER);
 
@@ -164,7 +164,7 @@ public class DefaultRobolectricPackageManagerTest {
   @Test
   @Config(manifest = "src/test/resources/TestAndroidManifestForActivitiesWithIntentFilterWithData.xml")
   public void queryIntentActivities_MatchWithImplicitIntents() throws Exception {
-    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
+    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), RuntimeEnvironment.getAppResourceLoader());
     Uri uri = Uri.parse("content://testhost1.com:1/testPath/test.jpeg");
     Intent i = new Intent(Intent.ACTION_VIEW);
     i.addCategory(Intent.CATEGORY_DEFAULT);
@@ -181,7 +181,7 @@ public class DefaultRobolectricPackageManagerTest {
   @Test
   @Config(manifest = "src/test/resources/TestAndroidManifestForActivityAliases.xml")
   public void queryIntentActivities_MatchWithAliasIntents() throws Exception {
-    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
+    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), RuntimeEnvironment.getAppResourceLoader());
     Intent i = new Intent(Intent.ACTION_MAIN);
     i.addCategory(Intent.CATEGORY_LAUNCHER);
 
@@ -335,7 +335,7 @@ public class DefaultRobolectricPackageManagerTest {
   @Config(manifest = "src/test/resources/TestAndroidManifestWithReceivers.xml")
   public void testReceiverInfo() throws Exception {
     ShadowApplication app = ShadowApplication.getInstance();
-    rpm.addManifest(app.getAppManifest(), shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
+    rpm.addManifest(app.getAppManifest(), RuntimeEnvironment.getAppResourceLoader());
     ActivityInfo info = rpm.getReceiverInfo(new ComponentName(app.getApplicationContext(), ".test.ConfigTestReceiver"), PackageManager.GET_META_DATA);
     Bundle meta = info.metaData;
     Object metaValue = meta.get("org.robolectric.metaName1");
@@ -507,7 +507,7 @@ public class DefaultRobolectricPackageManagerTest {
   @Test
   public void shouldAssignTheApplicationNameFromTheManifest() throws Exception {
     AndroidManifest appManifest = newConfigWith("<application android:name=\"org.robolectric.TestApplication\"/>");
-    rpm.addManifest(appManifest, shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
+    rpm.addManifest(appManifest, RuntimeEnvironment.getAppResourceLoader());
     ApplicationInfo applicationInfo = rpm.getApplicationInfo("org.robolectric", 0);
     assertThat(applicationInfo.name).isEqualTo("org.robolectric.TestApplication");
   }
@@ -679,7 +679,7 @@ public class DefaultRobolectricPackageManagerTest {
   @Test
   @Config(manifest = "src/test/resources/TestAndroidManifest.xml")
   public void shouldAssignLabelResFromTheManifest() throws Exception {
-    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
+    rpm.addManifest(ShadowApplication.getInstance().getAppManifest(), RuntimeEnvironment.getAppResourceLoader());
     ApplicationInfo applicationInfo = rpm.getApplicationInfo("org.robolectric", 0);
     String appName = ShadowApplication.getInstance().getApplicationContext().getString(applicationInfo.labelRes);
     assertThat(appName).isEqualTo("Testing App");

--- a/robolectric/src/test/java/org/robolectric/res/ResourceLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/ResourceLoaderTest.java
@@ -58,7 +58,7 @@ public class ResourceLoaderTest {
 
   @Test
   public void shouldMakeInternalResourcesAvailable() throws Exception {
-    ResourceLoader resourceLoader = shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader();
+    ResourceLoader resourceLoader = RuntimeEnvironment.getAppResourceLoader();
     ResName internalResource = new ResName("android", "string", "badPin");
     Integer resId = resourceLoader.getResourceIndex().getResourceId(internalResource);
     assertThat(resId).isNotNull();
@@ -71,6 +71,4 @@ public class ResourceLoaderTest {
 
     assertThat(RuntimeEnvironment.application.getResources().getString(resId)).isEqualTo("The old PIN you typed isn't correct.");
   }
-
-  private static class TestPreferenceActivity extends PreferenceActivity { }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLayoutInflaterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLayoutInflaterTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 import org.robolectric.annotation.Config;
 import org.robolectric.res.ResName;
@@ -446,7 +447,7 @@ public class ShadowLayoutInflaterTest {
 
   private View inflate(Context context, String packageName, String key, ViewGroup parent) {
     ResName resName = new ResName(packageName + ":layout/" + key);
-    ResourceLoader resourceLoader = shadowOf(context.getResources().getAssets()).getResourceLoader();
+    ResourceLoader resourceLoader = RuntimeEnvironment.getAppResourceLoader();
     Integer layoutResId = resourceLoader.getResourceIndex().getResourceId(resName);
     if (layoutResId == null) throw new AssertionError("no such resource " + resName);
     return LayoutInflater.from(context).inflate(layoutResId, parent);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -395,12 +395,6 @@ public class ShadowResourcesTest {
   }
 
   @Test
-  public void shouldGetResourceLoader() {
-    assertThat(shadowOf(resources).getResourceLoader()).isEqualTo(
-        shadowOf(RuntimeEnvironment.application.getAssets()).getResourceLoader());
-  }
-
-  @Test
   public void shouldLoadRawResources() throws Exception {
     InputStream resourceStream = resources.openRawResource(R.raw.raw_resource);
     assertThat(resourceStream).isNotNull();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
@@ -61,15 +61,11 @@ import static org.robolectric.Shadows.shadowOf;
 public class ShadowViewTest {
   private View view;
   private Transcript transcript;
-  private Resources resources;
-  private ResourceLoader resourceLoader;
 
   @Before
   public void setUp() throws Exception {
     transcript = new Transcript();
     view = new View(RuntimeEnvironment.application);
-    resources = RuntimeEnvironment.application.getResources();
-    resourceLoader = shadowOf(resources.getAssets()).getResourceLoader();
   }
 
   @Test


### PR DESCRIPTION
### Overview

Creating a ShadowAssetManager is a messy process determining which instances get which ResourceLoaders. Currently it is determined by a having shadowing getSystem() and settings its resource loader as the system version. All other accesses are through a deferred call to getResourceLoader() which if not set uses the Application resource loader.

### Proposed Changes

Simplify the construction of ShadowAssetManager and assignment of resource loaders.

Don't pass the ResourceLoaders to the ShadowAssetManager via the CoreShadowsAdapter, instead, set them on RuntimeEnvironment.

ShadowAssetManager can now initialize its own ResourceLoader by shadowing the constructors which simplifiest the assignment of ResourceLoaders between System and App instances.

Prefer accessing ResourceLoaders via RuntimeEnvironment rather than through the ShadowAssetManager.