### PR TITLE
Add support for `targetSdkVersion="O"`

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -152,7 +152,14 @@ public class AndroidManifest {
         }
 
         minSdkVersion = getTagAttributeIntValue(manifestDocument, "uses-sdk", "android:minSdkVersion");
-        targetSdkVersion = getTagAttributeIntValue(manifestDocument, "uses-sdk", "android:targetSdkVersion");
+
+        String targetSdkText = getTagAttributeText(manifestDocument, "uses-sdk",
+            "android:targetSdkVersion");
+        if (targetSdkText != null) {
+          // Support Android O Preview. This can be removed once Android O is officially launched.
+          targetSdkVersion = targetSdkText.equals("O") ? 26 : Integer.parseInt(targetSdkText);
+        }
+
         maxSdkVersion = getTagAttributeIntValue(manifestDocument, "uses-sdk", "android:maxSdkVersion");
         if (processName == null) {
           processName = packageName;

--- a/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
+++ b/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
@@ -173,6 +173,16 @@ public class AndroidManifestTest {
     assertEquals(1, newConfigWith("").getMinSdkVersion());
   }
 
+  /**
+   * For Android O preview, apps are encouraged to use targetSdkVersion="O".
+   *
+   * @see <a href="http://google.com">https://developer.android.com/preview/migration.html</a>
+   */
+  @Test
+  public void shouldReadTargetSDKVersionOPreview() throws Exception {
+    assertEquals(26, newConfigWith("android:targetSdkVersion=\"O\"").getTargetSdkVersion());
+  }
+
   @Test
   public void shouldReadProcessFromAndroidManifest() throws Exception {
     assertEquals("robolectricprocess", newConfig("TestAndroidManifestWithProcess.xml").getProcessName());


### PR DESCRIPTION
According to the Android migration docs, during the O preview, apps are
encouraged to use `targetSdkVersion="O"` instead of a numeric SDK
version. If this is added to the manifest, Robolectric is unable to
parse the targetSdkVersion, and the min sdk version is used instead.
This mismatch may cause problems because the runtime SDK beleives the
app is targeting an older SDK version than it actually is.

Once Android O officially launches, this can be removed.

See https://developer.android.com/preview/migration.html for details.