### PR TITLE
Remove unnessesary usage of converter from RoboAttributeSet.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/shadows/Converter.java
+++ b/robolectric-resources/src/main/java/org/robolectric/shadows/Converter.java
@@ -14,9 +14,6 @@ import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.TypedResource;
 import org.robolectric.util.Util;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 public class Converter<T> {
   private static int nextStringCookie = 0xbaaa5;
 
@@ -41,10 +38,6 @@ public class Converter<T> {
     }
 
     AttrData attrData = (AttrData) attrTypeData.getData();
-    convertAndFill(attribute, outValue, resourceLoader, qualifiers, attrData, resolveRefs);
-  }
-
-  public static void convertAndFill(Attribute attribute, TypedValue outValue, ResourceLoader resourceLoader, String qualifiers, AttrData attrData, boolean resolveRefs) {
     // short-circuit Android caching of loaded resources cuz our string positions don't remain stable...
     outValue.assetCookie = getNextStringCookie();
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboAttributeSet.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboAttributeSet.java
@@ -2,12 +2,14 @@ package org.robolectric.fakes;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import com.android.internal.util.XmlUtils;
+import android.util.TypedValue;
 import com.google.android.collect.Lists;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.res.Attribute;
 import org.robolectric.res.ResName;
 import org.robolectric.res.ResourceIndex;
 import org.robolectric.res.ResourceLoader;
+import org.robolectric.shadows.Converter;
 
 import java.util.List;
 
@@ -49,7 +51,17 @@ public class RoboAttributeSet implements AttributeSet {
 
   @Override
   public int getAttributeIntValue(String namespace, String attribute, int defaultValue) {
-    return XmlUtils.convertValueToInt(this.getAttributeValue(namespace, attribute), defaultValue);
+    ResName resName = getAttrResName(namespace, attribute);
+    Attribute attr = findByName(resName);
+    if (attr == null) return defaultValue;
+
+    TypedValue outValue = new TypedValue();
+    Converter.convertAndFill(attr, outValue, resourceLoader, RuntimeEnvironment.getQualifiers(), false);
+    if (outValue.type == TypedValue.TYPE_NULL) {
+      return defaultValue;
+
+  }
+    return outValue.data;
   }
 
   @Override

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboAttributeSet.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboAttributeSet.java
@@ -2,19 +2,12 @@ package org.robolectric.fakes;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.util.TypedValue;
-
+import com.android.internal.util.XmlUtils;
 import com.google.android.collect.Lists;
-
-import org.robolectric.RuntimeEnvironment;
-import org.robolectric.res.AttrData;
 import org.robolectric.res.Attribute;
 import org.robolectric.res.ResName;
-import org.robolectric.res.ResType;
 import org.robolectric.res.ResourceIndex;
 import org.robolectric.res.ResourceLoader;
-import org.robolectric.res.TypedResource;
-import org.robolectric.shadows.Converter;
 
 import java.util.List;
 
@@ -56,23 +49,7 @@ public class RoboAttributeSet implements AttributeSet {
 
   @Override
   public int getAttributeIntValue(String namespace, String attribute, int defaultValue) {
-    ResName resName = getAttrResName(namespace, attribute);
-    Attribute attr = findByName(resName);
-    if (attr == null) return defaultValue;
-
-    String qualifiers = RuntimeEnvironment.getQualifiers();
-    TypedResource<AttrData> typedResource = resourceLoader.getValue(resName, qualifiers);
-    if (typedResource == null) {
-      typedResource = new TypedResource<>(new AttrData(attribute, "integer", null), ResType.INTEGER);
-    }
-
-    TypedValue outValue = new TypedValue();
-    Converter.convertAndFill(attr, outValue, resourceLoader, qualifiers, typedResource.getData(), false);
-    if (outValue.type == TypedValue.TYPE_NULL) {
-      return defaultValue;
-    }
-
-    return outValue.data;
+    return XmlUtils.convertValueToInt(this.getAttributeValue(namespace, attribute), defaultValue);
   }
 
   @Override

--- a/robolectric/src/test/resources/res/values/attrs.xml
+++ b/robolectric/src/test/resources/res/values/attrs.xml
@@ -19,6 +19,8 @@
       <enum name="auto_fit" value="-1" />
     </attr>
 
+    <attr name="sugarinessPercent" format="integer" min="0"/>
+
     <attr name="gravity"/>
 
     <attr name="keycode"/>


### PR DESCRIPTION
RoboAttributeSet should be simplified to remove dependencies on the converter, this will help for future refactorings.

