### PR TITLE
Synchronize access to ShadowContentResolve#contentObservers field

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
@@ -294,7 +294,10 @@ public class ShadowContentResolver {
   public void notifyChange(Uri uri, ContentObserver observer, boolean syncToNetwork) {
     notifiedUris.add(new NotifiedUri(uri, observer, syncToNetwork));
 
-    CopyOnWriteArraySet<ContentObserver> observers = contentObservers.get(uri);
+    CopyOnWriteArraySet<ContentObserver> observers;
+    synchronized (this) {
+      observers = contentObservers.get(uri);
+    }
     if (observers != null) {
       for (ContentObserver obs : observers) {
         if ( obs != null && obs != observer  ) {
@@ -530,7 +533,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public void registerContentObserver( Uri uri, boolean notifyForDescendents, ContentObserver observer) {
+  synchronized public void registerContentObserver( Uri uri, boolean notifyForDescendents, ContentObserver observer) {
     CopyOnWriteArraySet<ContentObserver> observers = contentObservers.get(uri);
     if (observers == null) {
       observers = new CopyOnWriteArraySet<>();
@@ -547,7 +550,11 @@ public class ShadowContentResolver {
   @Implementation
   public void unregisterContentObserver( ContentObserver observer ) {
     if ( observer != null ) {
-      for (CopyOnWriteArraySet<ContentObserver> observers : contentObservers.values()) {
+      Collection<CopyOnWriteArraySet<ContentObserver>> observerSets;
+      synchronized (this) {
+        observerSets = contentObservers.values();
+      }
+      for (CopyOnWriteArraySet<ContentObserver> observers : observerSets) {
         observers.remove(observer);
       }
     }
@@ -557,7 +564,7 @@ public class ShadowContentResolver {
    * Non-Android accessor.  Clears the list of registered content observers.
    * Commonly used in test case setup.
    */
-  public void clearContentObservers() {
+  synchronized public void clearContentObservers() {
     contentObservers.clear();
   }
 
@@ -582,7 +589,7 @@ public class ShadowContentResolver {
    * @param uri Given URI
    * @return The content observers
    */
-  public Collection<ContentObserver> getContentObservers( Uri uri ) {
+  synchronized public Collection<ContentObserver> getContentObservers( Uri uri ) {
     CopyOnWriteArraySet<ContentObserver> observers = contentObservers.get(uri);
     return (observers == null) ? Collections.<ContentObserver>emptyList() : observers;
   }


### PR DESCRIPTION
Closing a Cursor on a background thread can result in a
ConcurrentModificationException on the HashMap's iterator.

I maintained the wrong ordering of synchronized that already existed elsewhere in this file.

Example failure:

```
java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1438)
	at java.util.HashMap$ValueIterator.next(HashMap.java:1467)
	at org.robolectric.shadows.ShadowContentResolver.unregisterContentObserver(ShadowContentResolver.java:550)
	at android.content.ContentResolver.unregisterContentObserver(ContentResolver.java)
	at android.database.AbstractCursor.onDeactivateOrClose(AbstractCursor.java:126)
	at android.database.AbstractWindowedCursor.onDeactivateOrClose(AbstractWindowedCursor.java:207)
	at android.database.AbstractCursor.close(AbstractCursor.java:148)
	at android.database.sqlite.SQLiteCursor.close(SQLiteCursor.java:206)
	at org.robolectric.shadows.ShadowCursorWrapper.close(ShadowCursorWrapper.java:171)
	at android.database.CursorWrapper.close(CursorWrapper.java)
        ....
```