### PR TITLE
Upgrade the Android M SDK revision to 6.0.1_r3

### DIFF
--- a/buildSrc/src/main/groovy/AndroidSdk.groovy
+++ b/buildSrc/src/main/groovy/AndroidSdk.groovy
@@ -5,7 +5,7 @@ class AndroidSdk implements Comparable<AndroidSdk> {
     static final KITKAT = new AndroidSdk(19, "4.4_r1", 1, "1.7")
     static final LOLLIPOP = new AndroidSdk(21, "5.0.0_r2", 1, "1.7")
     static final LOLLIPOP_MR1 = new AndroidSdk(22, "5.1.1_r9", 1, "1.7")
-    static final M = new AndroidSdk(23, "6.0.0_r1", 0, "1.7")
+    static final M = new AndroidSdk(23, "6.0.1_r3", 0, "1.7")
     static final N = new AndroidSdk(24, "7.0.0_r1", 0, "1.8")
 
     private static final double jdkVersion = Double.parseDouble(System.getProperty("java.specification.version"));

--- a/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
@@ -26,7 +26,7 @@ public class SdkConfig {
       addSdk(Build.VERSION_CODES.KITKAT, "4.4_r1", "1", "1.7");
       addSdk(Build.VERSION_CODES.LOLLIPOP, "5.0.0_r2", "1", "1.7");
       addSdk(Build.VERSION_CODES.LOLLIPOP_MR1, "5.1.1_r9", "1", "1.7");
-      addSdk(Build.VERSION_CODES.M, "6.0.0_r1", "0", "1.7");
+      addSdk(Build.VERSION_CODES.M, "6.0.1_r3", "0", "1.7");
 //      addSdk(Build.VERSION_CODES.N, "7.0.0_r1", "0", "1.8");
     }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowTest.java
@@ -9,7 +9,6 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
-import com.android.internal.policy.PolicyManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -107,16 +106,6 @@ public class ShadowWindowTest {
   public void forM_create_shouldCreatePhoneWindow() throws Exception {
     assertThat(ShadowWindow.create(RuntimeEnvironment.application).getClass().getName())
         .isEqualTo("com.android.internal.policy.PhoneWindow");
-  }
-
-  @Test
-  public void makeNewWindowSucks() throws Exception {
-    PolicyManager.makeNewWindow(RuntimeEnvironment.application);
-  }
-
-  @Test @Config(minSdk = LOLLIPOP_MR1)
-  public void withLollipop_makeNewWindowSucks() throws Exception {
-    PolicyManager.makeNewWindow(RuntimeEnvironment.application);
   }
 
   public static class TestActivity extends Activity {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,9 +48,9 @@ To check out a branch other than `master`, specify it with `-b`. For a list of b
 *  `4.4_r1`      - Kit Kat
 *  `5.0.0_r2`    - Lollipop
 *  `5.1.1_r9`    - Lollipop MR1
-*  `6.0.0_r1`    - Marshmallow
+*  `6.0.1_r3`    - Marshmallow
 ```
-$ repo init -u https://android.googlesource.com/platform/manifest -b android-6.0.0_r1
+$ repo init -u https://android.googlesource.com/platform/manifest -b android-6.0.1_r3
 ```
 
 A successful initialization will end with a message stating that Repo is initialized in your working directory. Your client directory should now contain a `.repo` directory where files such as the manifest will be kept.
@@ -113,4 +113,4 @@ Finally, in your Robolectric directory run:
 $ build-android.sh <android version> <robolectric sub-version>
 ```
 
-For Robolectric version `6.0.0_r1-robolectric-0`, android version would be `6.0.0_r1` and  robolectric sub-version `0`.
+For Robolectric version `6.0.1_r3-robolectric-0`, android version would be `6.0.1_r3` and  robolectric sub-version `0`.

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -69,7 +69,7 @@ build_platform() {
         ARTIFACTS=("core-libart" "services" "telephony-common" "framework" "android.policy" "ext")
     elif [[ "${ANDROID_VERSION}" == "5.1.1_r9" ]]; then
         ARTIFACTS=("core-libart" "services" "telephony-common" "framework" "android.policy" "ext")
-    elif [[ "${ANDROID_VERSION}" == "6.0.0_r1" ]]; then
+    elif [[ "${ANDROID_VERSION}" == "6.0.1_r3" ]]; then
         ARTIFACTS=("core-libart" "services" "services.accessibility" "telephony-common" "framework" "ext" "icu4j-icudata-jarjar")
         LIB_PHONE_NUMBERS_PKG="com/google/i18n/phonenumbers"
         LIB_PHONE_NUMBERS_PATH="external/libphonenumber/libphonenumber/src"


### PR DESCRIPTION
In order to match the version of Android M distributed by Android Studio
SDK manager, upgrade the Android M SDK revision to 6.0.1_r3.

After the upgrade two tests that referenced
com.android.internal.policy.PolicyManager began to fail. At some point
between 6.0.0_r1 and 6.0.1_r3 this class was deleted. Remove those
tests.

The main benefit of this change is it makes debugging Android issues in
tests using Android Studio slightly easier. This is because the sources
have the correct line numbers.

Fixes #2721