### PR TITLE
Fix getIdAttributeResourceValue always returns defaultVaue

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/builder/XmlResourceParserImpl.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/builder/XmlResourceParserImpl.java
@@ -739,15 +739,7 @@ public class XmlResourceParserImpl implements XmlResourceParser {
 
   @Override
   public int getIdAttributeResourceValue(int defaultValue) {
-    String id = getIdAttribute();
-    if (id == null) {
-      return defaultValue;
-    }
-    try {
-      return Integer.parseInt(id);
-    } catch (NumberFormatException ex) {
-      return defaultValue;
-    }
+    return getAttributeResourceValue(null, "id", defaultValue);
   }
 
   @Override


### PR DESCRIPTION
### Overview
getIdAttributeResourceValue always return default values
I have a xml file 

```xml
<foo>
<tab id="@+id/tab1"/>
</foo>
```

I want to get the id and set to a view, but the Integer.parseInt failed and returned me default values

### Proposed Changes
use getAttributeResourceValue(null, "id", defaultValue) instead.

