### PR TITLE
Shadow notification content text sub text

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
@@ -65,6 +65,21 @@ public class ShadowNotificationBuilderTest {
   }
 
   @Test
+  public void build_setsSubTextOnNotification() throws Exception {
+    Notification notification = builder.setSubText("Greetings SubText").build();
+
+    assertThat(shadowOf(notification).getContentText().toString()).isEqualTo("Greetings SubText");
+  }
+
+  @Test
+  public void build_setsContentTextAndSubTextOnNotification() throws Exception {
+    Notification notification = builder.setContentText("Hello Text").setSubText("Greetings SubText").build();
+
+    assertThat(shadowOf(notification).getContentText().toString()).contains("Hello Text");
+    assertThat(shadowOf(notification).getContentText().toString()).contains("Greetings SubText");
+  }
+
+  @Test
   public void build_setsTickerOnNotification() throws Exception {
     Notification notification = builder.setTicker("My ticker").build();
 
@@ -135,6 +150,13 @@ public class ShadowNotificationBuilderTest {
   @Test
   public void build_handlesNullContentText() {
     Notification notification = builder.setContentText(null).build();
+
+    assertThat(shadowOf(notification).getContentText()).isNullOrEmpty();
+  }
+
+  @Test
+  public void build_handlesNullSubText() {
+    Notification notification = builder.setSubText(null).build();
 
     assertThat(shadowOf(notification).getContentText()).isNullOrEmpty();
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
@@ -58,25 +58,32 @@ public class ShadowNotificationBuilderTest {
   }
 
   @Test
-  public void build_setsContentTextOnNotification() throws Exception {
+  public void build_getContentText_setsContentTextOnNotification() throws Exception {
     Notification notification = builder.setContentText("Hello Text").build();
 
     assertThat(shadowOf(notification).getContentText().toString()).isEqualTo("Hello Text");
   }
 
   @Test
+  public void build_setsContentTextOnNotification() throws Exception {
+    Notification notification = builder.setContentText("Hello Text").build();
+
+    assertThat(shadowOf(notification).getCombinedContentText().toString()).isEqualTo("Hello Text");
+  }
+
+  @Test
   public void build_setsSubTextOnNotification() throws Exception {
     Notification notification = builder.setSubText("Greetings SubText").build();
 
-    assertThat(shadowOf(notification).getContentText().toString()).isEqualTo("Greetings SubText");
+    assertThat(shadowOf(notification).getCombinedContentText().toString()).isEqualTo("Greetings SubText");
   }
 
   @Test
   public void build_setsContentTextAndSubTextOnNotification() throws Exception {
     Notification notification = builder.setContentText("Hello Text").setSubText("Greetings SubText").build();
 
-    assertThat(shadowOf(notification).getContentText().toString()).contains("Hello Text");
-    assertThat(shadowOf(notification).getContentText().toString()).contains("Greetings SubText");
+    assertThat(shadowOf(notification).getCombinedContentText().toString()).contains("Hello Text");
+    assertThat(shadowOf(notification).getCombinedContentText().toString()).contains("Greetings SubText");
   }
 
   @Test
@@ -148,17 +155,24 @@ public class ShadowNotificationBuilderTest {
   }
 
   @Test
-  public void build_handlesNullContentText() {
+  public void build_getContentText_handlesNullContentText() {
     Notification notification = builder.setContentText(null).build();
 
     assertThat(shadowOf(notification).getContentText()).isNullOrEmpty();
   }
 
   @Test
+  public void build_handlesNullContentText() {
+    Notification notification = builder.setContentText(null).build();
+
+    assertThat(shadowOf(notification).getCombinedContentText()).isNullOrEmpty();
+  }
+
+  @Test
   public void build_handlesNullSubText() {
     Notification notification = builder.setSubText(null).build();
 
-    assertThat(shadowOf(notification).getContentText()).isNullOrEmpty();
+    assertThat(shadowOf(notification).getCombinedContentText()).isNullOrEmpty();
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
@@ -33,13 +33,23 @@ public class ShadowNotification {
         : findText(applyContentView(), "title");
   }
 
+  /**
+   * @deprecated use @{link #getCombinedContentText()} instead for better subText support.
+   */
+  @Deprecated
   public CharSequence getContentText() {
+    return getApiLevel() >= N
+        ? realNotification.extras.getString(Notification.EXTRA_TEXT)
+        : findText(applyContentView(), "text");
+  }
+
+  public CharSequence getCombinedContentText() {
     CharSequence text = getApiLevel() >= N
-            ? realNotification.extras.getString(Notification.EXTRA_TEXT)
-            : findText(applyContentView(), "text");
+        ? realNotification.extras.getString(Notification.EXTRA_TEXT)
+        : findText(applyContentView(), "text");
     CharSequence text2 = getApiLevel() >= N
-            ? realNotification.extras.getString(Notification.EXTRA_SUB_TEXT)
-            : findText(applyContentView(), "text2");
+        ? realNotification.extras.getString(Notification.EXTRA_SUB_TEXT)
+        : findText(applyContentView(), "text2");
 
     if (text2 == null || text2.length() == 0) {
       return text;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
@@ -34,16 +34,19 @@ public class ShadowNotification {
   }
 
   public CharSequence getContentText() {
-    if (RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.N) {
-      return realNotification.extras.getString(Notification.EXTRA_TEXT);
+    CharSequence text = getApiLevel() >= N
+            ? realNotification.extras.getString(Notification.EXTRA_TEXT)
+            : findText(applyContentView(), "text");
+    CharSequence text2 = getApiLevel() >= N
+            ? realNotification.extras.getString(Notification.EXTRA_SUB_TEXT)
+            : findText(applyContentView(), "text2");
+
+    if (text2 == null || text2.length() == 0) {
+      return text;
+    } else if (text == null || text.length() == 0) {
+      return text2;
     } else {
-      TextView textView = (TextView) applyContentView().findViewById(getInternalResourceId("text"));
-      TextView textView2 = (TextView) applyContentView().findViewById(getInternalResourceId("text2"));
-      if (textView2.getVisibility() != View.GONE && textView2.getText() != null) {
-        return new StringBuilder().append(textView.getText()).append(" ").append(textView2.getText()).toString();
-      } else {
-        return textView.getText();
-      }
+      return new StringBuilder().append(text).append(" ").append(text2).toString();
     }
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
@@ -34,9 +34,17 @@ public class ShadowNotification {
   }
 
   public CharSequence getContentText() {
-    return RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.N
-        ? realNotification.extras.getString(Notification.EXTRA_TEXT)
-        : findText(applyContentView(), "text");
+    if (RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.N) {
+      return realNotification.extras.getString(Notification.EXTRA_TEXT);
+    } else {
+      TextView textView = (TextView) applyContentView().findViewById(getInternalResourceId("text"));
+      TextView textView2 = (TextView) applyContentView().findViewById(getInternalResourceId("text2"));
+      if (textView2.getVisibility() != View.GONE && textView2.getText() != null) {
+        return new StringBuilder().append(textView.getText()).append(" ").append(textView2.getText()).toString();
+      } else {
+        return textView.getText();
+      }
+    }
   }
 
   public CharSequence getContentInfo() {


### PR DESCRIPTION
### Overview

ShadowNotifiction#getContentText() returns subtext if subtext is set in the Notification. (fixes #2470)

There are three scenarios:
1. If only **contentText** is set, the content text is set to the texview with "R.id.text"
2. If both **contentText** and **subText** are set, the sub text is set to the texview with "R.id.text" and  the content text is set to the texview with "R.id.text2"
3. If only **subText** is set, the sub text is set to the texview with "R.id.text"

It does not seem like there is an easy way to distinguish 1 and 3 without shadowing the Notification.Builder.
### Proposed Changes

Since we have just moved away from shadowing the notification builder, I propose that we change ShadowNotification#getContentText to getCombinedContentText to return both content text and sub text. 
