### PR TITLE
PackageManager cleanup.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/RuntimeEnvironment.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/RuntimeEnvironment.java
@@ -74,6 +74,10 @@ public class RuntimeEnvironment {
     activityThread = newActivityThread;
   }
 
+  /**
+   * @deprecated Prefer Android API {@link android.content.Context#getPackageManager()} instead.
+   */
+  @Deprecated
   public static PackageManager getPackageManager() {
     return (PackageManager) packageManager;
   }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
@@ -35,7 +35,7 @@ public class ShadowActivityThread {
           String packageName = (String) args[0];
           int flags = (Integer) args[1];
           try {
-            return RuntimeEnvironment.getPackageManager().getApplicationInfo(packageName, flags);
+            return RuntimeEnvironment.application.getPackageManager().getApplicationInfo(packageName, flags);
           } catch (PackageManager.NameNotFoundException e) {
             return null;
           }

--- a/robolectric/src/main/java/org/robolectric/android/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/android/ParallelUniverse.java
@@ -3,10 +3,8 @@ package org.robolectric.android;
 import android.app.Application;
 import android.app.LoadedApk;
 import android.content.Context;
-import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Looper;
@@ -20,19 +18,16 @@ import org.robolectric.annotation.Config;
 import org.robolectric.internal.ParallelUniverseInterface;
 import org.robolectric.internal.SdkConfig;
 import org.robolectric.android.fakes.RoboInstrumentation;
-import org.robolectric.manifest.ActivityData;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.manifest.RoboNotFoundException;
 import org.robolectric.res.*;
 import org.robolectric.res.builder.DefaultPackageManager;
-import org.robolectric.res.builder.RobolectricPackageManager;
 import org.robolectric.shadows.ShadowLooper;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.Scheduler;
 
 import java.lang.reflect.Method;
 import java.security.Security;
-import java.util.Map;
 
 import static org.robolectric.util.ReflectionHelpers.ClassParameter;
 
@@ -113,7 +108,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
 
       ApplicationInfo applicationInfo;
       try {
-        applicationInfo = RuntimeEnvironment.getPackageManager().getApplicationInfo(appManifest.getPackageName(), 0);
+        applicationInfo = packageManager.getApplicationInfo(appManifest.getPackageName(), 0);
       } catch (PackageManager.NameNotFoundException e) {
         throw new RuntimeException(e);
       }
@@ -132,8 +127,6 @@ public class ParallelUniverse implements ParallelUniverseInterface {
       } catch (PackageManager.NameNotFoundException e) {
         throw new RuntimeException(e);
       }
-
-      addManifestActivitiesToPackageManager(appManifest, application);
 
       Resources appResources = application.getResources();
       ReflectionHelpers.setField(loadedApk, "mResources", appResources);
@@ -159,20 +152,6 @@ public class ParallelUniverse implements ParallelUniverseInterface {
       labelRes = id != null ? id : 0;
     }
     packageManager.addManifest(appManifest, labelRes);
-  }
-
-  private void addManifestActivitiesToPackageManager(AndroidManifest appManifest, Application application) {
-    if (appManifest != null) {
-      Map<String,ActivityData> activityDatas = appManifest.getActivityDatas();
-
-      RobolectricPackageManager packageManager = (RobolectricPackageManager) application.getPackageManager();
-
-      for (ActivityData data : activityDatas.values()) {
-        String name = data.getName();
-        String activityName = name.startsWith(".") ? appManifest.getPackageName() + name : name;
-        packageManager.addResolveInfoForIntent(new Intent(activityName), new ResolveInfo());
-      }
-    }
   }
 
   @Override

--- a/robolectric/src/main/java/org/robolectric/android/controller/ContentProviderController.java
+++ b/robolectric/src/main/java/org/robolectric/android/controller/ContentProviderController.java
@@ -30,7 +30,7 @@ public class ContentProviderController<T extends ContentProvider> extends org.ro
 
     ProviderInfo providerInfo = null;
     try {
-      providerInfo = RuntimeEnvironment.getPackageManager().getProviderInfo(componentName, 0);
+      providerInfo = baseContext.getPackageManager().getProviderInfo(componentName, 0);
     } catch (PackageManager.NameNotFoundException e) {
       Logger.strict("Unable to find provider info for " + componentName, e);
     }

--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -622,6 +622,14 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
     packageInfo.versionName = androidManifest.getVersionName();
     packageInfo.versionCode = androidManifest.getVersionCode();
 
+    Map<String,ActivityData> activityDatas = androidManifest.getActivityDatas();
+
+    for (ActivityData data : activityDatas.values()) {
+      String name = data.getName();
+      String activityName = name.startsWith(".") ? androidManifest.getPackageName() + name : name;
+      addResolveInfoForIntent(new Intent(activityName), new ResolveInfo());
+    }
+
     ContentProviderData[] cpdata = androidManifest.getContentProviders().toArray(new ContentProviderData[]{});
     if (cpdata.length == 0) {
       packageInfo.providers = null;

--- a/robolectric/src/test/java/org/robolectric/RobolectricTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTest.java
@@ -199,7 +199,7 @@ public class RobolectricTest {
     }
     assertThat(order).as("reset order").containsExactly("shadowProvider", "packageManager");
     assertThat(RuntimeEnvironment.application).as("app after reset").isNull();
-    assertThat(RuntimeEnvironment.getPackageManager()).as("packageManager after reset").isNull();
+    assertThat(RuntimeEnvironment.getRobolectricPackageManager()).as("packageManager after reset").isNull();
     assertThat(RuntimeEnvironment.getActivityThread()).as("activityThread after reset").isNull();
   }
   
@@ -240,18 +240,4 @@ public class RobolectricTest {
     }
   }
 
-  private static class MyContextWrapper extends ContextWrapper {
-
-    String someText;
-
-    public MyContextWrapper() {
-      super(null);
-    }
-
-    public MyContextWrapper(String someText) {
-      this();
-      this.someText = someText;
-    }
-
-  }
 }

--- a/robolectric/src/test/java/org/robolectric/android/DefaultPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/DefaultPackageManagerTest.java
@@ -794,7 +794,7 @@ public class DefaultPackageManagerTest {
   public void getActivityMetaData_configChanges() throws Exception {
     Activity activity = setupActivity(ActivityWithConfigChanges.class);
 
-    ActivityInfo activityInfo = RuntimeEnvironment.getPackageManager().getActivityInfo(activity.getComponentName(), 0);
+    ActivityInfo activityInfo = activity.getPackageManager().getActivityInfo(activity.getComponentName(), 0);
 
     int configChanges = activityInfo.configChanges;
     assertThat(configChanges & ActivityInfo.CONFIG_MCC).isEqualTo(ActivityInfo.CONFIG_MCC);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
@@ -25,7 +25,7 @@ public class ShadowContextTest {
 
   @Before
   public void setUp() throws Exception {
-    File dataDir = new File(RuntimeEnvironment.getPackageManager()
+    File dataDir = new File(context.getPackageManager()
         .getPackageInfo("org.robolectric", 0).applicationInfo.dataDir);
 
     File[] files = dataDir.listFiles();
@@ -44,7 +44,7 @@ public class ShadowContextTest {
 
   @Test
   public void shouldCreateIfDoesNotExistAndGetApplicationDataDirectory() throws Exception {
-    File dataDir = new File(RuntimeEnvironment.getPackageManager()
+    File dataDir = new File(context.getPackageManager()
         .getPackageInfo("org.robolectric", 0).applicationInfo.dataDir, "data");
 
     assertThat(dataDir).doesNotExist();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNonAppLibraryTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNonAppLibraryTest.java
@@ -25,7 +25,7 @@ public class ShadowNonAppLibraryTest {
   }
 
   @Test public void shouldHaveDefaultPackageInfo() throws Exception {
-    PackageInfo packageInfo = RuntimeEnvironment.getPackageManager().getPackageInfo("org.robolectric.default", 0);
+    PackageInfo packageInfo = RuntimeEnvironment.application.getPackageManager().getPackageInfo("org.robolectric.default", 0);
     assertThat(packageInfo).isNotNull();
 
     ApplicationInfo applicationInfo = packageInfo.applicationInfo;


### PR DESCRIPTION
* @Deprecate RuntimeEnvironment.getPackageManager() - users should
prefer Android APIs. Remove usages internally.
* Move Activity Intent resolve info population into
DefaultPackageManager from ParallelUniverse (this is where similar code
for content providers etc live). This could lead to completely lazily
loading Manifest parsing code.
