### PR TITLE
Performance + Memory improvements - Application's resource loader is …

### DIFF
--- a/robolectric/src/main/java/org/robolectric/ParameterizedRobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/ParameterizedRobolectricTestRunner.java
@@ -102,13 +102,13 @@ public final class ParameterizedRobolectricTestRunner extends Suite {
     }
 
     @Override
-    Statement methodBlock(FrameworkMethod method, Config config, AndroidManifest appManifest, SdkEnvironment environment, EmptyResourceLoader sdkEnvironment) {
+    Statement methodBlock(FrameworkMethod method, Config config, AndroidManifest appManifest, SdkEnvironment environment) {
       configureShadows(environment, config);
 
       DeepCloner deepCloner = new DeepCloner(environment.getRobolectricClassLoader());
       parameters = deepCloner.clone(parameters);
 
-      return super.methodBlock(method, config, appManifest, environment, sdkEnvironment);
+      return super.methodBlock(method, config, appManifest, environment);
     }
 
     @Override

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -58,13 +58,12 @@ public class ParallelUniverse implements ParallelUniverseInterface {
   }
 
   @Override
-  public void setUpApplicationState(Method method, TestLifecycle testLifecycle, ResourceLoader systemResourceLoader, ResourceLoader compiletimeSdkResourceLoader, AndroidManifest appManifest, Config config) {
+  public void setUpApplicationState(Method method, TestLifecycle testLifecycle, ResourceLoader systemResourceLoader, ResourceLoader appResourceLoader, AndroidManifest appManifest, Config config) {
     ReflectionHelpers.setStaticField(RuntimeEnvironment.class, "apiLevel", sdkConfig.getApiLevel());
 
     RuntimeEnvironment.application = null;
     RuntimeEnvironment.setMasterScheduler(new Scheduler());
     RuntimeEnvironment.setMainThread(Thread.currentThread());
-    ResourceLoader appResourceLoader = robolectricTestRunner.getAppResourceLoader(sdkConfig, compiletimeSdkResourceLoader, appManifest);
 
     DefaultPackageManager packageManager = new DefaultPackageManager();
     initializeAppManifest(appManifest, appResourceLoader, packageManager);


### PR DESCRIPTION
### Overview

### Proposed Changes

…no longer tied to the Android Runtime's resource loader so we don't need to cache per sdk. Also cache the compile time SDK resource loader as this is constant across all tests.