### PR TITLE
Fix `ShadowAssetManager` to better support themes created by different `Resources`

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/EmptyStyle.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/EmptyStyle.java
@@ -1,0 +1,13 @@
+package org.robolectric.res;
+
+public class EmptyStyle implements Style {
+  @Override
+  public AttributeResource getAttrValue(ResName resName) {
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return "Empty Style";
+  }
+}

--- a/robolectric-resources/src/main/java/org/robolectric/res/OverlayResourceLoader.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/OverlayResourceLoader.java
@@ -136,4 +136,9 @@ public class OverlayResourceLoader extends XResourceLoader {
 
     super.receive(visitor);
   }
+
+  @Override
+  public String toString() {
+    return "OverlayResourceLoader for " + packageName + " with " + subResourceLoaders.size() + " sub loaders";
+  }
 }

--- a/robolectric-resources/src/main/java/org/robolectric/res/PackageResourceLoader.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/PackageResourceLoader.java
@@ -67,9 +67,7 @@ public class PackageResourceLoader extends XResourceLoader {
 
   @Override
   public String toString() {
-    return "PackageResourceLoader{" +
-        "resourcePath=" + resourcePath +
-        '}';
+    return "PackageResourceLoader{" + resourcePath.getPackageName() + '}';
   }
 
   @Override public boolean providesFor(String namespace) {

--- a/robolectric-resources/src/main/java/org/robolectric/res/RoutingResourceLoader.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/RoutingResourceLoader.java
@@ -96,4 +96,9 @@ public class RoutingResourceLoader extends ResourceLoader {
       return true;
     }
   }
+
+  @Override
+  public String toString() {
+    return "RoutingResourceLoader{" + resourceLoaders + "}";
+  }
 }

--- a/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
+++ b/robolectric-shadows/shadows-core/src/main/resources/org/robolectric/shadows/ShadowAssetManager.java.vm
@@ -16,6 +16,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.res.AttributeResource;
 import org.robolectric.res.DrawableResourceLoader;
+import org.robolectric.res.EmptyStyle;
 import org.robolectric.res.FileTypedResource;
 import org.robolectric.res.FsFile;
 import org.robolectric.res.ResName;
@@ -36,6 +37,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -57,17 +59,14 @@ public final class ShadowAssetManager {
 
   boolean strictErrors = false;
 
-  private Map<Number, ThemeStyleSet> themes =
-      Collections.synchronizedMap(new HashMap<Number, ThemeStyleSet>());
-  private $ptrClass nextInternalThemeId = 1000;
+  private static $ptrClass nextInternalThemeId = 1000;
+  private static Map<Number, WeakReference<Resources.Theme>> themes
+      = new HashMap<Number, WeakReference<Resources.Theme>>();
+
   private ResourceLoader resourceLoader;
 
   @RealObject
   AssetManager realObject;
-
-  public ResourceLoader getResourceLoader() {
-    return resourceLoader;
-  }
 
   public void __constructor__() {
     resourceLoader = RuntimeEnvironment.getAppResourceLoader();
@@ -75,6 +74,10 @@ public final class ShadowAssetManager {
 
   public void __constructor__(boolean isSystem) {
     resourceLoader = isSystem ? RuntimeEnvironment.getSystemResourceLoader() : RuntimeEnvironment.getAppResourceLoader();
+  }
+
+  public ResourceLoader getResourceLoader() {
+    return resourceLoader;
   }
 
   @HiddenApi @Implementation
@@ -152,7 +155,7 @@ public final class ShadowAssetManager {
     ResourceIndex resourceIndex = resourceLoader.getResourceIndex();
     ResName resName = resourceIndex.getResName(ident);
 
-    ThemeStyleSet themeStyleSet = getThemeStyleSet(themePtr);
+    ThemeStyleSet themeStyleSet = shadowOf(getTheme(themePtr)).getThemeStyleSet();
     AttributeResource attrValue = themeStyleSet.getAttrValue(resName);
     while(resolveRefs && attrValue != null && attrValue.isStyleReference()) {
       ResName attrResName = new ResName(attrValue.contextPackageName, "attr", attrValue.value.substring(1));
@@ -272,45 +275,57 @@ public final class ShadowAssetManager {
   }
 
   @HiddenApi @Implementation
-  synchronized public $ptrClass createTheme() {
-    return nextInternalThemeId++;
+  public $ptrClass createTheme() {
+    synchronized (themes) {
+      $ptrClass themePtr = nextInternalThemeId++;
+      return themePtr;
+    }
+  }
+
+  public static void saveTheme(Number themePtr, Resources.Theme theme) {
+    synchronized (themes) {
+      themes.put(themePtr, new WeakReference<>(theme));
+    }
+  }
+
+  private static Resources.Theme getTheme($ptrClass themePtr) {
+    WeakReference<Resources.Theme> themeRef;
+    synchronized (themes) {
+      themeRef = themes.get(themePtr);
+    }
+    if (themeRef == null) {
+      throw new RuntimeException("no theme " + themePtr + " found in AssetManager");
+    }
+    return themeRef.get();
   }
 
   @HiddenApi @Implementation
   public void releaseTheme($ptrClass themePtr) {
-    themes.remove(themePtr);
+    synchronized (themes) {
+      themes.remove(themePtr);
+    }
   }
 
   @HiddenApi @Implementation
   public static void applyThemeStyle($ptrClass themePtr, int styleRes, boolean force) {
-    ShadowAssetManager assetManager = shadowOf(RuntimeEnvironment.application.getAssets());
-
-    final Map<Number, ThemeStyleSet> themes = assetManager.themes;
-
-    ThemeStyleSet themeStyleSet = themes.get(themePtr);
-    if (themeStyleSet == null) {
-      themeStyleSet = new ThemeStyleSet();
-      themes.put(themePtr, themeStyleSet);
-    }
-
-    Style style = assetManager.resolveStyle(styleRes, null);
-
-    themeStyleSet.apply(style, force);
+    Resources.Theme theme = getTheme(themePtr);
+    ShadowResources.ShadowTheme shadowTheme = shadowOf(theme);
   }
 
   @HiddenApi @Implementation
   public static void copyTheme($ptrClass destPtr, $ptrClass sourcePtr) {
-    ShadowAssetManager assetManager = shadowOf(RuntimeEnvironment.application.getAssets());
-    assetManager.themes.put(destPtr, assetManager.getThemeStyleSet(sourcePtr).copy());
+    Resources.Theme destTheme = getTheme(destPtr);
+    Resources.Theme sourceTheme = getTheme(sourcePtr);
+    shadowOf(destTheme).setThemeStyleSet(shadowOf(sourceTheme).getThemeStyleSet().copy());
   }
 
   /////////////////////////
 
-  private Style resolveStyle(int resId, Style themeStyleSet) {
+  Style resolveStyle(int resId, Style themeStyleSet) {
     return resolveStyle(getResName(resId), themeStyleSet);
   }
 
-  private Style resolveStyle(@NotNull ResName themeStyleName, Style themeStyleSet) {
+  Style resolveStyle(@NotNull ResName themeStyleName, Style themeStyleSet) {
     TypedResource themeStyleResource = resourceLoader.getValue(themeStyleName, RuntimeEnvironment.getQualifiers());
     if (themeStyleResource == null) return null;
     StyleData themeStyleData = (StyleData) themeStyleResource.getData();
@@ -345,7 +360,7 @@ public final class ShadowAssetManager {
     return resourceLoader.resolveResourceValue(value, qualifiers, resId);
   }
 
-  private AttributeResource buildAttribute(AttributeSet set, int resId, int defStyleAttr, $ptrClass themePtr, int defStyleRes) {
+  private AttributeResource buildAttribute(AttributeSet set, int resId, int defStyleAttr, Style themeStyleSet, int defStyleRes) {
     /*
      * When determining the final value of a particular attribute, there are four inputs that come into play:
      *
@@ -358,10 +373,6 @@ public final class ShadowAssetManager {
     Style defStyleFromRes = null;
     Style styleAttrStyle = null;
 
-    ThemeStyleSet themeStyleSet = getThemeStyleSet(themePtr);
-    if (themeStyleSet == null) {
-      themeStyleSet = new ThemeStyleSet();
-    }
     if (defStyleAttr != 0) {
       // Load the theme attribute for the default style attributes. E.g., attr/buttonStyle
       ResName defStyleName = getResName(defStyleAttr);
@@ -442,26 +453,20 @@ public final class ShadowAssetManager {
     }
   }
 
-  private ThemeStyleSet getThemeStyleSet($ptrClass themePtr) {
-    ThemeStyleSet themeStyleSet = themes.get(themePtr);
-    return themeStyleSet == null ? new ThemeStyleSet() : themeStyleSet;
-  }
-
   TypedArray attrsToTypedArray(Resources resources, AttributeSet set, int[] attrs, int defStyleAttr, Resources.Theme theme, int defStyleRes) {
-      $ptrClass themePtr = ReflectionHelpers.getField(theme, "mTheme");
-      return attrsToTypedArray(resources, set, attrs, defStyleAttr, themePtr, defStyleRes);
-  }
-
-  TypedArray attrsToTypedArray(Resources resources, AttributeSet set, int[] attrs, int defStyleAttr, $ptrClass themePtr, int defStyleRes) {
     CharSequence[] stringData = new CharSequence[attrs.length];
     int[] data = new int[attrs.length * ShadowAssetManager.STYLE_NUM_ENTRIES];
     int[] indices = new int[attrs.length + 1];
     int nextIndex = 0;
 
+    Style themeStyleSet = theme == null
+        ? new EmptyStyle()
+        : shadowOf(theme).getThemeStyleSet();
+
     for (int i = 0; i < attrs.length; i++) {
       int offset = i * ShadowAssetManager.STYLE_NUM_ENTRIES;
 
-      AttributeResource attribute = buildAttribute(set, attrs[i], defStyleAttr, themePtr, defStyleRes);
+      AttributeResource attribute = buildAttribute(set, attrs[i], defStyleAttr, themeStyleSet, defStyleRes);
       if (attribute != null && !attribute.isNull()) {
         TypedValue typedValue = new TypedValue();
         // If there is an AttributeSet then use the resource loader that the attribute set was created with.
@@ -492,7 +497,7 @@ public final class ShadowAssetManager {
     return typedArray;
   }
 
-  private AttributeResource findAttributeValue(int resId, AttributeSet attributeSet, Style styleAttrStyle, Style defStyleFromAttr, Style defStyleFromRes, @NotNull ThemeStyleSet themeStyleSet) {
+  private AttributeResource findAttributeValue(int resId, AttributeSet attributeSet, Style styleAttrStyle, Style defStyleFromAttr, Style defStyleFromRes, @NotNull Style themeStyleSet) {
     if (attributeSet != null) {
       for (int i = 0; i < attributeSet.getAttributeCount(); i++) {
         if (attributeSet.getAttributeNameResource(i) == resId && attributeSet.getAttributeValue(i) != null) {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import android.app.Activity;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
+import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.util.TypedValue;
@@ -321,6 +322,29 @@ public class ShadowThemeTest {
       super.onCreate(savedInstanceState);
       setContentView(R.layout.styles_button_layout);
     }
+  }
+
+  @Test
+  public void themesShouldBeApplyableAcrossResources() throws Exception {
+    Resources.Theme themeFromSystem = Resources.getSystem().newTheme();
+    themeFromSystem.applyStyle(android.R.style.Theme_Light, true);
+
+    Resources.Theme themeFromApp = RuntimeEnvironment.application.getResources().newTheme();
+    themeFromApp.applyStyle(android.R.style.Theme, true);
+
+    // themeFromSystem is Theme_Light, which has a white background...
+    assertThat(shadowOf(themeFromSystem).obtainStyledAttributes(new int[]{android.R.attr.colorBackground}).getColor(0, 123))
+        .isEqualTo(Color.WHITE);
+
+    // themeFromApp is Theme, which has a black background...
+    assertThat(shadowOf(themeFromApp).obtainStyledAttributes(new int[]{android.R.attr.colorBackground}).getColor(0, 123))
+        .isEqualTo(Color.BLACK);
+
+    themeFromApp.setTo(themeFromSystem);
+
+    // themeFromApp now has style values from themeFromSystem, so now it has a black background...
+    assertThat(shadowOf(themeFromApp).obtainStyledAttributes(new int[]{android.R.attr.colorBackground}).getColor(0, 123))
+        .isEqualTo(Color.WHITE);
   }
 
   public static class TestActivityWithAnotherTheme extends TestActivity {


### PR DESCRIPTION
`ShadowAssetManager.themes` is now static. It shouldn't be reset between tests because it'll cause explosions in background threads etc. Instead, use `WeakReferences` and `Themefinalize()` to try to avoid memory leaks.
`Theme`s' shadow now hold its own `ThemeStyleSet`.