### PR TITLE
Fix NPE in ShadowBitmapRegionDecoder

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapRegionDecoder.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBitmapRegionDecoder.java
@@ -40,10 +40,12 @@ public class ShadowBitmapRegionDecoder {
   }
 
   private static BitmapRegionDecoder fillWidthAndHeight(BitmapRegionDecoder bitmapRegionDecoder, InputStream is) {
-    Point imageSize = ImageUtil.getImageSizeFromStream(is);
     ShadowBitmapRegionDecoder shadowDecoder = shadowOf(bitmapRegionDecoder);
-    shadowDecoder.width = imageSize.x;
-    shadowDecoder.height = imageSize.y;
+    Point imageSize = ImageUtil.getImageSizeFromStream(is);
+    if (imageSize != null) {
+      shadowDecoder.width = imageSize.x;
+      shadowDecoder.height = imageSize.y;
+    }
     return bitmapRegionDecoder;
   }
 


### PR DESCRIPTION
BitmapRegionDecoder should not crash if it can't determine the size of an image (for example, if trying to load a bitmap written using Bitmap.compress).
