### PR TITLE
Fix memory leak from WindowManagerGlobal

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWindowManagerGlobal.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowWindowManagerGlobal.java
@@ -4,6 +4,8 @@ import android.os.Looper;
 import android.view.WindowManagerGlobal;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
+import org.robolectric.util.ReflectionHelpers;
 
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
 
@@ -12,6 +14,11 @@ import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
  */
 @Implements(value = WindowManagerGlobal.class, isInAndroidSdk = false, minSdk = JELLY_BEAN_MR1)
 public class ShadowWindowManagerGlobal {
+
+  @Resetter
+  public static void reset() {
+    ReflectionHelpers.setStaticField(WindowManagerGlobal.class, "sDefaultWindowManager", null);
+  }
 
   @Implementation
   public static Object getWindowSession() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowManagerGlobalUnitTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowManagerGlobalUnitTest.java
@@ -1,0 +1,33 @@
+package org.robolectric.shadows;
+
+import android.app.Activity;
+import android.view.WindowManagerGlobal;
+import org.junit.Test;
+import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
+import org.robolectric.util.FailureListener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ShadowWindowManagerGlobalUnitTest {
+  @Test
+  public void shouldReset() throws Exception {
+    assertThat(FailureListener.runTests(DummyTest.class)).isEmpty();
+  }
+
+  @Config(sdk = 23)
+  public static class DummyTest {
+    @Test
+    public void first() throws Exception {
+      assertThat(WindowManagerGlobal.getInstance().getViewRootNames()).isEmpty();
+      Robolectric.setupActivity(Activity.class);
+    }
+
+    @Test
+    public void second() throws Exception {
+      assertThat(WindowManagerGlobal.getInstance().getViewRootNames()).isEmpty();
+      Robolectric.setupActivity(Activity.class);
+    }
+  }
+
+}

--- a/robolectric/src/test/java/org/robolectric/util/FailureListener.java
+++ b/robolectric/src/test/java/org/robolectric/util/FailureListener.java
@@ -1,0 +1,34 @@
+package org.robolectric.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FailureListener extends RunListener {
+  @NotNull
+  public static List<Failure> runTests(Class<?> testClass) throws InitializationError {
+    RunNotifier notifier = new RunNotifier();
+    FailureListener failureListener = new FailureListener();
+    notifier.addListener(failureListener);
+    new RobolectricTestRunner(testClass).run(notifier);
+    return failureListener.failures;
+  }
+
+  public final List<Failure> failures = new ArrayList<>();
+
+  @Override
+  public void testFailure(Failure failure) throws Exception {
+    failures.add(failure);
+  }
+
+  @Override
+  public void testAssumptionFailure(Failure failure) {
+    failures.add(failure);
+  }
+}


### PR DESCRIPTION
Reset static instance so we don't hold on to views between tests.

Fixes #2068.