### PR TITLE
When loading XML resource files from the framework, must use AssetManager.getSystem() as this includes only the framework resources.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/ResourceIds.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/ResourceIds.java
@@ -1,0 +1,22 @@
+package org.robolectric.res;
+
+/**
+ * Resource IDs are defined in the following format:-
+ *
+ * 0xPPTTEEEE
+ *
+ * Where:
+ *
+ * PP   = Package, 01 = Framework, 7F = App
+ * TT   = Type
+ * EEEE = Entry
+ */
+public class ResourceIds {
+
+  /**
+   * Returns true if a resource ID is a Framework ID, false otherwise.
+   */
+  public static boolean isFrameworkResource(int resId) {
+    return (resId & 0xFF000000) == 0x01000000;
+  }
+}

--- a/robolectric-resources/src/test/java/org/robolectric/res/ResourceIdsTest.java
+++ b/robolectric-resources/src/test/java/org/robolectric/res/ResourceIdsTest.java
@@ -1,0 +1,22 @@
+package org.robolectric.res;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ResourceIds}
+ */
+public class ResourceIdsTest {
+
+  @Test
+  public void testIsFrameworkResource() {
+    assertThat(ResourceIds.isFrameworkResource(0x01000000)).isTrue();
+    assertThat(ResourceIds.isFrameworkResource(0x01223333)).isTrue();
+    assertThat(ResourceIds.isFrameworkResource(0x01FFFFFF)).isTrue();
+
+    assertThat(ResourceIds.isFrameworkResource(0x7F000000)).isFalse();
+    assertThat(ResourceIds.isFrameworkResource(0x7F223333)).isFalse();
+    assertThat(ResourceIds.isFrameworkResource(0x7FFFFFFF)).isFalse();
+  }
+}

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -26,6 +26,7 @@ import org.robolectric.res.Attribute;
 import org.robolectric.res.Plural;
 import org.robolectric.res.ResName;
 import org.robolectric.res.ResType;
+import org.robolectric.res.ResourceIds;
 import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.TypedResource;
 import org.robolectric.res.builder.ResourceParser;
@@ -216,11 +217,18 @@ public class ShadowResources {
 
   @HiddenApi @Implementation
   public XmlResourceParser loadXmlResourceParser(int id, String type) throws Resources.NotFoundException {
+<<<<<<< Updated upstream
     ShadowAssetManager shadowAssetManager = shadowOf(realResources.getAssets());
     ResName resName = shadowAssetManager.resolveResName(id);
+=======
+    AssetManager assetManager = ResourceIds.isFrameworkResource(id) ? AssetManager.getSystem() : realResources.getAssets();
+
+    ShadowAssetManager shadowAssetManager = shadowOf(assetManager);
+    ResName resName = shadowAssetManager.getResourceLoader().resolveResName(id, RuntimeEnvironment.getQualifiers());
+>>>>>>> Stashed changes
     XmlBlock block = shadowAssetManager.getResourceLoader().getXml(resName, RuntimeEnvironment.getQualifiers());
     if (block == null) {
-      throw new Resources.NotFoundException();
+      throw new Resources.NotFoundException(resName.getFullyQualifiedName());
     }
     return ResourceParser.from(block, resName.packageName, shadowAssetManager.getResourceLoader().getResourceIndex());
   }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -217,15 +217,10 @@ public class ShadowResources {
 
   @HiddenApi @Implementation
   public XmlResourceParser loadXmlResourceParser(int id, String type) throws Resources.NotFoundException {
-<<<<<<< Updated upstream
-    ShadowAssetManager shadowAssetManager = shadowOf(realResources.getAssets());
-    ResName resName = shadowAssetManager.resolveResName(id);
-=======
     AssetManager assetManager = ResourceIds.isFrameworkResource(id) ? AssetManager.getSystem() : realResources.getAssets();
 
     ShadowAssetManager shadowAssetManager = shadowOf(assetManager);
     ResName resName = shadowAssetManager.getResourceLoader().resolveResName(id, RuntimeEnvironment.getQualifiers());
->>>>>>> Stashed changes
     XmlBlock block = shadowAssetManager.getResourceLoader().getXml(resName, RuntimeEnvironment.getQualifiers());
     if (block == null) {
       throw new Resources.NotFoundException(resName.getFullyQualifiedName());

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -217,13 +217,11 @@ public class ShadowResources {
 
   @HiddenApi @Implementation
   public XmlResourceParser loadXmlResourceParser(int id, String type) throws Resources.NotFoundException {
-    AssetManager assetManager = ResourceIds.isFrameworkResource(id) ? AssetManager.getSystem() : realResources.getAssets();
-
-    ShadowAssetManager shadowAssetManager = shadowOf(assetManager);
-    ResName resName = shadowAssetManager.getResourceLoader().resolveResName(id, RuntimeEnvironment.getQualifiers());
+    ShadowAssetManager shadowAssetManager = ResourceIds.isFrameworkResource(id) ? shadowOf(AssetManager.getSystem()) : shadowOf(realResources.getAssets());
+    ResName resName = shadowAssetManager.resolveResName(id);
     XmlBlock block = shadowAssetManager.getResourceLoader().getXml(resName, RuntimeEnvironment.getQualifiers());
     if (block == null) {
-      throw new Resources.NotFoundException(resName.getFullyQualifiedName());
+      throw new Resources.NotFoundException();
     }
     return ResourceParser.from(block, resName.packageName, shadowAssetManager.getResourceLoader().getResourceIndex());
   }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -26,6 +26,7 @@ import org.robolectric.res.Style;
 import org.robolectric.res.StyleData;
 import org.robolectric.res.TypedResource;
 import org.robolectric.res.builder.ResourceParser;
+import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.Strings;
 
 import java.io.ByteArrayInputStream;
@@ -42,7 +43,6 @@ import java.util.Map;
 import org.robolectric.annotation.Resetter;
 
 import static org.robolectric.Shadows.shadowOf;
-import static org.robolectric.shadows.ShadowApplication.getInstance;
 
 /**
  * Shadow for {@link android.content.res.AssetManager}.
@@ -794,5 +794,10 @@ public final class ShadowAssetManager {
   @Implementation
   public String getResourceEntryName(int resid) {
    return getResName(resid).name;
+  }
+
+  @Resetter
+  public static void reset() {
+    ReflectionHelpers.setStaticField(AssetManager.class, "sSystem", null);
   }
 }


### PR DESCRIPTION
When loading XML resource files from the framework, must use AssetManager.getSystem() as this includes only the framework resources.