### PR TITLE
Fix Looper-related memory leak.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/BackgroundLooperUnitTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/BackgroundLooperUnitTest.java
@@ -1,0 +1,48 @@
+package org.robolectric.shadows;
+
+import android.os.Looper;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.robolectric.util.FailureListener;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BackgroundLooperUnitTest {
+  @Rule public final Timeout timeout = new Timeout(10, TimeUnit.SECONDS);
+
+  @Test
+  public void backgroundThreadsWithActiveLoopersShouldBeReleasedAfterTest() throws Exception {
+    assertThat(FailureListener.runTests(TestWithBackgroundThreads.class)).isEmpty();
+  }
+
+  public static class TestWithBackgroundThreads {
+    private static Thread thread;
+
+    @Test
+    public void first() throws Exception {
+      if (thread != null) thread.join();
+      thread = startBackgroundThread();
+    }
+
+    @Test
+    public void second() throws Exception {
+      if (thread != null) thread.join();
+      thread = startBackgroundThread();
+    }
+
+    private Thread startBackgroundThread() {
+      Thread thread = new Thread(new Runnable() {
+        @Override
+        public void run() {
+          Looper.prepare();
+          Looper.loop();
+        }
+      });
+      thread.start();
+      return thread;
+    }
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/util/FailureListener.java
+++ b/robolectric/src/test/java/org/robolectric/util/FailureListener.java
@@ -1,0 +1,34 @@
+package org.robolectric.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FailureListener extends RunListener {
+  @NotNull
+  public static List<Failure> runTests(Class<?> testClass) throws InitializationError {
+    RunNotifier notifier = new RunNotifier();
+    FailureListener failureListener = new FailureListener();
+    notifier.addListener(failureListener);
+    new RobolectricTestRunner(testClass).run(notifier);
+    return failureListener.failures;
+  }
+
+  public final List<Failure> failures = new ArrayList<>();
+
+  @Override
+  public void testFailure(Failure failure) throws Exception {
+    failures.add(failure);
+  }
+
+  @Override
+  public void testAssumptionFailure(Failure failure) {
+    failures.add(failure);
+  }
+}


### PR DESCRIPTION
Don't hold `Loopers` in a `Thread-`keyed `WeakHashMap` because the value
(Looper) refers back to the key (Thread), defeating the weak reference.

Fixes #2791.