### PR TITLE
Build backup agent

### DIFF
--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -4,12 +4,14 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.app.Service;
 import android.app.IntentService;
+import android.app.backup.BackupAgent;
 import android.content.ContentProvider;
 import android.content.Intent;
 
 import android.util.AttributeSet;
 import android.view.View;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.android.controller.BackupAgentController;
 import org.robolectric.android.controller.ContentProviderController;
 import org.robolectric.android.controller.FragmentController;
 import org.robolectric.android.controller.IntentServiceController;
@@ -111,6 +113,14 @@ public class Robolectric {
 
   public static <T extends Fragment> FragmentController<T> buildFragment(Class<T> fragmentClass, Class<? extends Activity> activityClass, Intent intent) {
     return FragmentController.of(ReflectionHelpers.callConstructor(fragmentClass), activityClass, intent);
+  }
+
+  public static <T extends BackupAgent> BackupAgentController<T> buildBackupAgent(Class<T> backupAgentClass) {
+    return BackupAgentController.of(ReflectionHelpers.callConstructor(backupAgentClass));
+  }
+
+  public static <T extends BackupAgent> T setupBackupAgent(Class<T> backupAgentClass) {
+    return buildBackupAgent(backupAgentClass).get();
   }
 
   /**

--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -120,7 +120,7 @@ public class Robolectric {
   }
 
   public static <T extends BackupAgent> T setupBackupAgent(Class<T> backupAgentClass) {
-    return buildBackupAgent(backupAgentClass).get();
+    return buildBackupAgent(backupAgentClass).setUp().get();
   }
 
   /**

--- a/robolectric/src/main/java/org/robolectric/android/controller/BackupAgentController.java
+++ b/robolectric/src/main/java/org/robolectric/android/controller/BackupAgentController.java
@@ -1,0 +1,31 @@
+package org.robolectric.android.controller;
+
+import android.app.backup.BackupAgent;
+import android.content.Context;
+
+import org.robolectric.RuntimeEnvironment;
+
+public class BackupAgentController<T extends BackupAgent> {
+  private T backupAgent;
+
+  private BackupAgentController(T backupAgent) {
+    this.backupAgent = backupAgent;
+  }
+
+  public static <T extends BackupAgent> BackupAgentController<T> of(T backupAgent) {
+    return new BackupAgentController<>(backupAgent);
+  }
+
+  /**
+   * Sets up the {@link BackupAgent} with the Runtime.environment attached as a base context.
+   */
+  public BackupAgentController<T> setUp() {
+    Context baseContext = RuntimeEnvironment.application.getBaseContext();
+    backupAgent.attach(baseContext);
+    return this;
+  }
+
+  public T get() {
+    return backupAgent;
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/android/controller/BackupAgentControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/BackupAgentControllerTest.java
@@ -1,0 +1,41 @@
+package org.robolectric.android.controller;
+
+import android.app.backup.BackupAgent;
+import android.app.backup.BackupDataInput;
+import android.app.backup.BackupDataOutput;
+import android.os.ParcelFileDescriptor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, sdk = 23)
+public class BackupAgentControllerTest {
+  private final BackupAgentController<MyBackupAgent> backupAgentController = Robolectric.buildBackupAgent(MyBackupAgent.class);
+
+  @Test
+  public void shouldSetBaseContext() throws Exception {
+    MyBackupAgent myBackupAgent = backupAgentController.setUp().get();
+    assertThat(myBackupAgent.getBaseContext()).isEqualTo(RuntimeEnvironment.application.getBaseContext());
+  }
+
+  public static class MyBackupAgent extends BackupAgent {
+    @Override
+    public void onBackup(ParcelFileDescriptor parcelFileDescriptor, BackupDataOutput backupDataOutput, ParcelFileDescriptor parcelFileDescriptor1) throws IOException {
+      // no op
+    }
+
+    @Override
+    public void onRestore(BackupDataInput backupDataInput, int i, ParcelFileDescriptor parcelFileDescriptor) throws IOException {
+      // no op
+    }
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/android/controller/BackupAgentControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/BackupAgentControllerTest.java
@@ -8,16 +8,14 @@ import android.os.ParcelFileDescriptor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
+import org.robolectric.TestRunners;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 23)
+@RunWith(TestRunners.SelfTest.class)
 public class BackupAgentControllerTest {
   private final BackupAgentController<MyBackupAgent> backupAgentController = Robolectric.buildBackupAgent(MyBackupAgent.class);
 


### PR DESCRIPTION
Adds Robolectric#buildBackupAgent and Robolectric#setupBackupAgent helpers to Robolectric.java and addresses the use case described in #3010.

Does *not* add manifest tag support for BackupAgent (android:backupAgent="foo").
