### PR TITLE
Call standard View.getGlobalVisibleRect() is the view is laid out

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowView.java
@@ -563,13 +563,7 @@ public class ShadowView {
   @Implementation
   public boolean getGlobalVisibleRect(Rect rect, Point globalOffset) {
     if (globalVisibleRect == null) {
-      /*
-       * The global visible rect is not initialized. The value is not reliable as Robolectric does
-       * not perform layouts in most cases. Use a substitute concept of visibility if no rect
-       * had been set explicitly.
-       */
-      rect.setEmpty();
-      return realView.isShown();
+      return directly().getGlobalVisibleRect(rect, globalOffset);
     }
 
     if (!globalVisibleRect.isEmpty()) {
@@ -584,8 +578,12 @@ public class ShadowView {
   }
 
   public void setGlobalVisibleRect(Rect rect) {
-    globalVisibleRect = new Rect();
-    globalVisibleRect.set(rect);
+    if (rect != null) {
+      globalVisibleRect = new Rect();
+      globalVisibleRect.set(rect);
+    } else {
+      globalVisibleRect = null;
+    }
   }
 
   public int lastHapticFeedbackPerformed() {


### PR DESCRIPTION
`getGlobalVisibleRect()` behaves correctly if the view is part of a view hierarchy and has been laid out. The current implementation of this method in `ShadowView` makes the assumption that the view is not laid out, and avoids using the standard implementation, which causes bugs in some
tests.

This patch calls `getGlobalVisibleRect()` in the SDK whenever the view has been laid out. I left the original code in place so that my change won't break existing tests that may rely on this behavior - I think, however, that tests should ideally lay out views instead of relying on non standard
behavior.