### PR TITLE
Support PackageManager.getXml().

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -650,11 +650,6 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public XmlResourceParser getXml(String packageName, @XmlRes int resid, ApplicationInfo appInfo) {
-    return getDelegatePackageManager().getXml(packageName, resid, appInfo);
-  }
-
-  @Implementation
   public void installPackage(Uri packageURI, IPackageInstallObserver observer, int flags, String installerPackageName) {
     getDelegatePackageManager().installPackage(packageURI, observer, flags, installerPackageName);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.*;
 import android.content.pm.PackageManager;
+import android.content.res.XmlResourceParser;
 import android.graphics.Color;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
@@ -1068,5 +1069,13 @@ public class ShadowPackageManagerTest {
     packageManager.setInstallerPackageName("target.package", "installer.package");
 
     assertThat(packageManager.getInstallerPackageName("target.package")).isEqualTo("installer.package");
+  }
+
+  @Test
+  public void getXml() throws Exception {
+    XmlResourceParser in = packageManager.getXml(RuntimeEnvironment.application.getPackageName(),
+        R.xml.dialog_preferences,
+        RuntimeEnvironment.application.getApplicationInfo());
+    assertThat(in).isNotNull();
   }
 }


### PR DESCRIPTION
We support this by removing the delegating
ShadowApplicationPackageManager.getXml(). This method delegates
to DefaultPackageManager which doesn't implement the method leaving StubPackageManager to return null.
