### PR TITLE
Reset shared preferences static cache.

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
@@ -14,13 +14,18 @@ import android.content.ServiceConnection;
 import android.hardware.SystemSensorManager;
 import android.net.wifi.p2p.IWifiP2pManager;
 import android.net.wifi.p2p.WifiP2pManager;
-import android.os.*;
+import android.os.Bundle;
+import android.os.Environment;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.UserHandle;
 import android.view.Display;
 import android.view.accessibility.AccessibilityManager;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
+import org.robolectric.annotation.Resetter;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
@@ -361,5 +366,13 @@ public class ShadowContextImpl {
   @Implementation(minSdk = KITKAT)
   public File[] getExternalFilesDirs(String type) {
     return new File[] { Environment.getExternalStoragePublicDirectory(type) };
+  }
+
+  @Resetter
+  public static void reset() {
+    String prefsCacheFieldName = RuntimeEnvironment.getApiLevel() >= N ? "sSharedPrefsCache" : "sSharedPrefs";
+    Object prefsDefaultValue = RuntimeEnvironment.getApiLevel() >= KITKAT ? null : new HashMap<>();
+    Class<?> contextImplClass = ReflectionHelpers.loadClass(ShadowContextImpl.class.getClassLoader(), "android.app.ContextImpl");
+    ReflectionHelpers.setStaticField(contextImplClass, prefsCacheFieldName, prefsDefaultValue);
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIoUtils.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowIoUtils.java
@@ -1,0 +1,19 @@
+package org.robolectric.shadows;
+
+
+import libcore.io.IoUtils;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+@Implements(value = IoUtils.class, isInAndroidSdk = false)
+public class ShadowIoUtils {
+
+  @Implementation
+  public static String readFileAsString(String absolutePath) throws IOException {
+    return new String(Files.readAllBytes(Paths.get(absolutePath)));
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
+++ b/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
@@ -74,7 +74,8 @@ public class AndroidConfigurer {
 
     builder.addClassNameTranslation("java.net.ExtendedResponseCache", RoboExtendedResponseCache.class.getName())
         .addClassNameTranslation("java.net.ResponseSource", RoboResponseSource.class.getName())
-        .addClassNameTranslation("java.nio.charset.Charsets", RoboCharsets.class.getName());
+        .addClassNameTranslation("java.nio.charset.Charsets", RoboCharsets.class.getName())
+        .addClassNameTranslation("java.lang.UnsafeByteSequence", Object.class.getName());
 
     // Instrumenting these classes causes a weird failure.
     builder.doNotInstrumentClass("android.R")

--- a/robolectric/src/test/java/org/robolectric/android/internal/ParallelUniverseTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/ParallelUniverseTest.java
@@ -2,6 +2,7 @@ package org.robolectric.android.internal;
 
 import android.app.Application;
 
+import android.os.Build;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +44,7 @@ public class ParallelUniverseTest {
   @Before
   public void setUp() throws InitializationError {
     pu = new ParallelUniverse();
-    pu.setSdkConfig(new SdkConfig(18));
+    pu.setSdkConfig(new SdkConfig(Build.VERSION_CODES.M));
   }
 
   private void setUpApplicationState(Config defaultConfig) {
@@ -128,7 +129,7 @@ public class ParallelUniverseTest {
     String givenQualifiers = "";
     Config c = new Config.Builder().setQualifiers(givenQualifiers).build();
     setUpApplicationState(c);
-    assertThat(RuntimeEnvironment.getQualifiers()).contains("v18");
+    assertThat(RuntimeEnvironment.getQualifiers()).contains("v23");
   }
   
   @Test
@@ -144,7 +145,7 @@ public class ParallelUniverseTest {
     String givenQualifiers = "large-land";
     Config c = new Config.Builder().setQualifiers(givenQualifiers).build();
     setUpApplicationState(c);
-    assertThat(RuntimeEnvironment.getQualifiers()).contains("large-land-v18");
+    assertThat(RuntimeEnvironment.getQualifiers()).contains("large-land-v23");
   }
   
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowIoUtilsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowIoUtilsTest.java
@@ -1,0 +1,28 @@
+package org.robolectric.shadows;
+
+
+import libcore.io.IoUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.TestRunners;
+import org.robolectric.test.TemporaryFolder;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(TestRunners.MultiApiSelfTest.class)
+public class ShadowIoUtilsTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void ioUtils() throws Exception {
+
+    File fontFile = temporaryFolder.newFile("test_file.txt", "some contents");
+
+    String contents = IoUtils.readFileAsString(fontFile.getAbsolutePath());
+    assertThat(contents).isEqualTo("some contents");
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSharedPreferencesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSharedPreferencesTest.java
@@ -1,16 +1,12 @@
 package org.robolectric.shadows;
 
-import android.app.QueuedWork;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
-import org.robolectric.annotation.Config;
 
 import java.util.*;
 
@@ -35,7 +31,7 @@ public class ShadowSharedPreferencesTest {
     context = RuntimeEnvironment.application;
 
     sharedPreferences = context.getSharedPreferences(FILENAME, 3);
-    editor = sharedPreferences.edit().clear();
+    editor = sharedPreferences.edit();
     editor.putBoolean("boolean", true);
     editor.putFloat("float", 1.1f);
     editor.putInt("int", 2);
@@ -46,13 +42,6 @@ public class ShadowSharedPreferencesTest {
     stringSet.add( "string2" );
     stringSet.add( "string3" );
     editor.putStringSet("stringSet", stringSet);
-  }
-
-  @After
-  public void tearDown() {
-    // TODO: Should be done in resetter for ShadowQueuedWork but this relies on getting a handler from main thread
-    // which has already been reset at that point.
-    QueuedWork.waitToFinish();
   }
 
   @Test


### PR DESCRIPTION
Prevents test pollution. On some platform versions this is initialized
to a HashMap, on later versions it is lazy initialized to an ArrayMap,
the field name has also changed across API versions.
