### PR TITLE
Only search missing attrs for framework resources

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/PackageResourceTable.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/PackageResourceTable.java
@@ -100,7 +100,7 @@ public class PackageResourceTable implements ResourceTable {
       if (getPackageIdentifier() == 0) {
         this.packageIdentifier = resIdPackageIdentifier;
       } else if (getPackageIdentifier() != resIdPackageIdentifier) {
-        throw new IllegalArgumentException("Attempted to add resId " + resIdPackageIdentifier + " to ResourceIndex with packageIdentifier " + getPackageIdentifier());
+        throw new IllegalArgumentException("Incompatible package for " + packageName + ":" + type + "/" + name + " with resId " + resIdPackageIdentifier + " to ResourceIndex with packageIdentifier " + getPackageIdentifier());
       }
 
       ResName existingEntry = resourceTable.put(resId, resName);

--- a/robolectric-resources/src/main/java/org/robolectric/res/PackageResourceTable.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/PackageResourceTable.java
@@ -7,7 +7,6 @@ import org.robolectric.res.builder.XmlBlock;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.logging.Logger;
 
 /**
  * A {@link ResourceTable} for a single package, e.g: "android" / ox01
@@ -82,13 +81,6 @@ public class PackageResourceTable implements ResourceTable {
   @Override
   public void receive(Visitor visitor) {
     resources.receive(visitor);
-  }
-
-  @Override
-  public boolean hasValue(ResName resName, String qualifiers) {
-    return getValue(resName, qualifiers) != null
-        || getXml(resName, qualifiers) != null
-        || getRawValue(resName, qualifiers) != null;
   }
 
   void addResource(int resId, String type, String name) {

--- a/robolectric-resources/src/main/java/org/robolectric/res/ResourceTable.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/ResourceTable.java
@@ -25,8 +25,6 @@ public interface ResourceTable {
 
   void receive(Visitor visitor);
 
-  boolean hasValue(ResName resName, String qualifiers);
-
   interface Visitor<T> {
 
     void visit(ResName key, Iterable<T> values);

--- a/robolectric-resources/src/main/java/org/robolectric/res/RoutingResourceTable.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/RoutingResourceTable.java
@@ -3,11 +3,8 @@ package org.robolectric.res;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import org.robolectric.res.builder.XmlBlock;
 
@@ -25,10 +22,6 @@ public class RoutingResourceTable implements ResourceTable {
 
   public InputStream getRawValue(int resId, String qualifiers) {
     return getRawValue(getResName(resId), qualifiers);
-  }
-
-  public boolean hasValue(ResName resName, String qualifiers) {
-    return pickFor(resName).hasValue(resName, qualifiers);
   }
 
   @Override public TypedResource getValue(@NotNull ResName resName, String qualifiers) {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -232,15 +232,7 @@ public final class ShadowAssetManager {
 
   @HiddenApi @Implementation
   public int getResourceIdentifier(String name, String defType, String defPackage) {
-    ResName resName = ResName.qualifyResName(name, defPackage, defType);
-
-    // If the resource does not exist then return 0, otherwise ResourceIndex.getResourceId() will generate a placeholder.
-    if (!ResName.ID_TYPE.equals(resName.type)
-        && !resourceTable.hasValue(resName, RuntimeEnvironment.getQualifiers())) {
-      return 0;
-    }
-
-    Integer resourceId = resourceTable.getResourceId(resName);
+    Integer resourceId = resourceTable.getResourceId(ResName.qualifyResName(name, defPackage, defType));
     return resourceId == null ? 0 : resourceId;
   }
 

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -273,7 +273,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
   @NotNull
   private static PackageResourceTable getCompiletimeSdkResourceTable() {
     if (compiletimeSdkResourceTable == null) {
-      compiletimeSdkResourceTable = ResourceTableFactory.newResourceTable("android", new ResourcePath(android.R.class, null, null));
+      compiletimeSdkResourceTable = ResourceTableFactory.newFrameworkResourceTable(new ResourcePath(android.R.class, null, null));
     }
     return compiletimeSdkResourceTable;
   }

--- a/robolectric/src/main/java/org/robolectric/internal/SdkEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SdkEnvironment.java
@@ -12,7 +12,6 @@ public class SdkEnvironment {
   private final ShadowInvalidator shadowInvalidator;
   private ShadowMap shadowMap = ShadowMap.EMPTY;
   private PackageResourceTable systemResourceTable;
-  public static final String ANDROID_PACKAGE_NAME = android.R.class.getPackage().getName();
 
   public SdkEnvironment(SdkConfig sdkConfig, ClassLoader robolectricClassLoader) {
     this.sdkConfig = sdkConfig;
@@ -23,7 +22,7 @@ public class SdkEnvironment {
   public synchronized PackageResourceTable getSystemResourceTable(DependencyResolver dependencyResolver) {
     if (systemResourceTable == null) {
       ResourcePath resourcePath = createRuntimeSdkResourcePath(dependencyResolver);
-      systemResourceTable = ResourceTableFactory.newResourceTable(ANDROID_PACKAGE_NAME, resourcePath);
+      systemResourceTable = ResourceTableFactory.newFrameworkResourceTable(resourcePath);
     }
     return systemResourceTable;
   }

--- a/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParallelUniverseTest.java
@@ -43,7 +43,7 @@ public class ParallelUniverseTest {
   }
 
   private void setUpApplicationState(Config defaultConfig) {
-    ResourceTable sdkResourceProvider = ResourceTableFactory.newResourceTable("android", new ResourcePath(android.R.class, null, null));
+    ResourceTable sdkResourceProvider = ResourceTableFactory.newFrameworkResourceTable(new ResourcePath(android.R.class, null, null));
     final RoutingResourceTable routingResourceTable = new RoutingResourceTable(ResourceTableFactory.newResourceTable("org.robolectric", new ResourcePath(R.class, null, null)));
     pu.setUpApplicationState(null, new DefaultTestLifecycle(),
         new AndroidManifest(null, null, null, "package"), defaultConfig,

--- a/robolectric/src/test/java/org/robolectric/res/ResourceTableFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/ResourceTableFactoryTest.java
@@ -25,8 +25,7 @@ public class ResourceTableFactoryTest {
         lib1Resources(),
         testResources());
 
-    systemResourceTable = ResourceTableFactory.newResourceTable("android",
-        systemResources());
+    systemResourceTable = ResourceTableFactory.newFrameworkResourceTable(systemResources());
   }
 
   @Test


### PR DESCRIPTION
Framework resources can have missing attribute values in their R files, this logic turns out to break application resources which can have styleable attributes with a more complex naming scheme eg.:
`
class styleable {
  public static int[] MyStyleable = [ 0x01TTEEEE ];

  public int MyStyleable_android_layout_gravity;
}
`
i.e: if application resources refer to an android attribute its "android" namespace is encoded in the generated R field name.

To work around this create two separate factory methods, one for framework resources which does this processing, the other which does not.