### PR TITLE
Remove code from RobolectricGradleTestRunner 

### DIFF
--- a/robolectric/src/main/java/org/robolectric/GradleManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/GradleManifestFactory.java
@@ -1,21 +1,17 @@
 package org.robolectric;
 
-import org.robolectric.annotation.*;
 import org.robolectric.annotation.Config;
-import org.robolectric.internal.bytecode.*;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.FileFsFile;
 import org.robolectric.util.Logger;
 import org.robolectric.util.ReflectionHelpers;
 
 import java.io.File;
-import java.lang.reflect.*;
-import java.util.*;
 
 /* package */ class GradleManifestFactory extends ManifestFactory {
   private final Config config;
 
-  protected GradleManifestFactory(Config config) {
+  GradleManifestFactory(Config config) {
     this.config = config;
   }
 
@@ -30,6 +26,7 @@ import java.util.*;
     final String buildOutputDir = getBuildOutputDir(config);
     final String type = getType(config);
     final String flavor = getFlavor(config);
+    final String abiSplit = getAbiSplit(config);
     final String packageName = getPackageName(config);
 
     final FileFsFile res;
@@ -56,9 +53,9 @@ import java.util.*;
     }
 
     if (FileFsFile.from(buildOutputDir, "manifests").exists()) {
-      manifest = FileFsFile.from(buildOutputDir, "manifests", "full", flavor, type, DEFAULT_MANIFEST_NAME);
+      manifest = FileFsFile.from(buildOutputDir, "manifests", "full", flavor, abiSplit, type, DEFAULT_MANIFEST_NAME);
     } else {
-      manifest = FileFsFile.from(buildOutputDir, "bundles", flavor, type, DEFAULT_MANIFEST_NAME);
+      manifest = FileFsFile.from(buildOutputDir, "bundles", flavor, abiSplit, type, DEFAULT_MANIFEST_NAME);
     }
 
     Logger.debug("Robolectric assets directory: " + assets.getPath());
@@ -88,6 +85,14 @@ import java.util.*;
   private static String getFlavor(Config config) {
     try {
       return ReflectionHelpers.getStaticField(config.constants(), "FLAVOR");
+    } catch (Throwable e) {
+      return null;
+    }
+  }
+
+  private static String getAbiSplit(Config config) {
+    try {
+      return config.abiSplit();
     } catch (Throwable e) {
       return null;
     }

--- a/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricGradleTestRunner.java
@@ -1,13 +1,6 @@
 package org.robolectric;
 
-import org.robolectric.res.FileFsFile;
-import org.robolectric.annotation.Config;
-import org.robolectric.manifest.AndroidManifest;
 import org.junit.runners.model.InitializationError;
-import org.robolectric.util.Logger;
-import org.robolectric.util.ReflectionHelpers;
-
-import java.io.File;
 
 /**
  * Test runner customized for running unit tests either through the Gradle CLI or
@@ -16,105 +9,12 @@ import java.io.File;
  *
  * This test runner requires that you set the 'constants' field on the @Config
  * annotation (or the org.robolectric.Config.properties file) for your tests.
+ *
+ * @deprecated Please use {@link RobolectricTestRunner directly since this now supports Gradle}
  */
+@Deprecated
 public class RobolectricGradleTestRunner extends RobolectricTestRunner {
   public RobolectricGradleTestRunner(Class<?> klass) throws InitializationError {
     super(klass);
-  }
-
-  @Override
-  protected AndroidManifest getAppManifest(final Config config) {
-    if (config.constants() == Void.class) {
-      Logger.error("Field 'constants' not specified in @Config annotation");
-      Logger.error("This is required when using RobolectricGradleTestRunner!");
-      throw new RuntimeException("No 'constants' field in @Config annotation!");
-    }
-
-    final String buildOutputDir = getBuildOutputDir(config);
-    final String type = getType(config);
-    final String flavor = getFlavor(config);
-    final String abiSplit = getAbiSplit(config);
-    final String packageName = getPackageName(config);
-
-    final FileFsFile res;
-    final FileFsFile assets;
-    final FileFsFile manifest;
-
-    if (FileFsFile.from(buildOutputDir, "data-binding-layout-out").exists()) {
-      // Android gradle plugin 1.5.0+ puts the merged layouts in data-binding-layout-out.
-      // https://github.com/robolectric/robolectric/issues/2143
-      res = FileFsFile.from(buildOutputDir, "data-binding-layout-out", flavor, type);
-    } else if (FileFsFile.from(buildOutputDir, "res", "merged").exists()) {
-      // res/merged added in Android Gradle plugin 1.3-beta1
-      res = FileFsFile.from(buildOutputDir, "res", "merged", flavor, type);
-    } else if (FileFsFile.from(buildOutputDir, "res").exists()) {
-      res = FileFsFile.from(buildOutputDir, "res", flavor, type);
-    } else {
-      res = FileFsFile.from(buildOutputDir, "bundles", flavor, type, "res");
-    }
-
-    if (FileFsFile.from(buildOutputDir, "assets").exists()) {
-      assets = FileFsFile.from(buildOutputDir, "assets", flavor, type);
-    } else {
-      assets = FileFsFile.from(buildOutputDir, "bundles", flavor, type, "assets");
-    }
-
-    if (FileFsFile.from(buildOutputDir, "manifests").exists()) {
-      manifest = FileFsFile.from(buildOutputDir, "manifests", "full", flavor, abiSplit, type, "AndroidManifest.xml");
-    } else {
-      manifest = FileFsFile.from(buildOutputDir, "bundles", flavor, abiSplit, type, "AndroidManifest.xml");
-    }
-
-    Logger.debug("Robolectric assets directory: " + assets.getPath());
-    Logger.debug("   Robolectric res directory: " + res.getPath());
-    Logger.debug("   Robolectric manifest path: " + manifest.getPath());
-    Logger.debug("    Robolectric package name: " + packageName);
-    return new AndroidManifest(manifest, res, assets, packageName) {
-      @Override
-      public String getRClassName() throws Exception {
-        return config.constants().getPackage().getName().concat(".R");
-      }
-    };
-  }
-
-  private static String getBuildOutputDir(Config config) {
-    return config.buildDir() + File.separator + "intermediates";
-  }
-
-  private static String getType(Config config) {
-    try {
-      return ReflectionHelpers.getStaticField(config.constants(), "BUILD_TYPE");
-    } catch (Throwable e) {
-      return null;
-    }
-  }
-
-  private static String getFlavor(Config config) {
-    try {
-      return ReflectionHelpers.getStaticField(config.constants(), "FLAVOR");
-    } catch (Throwable e) {
-      return null;
-    }
-  }
-
-  private static String getAbiSplit(Config config) {
-    try {
-      return config.abiSplit();
-    } catch (Throwable e) {
-      return null;
-    }
-  }
-
-  private static String getPackageName(Config config) {
-    try {
-      final String packageName = config.packageName();
-      if (packageName != null && !packageName.isEmpty()) {
-        return packageName;
-      } else {
-        return ReflectionHelpers.getStaticField(config.constants(), "APPLICATION_ID");
-      }
-    } catch (Throwable e) {
-      return null;
-    }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricGradleTestRunnerTest.java
@@ -126,13 +126,6 @@ public class RobolectricGradleTestRunnerTest {
   }
 
   @Test
-  public void getAppManifest_shouldThrowException_whenConstantsNotSpecified() throws Exception {
-    final RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(NoConstantsTest.class);
-    exception.expect(RuntimeException.class);
-    runner.getAppManifest(runner.getConfig(NoConstantsTest.class.getMethod("withoutAnnotation")));
-  }
-
-  @Test
   public void rClassShouldBeInTheSamePackageAsBuildConfig() throws Exception {
     RobolectricGradleTestRunner runner = new RobolectricGradleTestRunner(RFileTest.class);
     AndroidManifest manifest = runner.getAppManifest(runner.getConfig(RFileTest.class.getMethod("withoutAnnotation")));


### PR DESCRIPTION
### Overview

RobolectricTestRunner now supports Gradle out of the box therefore a dedicated RobolectricGradleTestRunner is not needed. We should deprecate it and remove in the future.

### Proposed Changes

Remove code from the test runner since this functionality has been implemented in the ManifestFactories. Add missing abi split functionality that got dropped. Deprecate RobolectricGradleTestRunner in favor of using RobolectricTestRunner