### PR TITLE
Prevent duplicate location listeners

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLocationManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLocationManager.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -233,9 +234,20 @@ public class ShadowLocationManager {
       providerListeners = new ArrayList<>();
       locationListeners.put(provider, providerListeners);
     }
+    removeDuplicates(listener, providerListeners);
     providerListeners.add(new ListenerRegistration(provider,
         minTime, minDistance, copyOf(getLastKnownLocation(provider)), listener));
 
+  }
+
+  private void removeDuplicates(LocationListener listener,
+      List<ListenerRegistration> providerListeners) {
+    final Iterator<ListenerRegistration> iterator = providerListeners.iterator();
+    while (iterator.hasNext()) {
+      if (iterator.next().listener.equals(listener)) {
+        iterator.remove();
+      }
+    }
   }
 
   @Implementation

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLocationManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLocationManagerTest.java
@@ -430,6 +430,15 @@ public class ShadowLocationManagerTest {
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners().size()).isEqualTo(0);
   }
 
+  @Test
+  public void requestLocationUpdates_shouldNotRegisterDuplicateListeners() throws Exception {
+    TestLocationListener listener = new TestLocationListener();
+    shadowLocationManager.requestLocationUpdates(GPS_PROVIDER, 0, 0, listener);
+    shadowLocationManager.requestLocationUpdates(GPS_PROVIDER, 0, 0, listener);
+    shadowLocationManager.simulateLocation(new Location(GPS_PROVIDER));
+    assertThat(listener.updateCount).isEqualTo(1);
+  }
+
   private Listener addGpsListenerToLocationManager() {
     Listener listener = new TestGpsListener();
     locationManager.addGpsStatusListener(listener);
@@ -437,12 +446,14 @@ public class ShadowLocationManagerTest {
   }
 
   private static class TestLocationListener implements LocationListener {
-    public boolean providerEnabled;
-    public Location location;
+    boolean providerEnabled;
+    Location location;
+    int updateCount;
 
     @Override
     public void onLocationChanged(Location location) {
       this.location = location;
+      updateCount++;
     }
 
     @Override


### PR DESCRIPTION
### Overview

When a location listener is registered using `LocationManager#requestLocationUpdates(...)`, first check if the listener already exists and if so remove the old registration.
### Proposed Changes

This prevents the same listener from receiving duplicate location updates when `ShadowLocationManager#simulateLocation()` is called.

Closes #2603
