### PR TITLE
Add support for the buck build system

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -10,6 +10,7 @@ import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
 import org.robolectric.annotation.Config;
 import org.robolectric.internal.AndroidConfigurer;
+import org.robolectric.internal.BuckManifestFactory;
 import org.robolectric.internal.GradleManifestFactory;
 import org.robolectric.internal.SandboxFactory;
 import org.robolectric.internal.SandboxTestRunner;
@@ -353,7 +354,9 @@ public class RobolectricTestRunner extends SandboxTestRunner {
   protected ManifestFactory getManifestFactory(Config config) {
     Class<?> buildConstants = config.constants();
     //noinspection ConstantConditions
-    if (buildConstants != null && buildConstants != Void.class) {
+    if (BuckManifestFactory.isBuck()) {
+      return new BuckManifestFactory();
+    } else if (buildConstants != null && buildConstants != Void.class) {
       return new GradleManifestFactory();
     } else {
       return new MavenManifestFactory();

--- a/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
@@ -40,9 +40,9 @@ public class BuckManifestFactory implements ManifestFactory {
     final List<String> buckAssets = buckAssetsDirs == null ? null :
               Arrays.asList(buckAssetsDirs.split(File.pathSeparator));
 
-    final FsFile resDir = buckResources == null ? null :
+    final FsFile resDir = (buckResources == null || "".equals(buckResources)) ? null :
             Fs.fileFromPath(buckResources.get(buckResources.size() - 1));
-    final FsFile assetsDir = buckAssets == null ? null :
+    final FsFile assetsDir = (buckAssets == null || "".equals(buckAssets)) ? null :
             Fs.fileFromPath(buckAssets.get(buckAssets.size() - 1));
 
     Logger.debug("Robolectric assets directory: " + (assetsDir == null ? null : assetsDir.getPath()));

--- a/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
@@ -1,0 +1,77 @@
+package org.robolectric.internal;
+
+import org.robolectric.annotation.Config;
+import org.robolectric.manifest.AndroidManifest;
+import org.robolectric.res.Fs;
+import org.robolectric.res.FsFile;
+import org.robolectric.res.ResourcePath;
+import org.robolectric.util.Logger;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.ListIterator;
+
+public class BuckManifestFactory implements ManifestFactory {
+
+  private static final String BUCK_ROBOLECTRIC_RES_DIRECTORIES = "buck.robolectric_res_directories";
+  private static final String BUCK_ROBOLECTRIC_ASSETS_DIRECTORIES = "buck.robolectric_assets_directories";
+  private static final String BUCK_ROBOLECTRIC_MANIFEST = "buck.robolectric_manifest";
+
+  @Override
+  public ManifestIdentifier identify(Config config) {
+    String buckManifest = System.getProperty(BUCK_ROBOLECTRIC_MANIFEST);
+    FsFile manifestFile = Fs.fileFromPath(buckManifest);
+    return new ManifestIdentifier(manifestFile, null, null, config.packageName(), null);
+  }
+
+  @Override
+  public AndroidManifest create(ManifestIdentifier manifestIdentifier) {
+    String buckResDirs = System.getProperty(BUCK_ROBOLECTRIC_RES_DIRECTORIES);
+    String buckAssetsDirs = System.getProperty(BUCK_ROBOLECTRIC_ASSETS_DIRECTORIES);
+    String packageName = manifestIdentifier.getPackageName();
+    FsFile manifestFile = manifestIdentifier.getManifestFile();
+
+    final List<String> buckResources = buckResDirs == null ? null :
+            Arrays.asList(buckResDirs.split(File.pathSeparator));
+    final List<String> buckAssets = buckAssetsDirs == null ? null :
+              Arrays.asList(buckAssetsDirs.split(File.pathSeparator));
+
+    final FsFile resDir = buckResources == null ? null :
+            Fs.fileFromPath(buckResources.get(buckResources.size() - 1));
+    final FsFile assetsDir = buckAssets == null ? null :
+            Fs.fileFromPath(buckAssets.get(buckAssets.size() - 1));
+
+    Logger.debug("Robolectric assets directory: " + (assetsDir == null ? null : assetsDir.getPath()));
+    Logger.debug("   Robolectric res directory: " + (resDir == null ? null : resDir.getPath()));
+    Logger.debug("   Robolectric manifest path: " + manifestFile.getPath());
+    Logger.debug("    Robolectric package name: " + packageName);
+
+    return new AndroidManifest(manifestFile, resDir, assetsDir, packageName) {
+        @Override
+        public List<ResourcePath> getIncludedResourcePaths() {
+            Collection<ResourcePath> resourcePaths = new LinkedHashSet<>(); // Needs stable ordering and no duplicates
+            resourcePaths.add(super.getResourcePath());
+
+            // Add all the buck resource folders, no duplicates as they are being added to a set.
+            if (buckResources != null) {
+                ListIterator<String> it = buckResources.listIterator(buckResources.size());
+                while (it.hasPrevious()) {
+                    resourcePaths.add(new ResourcePath(
+                            getRClass(),
+                            Fs.fileFromPath(it.previous()),
+                            getAssetsDirectory()));
+                }
+            }
+            return new ArrayList<>(resourcePaths);
+        }
+    };
+  }
+
+  public static boolean isBuck() {
+    return System.getProperty(BUCK_ROBOLECTRIC_MANIFEST) != null;
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/internal/ManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ManifestFactory.java
@@ -11,6 +11,7 @@ import org.robolectric.manifest.AndroidManifest;
  * <ul>
  *   <li>Maven</li>
  *   <li>Gradle</li>
+ *   <li>Buck</li>
  * </ul>
  */
 public interface ManifestFactory {

--- a/robolectric/src/test/java/org/robolectric/internal/BuckManifestFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/BuckManifestFactoryTest.java
@@ -1,0 +1,59 @@
+package org.robolectric.internal;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.annotation.Config;
+import org.robolectric.manifest.AndroidManifest;
+import org.robolectric.res.FileFsFile;
+import org.robolectric.res.ResourcePath;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BuckManifestFactoryTest {
+
+  private Config.Builder configBuilder;
+  private BuckManifestFactory buckManifestFactory;
+
+  @Before
+  public void setUp() throws Exception {
+    configBuilder = Config.Builder.defaults().setPackageName("com.robolectric.buck");
+    System.setProperty("buck.robolectric_manifest", "buck/AndroidManifest.xml");
+    System.setProperty("buck.robolectric_res_directories", "buck/res1:buck/res2");
+    System.setProperty("buck.robolectric_assets_directories", "buck/assets");
+    buckManifestFactory = new BuckManifestFactory();
+  }
+
+  @After
+  public void tearDown() {
+    System.clearProperty("buck.robolectric_manifest");
+    System.clearProperty("buck.robolectric_res_directories");
+    System.clearProperty("buck.robolectric_assets_directories");
+  }
+
+  @Test public void identify() throws Exception {
+    ManifestIdentifier manifestIdentifier = buckManifestFactory.identify(configBuilder.build());
+    assertThat(manifestIdentifier.getManifestFile())
+        .isEqualTo(FileFsFile.from("buck/AndroidManifest.xml"));
+    assertThat(manifestIdentifier.getPackageName())
+        .isEqualTo("com.robolectric.buck");
+  }
+
+  @Test public void multiple_res_dirs() throws Exception {
+    ManifestIdentifier manifestIdentifier = buckManifestFactory.identify(configBuilder.build());
+    AndroidManifest manifest = buckManifestFactory.create(manifestIdentifier);
+    assertThat(manifest.getResDirectory())
+            .isEqualTo(FileFsFile.from("buck/res2"));
+    assertThat(manifest.getAssetsDirectory())
+            .isEqualTo(FileFsFile.from("buck/assets"));
+
+    List<ResourcePath> resourcePathList = manifest.getIncludedResourcePaths();
+    assertThat(resourcePathList.size()).isEqualTo(2);
+    assertThat(resourcePathList).containsExactly(
+            new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res2"), FileFsFile.from("buck/assets")),
+            new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res1"), FileFsFile.from("buck/assets"))
+    );
+  }
+}


### PR DESCRIPTION
### Overview
This PR adds support for the [buck](https://buckbuild.com/) build system. It is mostly based off the supported features in [RobolectricTest](https://github.com/facebook/buck/blob/master/src/com/facebook/buck/android/RobolectricTest.java)

### Proposed Changes
- Adds a new `BuckManifestFactory` and corresponding tests to let robolectric run tests in buck without requiring a custom test runner.
- The logic for `asset` directories is not available in buck yet, but plan to open a PR on buck to add the same.