### PR TITLE
Remove robolectric main dep for shadow projects.

### DIFF
--- a/robolectric-shadows/shadows-httpclient/build.gradle
+++ b/robolectric-shadows/shadows-httpclient/build.gradle
@@ -14,8 +14,7 @@ configurations {
 
 dependencies {
     // Project dependencies
-    compile project(":robolectric")
-    compile project(":robolectric-shadows/shadows-core")
+    compileOnly project(":robolectric-shadows/shadows-core")
 
     // Compile dependencies
     earlyRuntime "org.apache.httpcomponents:httpcore:4.0.1"
@@ -23,6 +22,7 @@ dependencies {
     compileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates) { force = true }
 
     // Testing dependencies
+    testCompile project(":robolectric")
     testCompile "junit:junit:4.12"
     testCompile "org.assertj:assertj-core:2.6.0"
     testCompile "org.mockito:mockito-core:2.5.4"

--- a/robolectric-shadows/shadows-maps/build.gradle
+++ b/robolectric-shadows/shadows-maps/build.gradle
@@ -9,14 +9,14 @@ shadows {
 }
 
 dependencies {
-    compile project(":robolectric")
-    compile project(":robolectric-shadows/shadows-core")
+    compileOnly project(":robolectric-shadows/shadows-core")
 
     compileOnly AndroidSdk.MAX_SDK.coordinates
     compile "com.ibm.icu:icu4j:53.1"
 
     compileOnly "com.google.android.maps:maps:23_r1"
 
+    testCompile project(":robolectric")
     testCompile "junit:junit:4.12"
     testCompile "org.assertj:assertj-core:2.6.0"
     testCompile "org.mockito:mockito-core:2.5.4"

--- a/robolectric-shadows/shadows-multidex/build.gradle
+++ b/robolectric-shadows/shadows-multidex/build.gradle
@@ -9,12 +9,13 @@ shadows {
 }
 
 dependencies {
-    compile project(":robolectric")
-    compile project(":robolectric-shadows/shadows-core")
+    compileOnly project(":robolectric-shadows/shadows-core")
 
     compileOnly "com.android.support:multidex:1.0.1"
 
     compileOnly AndroidSdk.MAX_SDK.coordinates
+
+    testCompile project(":robolectric")
 }
 
 // change local artifact name to match dependencies

--- a/robolectric-shadows/shadows-play-services/build.gradle
+++ b/robolectric-shadows/shadows-play-services/build.gradle
@@ -9,8 +9,7 @@ shadows {
 }
 
 dependencies {
-    compile project(":robolectric")
-    compile project(":robolectric-shadows/shadows-core")
+    compileOnly project(":robolectric-shadows/shadows-core")
 
     compileOnly "com.android.support:support-v4:23.2.0"
     compileOnly "com.google.android.gms:play-services-base:8.4.0"
@@ -19,6 +18,7 @@ dependencies {
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
     // Testing dependencies
+    testCompile project(":robolectric")
     testCompile "junit:junit:4.12"
     testCompile "org.assertj:assertj-core:2.6.0"
     testCompile "org.mockito:mockito-core:2.5.4"

--- a/robolectric-shadows/shadows-support-v4/build.gradle
+++ b/robolectric-shadows/shadows-support-v4/build.gradle
@@ -14,8 +14,8 @@ configurations {
 
 dependencies {
     // Project dependencies
-    compile project(":robolectric")
-    compile project(":robolectric-shadows/shadows-core")
+    compileOnly project(":robolectric")
+    compileOnly project(":robolectric-shadows/shadows-core")
 
     // Compile dependencies
     compileOnly AndroidSdk.MAX_SDK.coordinates
@@ -23,6 +23,7 @@ dependencies {
     compileOnly "com.android.support:internal_impl:23.2.0"
 
     // Testing dependencies
+    testCompile project(":robolectric")
     testCompile "junit:junit:4.12"
     testCompile "org.hamcrest:hamcrest-junit:2.0.0.0"
     testCompile "org.assertj:assertj-core:2.6.0"


### PR DESCRIPTION
Shadow projects don't need a dependency on org.robolectric:robolectric, it'll already be on the classpath.

This makes it easier to exclude `maven-ant-tasks` and `ant` from dependencies for hermetic builds.