### PR TITLE
Fix qualifier matching for smallest width

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/Qualifiers.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/Qualifiers.java
@@ -1,0 +1,117 @@
+package org.robolectric.res;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Android qualifers as defined by https://developer.android.com/guide/topics/resources/providing-resources.html
+ */
+public class Qualifiers {
+  // Matches a version qualifier like "v14". Parentheses capture the numeric
+  // part for easy retrieval with Matcher.group(2).
+  private static final Pattern VERSION_QUALIFIER_PATTERN = Pattern.compile("(v)([0-9]+)$");
+  private static final Pattern SIZE_QUALIFIER_PATTERN = Pattern.compile("(s?[wh])([0-9]+)dp$");
+
+  // Version are matched in the end, and hence have least order
+  private static final int ORDER_VERSION = 0;
+  // Various size qualifies, in increasing order of importance.
+  private static final List<String> INT_QUALIFIERS = Arrays.asList("v", "h", "w", "sh", "sw");
+  private static final int TOTAL_ORDER_COUNT = INT_QUALIFIERS.size();
+
+  private static Map<String, Qualifiers> sQualifiersCache = new HashMap<>();
+
+  private final int[] mWeights = new int[TOTAL_ORDER_COUNT];
+  // Set of all the qualifiers which need exact matching.
+  private final List<String> mDefaults = new ArrayList<>();
+
+  public boolean matches(Qualifiers other) {
+    if (!passesRequirements(other)) {
+      return false;
+    }
+    return other.mDefaults.containsAll(mDefaults);
+  }
+
+  public boolean passesRequirements(Qualifiers other) {
+    for (int i = 0; i < TOTAL_ORDER_COUNT; i++) {
+      if (other.mWeights[i] != -1 && mWeights[i] != -1 && other.mWeights[i] < mWeights[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public boolean isBetterThan(Qualifiers other, Qualifiers context) {
+    // Compare the defaults in the order they appear in the context.
+    for (String qualifier : context.mDefaults) {
+      if (other.mDefaults.contains(qualifier) ^ mDefaults.contains(qualifier)) {
+        return mDefaults.contains(qualifier);
+      }
+    }
+
+    for (int i = TOTAL_ORDER_COUNT - 1; i > ORDER_VERSION; i--) {
+      if (other.mWeights[i] != mWeights[i]) {
+        return mWeights[i] > other.mWeights[i];
+      }
+    }
+
+    // Compare the version only if the context defines a version.
+    if (context.mWeights[ORDER_VERSION] != -1
+        && other.mWeights[ORDER_VERSION] != mWeights[ORDER_VERSION]) {
+      return mWeights[ORDER_VERSION] > other.mWeights[ORDER_VERSION];
+    }
+
+    // The qualifiers match completely
+    return false;
+  }
+
+  public static int getVersionQualifierApiLevel(String qualifiers) {
+    Matcher m = VERSION_QUALIFIER_PATTERN.matcher(qualifiers);
+    if (m.find()) {
+      return Integer.parseInt(m.group(2));
+    }
+    return -1;
+  }
+
+  public static Qualifiers parse(String qualifiersStr) {
+    synchronized (sQualifiersCache) {
+      Qualifiers result = sQualifiersCache.get(qualifiersStr);
+      if (result != null) {
+        return result;
+      }
+      StringTokenizer st = new StringTokenizer(qualifiersStr, "-");
+      result = new Qualifiers();
+      // Version qualifiers are also allowed to match when only one of the qualifiers
+      // defines a version restriction.
+      result.mWeights[ORDER_VERSION] = -1;
+
+      while (st.hasMoreTokens()) {
+        String qualifier = st.nextToken();
+        if (qualifier.isEmpty()) {
+          continue;
+        }
+
+        Matcher m = VERSION_QUALIFIER_PATTERN.matcher(qualifier);
+        if (!m.find()) {
+          m = SIZE_QUALIFIER_PATTERN.matcher(qualifier);
+          if (!m.find()) {
+            m = null;
+          }
+        }
+        if (m != null) {
+          int order = INT_QUALIFIERS.indexOf(m.group(1));
+          if (order == ORDER_VERSION && result.mWeights[ORDER_VERSION] != -1) {
+            throw new IllegalStateException(
+                "A resource file was found that had two API level qualifiers: " + qualifiersStr);
+          }
+          result.mWeights[order] = Integer.parseInt(m.group(2));
+        } else {
+          result.mDefaults.add(qualifier);
+        }
+      }
+
+      sQualifiersCache.put(qualifiersStr, result);
+      return result;
+    }
+  }
+}

--- a/robolectric-resources/src/test/java/org/robolectric/res/QualifiersTest.java
+++ b/robolectric-resources/src/test/java/org/robolectric/res/QualifiersTest.java
@@ -1,0 +1,25 @@
+package org.robolectric.res;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnit4.class)
+public class QualifiersTest {
+
+  @Test public void getSmallestScreenWidth() {
+    assertThat(Qualifiers.getSmallestScreenWidth("sw320dp")).isEqualTo(320);
+    assertThat(Qualifiers.getSmallestScreenWidth("sw320dp-v7")).isEqualTo(320);
+    assertThat(Qualifiers.getSmallestScreenWidth("en-rUS-sw320dp")).isEqualTo(320);
+    assertThat(Qualifiers.getSmallestScreenWidth("en-rUS-sw320dp-v7")).isEqualTo(320);
+    assertThat(Qualifiers.getSmallestScreenWidth("en-rUS-v7")).isEqualTo(-1);
+    assertThat(Qualifiers.getSmallestScreenWidth("en-rUS-w320dp-v7")).isEqualTo(-1);
+  }
+
+  @Test public void getAddSmallestScreenWidth() {
+    assertThat(Qualifiers.addSmallestScreenWidth("v7", 320)).isEqualTo("v7-sw320dp");
+    assertThat(Qualifiers.addSmallestScreenWidth("sw320dp-v7", 480)).isEqualTo("sw320dp-v7");
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -78,6 +78,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
     qualifiers = Qualifiers.addSmallestScreenWidth(qualifiers, 320);
     Resources systemResources = Resources.getSystem();
     Configuration configuration = systemResources.getConfiguration();
+    configuration.smallestScreenWidthDp = Qualifiers.getSmallestScreenWidth(qualifiers);
     shadowsAdapter.overrideQualifiers(configuration, qualifiers);
     systemResources.updateConfiguration(configuration, systemResources.getDisplayMetrics());
     RuntimeEnvironment.setQualifiers(qualifiers);

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -20,10 +20,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.internal.fakes.RoboInstrumentation;
 import org.robolectric.manifest.ActivityData;
 import org.robolectric.manifest.AndroidManifest;
-import org.robolectric.res.ResBundle;
-import org.robolectric.res.ResName;
-import org.robolectric.res.ResourceIndex;
-import org.robolectric.res.ResourceLoader;
+import org.robolectric.res.*;
 import org.robolectric.res.builder.DefaultPackageManager;
 import org.robolectric.res.builder.RobolectricPackageManager;
 import org.robolectric.shadows.ShadowLooper;
@@ -61,10 +58,10 @@ public class ParallelUniverse implements ParallelUniverseInterface {
 
   /*
    * If the Config already has a version qualifier, do nothing. Otherwise, add a version
-   * qualifier for the target api level (which comes from the manifest or Config.emulateSdk()).
+   * qualifier for the target api level (which comes from the manifest or Config.sdk()).
    */
   private String addVersionQualifierToQualifiers(String qualifiers) {
-    int versionQualifierApiLevel = ResBundle.getVersionQualifierApiLevel(qualifiers);
+    int versionQualifierApiLevel = Qualifiers.getVersionQualifierApiLevel(qualifiers);
     if (versionQualifierApiLevel == -1) {
       if (qualifiers.length() > 0) {
         qualifiers += "-";

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -56,21 +56,6 @@ public class ParallelUniverse implements ParallelUniverseInterface {
     }
   }
 
-  /*
-   * If the Config already has a version qualifier, do nothing. Otherwise, add a version
-   * qualifier for the target api level (which comes from the manifest or Config.sdk()).
-   */
-  private String addVersionQualifierToQualifiers(String qualifiers) {
-    int versionQualifierApiLevel = Qualifiers.getVersionQualifierApiLevel(qualifiers);
-    if (versionQualifierApiLevel == -1) {
-      if (qualifiers.length() > 0) {
-        qualifiers += "-";
-      }
-      qualifiers += "v" + sdkConfig.getApiLevel();
-    }
-    return qualifiers;
-  }
-
   @Override
   public void setUpApplicationState(Method method, TestLifecycle testLifecycle, ResourceLoader systemResourceLoader, AndroidManifest appManifest, Config config) {
     RuntimeEnvironment.application = null;
@@ -89,7 +74,8 @@ public class ParallelUniverse implements ParallelUniverseInterface {
       Security.insertProviderAt(new BouncyCastleProvider(), 1);
     }
 
-    String qualifiers = addVersionQualifierToQualifiers(config.qualifiers());
+    String qualifiers = Qualifiers.addPlatformVersion(config.qualifiers(), sdkConfig.getApiLevel());
+    qualifiers = Qualifiers.addSmallestScreenWidth(qualifiers, 320);
     Resources systemResources = Resources.getSystem();
     Configuration configuration = systemResources.getConfiguration();
     shadowsAdapter.overrideQualifiers(configuration, qualifiers);

--- a/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
@@ -117,8 +117,8 @@ public class ParallelUniverseTest {
     String givenQualifiers = "";
     Config c = new Config.Builder().setQualifiers(givenQualifiers).build();
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), RuntimeEnvironment.getSystemResourceLoader(), new AndroidManifest(null, null, null, "packagename"), c);
-    assertThat(getQualifiersfromSystemResources()).isEqualTo("v18");
-    assertThat(RuntimeEnvironment.getQualifiers()).isEqualTo("v18");
+    assertThat(getQualifiersfromSystemResources()).contains("v18");
+    assertThat(RuntimeEnvironment.getQualifiers()).contains("v18");
   }
   
   @Test
@@ -126,8 +126,8 @@ public class ParallelUniverseTest {
     String givenQualifiers = "land-v17";
     Config c = new Config.Builder().setQualifiers(givenQualifiers).build();
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), RuntimeEnvironment.getSystemResourceLoader(), new AndroidManifest(null, null, null, "packagename"), c);
-    assertThat(getQualifiersfromSystemResources()).isEqualTo("land-v17");
-    assertThat(RuntimeEnvironment.getQualifiers()).isEqualTo("land-v17");
+    assertThat(getQualifiersfromSystemResources()).contains("land-v17");
+    assertThat(RuntimeEnvironment.getQualifiers()).contains("land-v17");
   }
   
   @Test
@@ -135,8 +135,8 @@ public class ParallelUniverseTest {
     String givenQualifiers = "large-land";
     Config c = new Config.Builder().setQualifiers(givenQualifiers).build();
     pu.setUpApplicationState(null, new DefaultTestLifecycle(), RuntimeEnvironment.getSystemResourceLoader(), new AndroidManifest(null, null, null, "packagename"), c);
-    assertThat(getQualifiersfromSystemResources()).isEqualTo("large-land-v18");
-    assertThat(RuntimeEnvironment.getQualifiers()).isEqualTo("large-land-v18");
+    assertThat(getQualifiersfromSystemResources()).contains("large-land-v18");
+    assertThat(RuntimeEnvironment.getQualifiers()).contains("large-land-v18");
   }
   
   @Test

--- a/robolectric/src/test/java/org/robolectric/QualifiersTest.java
+++ b/robolectric/src/test/java/org/robolectric/QualifiersTest.java
@@ -1,5 +1,6 @@
 package org.robolectric;
 
+import android.app.Activity;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
@@ -25,5 +26,10 @@ public class QualifiersTest {
   @Test @Config(qualifiers = "de")
   public void getQuantityString() throws Exception {
     assertThat(RuntimeEnvironment.application.getResources().getQuantityString(R.plurals.minute, 2)).isEqualTo(RuntimeEnvironment.application.getResources().getString(R.string.minute_plural));
+  }
+
+  @Test
+  public void getLayout() throws Exception {
+    Robolectric.setupActivity(Activity.class).getLayoutInflater().inflate(R.layout.layout_320_smallest_width, null);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/QualifiersTest.java
+++ b/robolectric/src/test/java/org/robolectric/QualifiersTest.java
@@ -1,6 +1,8 @@
 package org.robolectric;
 
 import android.app.Activity;
+import android.view.View;
+import android.widget.TextView;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
@@ -13,14 +15,12 @@ public class QualifiersTest {
 
   @Test
   public void shouldGetFromClass() throws Exception {
-    String expectedQualifiers = "en" + TestRunners.WithDefaults.SDK_TARGETED_BY_MANIFEST;
-    assertThat(RuntimeEnvironment.getQualifiers()).isEqualTo(expectedQualifiers);
+    assertThat(RuntimeEnvironment.getQualifiers()).contains("en");
   }
 
   @Test @Config(qualifiers = "fr")
   public void shouldGetFromMethod() throws Exception {
-    String expectedQualifiers = "fr" + TestRunners.WithDefaults.SDK_TARGETED_BY_MANIFEST;
-    assertThat(RuntimeEnvironment.getQualifiers()).isEqualTo(expectedQualifiers);
+    assertThat(RuntimeEnvironment.getQualifiers()).contains("fr");
   }
 
   @Test @Config(qualifiers = "de")
@@ -29,7 +29,16 @@ public class QualifiersTest {
   }
 
   @Test
-  public void getLayout() throws Exception {
-    Robolectric.setupActivity(Activity.class).getLayoutInflater().inflate(R.layout.layout_320_smallest_width, null);
+  public void inflateLayout_defaultsTo_sw320dp() throws Exception {
+    View view = Robolectric.setupActivity(Activity.class).getLayoutInflater().inflate(R.layout.layout_smallest_width, null);
+    TextView textView = (TextView) view.findViewById(R.id.text1);
+    assertThat(textView.getText()).isEqualTo("320");
+  }
+
+  @Test @Config(qualifiers = "sw720dp")
+  public void inflateLayout_overridesTo_sw720dp() throws Exception {
+    View view = Robolectric.setupActivity(Activity.class).getLayoutInflater().inflate(R.layout.layout_smallest_width, null);
+    TextView textView = (TextView) view.findViewById(R.id.text1);
+    assertThat(textView.getText()).isEqualTo("720");
   }
 }

--- a/robolectric/src/test/java/org/robolectric/QualifiersTest.java
+++ b/robolectric/src/test/java/org/robolectric/QualifiersTest.java
@@ -33,6 +33,8 @@ public class QualifiersTest {
     View view = Robolectric.setupActivity(Activity.class).getLayoutInflater().inflate(R.layout.layout_smallest_width, null);
     TextView textView = (TextView) view.findViewById(R.id.text1);
     assertThat(textView.getText()).isEqualTo("320");
+
+    assertThat(RuntimeEnvironment.application.getResources().getConfiguration().smallestScreenWidthDp).isEqualTo(320);
   }
 
   @Test @Config(qualifiers = "sw720dp")
@@ -40,5 +42,7 @@ public class QualifiersTest {
     View view = Robolectric.setupActivity(Activity.class).getLayoutInflater().inflate(R.layout.layout_smallest_width, null);
     TextView textView = (TextView) view.findViewById(R.id.text1);
     assertThat(textView.getText()).isEqualTo("720");
+
+    assertThat(RuntimeEnvironment.application.getResources().getConfiguration().smallestScreenWidthDp).isEqualTo(720);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/R.java
+++ b/robolectric/src/test/java/org/robolectric/R.java
@@ -219,6 +219,7 @@ public final class R {
     public static final int ordinal_scrollbar = 0x10625;
     public static final int custom_layout5 = 0x10626;
     public static final int custom_layout6 = 0x10627;
+    public static final int layout_320_smallest_width = 0x10628;
   }
 
   public static final class anim {

--- a/robolectric/src/test/java/org/robolectric/R.java
+++ b/robolectric/src/test/java/org/robolectric/R.java
@@ -219,7 +219,7 @@ public final class R {
     public static final int ordinal_scrollbar = 0x10625;
     public static final int custom_layout5 = 0x10626;
     public static final int custom_layout6 = 0x10627;
-    public static final int layout_320_smallest_width = 0x10628;
+    public static final int layout_smallest_width = 0x10628;
   }
 
   public static final class anim {

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
@@ -63,8 +63,7 @@ public class RobolectricTestRunnerSelfTest {
   @Test
   @Config(qualifiers = "fr")
   public void internalBeforeTest_testValuesResQualifiers() {
-    String expectedQualifiers = "fr" + TestRunners.WithDefaults.SDK_TARGETED_BY_MANIFEST;
-    assertThat(RuntimeEnvironment.getQualifiers()).isEqualTo(expectedQualifiers);
+    assertThat(RuntimeEnvironment.getQualifiers()).contains("fr");
   }
 
   @Test

--- a/robolectric/src/test/resources/res/layout-sw320dp/layout_320_smallest_width.xml
+++ b/robolectric/src/test/resources/res/layout-sw320dp/layout_320_smallest_width.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:orientation="vertical"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+/>

--- a/robolectric/src/test/resources/res/layout-sw320dp/layout_320_smallest_width.xml
+++ b/robolectric/src/test/resources/res/layout-sw320dp/layout_320_smallest_width.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:orientation="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-/>

--- a/robolectric/src/test/resources/res/layout-sw320dp/layout_smallest_width.xml
+++ b/robolectric/src/test/resources/res/layout-sw320dp/layout_smallest_width.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:orientation="vertical"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+        <TextView android:id="@id/text1"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:text="320"/>
+></LinearLayout>

--- a/robolectric/src/test/resources/res/layout-sw720dp/layout_smallest_width.xml
+++ b/robolectric/src/test/resources/res/layout-sw720dp/layout_smallest_width.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:orientation="vertical"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+        <TextView android:id="@id/text1"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:text="720"/>
+></LinearLayout>


### PR DESCRIPTION
When using qualifiers for smallest widths Robolectric would fail because the default smallest width is 0. Choose a sensible default, i.e: sw320dp

TODO: Clean up Qualifiers class, use it as a parser for @Config(qualifiers = ) and ensure that it sets Configuration correctly for all values.