### PR TITLE
Invoke super.classBlock in classBlock

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -191,7 +191,7 @@ public class RobolectricTestRunner extends BlockJUnit4ClassRunner {
 
   @Override
   protected Statement classBlock(RunNotifier notifier) {
-    final Statement statement = childrenInvoker(notifier);
+    final Statement statement = super.classBlock(notifier);
     return new Statement() {
       @Override
       public void evaluate() throws Throwable {


### PR DESCRIPTION
This should ensure that annotations processed ordinarily in JUnit4, e.g. @ClassRule, are run.

Intended to fix https://github.com/robolectric/robolectric/issues/2637

### Overview

### Proposed Changes
