### PR TITLE
Reduce Synchronicity of Scheduler

### DIFF
--- a/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
+++ b/robolectric-utils/src/main/java/org/robolectric/util/Scheduler.java
@@ -47,11 +47,11 @@ public class Scheduler {
     CONSTANT_IDLE
   }
 
-  private long currentTime = 100;
+  private volatile long currentTime = 100;
   private boolean isExecutingRunnable = false;
   private final Thread associatedThread = Thread.currentThread();
   private final List<ScheduledRunnable> runnables = new ArrayList<>();
-  private IdleState idleState = UNPAUSED;
+  private volatile IdleState idleState = UNPAUSED;
 
   /**
    * Retrieves the current idling state of this <tt>Scheduler</tt>.
@@ -59,7 +59,7 @@ public class Scheduler {
    * @see #setIdleState(IdleState)
    * @see #isPaused()
    */
-  public synchronized IdleState getIdleState() {
+  public IdleState getIdleState() {
     return idleState;
   }
 
@@ -89,7 +89,7 @@ public class Scheduler {
    *
    * @return  Current time in milliseconds.
    */
-  public synchronized long getCurrentTime() {
+  public long getCurrentTime() {
     return currentTime;
   }
 
@@ -118,7 +118,7 @@ public class Scheduler {
    *
    * @return  <tt>true</tt> if it is paused.
    */
-  public synchronized boolean isPaused() {
+  public boolean isPaused() {
     return idleState == PAUSED;
   }
 

--- a/robolectric-utils/src/test/java/org/robolectric/util/SchedulerTest.java
+++ b/robolectric-utils/src/test/java/org/robolectric/util/SchedulerTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.util.Scheduler.IdleState.*;
@@ -449,6 +450,55 @@ public class SchedulerTest {
     });
 
     assertThat(runnablesThatWereRun).containsExactly(1, 2);
+  }
+
+  @Test(timeout=1000)
+  public void schedulerAllowsConcurrentTimeRead_whileLockIsHeld() throws InterruptedException {
+    final AtomicLong l = new AtomicLong();
+    Thread t = new Thread("schedulerAllowsConcurrentTimeRead") {
+      @Override
+      public void run() {
+        l.set(scheduler.getCurrentTime());
+      }
+    };
+    // Grab the lock and then start a thread that tries to get the current time. The other thread
+    // should not deadlock.
+    synchronized (scheduler) {
+      t.start();
+      t.join();
+    }
+  }
+
+  @Test(timeout = 1000)
+  public void schedulerAllowsConcurrentStateRead_whileLockIsHeld() throws InterruptedException {
+    Thread t = new Thread("schedulerAllowsConcurrentStateRead") {
+      @Override
+      public void run() {
+        scheduler.getIdleState();
+      }
+    };
+    // Grab the lock and then start a thread that tries to get the idle state. The other thread
+    // should not deadlock.
+    synchronized (scheduler) {
+      t.start();
+      t.join();
+    }
+  }
+
+  @Test(timeout = 1000)
+  public void schedulerAllowsConcurrentIsPaused_whileLockIsHeld() throws InterruptedException {
+    Thread t = new Thread("schedulerAllowsConcurrentIsPaused") {
+      @Override
+      public void run() {
+        scheduler.isPaused();
+      }
+    };
+    // Grab the lock and then start a thread that tries to get the paused state. The other thread
+    // should not deadlock.
+    synchronized (scheduler) {
+      t.start();
+      t.join();
+    }
   }
 
   private class AddToTranscript implements Runnable {


### PR DESCRIPTION
Reduce synchronicity on accesses to currentTime and idleState.

Shamelessly lifted from #2116.

### Overview
`Scheduler` backs the `SystemClock` with a synchronized method, but also handles dispatching events. If a dispatched event uses its own lock while another thread holding that lock tries to, for example, get the current time and deadlock will occur.

### Proposed Changes
While there are some larger changes that could improve things further, a fairly contained fix for this particular style of deadlock is to make the read-only methods that access `currentTime` and `idleState` not synchronized.