### PR TITLE
Quiet some spurious exceptions.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -124,41 +124,48 @@ public class AndroidManifest {
     if (androidManifestFile == null || manifestIsParsed) {
       return;
     }
-    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-    try {
-      DocumentBuilder db = dbf.newDocumentBuilder();
-      InputStream inputStream = androidManifestFile.getInputStream();
-      Document manifestDocument = db.parse(inputStream);
-      inputStream.close();
 
-      if (packageName == null || packageName.isEmpty()) {
-        packageName = getTagAttributeText(manifestDocument, "manifest", "package");
+    if (androidManifestFile.exists()) {
+      try {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        InputStream inputStream = androidManifestFile.getInputStream();
+        Document manifestDocument = db.parse(inputStream);
+        inputStream.close();
+
+        if (packageName == null || packageName.isEmpty()) {
+          packageName = getTagAttributeText(manifestDocument, "manifest", "package");
+        }
+        versionCode = getTagAttributeIntValue(manifestDocument, "manifest", "android:versionCode", 0);
+        versionName = getTagAttributeText(manifestDocument, "manifest", "android:versionName");
+        rClassName = packageName + ".R";
+        applicationName = getTagAttributeText(manifestDocument, "application", "android:name");
+        applicationLabel = getTagAttributeText(manifestDocument, "application", "android:label");
+        minSdkVersion = getTagAttributeIntValue(manifestDocument, "uses-sdk", "android:minSdkVersion");
+        targetSdkVersion = getTagAttributeIntValue(manifestDocument, "uses-sdk", "android:targetSdkVersion");
+        processName = getTagAttributeText(manifestDocument, "application", "android:process");
+        if (processName == null) {
+          processName = packageName;
+        }
+
+        themeRef = getTagAttributeText(manifestDocument, "application", "android:theme");
+        labelRef = getTagAttributeText(manifestDocument, "application", "android:label");
+
+        parseApplicationFlags(manifestDocument);
+        parseReceivers(manifestDocument);
+        parseServices(manifestDocument);
+        parseActivities(manifestDocument);
+        parseApplicationMetaData(manifestDocument);
+        parseContentProviders(manifestDocument);
+        parseUsedPermissions(manifestDocument);
+      } catch (Exception ignored) {
+        ignored.printStackTrace();
       }
-      versionCode = getTagAttributeIntValue(manifestDocument, "manifest", "android:versionCode", 0);
-      versionName = getTagAttributeText(manifestDocument, "manifest", "android:versionName");
-      rClassName = packageName + ".R";
-      applicationName = getTagAttributeText(manifestDocument, "application", "android:name");
-      applicationLabel = getTagAttributeText(manifestDocument, "application", "android:label");
-      minSdkVersion = getTagAttributeIntValue(manifestDocument, "uses-sdk", "android:minSdkVersion");
-      targetSdkVersion = getTagAttributeIntValue(manifestDocument, "uses-sdk", "android:targetSdkVersion");
-      processName = getTagAttributeText(manifestDocument, "application", "android:process");
-      if (processName == null) {
-        processName = packageName;
-      }
-
-      themeRef = getTagAttributeText(manifestDocument, "application", "android:theme");
-      labelRef = getTagAttributeText(manifestDocument, "application", "android:label");
-
-      parseApplicationFlags(manifestDocument);
-      parseReceivers(manifestDocument);
-      parseServices(manifestDocument);
-      parseActivities(manifestDocument);
-      parseApplicationMetaData(manifestDocument);
-      parseContentProviders(manifestDocument);
-      parseUsedPermissions(manifestDocument);
-    } catch (Exception ignored) {
-      ignored.printStackTrace();
+    } else {
+      System.err.println("No such manifest file: " + androidManifestFile);
     }
+
     manifestIsParsed = true;
   }
 


### PR DESCRIPTION
No reason to spew a full stacktrace when a manifest file is missing, just log a message.