### PR TITLE
Add Shadow support for PackageManager.

### DIFF
--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/RobolectricModel.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/RobolectricModel.java
@@ -1,19 +1,14 @@
 package org.robolectric.annotation.processing;
 
-import static com.google.common.collect.Lists.*;
-import static com.google.common.collect.Maps.*;
-import static com.google.common.collect.Sets.*;
-
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
+import com.google.common.base.Equivalence;
+import com.google.common.base.Objects;
+import com.google.common.base.Predicate;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimaps;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.processing.validator.ImplementsValidator;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -22,7 +17,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementVisitor;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
-import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
@@ -34,16 +28,20 @@ import javax.lang.model.util.SimpleAnnotationValueVisitor6;
 import javax.lang.model.util.SimpleElementVisitor6;
 import javax.lang.model.util.SimpleTypeVisitor6;
 import javax.lang.model.util.Types;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
-import com.google.common.base.Equivalence;
-import com.google.common.base.Objects;
-import com.google.common.base.Predicate;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimaps;
-import org.robolectric.annotation.Implements;
-import org.robolectric.annotation.processing.validator.ImplementsValidator;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Maps.newTreeMap;
+import static com.google.common.collect.Sets.newTreeSet;
 
 /**
  * Model describing the Robolectric source file.
@@ -344,9 +342,16 @@ public class RobolectricModel {
   }
 
   public Collection<String> getShadowedPackages() {
-    Set<String> packages = new HashSet<>();
-    for (TypeElement element : getVisibleShadowTypes().values()) {
-      packages.add("\"" + elements.getPackageOf(element).toString() + "\"");
+    Set<String> packages = new TreeSet<>();
+    for (TypeElement element : shadowTypes.values()) {
+      String packageName = elements.getPackageOf(element).toString();
+
+      // org.robolectric.* should never be instrumented
+      if (packageName.matches("org.robolectric(\\..*)?")) {
+        continue;
+      }
+
+      packages.add("\"" + packageName + "\"");
     }
     return packages;
   }

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/ShadowProviderGenerator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/ShadowProviderGenerator.java
@@ -171,11 +171,11 @@ public class ShadowProviderGenerator extends Generator {
 
     writer.println("  @Override");
     writer.println("  public String[] getProvidedPackageNames() {");
-    String providedPackages = "";
+    writer.println("    return new String[] {");
     if (shouldInstrumentPackages) {
-      providedPackages = Joiner.on(",").join(model.getShadowedPackages());
+      writer.println("      " + Joiner.on(",\n      ").join(model.getShadowedPackages()));
     }
-    writer.println("    return new String[] {" + providedPackages + "};");
+    writer.println("    };");
     writer.println("  }");
 
     writer.println('}');

--- a/robolectric-processor/src/test/java/com/example/objects/AnyObject.java
+++ b/robolectric-processor/src/test/java/com/example/objects/AnyObject.java
@@ -1,0 +1,4 @@
+package com.example.objects;
+
+public class AnyObject {
+}

--- a/robolectric-processor/src/test/java/com/example/objects/Dummy.java
+++ b/robolectric-processor/src/test/java/com/example/objects/Dummy.java
@@ -1,0 +1,4 @@
+package com.example.objects;
+
+public class Dummy {
+}

--- a/robolectric-processor/src/test/java/com/example/objects/OuterDummy.java
+++ b/robolectric-processor/src/test/java/com/example/objects/OuterDummy.java
@@ -1,4 +1,4 @@
-package org.robolectric.annotation.processing.objects;
+package com.example.objects;
 
 public class OuterDummy {
   public class InnerDummy {

--- a/robolectric-processor/src/test/java/com/example/objects/OuterDummy2.java
+++ b/robolectric-processor/src/test/java/com/example/objects/OuterDummy2.java
@@ -1,4 +1,4 @@
-package org.robolectric.annotation.processing.objects;
+package com.example.objects;
 
 public class OuterDummy2 {
   protected class InnerProtected {

--- a/robolectric-processor/src/test/java/com/example/objects/ParameterizedDummy.java
+++ b/robolectric-processor/src/test/java/com/example/objects/ParameterizedDummy.java
@@ -1,4 +1,4 @@
-package org.robolectric.annotation.processing.objects;
+package com.example.objects;
 
 public class ParameterizedDummy<T, N extends Number> {
 

--- a/robolectric-processor/src/test/java/com/example/objects/Private.java
+++ b/robolectric-processor/src/test/java/com/example/objects/Private.java
@@ -1,0 +1,4 @@
+package com.example.objects;
+
+class Private {
+}

--- a/robolectric-processor/src/test/java/com/example/objects/UniqueDummy.java
+++ b/robolectric-processor/src/test/java/com/example/objects/UniqueDummy.java
@@ -1,4 +1,4 @@
-package org.robolectric.annotation.processing.objects;
+package com.example.objects;
 
 public class UniqueDummy {
 

--- a/robolectric-processor/src/test/java/com/example/objects2/Dummy.java
+++ b/robolectric-processor/src/test/java/com/example/objects2/Dummy.java
@@ -1,0 +1,5 @@
+package com.example.objects2;
+
+public class Dummy {
+
+}

--- a/robolectric-processor/src/test/java/com/example/objects2/OuterDummy.java
+++ b/robolectric-processor/src/test/java/com/example/objects2/OuterDummy.java
@@ -1,4 +1,4 @@
-package org.robolectric.annotation.processing.objects2;
+package com.example.objects2;
 
 public class OuterDummy {
 

--- a/robolectric-processor/src/test/java/org/robolectric/annotation/processing/objects/AnyObject.java
+++ b/robolectric-processor/src/test/java/org/robolectric/annotation/processing/objects/AnyObject.java
@@ -1,4 +1,0 @@
-package org.robolectric.annotation.processing.objects;
-
-public class AnyObject {
-}

--- a/robolectric-processor/src/test/java/org/robolectric/annotation/processing/objects/Dummy.java
+++ b/robolectric-processor/src/test/java/org/robolectric/annotation/processing/objects/Dummy.java
@@ -1,4 +1,0 @@
-package org.robolectric.annotation.processing.objects;
-
-public class Dummy {
-}

--- a/robolectric-processor/src/test/java/org/robolectric/annotation/processing/objects/Private.java
+++ b/robolectric-processor/src/test/java/org/robolectric/annotation/processing/objects/Private.java
@@ -1,4 +1,0 @@
-package org.robolectric.annotation.processing.objects;
-
-class Private {
-}

--- a/robolectric-processor/src/test/java/org/robolectric/annotation/processing/objects2/Dummy.java
+++ b/robolectric-processor/src/test/java/org/robolectric/annotation/processing/objects2/Dummy.java
@@ -1,5 +1,0 @@
-package org.robolectric.annotation.processing.objects2;
-
-public class Dummy {
-
-}

--- a/robolectric-processor/src/test/java/org/robolectric/annotation/processing/validator/ImplementsValidatorTest.java
+++ b/robolectric-processor/src/test/java/org/robolectric/annotation/processing/validator/ImplementsValidatorTest.java
@@ -51,7 +51,7 @@ public class ImplementsValidatorTest {
       .that(testClass)
       .failsToCompile()
       .withErrorContaining("@Implements: cannot specify both <value> and <className> attributes")
-      .onLine(7);
+      .onLine(6);
   }
 
   @Test

--- a/robolectric-processor/src/test/java/org/robolectric/annotation/processing/validator/RealObjectValidatorTest.java
+++ b/robolectric-processor/src/test/java/org/robolectric/annotation/processing/validator/RealObjectValidatorTest.java
@@ -75,7 +75,7 @@ public class RealObjectValidatorTest {
     ASSERT.about(singleClass())
       .that(testClass)
       .failsToCompile()
-      .withErrorContaining("@RealObject with type <org.robolectric.annotation.processing.objects.UniqueDummy>; expected <org.robolectric.annotation.processing.objects.Dummy>")
+      .withErrorContaining("@RealObject with type <com.example.objects.UniqueDummy>; expected <com.example.objects.Dummy>")
       .onLine(11);
   }
 
@@ -85,7 +85,7 @@ public class RealObjectValidatorTest {
     ASSERT.about(singleClass())
       .that(testClass)
       .failsToCompile()
-      .withErrorContaining("@RealObject with type <org.robolectric.annotation.processing.objects.UniqueDummy>; expected <org.robolectric.annotation.processing.objects.Dummy>")
+      .withErrorContaining("@RealObject with type <com.example.objects.UniqueDummy>; expected <com.example.objects.Dummy>")
       .onLine(10);
   }
 

--- a/robolectric-processor/src/test/resources/org/robolectric/Robolectric_Anything.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/Robolectric_Anything.java
@@ -1,11 +1,10 @@
 package org.robolectric;
 
+import com.example.objects.AnyObject;
+import com.example.objects.Dummy;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Generated;
-
-import org.robolectric.annotation.processing.objects.AnyObject;
-import org.robolectric.annotation.processing.objects.Dummy;
 import org.robolectric.annotation.processing.shadows.ShadowAnything;
 import org.robolectric.annotation.processing.shadows.ShadowDummy;
 import org.robolectric.internal.ShadowExtractor;
@@ -17,8 +16,8 @@ public class Shadows implements ShadowProvider {
   private static final Map<String, String> SHADOW_MAP = new HashMap<>(2);
 
   static {
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.AnyObject", "org.robolectric.annotation.processing.shadows.ShadowAnything");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
+    SHADOW_MAP.put("com.example.objects.AnyObject", "org.robolectric.annotation.processing.shadows.ShadowAnything");
+    SHADOW_MAP.put("com.example.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
   }
 
   public static ShadowAnything shadowOf(AnyObject actual) {
@@ -41,6 +40,6 @@ public class Shadows implements ShadowProvider {
 
   @Override
   public String[] getProvidedPackageNames() {
-    return new String[] {"org.robolectric.annotation.processing.objects"};
+    return new String[] {"com.example.objects"};
   }
 }

--- a/robolectric-processor/src/test/resources/org/robolectric/Robolectric_ClassNameOnly.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/Robolectric_ClassNameOnly.java
@@ -1,11 +1,10 @@
 package org.robolectric;
 
+import com.example.objects.AnyObject;
+import com.example.objects.Dummy;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Generated;
-
-import org.robolectric.annotation.processing.objects.AnyObject;
-import org.robolectric.annotation.processing.objects.Dummy;
 import org.robolectric.annotation.processing.shadows.ShadowClassNameOnly;
 import org.robolectric.annotation.processing.shadows.ShadowDummy;
 import org.robolectric.internal.ShadowExtractor;
@@ -17,8 +16,8 @@ public class Shadows implements ShadowProvider {
   private static final Map<String, String> SHADOW_MAP = new HashMap<>(2);
 
   static {
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.AnyObject", "org.robolectric.annotation.processing.shadows.ShadowClassNameOnly");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
+    SHADOW_MAP.put("com.example.objects.AnyObject", "org.robolectric.annotation.processing.shadows.ShadowClassNameOnly");
+    SHADOW_MAP.put("com.example.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
   }
 
   public static ShadowClassNameOnly shadowOf(AnyObject actual) {
@@ -41,6 +40,6 @@ public class Shadows implements ShadowProvider {
 
   @Override
   public String[] getProvidedPackageNames() {
-    return new String[] {"org.robolectric.annotation.processing.objects"};
+    return new String[] {"com.example.objects"};
   }
 }

--- a/robolectric-processor/src/test/resources/org/robolectric/Robolectric_EmptyProvidedPackageNames.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/Robolectric_EmptyProvidedPackageNames.java
@@ -1,11 +1,10 @@
 package org.robolectric;
 
+import com.example.objects.AnyObject;
+import com.example.objects.Dummy;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Generated;
-
-import org.robolectric.annotation.processing.objects.AnyObject;
-import org.robolectric.annotation.processing.objects.Dummy;
 import org.robolectric.annotation.processing.shadows.ShadowAnything;
 import org.robolectric.annotation.processing.shadows.ShadowDummy;
 import org.robolectric.internal.ShadowExtractor;
@@ -17,8 +16,8 @@ public class Shadows implements ShadowProvider {
   private static final Map<String, String> SHADOW_MAP = new HashMap<>(2);
 
   static {
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.AnyObject", "org.robolectric.annotation.processing.shadows.ShadowAnything");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
+    SHADOW_MAP.put("com.example.objects.AnyObject", "org.robolectric.annotation.processing.shadows.ShadowAnything");
+    SHADOW_MAP.put("com.example.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
   }
 
   public static ShadowAnything shadowOf(AnyObject actual) {

--- a/robolectric-processor/src/test/resources/org/robolectric/Robolectric_HiddenClasses.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/Robolectric_HiddenClasses.java
@@ -1,11 +1,10 @@
 package org.robolectric;
 
+import com.example.objects.Dummy;
+import com.example.objects.OuterDummy2;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Generated;
-
-import org.robolectric.annotation.processing.objects.Dummy;
-import org.robolectric.annotation.processing.objects.OuterDummy2;
 import org.robolectric.annotation.processing.shadows.ShadowDummy;
 import org.robolectric.annotation.processing.shadows.ShadowOuterDummy2;
 import org.robolectric.annotation.processing.shadows.ShadowOuterDummy2.ShadowInnerPackage;
@@ -21,12 +20,12 @@ public class Shadows implements ShadowProvider {
   private static final Map<String, String> SHADOW_MAP = new HashMap<>(6);
 
   static {
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.OuterDummy2", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy2");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.OuterDummy2.InnerPackage", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy2$ShadowInnerPackage");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.OuterDummy2.InnerPrivate", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy2$ShadowInnerPrivate");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.OuterDummy2.InnerProtected", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy2$ShadowInnerProtected");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Private", "org.robolectric.annotation.processing.shadows.ShadowPrivate");
+    SHADOW_MAP.put("com.example.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
+    SHADOW_MAP.put("com.example.objects.OuterDummy2", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy2");
+    SHADOW_MAP.put("com.example.objects.OuterDummy2.InnerPackage", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy2$ShadowInnerPackage");
+    SHADOW_MAP.put("com.example.objects.OuterDummy2.InnerPrivate", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy2$ShadowInnerPrivate");
+    SHADOW_MAP.put("com.example.objects.OuterDummy2.InnerProtected", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy2$ShadowInnerProtected");
+    SHADOW_MAP.put("com.example.objects.Private", "org.robolectric.annotation.processing.shadows.ShadowPrivate");
   }
 
   public static ShadowDummy shadowOf(Dummy actual) {
@@ -49,6 +48,6 @@ public class Shadows implements ShadowProvider {
 
   @Override
   public String[] getProvidedPackageNames() {
-    return new String[] {"org.robolectric.annotation.processing.objects"};
+    return new String[] {"com.example.objects"};
   }
 }

--- a/robolectric-processor/src/test/resources/org/robolectric/Robolectric_InnerClassCollision.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/Robolectric_InnerClassCollision.java
@@ -1,13 +1,12 @@
 package org.robolectric;
 
+import com.example.objects.Dummy;
+import com.example.objects.OuterDummy;
+import com.example.objects.UniqueDummy;
+import com.example.objects.UniqueDummy.UniqueInnerDummy;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Generated;
-
-import org.robolectric.annotation.processing.objects.Dummy;
-import org.robolectric.annotation.processing.objects.OuterDummy;
-import org.robolectric.annotation.processing.objects.UniqueDummy;
-import org.robolectric.annotation.processing.objects.UniqueDummy.UniqueInnerDummy;
 import org.robolectric.annotation.processing.shadows.ShadowDummy;
 import org.robolectric.annotation.processing.shadows.ShadowOuterDummy;
 import org.robolectric.annotation.processing.shadows.ShadowUniqueDummy;
@@ -21,12 +20,12 @@ public class Shadows implements ShadowProvider {
   private static final Map<String, String> SHADOW_MAP = new HashMap<>(6);
 
   static {
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.OuterDummy", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.OuterDummy.InnerDummy", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy$ShadowInnerDummy");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.UniqueDummy", "org.robolectric.annotation.processing.shadows.ShadowUniqueDummy");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.UniqueDummy.InnerDummy", "org.robolectric.annotation.processing.shadows.ShadowUniqueDummy$ShadowInnerDummy");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.UniqueDummy.UniqueInnerDummy", "org.robolectric.annotation.processing.shadows.ShadowUniqueDummy$ShadowUniqueInnerDummy");
+    SHADOW_MAP.put("com.example.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
+    SHADOW_MAP.put("com.example.objects.OuterDummy", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy");
+    SHADOW_MAP.put("com.example.objects.OuterDummy.InnerDummy", "org.robolectric.annotation.processing.shadows.ShadowOuterDummy$ShadowInnerDummy");
+    SHADOW_MAP.put("com.example.objects.UniqueDummy", "org.robolectric.annotation.processing.shadows.ShadowUniqueDummy");
+    SHADOW_MAP.put("com.example.objects.UniqueDummy.InnerDummy", "org.robolectric.annotation.processing.shadows.ShadowUniqueDummy$ShadowInnerDummy");
+    SHADOW_MAP.put("com.example.objects.UniqueDummy.UniqueInnerDummy", "org.robolectric.annotation.processing.shadows.ShadowUniqueDummy$ShadowUniqueInnerDummy");
   }
 
   public static ShadowDummy shadowOf(Dummy actual) {
@@ -64,6 +63,6 @@ public class Shadows implements ShadowProvider {
 
   @Override
   public String[] getProvidedPackageNames() {
-    return new String[]{"org.robolectric.annotation.processing.objects"};
+    return new String[] {"com.example.objects"};
   }
 }

--- a/robolectric-processor/src/test/resources/org/robolectric/Robolectric_NoExcludedTypes.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/Robolectric_NoExcludedTypes.java
@@ -16,7 +16,7 @@ public class Shadows implements ShadowProvider {
   private static final Map<String, String> SHADOW_MAP = new HashMap<>(1);
 
   static {
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowExcludedFromAndroidSdk");
+    SHADOW_MAP.put("com.example.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowExcludedFromAndroidSdk");
   }
 
   public void reset() {
@@ -29,6 +29,6 @@ public class Shadows implements ShadowProvider {
 
   @Override
   public String[] getProvidedPackageNames() {
-    return new String[] {};
+    return new String[] {"com.example.objects"};
   }
 }

--- a/robolectric-processor/src/test/resources/org/robolectric/Robolectric_Parameterized.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/Robolectric_Parameterized.java
@@ -1,11 +1,10 @@
 package org.robolectric;
 
+import com.example.objects.Dummy;
+import com.example.objects.ParameterizedDummy;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Generated;
-
-import org.robolectric.annotation.processing.objects.Dummy;
-import org.robolectric.annotation.processing.objects.ParameterizedDummy;
 import org.robolectric.annotation.processing.shadows.ShadowDummy;
 import org.robolectric.annotation.processing.shadows.ShadowParameterizedDummy;
 import org.robolectric.internal.ShadowExtractor;
@@ -17,8 +16,8 @@ public class Shadows implements ShadowProvider {
   private static final Map<String, String> SHADOW_MAP = new HashMap<>(2);
 
   static {
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
-    SHADOW_MAP.put("org.robolectric.annotation.processing.objects.ParameterizedDummy", "org.robolectric.annotation.processing.shadows.ShadowParameterizedDummy");
+    SHADOW_MAP.put("com.example.objects.Dummy", "org.robolectric.annotation.processing.shadows.ShadowDummy");
+    SHADOW_MAP.put("com.example.objects.ParameterizedDummy", "org.robolectric.annotation.processing.shadows.ShadowParameterizedDummy");
   }
 
   public static ShadowDummy shadowOf(Dummy actual) {
@@ -40,6 +39,6 @@ public class Shadows implements ShadowProvider {
 
   @Override
   public String[] getProvidedPackageNames() {
-    return new String[] {"org.robolectric.annotation.processing.objects"};
+    return new String[] {"com.example.objects"};
   }
 }

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowAnything.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowAnything.java
@@ -5,7 +5,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
 
 @Implements(value = Robolectric.Anything.class,
-            className = "org.robolectric.annotation.processing.objects.AnyObject")
+            className = "com.example.objects.AnyObject")
 public class ShadowAnything {
   public static int resetCount = 0;
   @Resetter

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowClassNameOnly.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowClassNameOnly.java
@@ -3,7 +3,7 @@ package org.robolectric.annotation.processing.shadows;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
 
-@Implements(className = "org.robolectric.annotation.processing.objects.AnyObject")
+@Implements(className = "com.example.objects.AnyObject")
 public class ShadowClassNameOnly {
   public static int resetCount = 0;
   @Resetter

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowDummy.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowDummy.java
@@ -2,7 +2,7 @@ package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
-import org.robolectric.annotation.processing.objects.Dummy;
+import com.example.objects.Dummy;
 
 @Implements(Dummy.class)
 public class ShadowDummy {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowExcludedFromAndroidSdk.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowExcludedFromAndroidSdk.java
@@ -1,8 +1,7 @@
 package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
-import org.robolectric.annotation.Resetter;
-import org.robolectric.annotation.processing.objects.Dummy;
+import com.example.objects.Dummy;
 
 @Implements(value = Dummy.class, isInAndroidSdk = false)
 public class ShadowExcludedFromAndroidSdk {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementsAnythingWithUnresolvableClassNameAndOldMaxSdk.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementsAnythingWithUnresolvableClassNameAndOldMaxSdk.java
@@ -1,8 +1,6 @@
 package org.robolectric.annotation.processing.shadows;
 
-import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implements;
-import org.robolectric.annotation.processing.objects.Dummy;
 
 @Implements(className="some.Stuff", maxSdk = 21)
 public class ShadowImplementsAnythingWithUnresolvableClassNameAndOldMaxSdk {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementsDummyWithOuterDummyClassName.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementsDummyWithOuterDummyClassName.java
@@ -1,11 +1,10 @@
 package org.robolectric.annotation.processing.shadows;
 
-import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implements;
-import org.robolectric.annotation.processing.objects.Dummy;
+import com.example.objects.Dummy;
 
 @Implements(value = Dummy.class,
-            className="org.robolectric.annotation.processing.objects.OuterDummy")
+            className="com.example.objects.OuterDummy")
 public class ShadowImplementsDummyWithOuterDummyClassName {
   
 }

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementsWithExtraParameters.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementsWithExtraParameters.java
@@ -1,7 +1,7 @@
 package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
-import org.robolectric.annotation.processing.objects.Dummy;
+import com.example.objects.Dummy;
 
 @Implements(Dummy.class)
 public class ShadowImplementsWithExtraParameters<T,S,R> {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementsWithMissingParameters.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementsWithMissingParameters.java
@@ -1,7 +1,7 @@
 package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
-import org.robolectric.annotation.processing.objects.ParameterizedDummy;
+import com.example.objects.ParameterizedDummy;
 
 @Implements(ParameterizedDummy.class)
 public class ShadowImplementsWithMissingParameters {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementsWithParameterMismatch.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementsWithParameterMismatch.java
@@ -1,7 +1,7 @@
 package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
-import org.robolectric.annotation.processing.objects.ParameterizedDummy;
+import com.example.objects.ParameterizedDummy;
 
 @Implements(ParameterizedDummy.class)
 public class ShadowImplementsWithParameterMismatch<N extends Number,T> {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowOuterDummy.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowOuterDummy.java
@@ -1,7 +1,7 @@
 package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
-import org.robolectric.annotation.processing.objects.OuterDummy;
+import com.example.objects.OuterDummy;
 
 @Implements(OuterDummy.class)
 public class ShadowOuterDummy {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowOuterDummy2.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowOuterDummy2.java
@@ -2,24 +2,23 @@ package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implements;
-import org.robolectric.annotation.Resetter;
-import org.robolectric.annotation.processing.objects.OuterDummy2;
+import com.example.objects.OuterDummy2;
 
 @Implements(OuterDummy2.class)
 public class ShadowOuterDummy2 {
 
   @Implements(value=Robolectric.Anything.class,
-              className="org.robolectric.annotation.processing.objects.OuterDummy2$InnerProtected")
+              className="com.example.objects.OuterDummy2$InnerProtected")
   public class ShadowInnerProtected {
   }
 
   @Implements(value=Robolectric.Anything.class,
-              className="org.robolectric.annotation.processing.objects.OuterDummy2$InnerPackage")
+              className="com.example.objects.OuterDummy2$InnerPackage")
   public class ShadowInnerPackage {
   }
 
   @Implements(value=Robolectric.Anything.class,
-              className="org.robolectric.annotation.processing.objects.OuterDummy2$InnerPrivate")
+              className="com.example.objects.OuterDummy2$InnerPrivate")
   public class ShadowInnerPrivate {
   }
 }

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowParameterizedDummy.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowParameterizedDummy.java
@@ -2,7 +2,7 @@ package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.annotation.processing.objects.ParameterizedDummy;
+import com.example.objects.ParameterizedDummy;
 
 @Implements(ParameterizedDummy.class)
 public class ShadowParameterizedDummy<T, S extends Number> {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowPrivate.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowPrivate.java
@@ -5,7 +5,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
 
 @Implements(value=Robolectric.Anything.class,
-            className="org.robolectric.annotation.processing.objects.Private")
+            className="com.example.objects.Private")
 public class ShadowPrivate {
   @Resetter
   public static void resetMethod() {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectParameterizedMismatch.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectParameterizedMismatch.java
@@ -2,7 +2,7 @@ package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.annotation.processing.objects.ParameterizedDummy;
+import com.example.objects.ParameterizedDummy;
 
 @Implements(ParameterizedDummy.class)
 public class ShadowRealObjectParameterizedMismatch<T,S extends Number> {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectParameterizedMissingParameters.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectParameterizedMissingParameters.java
@@ -2,7 +2,7 @@ package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.annotation.processing.objects.ParameterizedDummy;
+import com.example.objects.ParameterizedDummy;
 
 @Implements(ParameterizedDummy.class)
 public class ShadowRealObjectParameterizedMissingParameters<T,S extends Number> {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectWithCorrectAnything.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectWithCorrectAnything.java
@@ -3,10 +3,10 @@ package org.robolectric.annotation.processing.shadows;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.annotation.processing.objects.Dummy;
+import com.example.objects.Dummy;
 
 @Implements(value=Robolectric.Anything.class,
-            className="org.robolectric.annotation.processing.objects.Dummy"
+            className="com.example.objects.Dummy"
             )
 public class ShadowRealObjectWithCorrectAnything {
 

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectWithCorrectClassName.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectWithCorrectClassName.java
@@ -2,9 +2,9 @@ package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.annotation.processing.objects.Dummy;
+import com.example.objects.Dummy;
 
-@Implements(className="org.robolectric.annotation.processing.objects.Dummy")
+@Implements(className="com.example.objects.Dummy")
 public class ShadowRealObjectWithCorrectClassName {
 
   @RealObject Dummy someField;

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectWithCorrectType.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectWithCorrectType.java
@@ -2,7 +2,7 @@ package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.annotation.processing.objects.Dummy;
+import com.example.objects.Dummy;
 
 @Implements(Dummy.class)
 public class ShadowRealObjectWithCorrectType {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectWithIncorrectClassName.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectWithIncorrectClassName.java
@@ -2,9 +2,9 @@ package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.annotation.processing.objects.UniqueDummy;
+import com.example.objects.UniqueDummy;
 
-@Implements(className="org.robolectric.annotation.processing.objects.Dummy")
+@Implements(className="com.example.objects.Dummy")
 public class ShadowRealObjectWithIncorrectClassName {
 
   @RealObject UniqueDummy someField;

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectWithNestedClassName.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectWithNestedClassName.java
@@ -3,10 +3,10 @@ package org.robolectric.annotation.processing.shadows;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.annotation.processing.objects.OuterDummy;
+import com.example.objects.OuterDummy;
 
 @Implements(value=Robolectric.Anything.class,
-            className="org.robolectric.annotation.processing.objects.OuterDummy$InnerDummy")
+            className="com.example.objects.OuterDummy$InnerDummy")
 public class ShadowRealObjectWithNestedClassName {
 
   @RealObject OuterDummy.InnerDummy someField;

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectWithWrongType.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowRealObjectWithWrongType.java
@@ -2,8 +2,8 @@ package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.annotation.processing.objects.Dummy;
-import org.robolectric.annotation.processing.objects.UniqueDummy;
+import com.example.objects.Dummy;
+import com.example.objects.UniqueDummy;
 
 @Implements(Dummy.class)
 public class ShadowRealObjectWithWrongType {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowResetterNonPublic.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowResetterNonPublic.java
@@ -2,7 +2,7 @@ package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
-import org.robolectric.annotation.processing.objects.Dummy;
+import com.example.objects.Dummy;
 
 @Implements(Dummy.class)
 public class ShadowResetterNonPublic {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowResetterNonStatic.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowResetterNonStatic.java
@@ -2,7 +2,7 @@ package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
-import org.robolectric.annotation.processing.objects.Dummy;
+import com.example.objects.Dummy;
 
 @Implements(Dummy.class)
 public class ShadowResetterNonStatic {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowResetterWithParameters.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowResetterWithParameters.java
@@ -2,7 +2,7 @@ package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
-import org.robolectric.annotation.processing.objects.Dummy;
+import com.example.objects.Dummy;
 
 @Implements(Dummy.class)
 public class ShadowResetterWithParameters {

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowUniqueDummy.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowUniqueDummy.java
@@ -1,7 +1,7 @@
 package org.robolectric.annotation.processing.shadows;
 
 import org.robolectric.annotation.Implements;
-import org.robolectric.annotation.processing.objects.UniqueDummy;
+import com.example.objects.UniqueDummy;
 
 @Implements(UniqueDummy.class)
 public class ShadowUniqueDummy {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/RuntimeEnvironment.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/RuntimeEnvironment.java
@@ -82,10 +82,26 @@ public class RuntimeEnvironment {
     return (PackageManager) packageManager;
   }
 
+  /**
+   * @deprecated Use {@link org.robolectric.shadows.ShadowPackageManager} instead.
+   * <pre>
+   *   ShadowPackageManager shadowPackageManager = shadowOf(context.getPackageManager());
+   * </pre>
+   */
+  @Deprecated
   public static RobolectricPackageManager getRobolectricPackageManager() {
     return packageManager;
   }
 
+  /**
+   * @deprecated Use {@link org.robolectric.shadows.ShadowPackageManager} instead.
+   * <pre>
+   *   ShadowPackageManager shadowPackageManager = shadowOf(context.getPackageManager());
+   * </pre>
+   *
+   * If there is functionality you are missing you can extend ShadowPackageManager.
+   */
+  @Deprecated
   public static void setRobolectricPackageManager(RobolectricPackageManager newPackageManager) {
     if (packageManager != null) {
       packageManager.reset();

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/android/StubPackageManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/android/StubPackageManager.java
@@ -26,7 +26,6 @@ import android.content.pm.PermissionInfo;
 import android.content.pm.ProviderInfo;
 import android.content.pm.ResolveInfo;
 import android.content.pm.ServiceInfo;
-import android.content.pm.VerificationParams;
 import android.content.pm.VerifierDeviceIdentity;
 import android.content.res.Resources;
 import android.content.res.XmlResourceParser;
@@ -40,6 +39,14 @@ import android.os.storage.VolumeInfo;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * @deprecated Use {@link org.robolectric.shadows.ShadowPackageManager} instead.
+ * <pre>
+ *   ShadowPackageManager shadowPackageManager = shadowOf(context.getPackageManager());
+ * </pre>
+ *
+ * If there is functionality you are missing you can extend ShadowPackageManager.
+ */
 public class StubPackageManager extends PackageManager {
 
   @Override

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/android/StubPackageManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/android/StubPackageManager.java
@@ -35,6 +35,7 @@ import android.net.Uri;
 import android.os.Handler;
 import android.os.UserHandle;
 import android.os.storage.VolumeInfo;
+import org.robolectric.annotation.internal.Instrument;
 
 import java.util.Collections;
 import java.util.List;
@@ -47,6 +48,7 @@ import java.util.List;
  *
  * If there is functionality you are missing you can extend ShadowPackageManager.
  */
+@Instrument
 public class StubPackageManager extends PackageManager {
 
   @Override

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/res/builder/RobolectricPackageManager.java
@@ -62,6 +62,8 @@ public interface RobolectricPackageManager {
 
   ComponentState getComponentState(ComponentName componentName);
 
+  void addPackage(PackageInfo packageInfo, PackageStats packageStats);
+
   void addPackage(PackageInfo packageInfo);
 
   void addPackage(String packageName);

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -1,0 +1,286 @@
+package org.robolectric.shadows;
+
+import android.annotation.NonNull;
+import android.annotation.Nullable;
+import android.annotation.UserIdInt;
+import android.app.ApplicationPackageManager;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.pm.*;
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.os.UserHandle;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+import java.util.List;
+
+import static android.os.Build.VERSION_CODES.*;
+
+@Implements(value = ApplicationPackageManager.class, isInAndroidSdk = false)
+public class ShadowApplicationPackageManager extends ShadowPackageManager {
+
+  @Implementation(minSdk = Build.VERSION_CODES.LOLLIPOP)
+  public PackageInstaller getPackageInstaller() {
+    return ((PackageManager) RuntimeEnvironment.getRobolectricPackageManager()).getPackageInstaller();
+  }
+
+  @Implementation
+  public List<PackageInfo> getInstalledPackages(int flags) {
+    return RuntimeEnvironment.getRobolectricPackageManager().getInstalledPackages(flags);
+  }
+
+  @Implementation
+  public ActivityInfo getActivityInfo(ComponentName component, int flags) throws PackageManager.NameNotFoundException {
+    return RuntimeEnvironment.getRobolectricPackageManager().getActivityInfo(component, flags);
+  }
+
+  @Implementation
+  public boolean hasSystemFeature(String name) {
+    return RuntimeEnvironment.getRobolectricPackageManager().hasSystemFeature(name);
+  }
+
+  @Implementation
+  public int getComponentEnabledSetting(ComponentName componentName) {
+    return ((PackageManager) RuntimeEnvironment.getRobolectricPackageManager()).getComponentEnabledSetting(componentName);
+  }
+
+  @Implementation
+  public @Nullable String getNameForUid(int uid) {
+    return ((PackageManager) RuntimeEnvironment.getRobolectricPackageManager()).getNameForUid(uid);
+  }
+
+  @Implementation
+  public @Nullable String[] getPackagesForUid(int uid) {
+    return ((PackageManager) RuntimeEnvironment.getRobolectricPackageManager()).getPackagesForUid(uid);
+  }
+
+  @Implementation
+  public int getApplicationEnabledSetting(String packageName) {
+    return ((PackageManager) RuntimeEnvironment.getRobolectricPackageManager()).getApplicationEnabledSetting(packageName);
+  }
+
+  @Implementation
+  public ProviderInfo getProviderInfo(ComponentName component, int flags) throws PackageManager.NameNotFoundException {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).getProviderInfo(component, flags);
+  }
+
+  @Implementation
+  public void setComponentEnabledSetting(ComponentName componentName, int newState, int flags) {
+    RuntimeEnvironment.getRobolectricPackageManager().setComponentEnabledSetting(componentName, newState, flags);
+  }
+
+  @Implementation
+  public void setApplicationEnabledSetting(String packageName, int newState, int flags) {
+    ((PackageManager) RuntimeEnvironment.getRobolectricPackageManager()).setApplicationEnabledSetting(packageName, newState, flags);
+  }
+
+  @Implementation
+  public ApplicationInfo getApplicationInfo(String packageName, int flags) throws PackageManager.NameNotFoundException {
+    return RuntimeEnvironment.getRobolectricPackageManager().getApplicationInfo(packageName, flags);
+  }
+
+  @Implementation
+  public ResolveInfo resolveActivity(Intent intent, int flags) {
+    return RuntimeEnvironment.getRobolectricPackageManager().resolveActivity(intent, flags);
+  }
+
+  @Implementation
+  public ProviderInfo resolveContentProvider(String name, int flags) {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).resolveContentProvider(name, flags);
+  }
+
+  @Implementation
+  public ProviderInfo resolveContentProviderAsUser(String name, int flags, @UserIdInt int userId) {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).resolveContentProviderAsUser(name, flags, userId);
+  }
+
+  @Implementation
+  public PackageInfo getPackageInfo(String packageName, int flags) throws PackageManager.NameNotFoundException {
+    return RuntimeEnvironment.getRobolectricPackageManager().getPackageInfo(packageName, flags);
+  }
+
+  @Implementation
+  public List<ResolveInfo> queryIntentServices(Intent intent, int flags) {
+    return RuntimeEnvironment.getRobolectricPackageManager().queryIntentServices(intent, flags);
+  }
+
+  @Implementation
+  public List<ResolveInfo> queryIntentActivities(Intent intent, int flags) {
+    return RuntimeEnvironment.getRobolectricPackageManager().queryIntentActivities(intent, flags);
+  }
+
+  @Implementation
+  public int checkPermission(String permName, String pkgName) {
+    return RuntimeEnvironment.getRobolectricPackageManager().checkPermission(permName, pkgName);
+  }
+
+  @Implementation
+  public ActivityInfo getReceiverInfo(ComponentName className, int flags) throws PackageManager.NameNotFoundException {
+    return RuntimeEnvironment.getRobolectricPackageManager().getReceiverInfo(className, flags);
+  }
+
+  @Implementation
+  public List<ResolveInfo> queryBroadcastReceivers(Intent intent, int flags) {
+    return RuntimeEnvironment.getRobolectricPackageManager().queryBroadcastReceivers(intent, flags);
+  }
+
+  @Implementation
+  public ResolveInfo resolveService(Intent intent, int flags) {
+    return RuntimeEnvironment.getRobolectricPackageManager().resolveService(intent, flags);
+  }
+
+  @Implementation
+  public ServiceInfo getServiceInfo(ComponentName className, int flags) throws PackageManager.NameNotFoundException {
+    return RuntimeEnvironment.getRobolectricPackageManager().getServiceInfo(className, flags);
+  }
+
+  @Implementation
+  public Resources getResourcesForApplication(@NonNull ApplicationInfo applicationInfo) throws PackageManager.NameNotFoundException {
+    if (RuntimeEnvironment.application.getPackageName().equals(applicationInfo.packageName)) {
+      return RuntimeEnvironment.application.getResources();
+    }
+    throw new PackageManager.NameNotFoundException(applicationInfo.packageName);
+  }
+
+  @Implementation
+  public List<ApplicationInfo> getInstalledApplications(int flags) {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).getInstalledApplications(flags);
+  }
+
+  @Implementation
+  public String getInstallerPackageName(String packageName) {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).getInstallerPackageName(packageName);
+  }
+
+  @Implementation
+  public PermissionInfo getPermissionInfo(String name, int flags) throws PackageManager.NameNotFoundException {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).getPermissionInfo(name, flags);
+  }
+
+  @Implementation(minSdk = M)
+  public boolean shouldShowRequestPermissionRationale(String permission) {
+    return permissionRationaleMap.containsKey(permission) ? permissionRationaleMap.get(permission) : false;
+  }
+
+  @Implementation
+  public FeatureInfo[] getSystemAvailableFeatures() {
+    return systemAvailableFeatures.isEmpty() ? null : systemAvailableFeatures.toArray(new FeatureInfo[systemAvailableFeatures.size()]);
+  }
+
+  @Implementation
+  public void verifyPendingInstall(int id, int verificationCode) {
+    if (verificationResults.containsKey(id)) {
+      throw new IllegalStateException("Multiple verifications for id=" + id);
+    }
+    verificationResults.put(id, verificationCode);
+  }
+
+  @Implementation
+  public void freeStorageAndNotify(long freeStorageSize, IPackageDataObserver observer) {
+
+  }
+
+  @Implementation
+  public void freeStorageAndNotify(String volumeUuid, long freeStorageSize, IPackageDataObserver observer) {
+
+  }
+
+  @Implementation
+  public void setInstallerPackageName(String targetPackage, String installerPackageName) {
+    ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).setInstallerPackageName(targetPackage, installerPackageName);
+  }
+
+  @Implementation
+  public List<ResolveInfo> queryIntentContentProviders(Intent intent, int flags) {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).queryIntentContentProviders(intent, flags);
+  }
+
+  @Implementation
+  public List<ResolveInfo> queryIntentContentProvidersAsUser(Intent intent, int flags, int userId) {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).queryIntentContentProvidersAsUser(intent, flags, userId);
+  }
+
+  @Implementation
+  public String getPermissionControllerPackageName() {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).getPermissionControllerPackageName();
+  }
+
+  @Implementation(maxSdk = JELLY_BEAN)
+  public void getPackageSizeInfo(String packageName, IPackageStatsObserver observer) {
+    ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).getPackageSizeInfoAsUser(packageName, UserHandle.myUserId(), observer);
+  }
+
+  @Implementation(minSdk = JELLY_BEAN_MR1, maxSdk = M)
+  public void getPackageSizeInfo(String pkgName, int uid, final IPackageStatsObserver callback) {
+    ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).getPackageSizeInfoAsUser(pkgName, uid, callback);
+  }
+
+  @Implementation(minSdk = N)
+  public void getPackageSizeInfoAsUser(String pkgName, int uid, final IPackageStatsObserver callback) {
+    ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).getPackageSizeInfoAsUser(pkgName, uid, callback);
+  }
+
+  @Implementation
+  public void deletePackage(String packageName, IPackageDeleteObserver observer, int flags) {
+  }
+
+  @Implementation
+  public String[] currentToCanonicalPackageNames(String[] names) {
+    String[] out = new String[names.length];
+    for (int i = names.length - 1; i >= 0; i--) {
+      if (currentToCanonicalNames.containsKey(names[i])) {
+        out[i] = currentToCanonicalNames.get(names[i]);
+      } else {
+        out[i] = names[i];
+      }
+    }
+    return out;
+  }
+
+  @Implementation
+  public boolean isSafeMode() {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).isSafeMode();
+  }
+
+  @Implementation
+  public Drawable getApplicationIcon(String packageName) throws PackageManager.NameNotFoundException {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).getApplicationIcon(packageName);
+  }
+
+  @Implementation
+  public Drawable getApplicationIcon(ApplicationInfo info) {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).getApplicationIcon(info);
+  }
+
+  @Implementation
+  public Drawable getUserBadgeForDensity(UserHandle userHandle, int i) {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).getUserBadgeForDensity(userHandle, i);
+  }
+
+  @Implementation
+  public int checkSignatures(String pkg1, String pkg2) {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).checkSignatures(pkg1, pkg2);
+  }
+
+  @Implementation
+  public int checkSignatures(int uid1, int uid2) {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).checkSignatures(uid1, uid2);
+  }
+
+  @Implementation
+  public List<PermissionInfo> queryPermissionsByGroup(String group, int flags) throws PackageManager.NameNotFoundException {
+    return ((PackageManager)RuntimeEnvironment.getRobolectricPackageManager()).queryPermissionsByGroup(group, flags);
+  }
+
+  public CharSequence getApplicationLabel(ApplicationInfo info) {
+    return RuntimeEnvironment.getRobolectricPackageManager().getApplicationLabel(info);
+  }
+
+  @Implementation
+  public Intent getLaunchIntentForPackage(String packageName) {
+    return RuntimeEnvironment.getRobolectricPackageManager().getLaunchIntentForPackage(packageName);
+  }
+}

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
@@ -307,11 +307,6 @@ public class ShadowContextImpl {
   }
 
   @Implementation
-  public PackageManager getPackageManager() {
-    return RuntimeEnvironment.getPackageManager();
-  }
-
-  @Implementation
   public boolean stopService(Intent name) {
     return ShadowApplication.getInstance().stopService(name);
   }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
@@ -1,0 +1,287 @@
+package org.robolectric.shadows;
+
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.*;
+import android.graphics.drawable.Drawable;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.StubPackageManager;
+import org.robolectric.annotation.Implements;
+import org.robolectric.manifest.AndroidManifest;
+import org.robolectric.res.builder.RobolectricPackageManager;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+@Implements(PackageManager.class)
+abstract public class ShadowPackageManager implements RobolectricPackageManager {
+
+  protected Map<String, Boolean> permissionRationaleMap = new HashMap<>();
+  protected List<FeatureInfo> systemAvailableFeatures = new LinkedList<>();
+  private Map<String, PackageInfo> packageArchiveInfo = new HashMap<>();
+  protected final Map<Integer, Integer> verificationResults = new HashMap<>();
+  protected final Map<String, String> currentToCanonicalNames = new HashMap<>();
+
+  @Override
+  public void addResolveInfoForIntent(Intent intent, List<ResolveInfo> info) {
+    RuntimeEnvironment.getRobolectricPackageManager().addResolveInfoForIntent(intent, info);
+  }
+
+  @Override
+  public void addResolveInfoForIntent(Intent intent, ResolveInfo info) {
+    RuntimeEnvironment.getRobolectricPackageManager().addResolveInfoForIntent(intent, info);
+  }
+
+  @Override
+  public void removeResolveInfosForIntent(Intent intent, String packageName) {
+    RuntimeEnvironment.getRobolectricPackageManager().removeResolveInfosForIntent(intent, packageName);
+  }
+
+  @Override
+  public Drawable getActivityIcon(Intent intent) {
+    return RuntimeEnvironment.getRobolectricPackageManager().getActivityIcon(intent);
+  }
+
+  @Override
+  public Drawable getActivityIcon(ComponentName componentName) {
+    return RuntimeEnvironment.getRobolectricPackageManager().getActivityIcon(componentName);
+  }
+
+  @Override
+  public void addActivityIcon(ComponentName component, Drawable drawable) {
+    RuntimeEnvironment.getRobolectricPackageManager().addActivityIcon(component, drawable);
+  }
+
+  @Override
+  public void addActivityIcon(Intent intent, Drawable drawable) {
+    RuntimeEnvironment.getRobolectricPackageManager().addActivityIcon(intent, drawable);
+  }
+
+  @Override
+  public void setApplicationIcon(String packageName, Drawable drawable) {
+    RuntimeEnvironment.getRobolectricPackageManager().setApplicationIcon(packageName, drawable);
+  }
+
+  @Override
+  public void addPreferredActivity(IntentFilter filter, int match, ComponentName[] set, ComponentName activity) {
+    RuntimeEnvironment.getRobolectricPackageManager().addPreferredActivity(filter, match, set, activity);
+  }
+
+  @Override
+  public int getPreferredActivities(List<IntentFilter> outFilters, List<ComponentName> outActivities, String packageName) {
+    return RuntimeEnvironment.getRobolectricPackageManager().getPreferredActivities(outFilters, outActivities, packageName);
+  }
+
+  @Override
+  public ComponentState getComponentState(ComponentName componentName) {
+    return RuntimeEnvironment.getRobolectricPackageManager().getComponentState(componentName);
+  }
+
+  @Override
+  public void addPackage(PackageInfo packageInfo) {
+    RuntimeEnvironment.getRobolectricPackageManager().addPackage(packageInfo);
+  }
+
+  @Override
+  public void addPackage(PackageInfo packageInfo, PackageStats packageStats) {
+    RuntimeEnvironment.getRobolectricPackageManager().addPackage(packageInfo, packageStats);
+  }
+
+  @Override
+  public void addPermissionInfo(PermissionInfo permissionInfo) {
+    RuntimeEnvironment.getRobolectricPackageManager().addPermissionInfo(permissionInfo);
+  }
+
+  @Override
+  public void addPackage(String packageName) {
+    RuntimeEnvironment.getRobolectricPackageManager().addPackage(packageName);
+  }
+
+  @Override
+  public void addManifest(AndroidManifest androidManifest, int labelRes) {
+    RuntimeEnvironment.getRobolectricPackageManager().addManifest(androidManifest, labelRes);
+  }
+
+  @Override
+  public void removePackage(String packageName) {
+    RuntimeEnvironment.getRobolectricPackageManager().removePackage(packageName);
+  }
+
+  @Override
+  public void setSystemFeature(String name, boolean supported) {
+    RuntimeEnvironment.getRobolectricPackageManager().setSystemFeature(name, supported);
+  }
+
+  @Override
+  public void addDrawableResolution(String packageName, int resourceId, Drawable drawable) {
+    RuntimeEnvironment.getRobolectricPackageManager().addDrawableResolution(packageName, resourceId, drawable);
+  }
+
+  @Override
+  public Drawable getDrawable(String packageName, int resourceId, ApplicationInfo applicationInfo) {
+    return RuntimeEnvironment.getRobolectricPackageManager().getDrawable(packageName, resourceId, applicationInfo);
+  }
+
+  @Override
+  public boolean isQueryIntentImplicitly() {
+    return RuntimeEnvironment.getRobolectricPackageManager().isQueryIntentImplicitly();
+  }
+
+  @Override
+  public void setQueryIntentImplicitly(boolean queryIntentImplicitly) {
+    RuntimeEnvironment.getRobolectricPackageManager().setQueryIntentImplicitly(queryIntentImplicitly);
+  }
+
+  @Override
+  public void reset() {
+    RuntimeEnvironment.getRobolectricPackageManager().reset();
+  }
+
+  @Override
+  public void setNameForUid(int uid, String name) {
+    RuntimeEnvironment.getRobolectricPackageManager().setNameForUid(uid, name);
+  }
+
+  @Override
+  public void setPackagesForCallingUid(String... packagesForCallingUid) {
+    RuntimeEnvironment.getRobolectricPackageManager().setPackagesForCallingUid(packagesForCallingUid);
+  }
+
+  @Override
+  public void setPackagesForUid(int uid, String... packagesForCallingUid) {
+    RuntimeEnvironment.getRobolectricPackageManager().setPackagesForUid(uid, packagesForCallingUid);
+  }
+
+  @Override
+  public PackageInfo getPackageArchiveInfo(String archiveFilePath, int flags) {
+    return RuntimeEnvironment.getRobolectricPackageManager().getPackageArchiveInfo(archiveFilePath, flags);
+  }
+
+  public void setPackageArchiveInfo(String archiveFilePath, PackageInfo packageInfo) {
+    packageArchiveInfo.put(archiveFilePath, packageInfo);
+  }
+
+  public int getVerificationResult(int id) {
+    Integer result = verificationResults.get(id);
+    if (result == null) {
+      // 0 isn't a "valid" result, so we can check for the case when verification isn't
+      // called, if needed
+      return 0;
+    }
+    return result;
+  }
+
+  public void setShouldShowRequestPermissionRationale(String permission, boolean show) {
+    permissionRationaleMap.put(permission, show);
+  }
+
+  public void addSystemAvailableFeature(FeatureInfo featureInfo) {
+    systemAvailableFeatures.add(featureInfo);
+  }
+
+  public void clearSystemAvailableFeatures() {
+    systemAvailableFeatures.clear();
+  }
+
+  public void addCurrentToCannonicalName(String currentName, String canonicalName) {
+    currentToCanonicalNames.put(currentName, canonicalName);
+  }
+
+  public abstract void getPackageSizeInfo(String pkgName, int uid, IPackageStatsObserver callback);
+
+  @Implements(StubPackageManager.class)
+  public static class ShadowStubPackageManager extends ShadowPackageManager {
+    @Override
+    public PackageInfo getPackageInfo(String packageName, int flags) throws PackageManager.NameNotFoundException {
+      return null;
+    }
+
+    @Override
+    public ApplicationInfo getApplicationInfo(String packageName, int flags) throws PackageManager.NameNotFoundException {
+      return null;
+    }
+
+    @Override
+    public ActivityInfo getActivityInfo(ComponentName className, int flags) throws PackageManager.NameNotFoundException {
+      return null;
+    }
+
+    @Override
+    public ActivityInfo getReceiverInfo(ComponentName className, int flags) throws PackageManager.NameNotFoundException {
+      return null;
+    }
+
+    @Override
+    public ServiceInfo getServiceInfo(ComponentName className, int flags) throws PackageManager.NameNotFoundException {
+      return null;
+    }
+
+    @Override
+    public List<PackageInfo> getInstalledPackages(int flags) {
+      return null;
+    }
+
+    @Override
+    public List<ResolveInfo> queryIntentActivities(Intent intent, int flags) {
+      return null;
+    }
+
+    @Override
+    public List<ResolveInfo> queryIntentServices(Intent intent, int flags) {
+      return null;
+    }
+
+    @Override
+    public List<ResolveInfo> queryBroadcastReceivers(Intent intent, int flags) {
+      return null;
+    }
+
+    @Override
+    public ResolveInfo resolveActivity(Intent intent, int flags) {
+      return null;
+    }
+
+    @Override
+    public ResolveInfo resolveService(Intent intent, int flags) {
+      return null;
+    }
+
+    @Override
+    public Drawable getApplicationIcon(String packageName) throws PackageManager.NameNotFoundException {
+      return null;
+    }
+
+    @Override
+    public Intent getLaunchIntentForPackage(String packageName) {
+      return null;
+    }
+
+    @Override
+    public CharSequence getApplicationLabel(ApplicationInfo info) {
+      return null;
+    }
+
+    @Override
+    public void setComponentEnabledSetting(ComponentName componentName, int newState, int flags) {
+
+    }
+
+    @Override
+    public boolean hasSystemFeature(String name) {
+      return false;
+    }
+
+    @Override
+    public int checkPermission(String permName, String pkgName) {
+      return 0;
+    }
+
+    @Override
+    public void getPackageSizeInfo(String pkgName, int uid, IPackageStatsObserver callback) {
+
+    }
+  }
+}

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
@@ -192,7 +192,7 @@ abstract public class ShadowPackageManager implements RobolectricPackageManager 
 
   public abstract void getPackageSizeInfo(String pkgName, int uid, IPackageStatsObserver callback);
 
-  @Implements(StubPackageManager.class)
+  @Implements(value = StubPackageManager.class, isInAndroidSdk = false)
   public static class ShadowStubPackageManager extends ShadowPackageManager {
     @Override
     public PackageInfo getPackageInfo(String packageName, int flags) throws PackageManager.NameNotFoundException {

--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -1018,6 +1018,11 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
 
   @Override
   public void getPackageSizeInfo(String pkgName, int uid, final IPackageStatsObserver callback) {
+    this.getPackageSizeInfoAsUser(pkgName, uid, callback);
+  }
+
+  @Override
+  public void getPackageSizeInfoAsUser(String pkgName, int uid, final IPackageStatsObserver callback) {
     final PackageStats packageStats = packageStatsMap.get(pkgName);
     new Handler(Looper.getMainLooper()).post(new Runnable() {
       @Override

--- a/robolectric/src/main/java/org/robolectric/res/builder/StubPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/StubPackageManager.java
@@ -1,7 +1,12 @@
 package org.robolectric.res.builder;
 
 /**
- * @deprecated Use {@link org.robolectric.android.StubPackageManager} instead.
+ * @deprecated Use {@link org.robolectric.shadows.ShadowPackageManager} instead.
+ * <pre>
+ *   ShadowPackageManager shadowPackageManager = shadowOf(context.getPackageManager());
+ * </pre>
+ *
+ * If there is functionality you are missing you can extend ShadowPackageManager.
  */
 @Deprecated
 public class StubPackageManager extends org.robolectric.android.StubPackageManager {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -861,6 +861,7 @@ public class ShadowPackageManagerTest {
   }
 
   @Test
+  @Config(minSdk = N)
   public void whenNotPreconfigured_getPackageSizeInfo_callsBackWithDefaults() throws Exception {
     packageManager.getPackageSizeInfo("org.robolectric", packageStatsObserver);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -1,0 +1,1071 @@
+package org.robolectric.shadows;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.*;
+import android.content.pm.PackageManager;
+import android.graphics.Color;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.os.Bundle;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.R;
+import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
+import org.robolectric.test.TemporaryFolder;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static android.content.pm.PackageManager.*;
+import static android.os.Build.VERSION_CODES.M;
+import static android.os.Build.VERSION_CODES.N;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.robolectric.Robolectric.setupActivity;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(TestRunners.MultiApiSelfTest.class)
+public class ShadowPackageManagerTest {
+
+  private static final String TEST_PACKAGE_NAME = "com.some.other.package";
+  private static final String TEST_PACKAGE_LABEL = "My Little App";
+  private static final String TEST_APP_PATH = "/values/app/application.apk";
+  private ShadowPackageManager shadowPackageManager;
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private PackageManager packageManager;
+
+  private final IPackageStatsObserver packageStatsObserver = mock(IPackageStatsObserver.class);
+  private final ArgumentCaptor<PackageStats> packageStatsCaptor = ArgumentCaptor.forClass(PackageStats.class);
+
+  @Before
+  public void setUp() {
+    shadowPackageManager = shadowOf(RuntimeEnvironment.application.getPackageManager());
+    packageManager = RuntimeEnvironment.application.getPackageManager();
+  }
+
+  @Test
+  public void getPackageArchiveInfo() {
+    ApplicationInfo appInfo = new ApplicationInfo();
+    appInfo.flags = 0;
+    appInfo.packageName = TEST_PACKAGE_NAME;
+    appInfo.sourceDir = TEST_APP_PATH;
+    appInfo.name = TEST_PACKAGE_LABEL;
+
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = TEST_PACKAGE_NAME;
+    packageInfo.applicationInfo = appInfo;
+    shadowPackageManager.addPackage(packageInfo);
+
+    PackageInfo packageInfoResult = shadowPackageManager.getPackageArchiveInfo(TEST_APP_PATH, 0);
+    assertThat(packageInfoResult).isNotNull();
+    ApplicationInfo applicationInfo = packageInfoResult.applicationInfo;
+    assertThat(applicationInfo).isInstanceOf(ApplicationInfo.class);
+    assertThat(applicationInfo.packageName).isEqualTo(TEST_PACKAGE_NAME);
+    assertThat(applicationInfo.sourceDir).isEqualTo(TEST_APP_PATH);
+
+  }
+
+  @Test
+  public void getApplicationInfo_ThisApplication() throws Exception {
+    ApplicationInfo info = shadowPackageManager.getApplicationInfo(RuntimeEnvironment.application.getPackageName(), 0);
+    assertThat(info).isNotNull();
+    assertThat(info.packageName).isEqualTo(RuntimeEnvironment.application.getPackageName());
+  }
+
+  @Test(expected = PackageManager.NameNotFoundException.class)
+  public void getApplicationInfo_whenUnknown_shouldThrowNameNotFoundException() throws Exception {
+    try {
+      shadowPackageManager.getApplicationInfo("unknown_package", 0);
+      fail("should have thrown NameNotFoundException");
+    } catch (PackageManager.NameNotFoundException e) {
+      assertThat(e.getMessage()).contains("unknown_package");
+      throw e;
+    }
+  }
+
+  @Test
+  public void getApplicationInfo_OtherApplication() throws Exception {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = TEST_PACKAGE_NAME;
+    packageInfo.applicationInfo = new ApplicationInfo();
+    packageInfo.applicationInfo.packageName = TEST_PACKAGE_NAME;
+    packageInfo.applicationInfo.name = TEST_PACKAGE_LABEL;
+    shadowPackageManager.addPackage(packageInfo);
+
+    ApplicationInfo info = shadowPackageManager.getApplicationInfo(TEST_PACKAGE_NAME, 0);
+    assertThat(info).isNotNull();
+    assertThat(info.packageName).isEqualTo(TEST_PACKAGE_NAME);
+    assertThat(shadowPackageManager.getApplicationLabel(info).toString()).isEqualTo(TEST_PACKAGE_LABEL);
+  }
+
+  @Test(expected = PackageManager.NameNotFoundException.class)
+  public void removePackage_shouldHideItFromGetApplicationInfo() throws Exception {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = TEST_PACKAGE_NAME;
+    packageInfo.applicationInfo = new ApplicationInfo();
+    packageInfo.applicationInfo.packageName = TEST_PACKAGE_NAME;
+    packageInfo.applicationInfo.name = TEST_PACKAGE_LABEL;
+    shadowPackageManager.addPackage(packageInfo);
+    shadowPackageManager.removePackage(TEST_PACKAGE_NAME);
+
+    shadowPackageManager.getApplicationInfo(TEST_PACKAGE_NAME, 0);
+  }
+
+  @Test
+  public void queryIntentActivities_EmptyResult() throws Exception {
+    Intent i = new Intent(Intent.ACTION_MAIN, null);
+    i.addCategory(Intent.CATEGORY_LAUNCHER);
+
+    List<ResolveInfo> activities = shadowPackageManager.queryIntentActivities(i, 0);
+    assertThat(activities).isEmpty();
+  }
+
+  @Test
+  public void queryIntentActivities_Match() throws Exception {
+    Intent i = new Intent(Intent.ACTION_MAIN, null);
+    i.addCategory(Intent.CATEGORY_LAUNCHER);
+
+    ResolveInfo info = new ResolveInfo();
+    info.nonLocalizedLabel = TEST_PACKAGE_LABEL;
+
+    shadowPackageManager.addResolveInfoForIntent(i, info);
+
+    List<ResolveInfo> activities = shadowPackageManager.queryIntentActivities(i, 0);
+    assertThat(activities).isNotNull();
+    assertThat(activities).hasSize(1);
+    assertThat(activities.get(0).nonLocalizedLabel.toString()).isEqualTo(TEST_PACKAGE_LABEL);
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestForActivitiesWithIntentFilterWithData.xml")
+  public void queryIntentActivities_EmptyResultWithNoMatchingImplicitIntents() throws Exception {
+    Intent i = new Intent(Intent.ACTION_MAIN, null);
+    i.addCategory(Intent.CATEGORY_LAUNCHER);
+
+    shadowPackageManager.setQueryIntentImplicitly(true);
+    List<ResolveInfo> activities = shadowPackageManager.queryIntentActivities(i, 0);
+    assertThat(activities).isEmpty();
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestForActivitiesWithIntentFilterWithData.xml")
+  public void queryIntentActivities_MatchWithImplicitIntents() throws Exception {
+    Uri uri = Uri.parse("content://testhost1.com:1/testPath/test.jpeg");
+    Intent i = new Intent(Intent.ACTION_VIEW);
+    i.addCategory(Intent.CATEGORY_DEFAULT);
+    i.setDataAndType(uri, "image/jpeg");
+
+    shadowPackageManager.setQueryIntentImplicitly(true);
+    List<ResolveInfo> activities = shadowPackageManager.queryIntentActivities(i, 0);
+    assertThat(activities).isNotNull();
+    assertThat(activities).hasSize(1);
+    assertThat(activities.get(0).resolvePackageName.toString()).isEqualTo("org.robolectric");
+    assertThat(activities.get(0).activityInfo.targetActivity.toString()).isEqualTo("org.robolectric.shadows.TestActivity");
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestForActivityAliases.xml")
+  public void queryIntentActivities_MatchWithAliasIntents() throws Exception {
+    Intent i = new Intent(Intent.ACTION_MAIN);
+    i.addCategory(Intent.CATEGORY_LAUNCHER);
+
+    shadowPackageManager.setQueryIntentImplicitly(true);
+    List<ResolveInfo> activities = shadowPackageManager.queryIntentActivities(i, 0);
+    assertThat(activities).isNotNull();
+    assertThat(activities).hasSize(1);
+    assertThat(activities.get(0).resolvePackageName.toString()).isEqualTo("org.robolectric");
+    assertThat(activities.get(0).activityInfo.targetActivity.toString()).isEqualTo("org.robolectric.shadows.TestActivity");
+  }
+
+  @Test
+  public void resolveActivity_Match() throws Exception {
+    Intent i = new Intent(Intent.ACTION_MAIN, null).addCategory(Intent.CATEGORY_LAUNCHER);
+    ResolveInfo info = new ResolveInfo();
+    info.nonLocalizedLabel = TEST_PACKAGE_LABEL;
+    shadowPackageManager.addResolveInfoForIntent(i, info);
+
+    assertThat(shadowPackageManager.resolveActivity(i, 0)).isSameAs(info);
+  }
+
+  @Test
+  public void resolveActivity_NoMatch() throws Exception {
+    Intent i = new Intent();
+    i.setComponent(new ComponentName("foo.bar", "No Activity"));
+    assertThat(shadowPackageManager.resolveActivity(i, 0)).isNull();
+  }
+
+  @Test
+  public void queryIntentServices_EmptyResult() throws Exception {
+    Intent i = new Intent(Intent.ACTION_MAIN, null);
+    i.addCategory(Intent.CATEGORY_LAUNCHER);
+
+    List<ResolveInfo> activities = shadowPackageManager.queryIntentServices(i, 0);
+    assertThat(activities).isEmpty();
+  }
+
+  @Test
+  public void queryIntentServices_Match() throws Exception {
+    Intent i = new Intent(Intent.ACTION_MAIN, null);
+
+    ResolveInfo info = new ResolveInfo();
+    info.nonLocalizedLabel = TEST_PACKAGE_LABEL;
+
+    shadowPackageManager.addResolveInfoForIntent(i, info);
+
+    List<ResolveInfo> activities = shadowPackageManager.queryIntentServices(i, 0);
+    assertThat(activities).hasSize(1);
+    assertThat(activities.get(0).nonLocalizedLabel.toString()).isEqualTo(TEST_PACKAGE_LABEL);
+  }
+
+  @Test
+  public void queryBroadcastReceivers_EmptyResult() throws Exception {
+    Intent i = new Intent(Intent.ACTION_MAIN, null);
+    i.addCategory(Intent.CATEGORY_LAUNCHER);
+
+    List<ResolveInfo> broadCastReceivers = shadowPackageManager.queryBroadcastReceivers(i, 0);
+    assertThat(broadCastReceivers).isEmpty();
+  }
+
+  @Test
+  public void queryBroadcastReceivers_Match() throws Exception {
+    Intent i = new Intent(Intent.ACTION_MAIN, null);
+
+    ResolveInfo info = new ResolveInfo();
+    info.nonLocalizedLabel = TEST_PACKAGE_LABEL;
+
+    shadowPackageManager.addResolveInfoForIntent(i, info);
+
+    List<ResolveInfo> broadCastReceivers = shadowPackageManager.queryBroadcastReceivers(i, 0);
+    assertThat(broadCastReceivers).hasSize(1);
+    assertThat(broadCastReceivers.get(0).nonLocalizedLabel.toString())
+        .isEqualTo(TEST_PACKAGE_LABEL);
+  }
+
+  @Test
+  public void resolveService_Match() throws Exception {
+    Intent i = new Intent(Intent.ACTION_MAIN, null);
+    ResolveInfo info = new ResolveInfo();
+    shadowPackageManager.addResolveInfoForIntent(i, info);
+    assertThat(shadowPackageManager.resolveService(i, 0)).isSameAs(info);
+  }
+
+  @Test
+  public void removeResolveInfosForIntent_shouldCauseResolveActivityToReturnNull() throws Exception {
+    Intent intent = new Intent(Intent.ACTION_MAIN, null).addCategory(Intent.CATEGORY_LAUNCHER);
+    ResolveInfo info = new ResolveInfo();
+    info.nonLocalizedLabel = TEST_PACKAGE_LABEL;
+    info.activityInfo = new ActivityInfo();
+    info.activityInfo.packageName = "com.org";
+    shadowPackageManager.addResolveInfoForIntent(intent, info);
+
+    shadowPackageManager.removeResolveInfosForIntent(intent, "com.org");
+
+    assertThat(shadowPackageManager.resolveActivity(intent, 0)).isNull();
+  }
+
+  @Test
+  public void resolveService_NoMatch() throws Exception {
+    Intent i = new Intent();
+    i.setComponent(new ComponentName("foo.bar", "No Activity"));
+    assertThat(shadowPackageManager.resolveService(i, 0)).isNull();
+  }
+
+  @Test
+  public void queryActivityIcons_Match() throws Exception {
+    Intent i = new Intent();
+    i.setComponent(new ComponentName(TEST_PACKAGE_NAME, ""));
+    Drawable d = new BitmapDrawable();
+
+    shadowPackageManager.addActivityIcon(i, d);
+
+    assertThat(shadowPackageManager.getActivityIcon(i)).isSameAs(d);
+    assertThat(shadowPackageManager.getActivityIcon(i.getComponent())).isSameAs(d);
+  }
+
+  @Test
+  public void hasSystemFeature() throws Exception {
+    // uninitialized
+    assertThat(shadowPackageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA)).isFalse();
+
+    // positive
+    shadowPackageManager.setSystemFeature(PackageManager.FEATURE_CAMERA, true);
+    assertThat(shadowPackageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA)).isTrue();
+
+    // negative
+    shadowPackageManager.setSystemFeature(PackageManager.FEATURE_CAMERA, false);
+    assertThat(shadowPackageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA)).isFalse();
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithContentProviders.xml")
+  public void getPackageInfo_getProvidersShouldReturnProviderInfos() throws Exception {
+    PackageInfo packageInfo = shadowPackageManager.getPackageInfo(RuntimeEnvironment.application.getPackageName(), PackageManager.GET_PROVIDERS);
+    ProviderInfo[] providers = packageInfo.providers;
+    assertThat(providers).isNotEmpty();
+    assertThat(providers.length).isEqualTo(3);
+    assertThat(providers[0].packageName).isEqualTo("org.robolectric");
+    assertThat(providers[1].packageName).isEqualTo("org.robolectric");
+    assertThat(providers[2].packageName).isEqualTo("org.robolectric");
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithContentProviders.xml")
+  public void getProviderInfo_shouldReturnProviderInfos() throws Exception {
+    ProviderInfo providerInfo1 = packageManager.getProviderInfo(new ComponentName(RuntimeEnvironment.application, ".tester.FullyQualifiedClassName"), 0);
+    assertThat(providerInfo1.packageName).isEqualTo("org.robolectric");
+    assertThat(providerInfo1.authority).isEqualTo("org.robolectric.authority1");
+
+    ProviderInfo providerInfo2 = packageManager.getProviderInfo(new ComponentName(RuntimeEnvironment.application, "org.robolectric.tester.PartiallyQualifiedClassName"), 0);
+    assertThat(providerInfo2.packageName).isEqualTo("org.robolectric");
+    assertThat(providerInfo2.authority).isEqualTo("org.robolectric.authority2");
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithContentProviders.xml")
+  public void getProviderInfo_shouldPopulatePermissionsInProviderInfos() throws Exception {
+    ProviderInfo providerInfo = packageManager.getProviderInfo(new ComponentName(RuntimeEnvironment.application, "org.robolectric.android.controller.ContentProviderControllerTest$MyContentProvider"), 0);
+    assertThat(providerInfo.authority).isEqualTo("org.robolectric.authority2");
+
+    assertThat(providerInfo.readPermission).isEqualTo("READ_PERMISSION");
+    assertThat(providerInfo.writePermission).isEqualTo("WRITE_PERMISSION");
+
+    assertThat(providerInfo.pathPermissions).hasSize(1);
+    assertThat(providerInfo.pathPermissions[0].getPath()).isEqualTo("/path/*");
+    assertThat(providerInfo.pathPermissions[0].getType()).isEqualTo(PathPermission.PATTERN_SIMPLE_GLOB);
+    assertThat(providerInfo.pathPermissions[0].getReadPermission()).isEqualTo("PATH_READ_PERMISSION");
+    assertThat(providerInfo.pathPermissions[0].getWritePermission()).isEqualTo("PATH_WRITE_PERMISSION");
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithContentProviders.xml")
+  public void resolveContentProvider_shouldResolveByPackageName() throws Exception {
+    ProviderInfo providerInfo = packageManager.resolveContentProvider("org.robolectric.authority1", 0);
+    assertThat(providerInfo.packageName).isEqualTo("org.robolectric");
+    assertThat(providerInfo.authority).isEqualTo("org.robolectric.authority1");
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithNoContentProviders.xml")
+  public void getPackageInfo_getProvidersShouldReturnNullOnNoProviders() throws Exception {
+    PackageInfo packageInfo = shadowPackageManager.getPackageInfo(RuntimeEnvironment.application.getPackageName(), PackageManager.GET_PROVIDERS);
+    ProviderInfo[] providers = packageInfo.providers;
+    assertThat(providers).isNull();
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithReceivers.xml")
+  public void testReceiverInfo() throws Exception {
+    ActivityInfo info = shadowPackageManager.getReceiverInfo(new ComponentName(RuntimeEnvironment.application, ".test.ConfigTestReceiver"), PackageManager.GET_META_DATA);
+    Bundle meta = info.metaData;
+    Object metaValue = meta.get("org.robolectric.metaName1");
+    assertTrue(String.class.isInstance(metaValue));
+    assertEquals("metaValue1", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaName2");
+    assertTrue(String.class.isInstance(metaValue));
+    assertEquals("metaValue2", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaFalse");
+    assertTrue(Boolean.class.isInstance(metaValue));
+    assertEquals(false, metaValue);
+
+    metaValue = meta.get("org.robolectric.metaTrue");
+    assertTrue(Boolean.class.isInstance(metaValue));
+    assertEquals(true, metaValue);
+
+    metaValue = meta.get("org.robolectric.metaInt");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(123, metaValue);
+
+    metaValue = meta.get("org.robolectric.metaFloat");
+    assertTrue(Float.class.isInstance(metaValue));
+    assertEquals(new Float(1.23), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaColor");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(Color.WHITE, metaValue);
+
+    metaValue = meta.get("org.robolectric.metaBooleanFromRes");
+    assertTrue(Boolean.class.isInstance(metaValue));
+    assertEquals(RuntimeEnvironment.application.getResources().getBoolean(R.bool.false_bool_value), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaIntFromRes");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(RuntimeEnvironment.application.getResources().getInteger(R.integer.test_integer1), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaColorFromRes");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(RuntimeEnvironment.application.getResources().getColor(R.color.clear), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringFromRes");
+    assertTrue(String.class.isInstance(metaValue));
+    assertEquals(RuntimeEnvironment.application.getString(R.string.app_name), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringOfIntFromRes");
+    assertTrue(String.class.isInstance(metaValue));
+    assertEquals(RuntimeEnvironment.application.getString(R.string.str_int), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringRes");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(R.string.app_name, metaValue);
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithPermissions.xml")
+  public void testCheckPermissions() throws Exception {
+    assertEquals(PackageManager.PERMISSION_GRANTED, shadowPackageManager.checkPermission("android.permission.INTERNET", RuntimeEnvironment.application.getPackageName()));
+    assertEquals(PackageManager.PERMISSION_GRANTED, shadowPackageManager.checkPermission("android.permission.SYSTEM_ALERT_WINDOW", RuntimeEnvironment.application.getPackageName()));
+    assertEquals(PackageManager.PERMISSION_GRANTED, shadowPackageManager.checkPermission("android.permission.GET_TASKS", RuntimeEnvironment.application.getPackageName()));
+
+    assertEquals(PackageManager.PERMISSION_DENIED, shadowPackageManager.checkPermission("android.permission.ACCESS_FINE_LOCATION", RuntimeEnvironment.application.getPackageName()));
+    assertEquals(PackageManager.PERMISSION_DENIED, shadowPackageManager.checkPermission("android.permission.ACCESS_FINE_LOCATION", "random-package"));
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithReceivers.xml")
+  public void testQueryBroadcastReceiverSucceeds() {
+    Intent intent = new Intent("org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE");
+    intent.setPackage(RuntimeEnvironment.application.getPackageName());
+
+    List<ResolveInfo> receiverInfos = shadowPackageManager.queryBroadcastReceivers(intent, PackageManager.GET_INTENT_FILTERS);
+    assertTrue(receiverInfos.size() == 1);
+    assertEquals("org.robolectric.ConfigTestReceiverPermissionsAndActions", receiverInfos.get(0).activityInfo.name);
+    assertEquals("org.robolectric.CUSTOM_PERM", receiverInfos.get(0).activityInfo.permission);
+    assertEquals("org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE", receiverInfos.get(0).filter.getAction(0));
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithReceivers.xml")
+  public void testQueryBroadcastReceiverFailsForMissingPackageName() {
+    Intent intent = new Intent("org.robolectric.ACTION_ONE_MORE_PACKAGE");
+    List<ResolveInfo> receiverInfos = shadowPackageManager.queryBroadcastReceivers(intent, PackageManager.GET_INTENT_FILTERS);
+    assertTrue(receiverInfos.size() == 0);
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithReceivers.xml")
+  public void testQueryBroadcastReceiverFailsForMissingAction() {
+    Intent intent = new Intent();
+    intent.setPackage(RuntimeEnvironment.application.getPackageName());
+    List<ResolveInfo> receiverInfos = shadowPackageManager.queryBroadcastReceivers(intent, PackageManager.GET_INTENT_FILTERS);
+    assertTrue(receiverInfos.size() == 0);
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithReceiversCustomPackage.xml")
+  public void testGetPackageInfo_ForReceiversSucceeds() throws Exception {
+    PackageInfo receiverInfos = shadowPackageManager.getPackageInfo(RuntimeEnvironment.application.getPackageName(), PackageManager.GET_RECEIVERS);
+
+    assertEquals(1, receiverInfos.receivers.length);
+    assertEquals("org.robolectric.ConfigTestReceiverPermissionsAndActions", receiverInfos.receivers[0].name);
+    assertEquals("org.robolectric.CUSTOM_PERM", receiverInfos.receivers[0].permission);
+  }
+
+  @Test(expected = PackageManager.NameNotFoundException.class)
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithReceiversCustomPackage.xml")
+  public void testGetPackageInfo_ForReceiversIncorrectPackage() throws Exception {
+    try {
+      shadowPackageManager.getPackageInfo("unknown_package", PackageManager.GET_RECEIVERS);
+      fail("should have thrown NameNotFoundException");
+    } catch (PackageManager.NameNotFoundException e) {
+      assertThat(e.getMessage()).contains("unknown_package");
+      throw e;
+    }
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithPermissions.xml")
+  public void getPackageInfo_shouldReturnRequestedPermissions() throws Exception {
+    PackageInfo packageInfo = shadowPackageManager.getPackageInfo(RuntimeEnvironment.application.getPackageName(), PackageManager.GET_PERMISSIONS);
+    String[] permissions = packageInfo.requestedPermissions;
+    assertThat(permissions).isNotNull();
+    assertThat(permissions.length).isEqualTo(3);
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithoutPermissions.xml")
+  public void getPackageInfo_shouldReturnNullOnNoRequestedPermissions() throws Exception {
+    PackageInfo packageInfo = shadowPackageManager.getPackageInfo(RuntimeEnvironment.application.getPackageName(), PackageManager.GET_PERMISSIONS);
+    String[] permissions = packageInfo.requestedPermissions;
+    assertThat(permissions).isNull();
+  }
+
+  @Test
+  public void testGetPreferredActivities() throws Exception {
+    // Setup an intentfilter and add to packagemanager
+    IntentFilter filter = new IntentFilter(Intent.ACTION_MAIN);
+    filter.addCategory(Intent.CATEGORY_HOME);
+    final String packageName = "com.example.dummy";
+    ComponentName name = new ComponentName(packageName, "LauncherActivity");
+    shadowPackageManager.addPreferredActivity(filter, 0, null, name);
+
+    // Test match
+    List<IntentFilter> filters = new ArrayList<>();
+    filters.add(filter);
+
+    List<ComponentName> activities = new ArrayList<>();
+    shadowPackageManager.getPreferredActivities(filters, activities, null);
+
+    assertThat(activities.size()).isEqualTo(1);
+    assertThat(activities.get(0).getPackageName()).isEqualTo(packageName);
+
+    // Test not match
+    IntentFilter filter1 = new IntentFilter(Intent.ACTION_VIEW);
+    filters.add(filter1);
+    filters.clear();
+    activities.clear();
+    filters.add(filter1);
+
+    shadowPackageManager.getPreferredActivities(filters, activities, null);
+
+    assertThat(activities.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void canResolveDrawableGivenPackageAndResourceId() throws Exception {
+    Drawable drawable = ShadowDrawable.createFromStream(new ByteArrayInputStream(new byte[0]), "my_source");
+    shadowPackageManager.addDrawableResolution("com.example.foo", 4334, drawable);
+    Drawable actual = shadowPackageManager.getDrawable("com.example.foo", 4334, null);
+    assertThat(actual).isSameAs(drawable);
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifest.xml")
+  public void shouldAssignTheApplicationNameFromTheManifest() throws Exception {
+    ApplicationInfo applicationInfo = shadowPackageManager.getApplicationInfo("org.robolectric", 0);
+    assertThat(applicationInfo.name).isEqualTo("org.robolectric.TestApplication");
+  }
+
+  @Test
+  public void testLaunchIntentForPackage() {
+    Intent intent = shadowPackageManager.getLaunchIntentForPackage(TEST_PACKAGE_LABEL);
+    assertThat(intent).isNull();
+
+    Intent launchIntent = new Intent(Intent.ACTION_MAIN);
+    launchIntent.setPackage(TEST_PACKAGE_LABEL);
+    launchIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+    ResolveInfo resolveInfo = new ResolveInfo();
+    resolveInfo.activityInfo = new ActivityInfo();
+    resolveInfo.activityInfo.packageName = TEST_PACKAGE_LABEL;
+    resolveInfo.activityInfo.name = "LauncherActivity";
+    shadowPackageManager.addResolveInfoForIntent(launchIntent, resolveInfo);
+
+    intent = shadowPackageManager.getLaunchIntentForPackage(TEST_PACKAGE_LABEL);
+    assertThat(intent).isNotNull();
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithAppMetaData.xml")
+  public void shouldAssignTheAppMetaDataFromTheManifest() throws Exception {
+    ShadowApplication app = ShadowApplication.getInstance();
+    String packageName = app.getAppManifest().getPackageName();
+    ApplicationInfo info = packageManager.getApplicationInfo(packageName, 0);
+    Bundle meta = info.metaData;
+
+    Object metaValue = meta.get("org.robolectric.metaName1");
+    assertTrue(String.class.isInstance(metaValue));
+    assertEquals("metaValue1", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaName2");
+    assertTrue(String.class.isInstance(metaValue));
+    assertEquals("metaValue2", metaValue);
+
+    metaValue = meta.get("org.robolectric.metaFalse");
+    assertTrue(Boolean.class.isInstance(metaValue));
+    assertEquals(false, metaValue);
+
+    metaValue = meta.get("org.robolectric.metaTrue");
+    assertTrue(Boolean.class.isInstance(metaValue));
+    assertEquals(true, metaValue);
+
+    metaValue = meta.get("org.robolectric.metaInt");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(123, metaValue);
+
+    metaValue = meta.get("org.robolectric.metaFloat");
+    assertTrue(Float.class.isInstance(metaValue));
+    assertEquals(new Float(1.23), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaColor");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(Color.WHITE, metaValue);
+
+    metaValue = meta.get("org.robolectric.metaBooleanFromRes");
+    assertTrue(Boolean.class.isInstance(metaValue));
+    assertEquals(RuntimeEnvironment.application.getResources().getBoolean(R.bool.false_bool_value), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaIntFromRes");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(RuntimeEnvironment.application.getResources().getInteger(R.integer.test_integer1), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaColorFromRes");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(RuntimeEnvironment.application.getResources().getColor(R.color.clear), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringFromRes");
+    assertTrue(String.class.isInstance(metaValue));
+    assertEquals(RuntimeEnvironment.application.getString(R.string.app_name), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringOfIntFromRes");
+    assertTrue(String.class.isInstance(metaValue));
+    assertEquals(RuntimeEnvironment.application.getString(R.string.str_int), metaValue);
+
+    metaValue = meta.get("org.robolectric.metaStringRes");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(R.string.app_name, metaValue);
+  }
+
+  @Test
+  public void testResolveDifferentIntentObjects() {
+    Intent intent1 = shadowPackageManager.getLaunchIntentForPackage(TEST_PACKAGE_LABEL);
+    assertThat(intent1).isNull();
+
+    intent1 = new Intent(Intent.ACTION_MAIN);
+    intent1.setPackage(TEST_PACKAGE_LABEL);
+    intent1.addCategory(Intent.CATEGORY_LAUNCHER);
+    ResolveInfo resolveInfo = new ResolveInfo();
+    resolveInfo.activityInfo = new ActivityInfo();
+    resolveInfo.activityInfo.packageName = TEST_PACKAGE_LABEL;
+    resolveInfo.activityInfo.name = "LauncherActivity";
+    shadowPackageManager.addResolveInfoForIntent(intent1, resolveInfo);
+
+    // the original intent object should yield a result
+    ResolveInfo result  = shadowPackageManager.resolveActivity(intent1, -1);
+    assertThat(result).isNotNull();
+
+    // AND a new, functionally equivalent intent should also yield a result
+    Intent intent2 = new Intent(Intent.ACTION_MAIN);
+    intent2.setPackage(TEST_PACKAGE_LABEL);
+    intent2.addCategory(Intent.CATEGORY_LAUNCHER);
+    result = shadowPackageManager.resolveActivity(intent2, -1);
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  public void testResolvePartiallySimilarIntents() {
+    Intent intent1 = shadowPackageManager.getLaunchIntentForPackage(TEST_PACKAGE_LABEL);
+    assertThat(intent1).isNull();
+
+    intent1 = new Intent(Intent.ACTION_MAIN);
+    intent1.setPackage(TEST_PACKAGE_LABEL);
+    intent1.addCategory(Intent.CATEGORY_LAUNCHER);
+    ResolveInfo resolveInfo = new ResolveInfo();
+    resolveInfo.activityInfo = new ActivityInfo();
+    resolveInfo.activityInfo.packageName = TEST_PACKAGE_LABEL;
+    resolveInfo.activityInfo.name = "LauncherActivity";
+    shadowPackageManager.addResolveInfoForIntent(intent1, resolveInfo);
+
+    // the original intent object should yield a result
+    ResolveInfo result  = shadowPackageManager.resolveActivity(intent1, -1);
+    assertThat(result).isNotNull();
+
+    // an intent with just the same action should not be considered the same
+    Intent intent2 = new Intent(Intent.ACTION_MAIN);
+    result = shadowPackageManager.resolveActivity(intent2, -1);
+    assertThat(result).isNull();
+
+    // an intent with just the same category should not be considered the same
+    Intent intent3 = new Intent();
+    intent3.addCategory(Intent.CATEGORY_LAUNCHER);
+    result = shadowPackageManager.resolveActivity(intent3, -1);
+    assertThat(result).isNull();
+
+    // an intent without the correct package restriction should not be the same
+    Intent intent4 = new Intent(Intent.ACTION_MAIN);
+    intent4.addCategory(Intent.CATEGORY_LAUNCHER);
+    result = shadowPackageManager.resolveActivity(intent4, -1);
+    assertThat(result).isNull();
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifest.xml")
+  public void testSetApplicationEnabledSetting() {
+    assertThat(packageManager.getApplicationEnabledSetting("org.robolectric")).isEqualTo(PackageManager.COMPONENT_ENABLED_STATE_DEFAULT);
+
+    packageManager.setApplicationEnabledSetting("org.robolectric", PackageManager.COMPONENT_ENABLED_STATE_DISABLED, 0);
+
+    assertThat(packageManager.getApplicationEnabledSetting("org.robolectric")).isEqualTo(PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifest.xml")
+  public void testSetComponentEnabledSetting() {
+    ComponentName componentName = new ComponentName(RuntimeEnvironment.application, "org.robolectric.component");
+    assertThat(packageManager.getComponentEnabledSetting(componentName)).isEqualTo(PackageManager.COMPONENT_ENABLED_STATE_DEFAULT);
+
+    packageManager.setComponentEnabledSetting(componentName, PackageManager.COMPONENT_ENABLED_STATE_DISABLED, 0);
+
+    assertThat(packageManager.getComponentEnabledSetting(componentName)).isEqualTo(PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+  }
+
+  public static class ActivityWithMetadata extends Activity { }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifest.xml")
+  public void getActivityMetaData() throws Exception {
+    Activity activity = setupActivity(ActivityWithMetadata.class);
+
+    ActivityInfo activityInfo = packageManager.getActivityInfo(activity.getComponentName(), PackageManager.GET_ACTIVITIES|PackageManager.GET_META_DATA);
+    assertThat(activityInfo.metaData.get("someName")).isEqualTo("someValue");
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifest.xml")
+  public void shouldAssignLabelResFromTheManifest() throws Exception {
+    ApplicationInfo applicationInfo = shadowPackageManager.getApplicationInfo("org.robolectric", 0);
+    assertThat(applicationInfo.labelRes).isEqualTo(R.string.app_name);
+    assertThat(applicationInfo.nonLocalizedLabel).isNull();
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithAppMetaData.xml")
+  public void shouldAssignNonLocalizedLabelFromTheManifest() throws Exception {
+    ApplicationInfo applicationInfo = shadowPackageManager.getApplicationInfo("org.robolectric", 0);
+    assertThat(applicationInfo.labelRes).isEqualTo(0);
+    assertThat(applicationInfo.nonLocalizedLabel).isEqualTo("App Label");
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestPackageManagerGetServiceInfo.xml")
+  public void getServiceInfo_shouldReturnServiceInfoIfExists() throws Exception {
+    ServiceInfo serviceInfo = shadowPackageManager.getServiceInfo(new ComponentName("org.robolectric", "com.foo.Service"), PackageManager.GET_SERVICES);
+    assertEquals(serviceInfo.packageName, "org.robolectric");
+    assertEquals(serviceInfo.name, "com.foo.Service");
+    assertEquals(serviceInfo.permission, "com.foo.MY_PERMISSION");
+    assertNotNull(serviceInfo.applicationInfo);
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestPackageManagerGetServiceInfo.xml")
+  public void getServiceInfo_shouldReturnServiceInfoWithMetaDataWhenFlagsSet() throws Exception {
+    ServiceInfo serviceInfo = shadowPackageManager.getServiceInfo(new ComponentName("org.robolectric", "com.foo.Service"), PackageManager.GET_META_DATA);
+    assertNotNull(serviceInfo.metaData);
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestPackageManagerGetServiceInfo.xml")
+  public void getServiceInfo_shouldReturnServiceInfoWithoutMetaDataWhenFlagsNotSet() throws Exception {
+    ServiceInfo serviceInfo = shadowPackageManager.getServiceInfo(new ComponentName("org.robolectric", "com.foo.Service"), PackageManager.GET_SERVICES);
+    assertNull(serviceInfo.metaData);
+  }
+
+  @Test(expected = PackageManager.NameNotFoundException.class)
+  @Config(manifest = "src/test/resources/TestPackageManagerGetServiceInfo.xml")
+  public void getServiceInfo_shouldThrowNameNotFoundExceptionIfNotExist() throws Exception {
+    ComponentName nonExistComponent = new ComponentName("org.robolectric", "com.foo.NonExistService");
+    try {
+      shadowPackageManager.getServiceInfo(nonExistComponent, PackageManager.GET_SERVICES);
+      fail("should have thrown NameNotFoundException");
+    } catch (PackageManager.NameNotFoundException e) {
+      assertThat(e.getMessage()).contains("com.foo.NonExistService");
+      throw e;
+    }
+  }
+
+  @Test
+  public void getNameForUid() {
+    assertThat(packageManager.getNameForUid(10)).isNull();
+
+    shadowPackageManager.setNameForUid(10, "a_name");
+
+    assertThat(packageManager.getNameForUid(10)).isEqualTo("a_name");
+  }
+
+  @Test
+  public void getPackagesForUid() {
+    assertThat(packageManager.getPackagesForUid(10)).isNull();
+
+    shadowPackageManager.setPackagesForUid(10, new String[] {"a_name"});
+
+    assertThat(packageManager.getPackagesForUid(10)).containsExactly("a_name");
+  }
+
+  @Test
+  public void getResourcesForApplication_currentApplication() throws Exception {
+    assertThat(packageManager.getResourcesForApplication("org.robolectric").getString(R.string.app_name))
+        .isEqualTo(RuntimeEnvironment.application.getString(R.string.app_name));
+  }
+
+  @Test(expected = PackageManager.NameNotFoundException.class)
+  public void getResourcesForApplication_unknownPackage() throws Exception {
+    packageManager.getResourcesForApplication("non.existent.package");
+  }
+
+  @Test @Config(minSdk = M)
+  public void shouldShowRequestPermissionRationale() {
+    assertThat(packageManager.shouldShowRequestPermissionRationale(Manifest.permission.CAMERA)).isFalse();
+
+    shadowPackageManager.setShouldShowRequestPermissionRationale(Manifest.permission.CAMERA, true);
+
+    assertThat(packageManager.shouldShowRequestPermissionRationale(Manifest.permission.CAMERA)).isTrue();
+  }
+
+  @Test
+  public void getSystemAvailableFeatures() {
+    assertThat(packageManager.getSystemAvailableFeatures()).isNull();
+
+    FeatureInfo feature = new FeatureInfo();
+    feature.reqGlEsVersion = 0x20000;
+    feature.flags = FeatureInfo.FLAG_REQUIRED;
+    shadowPackageManager.addSystemAvailableFeature(feature);
+
+    assertThat(packageManager.getSystemAvailableFeatures()).contains(feature);
+
+    shadowPackageManager.clearSystemAvailableFeatures();
+
+    assertThat(packageManager.getSystemAvailableFeatures()).isNull();
+  }
+
+  @Test
+  public void verifyPendingInstall() {
+    packageManager.verifyPendingInstall(1234, VERIFICATION_ALLOW);
+
+    assertThat(shadowPackageManager.getVerificationResult(1234)).isEqualTo(VERIFICATION_ALLOW);
+  }
+
+  @Test
+  @Config(minSdk = N)
+  public void whenPackageNotPresent_getPackageSizeInfo_callsBackWithFailure() throws Exception {
+    packageManager.getPackageSizeInfo("nonexistant.package", packageStatsObserver);
+
+    verify(packageStatsObserver).onGetStatsCompleted(packageStatsCaptor.capture(), eq(false));
+    assertThat(packageStatsCaptor.getValue()).isNull();
+  }
+
+  @Test
+  @Config(minSdk = N)
+  public void whenPackageNotPresentAndPaused_getPackageSizeInfo_callsBackWithFailure() throws Exception {
+    Robolectric.getForegroundThreadScheduler().pause();
+
+    packageManager.getPackageSizeInfo("nonexistant.package", packageStatsObserver);
+
+    verifyZeroInteractions(packageStatsObserver);
+
+    Robolectric.getForegroundThreadScheduler().advanceToLastPostedRunnable();
+    verify(packageStatsObserver).onGetStatsCompleted(packageStatsCaptor.capture(), eq(false));
+    assertThat(packageStatsCaptor.getValue()).isNull();
+  }
+
+  @Test
+  public void whenNotPreconfigured_getPackageSizeInfo_callsBackWithDefaults() throws Exception {
+    packageManager.getPackageSizeInfo("org.robolectric", packageStatsObserver);
+
+    verify(packageStatsObserver).onGetStatsCompleted(packageStatsCaptor.capture(), eq(true));
+    assertThat(packageStatsCaptor.getValue().packageName).isEqualTo("org.robolectric");
+  }
+
+  @Test
+  @Config(minSdk = N)
+  public void whenPreconfigured_getPackageSizeInfo_callsBackWithConfiguredValues() throws Exception {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = "org.robolectric";
+    PackageStats packageStats = new PackageStats("org.robolectric");
+    shadowPackageManager.addPackage(packageInfo, packageStats);
+
+    packageManager.getPackageSizeInfo("org.robolectric", packageStatsObserver);
+
+    verify(packageStatsObserver).onGetStatsCompleted(packageStatsCaptor.capture(), eq(true));
+    assertThat(packageStatsCaptor.getValue().packageName).isEqualTo("org.robolectric");
+    assertThat(packageStatsCaptor.getValue().toString()).isEqualTo(packageStats.toString());
+  }
+
+  @Test
+  @Config(minSdk = N)
+  public void whenPreconfiguredForAnotherPackage_getPackageSizeInfo_callsBackWithConfiguredValues() throws Exception {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = "org.other";
+    PackageStats packageStats = new PackageStats("org.other");
+    shadowPackageManager.addPackage(packageInfo, packageStats);
+
+    packageManager.getPackageSizeInfo("org.other", packageStatsObserver);
+
+    verify(packageStatsObserver).onGetStatsCompleted(packageStatsCaptor.capture(), eq(true));
+    assertThat(packageStatsCaptor.getValue().packageName).isEqualTo("org.other");
+    assertThat(packageStatsCaptor.getValue().toString()).isEqualTo(packageStats.toString());
+  }
+
+  @Test
+  @Config(minSdk = N)
+  public void whenPaused_getPackageSizeInfo_callsBackWithConfiguredValuesAfterIdle() throws Exception {
+    Robolectric.getForegroundThreadScheduler().pause();
+
+    packageManager.getPackageSizeInfo("org.robolectric", packageStatsObserver);
+
+    verifyZeroInteractions(packageStatsObserver);
+
+    Robolectric.getForegroundThreadScheduler().advanceToLastPostedRunnable();
+    verify(packageStatsObserver).onGetStatsCompleted(packageStatsCaptor.capture(), eq(true));
+    assertThat(packageStatsCaptor.getValue().packageName).isEqualTo("org.robolectric");
+  }
+
+  @Test
+  public void currentToCanonicalPackageNames() {
+    shadowPackageManager.addCurrentToCannonicalName("current_name_1", "cannonical_name_1");
+    shadowPackageManager.addCurrentToCannonicalName("current_name_2", "cannonical_name_2");
+
+    packageManager.currentToCanonicalPackageNames(new String[] {"current_name_1", "current_name_2"});
+  }
+
+  @Test
+  public void getInstalledApplications() {
+    List<ApplicationInfo> installedApplications = packageManager.getInstalledApplications(0);
+
+    // Default should include the application under test
+    assertThat(installedApplications).hasSize(1);
+    assertThat(installedApplications.get(0).packageName).isEqualTo("org.robolectric");
+
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = "org.other";
+    packageInfo.applicationInfo = new ApplicationInfo();
+    packageInfo.applicationInfo.packageName = "org.other";
+    shadowPackageManager.addPackage(packageInfo);
+
+    installedApplications = packageManager.getInstalledApplications(0);
+    assertThat(installedApplications).hasSize(2);
+    assertThat(installedApplications.get(1).packageName).isEqualTo("org.other");
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithPermissions.xml")
+  public void getPermissionInfo() throws Exception {
+    PermissionInfo permission = RuntimeEnvironment.application.getPackageManager().getPermissionInfo("some_permission", 0);
+    assertThat(permission.labelRes).isEqualTo(R.string.test_permission_label);
+    assertThat(permission.descriptionRes).isEqualTo(R.string.test_permission_description);
+    assertThat(permission.name).isEqualTo("some_permission");
+  }
+
+  @Test
+  public void checkSignatures_same() throws Exception {
+    shadowPackageManager.addPackage(newPackageInfo("first.package", new Signature("00000000")));
+    shadowPackageManager.addPackage(newPackageInfo("second.package", new Signature("00000000")));
+    assertThat(packageManager.checkSignatures("first.package", "second.package")).isEqualTo(SIGNATURE_MATCH);
+  }
+
+  @Test
+  public void checkSignatures_firstNotSigned() throws Exception {
+    shadowPackageManager.addPackage(newPackageInfo("first.package", (Signature[]) null));
+    shadowPackageManager.addPackage(newPackageInfo("second.package", new Signature("00000000")));
+    assertThat(packageManager.checkSignatures("first.package", "second.package")).isEqualTo(SIGNATURE_FIRST_NOT_SIGNED);
+  }
+
+  @Test
+  public void checkSignatures_secondNotSigned() throws Exception {
+    shadowPackageManager.addPackage(newPackageInfo("first.package", new Signature("00000000")));
+    shadowPackageManager.addPackage(newPackageInfo("second.package", (Signature[]) null));
+    assertThat(packageManager.checkSignatures("first.package", "second.package")).isEqualTo(SIGNATURE_SECOND_NOT_SIGNED);
+  }
+
+  @Test
+  public void checkSignatures_neitherSigned() throws Exception {
+    shadowPackageManager.addPackage(newPackageInfo("first.package", (Signature[]) null));
+    shadowPackageManager.addPackage(newPackageInfo("second.package", (Signature[]) null));
+    assertThat(packageManager.checkSignatures("first.package", "second.package")).isEqualTo(SIGNATURE_NEITHER_SIGNED);
+  }
+
+  @Test
+  public void checkSignatures_noMatch() throws Exception {
+    shadowPackageManager.addPackage(newPackageInfo("first.package", new Signature("00000000")));
+    shadowPackageManager.addPackage(newPackageInfo("second.package", new Signature("FFFFFFFF")));
+    assertThat(packageManager.checkSignatures("first.package", "second.package")).isEqualTo(SIGNATURE_NO_MATCH);
+  }
+
+  @Test
+  public void checkSignatures_noMatch_mustBeExact() throws Exception {
+    shadowPackageManager.addPackage(newPackageInfo("first.package", new Signature("00000000")));
+    shadowPackageManager.addPackage(newPackageInfo("second.package", new Signature("00000000"), new Signature("FFFFFFFF")));
+    assertThat(packageManager.checkSignatures("first.package", "second.package")).isEqualTo(SIGNATURE_NO_MATCH);
+  }
+
+  @Test
+  public void checkSignatures_unknownPackage() throws Exception {
+    assertThat(packageManager.checkSignatures("first.package", "second.package")).isEqualTo(SIGNATURE_UNKNOWN_PACKAGE);
+  }
+
+  private static PackageInfo newPackageInfo(String packageName, Signature... signatures) {
+    PackageInfo firstPackageInfo = new PackageInfo();
+    firstPackageInfo.packageName = packageName;
+    firstPackageInfo.signatures = signatures;
+    return firstPackageInfo;
+  }
+
+  @Test(expected = PackageManager.NameNotFoundException.class)
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithPermissions.xml")
+  public void getPermissionInfo_notFound() throws Exception {
+    packageManager.getPermissionInfo("non_existant_permission", 0);
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithPermissions.xml")
+  public void getPermissionInfo_noMetaData() throws Exception {
+    PermissionInfo permission = packageManager.getPermissionInfo("some_permission", 0);
+    assertThat(permission.metaData).isNull();
+    assertThat(permission.name).isEqualTo("some_permission");
+    assertThat(permission.descriptionRes).isEqualTo(R.string.test_permission_description);
+    assertThat(permission.labelRes).isEqualTo(R.string.test_permission_label);
+    assertThat(permission.nonLocalizedLabel).isNullOrEmpty();
+    assertThat(permission.group).isEqualTo("my_permission_group");
+    assertThat(permission.protectionLevel).isEqualTo(PermissionInfo.PROTECTION_DANGEROUS);
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithPermissions.xml")
+  public void getPermissionInfo_withMetaData() throws Exception {
+    PermissionInfo permission = packageManager.getPermissionInfo("some_permission", PackageManager.GET_META_DATA);
+    assertThat(permission.metaData).isNotNull();
+    assertThat(permission.metaData.getString("meta_data_name")).isEqualTo("meta_data_value");
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestWithPermissions.xml")
+  public void getPermissionInfo_withLiteralLabel() throws Exception {
+    PermissionInfo permission = packageManager.getPermissionInfo("permission_with_literal_label", 0);
+    assertThat(permission.labelRes).isEqualTo(0);
+    assertThat(permission.nonLocalizedLabel).isEqualTo("Literal label");
+    assertThat(permission.protectionLevel).isEqualTo(PermissionInfo.PROTECTION_NORMAL);
+  }
+
+  @Test
+  public void getDefaultActivityIcon() {
+    assertThat(packageManager.getDefaultActivityIcon()).isNotNull();
+  }
+
+  @Test
+  public void addPackageShouldUseUidToProvidePackageName() throws Exception {
+    PackageInfo packageInfoOne = new PackageInfo();
+    packageInfoOne.packageName = "package.one";
+    packageInfoOne.applicationInfo = new ApplicationInfo();
+    packageInfoOne.applicationInfo.uid = 1234;
+    packageInfoOne.applicationInfo.packageName = packageInfoOne.packageName;
+    shadowPackageManager.addPackage(packageInfoOne);
+
+    PackageInfo packageInfoTwo = new PackageInfo();
+    packageInfoTwo.packageName = "package.two";
+    packageInfoTwo.applicationInfo = new ApplicationInfo();
+    packageInfoTwo.applicationInfo.uid = 1234;
+    packageInfoTwo.applicationInfo.packageName = packageInfoTwo.packageName;
+    shadowPackageManager.addPackage(packageInfoTwo);
+
+    assertThat(packageManager.getPackagesForUid(1234)).containsExactlyInAnyOrder("package.one", "package.two");
+  }
+
+  @Test
+  public void installerPackageName() throws Exception {
+    packageManager.setInstallerPackageName("target.package", "installer.package");
+
+    assertThat(packageManager.getInstallerPackageName("target.package")).isEqualTo("installer.package");
+  }
+}

--- a/robolectric/src/test/resources/TestAndroidManifest.xml
+++ b/robolectric/src/test/resources/TestAndroidManifest.xml
@@ -23,6 +23,10 @@
         <meta-data android:name="someName" android:value="someValue"/>
     </activity>
 
+    <activity android:name="org.robolectric.shadows.ShadowPackageManagerTest$ActivityWithMetadata">
+      <meta-data android:name="someName" android:value="someValue"/>
+    </activity>
+
     <activity android:name="org.robolectric.android.DefaultPackageManagerTest$ActivityWithConfigChanges"
               android:configChanges="mcc|screenLayout|orientation"/>
 

--- a/robolectric/src/test/resources/TestAndroidManifest25.xml
+++ b/robolectric/src/test/resources/TestAndroidManifest25.xml
@@ -23,6 +23,10 @@
         <meta-data android:name="someName" android:value="someValue"/>
     </activity>
 
+    <activity android:name="org.robolectric.shadows.ShadowPackageManagerTest$ActivityWithMetadata">
+      <meta-data android:name="someName" android:value="someValue"/>
+    </activity>
+
     <activity android:name="org.robolectric.shadows.ShadowActivityTest$LabelTestActivity1" />
     <activity android:name="org.robolectric.shadows.ShadowActivityTest$LabelTestActivity2"
               android:label="@string/activity_name"/>


### PR DESCRIPTION
Create `ShadowPackageManager` & `ShadowApplicationPackageManager`.

For now these just delegate to `RuntimeEnvironment.getPackageManager()` or `RuntimeEnvironment.getRobolectricPackageManager()` depending where the method definition lives.

Remove `ShadowContextImpl.getPackageManager()` to ensure getting a real `ApplicationPackageManager` instead.