### PR TITLE
Ensuring robolectric.properties at root is loaded

### DIFF
--- a/robolectric/src/main/java/org/robolectric/ConfigMerger.java
+++ b/robolectric/src/main/java/org/robolectric/ConfigMerger.java
@@ -78,7 +78,7 @@ public class ConfigMerger {
    * @since 3.2
    */
   protected Properties getConfigProperties(String packageName) {
-    String resourceName = packageName.replace('.', '/') + "/" + RobolectricTestRunner.CONFIG_PROPERTIES;
+    String resourceName = packageName.isEmpty? RobolectricTestRunner.CONFIG_PROPERTIES : packageName.replace('.', '/') + "/" + RobolectricTestRunner.CONFIG_PROPERTIES;
     try (InputStream resourceAsStream = getResourceAsStream(resourceName)) {
       if (resourceAsStream == null) return null;
       Properties properties = new Properties();

--- a/robolectric/src/test/java/org/robolectric/ConfigMergerTest.java
+++ b/robolectric/src/test/java/org/robolectric/ConfigMergerTest.java
@@ -118,7 +118,7 @@ public class ConfigMergerTest {
             "libraries: libs/test, libs/test2\n" +
             "constants: " + ConfigMergerTest.BuildConfigConstants3.class.getName();
 
-    assertConfig(configFor(Test2.class, "withoutAnnotation", of("/robolectric.properties", properties)),
+    assertConfig(configFor(Test2.class, "withoutAnnotation", of("robolectric.properties", properties)),
         new int[] {432}, "--none", TestFakeApp.class, "com.example.test", "from-properties-file", "from/properties/file/res", "from/properties/file/assets", new Class[] {ShadowView.class, ShadowViewGroup.class}, new String[]{"com.example.test1", "com.example.test2"}, new String[]{"libs/test", "libs/test2"}, BuildConfigConstants3.class);
   }
 
@@ -134,7 +134,7 @@ public class ConfigMergerTest {
         of(
             "org/robolectric/robolectric.properties", "qualifiers: from-org-robolectric\nlibraries: FromOrgRobolectric\n",
             "org/robolectric.properties", "sdk: 123\nqualifiers: from-org\nlibraries: FromOrg\n",
-            "/robolectric.properties", "sdk: 456\nqualifiers: from-top-level\nlibraries: FromTopLevel\n"
+            "robolectric.properties", "sdk: 456\nqualifiers: from-top-level\nlibraries: FromTopLevel\n"
             )
         ),
         new int[] {123}, "AndroidManifest.xml", DEFAULT_APPLICATION, "", "from-org-robolectric", "res", "assets", new Class[] {}, new String[]{},
@@ -143,7 +143,7 @@ public class ConfigMergerTest {
 
   @Test
   public void withEmptyShadowList_shouldLoadDefaultsFromGlobalPropertiesFile() throws Exception {
-    assertConfig(configFor(Test2.class, "withoutAnnotation", of("/robolectric.properties", "shadows:")),
+    assertConfig(configFor(Test2.class, "withoutAnnotation", of("robolectric.properties", "shadows:")),
         new int[0],  "AndroidManifest.xml", DEFAULT_APPLICATION, "", "", "res", "assets", new Class[] {}, new String[]{}, new String[]{}, null);
   }
 


### PR DESCRIPTION
When `packageName` is empty, the method `getConfigProperties` will try to load the properties file `/robolectric.properties`, which it can't - any file in `resources` folder should be accessed by a relative pathname (ie, without a leading `/`).

This PR fixes https://github.com/robolectric/robolectric/issues/2843