### PR TITLE
Add sdk resource loaderc

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
@@ -6,7 +6,6 @@ import android.content.IntentFilter;
 import android.content.pm.*;
 import android.graphics.drawable.Drawable;
 import org.robolectric.manifest.AndroidManifest;
-import org.robolectric.res.ResourceLoader;
 
 import java.util.List;
 
@@ -67,7 +66,7 @@ public interface RobolectricPackageManager {
 
   void addPackage(String packageName);
 
-  void addManifest(AndroidManifest androidManifest, ResourceLoader loader);
+  void addManifest(AndroidManifest androidManifest);
 
   void removePackage(String packageName);
 

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -78,13 +78,13 @@ public class ParallelUniverse implements ParallelUniverseInterface {
     RuntimeEnvironment.application = null;
     RuntimeEnvironment.setMasterScheduler(new Scheduler());
     RuntimeEnvironment.setMainThread(Thread.currentThread());
-    RuntimeEnvironment.setRobolectricPackageManager(new DefaultPackageManager(shadowsAdapter));
+    RuntimeEnvironment.setRobolectricPackageManager(new DefaultPackageManager());
     RuntimeEnvironment.getRobolectricPackageManager().addPackage(DEFAULT_PACKAGE_NAME);
-    ResourceLoader resourceLoader;
+    ResourceLoader appResourceLoader;
     String packageName;
     if (appManifest != null) {
-      resourceLoader = robolectricTestRunner.getAppResourceLoader(sdkConfig, systemResourceLoader, appManifest);
-      RuntimeEnvironment.getRobolectricPackageManager().addManifest(appManifest, resourceLoader);
+      appResourceLoader = robolectricTestRunner.getAppResourceLoader(sdkConfig, systemResourceLoader, appManifest);
+      RuntimeEnvironment.getRobolectricPackageManager().addManifest(appManifest, appResourceLoader);
       packageName = appManifest.getPackageName();
     } else {
       // Fallback if there is no manifest specified. If a manifest was specified it will already
@@ -92,11 +92,11 @@ public class ParallelUniverse implements ParallelUniverseInterface {
       // name was specified without a manifest,
       packageName = config.packageName() != null && !config.packageName().isEmpty() ? config.packageName() : DEFAULT_PACKAGE_NAME;
       RuntimeEnvironment.getRobolectricPackageManager().addPackage(packageName);
-      resourceLoader = systemResourceLoader;
+      appResourceLoader = systemResourceLoader;
     }
 
     RuntimeEnvironment.setSystemResourceLoader(systemResourceLoader);
-    RuntimeEnvironment.setAppResourceLoader(resourceLoader);
+    RuntimeEnvironment.setAppResourceLoader(appResourceLoader);
 
     if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
       Security.insertProviderAt(new BouncyCastleProvider(), 1);

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -84,6 +84,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
     String packageName;
     if (appManifest != null) {
       appResourceLoader = robolectricTestRunner.getAppResourceLoader(sdkConfig, systemResourceLoader, appManifest);
+      RuntimeEnvironment.setAppResourceLoader(appResourceLoader);
       RuntimeEnvironment.getRobolectricPackageManager().addManifest(appManifest);
       packageName = appManifest.getPackageName();
     } else {
@@ -92,11 +93,10 @@ public class ParallelUniverse implements ParallelUniverseInterface {
       // name was specified without a manifest,
       packageName = config.packageName() != null && !config.packageName().isEmpty() ? config.packageName() : DEFAULT_PACKAGE_NAME;
       RuntimeEnvironment.getRobolectricPackageManager().addPackage(packageName);
-      appResourceLoader = systemResourceLoader;
+      RuntimeEnvironment.setAppResourceLoader(systemResourceLoader);
     }
 
     RuntimeEnvironment.setSystemResourceLoader(systemResourceLoader);
-    RuntimeEnvironment.setAppResourceLoader(appResourceLoader);
 
     if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
       Security.insertProviderAt(new BouncyCastleProvider(), 1);

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -84,7 +84,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
     String packageName;
     if (appManifest != null) {
       appResourceLoader = robolectricTestRunner.getAppResourceLoader(sdkConfig, systemResourceLoader, appManifest);
-      RuntimeEnvironment.getRobolectricPackageManager().addManifest(appManifest, appResourceLoader);
+      RuntimeEnvironment.getRobolectricPackageManager().addManifest(appManifest);
       packageName = appManifest.getPackageName();
     } else {
       // Fallback if there is no manifest specified. If a manifest was specified it will already

--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -52,10 +52,6 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
 
   private Map<Integer, String> namesForUid = new HashMap<>();
 
-  public DefaultPackageManager(ShadowsAdapter shadowsAdapter) {
-    this.shadowsAdapter = shadowsAdapter;
-  }
-
   static class IntentComparator implements Comparator<Intent> {
 
     @Override
@@ -118,7 +114,6 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
     }
   }
 
-  private final ShadowsAdapter shadowsAdapter;
   private final Map<String, AndroidManifest> androidManifests = new LinkedHashMap<>();
   private final Map<String, PackageInfo> packageInfos = new LinkedHashMap<>();
   private Map<Intent, List<ResolveInfo>> resolveInfoForIntent = new TreeMap<>(new IntentComparator());

--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.ShadowsAdapter;
 import org.robolectric.manifest.ActivityData;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.manifest.BroadcastReceiverData;
@@ -31,7 +30,6 @@ import org.robolectric.manifest.IntentFilterData;
 import org.robolectric.manifest.ServiceData;
 import org.robolectric.res.ResName;
 import org.robolectric.res.ResourceIndex;
-import org.robolectric.res.ResourceLoader;
 import org.robolectric.util.TempDirectory;
 
 import java.io.File;
@@ -438,12 +436,11 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
   }
 
   @Override
-  public void addManifest(AndroidManifest androidManifest, ResourceLoader loader) {
+  public void addManifest(AndroidManifest androidManifest) {
     androidManifests.put(androidManifest.getPackageName(), androidManifest);
-    ResourceIndex resourceIndex = loader.getResourceIndex();
 
     // first opportunity to access a resource index for this manifest, use it to init the references
-    androidManifest.initMetaData(loader);
+    androidManifest.initMetaData(RuntimeEnvironment.getAppResourceLoader());
 
     PackageInfo packageInfo = new PackageInfo();
     packageInfo.packageName = androidManifest.getPackageName();
@@ -509,6 +506,7 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
     applicationInfo.sourceDir = new File(".").getAbsolutePath();
     applicationInfo.dataDir = TempDirectory.create().toAbsolutePath().toString();
 
+    ResourceIndex resourceIndex = RuntimeEnvironment.getAppResourceLoader().getResourceIndex();
     if (androidManifest.getLabelRef() != null && resourceIndex != null) {
       Integer id = ResName.getResourceId(resourceIndex, androidManifest.getLabelRef(), androidManifest.getPackageName());
       applicationInfo.labelRes = id != null ? id : 0;

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -120,26 +120,6 @@ public class RobolectricTestRunnerTest {
     assertConfig(configFor(Test2.class, "withoutAnnotation", properties), new int[0],  "--default", Application.class, "", "", "res", "assets", new Class[] {}, new String[]{}, new String[]{}, null);
   }
 
-  @Test
-  public void rememberThatSomeTestRunnerMethodsShouldBeOverridable() throws Exception {
-    @SuppressWarnings("unused")
-    class CustomTestRunner extends RobolectricTestRunner {
-      public CustomTestRunner(Class<?> testClass) throws InitializationError {
-        super(testClass);
-      }
-
-      @Override public PackageResourceLoader createResourceLoader(ResourcePath resourcePath, ResourceIndex resourceIndex) {
-        return super.createResourceLoader(resourcePath, resourceIndex);
-      }
-
-      @Override
-      protected ResourceLoader createAppResourceLoader(ResourceLoader systemResourceLoader,
-          AndroidManifest appManifest) {
-        return super.createAppResourceLoader(systemResourceLoader, appManifest);
-      }
-    }
-  }
-
   private Config configFor(Class<?> testClass, String methodName, final Properties configProperties) throws InitializationError {
     Method info;
     try {


### PR DESCRIPTION
Clean up API between RobolectricPackageManager / RobolectricTestRunner. This in in preparation for a larger refactoring where the Application ResourceLoader should not be based on the runtime framework resources but rather the resources of the SDK that the app was built against. This is because the app and the frameworks resource table (arsc files) are different.

