### PR TITLE
Restore ClassHandler cache in SdkEnvironment

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -492,9 +492,20 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
       sdkEnvironment.getShadowInvalidator().invalidateClasses(invalidatedClasses);
     }
 
-    ClassHandler classHandler = new ShadowWrangler(shadowMap, sdkEnvironment.getSdkConfig()
-        .getApiLevel());
+    ClassHandler classHandler = getClassHandler(sdkEnvironment, shadowMap);
     injectEnvironment(sdkEnvironment.getRobolectricClassLoader(), classHandler, sdkEnvironment.getShadowInvalidator());
+  }
+
+  private ClassHandler getClassHandler(SdkEnvironment sdkEnvironment, ShadowMap shadowMap) {
+    ClassHandler classHandler;
+    synchronized (sdkEnvironment) {
+      classHandler = sdkEnvironment.getClassHandler(shadowMap);
+      if (classHandler == null) {
+        classHandler = new ShadowWrangler(shadowMap, sdkEnvironment.getSdkConfig().getApiLevel());
+        sdkEnvironment.addClassHandler(shadowMap, classHandler);
+      }
+    }
+    return classHandler;
   }
 
   protected int pickSdkVersion(Config config, AndroidManifest manifest) {

--- a/robolectric/src/main/java/org/robolectric/internal/SdkEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SdkEnvironment.java
@@ -1,14 +1,10 @@
 package org.robolectric.internal;
 
+import org.robolectric.internal.bytecode.ClassHandler;
 import org.robolectric.internal.bytecode.ShadowInvalidator;
-import org.robolectric.internal.dependency.DependencyResolver;
 import org.robolectric.internal.bytecode.ShadowMap;
-import org.robolectric.internal.bytecode.ShadowWrangler;
-import org.robolectric.res.Fs;
-import org.robolectric.res.PackageResourceLoader;
-import org.robolectric.res.ResourceExtractor;
-import org.robolectric.res.ResourceLoader;
-import org.robolectric.res.ResourcePath;
+import org.robolectric.internal.dependency.DependencyResolver;
+import org.robolectric.res.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +13,8 @@ public class SdkEnvironment {
   private final SdkConfig sdkConfig;
   private final ClassLoader robolectricClassLoader;
   private final ShadowInvalidator shadowInvalidator;
+  private final Map<ShadowMap, ClassHandler> classHandlersByShadowMap = new HashMap<>();
+
   private ShadowMap shadowMap = ShadowMap.EMPTY;
   private ResourceLoader systemResourceLoader;
 
@@ -24,6 +22,14 @@ public class SdkEnvironment {
     this.sdkConfig = sdkConfig;
     this.robolectricClassLoader = robolectricClassLoader;
     shadowInvalidator = new ShadowInvalidator();
+  }
+
+  public void addClassHandler(ShadowMap shadowMap, ClassHandler classHandler) {
+    classHandlersByShadowMap.put(shadowMap, classHandler);
+  }
+
+  public ClassHandler getClassHandler(ShadowMap shadowMap) {
+    return classHandlersByShadowMap.get(shadowMap);
   }
 
   public synchronized ResourceLoader getSystemResourceLoader(DependencyResolver dependencyResolver) {


### PR DESCRIPTION
### Overview

### Proposed Changes

In #2755, the ClassHandler cache in SdkEnvironment was removed because
it wasn't being used.

However, after some further consideration, there may be certain
situations where caching ClassHandlers could result in performace gains.

Instead, fix the caching, and add some accessors so
classHandlersByShadowMap cannot be modified outside of SdkEnvironment.