### PR TITLE
Adjust install directories for robolectric-shadows projects

### DIFF
--- a/robolectric-shadows/shadows-core/build.gradle
+++ b/robolectric-shadows/shadows-core/build.gradle
@@ -35,6 +35,13 @@ jar {
     dependsOn copyNatives
 }
 
+// change local artifact name to match dependencies
+install {
+    repositories.mavenInstaller {
+        pom.artifactId = 'shadows-core'
+    }
+}
+
 dependencies {
     // Project dependencies
     compile project(":robolectric-annotations")

--- a/robolectric-shadows/shadows-httpclient/build.gradle
+++ b/robolectric-shadows/shadows-httpclient/build.gradle
@@ -25,6 +25,13 @@ dependencies {
     testCompile "org.mockito:mockito-core:1.8.0"
 }
 
+// change local artifact name to match dependencies
+install {
+    repositories.mavenInstaller {
+        pom.artifactId = 'shadows-httpclient'
+    }
+}
+
 // httpcore needs to come before android-all on runtime classpath; the gradle IntelliJ plugin
 //   needs the compileClasspath order patched too (bug?)
 sourceSets.main.compileClasspath = configurations.earlyRuntime + sourceSets.main.compileClasspath

--- a/robolectric-shadows/shadows-maps/build.gradle
+++ b/robolectric-shadows/shadows-maps/build.gradle
@@ -18,3 +18,10 @@ dependencies {
     testCompile "org.assertj:assertj-core:2.0.0"
     testCompile "org.mockito:mockito-core:1.8.0"
 }
+
+// change local artifact name to match dependencies
+install {
+    repositories.mavenInstaller {
+        pom.artifactId = 'shadows-maps'
+    }
+}

--- a/robolectric-shadows/shadows-multidex/build.gradle
+++ b/robolectric-shadows/shadows-multidex/build.gradle
@@ -17,3 +17,10 @@ dependencies {
     testCompile "org.hamcrest:hamcrest-core:1.3"
     testCompile "org.assertj:assertj-core:2.0.0"
 }
+
+// change local artifact name to match dependencies
+install {
+    repositories.mavenInstaller {
+        pom.artifactId = 'shadows-multidex'
+    }
+}

--- a/robolectric-shadows/shadows-play-services/build.gradle
+++ b/robolectric-shadows/shadows-play-services/build.gradle
@@ -20,3 +20,9 @@ dependencies {
     testCompile "org.assertj:assertj-core:2.0.0"
     testCompile "org.mockito:mockito-core:1.8.0"
 }
+
+install {
+    repositories.mavenInstaller {
+        pom.artifactId = 'shadows-play-services'
+    }
+}

--- a/robolectric-shadows/shadows-support-v4/build.gradle
+++ b/robolectric-shadows/shadows-support-v4/build.gradle
@@ -27,6 +27,13 @@ dependencies {
     earlyRuntime "org.hamcrest:hamcrest-core:1.3"
 }
 
+// change local artifact name to match dependencies
+install {
+    repositories.mavenInstaller {
+        pom.artifactId = 'shadows-support-v4'
+    }
+}
+
 // hamcrest needs to come becore junit on runtime classpath; the gradle IntelliJ plugin
 //   needs the compileClasspath order patched too (bug?)
 sourceSets.main.compileClasspath = configurations.earlyRuntime + sourceSets.main.compileClasspath


### PR DESCRIPTION
### Overview

This fixes './gradles install' so that people can depend on projects in the  robolectric-shadows directory (e.g 'shadows-support-v4').

### Proposed Changes

Previously, when performing a `./gradlew install`, all projects in the
robolectric-shadows directory were installed to the maven path with the
parent directory `org/robolectric/robolectric-shadows/`. This is not
consistent with official artifact ids of these projects, and caused
build failures when trying to build the 3.2-SNAPSHOT version of these
projects. Instead, install them to the local path with the parent
directory `org/robolectric`.

After this change, it's possible to include 3.2-SNAPSHOT projects such
as shadows-support-v4 using:

    testCompile 'org.robolectric:shadows-support-v4:3.2-SNAPSHOT'

Fixes #2696