### PR TITLE
Load android.R from compile classpath (e.g. compileSdk), not runtime …

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
+++ b/robolectric/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
@@ -212,8 +212,7 @@ public class InstrumentationConfiguration {
 
     // Both internal and public R class must be loaded from the same classloader since they only
     // have stable ID's within a given API version.
-    if (name.matches("com\\.android\\.internal\\.R(\\$.*)?") ||
-        name.matches("android\\.R(\\$.*)?")) {
+    if (name.matches("com\\.android\\.internal\\.R(\\$.*)?")) {
       return true;
     }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -526,6 +526,22 @@ public class ShadowResourcesTest {
   }
 
   @Test
+  @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
+  public void whenAttrIsDefinedInRuntimeSdk_getResourceName_findsResource() {
+    assertThat(RuntimeEnvironment.application.getResources().getResourceName(android.R.attr.viewportHeight))
+        .isEqualTo("android:attr/viewportHeight");
+  }
+
+  @Test
+  @Config(sdk = Build.VERSION_CODES.KITKAT)
+  public void whenAttrIsNotDefinedInRuntimeSdk_getResourceName_doesntFindRequestedResourceButInsteadFindsInternalResourceWithSameId() {
+    // asking for an attr defined after the current SDK doesn't have a defined result; in this case it returns
+    //   numberPickerStyle from com.internal.android.R
+    assertThat(RuntimeEnvironment.application.getResources().getResourceName(android.R.attr.viewportHeight))
+        .isEqualTo("android:attr/numberPickerStyle");
+  }
+
+  @Test
   public void subClassInitializedOK() {
     SubClassResources subClassResources = new SubClassResources(RuntimeEnvironment.application.getResources());
     assertThat(subClassResources.openRawResource(R.raw.raw_resource)).isNotNull();


### PR DESCRIPTION
### Overview

### Proposed Changes

…classpath, since older SDKs might be missing some resources added in later SDKs. We still need to be able to resolve framework resource names that have been inlined as ints by the compiler.