### PR TITLE
* Add basic support for Device protected storage contexts. Device pro…

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowUserManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowUserManager.java
@@ -11,12 +11,12 @@ import java.util.Collections;
 import java.util.List;
 
 import static android.os.Build.VERSION_CODES;
-import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
-import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.*;
 
 @Implements(value = UserManager.class, minSdk = JELLY_BEAN_MR1)
 public class ShadowUserManager {
+
+  private boolean userUnlocked = true;
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
   public Bundle getApplicationRestrictions(String packageName) {
@@ -28,4 +28,15 @@ public class ShadowUserManager {
     return Collections.emptyList();
   }
 
+  @Implementation(minSdk = N)
+  public boolean isUserUnlocked() {
+    return userUnlocked;
+  }
+
+  /**
+   * Setter for {@link UserManager#isUserUnlocked()}
+   */
+  public void setUserUnlocked(boolean userUnlocked) {
+    this.userUnlocked = userUnlocked;
+  }
 }

--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import static android.os.Build.VERSION_CODES.N;
+
 public class DefaultPackageManager extends StubPackageManager implements RobolectricPackageManager {
 
   private Map<Integer, String> namesForUid = new HashMap<>();
@@ -560,6 +562,11 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
     applicationInfo.metaData = metaDataToBundle(androidManifest.getApplicationMetaData());
     applicationInfo.sourceDir = new File(".").getAbsolutePath();
     applicationInfo.dataDir = TempDirectory.create().toAbsolutePath().toString();
+
+    if (RuntimeEnvironment.getApiLevel() >= N) {
+      applicationInfo.credentialProtectedDataDir = TempDirectory.create().toAbsolutePath().toString();
+      applicationInfo.deviceProtectedDataDir = TempDirectory.create().toAbsolutePath().toString();
+    }
     applicationInfo.labelRes = labelRes;
     String labelRef = androidManifest.getLabelRef();
     if (labelRef != null && !labelRef.startsWith("@")) {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextImplTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextImplTest.java
@@ -19,11 +19,28 @@ import org.robolectric.TestRunners;
 import org.robolectric.annotation.Config;
 
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
+import static android.os.Build.VERSION_CODES.N;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(TestRunners.MultiApiSelfTest.class)
 public class ShadowContextImplTest {
   private final Context context = RuntimeEnvironment.application;
+
+  @Test
+  @Config(minSdk = N)
+  public void deviceProtectedContext() {
+    // Regular context should be credential protected, not device protected.
+    assertThat(context.isDeviceProtectedStorage()).isFalse();
+    assertThat(context.isCredentialProtectedStorage()).isFalse();
+
+    // Device protected storage context should have device protected rather than credential protected storage.
+    Context deviceProtectedStorageContext = context.createDeviceProtectedStorageContext();
+    assertThat(deviceProtectedStorageContext.isDeviceProtectedStorage()).isTrue();
+    assertThat(deviceProtectedStorageContext.isCredentialProtectedStorage()).isFalse();
+
+    // Data dirs of these two contexts must be different locations.
+    assertThat(context.getDataDir()).isNotEqualTo(deviceProtectedStorageContext.getDataDir());
+  }
 
   @Test
   @Config(minSdk = JELLY_BEAN_MR2)

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUserManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUserManagerTest.java
@@ -1,11 +1,15 @@
 package org.robolectric.shadows;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.os.UserHandle;
 import android.os.UserManager;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 import org.robolectric.annotation.Config;
 
@@ -13,15 +17,23 @@ import java.util.List;
 
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.N;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.MultiApiSelfTest.class)
 public class ShadowUserManagerTest {
 
+  private UserManager userManager;
+
+  @Before
+  public void setUp() {
+    userManager = (UserManager) RuntimeEnvironment.application.getSystemService(Context.USER_SERVICE);
+  }
+
   @Test
   @Config(minSdk = LOLLIPOP)
   public void shouldGetUserProfiles() {
-    UserManager userManager = new UserManager(null, null);
     List<UserHandle> userProfiles = userManager.getUserProfiles();
     assertThat(userProfiles).isNotNull();
   }
@@ -29,9 +41,16 @@ public class ShadowUserManagerTest {
   @Test
   @Config(minSdk = JELLY_BEAN_MR2)
   public void shouldGetApplicationRestrictions() {
-    UserManager userManager = new UserManager(null, null);
     Bundle userProfiles = userManager.getApplicationRestrictions("somepackage");
     // Should not NPE
+  }
+
+  @Test
+  @Config(minSdk = N)
+  public void isUserUnlocked() {
+    assertThat(userManager.isUserUnlocked()).isTrue();
+    shadowOf(userManager).setUserUnlocked(false);
+    assertThat(userManager.isUserUnlocked()).isFalse();
   }
 
 }


### PR DESCRIPTION
…tected storage context does not NPR on Context.getDataDir() and basic assumptions now work.

* Add basic support for setting state of UserManager.isUserUnlocked()

TODO: do not allow write operations to credential protected storage when UserManager.isUserLocked() == true

### Overview

### Proposed Changes
