### PR TITLE
Implement quitSafely() in ShadowLooper

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
@@ -16,6 +16,7 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
 import org.robolectric.util.Scheduler;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
 import static org.robolectric.RuntimeEnvironment.isMainThread;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.internal.Shadow.*;
@@ -110,6 +111,11 @@ public class ShadowLooper {
   public void quit() {
     if (this == getShadowMainLooper()) throw new RuntimeException("Main thread not allowed to quit");
     quitUnchecked();
+  }
+
+  @Implementation(minSdk = JELLY_BEAN_MR2)
+  public void quitSafely() {
+    quit();
   }
 
   public void quitUnchecked() {


### PR DESCRIPTION
`Looper.quitSafely()` was introduced in API 18. This small patch implements `quitSafely()` by calling `quit()`. I thought about calling `idle()` first (to simulate the behavior or running all messages that are due), but decided against it since I didn't want to assume that it was ok to unpause the looper.