### PR TITLE
Add IntentServiceController and tests

### DIFF
--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -3,6 +3,7 @@ package org.robolectric;
 import android.app.Activity;
 import android.app.Fragment;
 import android.app.Service;
+import android.app.IntentService;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.Intent;

--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -16,6 +16,7 @@ import org.robolectric.res.builder.XmlResourceParserImpl;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.util.ActivityController;
 import org.robolectric.util.FragmentController;
+import org.robolectric.util.IntentServiceController;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 import org.robolectric.util.Scheduler;
@@ -71,6 +72,18 @@ public class Robolectric {
 
   public static <T extends Service> T setupService(Class<T> serviceClass) {
     return buildService(serviceClass).create().get();
+  }
+
+  public static <T extends IntentService> IntentServiceController<T> buildIntentService(Class<T> serviceClass) {
+    return buildIntentService(serviceClass, null);
+  }
+
+  public static <T extends IntentService> IntentServiceController<T> buildIntentService(Class<T> serviceClass, Intent intent) {
+    return IntentServiceController.of(getShadowsAdapter(), ReflectionHelpers.callConstructor(serviceClass, new ReflectionHelpers.ClassParameter<String>(String.class, "IntentService")), intent);
+  }
+
+  public static <T extends IntentService> T setupIntentService(Class<T> serviceClass) {
+    return buildIntentService(serviceClass).create().get();
   }
 
   public static <T extends Activity> ActivityController<T> buildActivity(Class<T> activityClass) {

--- a/robolectric/src/main/java/org/robolectric/util/IntentServiceController.java
+++ b/robolectric/src/main/java/org/robolectric/util/IntentServiceController.java
@@ -1,6 +1,7 @@
 package org.robolectric.util;
 
 import android.app.Application;
+import android.app.Service;
 import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;

--- a/robolectric/src/main/java/org/robolectric/util/IntentServiceController.java
+++ b/robolectric/src/main/java/org/robolectric/util/IntentServiceController.java
@@ -6,19 +6,20 @@ import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
+
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.ShadowsAdapter;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 public class IntentServiceController<T extends IntentService> extends ComponentController<IntentServiceController<T>, T> {
-    private final  String shadowActivityThreadClassName;
+  private final String shadowActivityThreadClassName;
 
-    public static <T extends IntentService> IntentServiceController<T> of(final ShadowsAdapter shadowsAdapter,
-                                                                          final T service,
-                                                                          final Intent intent) {
-        final IntentServiceController<T> controller = new IntentServiceController<>(shadowsAdapter, service, intent);
-        controller.attach();
-        return controller;
+  public static <T extends IntentService> IntentServiceController<T> of(final ShadowsAdapter shadowsAdapter,
+                                                                        final T service,
+                                                                        final Intent intent) {
+    final IntentServiceController<T> controller = new IntentServiceController<>(shadowsAdapter, service, intent);
+      controller.attach();
+      return controller;
     }
 
     private IntentServiceController(final ShadowsAdapter shadowsAdapter, final T service, final Intent intent) {
@@ -27,66 +28,66 @@ public class IntentServiceController<T extends IntentService> extends ComponentC
     }
 
     public IntentServiceController<T> attach() {
-        if (attached) {
-            return this;
-        }
-
-        final Context baseContext = RuntimeEnvironment.application.getBaseContext();
-
-        final ClassLoader cl = baseContext.getClassLoader();
-        final Class<?> activityThreadClass;
-        try {
-            activityThreadClass = cl.loadClass(shadowActivityThreadClassName);
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
-
-        ReflectionHelpers.callInstanceMethod(Service.class, component, "attach",
-                ReflectionHelpers.ClassParameter.from(Context.class, baseContext),
-                ReflectionHelpers.ClassParameter.from(activityThreadClass, null),
-                ReflectionHelpers.ClassParameter.from(String.class, component.getClass().getSimpleName()),
-                ReflectionHelpers.ClassParameter.from(IBinder.class, null),
-                ReflectionHelpers.ClassParameter.from(Application.class, RuntimeEnvironment.application),
-                ReflectionHelpers.ClassParameter.from(Object.class, null));
-
-        attached = true;
+      if (attached) {
         return this;
+      }
+
+      final Context baseContext = RuntimeEnvironment.application.getBaseContext();
+
+      final ClassLoader cl = baseContext.getClassLoader();
+      final Class<?> activityThreadClass;
+        try {
+          activityThreadClass = cl.loadClass(shadowActivityThreadClassName);
+        } catch (ClassNotFoundException e) {
+          e.printStackTrace();
+          throw new RuntimeException(e);
+        }
+
+      ReflectionHelpers.callInstanceMethod(Service.class, component, "attach",
+         ReflectionHelpers.ClassParameter.from(Context.class, baseContext),
+         ReflectionHelpers.ClassParameter.from(activityThreadClass, null),
+         ReflectionHelpers.ClassParameter.from(String.class, component.getClass().getSimpleName()),
+         ReflectionHelpers.ClassParameter.from(IBinder.class, null),
+         ReflectionHelpers.ClassParameter.from(Application.class, RuntimeEnvironment.application),
+         ReflectionHelpers.ClassParameter.from(Object.class, null));
+
+      attached = true;
+      return this;
     }
 
     public IntentServiceController<T> bind() {
-        invokeWhilePaused("onBind", getIntent());
-        return this;
+      invokeWhilePaused("onBind", getIntent());
+      return this;
     }
 
     public IntentServiceController<T> create() {
-        invokeWhilePaused("onCreate");
-        return this;
+      invokeWhilePaused("onCreate");
+      return this;
     }
 
     public IntentServiceController<T> destroy() {
-        invokeWhilePaused("onDestroy");
-        return this;
+      invokeWhilePaused("onDestroy");
+      return this;
     }
 
     public IntentServiceController<T> rebind() {
-        invokeWhilePaused("onRebind", getIntent());
-        return this;
+      invokeWhilePaused("onRebind", getIntent());
+      return this;
     }
 
     public IntentServiceController<T> startCommand(final int flags, final int startId) {
-        final IntentServiceController<T> intentServiceController = handleIntent();
-        get().stopSelf(startId);
-        return intentServiceController;
+      final IntentServiceController<T> intentServiceController = handleIntent();
+      get().stopSelf(startId);
+      return intentServiceController;
     }
 
     public IntentServiceController<T> unbind() {
-        invokeWhilePaused("onUnbind", getIntent());
-        return this;
+      invokeWhilePaused("onUnbind", getIntent());
+      return this;
     }
 
     public IntentServiceController<T> handleIntent() {
-        invokeWhilePaused("onHandleIntent", getIntent());
-        return this;
+      invokeWhilePaused("onHandleIntent", getIntent());
+      return this;
     }
 }

--- a/robolectric/src/main/java/org/robolectric/util/IntentServiceController.java
+++ b/robolectric/src/main/java/org/robolectric/util/IntentServiceController.java
@@ -1,0 +1,91 @@
+package org.robolectric.util;
+
+import android.app.Application;
+import android.app.IntentService;
+import android.content.Context;
+import android.content.Intent;
+import android.os.IBinder;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.ShadowsAdapter;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
+
+public class IntentServiceController<T extends IntentService> extends ComponentController<IntentServiceController<T>, T> {
+    private final  String shadowActivityThreadClassName;
+
+    public static <T extends IntentService> IntentServiceController<T> of(final ShadowsAdapter shadowsAdapter,
+                                                                          final T service,
+                                                                          final Intent intent) {
+        final IntentServiceController<T> controller = new IntentServiceController<>(shadowsAdapter, service, intent);
+        controller.attach();
+        return controller;
+    }
+
+    private IntentServiceController(final ShadowsAdapter shadowsAdapter, final T service, final Intent intent) {
+        super(shadowsAdapter, service, intent);
+        shadowActivityThreadClassName = shadowsAdapter.getShadowActivityThreadClassName();
+    }
+
+    public IntentServiceController<T> attach() {
+        if (attached) {
+            return this;
+        }
+
+        final Context baseContext = RuntimeEnvironment.application.getBaseContext();
+
+        final ClassLoader cl = baseContext.getClassLoader();
+        final Class<?> activityThreadClass;
+        try {
+            activityThreadClass = cl.loadClass(shadowActivityThreadClassName);
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+
+        ReflectionHelpers.callInstanceMethod(Service.class, component, "attach",
+                ReflectionHelpers.ClassParameter.from(Context.class, baseContext),
+                ReflectionHelpers.ClassParameter.from(activityThreadClass, null),
+                ReflectionHelpers.ClassParameter.from(String.class, component.getClass().getSimpleName()),
+                ReflectionHelpers.ClassParameter.from(IBinder.class, null),
+                ReflectionHelpers.ClassParameter.from(Application.class, RuntimeEnvironment.application),
+                ReflectionHelpers.ClassParameter.from(Object.class, null));
+
+        attached = true;
+        return this;
+    }
+
+    public IntentServiceController<T> bind() {
+        invokeWhilePaused("onBind", getIntent());
+        return this;
+    }
+
+    public IntentServiceController<T> create() {
+        invokeWhilePaused("onCreate");
+        return this;
+    }
+
+    public IntentServiceController<T> destroy() {
+        invokeWhilePaused("onDestroy");
+        return this;
+    }
+
+    public IntentServiceController<T> rebind() {
+        invokeWhilePaused("onRebind", getIntent());
+        return this;
+    }
+
+    public IntentServiceController<T> startCommand(final int flags, final int startId) {
+        final IntentServiceController<T> intentServiceController = handleIntent();
+        get().stopSelf(startId);
+        return intentServiceController;
+    }
+
+    public IntentServiceController<T> unbind() {
+        invokeWhilePaused("onUnbind", getIntent());
+        return this;
+    }
+
+    public IntentServiceController<T> handleIntent() {
+        invokeWhilePaused("onHandleIntent", getIntent());
+        return this;
+    }
+}

--- a/robolectric/src/test/java/org/robolectric/util/IntentServiceControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/IntentServiceControllerTest.java
@@ -1,0 +1,179 @@
+package org.robolectric.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.TestRunners;
+
+import android.app.IntentService;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import org.robolectric.shadows.CoreShadowsAdapter;
+import org.robolectric.shadows.ShadowLooper;
+@RunWith(TestRunners.WithDefaults.class)
+public class IntentServiceControllerTest {
+    private static final Transcript transcript = new Transcript();
+    private final ComponentName componentName = new ComponentName("org.robolectric", MyService.class.getName());
+    private final IntentServiceController<MyService> controller = Robolectric.buildIntentService(MyService.class, new Intent());
+
+    @Before
+    public void setUp() throws Exception {
+        transcript.clear();
+    }
+
+    @Test
+    public void onBindShouldSetIntent() throws Exception {
+        MyService myService = controller.create().bind().get();
+        assertThat(myService.boundIntent).isNotNull();
+        assertThat(myService.boundIntent.getComponent()).isEqualTo(componentName);
+    }
+
+    @Test
+    public void onStartCommandShouldSetIntent() throws Exception {
+        MyService myService = controller.create().startCommand(3, 4).get();
+        assertThat(myService.startIntent).isNotNull();
+        assertThat(myService.startIntent.getComponent()).isEqualTo(componentName);
+    }
+
+    @Test
+    public void onBindShouldSetIntentComponentWithCustomIntentWithoutComponentSet() throws Exception {
+        MyService myService = controller.withIntent(new Intent(Intent.ACTION_VIEW)).bind().get();
+        assertThat(myService.boundIntent.getAction()).isEqualTo(Intent.ACTION_VIEW);
+        assertThat(myService.boundIntent.getComponent()).isEqualTo(componentName);
+    }
+
+    @Test
+    public void shouldSetIntentForGivenServiceInstance() throws Exception {
+        IntentServiceController<MyService> intentServiceController = IntentServiceController.of(new CoreShadowsAdapter(), new MyService(""), null).bind();
+        assertThat(intentServiceController.get().boundIntent).isNotNull();
+    }
+
+    @Test
+    public void whenLooperIsNotPaused_shouldCreateWithMainLooperPaused() throws Exception {
+        ShadowLooper.unPauseMainLooper();
+        controller.create();
+        assertThat(shadowOf(Looper.getMainLooper()).isPaused()).isFalse();
+        transcript.assertEventsInclude("finishedOnCreate", "onCreate");
+    }
+
+    @Test
+    public void whenLooperIsAlreadyPaused_shouldCreateWithMainLooperPaused() throws Exception {
+        ShadowLooper.pauseMainLooper();
+        controller.create();
+        assertThat(shadowOf(Looper.getMainLooper()).isPaused()).isTrue();
+        transcript.assertEventsInclude("finishedOnCreate");
+
+        ShadowLooper.unPauseMainLooper();
+        transcript.assertEventsInclude("onCreate");
+    }
+
+    @Test
+    public void unbind_callsUnbindWhilePaused() {
+        controller.create().bind().unbind();
+        transcript.assertEventsInclude("finishedOnUnbind", "onUnbind");
+    }
+
+    @Test
+    public void rebind_callsRebindWhilePaused() {
+        controller.create().bind().unbind().bind().rebind();
+        transcript.assertEventsInclude("finishedOnRebind", "onRebind");
+    }
+
+    @Test
+    public void destroy_callsOnDestroyWhilePaused() {
+        controller.create().destroy();
+        transcript.assertEventsInclude("finishedOnDestroy", "onDestroy");
+    }
+
+    @Test
+    public void bind_callsOnBindWhilePaused() {
+        controller.create().bind();
+        transcript.assertEventsInclude("finishedOnBind", "onBind");
+    }
+
+    @Test
+    public void startCommand_callsOnHandleIntentWhilePaused() {
+        controller.create().startCommand(1, 2);
+        transcript.assertEventsInclude("finishedOnHandleIntent", "onHandleIntent");
+    }
+
+    public static class MyService extends IntentService {
+
+        private Handler handler = new Handler(Looper.getMainLooper());
+
+        public Intent boundIntent;
+
+        public Intent reboundIntent;
+        public Intent startIntent;
+
+        public Intent unboundIntent;
+
+        public MyService(String name) {
+            super(name);
+        }
+
+        @Override
+        public IBinder onBind(Intent intent) {
+            boundIntent = intent;
+            transcribeWhilePaused("onBind");
+            transcript.add("finishedOnBind");
+            return null;
+        }
+
+        @Override
+        protected void onHandleIntent(Intent intent) {
+            startIntent = intent;
+            transcribeWhilePaused("onHandleIntent");
+            transcript.add("finishedOnHandleIntent");
+        }
+
+        @Override
+        public void onCreate() {
+            super.onCreate();
+            transcribeWhilePaused("onCreate");
+            transcript.add("finishedOnCreate");
+        }
+
+        @Override
+        public void onDestroy() {
+            super.onDestroy();
+            transcribeWhilePaused("onDestroy");
+            transcript.add("finishedOnDestroy");
+        }
+
+        @Override
+        public void onRebind(Intent intent) {
+            reboundIntent = intent;
+            transcribeWhilePaused("onRebind");
+            transcript.add("finishedOnRebind");
+        }
+
+        @Override
+        public boolean onUnbind(Intent intent) {
+            unboundIntent = intent;
+            transcribeWhilePaused("onUnbind");
+            transcript.add("finishedOnUnbind");
+            return false;
+        }
+
+        private void transcribeWhilePaused(final String event) {
+            runOnUiThread(new Runnable() {
+                @Override public void run() {
+                    transcript.add(event);
+                }
+            });
+        }
+
+        private void runOnUiThread(Runnable action) {
+            // This is meant to emulate the behavior of Activity.runOnUiThread();
+            shadowOf(handler.getLooper()).getScheduler().post(action);
+        }
+    }
+}

--- a/robolectric/src/test/java/org/robolectric/util/IntentServiceControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/IntentServiceControllerTest.java
@@ -19,161 +19,160 @@ import org.robolectric.shadows.CoreShadowsAdapter;
 import org.robolectric.shadows.ShadowLooper;
 @RunWith(TestRunners.WithDefaults.class)
 public class IntentServiceControllerTest {
-    private static final Transcript transcript = new Transcript();
-    private final ComponentName componentName = new ComponentName("org.robolectric", MyService.class.getName());
-    private final IntentServiceController<MyService> controller = Robolectric.buildIntentService(MyService.class, new Intent());
+  private static final Transcript transcript = new Transcript();
+  private final ComponentName componentName = new ComponentName("org.robolectric", MyService.class.getName());
+  private final IntentServiceController<MyService> controller = Robolectric.buildIntentService(MyService.class, new Intent());
 
-    @Before
-    public void setUp() throws Exception {
-        transcript.clear();
-    }
+  @Before
+  public void setUp() throws Exception {
+    transcript.clear();
+  }
 
-    @Test
-    public void onBindShouldSetIntent() throws Exception {
-        MyService myService = controller.create().bind().get();
-        assertThat(myService.boundIntent).isNotNull();
-        assertThat(myService.boundIntent.getComponent()).isEqualTo(componentName);
-    }
+  @Test
+  public void onBindShouldSetIntent() throws Exception {
+    MyService myService = controller.create().bind().get();
+    assertThat(myService.boundIntent).isNotNull();
+    assertThat(myService.boundIntent.getComponent()).isEqualTo(componentName);
+  }
 
-    @Test
-    public void onStartCommandShouldSetIntent() throws Exception {
-        MyService myService = controller.create().startCommand(3, 4).get();
-        assertThat(myService.startIntent).isNotNull();
-        assertThat(myService.startIntent.getComponent()).isEqualTo(componentName);
-    }
+  @Test
+  public void onStartCommandShouldSetIntent() throws Exception {
+    MyService myService = controller.create().startCommand(3, 4).get();
+    assertThat(myService.startIntent).isNotNull();
+    assertThat(myService.startIntent.getComponent()).isEqualTo(componentName);
+  }
 
-    @Test
-    public void onBindShouldSetIntentComponentWithCustomIntentWithoutComponentSet() throws Exception {
-        MyService myService = controller.withIntent(new Intent(Intent.ACTION_VIEW)).bind().get();
-        assertThat(myService.boundIntent.getAction()).isEqualTo(Intent.ACTION_VIEW);
-        assertThat(myService.boundIntent.getComponent()).isEqualTo(componentName);
-    }
+  @Test
+  public void onBindShouldSetIntentComponentWithCustomIntentWithoutComponentSet() throws Exception {
+    MyService myService = controller.withIntent(new Intent(Intent.ACTION_VIEW)).bind().get();
+    assertThat(myService.boundIntent.getAction()).isEqualTo(Intent.ACTION_VIEW);
+    assertThat(myService.boundIntent.getComponent()).isEqualTo(componentName);
+  }
 
-    @Test
-    public void shouldSetIntentForGivenServiceInstance() throws Exception {
-        IntentServiceController<MyService> intentServiceController = IntentServiceController.of(new CoreShadowsAdapter(), new MyService(""), null).bind();
-        assertThat(intentServiceController.get().boundIntent).isNotNull();
-    }
+  @Test
+  public void shouldSetIntentForGivenServiceInstance() throws Exception {
+    IntentServiceController<MyService> intentServiceController = IntentServiceController.of(new CoreShadowsAdapter(), new MyService(""), null).bind();
+    assertThat(intentServiceController.get().boundIntent).isNotNull();
+  }
 
-    @Test
-    public void whenLooperIsNotPaused_shouldCreateWithMainLooperPaused() throws Exception {
-        ShadowLooper.unPauseMainLooper();
-        controller.create();
-        assertThat(shadowOf(Looper.getMainLooper()).isPaused()).isFalse();
-        transcript.assertEventsInclude("finishedOnCreate", "onCreate");
-    }
+  @Test
+  public void whenLooperIsNotPaused_shouldCreateWithMainLooperPaused() throws Exception {
+    ShadowLooper.unPauseMainLooper();
+    controller.create();
+    assertThat(shadowOf(Looper.getMainLooper()).isPaused()).isFalse();
+    transcript.assertEventsInclude("finishedOnCreate", "onCreate");
+  }
 
-    @Test
-    public void whenLooperIsAlreadyPaused_shouldCreateWithMainLooperPaused() throws Exception {
-        ShadowLooper.pauseMainLooper();
-        controller.create();
-        assertThat(shadowOf(Looper.getMainLooper()).isPaused()).isTrue();
-        transcript.assertEventsInclude("finishedOnCreate");
+  @Test
+  public void whenLooperIsAlreadyPaused_shouldCreateWithMainLooperPaused() throws Exception {
+    ShadowLooper.pauseMainLooper();
+    controller.create();
+    assertThat(shadowOf(Looper.getMainLooper()).isPaused()).isTrue();
+    transcript.assertEventsInclude("finishedOnCreate");
 
-        ShadowLooper.unPauseMainLooper();
-        transcript.assertEventsInclude("onCreate");
-    }
+    ShadowLooper.unPauseMainLooper();
+    transcript.assertEventsInclude("onCreate");
+  }
 
-    @Test
-    public void unbind_callsUnbindWhilePaused() {
-        controller.create().bind().unbind();
-        transcript.assertEventsInclude("finishedOnUnbind", "onUnbind");
-    }
+  @Test
+  public void unbind_callsUnbindWhilePaused() {
+    controller.create().bind().unbind();
+    transcript.assertEventsInclude("finishedOnUnbind", "onUnbind");
+  }
 
-    @Test
-    public void rebind_callsRebindWhilePaused() {
-        controller.create().bind().unbind().bind().rebind();
-        transcript.assertEventsInclude("finishedOnRebind", "onRebind");
-    }
+  @Test
+  public void rebind_callsRebindWhilePaused() {
+    controller.create().bind().unbind().bind().rebind();
+    transcript.assertEventsInclude("finishedOnRebind", "onRebind");
+  }
 
-    @Test
-    public void destroy_callsOnDestroyWhilePaused() {
-        controller.create().destroy();
-        transcript.assertEventsInclude("finishedOnDestroy", "onDestroy");
-    }
+  @Test
+  public void destroy_callsOnDestroyWhilePaused() {
+    controller.create().destroy();
+    transcript.assertEventsInclude("finishedOnDestroy", "onDestroy");
+  }
 
-    @Test
-    public void bind_callsOnBindWhilePaused() {
-        controller.create().bind();
-        transcript.assertEventsInclude("finishedOnBind", "onBind");
-    }
+  @Test
+  public void bind_callsOnBindWhilePaused() {
+    controller.create().bind();
+    transcript.assertEventsInclude("finishedOnBind", "onBind");
+  }
 
-    @Test
-    public void startCommand_callsOnHandleIntentWhilePaused() {
-        controller.create().startCommand(1, 2);
-        transcript.assertEventsInclude("finishedOnHandleIntent", "onHandleIntent");
-    }
+  @Test
+  public void startCommand_callsOnHandleIntentWhilePaused() {
+    controller.create().startCommand(1, 2);
+    transcript.assertEventsInclude("finishedOnHandleIntent", "onHandleIntent");
+  }
 
-    public static class MyService extends IntentService {
+  public static class MyService extends IntentService {
+    private Handler handler = new Handler(Looper.getMainLooper());
 
-        private Handler handler = new Handler(Looper.getMainLooper());
+    public Intent boundIntent;
 
-        public Intent boundIntent;
+    public Intent reboundIntent;
+    public Intent startIntent;
 
-        public Intent reboundIntent;
-        public Intent startIntent;
+    public Intent unboundIntent;
 
-        public Intent unboundIntent;
-
-        public MyService(String name) {
+    public MyService(String name) {
             super(name);
         }
 
-        @Override
-        public IBinder onBind(Intent intent) {
-            boundIntent = intent;
-            transcribeWhilePaused("onBind");
-            transcript.add("finishedOnBind");
-            return null;
-        }
-
-        @Override
-        protected void onHandleIntent(Intent intent) {
-            startIntent = intent;
-            transcribeWhilePaused("onHandleIntent");
-            transcript.add("finishedOnHandleIntent");
-        }
-
-        @Override
-        public void onCreate() {
-            super.onCreate();
-            transcribeWhilePaused("onCreate");
-            transcript.add("finishedOnCreate");
-        }
-
-        @Override
-        public void onDestroy() {
-            super.onDestroy();
-            transcribeWhilePaused("onDestroy");
-            transcript.add("finishedOnDestroy");
-        }
-
-        @Override
-        public void onRebind(Intent intent) {
-            reboundIntent = intent;
-            transcribeWhilePaused("onRebind");
-            transcript.add("finishedOnRebind");
-        }
-
-        @Override
-        public boolean onUnbind(Intent intent) {
-            unboundIntent = intent;
-            transcribeWhilePaused("onUnbind");
-            transcript.add("finishedOnUnbind");
-            return false;
-        }
-
-        private void transcribeWhilePaused(final String event) {
-            runOnUiThread(new Runnable() {
-                @Override public void run() {
-                    transcript.add(event);
-                }
-            });
-        }
-
-        private void runOnUiThread(Runnable action) {
-            // This is meant to emulate the behavior of Activity.runOnUiThread();
-            shadowOf(handler.getLooper()).getScheduler().post(action);
-        }
+    @Override
+    public IBinder onBind(Intent intent) {
+      boundIntent = intent;
+      transcribeWhilePaused("onBind");
+      transcript.add("finishedOnBind");
+      return null;
     }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+      startIntent = intent;
+      transcribeWhilePaused("onHandleIntent");
+      transcript.add("finishedOnHandleIntent");
+    }
+
+    @Override
+    public void onCreate() {
+      super.onCreate();
+      transcribeWhilePaused("onCreate");
+      transcript.add("finishedOnCreate");
+    }
+
+    @Override
+    public void onDestroy() {
+      super.onDestroy();
+      transcribeWhilePaused("onDestroy");
+      transcript.add("finishedOnDestroy");
+    }
+
+    @Override
+    public void onRebind(Intent intent) {
+      reboundIntent = intent;
+      transcribeWhilePaused("onRebind");
+      transcript.add("finishedOnRebind");
+    }
+
+    @Override
+    public boolean onUnbind(Intent intent) {
+      unboundIntent = intent;
+      transcribeWhilePaused("onUnbind");
+      transcript.add("finishedOnUnbind");
+      return false;
+    }
+
+    private void transcribeWhilePaused(final String event) {
+      runOnUiThread(new Runnable() {
+        @Override public void run() {
+          transcript.add(event);
+        }
+      });
+    }
+
+    private void runOnUiThread(Runnable action) {
+      // This is meant to emulate the behavior of Activity.runOnUiThread();
+      shadowOf(handler.getLooper()).getScheduler().post(action);
+    }
+  }
 }


### PR DESCRIPTION
### Overview
Add a `ComponentController` for `IntentService`s 

### Proposed Changes
Add a version of `ServiceController` specifically for testing `IntentService`s which hardwire `startCommand()` calls to `handleIntent()` on a separate thread.  
