### PR TITLE
Fix log output when installing maps dependency

### DIFF
--- a/scripts/install-dependencies.rb
+++ b/scripts/install-dependencies.rb
@@ -83,14 +83,19 @@ def install_map(group_id, artifact_id, api, revision)
     exit 1
   end
 
-  version = `grep --color=never ^revision= "#{dir}/manifest.ini" | cut -d= -f2`
-  if version.strip != revision
+  revision_match = File.read("#{dir}/manifest.ini").match(/^revision=(\d+)$/)
+  if revision_match.nil?
+    puts "Manifest file missing revision number."
+    puts "Make sure that 'Google APIs' is up to date in the SDK manager for API #{api}."
+  end
+  manifest_revision = revision_match[1].strip
+  if manifest_revision != revision
     puts "#{group_id}:#{artifact_id} is an incompatible revision!"
-    puts "Make sure that 'Google APIs' is up to date in the SDK manager for API #{api}. Expected revision #{revision} but was #{version}."
+    puts "Make sure that 'Google APIs' is up to date in the SDK manager for API #{api}. Expected revision #{revision} but was #{manifest_revision}."
     exit 1
   end
 
-  puts "Installing Maps API #{group_id}:#{artifact_id}, API #{api}, version #{version}, revision #{revision}."
+  puts "Installing Maps API #{group_id}:#{artifact_id}, API #{api}, revision #{revision}."
   install(group_id, artifact_id, "#{api}_r#{revision}", path)
 end
 


### PR DESCRIPTION
### Overview

Fix log output when installing maps dependency

### Proposed Changes

When the maps JAR was installed by scripts/install-dependencies.rb, the
output was misformatted:

```
Installing Maps API com.google.android.maps:maps, API 23, version 1
, revision 1.
```

To fix this, use a Ruby regular expression to extract the manifest
version instead of shelling out to grep.

Also, abort if the manifest revision is missing.