### PR TITLE
Update Guava version to stable release: 19.0 -> 20.0

### DIFF
--- a/robolectric-processor/build.gradle
+++ b/robolectric-processor/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     compile project(":robolectric-annotations")
 
     // Compile dependencies
-    compile "com.google.guava:guava:19.0"
+    compile "com.google.guava:guava:20.0"
     compileOnly "com.intellij:annotations:12.0"
     compile files("${System.properties['java.home']}/../lib/tools.jar")
 

--- a/robolectric-resources/build.gradle
+++ b/robolectric-resources/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     // Compile dependencies
     compile "com.ximpleware:vtd-xml:2.11"
-    compile "com.google.guava:guava:19.0"
+    compile "com.google.guava:guava:20.0"
     compileOnly AndroidSdk.MAX_SDK.coordinates
     compileOnly "com.intellij:annotations:12.0"
 


### PR DESCRIPTION
### Overview

Robolectric's Guava dependency is lagging behind by one release.

### Proposed Changes

This updates from Guava 19.0 to Guava 20.0, released 2016-10-28.