### PR TITLE
Return copies in ShadowLog#getLogs and ShadowLog#getLogsForTag

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
@@ -255,4 +255,10 @@ public class ShadowLogTest {
     assertFalse(Log.isLoggable("Foo", Log.VERBOSE));
     ShadowLog.stream = old;
   }
+
+  @Test
+  public void getLogs_shouldReturnCopy() {
+    assertThat(ShadowLog.getLogs()).isNotSameAs(ShadowLog.getLogs());
+    assertThat(ShadowLog.getLogs()).isEqualTo(ShadowLog.getLogs());
+  }
 }


### PR DESCRIPTION
Previously, ShadowLog#getLogs and ShadowLog#getLogsForTag would return
the raw underlying data structure used to store the logs. This could
cause ConcurrentModificationExceptions if a test iterated over these
structures while another thread added more data to the logs.

Instead, return a copy of the logs each time ShadowLog#getLogs and
ShadowLog#getLogsForTag is called. This prevents tests from accidentally
interfering with the data and causing problems.

Also, update the data structures to be concurrent. Store logs in a
concurrent queue, and use synchronized structures for maps. This
eliminates the need to use class synchronization.
