### PR TITLE
Fix intent filter constructor

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntentFilter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntentFilter.java
@@ -37,8 +37,9 @@ public class ShadowIntentFilter {
     actions.add(action);
   }
 
-  public void __constructor__(String action, String dataType) {
+  public void __constructor__(String action, String dataType) throws IntentFilter.MalformedMimeTypeException {
     actions.add(action);
+    addDataType(dataType);
   }
 
   public void __constructor__(IntentFilter filter) {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntentFilter.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIntentFilter.java
@@ -34,11 +34,11 @@ public class ShadowIntentFilter {
   int priority;
 
   public void __constructor__(String action) {
-    actions.add(action);
+    addAction(action);
   }
 
   public void __constructor__(String action, String dataType) throws IntentFilter.MalformedMimeTypeException {
-    actions.add(action);
+    addAction(action);
     addDataType(dataType);
   }
 

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManagerTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManagerTest.java
@@ -88,11 +88,11 @@ public class ShadowLocalBroadcastManagerTest {
       @Override public void onReceive(Context context, Intent intent) {
         transcript.add("got intent " + intent.getAction());
       }
-    }, IntentFilter.create("foo", "blatz"));
+    }, IntentFilter.create("foo", "application/blatz"));
 
-    Intent intent1 = new Intent("foo");
+    Intent intent1 = new Intent("foo").setType("application/blatz");
     broadcastManager.sendBroadcast(intent1);
-    Intent intent2 = new Intent("bar");
+    Intent intent2 = new Intent("bar").setType("application/blatz");
     broadcastManager.sendBroadcast(intent2);
 
     transcript.assertEventsSoFar("got intent foo");


### PR DESCRIPTION
Back in 2013, in [this commit](https://github.com/robolectric/robolectric/commit/ab67958e4438214ab27f772d9bfbbfa6ba52f474#commitcomment-19884112), the 2-argument constructor for IntentFilter was overriden to *IGNORE* its second argument. This fixes that.
