### PR TITLE
Add ShadowIcon

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIcon.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIcon.java
@@ -1,0 +1,56 @@
+package org.robolectric.shadows;
+
+import android.graphics.Bitmap;
+import android.graphics.drawable.Icon;
+import android.net.Uri;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+
+import static org.robolectric.internal.Shadow.directlyOn;
+
+/**
+ * Shadow for {@link android.graphics.drawable.Icon}.
+ */
+@SuppressWarnings({"UnusedDeclaration"})
+@Implements(Icon.class)
+public class ShadowIcon {
+
+  @RealObject
+  private Icon realIcon;
+
+  @Implementation
+  public int getType() {
+    return directlyOn(realIcon, Icon.class, "getType");
+  }
+
+  @Implementation
+  public int getResId() {
+    return directlyOn(realIcon, Icon.class, "getResId");
+  }
+
+  @Implementation
+  public Bitmap getBitmap() {
+    return directlyOn(realIcon, Icon.class, "getBitmap");
+  }
+
+  @Implementation
+  public Uri getUri() {
+    return directlyOn(realIcon, Icon.class, "getUri");
+  }
+
+  @Implementation
+  public int getDataLength() {
+    return directlyOn(realIcon, Icon.class, "getDataLength");
+  }
+
+  @Implementation
+  public int getDataOffset() {
+    return directlyOn(realIcon, Icon.class, "getDataOffset");
+  }
+
+  @Implementation
+  public byte[] getDataBytes() {
+    return directlyOn(realIcon, Icon.class, "getDataBytes");
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowIconTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowIconTest.java
@@ -1,0 +1,55 @@
+package org.robolectric.shadows;
+
+import android.graphics.Bitmap;
+import android.graphics.drawable.Icon;
+import android.net.Uri;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
+
+import static android.os.Build.VERSION_CODES.L;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(TestRunners.MultiApiWithDefaults.class)
+public class ShadowIconTest {
+  public static final int TYPE_BITMAP = 1;
+  public static final int TYPE_RESOURCE = 2;
+  public static final int TYPE_DATA = 3;
+  public static final int TYPE_URI = 4;
+
+  @Test @Config(minSdk = L)
+  public void testGetRes() {
+    Icon icon = Icon.createWithResource(RuntimeEnvironment.application, android.R.drawable.ic_delete);
+    assertThat(shadowOf(icon).getType()).isEqualTo(TYPE_RESOURCE);
+    assertThat(shadowOf(icon).getResId()).isEqualTo(android.R.drawable.ic_delete);
+  }
+
+  @Test @Config(minSdk = L)
+  public void testGetBitmap() {
+    Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
+    Icon icon = Icon.createWithBitmap(bitmap);
+    assertThat(shadowOf(icon).getType()).isEqualTo(TYPE_BITMAP);
+    assertThat(shadowOf(icon).getBitmap()).isEqualTo(bitmap);
+  }
+
+  @Test @Config(minSdk = L)
+  public void testGetData() {
+    byte[] data = new byte[1000];
+    Icon icon = Icon.createWithData(data, 100, 200);
+    assertThat(shadowOf(icon).getType()).isEqualTo(TYPE_DATA);
+    assertThat(shadowOf(icon).getDataBytes()).isEqualTo(data);
+    assertThat(shadowOf(icon).getDataOffset()).isEqualTo(100);
+    assertThat(shadowOf(icon).getDataLength()).isEqualTo(200);
+  }
+
+  @Test @Config(minSdk = L)
+  public void testGetUri() {
+    Uri uri = Uri.parse("content://icons/icon");
+    Icon icon = Icon.createWithContentUri(uri);
+    assertThat(shadowOf(icon).getType()).isEqualTo(TYPE_URI);
+    assertThat(shadowOf(icon).getUri()).isEqualTo(uri);
+  }
+}


### PR DESCRIPTION
### Overview

### Proposed Changes

There are some hidden public methods on the Icon class that are useful
for test-related assertions.

For example, if a test displays a notification, it may be useful to
examine the icons in the notification or the icons that belong to
actions in the notification.

Currently tests for this class require Android L+ due to the reference
to Drawable.DEFAULT_TINT_MODE, which is only available in Android L and
above.