### PR TITLE
ResourceIndex/ResourceLoader API clean up.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/ResourceIndex.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/ResourceIndex.java
@@ -10,11 +10,6 @@ public abstract class ResourceIndex {
 
   public abstract Integer getResourceId(ResName resName);
 
-  public String getResourceName(int resourceId) {
-    ResName resName = getResName(resourceId);
-    return (resName != null) ? resName.getFullyQualifiedName() : null;
-  }
-
   public abstract ResName getResName(int resourceId);
 
   public abstract Collection<String> getPackages();

--- a/robolectric-resources/src/main/java/org/robolectric/res/ResourceLoader.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/ResourceLoader.java
@@ -2,14 +2,11 @@ package org.robolectric.res;
 
 import org.jetbrains.annotations.NotNull;
 import org.robolectric.res.builder.XmlBlock;
-import org.w3c.dom.Document;
 
 import java.io.InputStream;
 
 public interface ResourceLoader {
   String ANDROID_NS = Attribute.ANDROID_RES_NS_PREFIX + "android";
-
-  String getNameForId(int id);
 
   TypedResource getValue(@NotNull ResName resName, String qualifiers);
 

--- a/robolectric-resources/src/main/java/org/robolectric/res/RoutingResourceLoader.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/RoutingResourceLoader.java
@@ -22,11 +22,6 @@ public class RoutingResourceLoader implements ResourceLoader {
     resourceIndex = new MergedResourceIndex(resourceIndexes.toArray(new ResourceIndex[resourceIndexes.size()]));
   }
 
-  @Override
-  public String getNameForId(int id) {
-    return pickFor(id).getNameForId(id);
-  }
-
   @Override public TypedResource getValue(@NotNull ResName resName, String qualifiers) {
     return pickFor(resName).getValue(resName, qualifiers);
   }
@@ -103,11 +98,6 @@ public class RoutingResourceLoader implements ResourceLoader {
     }
 
     @Override void doInitialize() {
-    }
-
-    @Override
-    public String getNameForId(int id) {
-      return null;
     }
 
     @Override public boolean providesFor(String namespace) {

--- a/robolectric-resources/src/main/java/org/robolectric/res/XResourceLoader.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/XResourceLoader.java
@@ -43,11 +43,6 @@ abstract class XResourceLoader implements ResourceLoader {
     rawResources.makeImmutable();
   }
 
-  @Override
-  public String getNameForId(int id) {
-    return resourceIndex.getResourceName(id);
-  }
-
   public TypedResource getValue(@NotNull ResName resName, String qualifiers) {
     initialize();
     ResBundle.Value<TypedResource> value = data.getValue(resName, qualifiers);

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboAttributeSet.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboAttributeSet.java
@@ -25,11 +25,13 @@ import static org.robolectric.Shadows.shadowOf;
  */
 public class RoboAttributeSet implements AttributeSet {
   private final List<Attribute> attributes;
-  private final ResourceLoader resourceLoader;
+  private Context context;
+  private ResourceLoader resourceLoader;
 
-  private RoboAttributeSet(List<Attribute> attributes, ResourceLoader resourceLoader) {
+  private RoboAttributeSet(List<Attribute> attributes, Context context) {
     this.attributes = attributes;
-    this.resourceLoader = resourceLoader;
+    this.context = context;
+    resourceLoader = shadowOf(context.getAssets()).getResourceLoader();
   }
 
   /**
@@ -42,7 +44,7 @@ public class RoboAttributeSet implements AttributeSet {
   }
 
   public static AttributeSet create(Context context, List<Attribute> attributesList) {
-    return new RoboAttributeSet(attributesList, shadowOf(context.getAssets()).getResourceLoader());
+    return new RoboAttributeSet(attributesList, context);
   }
 
   @Override
@@ -156,7 +158,7 @@ public class RoboAttributeSet implements AttributeSet {
 
   @Override
   public int getAttributeResourceValue(int resourceId, int defaultValue) {
-    String attrName = resourceLoader.getResourceIndex().getResourceName(resourceId);
+    String attrName = context.getResources().getResourceName(resourceId);
     ResName resName = getAttrResName(null, attrName);
     Attribute attr = findByName(resName);
     if (attr == null) return defaultValue;


### PR DESCRIPTION
### Overview

Reduce API surface area of ResourceLoader / ResourceIndex by preferring public Android framework apis.

### Proposed Changes

Switch RoboAttributeSet to use real Android framework API instead of internal Robolectric one.

Removed now unused method from ResourceIndex/ResourceLoader API.