### PR TITLE
Context.obtainStyledAttributes cleanup.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -100,10 +100,6 @@ public class ShadowResources {
   }
 
   private TypedArray attrsToTypedArray(AttributeSet set, int[] attrs, int defStyleAttr, int themeResourceId, int defStyleRes) {
-    if (set == null) {
-      set = RoboAttributeSet.create(RuntimeEnvironment.application);
-    }
-
     List<Attribute> attributes = shadowOf(realResources.getAssets()).buildAttributes(set, attrs, defStyleAttr, themeResourceId, defStyleRes);
     ShadowAssetManager shadowAssetManager = shadowOf(realResources.getAssets());
     ResourceLoader resourceLoader = shadowAssetManager.getResourceLoader();
@@ -142,7 +138,9 @@ public class ShadowResources {
     indices[0] = nextIndex;
 
     TypedArray typedArray = ShadowTypedArray.create(realResources, attrs, data, indices, nextIndex, stringData);
-    shadowOf(typedArray).positionDescription = set.getPositionDescription();
+    if (set != null) {
+      shadowOf(typedArray).positionDescription = set.getPositionDescription();
+    }
     return typedArray;
   }
 

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -647,9 +647,8 @@ public final class ShadowAssetManager {
       }
     }
 
-    int styleAttrResId = set.getStyleAttribute();
-    if (styleAttrResId != 0) {
-      ResName styleAttributeResName = getResName(styleAttrResId);
+    if (set != null && set.getStyleAttribute() != 0) {
+      ResName styleAttributeResName = getResName(set.getStyleAttribute());
       while (styleAttributeResName.type.equals("attr")) {
         Attribute attrValue = getOverlayedThemeValue(styleAttributeResName, theme, overlayedStyles);
         if (attrValue.isResourceReference()) {
@@ -677,7 +676,6 @@ public final class ShadowAssetManager {
     }
 
     List<Attribute> attributes = new ArrayList<>();
-    if (attrs == null) attrs = new int[0];
     for (int attr : attrs) {
       ResName attrName = tryResName(attr); // todo probably getResName instead here?
       if (attrName == null) continue;
@@ -705,9 +703,11 @@ public final class ShadowAssetManager {
   }
 
   private Attribute findAttributeValue(ResName attrName, AttributeSet attributeSet, Style styleAttrStyle, Style defStyleFromAttr, Style defStyleFromRes, Style theme, List<ShadowAssetManager.OverlayedStyle> overlayedStyles) {
-    String attrValue = attributeSet.getAttributeValue(attrName.getNamespaceUri(), attrName.name);
-    if (attrValue != null) {
-      return new Attribute(attrName, attrValue, "fixme!!!");
+    if (attributeSet != null) {
+      String attrValue = attributeSet.getAttributeValue(attrName.getNamespaceUri(), attrName.name);
+      if (attrValue != null) {
+        return new Attribute(attrName, attrValue, "fixme!!!");
+      }
     }
 
     if (styleAttrStyle != null) {


### PR DESCRIPTION
int[] attrs cannot be null on the framework so don't convert null to empty array in the Shadows.

AttributeSet can be null, so don't create a dummy one (RoboAttributeSet) and instead add null checks.