### PR TITLE
Bump dependency versions.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/integration-tests/dependency-on-stubs/build.gradle
+++ b/integration-tests/dependency-on-stubs/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testCompile "com.google.android:android-stubs:23"
 
     // Testing dependencies
-    testCompile "org.hamcrest:hamcrest-core:1.3"
-    testCompile "org.assertj:assertj-core:2.0.0"
+    testCompile "org.hamcrest:hamcrest-junit:2.0.0.0"
+    testCompile "org.assertj:assertj-core:2.6.0"
     testCompile "org.mockito:mockito-core:2.5.4"
 }

--- a/integration-tests/mockito/build.gradle
+++ b/integration-tests/mockito/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testRuntime AndroidSdk.MAX_SDK_FOR_THIS_JDK.coordinates
     testCompile "com.android.support:support-v4:23.2.0"
     testCompile "com.android.support:internal_impl:23.2.0"
-    testCompile "org.hamcrest:hamcrest-core:1.3"
-    testCompile "org.assertj:assertj-core:2.0.0"
+    testCompile "org.hamcrest:hamcrest-junit:2.0.0.0"
+    testCompile "org.assertj:assertj-core:2.6.0"
     testCompile "org.mockito:mockito-core:2.5.4"
 }

--- a/robolectric-processor/build.gradle
+++ b/robolectric-processor/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     // Testing dependencies
     testCompile "junit:junit:4.12"
-    testCompile "org.hamcrest:hamcrest-core:1.3"
+    testCompile "org.hamcrest:hamcrest-junit:2.0.0.0"
     testCompile "org.mockito:mockito-core:2.5.4"
     testCompile "com.google.testing.compile:compile-testing:0.6"
 }

--- a/robolectric-resources/build.gradle
+++ b/robolectric-resources/build.gradle
@@ -11,8 +11,8 @@ dependencies {
 
     // Testing dependencies
     testCompile "junit:junit:4.12"
-    testCompile "org.hamcrest:hamcrest-core:1.3"
-    testCompile "org.assertj:assertj-core:2.0.0"
+    testCompile "org.hamcrest:hamcrest-junit:2.0.0.0"
+    testCompile "org.assertj:assertj-core:2.6.0"
     testCompile "com.google.testing.compile:compile-testing:0.6"
     testCompile "org.mockito:mockito-core:2.5.4"
     testRuntime AndroidSdk.MAX_SDK_FOR_THIS_JDK.coordinates

--- a/robolectric-shadows/shadows-httpclient/build.gradle
+++ b/robolectric-shadows/shadows-httpclient/build.gradle
@@ -20,8 +20,8 @@ dependencies {
 
     // Testing dependencies
     testCompile "junit:junit:4.12"
-    testCompile "org.hamcrest:hamcrest-core:1.3"
-    testCompile "org.assertj:assertj-core:2.0.0"
+    testCompile "org.hamcrest:hamcrest-junit:2.0.0.0"
+    testCompile "org.assertj:assertj-core:2.6.0"
     testCompile "org.mockito:mockito-core:2.5.4"
     testRuntime AndroidSdk.LOLLIPOP_MR1.coordinates
 }

--- a/robolectric-shadows/shadows-maps/build.gradle
+++ b/robolectric-shadows/shadows-maps/build.gradle
@@ -14,8 +14,8 @@ dependencies {
     compileOnly "com.google.android.maps:maps:23_r1"
 
     testCompile "junit:junit:4.12"
-    testCompile "org.hamcrest:hamcrest-core:1.3"
-    testCompile "org.assertj:assertj-core:2.0.0"
+    testCompile "org.hamcrest:hamcrest-junit:2.0.0.0"
+    testCompile "org.assertj:assertj-core:2.6.0"
     testCompile "org.mockito:mockito-core:2.5.4"
     testRuntime AndroidSdk.MAX_SDK_FOR_THIS_JDK.coordinates
     testRuntime "com.google.android.maps:maps:23_r1"

--- a/robolectric-shadows/shadows-play-services/build.gradle
+++ b/robolectric-shadows/shadows-play-services/build.gradle
@@ -16,8 +16,8 @@ dependencies {
 
     // Testing dependencies
     testCompile "junit:junit:4.12"
-    testCompile "org.hamcrest:hamcrest-core:1.3"
-    testCompile "org.assertj:assertj-core:2.0.0"
+    testCompile "org.hamcrest:hamcrest-junit:2.0.0.0"
+    testCompile "org.assertj:assertj-core:2.6.0"
     testCompile "org.mockito:mockito-core:2.5.4"
     testRuntime "com.android.support:support-v4:23.2.0"
     testRuntime "com.google.android.gms:play-services-base:8.4.0"

--- a/robolectric-shadows/shadows-support-v4/build.gradle
+++ b/robolectric-shadows/shadows-support-v4/build.gradle
@@ -20,11 +20,11 @@ dependencies {
 
     // Testing dependencies
     testCompile "junit:junit:4.12"
-    testCompile "org.hamcrest:hamcrest-core:1.3"
-    testCompile "org.assertj:assertj-core:2.0.0"
+    testCompile "org.hamcrest:hamcrest-junit:2.0.0.0"
+    testCompile "org.assertj:assertj-core:2.6.0"
     testCompile "org.mockito:mockito-core:2.5.4"
 
-    earlyTestRuntime "org.hamcrest:hamcrest-core:1.3"
+    earlyTestRuntime "org.hamcrest:hamcrest-junit:2.0.0.0"
     testRuntime AndroidSdk.MAX_SDK_FOR_THIS_JDK.coordinates
     testRuntime "com.android.support:support-v4:23.2.0"
     testRuntime "com.android.support:internal_impl:23.2.0"

--- a/robolectric-utils/build.gradle
+++ b/robolectric-utils/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     // Compile dependencies
     compileOnly "junit:junit:4.12"
-    compileOnly "org.hamcrest:hamcrest-core:1.3"
+    compileOnly "org.hamcrest:hamcrest-junit:2.0.0.0"
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
     compile "org.ow2.asm:asm:5.0.1"
@@ -11,8 +11,8 @@ dependencies {
 
     // Testing dependencies
     testCompile "junit:junit:4.12"
-    testCompile "org.assertj:assertj-core:2.0.0"
-    testCompile "org.hamcrest:hamcrest-core:1.3"
+    testCompile "org.assertj:assertj-core:2.6.0"
+    testCompile "org.hamcrest:hamcrest-junit:2.0.0.0"
     testCompile "org.mockito:mockito-core:2.5.4"
     testRuntime AndroidSdk.MAX_SDK_FOR_THIS_JDK.coordinates
 }

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -42,8 +42,8 @@ dependencies {
 
     // Testing dependencies
     testCompile "junit:junit:4.12"
-    testCompile "org.hamcrest:hamcrest-core:1.3"
-    testCompile "org.assertj:assertj-core:2.0.0"
+    testCompile "org.hamcrest:hamcrest-junit:2.0.0.0"
+    testCompile "org.assertj:assertj-core:2.6.0"
     testCompile "org.mockito:mockito-core:2.5.4"
     testCompileOnly AndroidSdk.MAX_SDK.coordinates // compile against latest Android SDK
     testRuntime AndroidSdk.MAX_SDK_FOR_THIS_JDK.coordinates // run against whatever this JDK supports


### PR DESCRIPTION
Gradle 3.1 -> 3.3.
Hamcrest 1.3 -> 2.0.
AssertJ 2.0 -> 2.6.