### PR TITLE
Manifest app label may be a literal string.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ParallelUniverse.java
@@ -154,7 +154,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
     int labelRes = 0;
     if (appManifest.getLabelRef() != null) {
       String fullyQualifiedName = ResName.qualifyResName(appManifest.getLabelRef(), appManifest.getPackageName());
-      Integer id = appResourceTable.getResourceId(new ResName(fullyQualifiedName));
+      Integer id = fullyQualifiedName == null ? null : appResourceTable.getResourceId(new ResName(fullyQualifiedName));
       labelRes = id != null ? id : 0;
     }
     packageManager.addManifest(appManifest, labelRes);

--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -561,6 +561,10 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
     applicationInfo.sourceDir = new File(".").getAbsolutePath();
     applicationInfo.dataDir = TempDirectory.create().toAbsolutePath().toString();
     applicationInfo.labelRes = labelRes;
+    String labelRef = androidManifest.getLabelRef();
+    if (labelRef != null && !labelRef.startsWith("@")) {
+      applicationInfo.nonLocalizedLabel = labelRef;
+    }
 
     packageInfo.applicationInfo = applicationInfo;
     addPackage(packageInfo);

--- a/robolectric/src/test/java/org/robolectric/res/DefaultPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/DefaultPackageManagerTest.java
@@ -748,10 +748,18 @@ public class DefaultPackageManagerTest {
   @Config(manifest = "src/test/resources/TestAndroidManifest.xml")
   public void shouldAssignLabelResFromTheManifest() throws Exception {
     ApplicationInfo applicationInfo = rpm.getApplicationInfo("org.robolectric", 0);
-    String appName = ShadowApplication.getInstance().getApplicationContext().getString(applicationInfo.labelRes);
-    assertThat(appName).isEqualTo("Testing App");
+    assertThat(applicationInfo.labelRes).isEqualTo(R.string.app_name);
+    assertThat(applicationInfo.nonLocalizedLabel).isNull();
   }
   
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithAppMetaData.xml")
+  public void shouldAssignNonLocalizedLabelFromTheManifest() throws Exception {
+    ApplicationInfo applicationInfo = rpm.getApplicationInfo("org.robolectric", 0);
+    assertThat(applicationInfo.labelRes).isEqualTo(0);
+    assertThat(applicationInfo.nonLocalizedLabel).isEqualTo("App Label");
+  }
+
   @Test
   @Config(manifest = "src/test/resources/TestPackageManagerGetServiceInfo.xml")
   public void getServiceInfo_shouldReturnServiceInfoIfExists() throws Exception {

--- a/robolectric/src/test/resources/TestAndroidManifest.xml
+++ b/robolectric/src/test/resources/TestAndroidManifest.xml
@@ -3,7 +3,6 @@
       package="org.robolectric">
   <uses-sdk android:targetSdkVersion="23"/>
 
-  <!-- todo: get @Config(manifest=xxx) working -->
   <application android:name="org.robolectric.TestApplication"
          android:theme="@style/Theme.Robolectric"
          android:label="@string/app_name">

--- a/robolectric/src/test/resources/TestAndroidManifestWithAppMetaData.xml
+++ b/robolectric/src/test/resources/TestAndroidManifestWithAppMetaData.xml
@@ -3,7 +3,8 @@
     package="org.robolectric">
 
   <uses-sdk android:targetSdkVersion="18"/>
-  <application android:name="org.robolectric.TestApplication">
+  <application android:name="org.robolectric.TestApplication"
+               android:label="App Label">
     <meta-data android:name="org.robolectric.metaName1" android:value="metaValue1" />
     <meta-data android:name="org.robolectric.metaName2" android:value="metaValue2" />
     <meta-data android:name="org.robolectric.metaTrue" android:value="true" />


### PR DESCRIPTION
Fixes an NPE for apps whose manifest has a literal string label.