### PR TITLE
Invoke zero-arg constructor when building an IntentService

### DIFF
--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -72,7 +72,7 @@ public class Robolectric {
   }
 
   public static <T extends IntentService> IntentServiceController<T> buildIntentService(Class<T> serviceClass, Intent intent) {
-    return IntentServiceController.of(getShadowsAdapter(), ReflectionHelpers.callConstructor(serviceClass, new ReflectionHelpers.ClassParameter<String>(String.class, "IntentService")), intent);
+    return IntentServiceController.of(getShadowsAdapter(), ReflectionHelpers.callConstructor(serviceClass), intent);
   }
 
   public static <T extends IntentService> T setupIntentService(Class<T> serviceClass) {

--- a/robolectric/src/test/java/org/robolectric/android/controller/IntentServiceControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/IntentServiceControllerTest.java
@@ -58,7 +58,7 @@ public class IntentServiceControllerTest {
 
   @Test
   public void shouldSetIntentForGivenServiceInstance() throws Exception {
-    IntentServiceController<MyService> intentServiceController = IntentServiceController.of(new CoreShadowsAdapter(), new MyService(""), null).bind();
+    IntentServiceController<MyService> intentServiceController = IntentServiceController.of(new CoreShadowsAdapter(), new MyService(), null).bind();
     assertThat(intentServiceController.get().boundIntent).isNotNull();
   }
 
@@ -121,9 +121,9 @@ public class IntentServiceControllerTest {
 
     public Intent unboundIntent;
 
-    public MyService(String name) {
-            super(name);
-        }
+    public MyService() {
+      super("ThreadName");
+    }
 
     @Override
     public IBinder onBind(Intent intent) {


### PR DESCRIPTION
Previously, Robolectric#buildServiceIntent invoked the one-arg
constructor of the IntentService subclass. If the IntentService subclass
did not have a one-arg constructor, a NoSuchMethodException was thrown.

An Android IntentService subclass is not really required to have a
one-arg constructor because the IntentService class provides a default
one that is usually called from the zero-arg constructor.

Instead, invoke the zero-arg constructor, which is required for all
Android Services. In most cases, the zero-arg constructor of the
subclass invokes the one-arg constructor of IntentService. This is more
consistent with the expectation in Android.

Fixes #3080