### PR TITLE
Fix NPE when calling DocumentsContract.isDocumentUri()

### DIFF
--- a/robolectric/src/main/java/org/robolectric/android/StubPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/android/StubPackageManager.java
@@ -37,6 +37,7 @@ import android.os.Handler;
 import android.os.UserHandle;
 import android.os.storage.VolumeInfo;
 
+import java.util.Collections;
 import java.util.List;
 
 public class StubPackageManager extends PackageManager {
@@ -724,12 +725,12 @@ public class StubPackageManager extends PackageManager {
 
   @Override
   public List<ResolveInfo> queryIntentContentProvidersAsUser(Intent intent, int flags, int userId) {
-    return null;
+    return Collections.emptyList();
   }
 
   @Override
   public List<ResolveInfo> queryIntentContentProviders(Intent intent, int flags) {
-    return null;
+    return Collections.emptyList();
   }
 
   @Override


### PR DESCRIPTION
The Javadoc of the `PackageManager.queryIntentContentProviders()` method documents that the return value may be null. However, there are places in the SDK (like `DocumentsContract.isDocumentsProvider()` that expects the result to be not null. This patch updates the stub package manager to return an empty list by default.
