### PR TITLE
Remove switching of ResourceLoaders based on resId or ResName.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
+++ b/robolectric-resources/src/main/java/org/robolectric/RuntimeEnvironment.java
@@ -20,6 +20,7 @@ public class RuntimeEnvironment {
   private static Scheduler masterScheduler;
   private static ResourceLoader systemResourceLoader;
   private static ResourceLoader appResourceLoader;
+  private static ResourceLoader compiletimeResourceLoader;
 
   /**
    * Tests if the given thread is currently set as the main thread.
@@ -149,5 +150,13 @@ public class RuntimeEnvironment {
 
   public static ResourceLoader getAppResourceLoader() {
     return appResourceLoader;
+  }
+
+  public static void setCompiletimeResourceLoader(ResourceLoader compiletimeResourceLoader) {
+    RuntimeEnvironment.compiletimeResourceLoader = compiletimeResourceLoader;
+  }
+
+  public static ResourceLoader getCompiletimeResourceLoader() {
+    return compiletimeResourceLoader;
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -95,7 +95,7 @@ public final class ShadowAssetManager {
       if (attribute.getReferenceResId() != null) {
         resourceId = attribute.getReferenceResId();
       } else {
-        resourceId = getResourceLoader(resName).getResourceIndex().getResourceId(resName);
+        resourceId = resourceLoader.getResourceIndex().getResourceId(resName);
       }
 
       if (resourceId == null) {
@@ -104,7 +104,7 @@ public final class ShadowAssetManager {
       outValue.type = TypedValue.TYPE_REFERENCE;
       outValue.resourceId = resourceId;
 
-      TypedResource dereferencedRef = getResourceLoader(resName).getValue(resName, qualifiers);
+      TypedResource dereferencedRef = resourceLoader.getValue(resName, qualifiers);
 
       if (dereferencedRef == null) {
         Logger.strict("couldn't resolve %s from %s", resName.getFullyQualifiedName(), attribute);
@@ -125,7 +125,7 @@ public final class ShadowAssetManager {
           return;
         } else if (DrawableResourceLoader.isStillHandledHere(resName.type)) {
           // wtf. color and drawable references reference are all kinds of stupid.
-          TypedResource drawableResource = getResourceLoader(resName).getValue(resName, qualifiers);
+          TypedResource drawableResource = resourceLoader.getValue(resName, qualifiers);
           if (drawableResource == null) {
             throw new Resources.NotFoundException("can't find file for " + resName);
           } else {
@@ -164,7 +164,7 @@ public final class ShadowAssetManager {
       return;
     }
 
-    TypedResource attrTypeData = getResourceLoader(attribute.resName).getValue(attribute.resName, qualifiers);
+    TypedResource attrTypeData = resourceLoader.getValue(attribute.resName, qualifiers);
     if (attrTypeData != null) {
       AttrData attrData = (AttrData) attrTypeData.getData();
       String format = attrData.getFormat();
@@ -233,11 +233,11 @@ public final class ShadowAssetManager {
 
     // If the resource does not exist then return 0, otherwise ResourceIndex.getResourceId() will generate a placeholder.
     if (!ResName.ID_TYPE.equals(resName.type)
-        && !getResourceLoader(resName).hasValue(resName, RuntimeEnvironment.getQualifiers())) {
+        && !resourceLoader.hasValue(resName, RuntimeEnvironment.getQualifiers())) {
       return 0;
     }
 
-    Integer resourceId = getResourceLoader(resName).getResourceIndex().getResourceId(resName);
+    Integer resourceId = resourceLoader.getResourceIndex().getResourceId(resName);
     return resourceId == null ? 0 : resourceId;
   }
 
@@ -279,7 +279,7 @@ public final class ShadowAssetManager {
 
   @HiddenApi @Implementation(minSdk = LOLLIPOP)
   public boolean getThemeValue(long themePtr, int ident, TypedValue outValue, boolean resolveRefs) {
-    ResourceIndex resourceIndex = getResourceLoader(ident).getResourceIndex();
+    ResourceIndex resourceIndex = resourceLoader.getResourceIndex();
     ResName resName = resourceIndex.getResName(ident);
 
     ThemeStyleSet themeStyleSet = getNativeTheme(themePtr).themeStyleSet;
@@ -329,8 +329,6 @@ public final class ShadowAssetManager {
   public final InputStream openNonAsset(int cookie, String fileName, int accessMode) throws IOException {
     final ResName resName = qualifyFromNonAssetFileName(fileName);
 
-    ResourceLoader resourceLoader = getResourceLoader(resName);
-
     final FileTypedResource typedResource =
         (FileTypedResource) resourceLoader.getValue(resName, RuntimeEnvironment.getQualifiers());
 
@@ -372,7 +370,7 @@ public final class ShadowAssetManager {
     }
     resName = resolvedResName;
 
-    ResourceLoader resourceLoader = getResourceLoader(resId);
+    ResourceLoader resourceLoader = ResourceIds.isFrameworkResource(resId) ? RuntimeEnvironment.getSystemResourceLoader() : RuntimeEnvironment.getCompiletimeResourceLoader();
     XmlBlock block = resourceLoader.getXml(resName, RuntimeEnvironment.getQualifiers());
     if (block == null) {
       throw new Resources.NotFoundException(resName.getFullyQualifiedName());
@@ -484,12 +482,11 @@ public final class ShadowAssetManager {
   /////////////////////////
 
   Style resolveStyle(int resId, Style themeStyleSet) {
-    ShadowAssetManager shadowAssetManager = ResourceIds.isFrameworkResource(resId) ? shadowOf(AssetManager.getSystem()) : this;
-    return shadowAssetManager.resolveStyle(getResName(resId), themeStyleSet);
+    return resolveStyle(getResName(resId), themeStyleSet);
   }
 
   private Style resolveStyle(@NotNull ResName themeStyleName, Style themeStyleSet) {
-    TypedResource themeStyleResource = getResourceLoader(themeStyleName).getValue(themeStyleName, RuntimeEnvironment.getQualifiers());
+    TypedResource themeStyleResource = resourceLoader.getValue(themeStyleName, RuntimeEnvironment.getQualifiers());
     if (themeStyleResource == null) return null;
     StyleData themeStyleData = (StyleData) themeStyleResource.getData();
     if (themeStyleSet == null) {
@@ -499,8 +496,6 @@ public final class ShadowAssetManager {
   }
 
   private TypedResource getAndResolve(int resId, String qualifiers, boolean resolveRefs) {
-    ResourceLoader resourceLoader = getResourceLoader(resId);
-
     TypedResource value = resourceLoader.getValue(resId, qualifiers);
     if (resolveRefs) {
       value = resolve(value, qualifiers, resId);
@@ -521,26 +516,12 @@ public final class ShadowAssetManager {
     return value;
   }
 
-  /**
-   * Returns either the Application's ResourceLoader or the Framework's ResourceLoader based on the package type of the resId
-   */
-  ResourceLoader getResourceLoader(int resId) {
-    return ResourceIds.isFrameworkResource(resId) ? shadowOf(AssetManager.getSystem()).getResourceLoader() : this.resourceLoader;
-  }
-
-  /**
-   * Returns either the Application's ResourceLoader or the Framework's ResourceLoader based on the package of the ResName
-   */
-  private ResourceLoader getResourceLoader(ResName resName) {
-    return "android".equals(resName.packageName) ? shadowOf(AssetManager.getSystem()).getResourceLoader() : this.resourceLoader;
-  }
-
   TypedResource resolve(TypedResource value, String qualifiers, int resId) {
     return resolveResourceValue(value, qualifiers, resId);
   }
 
   public ResName resolveResName(ResName resName, String qualifiers) {
-    TypedResource value = getResourceLoader(resName).getValue(resName, qualifiers);
+    TypedResource value = resourceLoader.getValue(resName, qualifiers);
     return resolveResource(value, qualifiers, resName);
   }
 
@@ -553,7 +534,7 @@ public final class ShadowAssetManager {
       } else {
         String refStr = s.substring(1).replace("+", "");
         resName = ResName.qualifyResName(refStr, resName);
-        value = getResourceLoader(resName).getValue(resName, qualifiers);
+        value = resourceLoader.getValue(resName, qualifiers);
       }
     }
 
@@ -568,7 +549,7 @@ public final class ShadowAssetManager {
       } else {
         String refStr = s.substring(1).replace("+", "");
         resName = ResName.qualifyResName(refStr, resName);
-        value = getResourceLoader(resName).getValue(resName, qualifiers);
+        value = resourceLoader.getValue(resName, qualifiers);
       }
     }
 
@@ -655,7 +636,7 @@ public final class ShadowAssetManager {
         Logger.info("huh... circular reference for %s?", attribute.resName.getFullyQualifiedName());
         return null;
       }
-      ResName resName = getResourceLoader(resId).getResourceIndex().getResName(resId);
+      ResName resName = resourceLoader.getResourceIndex().getResName(resId);
 
       AttributeResource otherAttr = themeStyleSet.getAttrValue(otherAttrName);
       if (otherAttr == null) {
@@ -725,24 +706,18 @@ public final class ShadowAssetManager {
     if (attributeSet != null) {
       for (int i = 0; i < attributeSet.getAttributeCount(); i++) {
         if (attributeSet.getAttributeNameResource(i) == resId && attributeSet.getAttributeValue(i) != null) {
-          // TODO: If there is a match in the XML then we should get the resource name from the XML rather than look it up from the app resource loader.
-          ResName resName = resourceLoader.getResourceIndex().getResName(resId);
+          String defaultPackageName = ResourceIds.isFrameworkResource(resId) ? "android" : RuntimeEnvironment.application.getPackageName();
+          ResName resName = ResName.qualifyResName(attributeSet.getAttributeName(i), defaultPackageName, "attr");
           Integer referenceResId = null;
           if (AttributeResource.isResourceReference(attributeSet.getAttributeValue(i))) {
             referenceResId = attributeSet.getAttributeResourceValue(i, -1);
           }
 
-          if (resName == null) {
-            // We're looking for an attribute that doesn't yet exist at this SDK level just pass it back blindly and
-            // assume the user knows what they're doing with it.
-            resName = ResName.qualifyResName(attributeSet.getAttributeName(i), null, "attr");
-          }
           return new AttributeResource(resName, attributeSet.getAttributeValue(i), "fixme!!!", referenceResId);
         }
       }
     }
 
-    ResourceLoader resourceLoader = getResourceLoader(resId);
     ResName attrName = resourceLoader.getResourceIndex().getResName(resId);
     if (attrName == null) return null;
 
@@ -773,7 +748,6 @@ public final class ShadowAssetManager {
   }
 
   @NotNull private ResName getResName(int id) {
-    ResourceLoader resourceLoader = getResourceLoader(id);
     ResName resName = resourceLoader.getResourceIndex().getResName(id);
     if (resName == null) {
       List<String> packages = new ArrayList<>(resourceLoader.getResourceIndex().getPackages());

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -107,7 +107,7 @@ public class ShadowResources {
   public String getQuantityString(int resId, int quantity) throws Resources.NotFoundException {
     ShadowAssetManager shadowAssetManager = shadowOf(realResources.getAssets());
 
-    TypedResource typedResource = shadowAssetManager.getResourceLoader(resId).getValue(resId, RuntimeEnvironment.getQualifiers());
+    TypedResource typedResource = shadowAssetManager.getResourceLoader().getValue(resId, RuntimeEnvironment.getQualifiers());
     if (typedResource != null && typedResource instanceof PluralResourceLoader.PluralRules) {
       PluralResourceLoader.PluralRules pluralRules = (PluralResourceLoader.PluralRules) typedResource;
       Plural plural = pluralRules.find(quantity);
@@ -127,7 +127,7 @@ public class ShadowResources {
 
   @Implementation
   public InputStream openRawResource(int id) throws Resources.NotFoundException {
-    return shadowOf(realResources.getAssets()).getResourceLoader(id).getRawValue(id);
+    return shadowOf(realResources.getAssets()).getResourceLoader().getRawValue(id);
   }
 
   @Implementation

--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -128,7 +128,7 @@ public class Robolectric {
     } catch (ParserConfigurationException e) {
       throw new RuntimeException(e);
     }
-    return new AttributeSetBuilder(document, RuntimeEnvironment.getAppResourceLoader());
+    return new AttributeSetBuilder(document, RuntimeEnvironment.getCompiletimeResourceLoader());
   }
 
   public static class AttributeSetBuilder {

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -281,7 +281,8 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
 
             ResourceLoader systemResourceLoader = sdkEnvironment.getSystemResourceLoader(getJarResolver());
             ResourceLoader appResourceLoader = getAppResourceLoader(appManifest);
-            parallelUniverseInterface.setUpApplicationState(bootstrappedMethod, testLifecycle, systemResourceLoader, appResourceLoader, appManifest, config);
+
+            parallelUniverseInterface.setUpApplicationState(bootstrappedMethod, testLifecycle, getCompiletimeSdkResourceLoader(), systemResourceLoader, appResourceLoader, appManifest, config);
             testLifecycle.beforeTest(bootstrappedMethod);
           } catch (Exception e) {
             throw new RuntimeException(e);
@@ -549,16 +550,11 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
   private final ResourceLoader getAppResourceLoader(final AndroidManifest appManifest) {
     ResourceLoader resourceLoader = appResourceLoaderCache.get(appManifest);
     if (resourceLoader == null) {
-      Map<String, ResourceLoader> resourceLoaders = new HashMap<>();
-      resourceLoaders.put("android", getCompiletimeSdkResourceLoader());
-
       List<PackageResourceLoader> appAndLibraryResourceLoaders = new ArrayList<>();
       for (ResourcePath resourcePath : appManifest.getIncludedResourcePaths()) {
         appAndLibraryResourceLoaders.add(new PackageResourceLoader(resourcePath, new ResourceExtractor(resourcePath)));
       }
-      resourceLoaders.put(appManifest.getPackageName(), new OverlayResourceLoader(appManifest.getPackageName(), appAndLibraryResourceLoaders));
-
-      resourceLoader = new RoutingResourceLoader(resourceLoaders);
+      resourceLoader = new OverlayResourceLoader(appManifest.getPackageName(), appAndLibraryResourceLoaders);
       appResourceLoaderCache.put(appManifest, resourceLoader);
     }
     return resourceLoader;

--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverseInterface.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverseInterface.java
@@ -9,7 +9,7 @@ import org.robolectric.res.ResourceLoader;
 public interface ParallelUniverseInterface {
   void resetStaticState(Config config);
 
-  void setUpApplicationState(Method method, TestLifecycle testLifecycle, ResourceLoader systemResourceLoader, ResourceLoader compiletimeSdkResourceLoader, AndroidManifest appManifest, Config config);
+  void setUpApplicationState(Method method, TestLifecycle testLifecycle, ResourceLoader sdkResourceLoader, ResourceLoader systemResourceLoader, ResourceLoader compiletimeSdkResourceLoader, AndroidManifest appManifest, Config config);
 
   Thread getMainThread();
 

--- a/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
@@ -15,6 +15,7 @@ import org.robolectric.internal.SdkConfig;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.EmptyResourceLoader;
 import org.robolectric.res.ResourceExtractor;
+import org.robolectric.res.ResourceLoader;
 import org.robolectric.res.ResourcePath;
 import org.robolectric.res.builder.RobolectricPackageManager;
 import org.robolectric.shadows.ShadowApplication;
@@ -45,8 +46,9 @@ public class ParallelUniverseTest {
   }
 
   private void setUpApplicationState(Config defaultConfig) {
-    pu.setUpApplicationState(null, new DefaultTestLifecycle(), RuntimeEnvironment.getSystemResourceLoader(),
-        new EmptyResourceLoader("android", new ResourceExtractor(new ResourcePath(android.R.class, "android", null, null))),
+    ResourceLoader sdkResourceLoader = new EmptyResourceLoader("android", new ResourceExtractor(new ResourcePath(android.R.class, "android", null, null)));
+    pu.setUpApplicationState(null, new DefaultTestLifecycle(), sdkResourceLoader, RuntimeEnvironment.getSystemResourceLoader(),
+        new EmptyResourceLoader("package", new ResourceExtractor(new ResourcePath(org.robolectric.R.class, "package", null, null))),
         new AndroidManifest(null, null, null, "package"), defaultConfig);
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
@@ -176,6 +176,7 @@ public class ShadowAssetManagerTest {
     AttributeSet mockAttributeSet = mock(AttributeSet.class);
     when(mockAttributeSet.getAttributeCount()).thenReturn(1);
     when(mockAttributeSet.getAttributeNameResource(0)).thenReturn(android.R.attr.windowBackground);
+    when(mockAttributeSet.getAttributeName(0)).thenReturn("android:windowBackground");
     when(mockAttributeSet.getAttributeValue(0)).thenReturn("value");
 
     resources.obtainAttributes(mockAttributeSet, new int[]{android.R.attr.windowBackground});


### PR DESCRIPTION
### Overview

### Proposed Changes

There are four use cases of ResourceLoaders:-

1) Resources.getSystem() / AssetManager.getSystem() - these use the runtime framework resource table.
2) AttributeSets from the framework - these use the runtime frameworks resource table.
3) Application.getResources() - these use both the application and the runtime frameworks resource table.
4) AttributeSets from the application - these contain the compiled in resource IDS from the application and the compile time SDK.