### PR TITLE
Travis 4x matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ language: android
 jdk:
   - oraclejdk7
   - oraclejdk8
+env:
+  matrix:
+    - APIs=16,17,18,19,20
+    - APIs=21,22,23,24
+  global:
+    - MALLOC_ARENA_MAX=2 # reduce memory usage, maybe avoid some exit 137's?
+    - secure: "AnsdYjHIvtLXrDMJmlf5FJhXJOW+aLSvsyXcGFLKse6EcwTSw8XnE4bGv2eSi2YWIwoHHCStIQbI0J02rkmUu9Z5oChxhOyGtCd8U4l1XciH2U7vJOJ/i9Auw5WgLM6x8HxgH6myhNrA9xrB4fcH+8WsDMf+qLqgvJQQjqQZQGM="
+    - secure: "tKWNiNnT+WPmHNY1MtXTgwId9peXtsKQ5owdOfZqmEQYTSHVdya5Bt3CiK8U829Pa1ZBuF+9mnGufTbw0WfQM5TKlClDn4ciEJzz6ChS2cqO+6trsWy335nppU7pQsDE44Irju+E7Jh4kIjfnB2pWRhI2YAoAUhNyz39PawXsz8="
 
 android:
   components:
@@ -22,7 +30,7 @@ before_install:
 
 script:
     - ./gradlew clean assemble install compileTest --info --stacktrace
-    - ./gradlew test --continue --info --stacktrace
+    - ./gradlew test --continue --info --stacktrace -Drobolectric.enabledApis=$APIs
 
 after_success:
   - ./scripts/deploy-snapshot.sh
@@ -37,9 +45,3 @@ cache:
   directories:
     - $HOME/.m2
     - $HOME/.gradle
-
-env:
-  global:
-    - MALLOC_ARENA_MAX=2 # reduce memory usage, maybe avoid some exit 137's?
-    - secure: "AnsdYjHIvtLXrDMJmlf5FJhXJOW+aLSvsyXcGFLKse6EcwTSw8XnE4bGv2eSi2YWIwoHHCStIQbI0J02rkmUu9Z5oChxhOyGtCd8U4l1XciH2U7vJOJ/i9Auw5WgLM6x8HxgH6myhNrA9xrB4fcH+8WsDMf+qLqgvJQQjqQZQGM="
-    - secure: "tKWNiNnT+WPmHNY1MtXTgwId9peXtsKQ5owdOfZqmEQYTSHVdya5Bt3CiK8U829Pa1ZBuF+9mnGufTbw0WfQM5TKlClDn4ciEJzz6ChS2cqO+6trsWy335nppU7pQsDE44Irju+E7Jh4kIjfnB2pWRhI2YAoAUhNyz39PawXsz8="

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,17 @@ allprojects {
 
         minHeapSize = "1024m"
         maxHeapSize = "2048m"
-        jvmArgs "-XX:MaxPermSize=1024m"
+
+        def forwardedSystemProperties = System.properties
+                .findAll { k,v -> k.startsWith("robolectric.") }
+                .collect { k,v -> "-D$k=$v" }
+        jvmArgs = ["-XX:MaxPermSize=1024m"] + forwardedSystemProperties
+
+        doFirst {
+            if (!forwardedSystemProperties.isEmpty()) {
+                println "Running tests with ${forwardedSystemProperties}"
+            }
+        }
     }
 
     signing {

--- a/robolectric/src/main/java/org/robolectric/MultiApiRobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/MultiApiRobolectricTestRunner.java
@@ -1,7 +1,5 @@
 package org.robolectric;
 
-import android.os.Build;
-
 import org.junit.runner.Runner;
 import org.junit.runners.Suite;
 import org.junit.runners.model.FrameworkMethod;
@@ -110,17 +108,17 @@ public class MultiApiRobolectricTestRunner extends Suite {
   /*
    * Only called reflectively. Do not use programmatically.
    */
-  public MultiApiRobolectricTestRunner(Class<?> klass) throws Throwable {
+  public MultiApiRobolectricTestRunner(Class<?> klass, Set<Integer> supportedApis) throws Throwable {
     super(klass, Collections.<Runner>emptyList());
 
-    for (Integer integer : getSupportedApis()) {
+    for (Integer integer : supportedApis) {
       runners.add(createTestRunner(integer));
     }
    }
 
-  protected Set<Integer> getSupportedApis() {
-    return SdkConfig.getSupportedApis();
-  }
+   public MultiApiRobolectricTestRunner(Class<?> klass) throws Throwable {
+    this(klass, SdkConfig.getSupportedApis());
+   }
 
   protected TestRunnerForApiVersion createTestRunner(Integer integer) throws InitializationError {
     return new TestRunnerForApiVersion(getTestClass().getJavaClass(), integer);

--- a/robolectric/src/main/java/org/robolectric/MultiApiRobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/MultiApiRobolectricTestRunner.java
@@ -1,5 +1,6 @@
 package org.robolectric;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.runner.Runner;
 import org.junit.runners.Suite;
 import org.junit.runners.model.FrameworkMethod;
@@ -10,6 +11,7 @@ import org.robolectric.manifest.AndroidManifest;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -117,8 +119,27 @@ public class MultiApiRobolectricTestRunner extends Suite {
    }
 
    public MultiApiRobolectricTestRunner(Class<?> klass) throws Throwable {
-    this(klass, SdkConfig.getSupportedApis());
+    this(klass, filterSupportedApis());
    }
+
+  @NotNull
+  private static Set<Integer> filterSupportedApis() {
+    Set<Integer> supportedApis = SdkConfig.getSupportedApis();
+
+    String overrideSupportedApis = System.getProperty("robolectric.enabledApis");
+    if (overrideSupportedApis == null || overrideSupportedApis.isEmpty()) {
+      return supportedApis;
+    } else {
+      Set<Integer> filteredApis = new HashSet<>();
+      for (String s : overrideSupportedApis.split(",")) {
+        int apiLevel = Integer.parseInt(s);
+        if (supportedApis.contains(apiLevel)) {
+          filteredApis.add(apiLevel);
+        }
+      }
+      return filteredApis;
+    }
+  }
 
   protected TestRunnerForApiVersion createTestRunner(Integer integer) throws InitializationError {
     return new TestRunnerForApiVersion(getTestClass().getJavaClass(), integer);

--- a/robolectric/src/main/java/org/robolectric/MultiApiRobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/MultiApiRobolectricTestRunner.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 
 /**
@@ -110,23 +111,21 @@ public class MultiApiRobolectricTestRunner extends Suite {
   /*
    * Only called reflectively. Do not use programmatically.
    */
-  public MultiApiRobolectricTestRunner(Class<?> klass, Set<Integer> supportedApis) throws Throwable {
+  public MultiApiRobolectricTestRunner(Class<?> klass) throws Throwable {
+    this(klass, SdkConfig.getSupportedApis(), System.getProperties());
+  }
+
+  MultiApiRobolectricTestRunner(Class<?> klass, Set<Integer> supportedApis, Properties properties) throws Throwable {
     super(klass, Collections.<Runner>emptyList());
 
-    for (Integer integer : supportedApis) {
+    for (Integer integer : filterSupportedApis(supportedApis, properties)) {
       runners.add(createTestRunner(integer));
     }
    }
 
-   public MultiApiRobolectricTestRunner(Class<?> klass) throws Throwable {
-    this(klass, filterSupportedApis());
-   }
-
   @NotNull
-  private static Set<Integer> filterSupportedApis() {
-    Set<Integer> supportedApis = SdkConfig.getSupportedApis();
-
-    String overrideSupportedApis = System.getProperty("robolectric.enabledApis");
+  private static Set<Integer> filterSupportedApis(Set<Integer> supportedApis, Properties properties) {
+    String overrideSupportedApis = properties.getProperty("robolectric.enabledApis");
     if (overrideSupportedApis == null || overrideSupportedApis.isEmpty()) {
       return supportedApis;
     } else {

--- a/robolectric/src/test/java/org/robolectric/MultiApiRobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/MultiApiRobolectricTestRunnerTest.java
@@ -2,6 +2,7 @@ package org.robolectric;
 
 import android.os.Build;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.Description;
@@ -24,16 +25,25 @@ import static org.mockito.Mockito.verify;
 @RunWith(JUnit4.class)
 public class MultiApiRobolectricTestRunnerTest {
 
+  private final ImmutableSet<Integer> APIS_FOR_TEST = ImmutableSet.of(
+      Build.VERSION_CODES.JELLY_BEAN,
+      Build.VERSION_CODES.JELLY_BEAN_MR1,
+      Build.VERSION_CODES.JELLY_BEAN_MR2,
+      Build.VERSION_CODES.KITKAT,
+      Build.VERSION_CODES.LOLLIPOP,
+      Build.VERSION_CODES.LOLLIPOP_MR1,
+      Build.VERSION_CODES.M);
+
   private int numSupportedApis;
 
   @Before
   public void setUp() {
-    numSupportedApis = SdkConfig.getSupportedApis().size();
+    numSupportedApis = APIS_FOR_TEST.size();
   }
 
   @Test
   public void createChildrenForEachSupportedApi() throws Throwable {
-    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestWithNoConfig.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestWithNoConfig.class, APIS_FOR_TEST);
 
     assertThat(runner.getChildren()).hasSize(numSupportedApis);
 
@@ -44,7 +54,7 @@ public class MultiApiRobolectricTestRunnerTest {
 
   @Test
   public void noConfig() throws Throwable {
-    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestWithNoConfig.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestWithNoConfig.class, APIS_FOR_TEST);
 
     RunNotifier runNotifier = new RunNotifier();
     RunListener runListener = mock(RunListener.class);
@@ -57,7 +67,7 @@ public class MultiApiRobolectricTestRunnerTest {
 
   @Test
   public void classConfigWithSdkGroup() throws Throwable {
-    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestClassConfigWithSdkGroup.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestClassConfigWithSdkGroup.class, APIS_FOR_TEST);
 
     assertThat(runner.getChildren()).hasSize(numSupportedApis);
 
@@ -73,7 +83,7 @@ public class MultiApiRobolectricTestRunnerTest {
 
   @Test
   public void methodConfigWithSdkGroup() throws Throwable {
-    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestMethodConfigWithSdkGroup.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestMethodConfigWithSdkGroup.class, APIS_FOR_TEST);
 
     assertThat(runner.getChildren()).hasSize(numSupportedApis);
 
@@ -89,7 +99,7 @@ public class MultiApiRobolectricTestRunnerTest {
 
   @Test
   public void classConfigMinSdk() throws Throwable {
-    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestClassLollipopAndUp.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestClassLollipopAndUp.class, APIS_FOR_TEST);
 
     assertThat(runner.getChildren()).hasSize(numSupportedApis);
 
@@ -105,7 +115,7 @@ public class MultiApiRobolectricTestRunnerTest {
 
   @Test
   public void classConfigMaxSdk() throws Throwable {
-    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestClassUpToAndIncludingLollipop.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestClassUpToAndIncludingLollipop.class, APIS_FOR_TEST);
 
     assertThat(runner.getChildren()).hasSize(numSupportedApis);
 
@@ -121,7 +131,7 @@ public class MultiApiRobolectricTestRunnerTest {
 
   @Test
   public void classConfigWithMinSdkAndMaxSdk() throws Throwable {
-    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestClassBetweenJellyBeanMr2AndLollipop.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestClassBetweenJellyBeanMr2AndLollipop.class, APIS_FOR_TEST);
 
     assertThat(runner.getChildren()).hasSize(numSupportedApis);
 
@@ -138,7 +148,7 @@ public class MultiApiRobolectricTestRunnerTest {
 
   @Test
   public void methodConfigMinSdk() throws Throwable {
-    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestMethodLollipopAndUp.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestMethodLollipopAndUp.class, APIS_FOR_TEST);
 
     assertThat(runner.getChildren()).hasSize(numSupportedApis);
 
@@ -154,7 +164,7 @@ public class MultiApiRobolectricTestRunnerTest {
 
   @Test
   public void methodConfigMaxSdk() throws Throwable {
-    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestMethodUpToAndIncludingLollipop.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestMethodUpToAndIncludingLollipop.class, APIS_FOR_TEST);
 
     assertThat(runner.getChildren()).hasSize(numSupportedApis);
 
@@ -170,7 +180,7 @@ public class MultiApiRobolectricTestRunnerTest {
 
   @Test
   public void methodConfigWithMinSdkAndMaxSdk() throws Throwable {
-    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestMethodBetweenJellyBeanMr2AndLollipop.class);
+    MultiApiRobolectricTestRunner runner = new MultiApiRobolectricTestRunner(TestMethodBetweenJellyBeanMr2AndLollipop.class, APIS_FOR_TEST);
 
     assertThat(runner.getChildren()).hasSize(numSupportedApis);
 

--- a/robolectric/src/test/java/org/robolectric/TestRunners.java
+++ b/robolectric/src/test/java/org/robolectric/TestRunners.java
@@ -1,13 +1,13 @@
 package org.robolectric;
 
-import static org.robolectric.util.TestUtil.resourceFile;
-
 import org.junit.runners.model.InitializationError;
 import org.robolectric.annotation.Config;
 import org.robolectric.manifest.AndroidManifest;
 
 import java.util.Locale;
 import java.util.Properties;
+
+import static org.robolectric.util.TestUtil.resourceFile;
 
 public class TestRunners {
 


### PR DESCRIPTION
Call `gradlew` with e.g. `-Drobolectric.enabledApis=16,17,18` to limit tests run by `MultiApiRobolectricTestRunner` to SDKs 16, 17, and 18.