### PR TITLE
Don't load resources twice.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/ResourceMerger.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/ResourceMerger.java
@@ -20,12 +20,7 @@ public class  ResourceMerger {
       }
     }
 
-    PackageResourceTable resourceTable = ResourceTableFactory.newResourceTable(appManifest.getPackageName(),
+    return ResourceTableFactory.newResourceTable(appManifest.getPackageName(),
         allResourcePaths.toArray(new ResourcePath[allResourcePaths.size()]));
-
-    for (ResourcePath resourcePath : allResourcePaths) {
-      ResourceParser.load(appManifest.getPackageName(), resourcePath, resourceTable);
-    }
-    return resourceTable;
   }
 }


### PR DESCRIPTION
They're already loaded in ResourceTableFactory.newResourceTable() - this was the result of a bad merge.