### PR TITLE
Backwards compatibility for RoboCursor.getColumnCount().

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboCursor.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboCursor.java
@@ -125,7 +125,11 @@ public class RoboCursor extends BaseCursor {
 
   @Override
   public int getColumnCount() {
-    return columnNames.size();
+    if (columnNames.isEmpty()) {
+      return results[0].length;
+    } else {
+      return columnNames.size();
+    }
   }
 
   @Override

--- a/robolectric/src/test/java/org/robolectric/fakes/RoboCursorTest.java
+++ b/robolectric/src/test/java/org/robolectric/fakes/RoboCursorTest.java
@@ -56,6 +56,19 @@ public class RoboCursorTest {
   }
 
   @Test
+  public void getColumnCount_whenSetColumnNamesHasntBeenCalled_shouldReturnCountFromData() throws Exception {
+    RoboCursor cursor = new RoboCursor();
+    cursor.setResults(new Object[][]{
+        new Object[] {1, 2, 3},
+        new Object[] {1, 2},
+    });
+    assertThat(cursor.getColumnCount()).isEqualTo(3);
+
+    cursor.setColumnNames(asList("a", "b", "c", "d"));
+    assertThat(cursor.getColumnCount()).isEqualTo(4);
+  }
+
+  @Test
   public void getColumnName_shouldReturnColumnName() throws Exception {
     assertThat(cursor.getColumnCount()).isEqualTo(8);
     assertThat(cursor.getColumnName(0)).isEqualTo(STRING_COLUMN);


### PR DESCRIPTION
If `RoboCursor.setColumnNames()` hasn't been called, `getColumnCount()`
will return the number of columns in the first row of data.

### Overview

### Proposed Changes
