### PR TITLE
Stop scheduling background tasks relative to foreground scheduler's current time

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
@@ -1,6 +1,7 @@
 package org.robolectric.shadows;
 
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.Message;
 
@@ -8,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.Shadows;
 import org.robolectric.TestRunners;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.Scheduler;
@@ -517,6 +519,17 @@ public class ShadowHandlerTest {
     h.sendMessageAtFrontOfQueue(h.obtainMessage());
   }
 
+  @Test
+  public void runToEndOfTasks_shouldRunAllTasks() {
+    HandlerThread handlerThread = new HandlerThread("name");
+    handlerThread.start();
+    Handler handler = new Handler(handlerThread.getLooper());
+    handler.postDelayed(new Say("one"), 2000);
+    Shadows.shadowOf(handler.getLooper()).runToEndOfTasks();
+    handler.post(new Say("two"));
+    Shadows.shadowOf(handler.getLooper()).runToEndOfTasks();
+    assertThat(transcript).containsExactly("one", "two");
+  }
 
   private class Say implements Runnable {
     private String event;


### PR DESCRIPTION
When calling Handler#post(Runnable) and variants, the scheduled time on
the background looper is relative to the foreground scheduler's current
time. This is because Handler#post(Runnable) ultimately make its way
down to Handler#sendMessageDelayed(Message, long), which invokes
SystemClock.uptimeMillis(), which returns the time relative to the
foreground scheduler's current time.

One side effect is that, in some cases, ShadowLooper#runToEndOfTasks may
be a no-op. This happens when scheduling a task on a background handler
when its scheduler has a greater current time than the foreground
scheduler.

Add an implementation of Handler#sendMessageDelayed, which schedules the
task relative to the Handler's current time.

At first I attempted to avoid scheduling tasks that occur in the past
(either in ShadowMessageQueue#enqueueMessage or in
Scheduler#queueRunnableAndSort), but that resulted in failing tests.

One side effect of this is that it un-deprecates ShadowHandler.

Fixes #2957