### PR TITLE
Deprecate AndroidManifest#setPackageName

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -458,6 +458,7 @@ public class AndroidManifest {
     return (data != null && data.getLabel() != null) ? data.getLabel() : applicationLabel;
   }
 
+  @Deprecated
   public void setPackageName(String packageName) {
     this.packageName = packageName;
   }


### PR DESCRIPTION
### Overview

Deprecate AndroidManifest#setPackageName

### Proposed Changes

There are several other ways to set the package name during Robolectric
tests. The most common ways seem to be using the four-argument
constructor of AndroidManifest, specifying it in the Config, or through
`parseAndroidManifest`.