### PR TITLE
Switch the default screen width from 1024 to 320

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -76,7 +76,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
 
     String qualifiers = Qualifiers.addPlatformVersion(config.qualifiers(), sdkConfig.getApiLevel());
     qualifiers = Qualifiers.addSmallestScreenWidth(qualifiers, 320);
-    qualifiers = Qualifiers.addScreenWidth(qualifiers, 1024);
+    qualifiers = Qualifiers.addScreenWidth(qualifiers, 320);
     Resources systemResources = Resources.getSystem();
     Configuration configuration = systemResources.getConfiguration();
     configuration.smallestScreenWidthDp = Qualifiers.getSmallestScreenWidth(qualifiers);

--- a/robolectric/src/test/java/org/robolectric/QualifiersTest.java
+++ b/robolectric/src/test/java/org/robolectric/QualifiersTest.java
@@ -48,7 +48,7 @@ public class QualifiersTest {
 
   @Test
   public void defaultScreenWidth() {
-    assertThat(RuntimeEnvironment.application.getResources().getBoolean(R.bool.value_only_present_in_w820dp)).isTrue();
-    assertThat(RuntimeEnvironment.application.getResources().getConfiguration().screenWidthDp).isEqualTo(1024);
+    assertThat(RuntimeEnvironment.application.getResources().getBoolean(R.bool.value_only_present_in_w320dp)).isTrue();
+    assertThat(RuntimeEnvironment.application.getResources().getConfiguration().screenWidthDp).isEqualTo(320);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/R.java
+++ b/robolectric/src/test/java/org/robolectric/R.java
@@ -332,7 +332,7 @@ public final class R {
     public static final int reference_to_true = 0x10f04;
     public static final int true_as_item = 0x10f05;
     public static final int different_resource_boolean=0x10f06;
-    public static final int value_only_present_in_w820dp=0x10f07;
+    public static final int value_only_present_in_w320dp=0x10f07;
   }
 
   public static final class style {

--- a/robolectric/src/test/resources/res/values-w320dp/bools.xml
+++ b/robolectric/src/test/resources/res/values-w320dp/bools.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <bool name="different_resource_boolean">true</bool>
+  <bool name="value_only_present_in_w320dp">true</bool>
 </resources>


### PR DESCRIPTION
### Overview

The existing default screen width is too large since it causes existing tests to fail in our corpus in the presence of other qualifiers which would otherwise be selected over the default.

### Proposed Changes

This has a more minimal impact on existing tests that would fail with a default screen width of 1024 due to the presence of other qualifiers, e.g: w800dp