### PR TITLE
Use containsKey() to check for entries in the Plan cache in ShadowWrangler.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
@@ -127,11 +127,10 @@ public class ShadowWrangler implements ClassHandler {
 
   @Override
   public Plan methodInvoked(String signature, boolean isStatic, Class<?> theClass) {
-    Plan plan = planCache.get(signature);
-    if (plan != null) {
-      return plan;
+    if (planCache.containsKey(signature)) {
+      return planCache.get(signature);
     }
-    plan = calculatePlan(signature, isStatic, theClass);
+    Plan plan = calculatePlan(signature, isStatic, theClass);
     planCache.put(signature, plan);
     return plan;
   }


### PR DESCRIPTION
### Overview
In https://github.com/robolectric/robolectric/pull/2458 methodInvoked() was changed to check the plan cache using get() and a null check, instead of containsKey(). Since CALL_REAL_CODE_PLAN is only ever set to null, this causes calculatePlan() to get called much more frequently, causing a ~7x slowdown in test run time.
There is probably some further cleanup so CALL_REAL_CODE_PLAN is set to something non-null, but for now this fixes the performance regression.

### Proposed Changes
Use containsKey() when checking planCache to decide whether or not to call calculatePlan().
