### PR TITLE
Fix AssetManger.getThemeValue() id resolution.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -280,10 +280,8 @@ public final class ShadowAssetManager {
 
   @HiddenApi @Implementation(minSdk = LOLLIPOP)
   public boolean getThemeValue(long themePtr, int ident, TypedValue outValue, boolean resolveRefs) {
-    ResourceIndex resourceIndex = getResourceLoader(ident).getResourceIndex();
-    ResName resName = resourceIndex.getResName(ident);
-
     ThemeStyleSet themeStyleSet = getNativeTheme(themePtr).themeStyleSet;
+    ResName resName = resourceLoader.getResourceIndex().getResName(ident);
     AttributeResource attrValue = themeStyleSet.getAttrValue(resName);
     while(resolveRefs && attrValue != null && attrValue.isStyleReference()) {
       ResName attrResName = new ResName(attrValue.contextPackageName, "attr", attrValue.value.substring(1));

--- a/robolectric/src/test/resources/res/values/themes.xml
+++ b/robolectric/src/test/resources/res/values/themes.xml
@@ -24,6 +24,7 @@
     <item name="typeface">custom_font</item>
     <item name="string1">string 1 from Theme.AnotherTheme</item>
     <item name="string2">string 2 from Theme.AnotherTheme</item>
+    <item name="android:colorPrimary">@color/white</item>
   </style>
 
   <style name="Theme.ThirdTheme" parent="@style/Theme.Robolectric">


### PR DESCRIPTION
### Overview

### Proposed Changes

AssetManager.getThemeValue() should use its ResourceLoader for resolving
the resource id rather than using the system ResourceLoader for all
framework resource ids.