### PR TITLE
bumping Guava to latest stable

### DIFF
--- a/robolectric-processor/build.gradle
+++ b/robolectric-processor/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     compile project(":robolectric-annotations")
 
     // Compile dependencies
-    compile "com.google.guava:guava:19.0-rc2"
+    compile "com.google.guava:guava:19.0"
     provided "com.intellij:annotations:12.0"
     compile files("${System.properties['java.home']}/../lib/tools.jar")
 

--- a/robolectric-resources/build.gradle
+++ b/robolectric-resources/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     // Compile dependencies
     compile "com.ximpleware:vtd-xml:2.11"
-    compile "com.google.guava:guava:19.0-rc2"
+    compile "com.google.guava:guava:19.0"
     provided "org.robolectric:android-all:6.0.0_r1-robolectric-0"
     provided "com.intellij:annotations:12.0"
 


### PR DESCRIPTION
### Overview
Depending on an RC/outdated library requires developers to explicitly exclude the group

