### PR TITLE
Fix getThemeValue style resolution

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -483,7 +483,7 @@ public class ShadowResourcesTest {
 
     theme.resolveAttribute(android.R.attr.windowBackground, out, false);
     assertThat(out.type).isEqualTo(TypedValue.TYPE_REFERENCE);
-    assertThat(out.resourceId).isEqualTo(android.R.color.black);
+    assertThat(out.data).isEqualTo(android.R.color.black);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
@@ -73,8 +73,8 @@ public class ShadowThemeTest {
   @Test public void shouldResolveReferencesThatStartWithAQuestionMark() throws Exception {
     TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
     Button theButton = (Button) activity.findViewById(R.id.button);
-    assertThat(theButton.getMinWidth()).isEqualTo(42); // via AnotherTheme.Button -> logoWidth and logoHeight
-//        assertThat(theButton.getMinHeight()).isEqualTo(42); todo 2.0-cleanup
+    assertThat(theButton.getMinWidth()).isEqualTo(42);
+    assertThat(theButton.getMinHeight()).isEqualTo(8);
   }
 
   @Test public void shouldLookUpStylesFromStyleResId() throws Exception {
@@ -120,6 +120,60 @@ public class ShadowThemeTest {
     assertThat(value1.resourceId).isEqualTo(R.layout.activity_main);
     assertThat(value2.resourceId).isEqualTo(R.layout.activity_main);
     assertThat(value1.coerceToString()).isEqualTo(value2.coerceToString());
+  }
+
+  @Test public void withResolveRefsFalse_shouldResolveValue() throws Exception {
+    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
+
+    TypedValue value = new TypedValue();
+    boolean resolved = activity.getTheme().resolveAttribute(R.attr.logoWidth, value, false);
+
+    assertThat(resolved).isTrue();
+    assertThat(value.type).isEqualTo(TypedValue.TYPE_DIMENSION);
+    assertThat(value.coerceToString()).isEqualTo("42.0px");
+  }
+
+  @Test public void withResolveRefsFalse_shouldNotResolveResource() throws Exception {
+    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
+
+    TypedValue value = new TypedValue();
+    boolean resolved = activity.getTheme().resolveAttribute(R.attr.logoHeight, value, false);
+
+    assertThat(resolved).isTrue();
+    assertThat(value.type).isEqualTo(TypedValue.TYPE_REFERENCE);
+    assertThat(value.data).isEqualTo(R.dimen.test_dp_dimen);
+  }
+
+  @Test public void withResolveRefsTrue_shouldResolveResource() throws Exception {
+    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
+
+    TypedValue value = new TypedValue();
+    boolean resolved = activity.getTheme().resolveAttribute(R.attr.logoHeight, value, true);
+
+    assertThat(resolved).isTrue();
+    assertThat(value.type).isEqualTo(TypedValue.TYPE_DIMENSION);
+    assertThat(value.resourceId).isEqualTo(R.dimen.test_dp_dimen);
+    assertThat(value.coerceToString()).isEqualTo("8.0dip");
+  }
+
+  @Test public void failToResolveCircularReference() throws Exception {
+    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
+
+    TypedValue value = new TypedValue();
+    boolean resolved = activity.getTheme().resolveAttribute(R.attr.isSugary, value, false);
+
+    assertThat(resolved).isFalse();
+  }
+
+  @Test public void canResolveAttrReferenceToDifferentPackage() throws Exception {
+    TestActivity activity = buildActivity(TestActivityWithAnotherTheme.class).create().get();
+
+    TypedValue value = new TypedValue();
+    boolean resolved = activity.getTheme().resolveAttribute(R.attr.styleReference, value, false);
+
+    assertThat(resolved).isTrue();
+    assertThat(value.type).isEqualTo(TypedValue.TYPE_REFERENCE);
+    assertThat(value.data).isEqualTo(R.style.Widget_AnotherTheme_Button);
   }
 
   @Test public void forStylesWithImplicitParents_shouldInheritValuesNotDefinedInChild() throws Exception {

--- a/robolectric/src/test/resources/res/values/themes.xml
+++ b/robolectric/src/test/resources/res/values/themes.xml
@@ -18,9 +18,11 @@
   <style name="Theme.AnotherTheme" parent="@style/Theme.Robolectric">
     <item name="android:buttonStyle">@style/Widget.AnotherTheme.Button</item>
     <item name="logoWidth">?attr/averageSheepWidth</item>
-    <item name="logoHeight">42dp</item>
+    <item name="logoHeight">@dimen/test_dp_dimen</item>
     <item name="averageSheepWidth">42px</item>
     <item name="animalStyle">@style/Gastropod</item>
+    <item name="isSugary">?attr/isSugary</item>
+    <item name="styleReference">?android:attr/buttonStyle</item>
     <item name="typeface">custom_font</item>
     <item name="string1">string 1 from Theme.AnotherTheme</item>
     <item name="string2">string 2 from Theme.AnotherTheme</item>


### PR DESCRIPTION
### Overview
Fix getThemeValue style resolution

### Proposed Changes

The resolveRefs parameter is meant to control whether resource values
should be resolved. It should always resolve style references.

Also use AttributeResource#getStyleReference() to correctly handle
cases where an attribute refers to another attribute in a different
package (e.g. ?attr/selectableItemBackground ->
?android:attr/selectableItemBackground).