### PR TITLE
Resources.openRawResourceFd() should return null.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/res/RoutingResourceTable.java
+++ b/robolectric-resources/src/main/java/org/robolectric/res/RoutingResourceTable.java
@@ -20,7 +20,8 @@ public class RoutingResourceTable implements ResourceTable {
   }
 
   public InputStream getRawValue(int resId, String qualifiers) {
-    return getRawValue(getResName(resId), qualifiers);
+    ResName resName = getResName(resId);
+    return resName != null ? getRawValue(resName, qualifiers) : null;
   }
 
   @Override public TypedResource getValue(@Nonnull ResName resName, String qualifiers) {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -134,9 +134,20 @@ public class ShadowResources {
     }
   }
 
+  /**
+   * Since {@link AssetFileDescriptor}s are not yet supported by Robolectric, {@code null} will
+   * be returned if the resource is found. If the resource cannot be found, {@link Resources.NotFoundException} will
+   * be thrown.
+   */
   @Implementation
   public AssetFileDescriptor openRawResourceFd(int id) throws Resources.NotFoundException {
-    FileInputStream fis = (FileInputStream)openRawResource(id);
+    InputStream inputStream = openRawResource(id);
+    if (!(inputStream instanceof FileInputStream)) {
+      // todo fixme
+      return null;
+    }
+
+    FileInputStream fis = (FileInputStream) inputStream;
     try {
       return new AssetFileDescriptor(ParcelFileDescriptor.dup(fis.getFD()), 0, fis.getChannel().size());
     } catch (IOException e) {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -558,9 +558,24 @@ public class ShadowResourcesTest {
     } catch (Resources.NotFoundException e) {
       // cool
     }
+  }
 
+  @Test
+  public void openRawResourceFd_returnsNull_todo_FIX() throws Exception {
+    assertThat(resources.openRawResourceFd(R.raw.raw_resource)).isNull();
+  }
+
+  @Test
+  public void openRawResourceFd_withNonFile_throwsNotFoundException() throws Exception {
     try {
       resources.openRawResourceFd(R.string.hello);
+      fail("should throw");
+    } catch (Resources.NotFoundException e) {
+      // cool
+    }
+
+    try {
+      resources.openRawResourceFd(-1234);
       fail("should throw");
     } catch (Resources.NotFoundException e) {
       // cool


### PR DESCRIPTION
Since AssetFileDescriptors aren't supported yet, keep returning null for now.