### PR TITLE
Add ShadowBatteryManager for L+.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBatteryManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowBatteryManager.java
@@ -1,0 +1,49 @@
+package org.robolectric.shadows;
+
+import android.os.BatteryManager;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.M;
+
+/**
+ * Shadow for {@link android.os.BatteryManager}.
+ */
+@Implements(BatteryManager.class)
+public class ShadowBatteryManager {
+  private boolean isCharging = false;
+  private final Map<Integer, Long> longProperties = new HashMap<>();
+  private final Map<Integer, Integer> intProperties = new HashMap<>();
+
+  @Implementation(minSdk = M)
+  public boolean isCharging() {
+    return isCharging;
+  }
+
+  public void setIsCharging(boolean charging) {
+    isCharging = charging;
+  }
+
+  @Implementation(minSdk = LOLLIPOP)
+  public int getIntProperty(int id) {
+    return intProperties.containsKey(id) ? intProperties.get(id) : Integer.MIN_VALUE;
+  }
+
+  public void setIntProperty(int id, int value) {
+    intProperties.put(id, value);
+  }
+
+  @Implementation(minSdk = LOLLIPOP)
+  public long getLongProperty(int id) {
+    return longProperties.containsKey(id) ? longProperties.get(id) : Long.MIN_VALUE;
+  }
+
+  public void setLongProperty(int id, long value) {
+    longProperties.put(id, value);
+  }
+}

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
@@ -99,6 +99,7 @@ public class ShadowContextImpl {
       SYSTEM_SERVICE_MAP.put(Context.JOB_SCHEDULER_SERVICE, "android.app.JobSchedulerImpl");
       SYSTEM_SERVICE_MAP.put(Context.TELECOM_SERVICE, "android.telecom.TelecomManager");
       SYSTEM_SERVICE_MAP.put(Context.MEDIA_SESSION_SERVICE, "android.media.session.MediaSessionManager");
+      SYSTEM_SERVICE_MAP.put(Context.BATTERY_SERVICE, "android.os.BatteryManager");
     }
     if (getApiLevel() >= LOLLIPOP_MR1) {
       SYSTEM_SERVICE_MAP.put(Context.TELEPHONY_SUBSCRIPTION_SERVICE, "android.telephony.SubscriptionManager");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
@@ -112,6 +112,7 @@ public class ShadowApplicationTest {
   @Config(minSdk = LOLLIPOP)
   public void shouldProvideMediaSessionService() throws Exception {
     checkSystemService(Context.MEDIA_SESSION_SERVICE, MediaSessionManager.class);
+    checkSystemService(Context.BATTERY_SERVICE, BatteryManager.class);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBatteryManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBatteryManagerTest.java
@@ -1,0 +1,73 @@
+package org.robolectric.shadows;
+
+import android.content.Context;
+import android.os.BatteryManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
+
+import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.M;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(TestRunners.MultiApiSelfTest.class)
+@Config(minSdk = LOLLIPOP)
+public class ShadowBatteryManagerTest {
+  private BatteryManager batteryManager;
+  private ShadowBatteryManager shadowBatteryManager;
+  private static final int TEST_ID = 123;
+
+  @Before
+  public void before() {
+    batteryManager = (BatteryManager) RuntimeEnvironment.application.getSystemService(
+        Context.BATTERY_SERVICE);
+    shadowBatteryManager = shadowOf(batteryManager);
+  }
+
+  @Test
+  @Config(minSdk = M)
+  public void testIsCharging() {
+    assertThat(batteryManager.isCharging()).isFalse();
+
+    shadowBatteryManager.setIsCharging(true);
+
+    assertThat(batteryManager.isCharging()).isTrue();
+
+    shadowBatteryManager.setIsCharging(false);
+
+    assertThat(batteryManager.isCharging()).isFalse();
+  }
+
+  @Test
+  public void testGetIntProperty() {
+    assertThat(batteryManager.getIntProperty(TEST_ID)).isEqualTo(Integer.MIN_VALUE);
+
+    shadowBatteryManager.setIntProperty(TEST_ID, 5);
+    assertThat(batteryManager.getIntProperty(TEST_ID)).isEqualTo(5);
+
+    shadowBatteryManager.setIntProperty(TEST_ID, 0);
+    assertThat(batteryManager.getIntProperty(TEST_ID)).isEqualTo(0);
+
+    shadowBatteryManager.setIntProperty(TEST_ID, Integer.MAX_VALUE);
+    assertThat(batteryManager.getIntProperty(TEST_ID)).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void testGetLongProperty() {
+    assertThat(batteryManager.getLongProperty(TEST_ID)).isEqualTo(Long.MIN_VALUE);
+
+    shadowBatteryManager.setLongProperty(TEST_ID, 5L);
+    assertThat(batteryManager.getLongProperty(TEST_ID)).isEqualTo(5L);
+
+    shadowBatteryManager.setLongProperty(TEST_ID, 0);
+    assertThat(batteryManager.getLongProperty(TEST_ID)).isEqualTo(0);
+
+    shadowBatteryManager.setLongProperty(TEST_ID, Long.MAX_VALUE);
+    assertThat(batteryManager.getLongProperty(TEST_ID)).isEqualTo(Long.MAX_VALUE);
+  }
+}


### PR DESCRIPTION
ShadowBatteryManager is useful for simulating charger state and int/long properties to retrieve battery status. Fixes https://github.com/robolectric/robolectric/issues/2999. 