### PR TITLE
Added onPostCreate() to the lifecycle methods invoked in ActivityController.configurationChange()

### DIFF
--- a/robolectric/src/main/java/org/robolectric/util/ActivityController.java
+++ b/robolectric/src/main/java/org/robolectric/util/ActivityController.java
@@ -303,6 +303,8 @@ public class ActivityController<T extends Activity> extends ComponentController<
           ReflectionHelpers.callInstanceMethod(Activity.class, recreatedActivity, "onStart");
           ReflectionHelpers.callInstanceMethod(Activity.class, recreatedActivity,
               "onRestoreInstanceState", ClassParameter.from(Bundle.class, outState));
+          ReflectionHelpers.callInstanceMethod(Activity.class, recreatedActivity,
+              "onPostCreate", ClassParameter.from(Bundle.class, outState));
           ReflectionHelpers.callInstanceMethod(Activity.class, recreatedActivity, "onResume");
         }
       });

--- a/robolectric/src/test/java/org/robolectric/util/ActivityControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/ActivityControllerTest.java
@@ -228,7 +228,15 @@ public class ActivityControllerTest {
     final float newFontScale = config.fontScale *= 2;
     
     controller.configurationChange(config);
-    transcript.assertEventsInclude("onPause", "onStop", "onDestroy", "onCreate", "onStart", "onResume");
+    transcript.assertEventsInclude(
+        "onPause",
+        "onStop",
+        "onDestroy",
+        "onCreate",
+        "onStart",
+        "onRestoreInstanceState",
+        "onPostCreate",
+        "onResume");
     assertThat(controller.get().getResources().getConfiguration().fontScale).isEqualTo(newFontScale);
   }
   


### PR DESCRIPTION
### Overview

Adds a missing lifecycle method invocation (onPostCreate()) to ActivityController's onConfigurationChange() method.

### Proposed Changes

Added the missing reflected call and tested for it. Added a test for onRestoreInstanceState() too, since it was missing.