### PR TITLE
Add implementation of drawBitmap with destination RectF

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCanvas.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowCanvas.java
@@ -8,6 +8,8 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.util.ReflectionHelpers;
@@ -120,6 +122,22 @@ public class ShadowCanvas {
 
   @Implementation
   public void drawBitmap(Bitmap bitmap, Rect src, Rect dst, Paint paint) {
+    describeBitmap(bitmap, paint);
+
+    StringBuilder descriptionBuilder = new StringBuilder();
+    if (dst != null) {
+      descriptionBuilder.append(" at (").append(dst.left).append(",").append(dst.top)
+          .append(") with height=").append(dst.height()).append(" and width=").append(dst.width());
+    }
+
+    if (src != null) {
+      descriptionBuilder.append( " taken from ").append(src.toString());
+    }
+    appendDescription(descriptionBuilder.toString());
+  }
+
+  @Implementation
+  public void drawBitmap(Bitmap bitmap, Rect src, RectF dst, Paint paint) {
     describeBitmap(bitmap, paint);
 
     StringBuilder descriptionBuilder = new StringBuilder();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCanvasTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCanvasTest.java
@@ -53,6 +53,14 @@ public class ShadowCanvasTest {
   }
 
   @Test
+  public void shouldDescribeBitmapDrawing_withDestinationRectF() throws Exception {
+    Canvas canvas = new Canvas(targetBitmap);
+    canvas.drawBitmap(imageBitmap, new Rect(1,2,3,4), new RectF(5.0f,6.0f,7.5f,8.5f), new Paint());
+
+    assertEquals("Bitmap for file:/an/image.jpg at (5.0,6.0) with height=2.5 and width=2.5 taken from Rect(1, 2 - 3, 4)", shadowOf(canvas).getDescription());
+  }
+
+  @Test
   public void shouldDescribeBitmapDrawing_WithMatrix() throws Exception {
     Canvas canvas = new Canvas(targetBitmap);
     canvas.drawBitmap(imageBitmap, new Matrix(), new Paint());


### PR DESCRIPTION
`ShadowBitmap` implemented `drawBitmap` with a destination `Rect`, but not `RectF`. This patch adds the missing implementation.