### PR TITLE
Fix download URL for jarjar-1.4.jar

### DIFF
--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -123,7 +123,7 @@ build_jarjared_classes() {
     echo "Robolectric: jarjaring classes..."
     mkdir ${OUT}/android-jarjar-workspace
     cd ${OUT}/android-jarjar-workspace
-    wget https://jarjar.googlecode.com/files/jarjar-1.4.jar
+    wget https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/jarjar/jarjar-1.4.jar
     echo "rule com.squareup.** com.android.**" >> rules
     echo "rule org.conscrypt.** com.android.**" >> rules
 


### PR DESCRIPTION
### Overview

### Proposed Changes

The URL for jarjar-1.4.jar in build-android.sh was invalid. The URL has
changed, likely due to the deprecation of Google code.