### PR TITLE
Added support for references to drawable resources

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/PackageResourceLoader.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/PackageResourceLoader.java
@@ -35,6 +35,7 @@ public class PackageResourceLoader extends XResourceLoader {
         new ValueResourceLoader(data, "/resources/color", "color", ResType.COLOR),
         new ValueResourceLoader(data, "/resources/drawable", "drawable", ResType.DRAWABLE),
         new ValueResourceLoader(data, "/resources/item[@type='color']", "color", ResType.COLOR),
+        new ValueResourceLoader(data, "/resources/item[@type='drawable']", "drawable", ResType.DRAWABLE),
         new ValueResourceLoader(data, "/resources/dimen", "dimen", ResType.DIMEN),
         new ValueResourceLoader(data, "/resources/item[@type='dimen']", "dimen", ResType.DIMEN),
         new ValueResourceLoader(data, "/resources/integer", "integer", ResType.INTEGER),

--- a/robolectric/src/test/java/org/robolectric/res/PackageResourceLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/PackageResourceLoaderTest.java
@@ -27,6 +27,16 @@ public class PackageResourceLoaderTest {
   }
 
   @Test
+  public void shouldLoadDrawableBitmapResourcesDefinedByItemTag() throws Exception {
+    PackageResourceLoader loader = new PackageResourceLoader(testResources());
+    TypedResource value = loader.getValue(new ResName("org.robolectric", "drawable", "example_item_drawable"), "");
+    assertThat(value).isNotNull();
+    assertThat(value.getResType()).isEqualTo(ResType.DRAWABLE);
+    assertThat(value.isReference()).isTrue();
+    assertThat((String) value.getData()).isEqualTo("@drawable/an_image");
+  }
+
+  @Test
   public void shouldLoadResourcesFromGradleOutputDirectories() {
     PackageResourceLoader loader = new PackageResourceLoader(gradleAppResources());
     TypedResource value = loader.getValue(org.robolectric.gradleapp.R.string.from_gradle_output, "");

--- a/robolectric/src/test/resources/res/values/refs.xml
+++ b/robolectric/src/test/resources/res/values/refs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="example_item_drawable" type="drawable">@drawable/an_image</item>
+</resources>


### PR DESCRIPTION
This is a fix for [Issue #1554](https://github.com/robolectric/robolectric/issues/1554#issuecomment-229771660).