### PR TITLE
Add Shadow for NotificationManager#getActiveNotifications()

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -2,8 +2,10 @@ package org.robolectric.shadows;
 
 import android.app.Notification;
 import android.app.NotificationManager;
+import android.service.notification.StatusBarNotification;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.RuntimeEnvironment;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -44,6 +46,27 @@ public class ShadowNotificationManager {
   @Implementation
   public void cancelAll() {
     notifications.clear();
+  }
+
+  @Implementation
+  public StatusBarNotification[] getActiveNotifications() {
+    StatusBarNotification[] statusBarNotifications =
+        new StatusBarNotification[notifications.size()];
+    int i = 0;
+    for (Map.Entry<Key, Notification> entry : notifications.entrySet()) {
+      statusBarNotifications[i++] = new StatusBarNotification(
+	  RuntimeEnvironment.application.getPackageName(),
+	  null /* opPkg */,
+	  entry.getKey().id,
+	  entry.getKey().tag,
+	  android.os.Process.myUid() /* uid */,
+	  android.os.Process.myPid() /* initialPid */,
+	  0 /* score */,
+	  entry.getValue(),
+	  android.os.Process.myUserHandle(),
+	  0 /* postTime */);
+    }
+    return statusBarNotifications;
   }
 
   public int size() {


### PR DESCRIPTION
See summary. This method was added in Android M but has no shadow available.