### PR TITLE
Fix ShadowPendingIntent#equals

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.robolectric.Shadows.shadowOf;
+
 /**
  * Shadow for {@code android.app.PendingIntent}.
  */
@@ -136,10 +138,8 @@ public class ShadowPendingIntent {
   @Implementation
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-
-    ShadowPendingIntent that = (ShadowPendingIntent) o;
-
+    if (o == null || realPendingIntent.getClass() != o.getClass()) return false;
+    ShadowPendingIntent that = shadowOf((PendingIntent) o);
     if (savedContext != null) {
       String packageName = savedContext.getPackageName();
       String thatPackageName = that.savedContext.getPackageName();
@@ -147,8 +147,19 @@ public class ShadowPendingIntent {
     } else {
       if (that.savedContext != null) return false;
     }
-    if (savedIntents != null) {
-      if (!Arrays.equals(this.savedIntents, that.savedIntents)) return false;
+    if (this.savedIntents == null) {
+      return that.savedIntents == null;
+    }
+    if (that.savedIntents == null) {
+      return false;
+    }
+    if (this.savedIntents.length != that.savedIntents.length) {
+      return false;
+    }
+    for (int i = 0; i < this.savedIntents.length; i++) {
+      if (!this.savedIntents[i].filterEquals(that.savedIntents[i])) {
+        return false;
+      }
     }
     return true;
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPendingIntentTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPendingIntentTest.java
@@ -199,4 +199,22 @@ public class ShadowPendingIntentTest {
     assertThat(saved).isNotNull();
     assertThat(intent).isEqualTo(shadowOf(saved).getSavedIntent());
   }
+
+  @Test
+  public void testEquals() {
+    Intent intent1 = new Intent("activity");
+    Intent intent2 = new Intent("activity");
+    PendingIntent pendingIntent1 = PendingIntent.getActivity(RuntimeEnvironment.application, 99, intent1, 100);
+    PendingIntent pendingIntent2 = PendingIntent.getActivity(RuntimeEnvironment.application, 99, intent2, 100);
+    assertThat(pendingIntent1).isEqualTo(pendingIntent2);
+  }
+
+  @Test
+  public void testNotEquals() {
+    Intent intent1 = new Intent("activity1");
+    Intent intent2 = new Intent("activity2");
+    PendingIntent pendingIntent1 = PendingIntent.getActivity(RuntimeEnvironment.application, 99, intent1, 100);
+    PendingIntent pendingIntent2 = PendingIntent.getActivity(RuntimeEnvironment.application, 99, intent2, 100);
+    assertThat(pendingIntent1).isNotEqualTo(pendingIntent2);
+  }
 }


### PR DESCRIPTION
### Overview

Fix ShadowPendingIntent#equals

### Proposed Changes

There were two problems with ShadowPendingIntent#equals:

1) It was using Arrays.equals to compare the savedIntents arrays. This
   resulted in comparing Intent objects using `equals`, which stopped
   working since #1914 was merged. Update it to iterate over the
   savedIntents and use Intent#filterEquals.

2) The `other` object in the equals comparison had to be a ShadowPendingIntent
   object. Change this to allow a regular PendingIntent to be the other
   object.