### PR TITLE
Move shadows to system classpath

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/InstrumentingClassLoaderFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/InstrumentingClassLoaderFactory.java
@@ -40,11 +40,9 @@ public class InstrumentingClassLoaderFactory {
 
     SdkEnvironment sdkEnvironment = sdkToEnvironment.get(key);
     if (sdkEnvironment == null) {
-      URL[] urls = dependencyResolver.getLocalArtifactUrls(
-          sdkConfig.getAndroidSdkDependency(),
-          sdkConfig.getCoreShadowsDependency());
+      URL url = dependencyResolver.getLocalArtifactUrl(sdkConfig.getAndroidSdkDependency());
 
-      ClassLoader robolectricClassLoader = new InstrumentingClassLoader(instrumentationConfig, urls);
+      ClassLoader robolectricClassLoader = new InstrumentingClassLoader(instrumentationConfig, url);
       sdkEnvironment = new SdkEnvironment(sdkConfig, robolectricClassLoader);
       sdkToEnvironment.put(key, sdkEnvironment);
     }

--- a/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
@@ -15,7 +15,6 @@ import java.util.Properties;
 import java.util.Set;
 
 public class SdkConfig implements Comparable<SdkConfig> {
-  private static final String ROBOLECTRIC_VERSION = getRobolectricVersion();
 
   private static final Map<Integer, SdkVersion> SUPPORTED_APIS = Collections.unmodifiableMap(new HashMap<Integer, SdkVersion>() {
     private final double jdkVersion = Double.parseDouble(System.getProperty("java.specification.version"));
@@ -66,10 +65,6 @@ public class SdkConfig implements Comparable<SdkConfig> {
     return createDependency("org.robolectric", "android-all", getSdkVersion().toString(), null);
   }
 
-  public DependencyJar getCoreShadowsDependency() {
-    return createDependency("org.robolectric", "shadows-core", ROBOLECTRIC_VERSION, null);
-  }
-
   @Override
   public boolean equals(Object that) {
     return that == this || that instanceof SdkConfig && ((SdkConfig) that).apiLevel == (apiLevel);
@@ -100,17 +95,6 @@ public class SdkConfig implements Comparable<SdkConfig> {
 
   private DependencyJar createDependency(String groupId, String artifactId, String version, String classifier) {
     return new DependencyJar(groupId, artifactId, version, classifier);
-  }
-
-  private static String getRobolectricVersion() {
-    ClassLoader classLoader = SdkVersion.class.getClassLoader();
-    try (InputStream is = classLoader.getResourceAsStream("robolectric-version.properties")) {
-      final Properties properties = new Properties();
-      properties.load(is);
-      return properties.getProperty("robolectric.version");
-    } catch (IOException e) {
-      throw new RuntimeException("Error determining Robolectric version: " + e.getMessage());
-    }
   }
 
   private static final class SdkVersion {

--- a/robolectric/src/main/java/org/robolectric/internal/dependency/CachedDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/internal/dependency/CachedDependencyResolver.java
@@ -12,8 +12,7 @@ import java.util.Date;
 import java.util.zip.CRC32;
 
 public class CachedDependencyResolver implements DependencyResolver {
-  private final static String CACHE_PREFIX_1 = "localArtifactUrls";
-  private final static String CACHE_PREFIX_2 = "localArtifactUrl";
+  private final static String CACHE_PREFIX = "localArtifactUrl";
 
   private final DependencyResolver dependencyResolver;
   private final CacheNamingStrategy cacheNamingStrategy;
@@ -32,22 +31,8 @@ public class CachedDependencyResolver implements DependencyResolver {
   }
 
   @Override
-  public URL[] getLocalArtifactUrls(DependencyJar... dependencies) {
-    final String cacheName = cacheNamingStrategy.getName(CACHE_PREFIX_1, dependencies);
-    final URL[] urlsFromCache = cache.load(cacheName, URL[].class);
-
-    if (urlsFromCache != null && cacheValidationStrategy.isValid(urlsFromCache)) {
-      return urlsFromCache;
-    }
-
-    final URL[] urls = dependencyResolver.getLocalArtifactUrls(dependencies);
-    cache.write(cacheName, urls);
-    return urls;
-  }
-
-  @Override
   public URL getLocalArtifactUrl(DependencyJar dependency) {
-    final String cacheName = cacheNamingStrategy.getName(CACHE_PREFIX_2, dependency);
+    final String cacheName = cacheNamingStrategy.getName(CACHE_PREFIX, dependency);
     final URL urlFromCache = cache.load(cacheName, URL.class);
 
     if (urlFromCache != null && cacheValidationStrategy.isValid(urlFromCache)) {

--- a/robolectric/src/main/java/org/robolectric/internal/dependency/DependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/internal/dependency/DependencyResolver.java
@@ -3,6 +3,5 @@ package org.robolectric.internal.dependency;
 import java.net.URL;
 
 public interface DependencyResolver {
-  URL[] getLocalArtifactUrls(DependencyJar... dependencies);
   URL getLocalArtifactUrl(DependencyJar dependency);
 }

--- a/robolectric/src/main/java/org/robolectric/internal/dependency/LocalDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/internal/dependency/LocalDependencyResolver.java
@@ -32,17 +32,6 @@ public class LocalDependencyResolver implements DependencyResolver {
     return fileToUrl(validateFile(new File(offlineJarDir, filenameBuilder.toString())));
   }
 
-  @Override
-  public URL[] getLocalArtifactUrls(DependencyJar... dependencies) {
-    URL[] urls = new URL[dependencies.length];
-
-    for (int i=0; i<dependencies.length; i++) {
-      urls[i] = getLocalArtifactUrl(dependencies[i]);
-    }
-
-    return urls;
-  }
-
   /**
    * Validates {@code file} is an existing file that is readable.
    *

--- a/robolectric/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
@@ -29,7 +29,6 @@ public class MavenDependencyResolver implements DependencyResolver {
    * Get an array of local artifact URLs for the given dependencies. The order of the URLs is guaranteed to be the
    * same as the input order of dependencies, i.e., urls[i] is the local artifact URL for dependencies[i].
    */
-  @Override
   public URL[] getLocalArtifactUrls(DependencyJar... dependencies) {
     DependenciesTask dependenciesTask = createDependenciesTask();
     configureMaven(dependenciesTask);

--- a/robolectric/src/main/java/org/robolectric/internal/dependency/PropertiesDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/internal/dependency/PropertiesDependencyResolver.java
@@ -1,6 +1,5 @@
 package org.robolectric.internal.dependency;
 
-import org.robolectric.res.FileFsFile;
 import org.robolectric.res.FsFile;
 
 import java.io.File;
@@ -8,8 +7,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Properties;
 
 public class PropertiesDependencyResolver implements DependencyResolver {
@@ -32,52 +29,25 @@ public class PropertiesDependencyResolver implements DependencyResolver {
   }
 
   @Override
-  public URL[] getLocalArtifactUrls(DependencyJar... dependencies) {
-    List<URL> urls = new ArrayList<>();
-    for (DependencyJar dependency : dependencies) {
-      urls.addAll(getUrlsForDependency(dependency));
-    }
-    return urls.toArray(new URL[urls.size()]);
-  }
-
-  @Override
   public URL getLocalArtifactUrl(DependencyJar dependency) {
-    List<URL> urls = getUrlsForDependency(dependency);
-    if (urls.size() != 1) {
-      throw new RuntimeException("should be exactly one URL for " + dependency + " but got " + urls);
-    } else {
-      return urls.get(0);
-    }
-  }
-
-  private List<URL> getUrlsForDependency(DependencyJar dependency) {
-    List<URL> urls = new ArrayList<>();
     String depShortName = dependency.getShortName();
     String path = properties.getProperty(depShortName);
     if (path != null) {
-      for (String pathPart : path.split(":")) {
-        File pathFile = new File(pathPart);
-        if (!pathFile.isAbsolute()) {
-          pathFile = new File(baseDir.getPath(), pathPart);
-        }
-        try {
-          URL url = pathFile.toURI().toURL();
-          urls.add(url);
-        } catch (MalformedURLException e) {
-          throw new RuntimeException(e);
-        }
+      File pathFile = new File(path);
+      if (!pathFile.isAbsolute()) {
+        pathFile = new File(baseDir.getPath(), path);
+      }
+      try {
+        return pathFile.toURI().toURL();
+      } catch (MalformedURLException e) {
+        throw new RuntimeException(e);
       }
     } else {
       if (delegate != null) {
-        urls.add(delegate.getLocalArtifactUrl(dependency));
+        return delegate.getLocalArtifactUrl(dependency);
       }
     }
 
-    if (urls.isEmpty()) {
-      throw new RuntimeException("no artifacts found for " + dependency);
-    }
-
-    return urls;
+    throw new RuntimeException("no artifacts found for " + dependency);
   }
-
 }

--- a/robolectric/src/test/java/org/robolectric/internal/dependency/CachedDependencyResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/dependency/CachedDependencyResolverTest.java
@@ -56,43 +56,6 @@ public class CachedDependencyResolverTest {
   }
 
   @Test
-  public void getLocalArtifactUrls_shouldWriteLocalArtifactsUrlsWhenCacheMiss() throws Exception {
-    DependencyResolver res = createResolver();
-
-    when(internalResolver.getLocalArtifactUrls(dependencies)).thenReturn(urls);
-
-    URL[] urls = res.getLocalArtifactUrls(dependencies);
-
-    assertArrayEquals(this.urls, urls);
-    assertCacheContents(urls);
-  }
-
-  @Test
-  public void getLocalArtifactUrls_shouldReadLocalArtifactUrlsFromCacheIfExists() throws Exception {
-    DependencyResolver res = createResolver();
-    cache.write(CACHE_NAME, urls);
-
-    URL[] urls = res.getLocalArtifactUrls(dependencies);
-
-    verify(internalResolver, never()).getLocalArtifactUrls(dependencies);
-
-    assertArrayEquals(this.urls, urls);
-  }
-
-  @Test
-  public void getLocalArtifactUrls_whenCacheInvalid_shouldFetchDependencyInformation() {
-    CacheValidationStrategy failStrategy = mock(CacheValidationStrategy.class);
-    when(failStrategy.isValid(any(URL[].class))).thenReturn(false);
-
-    DependencyResolver res = new CachedDependencyResolver(internalResolver, cache, cacheNamingStrategy, failStrategy);
-    cache.write(CACHE_NAME, this.urls);
-
-    res.getLocalArtifactUrls(dependencies);
-
-    verify(internalResolver).getLocalArtifactUrls(dependencies);
-  }
-
-  @Test
   public void getLocalArtifactUrl_shouldWriteLocalArtifactUrlWhenCacheMiss() throws Exception{
     DependencyResolver res = createResolver();
 

--- a/robolectric/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
@@ -106,39 +106,6 @@ public class MavenDependencyResolverTest {
     assertEquals("file:/path3", url.toExternalForm());
   }
 
-  @Test
-  public void getLocalArtifactUrls_shouldReturnEmptyArrayIfNoDependencyJarProvided() {
-    DependencyResolver dependencyResolver = createResolver();
-
-    URL[] urls = dependencyResolver.getLocalArtifactUrls();
-
-    assertEquals(0, urls.length);
-  }
-
-  @Test
-  public void getLocalArtifactUrls_shouldReturnURLsForEachDependencyJar() {
-    DependencyResolver dependencyResolver = createResolver();
-    DependencyJar dependencyJar1 = new DependencyJar("group1", "artifact1", "", null);
-    DependencyJar dependencyJar2 = new DependencyJar("group2", "artifact2", "", null);
-
-    URL[] urls = dependencyResolver.getLocalArtifactUrls(dependencyJar1, dependencyJar2);
-
-    assertEquals(2, urls.length);
-    assertEquals("file:/path1", urls[0].toExternalForm());
-    assertEquals("file:/path2", urls[1].toExternalForm());
-  }
-
-  @Test
-  public void getLocalArtifactUrls_shouldAddEachDependencyToDependenciesTask() {
-    DependencyResolver dependencyResolver = createResolver();
-    DependencyJar dependencyJar1 = new DependencyJar("group1", "artifact1", "", null);
-    DependencyJar dependencyJar2 = new DependencyJar("group2", "artifact2", "", null);
-
-    dependencyResolver.getLocalArtifactUrls(dependencyJar1, dependencyJar2);
-
-    verify(dependenciesTask, times(2)).addDependency(any(Dependency.class));
-  }
-
   private DependencyResolver createResolver() {
     return new MavenDependencyResolver(REPOSITORY_URL, REPOSITORY_ID) {
       @Override

--- a/robolectric/src/test/java/org/robolectric/internal/dependency/PropertiesDependencyResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/dependency/PropertiesDependencyResolverTest.java
@@ -26,28 +26,21 @@ public class PropertiesDependencyResolverTest {
   }
 
   @Test
-  public void whenAbsolutePathIsProvidedInProperties_shouldReturnFileUrls() throws Exception {
+  public void whenAbsolutePathIsProvidedInProperties_shouldReturnFileUrl() throws Exception {
     DependencyResolver resolver = new PropertiesDependencyResolver(
-        propsFile("com.group\\:example\\:1.3: /path/1:/path/2\n"), mock);
+        propsFile("com.group\\:example\\:1.3: /path/1\n"), mock);
 
-    URL[] urls = resolver.getLocalArtifactUrls(new DependencyJar("com.group", "example", "1.3", null));
-    assertThat(urls).containsExactly(
-        new URL("file:///path/1"),
-        new URL("file:///path/2")
-    );
+    URL url = resolver.getLocalArtifactUrl(new DependencyJar("com.group", "example", "1.3", null));
+    assertThat(url).isEqualTo(new URL("file:///path/1"));
   }
 
   @Test
-  public void whenRelativePathIsProvidedInProperties_shouldReturnFileUrls() throws Exception {
+  public void whenRelativePathIsProvidedInProperties_shouldReturnFileUrl() throws Exception {
     DependencyResolver resolver = new PropertiesDependencyResolver(
-        propsFile("com.group\\:example\\:1.3: path/1:/path/2:path/3\n"), mock);
+        propsFile("com.group\\:example\\:1.3: path/1\n"), mock);
 
-    URL[] urls = resolver.getLocalArtifactUrls(new DependencyJar("com.group", "example", "1.3", null));
-    assertThat(urls).containsExactly(
-        new URL("file://" + temporaryFolder.getRoot() + "/path/1"),
-        new URL("file:///path/2"),
-        new URL("file://" + temporaryFolder.getRoot() + "/path/3")
-    );
+    URL url = resolver.getLocalArtifactUrl(new DependencyJar("com.group", "example", "1.3", null));
+    assertThat(url).isEqualTo(new URL("file://" + temporaryFolder.getRoot() + "/path/1"));
   }
 
   @Test
@@ -57,9 +50,8 @@ public class PropertiesDependencyResolverTest {
 
     DependencyJar dependencyJar =  new DependencyJar("com.group", "example", "1.3", null);
     when(mock.getLocalArtifactUrl(dependencyJar)).thenReturn(new URL("file:///path/3"));
-    URL[] urls = resolver.getLocalArtifactUrls(dependencyJar);
-    assertThat(urls).containsExactly(
-        new URL("file:///path/3")
+    URL url = resolver.getLocalArtifactUrl(dependencyJar);
+    assertThat(url).isEqualTo(new URL("file:///path/3")
     );
   }
 
@@ -70,7 +62,7 @@ public class PropertiesDependencyResolverTest {
 
     DependencyJar dependencyJar =  new DependencyJar("com.group", "example", "1.3", null);
     try {
-      resolver.getLocalArtifactUrls(dependencyJar);
+      resolver.getLocalArtifactUrl(dependencyJar);
       fail("should have failed");
     } catch (Exception e) {
       assertThat(e.getMessage()).contains("no artifacts found for " + dependencyJar);


### PR DESCRIPTION
Since there is just a single shadows jar for all platform versions the only dependency we need to load as a data dependency are the platform jars and there is just one per version of the platform.