### PR TITLE
Fix getBestDateTimePattern argument order

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowICU.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowICU.java.vm
@@ -16,15 +16,9 @@ public class ShadowICU {
     return "en-US";
   }
 
-#if ($api >= 21)
   @Implementation
-  public static String getBestDateTimePattern(String skeleton, Locale locale) {
+  public static String getBestDateTimePattern(Locale locale, String skeleton) {
     return skeleton;
   }
-#else
-  @Implementation
-  public static String getBestDateTimePattern(String skeleton, String locale) {
-    return skeleton;
-  }
-#end
+
 }


### PR DESCRIPTION
### Overview

### Proposed Changes

Arguments were reversed from https://developer.android.com/reference/android/text/format/DateFormat.html#getBestDateTimePattern(java.util.Locale, java.lang.String)