### PR TITLE
Merge default config values in ConfigMerger.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/ConfigMerger.java
+++ b/robolectric/src/main/java/org/robolectric/ConfigMerger.java
@@ -24,8 +24,18 @@ public class ConfigMerger {
     }
   };
 
+  /**
+   * Calculate the {@link Config} for the given test.
+   *
+   * @param testClass the class containing the test
+   * @param method the test method
+   * @param globalConfig global configuration values
+   * @return the effective configuration
+   * @since 3.2
+   */
   public Config getConfig(Class<?> testClass, Method method, Config globalConfig) {
-    Config config = globalConfig;
+    Config config = Config.Builder.defaults().build();
+    config = override(config, globalConfig);
 
     for (String packageName : reverse(packageHierarchyOf(testClass))) {
       Config packageConfig = cachedPackageConfig(packageName);
@@ -55,6 +65,7 @@ public class ConfigMerger {
    *
    * @param packageName the name of the package, or empty string (<code>""</code>) for the top level package
    * @return {@link Config} object for the specified package
+   * @since 3.2
    */
   @Nullable
   private Config buildPackageConfig(String packageName) {
@@ -63,6 +74,8 @@ public class ConfigMerger {
 
   /**
    * Return a {@link Properties} file for the given package name, or <code>null</code> if none is available.
+   * 
+   * @since 3.2
    */
   protected Properties getConfigProperties(String packageName) {
     String resourceName = packageName.replace('.', '/') + "/" + RobolectricTestRunner.CONFIG_PROPERTIES;

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -454,12 +454,8 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
    * Configuration provided for specific packages, test classes, and test method
    * configurations will override values provided here.
    *
-   * The returned object is likely to be reused for many tests.
-   *
    * Custom TestRunner subclasses may wish to override this method to provide
-   * alternate configuration. Consider calling <code>super.buildGlobalConfig()</code>
-   * and overriding values as needed using a
-   * {@link Config.org.robolectric.annotation.Config.Builder}.
+   * alternate configuration. Consider using a {@link Config.Builder}.
    *
    * The default implementation has appropriate values for most use cases.
    *
@@ -467,7 +463,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
    * @since 3.1.3
    */
   protected Config buildGlobalConfig() {
-    return Config.Builder.defaults().build();
+    return new Config.Builder().build();
   }
 
   protected void configureShadows(SdkEnvironment sdkEnvironment, Config config) {

--- a/robolectric/src/test/java/org/robolectric/ConfigMergerTest.java
+++ b/robolectric/src/test/java/org/robolectric/ConfigMergerTest.java
@@ -20,6 +20,17 @@ import static org.robolectric.annotation.Config.DEFAULT_APPLICATION;
 import static org.robolectric.util.TestUtil.stringify;
 
 public class ConfigMergerTest {
+  @Test public void defaultValuesAreMerged() throws Exception {
+    assertThat(configFor(Test2.class, "withoutAnnotation",
+        new Config.Builder().build()).manifest())
+        .isEqualTo("AndroidManifest.xml");
+  }
+
+  @Test public void globalValuesAreMerged() throws Exception {
+    assertThat(configFor(Test2.class, "withoutAnnotation",
+        new Config.Builder().setManifest("ManifestFromGlobal.xml").build()).manifest())
+        .isEqualTo("ManifestFromGlobal.xml");
+  }
 
   @Test
   public void whenClassHasConfigAnnotation_getConfig_shouldMergeClassAndMethodConfig() throws Exception {
@@ -154,9 +165,14 @@ public class ConfigMergerTest {
     }.getConfig(testClass, info, Config.Builder.defaults().build());
   }
 
-  private Config configFor(Class<?> testClass, String methodName) throws InitializationError {
+  private Config configFor(Class<?> testClass, String methodName) {
+    Config.Implementation globalConfig = Config.Builder.defaults().build();
+    return configFor(testClass, methodName, globalConfig);
+  }
+
+  private Config configFor(Class<?> testClass, String methodName, Config.Implementation globalConfig) {
     Method info = getMethod(testClass, methodName);
-    return new ConfigMerger().getConfig(testClass, info, Config.Builder.defaults().build());
+    return new ConfigMerger().getConfig(testClass, info, globalConfig);
   }
 
   private static Method getMethod(Class<?> testClass, String methodName) {


### PR DESCRIPTION
RobolectricTestRunner.buildGlobalConfig() needn't return defaults.

Fixes #2792