### PR TITLE
Add unimplemented AlarmManager methods - fixes #2669

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAlarmManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAlarmManager.java
@@ -10,7 +10,6 @@ import org.robolectric.annotation.Implements;
 import java.util.ArrayList;
 import java.util.List;
 
-import static android.os.Build.VERSION_CODES;
 import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.M;
 
@@ -33,8 +32,19 @@ public class ShadowAlarmManager {
     internalSet(type, triggerAtTime, 0L, operation);
   }
 
+  @Implementation(minSdk = KITKAT)
+  public void setWindow(
+          int type, long windowStartMillis, long windowLengthMillis, PendingIntent operation) {
+    internalSet(type, windowStartMillis, 0L, operation);
+  }
+
   @Implementation(minSdk = M)
   public void setAndAllowWhileIdle(int type, long triggerAtTime, PendingIntent operation) {
+    internalSet(type, triggerAtTime, 0L, operation);
+  }
+
+  @Implementation(minSdk = M)
+  public void setExactAndAllowWhileIdle(int type, long triggerAtTime, PendingIntent operation) {
     internalSet(type, triggerAtTime, 0L, operation);
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
@@ -50,10 +50,26 @@ public class ShadowAlarmManagerTest {
   }
 
   @Test
+  @Config(minSdk = M)
+  public void setExactAndAllowWhileIdle_shouldRegisterAlarm() throws Exception {
+    assertThat(shadowAlarmManager.getNextScheduledAlarm()).isNull();
+    alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME, 0, PendingIntent.getActivity(activity, 0, new Intent(activity, activity.getClass()), 0));
+    assertThat(shadowAlarmManager.getNextScheduledAlarm()).isNotNull();
+  }
+
+  @Test
   @Config(minSdk = KITKAT)
   public void setExact_shouldRegisterAlarm_forApi19() throws Exception {
     assertThat(shadowAlarmManager.getNextScheduledAlarm()).isNull();
     alarmManager.setExact(AlarmManager.ELAPSED_REALTIME, 0, PendingIntent.getActivity(activity, 0, new Intent(activity, activity.getClass()), 0));
+    assertThat(shadowAlarmManager.getNextScheduledAlarm()).isNotNull();
+  }
+
+  @Test
+  @Config(minSdk = KITKAT)
+  public void setWindow_shouldRegisterAlarm_forApi19() throws Exception {
+    assertThat(shadowAlarmManager.getNextScheduledAlarm()).isNull();
+    alarmManager.setWindow(AlarmManager.ELAPSED_REALTIME, 0, 1, PendingIntent.getActivity(activity, 0, new Intent(activity, activity.getClass()), 0));
     assertThat(shadowAlarmManager.getNextScheduledAlarm()).isNotNull();
   }
 


### PR DESCRIPTION
### Overview
- setWindow has existed since API 19 but was not implemented in ShadowAlarmManager so calling it in a test would throw an NPE.
- Similarly, setExactAndAllowWhileIdle was introduced in API 23 but was not implemented in ShadowAlarmManager even though setAndAllowWhileIdle was.

### Proposed Changes
- Give the missing methods basic implementations in ShadowAlarmManager.
