### PR TITLE
Remove Robolectric.buildContextWrapper. 

### DIFF
--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -61,17 +61,6 @@ public class Robolectric {
     return shadowsAdapter;
   }
 
-  /**
-   * Creates an instance of a {@link ContextWrapper} subclass and attaches it to the environments base context.
-   * @param contextWrapperClass ContextWrapper implementation class.
-   * @param constructorArgs constructor arguments.
-   */
-  public static <T extends ContextWrapper> T buildContextWrapper(Class<T> contextWrapperClass, ClassParameter<?>... constructorArgs) {
-    T instance = ReflectionHelpers.callConstructor(contextWrapperClass, constructorArgs);
-    ReflectionHelpers.callInstanceMethod(ContextWrapper.class, instance, "attachBaseContext", ClassParameter.from(Context.class, RuntimeEnvironment.application.getBaseContext()));
-    return instance;
-  }
-
   public static <T extends Service> ServiceController<T> buildService(Class<T> serviceClass) {
     return buildService(serviceClass, null);
   }

--- a/robolectric/src/test/java/org/robolectric/RobolectricTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTest.java
@@ -242,13 +242,6 @@ public class RobolectricTest {
     }
   }
 
-  @Test
-  public void testBuildContextWrapper() {
-    MyContextWrapper contextWrapper = Robolectric.buildContextWrapper(MyContextWrapper.class, ClassParameter.from(String.class, "A String"));
-    assertThat(contextWrapper.getBaseContext()).isNotNull();
-    assertThat(contextWrapper.someText).isEqualTo("A String");
-  }
-
   private static class MyContextWrapper extends ContextWrapper {
 
     String someText;


### PR DESCRIPTION
ContextWrapper subclasses must either attach the base context bu passing it up through super() or themselves call attachBaseContext() through some other init method. As such it is not appropriate to create them using a compontent builder.