### PR TITLE
Add better handling for backslashes StringResources#escape

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/StringResources.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/StringResources.java
@@ -1,25 +1,11 @@
 package org.robolectric.res;
 
+import com.google.common.annotations.VisibleForTesting;
+import org.robolectric.util.Logger;
+
 public class StringResources {
 
   private static final int CODE_POINT_LENGTH = 4;
-
-  /**
-   * Provides escaping of String resources as described
-   *
-   * <a href="http://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling">here</a>
-   *
-   * @param text Text to escape.
-   * @return Escaped text.
-   */
-  public static String escape(String text) {
-    if (text.length() > 1 && text.charAt(0) == '"' && text.charAt(text.length() - 1) == '"') {
-      text = text.substring(1, text.length() - 1);
-    } else {
-      text = text.replaceAll("\\\\(['\"])", "$1");
-    }
-    return text;
-  }
 
   /**
    * Processes String resource values in the same way real Android does, namely:-
@@ -28,34 +14,86 @@ public class StringResources {
    * 3) Escapes
    */
   public static String processStringResources(String inputValue) {
-    return escape(convertCodePoints(inputValue.trim()
-            .replace("\\n", String.valueOf('\n'))
-            .replace("\\t", String.valueOf('\t'))
-    ));
+    return escape(inputValue.trim());
+  }
+
+  /**
+   * Provides escaping of String resources as described
+   * <p>
+   * <a href="http://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling">here</a>
+   *
+   * @param text Text to escape.
+   * @return Escaped text.
+   */
+  @VisibleForTesting
+  static String escape(String text) {
+    // unwrap double quotes
+    if (text.length() > 1 && text.charAt(0) == '"' && text.charAt(text.length() - 1) == '"') {
+      text = text.substring(1, text.length() - 1);
+    }
+    int i = 0;
+    int length = text.length();
+    StringBuilder result = new StringBuilder(text.length());
+    while (true) {
+      int j = text.indexOf('\\', i);
+      if (j == -1) {
+        result.append(text.substring(i));
+        break;
+      }
+      result.append(text.substring(i, j));
+      if (j == length - 1) {
+        // dangling backslash
+        break;
+      }
+      boolean isUnicodeEscape = false;
+      char escapeCode = text.charAt(j + 1);
+      switch (escapeCode) {
+        case '\'':
+        case '"':
+        case '\\':
+        case '?':
+        case '@':
+        case '#':
+          result.append(escapeCode);
+          break;
+        case 'n':
+          result.append('\n');
+          break;
+        case 't':
+          result.append('\t');
+          break;
+        case 'u':
+          isUnicodeEscape = true;
+          break;
+        default:
+          Logger.strict("Unsupported string resource escape code '%s'", escapeCode);
+      }
+      if (!isUnicodeEscape) {
+        i = j + 2;
+      } else {
+        j += 2;
+        if (length - j < CODE_POINT_LENGTH) {
+          throw new IllegalArgumentException("Too short code point: \\u" + text.substring(j));
+        }
+        String codePoint = text.substring(j, j + CODE_POINT_LENGTH);
+        result.append(extractCodePoint(codePoint));
+        i = j + CODE_POINT_LENGTH;
+      }
+    }
+    return result.toString();
   }
 
   /**
    * Converts code points in a given string to actual characters. This method doesn't handle code
    * points whose char counts are 2. In other words, this method doesn't handle U+10XXXX.
    */
-  private static String convertCodePoints(String src) {
-    String[] tokens = src.split("\\\\u");
-
-    StringBuilder retval = new StringBuilder(tokens[0]);
-    for (int i = 1; i < tokens.length; ++i) {
-      if (tokens[i].length() < CODE_POINT_LENGTH) {
-        throw new IllegalArgumentException("Too short code point: \\u" + tokens[i]);
-      }
-      String codePoint = tokens[i].substring(0, CODE_POINT_LENGTH);
-      try {
-        retval.append(Character.toChars(Integer.valueOf(codePoint, 16)))
-            .append(tokens[i].substring(CODE_POINT_LENGTH));
-      } catch (IllegalArgumentException e) {
-        // This may be caused by NumberFormatException of Integer.valueOf() or
-        // IllegalArgumentException of Character.toChars().
-        throw new IllegalArgumentException("Invalid code point: \\u" + codePoint, e);
-      }
+  private static char[] extractCodePoint(String codePoint) {
+    try {
+      return Character.toChars(Integer.valueOf(codePoint, 16));
+    } catch (IllegalArgumentException e) {
+      // This may be caused by NumberFormatException of Integer.valueOf() or
+      // IllegalArgumentException of Character.toChars().
+      throw new IllegalArgumentException("Invalid code point: \\u" + codePoint, e);
     }
-    return retval.toString();
   }
 }

--- a/robolectric/src/test/java/org/robolectric/res/StringResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/StringResourcesTest.java
@@ -1,6 +1,9 @@
 package org.robolectric.res;
 
 import org.junit.Test;
+
+import java.util.*;
+
 import static org.assertj.core.api.Assertions.*;
 
 public class StringResourcesTest {
@@ -8,5 +11,57 @@ public class StringResourcesTest {
   public void escape_shouldEscapeStrings() {
     assertThat(StringResources.escape("\"This'll work\"")).isEqualTo("This'll work");
     assertThat(StringResources.escape("This\\'ll also work")).isEqualTo("This'll also work");
+  }
+
+  @Test
+  public void escape_shouldEscapeCodePoints() {
+    Map<String, String> tests = new HashMap<>();
+    tests.put("\\u0031", "1");
+    tests.put("1\\u0032", "12");
+    tests.put("\\u00312", "12");
+    tests.put("1\\u00323", "123");
+    tests.put("\\u005A", "Z");
+    tests.put("\\u005a", "Z");
+
+    for (Map.Entry<String, String> t : tests.entrySet()) {
+      assertThat(StringResources.processStringResources(t.getKey())).isEqualTo(t.getValue());
+    }
+  }
+
+  // Unsupported escape codes should be ignored.
+  @Test
+  public void escape_shouldIgnoreUnsupportedEscapeCodes() {
+    assertThat(StringResources.processStringResources("\\ \\a\\b\\c\\d\\e\\ ")).isEqualTo("");
+  }
+
+  @Test
+  public void escape_shouldSupport() {
+    Map<String, String> tests = new HashMap<>();
+    tests.put("\\\\", "\\");
+    tests.put("domain\\\\username", "domain\\username");
+    for (Map.Entry<String, String> t : tests.entrySet()) {
+      assertThat(StringResources.processStringResources(t.getKey())).isEqualTo(t.getValue());
+    }
+  }
+
+  @Test
+  public void testInvalidCodePoints() {
+    List<String> tests = new LinkedList<>();
+    tests.add("\\u");
+    tests.add("\\u0");
+    tests.add("\\u00");
+    tests.add("\\u004");
+    tests.add("\\uzzzz");
+    tests.add("\\u0zzz");
+    tests.add("\\u00zz");
+    tests.add("\\u000z");
+    for (String t : tests) {
+      try {
+        StringResources.processStringResources(t);
+        fail("expected IllegalArgumentException with test '%s'", t);
+      } catch (IllegalArgumentException expected) {
+        // cool
+      }
+    }
   }
 }


### PR DESCRIPTION
Previously, StringResources#convertCodePoints did not support an edge
case where an escaped backslash was followed by another character. For
example, the string resource:

    <string name="test">\\\\user</string>

Would produce an IllegalArgumentException instead of being processed as
"\\user".

The underlying problem was that StringResources#escape repeatedly
scanned the string for escape sequences. However, it did not check if
the escape sequences were preceded by another backslash.

Update StringResources#escape to scan the string sequentially and detect
escaped backslashes. Also add some additional testing around this.

Fixes #3017