### PR TITLE
Fix Html.fromHtml() issue.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
+++ b/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
@@ -85,6 +85,7 @@ public class AndroidConfigurer {
         .addInstrumentedPackage("android.")
         .addInstrumentedPackage("com.android.internal.")
         .addInstrumentedPackage("org.apache.http.")
+        .addInstrumentedPackage("org.ccil.cowan.tagsoup")
         .addInstrumentedPackage("org.kxml2.");
 
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowHtmlTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowHtmlTest.java
@@ -1,21 +1,30 @@
 package org.robolectric.shadows;
 
 
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.os.Build;
 import android.text.Html;
 import android.text.Spanned;
 import android.widget.EditText;
 import android.widget.TextView;
+import org.codehaus.plexus.util.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
 
+import static android.os.Build.VERSION_CODES.M;
+import static android.os.Build.VERSION_CODES.N;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(TestRunners.MultiApiSelfTest.class)
 public class ShadowHtmlTest {
+  private static final String HTML_SHORT = "<img src='foo.png'>";
+  private static final String HTML_LONG = String.format("<img src='%s.png'>", StringUtils.repeat("foo", 100));
+
   private Context context;
 
   @Before
@@ -48,4 +57,30 @@ public class ShadowHtmlTest {
     Spanned spanned = Html.fromHtml(text);
     assertThat(spanned.toString()).isEqualTo("foo");
   }
+
+  @Config(maxSdk = M)
+  @Test public void testArraycopyLegacyShort() {
+    //noinspection deprecation
+    Html.fromHtml(HTML_SHORT, null, null);
+  }
+
+  @Config(maxSdk = M)
+  @Test public void testArraycopyLegacyLong() {
+    //noinspection deprecation
+    Html.fromHtml(HTML_LONG, null, null);
+  }
+
+  @TargetApi(N) @Config(minSdk = N)
+  @Test public void testArraycopyShort() {
+    Html.fromHtml(HTML_SHORT, Html.FROM_HTML_MODE_LEGACY, null, null);
+  }
+
+  /**
+   * this test requires that {@link org.ccil.cowan.tagsoup.HTMLScanner} be instrumented.
+   */
+  @TargetApi(N) @Config(minSdk = N)
+  @Test public void testArraycopyLong() {
+    Html.fromHtml(HTML_LONG, Html.FROM_HTML_MODE_LEGACY, null, null);
+  }
+
 }


### PR DESCRIPTION
Instrument org.ccil.cowan.tagsoup.HTMLScanner since it calls System.arraycopy() with JVM-incompatible signature.