### PR TITLE
Parse manifest file immediately to stabilize hashcode

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -93,6 +93,7 @@ public class AndroidManifest {
     this.resDirectory = resDirectory;
     this.assetsDirectory = assetsDirectory;
     this.packageName = packageName;
+    parseAndroidManifest();
   }
 
   public String getThemeRef(Class<? extends Activity> activityClass) {
@@ -105,7 +106,6 @@ public class AndroidManifest {
   }
 
   public String getRClassName() throws Exception {
-    parseAndroidManifest();
     return rClassName;
   }
 
@@ -448,12 +448,10 @@ public class AndroidManifest {
   }
 
   public String getApplicationName() {
-    parseAndroidManifest();
     return applicationName;
   }
 
   public String getActivityLabel(Class<? extends Activity> activity) {
-    parseAndroidManifest();
     ActivityData data = getActivityData(activity.getName());
     return (data != null && data.getLabel() != null) ? data.getLabel() : applicationLabel;
   }
@@ -464,7 +462,6 @@ public class AndroidManifest {
   }
 
   public String getPackageName() {
-    parseAndroidManifest();
     return packageName;
   }
 
@@ -481,27 +478,22 @@ public class AndroidManifest {
   }
 
   public int getMinSdkVersion() {
-    parseAndroidManifest();
     return minSdkVersion == null ? 1 : minSdkVersion;
   }
 
   public int getTargetSdkVersion() {
-    parseAndroidManifest();
     return targetSdkVersion == null ? getMinSdkVersion() : targetSdkVersion;
   }
 
   public int getApplicationFlags() {
-    parseAndroidManifest();
     return applicationFlags;
   }
 
   public String getProcessName() {
-    parseAndroidManifest();
     return processName;
   }
 
   public Map<String, Object> getApplicationMetaData() {
-    parseAndroidManifest();
     if (applicationMetaData == null) {
       applicationMetaData = new MetaData(Collections.<Node>emptyList());
     }
@@ -522,7 +514,6 @@ public class AndroidManifest {
   }
 
   public List<ContentProviderData> getContentProviders() {
-    parseAndroidManifest();
     return providers;
   }
 
@@ -549,12 +540,10 @@ public class AndroidManifest {
   }
 
   public List<BroadcastReceiverData> getBroadcastReceivers() {
-    parseAndroidManifest();
     return receivers;
   }
 
   public List<ServiceData> getServices() {
-    parseAndroidManifest();
     return new ArrayList<>(serviceDatas.values());
   }
 
@@ -608,12 +597,10 @@ public class AndroidManifest {
   }
 
   public Map<String, ActivityData> getActivityDatas() {
-    parseAndroidManifest();
     return activityDatas;
   }
 
   public List<String> getUsedPermissions() {
-    parseAndroidManifest();
     return usedPermissions;
   }
 }

--- a/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
+++ b/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
@@ -408,4 +408,13 @@ public class AndroidManifestTest {
     public void onReceive(Context context, Intent intent) {
     }
   }
+
+  @Test
+  public void shouldHaveStableHashCode() throws Exception {
+    AndroidManifest config = newConfig("TestAndroidManifestWithContentProviders.xml");
+    int hashCode1 = config.hashCode();
+    config.getServices();
+    int hashCode2 = config.hashCode();
+    assertEquals(hashCode1, hashCode2);
+  }
 }


### PR DESCRIPTION
### Overview

RobolectricTestRunner maintains a HashMap that is used to cache XML resource files. The AndroidManifest class is part of the key for this map. In certain situations, because of the instability of the hash code, resource caching could break. For applications with a large number of resources, this could cause a performance degradation while running tests.

### Proposed Changes

The hashCode function for the AndroidManifest class depends on the
package name. Initially, if an AndroidManifest object is constructed
without providing a package name, the initial package name is null.
After `parseAndroidManifest` is called, the packageName is extracted
from the manifest file, and `hashCode` will return a different value.

In certain situations, this broke resource caching in
RobolectricTestRunner. The cache is essentially a HashMap with an
AndroidManifest object as part of the key. Because the value of
`hashCode` changes, the lookups would not work properly.

To alleviate the issue, parse the manifest file immediately after
construction. This ensures that all components of the hashCode method
are provided at construction.

This fixes #2623