### PR TITLE
Add support for 1.8 source support for RAP

### DIFF
--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
@@ -33,7 +33,6 @@ import java.util.Set;
   RobolectricProcessor.PACKAGE_OPT, 
   RobolectricProcessor.SHOULD_INSTRUMENT_PKG_OPT})
 @SupportedAnnotationTypes("org.robolectric.annotation.*")
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class RobolectricProcessor extends AbstractProcessor {
   static final String PACKAGE_OPT = "org.robolectric.annotation.processing.shadowPackage";
   static final String SHOULD_INSTRUMENT_PKG_OPT = 
@@ -113,5 +112,10 @@ public class RobolectricProcessor extends AbstractProcessor {
           "false".equalsIgnoreCase(options.get(SHOULD_INSTRUMENT_PKG_OPT)) 
           ? false : true;
     }
+  }
+
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latest();
   }
 }


### PR DESCRIPTION
Previously, the Robolectric annotation processor used
@SupportedSourceVersion(SourceVersion.RELEASE_7). To fix an internal
lint check, add support for release 8. Initially I attempted to change
the annotation to @SupportedSourceVersion(SourceVersion.RELEASE_8).
However, that constant doesn't exist when running with a version 7 JVM.
Instead, override the getSupportedSourceVersion method and return the
latest support source version. This is safe because the Java code
generated by RAP is JVM version agnostic.