### PR TITLE
Make ShadowCursorWindow return an empty byte array instead of null wh…

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowCursorWindow.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowCursorWindow.java.vm
@@ -45,7 +45,9 @@ public class ShadowCursorWindow {
       case Cursor.FIELD_TYPE_NULL:
         return null;
       case Cursor.FIELD_TYPE_BLOB:
-        return (byte[])value.value;
+        // This matches Android's behavior, which does not match the SQLite spec
+        byte[] blob = (byte[])value.value;
+        return blob == null ? new byte[]{} : blob;
       case Cursor.FIELD_TYPE_STRING:
         return ((String)value.value).getBytes();
       default:

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCursorWindowTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCursorWindowTest.java
@@ -24,18 +24,22 @@ public class ShadowCursorWindowTest {
     MatrixCursor testCursor = new MatrixCursor(new String[] { "a", "b", "c", "d"});
     testCursor.addRow(new Object[] { 12, "hello", null, new byte[] {(byte) 0xba, (byte) 0xdc, (byte) 0xaf, (byte) 0xfe} });
     testCursor.addRow(new Object[] { 34, "baz",   1.2,  null  });
+    testCursor.addRow(new Object[] { 46, "foo",   2.4,  new byte[]{}  });
 
     DatabaseUtils.cursorFillWindow(testCursor, 0, window);
 
-    assertThat(window.getNumRows()).isEqualTo(2);
+    assertThat(window.getNumRows()).isEqualTo(3);
 
-    assertThat(window.getString(0, 1)).isEqualTo("hello");
     assertThat(window.getInt(0, 0)).isEqualTo(12);
+    assertThat(window.getString(0, 1)).isEqualTo("hello");
     assertThat(window.getString(0, 2)).isNull();
     assertThat(window.getBlob(0, 3)).isEqualTo(new byte[] {(byte) 0xba, (byte) 0xdc, (byte) 0xaf, (byte) 0xfe});
 
-    assertThat(window.getString(1, 1)).isEqualTo("baz");
     assertThat(window.getInt(1, 0)).isEqualTo(34);
+    assertThat(window.getString(1, 1)).isEqualTo("baz");
     assertThat(window.getFloat(1, 2)).isEqualTo(1.2f);
+    assertThat(window.getBlob(1, 3)).isEqualTo(null);
+
+    assertThat(window.getBlob(2, 3)).isEqualTo(new byte[]{});
   }
 }


### PR DESCRIPTION
### Overview

Fix for issue #2165

### Proposed Changes

ShadowCursorWindow now returns an empty byte array instead of null if a query returns an empty, non-null blob type.