### PR TITLE
Re-instate no-arg constructors for RoboMenu,RoboSubMenu,RoboMenuItem

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenu.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenu.java
@@ -7,6 +7,7 @@ import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.SubMenu;
+import org.robolectric.RuntimeEnvironment;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -19,6 +20,10 @@ import java.util.List;
 public class RoboMenu implements Menu {
   private List<MenuItem> menuItems = new ArrayList<>();
   private Context context;
+
+  public RoboMenu() {
+    this(RuntimeEnvironment.application);
+  }
 
   public RoboMenu(Context context) {
     this.context = context;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenuItem.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboMenuItem.java
@@ -8,6 +8,7 @@ import android.view.ContextMenu;
 import android.view.MenuItem;
 import android.view.SubMenu;
 import android.view.View;
+import org.robolectric.RuntimeEnvironment;
 
 /**
  * Robolectric implementation of {@link android.view.MenuItem}.
@@ -29,6 +30,10 @@ public class RoboMenuItem implements MenuItem {
   private OnActionExpandListener actionExpandListener;
   private int order;
   private Context context;
+
+  public RoboMenuItem() {
+    this(RuntimeEnvironment.application);
+  }
 
   public RoboMenuItem(Context context) {
     this.context = context;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboSubMenu.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboSubMenu.java
@@ -5,11 +5,16 @@ import android.graphics.drawable.Drawable;
 import android.view.MenuItem;
 import android.view.SubMenu;
 import android.view.View;
+import org.robolectric.RuntimeEnvironment;
 
 /**
  * Robolectric implementation of {@link android.view.SubMenu}.
  */
 public class RoboSubMenu extends RoboMenu implements SubMenu {
+
+  public RoboSubMenu() {
+    this(RuntimeEnvironment.application);
+  }
 
   public RoboSubMenu(Context context) {
     super(context);


### PR DESCRIPTION
### Overview

### Proposed Changes

For backwards compatibility.

 TODO: Evaluate migrating away from RoboMenu's in favor of using framework classes (MenuBuilder, MenuImpl etc). This are private internal Android i.e: not part of the SDK but could be created by something simple like:-

 Menu Robolectric.buildMenu();

 A bolder approach could be to add this support to the ActivityController.

 ActivityController openMenu()

 which would call onCreateOptionsMenu() the first time or onPrepareOptionsMenu() subsequent times. The controller would create the real Android implementation rather than RoboMenus, hold on to them and also offer a selectMenuItem(int id) totally abstracting the menus potentially, or providing an accessor to get them.