### PR TITLE
Attribute sets

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/builder/ResourceLoaderProvider.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/builder/ResourceLoaderProvider.java
@@ -1,0 +1,10 @@
+package org.robolectric.res.builder;
+
+import org.robolectric.res.ResourceLoader;
+
+/**
+ * Returns a {@link ResourceLoader} representing the resource table that the XML was loaded with.
+ */
+public interface ResourceLoaderProvider {
+    ResourceLoader getResourceLoader();
+}

--- a/robolectric-resources/src/main/java/org/robolectric/res/builder/ResourceParser.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/builder/ResourceParser.java
@@ -76,7 +76,7 @@ public class ResourceParser {
    * a set of native methods calls. Here those methods are
    * re-implemented in java when possible.
    */
-  static class XmlResourceParserImpl implements XmlResourceParser {
+  static class XmlResourceParserImpl implements ResourceLoaderProvider, XmlResourceParser {
 
     private static final ResName FAKE_RES_NAME = new ResName("_robolectric_", "attr", "_fake_");
 
@@ -837,6 +837,11 @@ public class ResourceParser {
         return name.substring(1);
       }
       return name;
+    }
+
+    @Override
+    public ResourceLoader getResourceLoader() {
+      return resourceLoader;
     }
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboAttributeSet.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboAttributeSet.java
@@ -24,10 +24,10 @@ public class RoboAttributeSet implements ResourceLoaderProvider, AttributeSet {
   private Context context;
   private ResourceLoader resourceLoader;
 
-  private RoboAttributeSet(List<Attribute> attributes, Context context) {
+  private RoboAttributeSet(List<Attribute> attributes, Context context, ResourceLoader resourceLoader) {
     this.attributes = attributes;
     this.context = context;
-    resourceLoader = shadowOf(context.getAssets()).getResourceLoader();
+    this.resourceLoader = resourceLoader;
   }
 
   /**
@@ -40,7 +40,11 @@ public class RoboAttributeSet implements ResourceLoaderProvider, AttributeSet {
   }
 
   public static AttributeSet create(Context context, List<Attribute> attributesList) {
-    return new RoboAttributeSet(attributesList, context);
+    return new RoboAttributeSet(attributesList, context, shadowOf(context.getAssets()).getResourceLoader());
+  }
+
+  public static AttributeSet create(Context context, List<Attribute> attributesList, ResourceLoader resourceLoader) {
+    return new RoboAttributeSet(attributesList, context, resourceLoader);
   }
 
   @Override

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboAttributeSet.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboAttributeSet.java
@@ -9,6 +9,7 @@ import org.robolectric.res.Attribute;
 import org.robolectric.res.ResName;
 import org.robolectric.res.ResourceIndex;
 import org.robolectric.res.ResourceLoader;
+import org.robolectric.res.builder.ResourceLoaderProvider;
 import org.robolectric.shadows.Converter;
 
 import java.util.List;
@@ -18,7 +19,7 @@ import static org.robolectric.Shadows.shadowOf;
 /**
  * Robolectric implementation of {@link android.util.AttributeSet}.
  */
-public class RoboAttributeSet implements AttributeSet {
+public class RoboAttributeSet implements ResourceLoaderProvider, AttributeSet {
   private final List<Attribute> attributes;
   private Context context;
   private ResourceLoader resourceLoader;
@@ -229,5 +230,10 @@ public class RoboAttributeSet implements AttributeSet {
       }
     }
     return null;
+  }
+
+  @Override
+  public ResourceLoader getResourceLoader() {
+    return resourceLoader;
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -177,7 +177,7 @@ public class ShadowResources {
     if (block == null) {
       throw new Resources.NotFoundException();
     }
-    return ResourceParser.from(block, resName.packageName, shadowAssetManager.getResourceLoader().getResourceIndex());
+    return ResourceParser.from(block, resName.packageName, shadowAssetManager.getResourceLoader());
   }
 
   @HiddenApi @Implementation

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -736,7 +736,7 @@ public final class ShadowAssetManager {
     if (attributeSet != null) {
       for (int i = 0; i < attributeSet.getAttributeCount(); i++) {
         if (attributeSet.getAttributeNameResource(i) == resId) {
-          return new Attribute(attributeSet.getAttributeName(i), attributeSet.getAttributeValue(i), "fixme!!!");
+          return new Attribute(ResName.qualifyResName(attributeSet.getAttributeName(i), "android", "attr"), attributeSet.getAttributeValue(i), "fixme!!!");
         }
       }
     }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -23,6 +23,7 @@ import org.robolectric.res.ResName;
 import org.robolectric.res.ResType;
 import org.robolectric.res.ResourceIndex;
 import org.robolectric.res.ResourceLoader;
+import org.robolectric.res.builder.ResourceLoaderProvider;
 import org.robolectric.res.Style;
 import org.robolectric.res.StyleData;
 import org.robolectric.res.TypedResource;
@@ -705,6 +706,8 @@ public final class ShadowAssetManager {
       Attribute attribute = buildAttribute(set, attrs[i], defStyleAttr, themeResourceId, defStyleRes);
       if (attribute != null && !attribute.isNull()) {
         TypedValue typedValue = new TypedValue();
+        // If there is an AttributeSet then use the resource loader that the attribute set was created with.
+        ResourceLoader resourceLoader = set != null ? ((ResourceLoaderProvider) set).getResourceLoader() : this.resourceLoader;
         Converter.convertAndFill(attribute, typedValue, resourceLoader, RuntimeEnvironment.getQualifiers(), true);
         //noinspection PointlessArithmeticExpression
         data[offset + ShadowAssetManager.STYLE_TYPE] = typedValue.type;

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -733,15 +733,16 @@ public final class ShadowAssetManager {
   }
 
   private Attribute findAttributeValue(int resId, AttributeSet attributeSet, Style styleAttrStyle, Style defStyleFromAttr, Style defStyleFromRes, Style theme, List<ShadowAssetManager.OverlayedStyle> overlayedStyles) {
-    ResName attrName = resourceLoader.getResourceIndex().getResName(resId);
-    if (attrName == null) return null;
-
     if (attributeSet != null) {
-      String attrValue = attributeSet.getAttributeValue(attrName.getNamespaceUri(), attrName.name);
-      if (attrValue != null) {
-        return new Attribute(attrName, attrValue, "fixme!!!");
+      for (int i = 0; i < attributeSet.getAttributeCount(); i++) {
+        if (attributeSet.getAttributeNameResource(i) == resId) {
+          return new Attribute(attributeSet.getAttributeName(i), attributeSet.getAttributeValue(i), "fixme!!!");
+        }
       }
     }
+
+    ResName attrName = resourceLoader.getResourceIndex().getResName(resId);
+    if (attrName == null) return null;
 
     if (styleAttrStyle != null) {
       Attribute attribute = styleAttrStyle.getAttrValue(attrName);

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -735,7 +735,7 @@ public final class ShadowAssetManager {
   private Attribute findAttributeValue(int resId, AttributeSet attributeSet, Style styleAttrStyle, Style defStyleFromAttr, Style defStyleFromRes, Style theme, List<ShadowAssetManager.OverlayedStyle> overlayedStyles) {
     if (attributeSet != null) {
       for (int i = 0; i < attributeSet.getAttributeCount(); i++) {
-        if (attributeSet.getAttributeNameResource(i) == resId) {
+        if (attributeSet.getAttributeNameResource(i) == resId && attributeSet.getAttributeValue(i) != null) {
           return new Attribute(ResName.qualifyResName(attributeSet.getAttributeName(i), "android", "attr"), attributeSet.getAttributeValue(i), "fixme!!!");
         }
       }

--- a/robolectric/src/test/java/org/robolectric/res/builder/XmlBlockLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/builder/XmlBlockLoaderTest.java
@@ -8,12 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.robolectric.R;
-import org.robolectric.res.DocumentLoader;
-import org.robolectric.res.ResBundle;
-import org.robolectric.res.ResName;
-import org.robolectric.res.ResourceExtractor;
-import org.robolectric.res.ResourceIndex;
-import org.robolectric.res.XmlBlockLoader;
+import org.robolectric.res.*;
 import org.robolectric.res.builder.ResourceParser.XmlResourceParserImpl;
 import org.robolectric.util.TestUtil;
 import org.w3c.dom.Document;
@@ -37,6 +32,8 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.robolectric.util.TestUtil.TEST_PACKAGE;
 import static org.robolectric.util.TestUtil.testResources;
 
@@ -55,9 +52,10 @@ import static org.robolectric.util.TestUtil.testResources;
 @RunWith(JUnit4.class)
 public class XmlBlockLoaderTest {
 
-  public static final String XMLNS_NS = "http://www.w3.org/2000/xmlns/";
+  private static final String XMLNS_NS = "http://www.w3.org/2000/xmlns/";
   private XmlResourceParserImpl parser;
   private ResourceIndex resourceIndex;
+  private ResourceLoader resourceLoader;
 
   @Before
   public void setUp() throws Exception {
@@ -68,7 +66,9 @@ public class XmlBlockLoaderTest {
     ResName resName = new ResName(TEST_PACKAGE, "xml", "preferences");
     XmlBlock xmlBlock = resBundle.get(resName, "");
     resourceIndex = new ResourceExtractor(testResources());
-    parser = (XmlResourceParserImpl) ResourceParser.from(xmlBlock, TEST_PACKAGE, resourceIndex);
+    resourceLoader = mock(ResourceLoader.class);
+    when(resourceLoader.getResourceIndex()).thenReturn(resourceIndex);
+    parser = (XmlResourceParserImpl) ResourceParser.from(xmlBlock, TEST_PACKAGE, resourceLoader);
   }
 
   @After
@@ -105,7 +105,7 @@ public class XmlBlockLoaderTest {
           new ByteArrayInputStream(xmlValue.getBytes()));
 
       parser = new XmlResourceParserImpl(document, "file", TestUtil.testResources().getPackageName(),
-          TEST_PACKAGE, resourceIndex);
+          TEST_PACKAGE, resourceLoader);
       // Navigate to the root element
       parseUntilNext(XmlResourceParser.START_TAG);
     } catch (Exception parsingException) {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -12,10 +12,14 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.NinePatchDrawable;
 import android.os.Build;
+import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.assertj.core.data.Offset;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,12 +29,26 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
 import org.robolectric.annotation.Config;
+import org.robolectric.fakes.RoboAttributeSet;
+import org.robolectric.res.AttrData;
+import org.robolectric.res.Attribute;
+import org.robolectric.res.DrawableNode;
+import org.robolectric.res.Plural;
+import org.robolectric.res.ResName;
+import org.robolectric.res.ResType;
+import org.robolectric.res.ResourceExtractor;
+import org.robolectric.res.ResourceIndex;
+import org.robolectric.res.ResourceLoader;
+import org.robolectric.res.ResourcePath;
+import org.robolectric.res.TypedResource;
+import org.robolectric.res.builder.XmlBlock;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.TestUtil;
 import org.xmlpull.v1.XmlPullParser;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
@@ -477,6 +495,42 @@ public class ShadowResourcesTest {
     assertThat(value.type).isGreaterThanOrEqualTo(TypedValue.TYPE_FIRST_COLOR_INT).isLessThanOrEqualTo(TypedValue.TYPE_LAST_INT);
   }
 
+  public static final class Lollipop_R_snippet {
+    public static final class attr {
+      public static final int viewportHeight = 16843779;
+      public static final int viewportWidth = 16843778;
+    }
+  }
+
+  @Test
+  public void obtainStyledAttributesShouldCheckXmlFirst() throws Exception {
+
+    // This simulates a ResourceLoader built from a 21+ SDK as viewportHeight / viewportWidth were introduced in API 21
+    // but the public ID values they are assigned clash with private com.android.internal.R values on older SDKs. This
+    // test ensures that even on older SDKs, on calls to obtainStyledAttributes() Robolectric will first check for matching
+    // resource ID values in the AttributeSet before checking the theme.
+    Map<String, AttrData> attributesTypes = ImmutableMap.<String, AttrData>builder()
+            .put("viewportWidth", new AttrData("viewportWidth", "float", null))
+            .put("viewportHeight", new AttrData("viewportHeight", "float", null))
+            .build();
+    ResourceLoader fakeResourceLoader = new FakeResourceLoader(attributesTypes,
+            new ResourceExtractor(new ResourcePath("android", null, null, Lollipop_R_snippet.class)));
+
+    AttributeSet attributes = RoboAttributeSet.create(RuntimeEnvironment.application,
+        ImmutableList.of(
+                new Attribute("android:attr/viewportWidth", "12.0", RuntimeEnvironment.application.getPackageName()),
+                new Attribute("android:attr/viewportHeight", "24.0", RuntimeEnvironment.application.getPackageName())),
+            fakeResourceLoader);
+
+    TypedArray typedArray = RuntimeEnvironment.application.getTheme().obtainStyledAttributes(attributes, new int[] {
+            Lollipop_R_snippet.attr.viewportWidth,
+            Lollipop_R_snippet.attr.viewportHeight
+    }, 0, 0);
+    assertThat(typedArray.getFloat(0, 0)).isEqualTo(12.0f);
+    assertThat(typedArray.getFloat(1, 0)).isEqualTo(24.0f);
+    typedArray.recycle();
+  }
+
   @Test
   public void subClassInitializedOK() {
     SubClassResources subClassResources = new SubClassResources(RuntimeEnvironment.application.getResources());
@@ -565,6 +619,51 @@ public class ShadowResourcesTest {
   private static class SubClassResources extends Resources {
     public SubClassResources(Resources res) {
       super(res.getAssets(), res.getDisplayMetrics(), res.getConfiguration());
+    }
+  }
+
+  private static class FakeResourceLoader implements ResourceLoader {
+    private final Map<String, AttrData> attributesTypes;
+    private final ResourceIndex resourceIndex;
+
+    public FakeResourceLoader(Map<String, AttrData> attributesTypes, ResourceIndex resourceIndex) {
+      this.attributesTypes = attributesTypes;
+      this.resourceIndex = resourceIndex;
+    }
+
+    @Override
+    public TypedResource getValue(@NotNull ResName resName, String qualifiers) {
+      return new TypedResource<>(attributesTypes.get(resName.name), ResType.FLOAT);
+    }
+
+    @Override
+    public Plural getPlural(ResName resName, int quantity, String qualifiers) {
+      return null;
+    }
+
+    @Override
+    public XmlBlock getXml(ResName resName, String qualifiers) {
+      return null;
+    }
+
+    @Override
+    public DrawableNode getDrawableNode(ResName resName, String qualifiers) {
+      return null;
+    }
+
+    @Override
+    public InputStream getRawValue(ResName resName) {
+      return null;
+    }
+
+    @Override
+    public ResourceIndex getResourceIndex() {
+      return resourceIndex;
+    }
+
+    @Override
+    public boolean providesFor(String namespace) {
+      return false;
     }
   }
 }


### PR DESCRIPTION
### Overview

Partial fix for: https://github.com/robolectric/robolectric/issues/2520

### Proposed Changes

For calls to obtainStyledAttributes() Robolectric should first check the XML (AttributeSet) for resource IDs matching those in the requested int[] array before checking the theme. The current implementation checks first for names, but in a corner case exposed by the above issue highlights the problem, if a resource ID is requested on a newer version of Android than Robolectric is emulating, then that ID value will not exist, the look up will either fail, or in the case illustrated by the bug results in a clash with a private resource value defined in com.android.internal.R
