### PR TITLE
Reset all Loopers' schedulers in ShadowLooper's resetter

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLooper.java
@@ -57,6 +57,10 @@ public class ShadowLooper {
         synchronized (looper) {
           if (!shadowOf(looper).quit) {
             looper.quit();
+          } else {
+            // Reset the schedulers of all loopers. This prevents un-run tasks queued up in static
+            // background handlers from leaking to subsequent tests.
+            shadowOf(looper).getScheduler().reset();
           }
         }
       }

--- a/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
@@ -47,7 +47,8 @@ public class Scheduler {
     CONSTANT_IDLE
   }
 
-  private volatile long currentTime = 100;
+  private final static long START_TIME = 100;
+  private volatile long currentTime = START_TIME;
   private boolean isExecutingRunnable = false;
   private final Thread associatedThread = Thread.currentThread();
   private final List<ScheduledRunnable> runnables = new ArrayList<>();
@@ -274,6 +275,8 @@ public class Scheduler {
   public synchronized void reset() {
     runnables.clear();
     idleState = UNPAUSED;
+    currentTime = START_TIME;
+    isExecutingRunnable = false;
   }
 
   /**


### PR DESCRIPTION
Previously, it was possible for tasks posted to a static Handler to leak
across tests. This was because background Loopers usually retained their
previous Scheduler state and Runnables (except after the first
invocation of the resetter when Loopers are quit).

Instead, call Scheduler#reset for each ShadowLooper. This clears any
posted tasks and clears the state of the Scheduler. Before this was only
done for the main Looper.

Fixes #2962
