### PR TITLE
Add support for library modules' manifest location with Gradle 2.2.0

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/GradleManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/GradleManifestFactory.java
@@ -49,8 +49,11 @@ public class GradleManifestFactory implements ManifestFactory {
       assets = FileFsFile.from(buildOutputDir, "bundles", flavor, type, "assets");
     }
 
-    if (FileFsFile.from(buildOutputDir, "manifests").exists()) {
+    if (FileFsFile.from(buildOutputDir, "manifests", "full").exists()) {
       manifest = FileFsFile.from(buildOutputDir, "manifests", "full", flavor, abiSplit, type, DEFAULT_MANIFEST_NAME);
+    } else if (FileFsFile.from(buildOutputDir, "manifests", "aapt").exists()) {
+      // Android gradle plugin 2.2.0+ can put library manifest files inside of "aapt" instead of "full"
+      manifest = FileFsFile.from(buildOutputDir, "manifests", "aapt", flavor, abiSplit, type, DEFAULT_MANIFEST_NAME);
     } else {
       manifest = FileFsFile.from(buildOutputDir, "bundles", flavor, abiSplit, type, DEFAULT_MANIFEST_NAME);
     }

--- a/robolectric/src/test/java/org/robolectric/internal/GradleManifestFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/GradleManifestFactoryTest.java
@@ -26,7 +26,7 @@ public class GradleManifestFactoryTest {
   public void setup() {
     FileFsFile.from("build", "intermediates", "res").getFile().mkdirs();
     FileFsFile.from("build", "intermediates", "assets").getFile().mkdirs();
-    FileFsFile.from("build", "intermediates", "manifests").getFile().mkdirs();
+    FileFsFile.from("build", "intermediates", "manifests", "full").getFile().mkdirs();
 
     FileFsFile.from("custom_build", "intermediates", "res").getFile().mkdirs();
     FileFsFile.from("custom_build", "intermediates", "assets").getFile().mkdirs();
@@ -38,14 +38,15 @@ public class GradleManifestFactoryTest {
   public void teardown() throws IOException {
     delete(FileFsFile.from("build", "intermediates", "res").getFile());
     delete(FileFsFile.from("build", "intermediates", "assets").getFile());
-    delete(FileFsFile.from("build", "intermediates", "manifests").getFile());
+    delete(FileFsFile.from("build", "intermediates", "manifests", "full").getFile());
+    delete(FileFsFile.from("build", "intermediates", "manifests", "aapt").getFile());
     delete(FileFsFile.from("build", "intermediates", "res", "merged").getFile());
 
     delete(FileFsFile.from("custom_build", "intermediates", "res").getFile());
     delete(FileFsFile.from("custom_build", "intermediates", "assets").getFile());
     delete(FileFsFile.from("custom_build", "intermediates", "manifests").getFile());
   }
-  
+
   @Test
   public void getAppManifest_forApplications_shouldCreateManifest() throws Exception {
     final AndroidManifest manifest = createManifest(
@@ -61,7 +62,7 @@ public class GradleManifestFactoryTest {
   public void getAppManifest_forLibraries_shouldCreateManifest() throws Exception {
     delete(FileFsFile.from("build", "intermediates", "res").getFile());
     delete(FileFsFile.from("build", "intermediates", "assets").getFile());
-    delete(FileFsFile.from("build", "intermediates", "manifests").getFile());
+    delete(FileFsFile.from("build", "intermediates", "manifests", "full").getFile());
 
     final AndroidManifest manifest = createManifest(
         new Config.Builder().setConstants(BuildConfig.class).build());
@@ -70,6 +71,22 @@ public class GradleManifestFactoryTest {
     assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("build/intermediates/bundles/flavor1/type1/res"));
     assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("build/intermediates/bundles/flavor1/type1/assets"));
     assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("build/intermediates/bundles/flavor1/type1/AndroidManifest.xml"));
+  }
+
+  @Test
+  public void getAppManifest_forAaptLibraries_shouldCreateManifest() throws Exception {
+    delete(FileFsFile.from("build", "intermediates", "res").getFile());
+    delete(FileFsFile.from("build", "intermediates", "assets").getFile());
+    delete(FileFsFile.from("build", "intermediates", "manifests", "full").getFile());
+    FileFsFile.from("build", "intermediates", "manifests", "aapt").getFile().mkdirs();
+
+    final AndroidManifest manifest = createManifest(
+            new Config.Builder().setConstants(BuildConfig.class).build());
+
+    assertThat(manifest.getPackageName()).isEqualTo("org.robolectric.gradleapp");
+    assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("build/intermediates/bundles/flavor1/type1/res"));
+    assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("build/intermediates/bundles/flavor1/type1/assets"));
+    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("build/intermediates/manifests/aapt/flavor1/type1/AndroidManifest.xml"));
   }
 
   @Test
@@ -90,7 +107,7 @@ public class GradleManifestFactoryTest {
     assertThat(manifest.getPackageName()).isEqualTo("org.robolectric.gradleapp");
     assertThat(manifest.getResDirectory().getPath()).isEqualTo(convertPath("custom_build/intermediates/res/flavor1/type1"));
     assertThat(manifest.getAssetsDirectory().getPath()).isEqualTo(convertPath("custom_build/intermediates/assets/flavor1/type1"));
-    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("custom_build/intermediates/manifests/full/flavor1/type1/AndroidManifest.xml"));
+    assertThat(manifest.getAndroidManifestFile().getPath()).isEqualTo(convertPath("custom_build/intermediates/bundles/flavor1/type1/AndroidManifest.xml"));
   }
 
   @Test


### PR DESCRIPTION
### Overview

The Android Gradle plugin 2.2.0 changes the location of the generated AndroidManifest.xml file for library projects. This fixes #2581, please look at the issue for more information / motivation.
### Proposed Changes

If the default location for application manifest files is not found, try to locate the manifest file within the new `aapt` directory.
