### PR TITLE
Clarify how to use Robolectric#buildContentProvider in comment

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
@@ -452,7 +452,14 @@ public class ShadowContentResolver {
   }
 
   /**
-   * @deprecated Use {@link org.robolectric.Robolectric#buildContentProvider(Class)} instead.
+   * @deprecated
+   * Instead, use
+   * <pre>
+   * {@code
+   * ProviderInfo info = new ProviderInfo();
+   * info.authority = authority;
+   * Robolectric.buildContentProvider(ContentProvider.class).create(info);
+   * }</pre>
    */
   @Deprecated
   synchronized public static void registerProvider(String authority, ContentProvider provider) {


### PR DESCRIPTION
There was some confusion about how to use
Robolectric#buildContentProvider in place of
ShadowContentResolver#registerProvider. Instead, provide a small code
sample that demonstrates the new usage.

### Overview

### Proposed Changes
