### PR TITLE
Support null ContentValues in ShadowContentResolver

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
@@ -139,8 +139,8 @@ public class ShadowContentResolver {
   @Implementation
   public final Uri insert(Uri url, ContentValues values) {
     ContentProvider provider = getProvider(url);
-
-    InsertStatement insertStatement = new InsertStatement(url, provider, new ContentValues(values));
+    ContentValues valuesCopy = (values == null) ? null : new ContentValues(values);
+    InsertStatement insertStatement = new InsertStatement(url, provider, valuesCopy);
     statements.add(insertStatement);
     insertStatements.add(insertStatement);
 
@@ -165,8 +165,8 @@ public class ShadowContentResolver {
   @Implementation
   public int update(Uri uri, ContentValues values, String where, String[] selectionArgs) {
     ContentProvider provider = getProvider(uri);
-
-    UpdateStatement updateStatement = new UpdateStatement(uri, provider, new ContentValues(values), where, selectionArgs);
+    ContentValues valuesCopy = (values == null) ? null : new ContentValues(values);
+    UpdateStatement updateStatement = new UpdateStatement(uri, provider, valuesCopy, where, selectionArgs);
     statements.add(updateStatement);
     updateStatements.add(updateStatement);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
@@ -153,6 +153,18 @@ public class ShadowContentResolverTest {
   }
 
   @Test
+  public void insert_supportsNullContentValues() throws Exception {
+    contentResolver.insert(EXTERNAL_CONTENT_URI, null);
+    assertThat(shadowContentResolver.getInsertStatements().get(0).getContentValues()).isNull();
+  }
+
+  @Test
+  public void update_supportsNullContentValues() throws Exception {
+    contentResolver.update(EXTERNAL_CONTENT_URI, null, null, null);
+    assertThat(shadowContentResolver.getUpdateStatements().get(0).getContentValues()).isNull();
+  }
+
+  @Test
   public void delete_shouldTrackDeletedUris() throws Exception {
     assertThat(shadowContentResolver.getDeletedUris().size()).isEqualTo(0);
 


### PR DESCRIPTION
According to
https://developer.android.com/reference/android/content/ContentResolver.htm,
the `values` param in `update` and `insert` is not prohibited from being
null. Update ShadowContentResolver to support null values.

