### PR TITLE
Fix small bug in XmlResourceParserImpl.getAttributeName()

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/builder/XmlResourceParserImpl.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/builder/XmlResourceParserImpl.java
@@ -285,7 +285,7 @@ public class XmlResourceParserImpl implements XmlResourceParser {
     try {
       Node attr = getAttributeAt(index);
       String namespace = maybeReplaceNamespace(attr.getNamespaceURI());
-      return (AttributeResource.ANDROID_RES_NS_PREFIX + packageName).equals(namespace) ?
+      return applicationNamespace.equals(namespace) ?
         attr.getLocalName() :
         attr.getNodeName();
     } catch (IndexOutOfBoundsException ex) {


### PR DESCRIPTION
Was incorrectly comparing the wrong name space causing attribute name look-ups to resolve incorrectly, i.e: with the namespace prefix for non-android packages in some cases. This would in turn make the name-to-resourceId lookup fail.