### PR TITLE
Warn when style attr references fail to resolve.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -29,6 +29,7 @@ import org.robolectric.res.ThemeStyleSet;
 import org.robolectric.res.TypedResource;
 import org.robolectric.res.builder.ResourceParser;
 import org.robolectric.res.builder.XmlResourceParserImpl;
+import org.robolectric.util.Logger;
 import org.robolectric.util.ReflectionHelpers;
 
 import java.io.ByteArrayInputStream;
@@ -53,6 +54,8 @@ public final class ShadowAssetManager {
   public static final int STYLE_RESOURCE_ID = 3;
   public static final int STYLE_CHANGING_CONFIGURATIONS = 4;
   public static final int STYLE_DENSITY = 5;
+
+  boolean strictErrors = false;
 
   private Map<Number, ThemeStyleSet> themes =
       Collections.synchronizedMap(new HashMap<Number, ThemeStyleSet>());
@@ -417,14 +420,26 @@ public final class ShadowAssetManager {
     AttributeResource attribute = findAttributeValue(resId, set, styleAttrStyle, defStyleFromAttr, defStyleFromRes, themeStyleSet);
     while (attribute != null && attribute.isStyleReference()) {
       ResName otherAttrName = attribute.getStyleReference();
+      ResName resName = resourceLoader.getResourceIndex().getResName(resId);
 
-      attribute = themeStyleSet.getAttrValue(otherAttrName);
-      if (attribute != null) {
-        attribute = new AttributeResource(resourceLoader.getResourceIndex().getResName(resId), attribute.value, attribute.contextPackageName);
+      AttributeResource otherAttr = themeStyleSet.getAttrValue(otherAttrName);
+      if (otherAttr == null) {
+        strictError("no such attr %s in %s while resolving value for %s", attribute.value, themeStyleSet, resName.getFullyQualifiedName());
+        attribute = null;
+      } else {
+        attribute = new AttributeResource(resName, otherAttr.value, otherAttr.contextPackageName);
       }
     }
 
     return attribute;
+  }
+
+  private void strictError(String message, Object... args) {
+    if (strictErrors) {
+      throw new RuntimeException(String.format(message, args));
+    } else {
+      Logger.strict(message, args);
+    }
   }
 
   private ThemeStyleSet getThemeStyleSet($ptrClass themePtr) {

--- a/robolectric-utils/src/main/java/org/robolectric/util/Logger.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Logger.java
@@ -11,9 +11,17 @@ public class Logger {
   private static final String LOGGING_ENABLED = "robolectric.logging.enabled";
 
   public static void strict(String message, Throwable e) {
-    debug(message);
     if (Boolean.getBoolean(LOGGING_ENABLED)) {
+      System.out.print("WARNING: ");
+      System.out.println(message);
       e.printStackTrace();
+    }
+  }
+
+  public static void strict(String message, Object... args) {
+    if (Boolean.getBoolean(LOGGING_ENABLED)) {
+      System.out.print("WARNING: ");
+      System.out.println(String.format(message, args));
     }
   }
 
@@ -25,6 +33,7 @@ public class Logger {
    */
   public static void info(String message, Object... args) {
     if (Boolean.getBoolean(LOGGING_ENABLED)) {
+      System.out.print("INFO: ");
       System.out.println(String.format(message, args));
     }
   }
@@ -36,6 +45,7 @@ public class Logger {
    * @param args    Message arguments.
    */
   public static void error(String message, Object... args) {
+    System.err.print("ERROR: ");
     System.err.println(String.format(message, args));
   }
 
@@ -47,7 +57,8 @@ public class Logger {
    */
   public static void debug(String message, Object... args) {
     if (Boolean.getBoolean(LOGGING_ENABLED)) {
-      System.out.println("DEBUG: " + String.format(message, args));
+      System.out.print("DEBUG: ");
+      System.out.println(String.format(message, args));
     }
   }
 }

--- a/robolectric/src/test/resources/res/values/themes.xml
+++ b/robolectric/src/test/resources/res/values/themes.xml
@@ -18,7 +18,7 @@
   <style name="Theme.AnotherTheme" parent="@style/Theme.Robolectric">
     <item name="android:buttonStyle">@style/Widget.AnotherTheme.Button</item>
     <item name="logoWidth">?attr/averageSheepWidth</item>
-    <item name="logoHeight">?android:attr/listItemPreferredHeight</item>
+    <item name="logoHeight">42dp</item>
     <item name="averageSheepWidth">42px</item>
     <item name="animalStyle">@style/Gastropod</item>
     <item name="typeface">custom_font</item>


### PR DESCRIPTION
For now, just warn when a style reference fails to resolve.

```xml
  <style name="Theme">
    <item name="whatever">?unknownAttr</item>
  </style>
```

will generate a warning. Eventually it should probably generate an error.