### PR TITLE
Refactor ResourcePath for clarity

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -1,7 +1,7 @@
 package org.robolectric.manifest;
 
 import android.app.Activity;
-import java.io.IOException;
+
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -11,12 +11,10 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import com.google.common.base.Preconditions;
-import org.robolectric.annotation.Config;
 import org.robolectric.res.FsFile;
 import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.ResourcePath;
@@ -507,7 +505,7 @@ public class AndroidManifest {
   }
 
   public ResourcePath getResourcePath() {
-    return new ResourcePath(getPackageName(), resDirectory, assetsDirectory, getRClass());
+    return new ResourcePath(getRClass(), getPackageName(), resDirectory, assetsDirectory);
   }
 
   public List<ResourcePath> getIncludedResourcePaths() {

--- a/robolectric-resources/src/main/java/org/robolectric/res/DocumentLoader.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/DocumentLoader.java
@@ -16,7 +16,7 @@ public class DocumentLoader {
   private final VTDGen vtdGen;
 
   public DocumentLoader(ResourcePath resourcePath) {
-    this.resourceBase = resourcePath.resourceBase;
+    this.resourceBase = resourcePath.getResourceBase();
     this.packageName = resourcePath.getPackageName();
     vtdGen = new VTDGen();
   }

--- a/robolectric-resources/src/main/java/org/robolectric/res/DrawableResourceLoader.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/DrawableResourceLoader.java
@@ -36,7 +36,7 @@ public class DrawableResourceLoader extends XmlLoader {
    * @param resourcePath Resource path.
    */
   public void findDrawableResources(ResourcePath resourcePath) {
-    FsFile[] files = resourcePath.resourceBase.listFiles();
+    FsFile[] files = resourcePath.getResourceBase().listFiles();
     if (files != null) {
       for (FsFile f : files) {
         if (f.isDirectory() && f.getName().startsWith("drawable")) {

--- a/robolectric-resources/src/main/java/org/robolectric/res/PackageResourceLoader.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/PackageResourceLoader.java
@@ -25,7 +25,7 @@ public class PackageResourceLoader extends XResourceLoader {
   }
 
   private void loadEverything() throws Exception {
-    Logger.debug("Loading resources for %s from %s...", resourcePath.getPackageName(), resourcePath.resourceBase);
+    Logger.debug("Loading resources for %s from %s...", resourcePath.getPackageName(), resourcePath.getResourceBase());
 
     DocumentLoader documentLoader = new DocumentLoader(resourcePath);
 

--- a/robolectric-resources/src/main/java/org/robolectric/res/RawResourceLoader.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/RawResourceLoader.java
@@ -8,7 +8,7 @@ public class RawResourceLoader {
   }
 
   public void loadTo(ResBundle<FsFile> rawResourceFiles) {
-    FsFile rawDir = resourcePath.resourceBase.join("raw");
+    FsFile rawDir = resourcePath.getResourceBase().join("raw");
 
     if (rawDir != null) {
       FsFile[] files = rawDir.listFiles();

--- a/robolectric-resources/src/main/java/org/robolectric/res/ResourceExtractor.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/ResourceExtractor.java
@@ -14,14 +14,13 @@ public class ResourceExtractor extends ResourceIndex {
 
   public ResourceExtractor(ResourcePath resourcePath) {
     packageName = resourcePath.getPackageName();
-    if (resourcePath.rClasses == null) {
-      return;
+
+    if (resourcePath.getRClass() != null) {
+      gatherResourceIdsAndNames(resourcePath.getRClass(), packageName);
     }
-    for (int i = 0; i < resourcePath.rClasses.length; i++) {
-      Class<?> rClass = resourcePath.rClasses[i];
-      if (rClass != null) {
-        gatherResourceIdsAndNames(rClass, packageName);
-      }
+
+    if (resourcePath.getInternalRClass() != null) {
+      gatherResourceIdsAndNames(resourcePath.getInternalRClass(), packageName);
     }
   }
 

--- a/robolectric-resources/src/main/java/org/robolectric/res/ResourcePath.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/ResourcePath.java
@@ -1,22 +1,42 @@
 package org.robolectric.res;
 
-import java.util.Arrays;
-
 public class ResourcePath {
-  public final String packageName;
-  public final FsFile resourceBase;
-  public final FsFile assetsDir;
-  public Class<?>[] rClasses;
+  private final Class<?> rClass;
+  private final String packageName;
+  private final FsFile resourceBase;
+  private final FsFile assetsDir;
+  private final Class<?> internalRClass;
 
-  public ResourcePath(String packageName, FsFile resourceBase, FsFile assetsDir, Class<?>... rClasses) {
+  public ResourcePath(Class<?> rClass, String packageName, FsFile resourceBase, FsFile assetsDir) {
+    this(rClass, packageName, resourceBase, assetsDir, null);
+  }
+
+  public ResourcePath(Class<?> rClass, String packageName, FsFile resourceBase, FsFile assetsDir, Class<?> internalRClass) {
+    this.rClass = rClass;
     this.packageName = packageName;
     this.resourceBase = resourceBase;
     this.assetsDir = assetsDir;
-    this.rClasses = rClasses;
+    this.internalRClass = internalRClass;
+  }
+
+  public Class<?> getRClass() {
+    return rClass;
   }
 
   public String getPackageName() {
     return packageName;
+  }
+
+  public FsFile getResourceBase() {
+    return resourceBase;
+  }
+
+  public FsFile getAssetsDir() {
+    return assetsDir;
+  }
+
+  public Class<?> getInternalRClass() {
+    return internalRClass;
   }
 
   @Override
@@ -31,20 +51,21 @@ public class ResourcePath {
 
     ResourcePath that = (ResourcePath) o;
 
+    if (rClass != null ? !rClass.equals(that.rClass) : that.rClass != null) return false;
     if (packageName != null ? !packageName.equals(that.packageName) : that.packageName != null) return false;
     if (resourceBase != null ? !resourceBase.equals(that.resourceBase) : that.resourceBase != null) return false;
     if (assetsDir != null ? !assetsDir.equals(that.assetsDir) : that.assetsDir != null) return false;
-    // Probably incorrect - comparing Object[] arrays with Arrays.equals
-    return Arrays.equals(rClasses, that.rClasses);
+    return internalRClass != null ? internalRClass.equals(that.internalRClass) : that.internalRClass == null;
 
   }
 
   @Override
   public int hashCode() {
-    int result = packageName != null ? packageName.hashCode() : 0;
+    int result = rClass != null ? rClass.hashCode() : 0;
+    result = 31 * result + (packageName != null ? packageName.hashCode() : 0);
     result = 31 * result + (resourceBase != null ? resourceBase.hashCode() : 0);
     result = 31 * result + (assetsDir != null ? assetsDir.hashCode() : 0);
-    result = 31 * result + Arrays.hashCode(rClasses);
+    result = 31 * result + (internalRClass != null ? internalRClass.hashCode() : 0);
     return result;
   }
 }

--- a/robolectric/src/main/java/org/robolectric/internal/SdkEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SdkEnvironment.java
@@ -34,7 +34,7 @@ public class SdkEnvironment {
         Class<?> androidInternalRClass = getRobolectricClassLoader().loadClass("com.android.internal.R");
         Class<?> androidRClass = getRobolectricClassLoader().loadClass("android.R");
         Fs systemResFs = Fs.fromJar(dependencyResolver.getLocalArtifactUrl(sdkConfig.getAndroidSdkDependency()));
-        resourcePath = new ResourcePath(androidRClass.getPackage().getName(), systemResFs.join("res"), systemResFs.join("assets"), androidRClass, androidInternalRClass);
+        resourcePath = new ResourcePath(androidRClass, androidRClass.getPackage().getName(), systemResFs.join("res"), systemResFs.join("assets"), androidInternalRClass);
       } catch (ClassNotFoundException e) {
         throw new RuntimeException(e);
       }

--- a/robolectric/src/test/java/org/robolectric/ManifestFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/ManifestFactoryTest.java
@@ -56,7 +56,7 @@ public class ManifestFactoryTest {
   private List<String> stringify(Collection<ResourcePath> resourcePaths) {
     List<String> resourcePathBases = new ArrayList<>();
     for (ResourcePath resourcePath : resourcePaths) {
-      resourcePathBases.add(resourcePath.resourceBase.toString());
+      resourcePathBases.add(resourcePath.getResourceBase().toString());
     }
     return resourcePathBases;
   }

--- a/robolectric/src/test/java/org/robolectric/res/DrawableResourceLoaderNoRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DrawableResourceLoaderNoRunnerTest.java
@@ -54,12 +54,11 @@ public class DrawableResourceLoaderNoRunnerTest {
     when(mockTestDir.isDirectory()).thenReturn(true);
     FsFile mockTestBaseDir = mock(FsFile.class);
     when(mockTestBaseDir.listFiles()).thenReturn(new FsFile[]{mockTestDir});
-    ResourcePath mockResourcePath = mock(ResourcePath.class);
-    setResourceBase(mockTestBaseDir, mockResourcePath);
+    ResourcePath resourcePath = new ResourcePath(null, null, mockTestBaseDir, null);
 
     ResBundle<DrawableNode> bundle = mock(ResBundle.class);
     DrawableResourceLoader testLoader = new DrawableResourceLoader(bundle);
-    testLoader.findDrawableResources(mockResourcePath);
+    testLoader.findDrawableResources(resourcePath);
 
     verify(bundle).put(eq("drawable"), eq("bar.png"), (DrawableNode) any(), (XmlLoader.XmlContext) any());
   }
@@ -79,12 +78,11 @@ public class DrawableResourceLoaderNoRunnerTest {
     when(mockTestDir.isDirectory()).thenReturn(true);
     FsFile mockTestBaseDir = mock(FsFile.class);
     when(mockTestBaseDir.listFiles()).thenReturn(new FsFile[]{mockTestDir});
-    ResourcePath mockResourcePath = mock(ResourcePath.class);
-    setResourceBase(mockTestBaseDir, mockResourcePath);
+    ResourcePath resourcePath = new ResourcePath(null, null, mockTestBaseDir, null);
 
     ResBundle<DrawableNode> bundle = mock(ResBundle.class);
     DrawableResourceLoader testLoader = new DrawableResourceLoader(bundle);
-    testLoader.findDrawableResources(mockResourcePath);
+    testLoader.findDrawableResources(resourcePath);
 
     verify(bundle).put(eq("drawable"), eq("bar.png"), (DrawableNode) any(), (XmlLoader.XmlContext) any());
   }
@@ -104,12 +102,11 @@ public class DrawableResourceLoaderNoRunnerTest {
     when(mockTestDir.isDirectory()).thenReturn(true);
     FsFile mockTestBaseDir = mock(FsFile.class);
     when(mockTestBaseDir.listFiles()).thenReturn(new FsFile[]{mockTestDir});
-    ResourcePath mockResourcePath = mock(ResourcePath.class);
-    setResourceBase(mockTestBaseDir, mockResourcePath);
+    ResourcePath resourcePath = new ResourcePath(null, null, mockTestBaseDir, null);
 
     ResBundle<DrawableNode> bundle = mock(ResBundle.class);
     DrawableResourceLoader testLoader = new DrawableResourceLoader(bundle);
-    testLoader.findDrawableResources(mockResourcePath);
+    testLoader.findDrawableResources(resourcePath);
 
     verify(bundle).put(eq("drawable"), eq("bar.png"), (DrawableNode) any(), (XmlLoader.XmlContext) any());
   }
@@ -129,12 +126,11 @@ public class DrawableResourceLoaderNoRunnerTest {
     when(mockTestDir.isDirectory()).thenReturn(true);
     FsFile mockTestBaseDir = mock(FsFile.class);
     when(mockTestBaseDir.listFiles()).thenReturn(new FsFile[]{mockTestDir});
-    ResourcePath mockResourcePath = mock(ResourcePath.class);
-    setResourceBase(mockTestBaseDir, mockResourcePath);
+    ResourcePath resourcePath = new ResourcePath(null, null, mockTestBaseDir, null);
 
     ResBundle<DrawableNode> bundle = mock(ResBundle.class);
     DrawableResourceLoader testLoader = new DrawableResourceLoader(bundle);
-    testLoader.findDrawableResources(mockResourcePath);
+    testLoader.findDrawableResources(resourcePath);
 
     verify(bundle).put(eq("drawable"), eq("bar.png"), (DrawableNode) any(), (XmlLoader.XmlContext) any());
   }
@@ -143,11 +139,5 @@ public class DrawableResourceLoaderNoRunnerTest {
     Field field = File.class.getDeclaredField("separator");
     originalSeparator = ReflectionHelpers.getStaticField(field);
     ReflectionHelpers.setStaticField(field, separator);
-  }
-
-  private void setResourceBase(FsFile mockTestBaseDir, ResourcePath mockResourcePath) throws NoSuchFieldException, IllegalAccessException {
-    Field resourceBase = ResourcePath.class.getDeclaredField("resourceBase");
-    resourceBase.setAccessible(true);
-    resourceBase.set(mockResourcePath, mockTestBaseDir);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/res/RawResourceLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/RawResourceLoaderTest.java
@@ -27,12 +27,12 @@ public class RawResourceLoaderTest {
   @Test
   public void shouldReturnRawResourcesWithExtensions() throws Exception {
     FsFile f = rawResourceFiles.get(resourceIndex.getResName(R.raw.raw_resource), "");
-    assertThat(f).isEqualTo(TEST_RESOURCE_PATH.resourceBase.join("raw").join("raw_resource.txt"));
+    assertThat(f).isEqualTo(TEST_RESOURCE_PATH.getResourceBase().join("raw").join("raw_resource.txt"));
   }
 
   @Test
   public void shouldReturnRawResourcesWithoutExtensions() throws Exception {
     FsFile f = rawResourceFiles.get(resourceIndex.getResName(R.raw.raw_no_ext), "");
-    assertThat(f).isEqualTo(TEST_RESOURCE_PATH.resourceBase.join("raw").join("raw_no_ext"));
+    assertThat(f).isEqualTo(TEST_RESOURCE_PATH.getResourceBase().join("raw").join("raw_no_ext"));
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -511,7 +511,7 @@ public class ShadowResourcesTest {
             .put("viewportHeight", new AttrData("viewportHeight", "float", null))
             .build();
     ResourceLoader fakeResourceLoader = new FakeResourceLoader(attributesTypes,
-            new ResourceExtractor(new ResourcePath("android", null, null, Lollipop_R_snippet.class)));
+            new ResourceExtractor(new ResourcePath(Lollipop_R_snippet.class, "android", null, null)));
 
 
     RuntimeEnvironment.setAppResourceLoader(fakeResourceLoader);

--- a/robolectric/src/test/java/org/robolectric/util/TestUtil.java
+++ b/robolectric/src/test/java/org/robolectric/util/TestUtil.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class TestUtil {
   private static ResourcePath SYSTEM_RESOURCE_PATH;
-  public static final ResourcePath TEST_RESOURCE_PATH = new ResourcePath(R.class.getPackage().getName(), resourceFile("res"), resourceFile("assets"), R.class);
+  public static final ResourcePath TEST_RESOURCE_PATH = new ResourcePath(R.class, R.class.getPackage().getName(), resourceFile("res"), resourceFile("assets"));
   public static final String TEST_PACKAGE = R.class.getPackage().getName();
   public static File testDirLocation;
 
@@ -77,28 +77,28 @@ public abstract class TestUtil {
   }
 
   public static ResourcePath lib1Resources() {
-    return new ResourcePath("org.robolectric.lib1", resourceFile("lib1/res"), resourceFile("lib1/assets"), org.robolectric.lib1.R.class);
+    return new ResourcePath(org.robolectric.lib1.R.class, "org.robolectric.lib1", resourceFile("lib1/res"), resourceFile("lib1/assets"));
   }
 
   public static ResourcePath lib2Resources() {
-    return new ResourcePath("org.robolectric.lib2", resourceFile("lib2/res"), resourceFile("lib2/assets"), org.robolectric.lib2.R.class);
+    return new ResourcePath(org.robolectric.lib2.R.class, "org.robolectric.lib2", resourceFile("lib2/res"), resourceFile("lib2/assets"));
   }
 
   public static ResourcePath lib3Resources() {
-    return new ResourcePath("org.robolectric.lib3", resourceFile("lib3/res"), resourceFile("lib3/assets"), org.robolectric.lib3.R.class);
+    return new ResourcePath(org.robolectric.lib3.R.class, "org.robolectric.lib3", resourceFile("lib3/res"), resourceFile("lib3/assets"));
   }
 
   public static ResourcePath systemResources() {
     if (SYSTEM_RESOURCE_PATH == null) {
       SdkConfig sdkConfig = new SdkConfig(SdkConfig.FALLBACK_SDK_VERSION);
       Fs fs = Fs.fromJar(new MavenDependencyResolver().getLocalArtifactUrl(sdkConfig.getAndroidSdkDependency()));
-      SYSTEM_RESOURCE_PATH = new ResourcePath("android", fs.join("res"), fs.join("assets"), android.R.class);
+      SYSTEM_RESOURCE_PATH = new ResourcePath(android.R.class, "android", fs.join("res"), fs.join("assets"));
     }
     return SYSTEM_RESOURCE_PATH;
   }
 
   public static ResourcePath gradleAppResources() {
-    return new ResourcePath("org.robolectric.gradleapp", resourceFile("gradle/res/layoutFlavor/menuBuildType"), resourceFile("gradle/assets/layoutFlavor/menuBuildType"), org.robolectric.gradleapp.R.class);
+    return new ResourcePath(org.robolectric.gradleapp.R.class, "org.robolectric.gradleapp", resourceFile("gradle/res/layoutFlavor/menuBuildType"), resourceFile("gradle/assets/layoutFlavor/menuBuildType"));
   }
 
   public static AndroidManifest newConfig(String androidManifestFile) {


### PR DESCRIPTION
There can only ever be two R classes, are there's usually only one, so let's make it more explicit and prevent errors caused by arrays containing nulls.