### PR TITLE
ShadowPackageManager.addPackage() should not create sessions.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPackageInstaller.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPackageInstaller.java
@@ -58,6 +58,7 @@ public class ShadowPackageInstaller {
   public int createSession(@NonNull PackageInstaller.SessionParams params) throws IOException {
     final PackageInstaller.SessionInfo sessionInfo = new PackageInstaller.SessionInfo();
     sessionInfo.sessionId = nextSessionId++;
+    sessionInfo.active = true;
     sessionInfo.appPackageName = params.appPackageName;
     sessionInfos.put(sessionInfo.getSessionId(), sessionInfo);
 
@@ -164,6 +165,11 @@ public class ShadowPackageInstaller {
       if (outputStreamOpen) {
         throw new SecurityException("OutputStream still open");
       }
+    }
+
+    @Implementation
+    public void close() {
+
     }
   }
 }

--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -626,16 +626,6 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
     packageInfos.put(packageInfo.packageName, packageInfo);
     packageStatsMap.put(packageInfo.packageName, packageStats);
     applicationEnabledSettingMap.put(packageInfo.packageName, PackageManager.COMPONENT_ENABLED_STATE_DEFAULT);
-
-    if (RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.LOLLIPOP) {
-      PackageInstaller.SessionParams sessionParams = new PackageInstaller.SessionParams(0);
-      sessionParams.setAppPackageName(packageInfo.packageName);
-      try {
-        getPackageInstaller().createSession(sessionParams);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
   }
 
   @Override

--- a/robolectric/src/test/java/org/robolectric/android/DefaultPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/DefaultPackageManagerTest.java
@@ -75,36 +75,34 @@ public class DefaultPackageManagerTest {
   }
 
   @Test
-  public void getPackageInstaller() {
-    PackageInfo packageInfo = new PackageInfo();
-    packageInfo.packageName = TEST_PACKAGE_NAME;
-    packageInfo.applicationInfo = new ApplicationInfo();
-    packageInfo.applicationInfo.packageName = TEST_PACKAGE_NAME;
-    packageInfo.applicationInfo.name = TEST_PACKAGE_LABEL;
-    rpm.addPackage(packageInfo);
+  public void packageInstallerCreateSession() throws Exception {
+    PackageInstaller packageInstaller = RuntimeEnvironment.application.getPackageManager().getPackageInstaller();
+    int sessionId = packageInstaller.createSession(createSessionParams("packageName"));
 
-    List<PackageInstaller.SessionInfo> allSessions = packageManager.getPackageInstaller().getAllSessions();
+    PackageInstaller.SessionInfo sessionInfo = packageInstaller.getSessionInfo(sessionId);
+    assertThat(sessionInfo.isActive()).isTrue();
 
-    List<String> allPackageNames = new LinkedList<>();
-    for (PackageInstaller.SessionInfo session : allSessions) {
-      allPackageNames.add(session.appPackageName);
-    }
+    assertThat(sessionInfo.appPackageName).isEqualTo("packageName");
 
-    assertThat(allPackageNames).contains(TEST_PACKAGE_NAME);
+    packageInstaller.abandonSession(sessionId);
+
+    assertThat(packageInstaller.getSessionInfo(sessionId)).isNull();
   }
 
   @Test
-  public void packageInstallerAndGetInstalledPackagesAreConsistent() {
-    PackageInfo packageInfo = new PackageInfo();
-    packageInfo.packageName = TEST_PACKAGE_NAME;
-    packageInfo.applicationInfo = new ApplicationInfo();
-    packageInfo.applicationInfo.packageName = TEST_PACKAGE_NAME;
-    packageInfo.applicationInfo.name = TEST_PACKAGE_LABEL;
-    rpm.addPackage(packageInfo);
+  public void packageInstallerOpenSession() throws Exception {
+    PackageInstaller packageInstaller = RuntimeEnvironment.application.getPackageManager().getPackageInstaller();
+    int sessionId = packageInstaller.createSession(createSessionParams("packageName"));
 
-    List<PackageInstaller.SessionInfo> allSessions = packageManager.getPackageInstaller().getAllSessions();
+    PackageInstaller.Session session = packageInstaller.openSession(sessionId);
 
-    assertThat(allSessions).hasSameSizeAs(rpm.getInstalledPackages(0));
+    assertThat(session).isNotNull();
+  }
+
+  private static PackageInstaller.SessionParams createSessionParams(String appPackageName) {
+    PackageInstaller.SessionParams params = new PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL);
+    params.setAppPackageName(appPackageName);
+    return params;
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageInstallerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageInstallerTest.java
@@ -77,6 +77,7 @@ public class ShadowPackageInstallerTest {
     int sessionId = packageInstaller.createSession(createSessionParams("packageName"));
 
     PackageInstaller.SessionInfo sessionInfo = packageInstaller.getSessionInfo(sessionId);
+    assertThat(sessionInfo.isActive()).isTrue();
 
     assertThat(sessionInfo.appPackageName).isEqualTo("packageName");
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageInstallerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageInstallerTest.java
@@ -40,36 +40,8 @@ public class ShadowPackageInstallerTest {
   }
 
   @Test
-  public void getPackageInstaller() {
-    PackageInfo packageInfo = new PackageInfo();
-    packageInfo.packageName = TEST_PACKAGE_NAME;
-    packageInfo.applicationInfo = new ApplicationInfo();
-    packageInfo.applicationInfo.packageName = TEST_PACKAGE_NAME;
-    packageInfo.applicationInfo.name = TEST_PACKAGE_LABEL;
-    RuntimeEnvironment.getRobolectricPackageManager().addPackage(packageInfo);
-
-    List<PackageInstaller.SessionInfo> allSessions = packageInstaller.getAllSessions();
-
-    List<String> allPackageNames = new LinkedList<>();
-    for (PackageInstaller.SessionInfo session : allSessions) {
-      allPackageNames.add(session.appPackageName);
-    }
-
-    assertThat(allPackageNames).contains(TEST_PACKAGE_NAME);
-  }
-
-  @Test
-  public void packageInstallerAndGetInstalledPackagesAreConsistent() {
-    PackageInfo packageInfo = new PackageInfo();
-    packageInfo.packageName = TEST_PACKAGE_NAME;
-    packageInfo.applicationInfo = new ApplicationInfo();
-    packageInfo.applicationInfo.packageName = TEST_PACKAGE_NAME;
-    packageInfo.applicationInfo.name = TEST_PACKAGE_LABEL;
-    RuntimeEnvironment.getRobolectricPackageManager().addPackage(packageInfo);
-
-    List<PackageInstaller.SessionInfo> allSessions = packageInstaller.getAllSessions();
-
-    assertThat(allSessions).hasSameSizeAs(RuntimeEnvironment.application.getPackageManager().getInstalledPackages(0));
+  public void shouldBeNoInProcessSessionsOnRobolectricStartup() {
+    assertThat(packageInstaller.getAllSessions()).isEmpty();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -1078,4 +1078,14 @@ public class ShadowPackageManagerTest {
         RuntimeEnvironment.application.getApplicationInfo());
     assertThat(in).isNotNull();
   }
+
+  @Test
+  public void addPackageShouldNotCreateSessions() {
+
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = "test.package";
+    shadowPackageManager.addPackage(packageInfo);
+
+    assertThat(packageManager.getPackageInstaller().getAllSessions()).isEmpty();
+  }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -5,8 +5,19 @@ import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.pm.*;
+import android.content.pm.ActivityInfo;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.FeatureInfo;
+import android.content.pm.IPackageStatsObserver;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.pm.PackageStats;
+import android.content.pm.PathPermission;
+import android.content.pm.PermissionInfo;
+import android.content.pm.ProviderInfo;
+import android.content.pm.ResolveInfo;
+import android.content.pm.ServiceInfo;
+import android.content.pm.Signature;
 import android.content.res.XmlResourceParser;
 import android.graphics.Color;
 import android.graphics.drawable.BitmapDrawable;
@@ -29,12 +40,26 @@ import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static android.content.pm.PackageManager.*;
+import static android.content.pm.PackageManager.SIGNATURE_FIRST_NOT_SIGNED;
+import static android.content.pm.PackageManager.SIGNATURE_MATCH;
+import static android.content.pm.PackageManager.SIGNATURE_NEITHER_SIGNED;
+import static android.content.pm.PackageManager.SIGNATURE_NO_MATCH;
+import static android.content.pm.PackageManager.SIGNATURE_SECOND_NOT_SIGNED;
+import static android.content.pm.PackageManager.SIGNATURE_UNKNOWN_PACKAGE;
+import static android.content.pm.PackageManager.VERIFICATION_ALLOW;
+import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.N;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.robolectric.Robolectric.setupActivity;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -1079,7 +1104,7 @@ public class ShadowPackageManagerTest {
     assertThat(in).isNotNull();
   }
 
-  @Test
+  @Test @Config(minSdk = LOLLIPOP)
   public void addPackageShouldNotCreateSessions() {
 
     PackageInfo packageInfo = new PackageInfo();


### PR DESCRIPTION
Sessions can and should be created through the framework APIs.

ShadowPackageManager.addPackage() simulates an installed package on the
system for which the session would have been opened, closed and removed
by the system.

Fixes #2950 
