### PR TITLE
Observe descendant URI changes

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
@@ -69,6 +70,7 @@ public class ShadowContentResolver {
   private final List<UriPermission> uriPermissions = new ArrayList<>();
 
   private final Map<Uri, CopyOnWriteArraySet<ContentObserver>> contentObservers = new HashMap<>();
+  private final Set<ContentObserver> descendantsObservers = new CopyOnWriteArraySet<>();
 
   private static final Map<String, Map<Account, Status>> syncableAccounts = new HashMap<>();
   private static final Map<String, ContentProvider> providers = new HashMap<>();
@@ -355,17 +357,29 @@ public class ShadowContentResolver {
   public void notifyChange(Uri uri, ContentObserver observer, boolean syncToNetwork) {
     notifiedUris.add(new NotifiedUri(uri, observer, syncToNetwork));
 
-    CopyOnWriteArraySet<ContentObserver> observers;
+    CopyOnWriteArraySet<ContentObserver> observers = new CopyOnWriteArraySet<>();
     synchronized (this) {
-      observers = contentObservers.get(uri);
-    }
-    if (observers != null) {
-      for (ContentObserver obs : observers) {
-        if (obs != null && obs != observer) {
-          obs.dispatchChange(false, uri);
+      Set<Uri> uris = contentObservers.keySet();
+      for (Uri registeredUri : uris) {
+        CopyOnWriteArraySet<ContentObserver> registeredObservers = contentObservers.get(registeredUri);
+
+        if (uri.equals(registeredUri)) {
+          observers.addAll(registeredObservers);
+        } else if (uri.toString().startsWith(registeredUri.toString())) {
+          for (ContentObserver registeredObserver : registeredObservers) {
+            if (descendantsObservers.contains(registeredObserver)) {
+              observers.add(registeredObserver);
+            }
+          }
         }
       }
     }
+    for (ContentObserver obs : observers) {
+      if (obs != null && obs != observer) {
+        obs.dispatchChange(false, uri);
+      }
+    }
+
     if (observer != null && observer.deliverSelfNotifications()) {
       observer.dispatchChange(true, uri);
     }
@@ -711,6 +725,10 @@ public class ShadowContentResolver {
     return notifiedUris;
   }
 
+  public Set<ContentObserver> getDescendantsObservers() {
+    return descendantsObservers;
+  }
+
   public List<ContentProviderOperation> getContentProviderOperations(String authority) {
     List<ContentProviderOperation> operations = contentProviderOperations.get(authority);
     if (operations == null)
@@ -730,6 +748,10 @@ public class ShadowContentResolver {
       contentObservers.put(uri, observers);
     }
     observers.add(observer);
+
+    if (notifyForDescendents) {
+      descendantsObservers.add(observer);
+    }
   }
 
   @Implementation
@@ -747,6 +769,7 @@ public class ShadowContentResolver {
       for (CopyOnWriteArraySet<ContentObserver> observers : observerSets) {
         observers.remove(observer);
       }
+      descendantsObservers.remove(observer);
     }
   }
 
@@ -759,6 +782,7 @@ public class ShadowContentResolver {
   @SuppressWarnings({"unused", "WeakerAccess"})
   synchronized public void clearContentObservers() {
     contentObservers.clear();
+    descendantsObservers.clear();
   }
 
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
@@ -354,22 +354,20 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public void notifyChange(Uri uri, ContentObserver observer, boolean syncToNetwork) {
+  synchronized public void notifyChange(Uri uri, ContentObserver observer, boolean syncToNetwork) {
     notifiedUris.add(new NotifiedUri(uri, observer, syncToNetwork));
 
     CopyOnWriteArraySet<ContentObserver> observers = new CopyOnWriteArraySet<>();
-    synchronized (this) {
-      Set<Uri> uris = contentObservers.keySet();
-      for (Uri registeredUri : uris) {
-        CopyOnWriteArraySet<ContentObserver> registeredObservers = contentObservers.get(registeredUri);
+    Set<Uri> uris = contentObservers.keySet();
+    for (Uri registeredUri : uris) {
+      CopyOnWriteArraySet<ContentObserver> registeredObservers = contentObservers.get(registeredUri);
 
-        if (uri.equals(registeredUri)) {
-          observers.addAll(registeredObservers);
-        } else if (uri.toString().startsWith(registeredUri.toString())) {
-          for (ContentObserver registeredObserver : registeredObservers) {
-            if (descendantsObservers.contains(registeredObserver)) {
-              observers.add(registeredObserver);
-            }
+      if (uri.equals(registeredUri)) {
+        observers.addAll(registeredObservers);
+      } else if (uri.toString().startsWith(registeredUri.toString())) {
+        for (ContentObserver registeredObserver : registeredObservers) {
+          if (descendantsObservers.contains(registeredObserver)) {
+            observers.add(registeredObserver);
           }
         }
       }


### PR DESCRIPTION
### Overview
ContentResolver should notify observer registered with notifyForDescendants flag for descendants changes on URI. Observer registered on URI 'content://external' with notifyForDescendants = true should be notified on URI 'content://external/1' change

### Proposed Changes
Save notifyForDescendants observers in additional Set and notify them as needed.
