### PR TITLE
Re-instate hack to support attributes in dependency libraries

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/StyleData.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/StyleData.java
@@ -31,7 +31,20 @@ public class StyleData implements Style {
   }
 
   @Override public AttributeResource getAttrValue(ResName resName) {
-    return items.get(resName);
+    AttributeResource attributeResource = items.get(resName);
+
+    // This hack allows us to look up attributes from downstream dependencies, see comment in
+    // org.robolectric.shadows.ShadowThemeTest.obtainTypedArrayFromDependencyLibrary()
+    // for an explanation. TODO(jongerrish): Make Robolectric use a more realistic resource merging
+    // scheme.
+    if (attributeResource == null && !"android".equals(resName.packageName)) {
+      attributeResource = items.get(resName.withPackageName(packageName));
+      if (attributeResource != null && (!"android".equals(attributeResource.contextPackageName))) {
+        attributeResource = new AttributeResource(resName, attributeResource.value, resName.packageName);
+      }
+    }
+
+    return attributeResource;
   }
 
   @Override

--- a/robolectric/src/test/java/org/robolectric/R.java
+++ b/robolectric/src/test/java/org/robolectric/R.java
@@ -259,6 +259,7 @@ public final class R {
     public static final int sugarinessPercent = 0x10a10;
     public static final int numColumns = 0x10a11;
     public static final int sugaryScale = 0x10a12;
+    public static final int selectableItemBackground = 0x10a13;
   }
 
   public static final class menu {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
@@ -13,10 +13,8 @@ import org.robolectric.R;
 import org.robolectric.Robolectric;
 import org.robolectric.TestRunners;
 import org.robolectric.res.ResName;
-import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.Style;
 import org.robolectric.util.ActivityController;
-import org.robolectric.util.TestUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Robolectric.buildActivity;
@@ -86,6 +84,26 @@ public class ShadowThemeTest {
     assertThat(a.getFloat(R.styleable.CustomView_aspectRatio, 0.2f)).isEqualTo(1.69f);
   }
 
+  @Test public void obtainTypedArrayFromDependencyLibrary() throws Exception {
+    TestActivity activity = buildActivity(TestActivityWithAThirdTheme.class).create().get();
+
+    // This is an Android framework attribute, see:
+    // https://developer.android.com/reference/android/R.attr.html#selectableItemBackground
+    // so can be accessed as android.R.attr.selectableItemBackground but it will also be merged by AAPT so
+    // that it can be accessed as org.robolectric.R.attr.selectableItemBackground and will have the same ID
+    // value. The application ResourceLoader contains a list of sub-package ResourceLoaders and this ID will
+    // have a match in the android namespace as well as any libraries that have a dependency on android (i.e:
+    // all of them) and Robolectric will find the first match which returns a ResName with a
+    // package == org.robolectric - this will fail when looking up in the theme as the attribute is in the
+    // android namespace.
+    TypedArray a  = activity.getTheme().obtainStyledAttributes(new int[]{R.attr.selectableItemBackground});
+
+    int resourceId = a.getResourceId(0, 0);
+
+    // We should find the value as defined by the framework
+    assertThat(resourceId).isNotEqualTo(0);
+  }
+
   @Test public void shouldGetValuesFromAttributeReference() throws Exception {
     TestActivity activity = buildActivity(TestActivityWithAThirdTheme.class).create().get();
 
@@ -138,17 +156,9 @@ public class ShadowThemeTest {
   }
 
   public static class TestActivityWithAnotherTheme extends TestActivity {
-    @Override protected void onCreate(Bundle savedInstanceState) {
-      super.onCreate(savedInstanceState);
-      setContentView(R.layout.styles_button_layout);
-    }
   }
 
   public static class TestActivityWithAThirdTheme extends TestActivity {
-    @Override protected void onCreate(Bundle savedInstanceState) {
-      super.onCreate(savedInstanceState);
-      setContentView(R.layout.styles_button_layout);
-    }
   }
 
   @Test public void shouldApplyFromStyleAttribute() throws Exception {


### PR DESCRIPTION
This causes a breakage when a resource loader hit returns a ResName that does not match the one in the chain of styleables.

Android has one giant package space so we really should be collapsing these duplicate resources during merging.