### PR TITLE
Add option to always use in-memory SQLiteConnections

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSQLiteConnection.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSQLiteConnection.java
@@ -62,6 +62,8 @@ public class ShadowSQLiteConnection {
   // indicates an ignored statement
   private static final int IGNORED_REINDEX_STMT = -2;
 
+  private static boolean useInMemoryDatabase;
+
   private static SQLiteConnection connection(long pointer) {
     return CONNECTIONS.getConnection(pointer);
   }
@@ -70,6 +72,9 @@ public class ShadowSQLiteConnection {
     return CONNECTIONS.getStatement(connectionPtr, pointer);
   }
 
+  public static void setUseInMemoryDatabase(boolean value) {
+    useInMemoryDatabase = value;
+  }
 
   @Implementation
   public static Number nativeOpen(String path, int openFlags, String label, boolean enableTrace, boolean enableProfile) {
@@ -99,6 +104,7 @@ public class ShadowSQLiteConnection {
   @Resetter
   public static void reset() {
     CONNECTIONS.reset();
+    useInMemoryDatabase = false;
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
@@ -496,7 +502,7 @@ static class Connections {
     SQLiteConnection dbConnection = execute("open SQLite connection", new Callable<SQLiteConnection>() {
       @Override
       public SQLiteConnection call() throws Exception {
-        SQLiteConnection connection = IN_MEMORY_PATH.equals(path)
+        SQLiteConnection connection = useInMemoryDatabase || IN_MEMORY_PATH.equals(path)
             ? new SQLiteConnection()
             : new SQLiteConnection(new File(path));
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSQLiteConnectionTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSQLiteConnectionTest.java
@@ -38,16 +38,11 @@ public class ShadowSQLiteConnectionTest {
   
   @Before
   public void setUp() throws Exception {
-    databasePath = RuntimeEnvironment.application.getDatabasePath("database.db");
-    databasePath.getParentFile().mkdirs();
-
-    database = SQLiteDatabase.openOrCreateDatabase(databasePath.getPath(), null);
+    database = createDatabase("database.db");
     SQLiteStatement createStatement = database.compileStatement(
         "CREATE TABLE `routine` (`id` INTEGER PRIMARY KEY AUTOINCREMENT , `name` VARCHAR , `lastUsed` INTEGER DEFAULT 0 ,  UNIQUE (`name`)) ;");
     createStatement.execute();
-    ptr = ShadowSQLiteConnection.nativeOpen(databasePath.getPath(), 0, "test connection", false, false).longValue();
-    CONNECTIONS = ReflectionHelpers.getStaticField(ShadowSQLiteConnection.class, "CONNECTIONS");
-    conn = CONNECTIONS.getConnection(ptr);
+    conn = getSQLiteConnection(database);
   }
 
   @After
@@ -158,5 +153,27 @@ public class ShadowSQLiteConnectionTest {
       Thread.interrupted();
     }
     ShadowSQLiteConnection.reset();
+  }
+
+  @Test
+  public void test_setUseInMemoryDatabase() throws Exception {
+    assertThat(conn.isMemoryDatabase()).isFalse();
+    ShadowSQLiteConnection.setUseInMemoryDatabase(true);
+    SQLiteDatabase inMemoryDb = createDatabase("in_memory.db");
+    SQLiteConnection inMemoryConn = getSQLiteConnection(inMemoryDb);
+    assertThat(inMemoryConn.isMemoryDatabase()).isTrue();
+    inMemoryDb.close();
+  }
+
+  private SQLiteDatabase createDatabase(String filename) {
+    databasePath = RuntimeEnvironment.application.getDatabasePath(filename);
+    databasePath.getParentFile().mkdirs();
+    return SQLiteDatabase.openOrCreateDatabase(databasePath.getPath(), null);
+  }
+
+  private SQLiteConnection getSQLiteConnection(SQLiteDatabase database) {
+    ptr = ShadowSQLiteConnection.nativeOpen(databasePath.getPath(), 0, "test connection", false, false).longValue();
+    CONNECTIONS = ReflectionHelpers.getStaticField(ShadowSQLiteConnection.class, "CONNECTIONS");
+    return CONNECTIONS.getConnection(ptr);
   }
 }


### PR DESCRIPTION
### Overview

Add option to always use in-memory SQLiteConnections

### Proposed Changes

After profiling my Robolectric test suite, I noticed a significant
amount of time is spent performing sqlite database opertions. Many of
these originate from SQLiteOpenHelper. By always using in-memory
SQLiteConnections, the overhead of syncing the database to a file is is
eliminated. This reduced the overall time it took our test suite by
nearly 30%.