### PR TITLE
Generate Javadoc for chrome plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,13 @@ buildscript {
 
     dependencies {
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:2.2.+'
+        classpath 'ch.raffael.pegdown-doclet:pegdown-doclet:1.3'
     }
 }
 
 apply plugin: 'nebula-aggregate-javadocs'
+apply plugin: 'ch.raffael.pegdown-doclet'
+
 rootProject.gradle.projectsEvaluated {
     rootProject.tasks['aggregateJavadocs'].failOnError = false
 }

--- a/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
@@ -90,6 +90,7 @@ class RoboJavaModulePlugin implements Plugin<Project> {
         if (owner.deploy) {
             project.apply plugin: "signing"
             project.apply plugin: "maven"
+            project.apply plugin: 'ch.raffael.pegdown-doclet'
 
             task('sourcesJar', type: Jar, dependsOn: classes) {
                 classifier "sources"

--- a/robolectric-processor/build.gradle
+++ b/robolectric-processor/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     // Compile dependencies
     compile "com.google.guava:guava:20.0"
     compileOnly "com.google.code.findbugs:jsr305:3.0.1"
+    compile "com.google.code.gson:gson:2.8.0"
+    compile 'ch.raffael.pegdown-doclet:pegdown-doclet:1.3'
+
     compile files("${System.properties['java.home']}/../lib/tools.jar")
 
     // Testing dependencies

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedElement.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedElement.java
@@ -1,0 +1,35 @@
+package org.robolectric.annotation.processing;
+
+import com.google.gson.JsonObject;
+
+import java.util.regex.Pattern;
+
+public abstract class DocumentedElement {
+  private static final Pattern START_OR_NEWLINE_SPACE = Pattern.compile("(^|\n) ");
+
+  private final String name;
+  private String documentation;
+
+  protected DocumentedElement(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + "{name='" + name + '\'' + '}';
+  }
+
+  public void setDocumentation(String docStr) {
+    if (docStr != null) {
+      this.documentation = START_OR_NEWLINE_SPACE.matcher(docStr).replaceAll("$1");
+    }
+  }
+
+  public String getDocumentation() {
+    return documentation;
+  }
+}

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedMethod.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedMethod.java
@@ -1,0 +1,19 @@
+package org.robolectric.annotation.processing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DocumentedMethod extends RobolectricModel.DocumentedElement {
+  public boolean isImplementation;
+  public List<String> modifiers = new ArrayList<>();
+  public String documentation;
+  public List<String> params = new ArrayList<>();
+  public String returnType;
+  public List<String> exceptions = new ArrayList<>();
+  public Integer minSdk;
+  public Integer maxSdk;
+
+  public DocumentedMethod(String name) {
+    super(name);
+  }
+}

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedMethod.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedMethod.java
@@ -3,10 +3,9 @@ package org.robolectric.annotation.processing;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DocumentedMethod extends RobolectricModel.DocumentedElement {
+public class DocumentedMethod extends DocumentedElement {
   public boolean isImplementation;
   public List<String> modifiers = new ArrayList<>();
-  public String documentation;
   public List<String> params = new ArrayList<>();
   public String returnType;
   public List<String> exceptions = new ArrayList<>();

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedPackage.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedPackage.java
@@ -1,0 +1,28 @@
+package org.robolectric.annotation.processing;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class DocumentedPackage extends RobolectricModel.DocumentedElement {
+  private final Map<String, DocumentedType> documentedTypes = new TreeMap<>();
+
+  public String documentation;
+
+  DocumentedPackage(String name) {
+    super(name);
+  }
+
+  public Collection<DocumentedType> getDocumentedTypes() {
+    return documentedTypes.values();
+  }
+
+  public DocumentedType getDocumentedType(String name) {
+    DocumentedType documentedType = documentedTypes.get(name);
+    if (documentedType == null) {
+      documentedType = new DocumentedType(name);
+      documentedTypes.put(name, documentedType);
+    }
+    return documentedType;
+  }
+}

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedPackage.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedPackage.java
@@ -4,10 +4,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
 
-public class DocumentedPackage extends RobolectricModel.DocumentedElement {
+public class DocumentedPackage extends DocumentedElement {
   private final Map<String, DocumentedType> documentedTypes = new TreeMap<>();
-
-  public String documentation;
 
   DocumentedPackage(String name) {
     super(name);

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedType.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedType.java
@@ -5,10 +5,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-public class DocumentedType extends RobolectricModel.DocumentedElement {
+public class DocumentedType extends DocumentedElement {
   public final Map<String, DocumentedMethod> methods = new TreeMap<>();
 
-  public String documentation;
   public List<String> imports;
 
   DocumentedType(String name) {

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedType.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/DocumentedType.java
@@ -1,0 +1,30 @@
+package org.robolectric.annotation.processing;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class DocumentedType extends RobolectricModel.DocumentedElement {
+  public final Map<String, DocumentedMethod> methods = new TreeMap<>();
+
+  public String documentation;
+  public List<String> imports;
+
+  DocumentedType(String name) {
+    super(name);
+  }
+
+  public DocumentedMethod getDocumentedMethod(String desc) {
+    DocumentedMethod documentedMethod = methods.get(desc);
+    if (documentedMethod == null) {
+      documentedMethod = new DocumentedMethod(desc);
+      methods.put(desc, documentedMethod);
+    }
+    return documentedMethod;
+  }
+
+  public Collection<DocumentedMethod> getMethods() {
+    return methods.values();
+  }
+}

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/RobolectricModel.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/RobolectricModel.java
@@ -81,25 +81,8 @@ public class RobolectricModel {
     return documentedPackages.values();
   }
 
-  public static abstract class DocumentedElement {
-    private final String name;
-
-    protected DocumentedElement(String name) {
-      this.name = name;
-    }
-
-    public String getName() {
-      return name;
-    }
-
-    @Override
-    public String toString() {
-      return getClass().getSimpleName() + "{name='" + name + '\'' + '}';
-    }
-  }
-
   public void documentPackage(String name, String documentation) {
-    getDocumentedPackage(name).documentation = documentation;
+    getDocumentedPackage(name).setDocumentation(documentation);
   }
 
   private DocumentedPackage getDocumentedPackage(String name) {
@@ -118,7 +101,7 @@ public class RobolectricModel {
 
   public void documentType(TypeElement type, String documentation, List<String> imports) {
     DocumentedType documentedType = getDocumentedType(type);
-    documentedType.documentation = documentation;
+    documentedType.setDocumentation(documentation);
     documentedType.imports = imports;
   }
 

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
@@ -1,6 +1,7 @@
 package org.robolectric.annotation.processing;
 
 import org.robolectric.annotation.processing.generator.Generator;
+import org.robolectric.annotation.processing.generator.JavadocJsonGenerator;
 import org.robolectric.annotation.processing.generator.ServiceLoaderGenerator;
 import org.robolectric.annotation.processing.generator.ShadowProviderGenerator;
 import org.robolectric.annotation.processing.validator.ImplementationValidator;
@@ -14,7 +15,6 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
@@ -75,6 +75,7 @@ public class RobolectricProcessor extends AbstractProcessor {
 
     generators.add(new ShadowProviderGenerator(model, environment, shadowPackage, shouldInstrumentPackages));
     generators.add(new ServiceLoaderGenerator(environment, shadowPackage));
+    generators.add(new JavadocJsonGenerator(model, environment));
   }
 
   @Override

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
@@ -10,7 +10,6 @@ import org.robolectric.annotation.processing.validator.ResetterValidator;
 import org.robolectric.annotation.processing.validator.Validator;
 
 import javax.annotation.processing.AbstractProcessor;
-import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -19,7 +18,6 @@ import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
-import javax.tools.Diagnostic.Kind;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -75,8 +73,8 @@ public class RobolectricProcessor extends AbstractProcessor {
     addValidator(new RealObjectValidator(model, environment));
     addValidator(new ResetterValidator(model, environment));
 
-    generators.add(new ShadowProviderGenerator(model, environment, shouldInstrumentPackages));
-    generators.add(new ServiceLoaderGenerator(model, environment));
+    generators.add(new ShadowProviderGenerator(model, environment, shadowPackage, shouldInstrumentPackages));
+    generators.add(new ServiceLoaderGenerator(environment, shadowPackage));
   }
 
   @Override
@@ -90,10 +88,10 @@ public class RobolectricProcessor extends AbstractProcessor {
       }
     }
 
-    if (!generated && shadowPackage != null) {
+    if (!generated) {
       model.prepare();
       for (Generator generator : generators) {
-        generator.generate(shadowPackage);
+        generator.generate();
       }
       generated = true;
     }
@@ -108,9 +106,8 @@ public class RobolectricProcessor extends AbstractProcessor {
     if (this.options == null) {
       this.options = options;
       this.shadowPackage = options.get(PACKAGE_OPT);
-      this.shouldInstrumentPackages = 
-          "false".equalsIgnoreCase(options.get(SHOULD_INSTRUMENT_PKG_OPT)) 
-          ? false : true;
+      this.shouldInstrumentPackages =
+          !"false".equalsIgnoreCase(options.get(SHOULD_INSTRUMENT_PKG_OPT));
     }
   }
 

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/Generator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/Generator.java
@@ -6,5 +6,5 @@ package org.robolectric.annotation.processing.generator;
 public abstract class Generator {
   protected static final String GEN_CLASS = "Shadows";
 
-  public abstract void generate(String shadowPackage);
+  public abstract void generate();
 }

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/JavadocJsonGenerator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/JavadocJsonGenerator.java
@@ -2,8 +2,6 @@ package org.robolectric.annotation.processing.generator;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
-import org.robolectric.annotation.processing.DocumentedMethod;
 import org.robolectric.annotation.processing.DocumentedPackage;
 import org.robolectric.annotation.processing.DocumentedType;
 import org.robolectric.annotation.processing.RobolectricModel;
@@ -18,11 +16,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 public class JavadocJsonGenerator extends Generator {
 
-  public static final Pattern START_OR_NEWLINE_SPACE = Pattern.compile("(^|\n) ");
   private final RobolectricModel model;
   private final Messager messager;
   private final Gson gson;
@@ -52,38 +48,13 @@ public class JavadocJsonGenerator extends Generator {
       shadowedTypes.put(shadowType, shadowedType);
     }
 
-    File docs = new File("robolectric-shadows/shadows-core/build/json-docs");
+    File docs = new File("build/docs/json");
 
     for (DocumentedPackage documentedPackage : model.getDocumentedPackages()) {
-      JsonObject packageJsonObj = new JsonObject();
-      packageJsonObj.addProperty("doc", documentedPackage.documentation);
-//      writeJson(packageJsonObj, new File(docs, documentedPackage.getName() + ".json"));
-
       for (DocumentedType documentedType : documentedPackage.getDocumentedTypes()) {
         String shadowedType = shadowedTypes.get(documentedType.getName());
-//        System.out.println("For " + shadowedType + " methods are " + documentedType.getMethods());
-
-        JsonObject typeJsonObj = new JsonObject();
-        typeJsonObj.addProperty("shadowClass", documentedType.getName());
-        putDoc(typeJsonObj, documentedType.documentation);
-
-        JsonObject methodsJsonObj = new JsonObject();
-        for (DocumentedMethod documentedMethod : documentedType.getMethods()) {
-          JsonObject methodJsonObj = new JsonObject();
-          methodsJsonObj.add(documentedMethod.getName(), methodJsonObj);
-          putDoc(methodJsonObj, documentedMethod.documentation);
-        }
-        typeJsonObj.add("methods", methodsJsonObj);
-
         writeJson(documentedType, new File(docs, shadowedType + ".json"));
       }
-    }
-  }
-
-  private void putDoc(JsonObject typeJsonObj, String docStr) {
-    if (docStr != null && !docStr.isEmpty()) {
-      String formattedDocStr = START_OR_NEWLINE_SPACE.matcher(docStr).replaceAll("$1");
-      typeJsonObj.addProperty("doc", formattedDocStr);
     }
   }
 

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/JavadocJsonGenerator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/JavadocJsonGenerator.java
@@ -1,0 +1,101 @@
+package org.robolectric.annotation.processing.generator;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import org.robolectric.annotation.processing.DocumentedMethod;
+import org.robolectric.annotation.processing.DocumentedPackage;
+import org.robolectric.annotation.processing.DocumentedType;
+import org.robolectric.annotation.processing.RobolectricModel;
+
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class JavadocJsonGenerator extends Generator {
+
+  public static final Pattern START_OR_NEWLINE_SPACE = Pattern.compile("(^|\n) ");
+  private final RobolectricModel model;
+  private final Messager messager;
+  private final Gson gson;
+
+  public JavadocJsonGenerator(RobolectricModel model, ProcessingEnvironment environment) {
+    super();
+
+    this.model = model;
+    this.messager = environment.getMessager();
+    gson = new GsonBuilder()
+        .setPrettyPrinting()
+        .create();
+  }
+
+  @Override
+  public void generate() {
+    Map<String, String> shadowedTypes = new HashMap<>();
+    for (Map.Entry<TypeElement, TypeElement> entry : model.getShadowOfMap().entrySet()) {
+      String shadowType = entry.getKey().getQualifiedName().toString();
+      String shadowedType = entry.getValue().getQualifiedName().toString();
+      shadowedTypes.put(shadowType, shadowedType);
+    }
+
+    for (Map.Entry<String, String> entry : model.getExtraShadowTypes().entrySet()) {
+      String shadowType = entry.getKey();
+      String shadowedType = entry.getValue();
+      shadowedTypes.put(shadowType, shadowedType);
+    }
+
+    File docs = new File("robolectric-shadows/shadows-core/build/json-docs");
+
+    for (DocumentedPackage documentedPackage : model.getDocumentedPackages()) {
+      JsonObject packageJsonObj = new JsonObject();
+      packageJsonObj.addProperty("doc", documentedPackage.documentation);
+//      writeJson(packageJsonObj, new File(docs, documentedPackage.getName() + ".json"));
+
+      for (DocumentedType documentedType : documentedPackage.getDocumentedTypes()) {
+        String shadowedType = shadowedTypes.get(documentedType.getName());
+//        System.out.println("For " + shadowedType + " methods are " + documentedType.getMethods());
+
+        JsonObject typeJsonObj = new JsonObject();
+        typeJsonObj.addProperty("shadowClass", documentedType.getName());
+        putDoc(typeJsonObj, documentedType.documentation);
+
+        JsonObject methodsJsonObj = new JsonObject();
+        for (DocumentedMethod documentedMethod : documentedType.getMethods()) {
+          JsonObject methodJsonObj = new JsonObject();
+          methodsJsonObj.add(documentedMethod.getName(), methodJsonObj);
+          putDoc(methodJsonObj, documentedMethod.documentation);
+        }
+        typeJsonObj.add("methods", methodsJsonObj);
+
+        writeJson(documentedType, new File(docs, shadowedType + ".json"));
+      }
+    }
+  }
+
+  private void putDoc(JsonObject typeJsonObj, String docStr) {
+    if (docStr != null && !docStr.isEmpty()) {
+      String formattedDocStr = START_OR_NEWLINE_SPACE.matcher(docStr).replaceAll("$1");
+      typeJsonObj.addProperty("doc", formattedDocStr);
+    }
+  }
+
+  private void writeJson(Object object, File file) {
+    file.getParentFile().mkdirs();
+
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+      gson.toJson(object, writer);
+    } catch (IOException e) {
+      messager.printMessage(Diagnostic.Kind.ERROR, "Failed to write javadoc JSON file: " + e);
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/ServiceLoaderGenerator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/ServiceLoaderGenerator.java
@@ -18,16 +18,16 @@ import java.io.PrintWriter;
 public class ServiceLoaderGenerator extends Generator {
   private final Filer filer;
   private final Messager messager;
-  private final RobolectricModel model;
+  private final String shadowPackage;
 
-  public ServiceLoaderGenerator(RobolectricModel model, ProcessingEnvironment environment) {
+  public ServiceLoaderGenerator(ProcessingEnvironment environment, String shadowPackage) {
     this.filer = environment.getFiler();
     this.messager = environment.getMessager();
-    this.model = model;
+    this.shadowPackage = shadowPackage;
   }
 
   @Override
-  public void generate(String shadowPackage) {
+  public void generate() {
     final String fileName = "org.robolectric.internal.ShadowProvider";
 
     try {

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/ShadowProviderGenerator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/ShadowProviderGenerator.java
@@ -28,19 +28,21 @@ public class ShadowProviderGenerator extends Generator {
   private final Messager messager;
   private final Elements elements;
   private final RobolectricModel model;
+  private final String shadowPackage;
   private final boolean shouldInstrumentPackages;
 
-  public ShadowProviderGenerator(RobolectricModel model, ProcessingEnvironment environment, 
-      boolean shouldInstrumentPackages) {
+  public ShadowProviderGenerator(RobolectricModel model, ProcessingEnvironment environment,
+                                 String shadowPackage, boolean shouldInstrumentPackages) {
     this.messager = environment.getMessager();
     this.elements = environment.getElementUtils();
     this.filer = environment.getFiler();
     this.model = model;
+    this.shadowPackage = shadowPackage;
     this.shouldInstrumentPackages = shouldInstrumentPackages;
   }
 
   @Override
-  public void generate(String shadowPackage) {
+  public void generate() {
     final String shadowClassName = shadowPackage + '.' + GEN_CLASS;
 
     // TODO: Because this was fairly simple to begin with I haven't
@@ -52,7 +54,7 @@ public class ShadowProviderGenerator extends Generator {
     try {
       JavaFileObject jfo = filer.createSourceFile(shadowClassName);
       writer = new PrintWriter(jfo.openWriter());
-      generate(shadowPackage, writer);
+      generate(writer);
     } catch (IOException e) {
       messager.printMessage(Diagnostic.Kind.ERROR, "Failed to write shadow class file: " + e);
       throw new RuntimeException(e);
@@ -64,7 +66,7 @@ public class ShadowProviderGenerator extends Generator {
     }
   }
 
-  void generate(String shadowPackage, PrintWriter writer) {
+  void generate(PrintWriter writer) {
     writer.print("package " + shadowPackage + ";\n");
     for (String name : model.getImports()) {
       writer.println("import " + name + ';');

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/ShadowProviderGenerator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/generator/ShadowProviderGenerator.java
@@ -43,6 +43,10 @@ public class ShadowProviderGenerator extends Generator {
 
   @Override
   public void generate() {
+    if (shadowPackage == null) {
+      return;
+    }
+
     final String shadowClassName = shadowPackage + '.' + GEN_CLASS;
 
     // TODO: Because this was fairly simple to begin with I haven't

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementsValidator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementsValidator.java
@@ -161,15 +161,11 @@ public class ImplementsValidator extends Validator {
       }
       String docMd = elementUtils.getDocComment(methodElement);
       if (docMd != null) {
-        documentedMethod.documentation = prepareJavadocMarkdown(docMd);
+        documentedMethod.setDocumentation(docMd);
       }
 
       model.documentMethod(elem, documentedMethod);
     }
-  }
-
-  static String prepareJavadocMarkdown(String docMd) {
-    return docMd.replaceAll("\n ", "\n").trim();
   }
 
   private Integer sdkOrNull(int sdk) {

--- a/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementsValidator.java
+++ b/robolectric-processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementsValidator.java
@@ -1,17 +1,26 @@
 package org.robolectric.annotation.processing.validator;
 
+import com.sun.source.tree.ImportTree;
+import com.sun.source.util.Trees;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.processing.DocumentedMethod;
 import org.robolectric.annotation.processing.RobolectricModel;
-
-import java.util.List;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic.Kind;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Validator that checks usages of {@link org.robolectric.annotation.Implements}.
@@ -21,8 +30,12 @@ public class ImplementsValidator extends Validator {
   public static final String IMPLEMENTS_CLASS = "org.robolectric.annotation.Implements";
   public static final int MAX_SUPPORTED_ANDROID_SDK = 10000; // Now == Build.VERSION_CODES.O
 
+  private final ProcessingEnvironment env;
+
   public ImplementsValidator(RobolectricModel model, ProcessingEnvironment env) {
     super(model, env, IMPLEMENTS_CLASS);
+
+    this.env = env;
   }
 
   private TypeElement getClassNameTypeElement(AnnotationValue cv) {
@@ -35,9 +48,11 @@ public class ImplementsValidator extends Validator {
     }
     return type;
   }
-  
+
   @Override
   public Void visitType(TypeElement elem, Element parent) {
+    captureJavadoc(elem);
+
     // Don't import nested classes because some of them have the same name.
     AnnotationMirror am = getCurrentAnnotation();
     AnnotationValue av = RobolectricModel.getAnnotationValue(am, "value");
@@ -112,5 +127,52 @@ public class ImplementsValidator extends Validator {
     }
     model.addShadowType(elem, type);
     return null;
+  }
+
+  private void captureJavadoc(TypeElement elem) {
+    List<String> imports = new ArrayList<>();
+    List<? extends ImportTree> importLines = Trees.instance(env).getPath(elem).getCompilationUnit().getImports();
+    for (ImportTree importLine : importLines) {
+      imports.add(importLine.getQualifiedIdentifier().toString());
+    }
+
+    Elements elementUtils = env.getElementUtils();
+    model.documentType(elem, elementUtils.getDocComment(elem), imports);
+
+    for (Element memberElement : ElementFilter.methodsIn(elem.getEnclosedElements())) {
+      ExecutableElement methodElement = (ExecutableElement) memberElement;
+      Implementation implementation = memberElement.getAnnotation(Implementation.class);
+
+      DocumentedMethod documentedMethod = new DocumentedMethod(memberElement.toString());
+      for (Modifier modifier : memberElement.getModifiers()) {
+        documentedMethod.modifiers.add(modifier.toString());
+      }
+      documentedMethod.isImplementation = implementation != null;
+      if (implementation != null) {
+        documentedMethod.minSdk = sdkOrNull(implementation.minSdk());
+        documentedMethod.maxSdk = sdkOrNull(implementation.maxSdk());
+      }
+      for (VariableElement variableElement : methodElement.getParameters()) {
+        documentedMethod.params.add(variableElement.toString());
+      }
+      documentedMethod.returnType = methodElement.getReturnType().toString();
+      for (TypeMirror typeMirror : methodElement.getThrownTypes()) {
+        documentedMethod.exceptions.add(typeMirror.toString());
+      }
+      String docMd = elementUtils.getDocComment(methodElement);
+      if (docMd != null) {
+        documentedMethod.documentation = prepareJavadocMarkdown(docMd);
+      }
+
+      model.documentMethod(elem, documentedMethod);
+    }
+  }
+
+  static String prepareJavadocMarkdown(String docMd) {
+    return docMd.replaceAll("\n ", "\n").trim();
+  }
+
+  private Integer sdkOrNull(int sdk) {
+    return sdk == -1 ? null : sdk;
   }
 }

--- a/robolectric-processor/src/test/java/com/example/objects/DocumentedObject.java
+++ b/robolectric-processor/src/test/java/com/example/objects/DocumentedObject.java
@@ -1,0 +1,15 @@
+package com.example.objects;
+
+import java.util.Map;
+
+public class DocumentedObject {
+  public String getSomething(int index, Map<String, String> defaultValue) {
+    return null;
+  }
+
+  public static class StaticInnerClass {
+    public static String main(String[] argv) {
+      return null;
+    }
+  }
+}

--- a/robolectric-processor/src/test/java/org/robolectric/annotation/processing/RobolectricProcessorTest.java
+++ b/robolectric-processor/src/test/java/org/robolectric/annotation/processing/RobolectricProcessorTest.java
@@ -12,6 +12,7 @@ import static org.robolectric.annotation.processing.validator.Utils.SHADOW_PROVI
 import static org.robolectric.annotation.processing.validator.Utils.SHADOW_EXTRACTOR_SOURCE;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -248,9 +249,9 @@ public class RobolectricProcessorTest {
         .processedWith(new RobolectricProcessor())
         .compilesWithoutError();
     JsonParser jsonParser = new JsonParser();
-    JsonElement json = jsonParser.parse(new BufferedReader(new FileReader("docs.json")));
-    assertThat(((JsonObject) json).getAsJsonObject("com.example.objects.AnyObject")
-        .getAsJsonPrimitive("doc").getAsString())
-        .isEqualTo("Robolectric Javadoc goes here!");
+    String jsonFile = "build/docs/json/org.robolectric.Robolectric.DocumentedObject.json";
+    JsonElement json = jsonParser.parse(new BufferedReader(new FileReader(jsonFile)));
+    assertThat(((JsonObject) json).get("documentation").getAsString())
+        .isEqualTo("Robolectric Javadoc goes here!\n");
   }
 }

--- a/robolectric-processor/src/test/java/org/robolectric/annotation/processing/RobolectricProcessorTest.java
+++ b/robolectric-processor/src/test/java/org/robolectric/annotation/processing/RobolectricProcessorTest.java
@@ -1,5 +1,6 @@
 package org.robolectric.annotation.processing;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.truth0.Truth.ASSERT;
 import static com.google.testing.compile.JavaFileObjects.*;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
@@ -11,11 +12,15 @@ import static org.robolectric.annotation.processing.validator.Utils.SHADOW_PROVI
 import static org.robolectric.annotation.processing.validator.Utils.SHADOW_EXTRACTOR_SOURCE;
 
 import java.io.BufferedReader;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -232,5 +237,20 @@ public class RobolectricProcessorTest {
     .compilesWithoutError()
     .and()
     .generatesSources(forResource("org/robolectric/Robolectric_EmptyProvidedPackageNames.java"));   
+  }
+
+  @Test
+  public void shouldGenerateJavadocJson() throws Exception {
+    ASSERT.about(javaSources())
+        .that(ImmutableList.of(
+            ROBO_SOURCE,
+            forResource("org/robolectric/annotation/processing/shadows/DocumentedObjectShadow.java")))
+        .processedWith(new RobolectricProcessor())
+        .compilesWithoutError();
+    JsonParser jsonParser = new JsonParser();
+    JsonElement json = jsonParser.parse(new BufferedReader(new FileReader("docs.json")));
+    assertThat(((JsonObject) json).getAsJsonObject("com.example.objects.AnyObject")
+        .getAsJsonPrimitive("doc").getAsString())
+        .isEqualTo("Robolectric Javadoc goes here!");
   }
 }

--- a/robolectric-processor/src/test/java/org/robolectric/annotation/processing/generator/ShadowProviderGeneratorTest.java
+++ b/robolectric-processor/src/test/java/org/robolectric/annotation/processing/generator/ShadowProviderGeneratorTest.java
@@ -27,7 +27,7 @@ public class ShadowProviderGeneratorTest {
   @Before
   public void setUp() throws Exception {
     model = mock(RobolectricModel.class);
-    generator = new ShadowProviderGenerator(model, mock(ProcessingEnvironment.class), true);
+    generator = new ShadowProviderGenerator(model, mock(ProcessingEnvironment.class), "the.package", true);
     writer = new StringWriter();
   }
 
@@ -40,7 +40,7 @@ public class ShadowProviderGeneratorTest {
     resetters.put(type("ShadowThing", 21, -1), element("resetMin21"));
     when(model.getResetters()).thenReturn(resetters);
 
-    generator.generate("the.package", new PrintWriter(writer));
+    generator.generate(new PrintWriter(writer));
 
     assertThat(writer.toString()).contains("if (org.robolectric.RuntimeEnvironment.getApiLevel() >= 19 && org.robolectric.RuntimeEnvironment.getApiLevel() <= 20) ShadowThing.reset19To20();");
     assertThat(writer.toString()).contains("if (org.robolectric.RuntimeEnvironment.getApiLevel() >= 21) ShadowThing.resetMin21();");

--- a/robolectric-processor/src/test/java/org/robolectric/annotation/processing/validator/ImplementsValidatorTest.java
+++ b/robolectric-processor/src/test/java/org/robolectric/annotation/processing/validator/ImplementsValidatorTest.java
@@ -5,6 +5,7 @@ import static org.robolectric.annotation.processing.validator.SingleClassSubject
 import static org.truth0.Truth.ASSERT;
 
 import org.junit.Test;
+import org.robolectric.annotation.processing.DocumentedMethod;
 
 public class ImplementsValidatorTest {
   @Test
@@ -87,8 +88,12 @@ public class ImplementsValidatorTest {
 
   @Test
   public void javadocMarkdownFormatting() throws Exception {
-    assertThat(ImplementsValidator.prepareJavadocMarkdown(
+    DocumentedMethod documentedMethod = new DocumentedMethod("name");
+    documentedMethod.setDocumentation(
         " First sentence.\n \n Second sentence.\n \n ASCII art:\n   *  *  *\n @return null\n"
-    )).isEqualTo("First sentence.\n\nSecond sentence.\n\nASCII art:\n  *  *  *\n@return null");
+    );
+
+    assertThat(documentedMethod.getDocumentation())
+        .isEqualTo("First sentence.\n\nSecond sentence.\n\nASCII art:\n  *  *  *\n@return null\n");
   }
 }

--- a/robolectric-processor/src/test/java/org/robolectric/annotation/processing/validator/ImplementsValidatorTest.java
+++ b/robolectric-processor/src/test/java/org/robolectric/annotation/processing/validator/ImplementsValidatorTest.java
@@ -1,5 +1,6 @@
 package org.robolectric.annotation.processing.validator;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.annotation.processing.validator.SingleClassSubject.singleClass;
 import static org.truth0.Truth.ASSERT;
 
@@ -82,5 +83,12 @@ public class ImplementsValidatorTest {
       .failsToCompile()
       .withErrorContaining("Shadow type has type parameters but real type does not")
       .onLine(7);
+  }
+
+  @Test
+  public void javadocMarkdownFormatting() throws Exception {
+    assertThat(ImplementsValidator.prepareJavadocMarkdown(
+        " First sentence.\n \n Second sentence.\n \n ASCII art:\n   *  *  *\n @return null\n"
+    )).isEqualTo("First sentence.\n\nSecond sentence.\n\nASCII art:\n  *  *  *\n@return null");
   }
 }

--- a/robolectric-processor/src/test/resources/mock-source/Robolectric.java
+++ b/robolectric-processor/src/test/resources/mock-source/Robolectric.java
@@ -14,4 +14,7 @@ package org.robolectric;
  */
 public class Robolectric {
   public interface Anything {}
+
+  public static class DocumentedObject {
+  }
 }

--- a/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/DocumentedObjectShadow.java
+++ b/robolectric-processor/src/test/resources/org/robolectric/annotation/processing/shadows/DocumentedObjectShadow.java
@@ -1,0 +1,22 @@
+package org.robolectric.annotation.processing.shadows;
+
+import org.robolectric.Robolectric;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
+
+import java.util.Map;
+
+/**
+ * Robolectric Javadoc goes here!
+ */
+@Implements(value = Robolectric.DocumentedObject.class)
+public class DocumentedObjectShadow {
+  /**
+   * Docs for shadow method go here!
+   */
+  @Implementation
+  public String getSomething(int index, Map<String, String> defaultValue) {
+    return null;
+  }
+}

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java
@@ -858,8 +858,14 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   /**
-   * Obtain flags for actions supported. Currently only supports ACTION_CLICK, ACTION_LONG_CLICK,
-   * ACTION_SCROLL_FORWARD, ACTION_PASTE, ACTION_FOCUS, ACTION_SET_SELECTION, ACTION_SCROLL_BACKWARD
+   * Obtain flags for actions supported. Currently only supports
+   * {@link AccessibilityNodeInfo#ACTION_CLICK},
+   * {@link AccessibilityNodeInfo#ACTION_LONG_CLICK},
+   * {@link AccessibilityNodeInfo#ACTION_SCROLL_FORWARD},
+   * {@link AccessibilityNodeInfo#ACTION_PASTE},
+   * {@link AccessibilityNodeInfo#ACTION_FOCUS},
+   * {@link AccessibilityNodeInfo#ACTION_SET_SELECTION},
+   * {@link AccessibilityNodeInfo#ACTION_SCROLL_BACKWARD}
    * Returned value is derived from the getters.
    *
    * @return Action mask. 0 if no actions supported.

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
@@ -55,7 +55,7 @@ import static org.robolectric.shadows.util.DataSource.toDataSource;
  * <li>Full support of the {@link MediaPlayer} internal states and their
  * transition map.</li>
  * <li>Configure time parameters such as playback duration, preparation delay
- * and (@link #setSeekDelay seek delay}.</li>
+ * and {@link #setSeekDelay seek delay}.</li>
  * <li>Emulation of asynchronous callback events during playback through
  * Robolectric's scheduling system using the {@link MediaInfo} inner class.</li>
  * <li>Emulation of error behavior when methods are called from invalid states,


### PR DESCRIPTION
* Javadoc now processed as markdown.
* `gradlew classes` now generates a bunch of json files in `build/docs/json` which can be uploaded (manually for now) to [robolectric.github.io](robolectric.github.io) for use by the Chrome plugin.