### PR TITLE
ShadowPendingIntent bug fixes (#3021, #2616, #2503, #2481, #2117)

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
@@ -6,10 +6,10 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -216,7 +216,7 @@ public class ShadowPendingIntent {
     return getCreatorPackage();
   }
 
-  @Implementation(minSdk = 17)
+  @Implementation(minSdk = Build.VERSION_CODES.JELLY_BEAN_MR1)
   public String getCreatorPackage() {
     return (creatorPackage == null)
         ? savedContext.getPackageName()

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
@@ -2,10 +2,12 @@ package org.robolectric.shadows;
 
 import android.app.PendingIntent;
 import android.app.PendingIntent.CanceledException;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.os.Bundle;
+import android.os.Handler;
 
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
@@ -19,80 +21,140 @@ import org.robolectric.util.ReflectionHelpers;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import static org.robolectric.Shadows.shadowOf;
 
 @Implements(PendingIntent.class)
 public class ShadowPendingIntent {
+
+  private static final int TYPE_ACTIVITY =  1;
+  private static final int TYPE_SERVICE = 2;
+  private static final int TYPE_BROADCAST = 3;
+
   private static final List<PendingIntent> createdIntents = new ArrayList<>();
 
   @RealObject
   PendingIntent realPendingIntent;
 
+  private int intentType;
   private Intent[] savedIntents;
   private Context savedContext;
-  private boolean isActivityIntent;
-  private boolean isBroadcastIntent;
-  private boolean isServiceIntent;
   private int requestCode;
   private int flags;
   private String creatorPackage;
+  private volatile boolean canceled;
+  private Bundle savedOptions;
 
   @Implementation
   public static PendingIntent getActivity(Context context, int requestCode, Intent intent, int flags) {
-    return create(context, new Intent[] {intent}, true, false, false, requestCode, flags);
+    return create(TYPE_ACTIVITY, context, requestCode, new Intent[] {intent}, flags, null);
   }
 
   @Implementation
   public static PendingIntent getActivity(Context context, int requestCode, Intent intent, int flags, Bundle options) {
-    return create(context, new Intent[] {intent}, true, false, false, requestCode, flags);
+    return create(TYPE_ACTIVITY, context, requestCode, new Intent[] {intent}, flags, options);
   }
 
   @Implementation
   public static PendingIntent getActivities(Context context, int requestCode, Intent[] intents, int flags) {
-    return create(context, intents, true, false, false, requestCode, flags);
+    return create(TYPE_ACTIVITY, context, requestCode, intents, flags, null);
   }
 
   @Implementation
   public static PendingIntent getActivities(Context context, int requestCode, Intent[] intents, int flags, Bundle options) {
-    return create(context, intents, true, false, false, requestCode, flags);
+    return create(TYPE_ACTIVITY, context, requestCode, intents, flags, options);
   }
 
   @Implementation
   public static PendingIntent getBroadcast(Context context, int requestCode, Intent intent, int flags) {
-    return create(context, new Intent[] {intent}, false, true, false, requestCode, flags);
+    return create(TYPE_BROADCAST, context, requestCode, new Intent[] {intent}, flags, null);
   }
 
   @Implementation
   public static PendingIntent getService(Context context, int requestCode, Intent intent, int flags) {
-    return create(context, new Intent[] {intent}, false, false, true, requestCode, flags);
+    return create(TYPE_SERVICE, context, requestCode, new Intent[] {intent}, flags, null);
   }
 
+  // this method is useless, but cannot be removed without breaking subclasses
   @Implementation
   public void send() throws CanceledException {
-    send(savedContext, 0, null);
+    send(null, 0, null, null, null, null, null);
+  }
+
+  // this method is useless, but cannot be removed without breaking subclasses
+  @Implementation
+  public void send(Context context, int code, Intent intent) throws CanceledException {
+    send(context, code, intent, null, null, null, null);
   }
 
   @Implementation
-  public void send(Context context, int code, Intent intent) throws CanceledException {
-    if (intent != null) {
-      for (Intent savedIntent : savedIntents) {
-        savedIntent.fillIn(intent, 0);
+  public void send(Context context, int resultCode, Intent intent, PendingIntent.OnFinished onFinished, Handler handler, String requiredPermission) throws CanceledException {
+    // forward directly to the full implementation of send rather than relying on PendingIntent to
+    // forward this; older versions of PendingIntent do not have the full overloads
+    send(
+        context,
+        resultCode,
+        intent,
+        onFinished,
+        handler,
+        requiredPermission,
+        null);
+  }
+
+  @Implementation(minSdk = 23)
+  public synchronized void send(Context context, int resultCode, Intent intent, final PendingIntent.OnFinished onFinished, final Handler handler, String requiredPermission, Bundle options)
+      throws CanceledException {
+    if (canceled) {
+      throw new CanceledException();
+    }
+
+    Intent[] sendIntents = copyIntents(savedIntents);
+    if ((flags & PendingIntent.FLAG_IMMUTABLE) == 0 && intent != null) {
+      for (int i = 0; i < savedIntents.length; i++) {
+        sendIntents[i].fillIn(intent, 0);
       }
     }
 
-    if (isActivityIntent) {
-      for (Intent savedIntent : savedIntents) {
-        context.startActivity(savedIntent);
+    if (isActivityIntent()) {
+      Bundle sendOptions = (savedOptions != null ? new Bundle(savedOptions) : null);
+      if (options != null) {
+        if (sendOptions == null) {
+          sendOptions = new Bundle();
+        }
+        sendOptions.putAll(options);
       }
-    } else if (isBroadcastIntent) {
-      for (Intent savedIntent : savedIntents) {
-        context.sendBroadcast(savedIntent);
+
+      for (Intent sendIntent : sendIntents) {
+        savedContext.startActivity(sendIntent, sendOptions);
       }
-    } else if (isServiceIntent) {
-      for (Intent savedIntent : savedIntents) {
-        context.startService(savedIntent);
-      }
+    } else if (isBroadcastIntent()) {
+      BroadcastReceiver finalBroadcastReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+          if (onFinished == null) {
+            return;
+          }
+
+          OnFinishedRunnable onFinishedRunnable = new OnFinishedRunnable(onFinished, intent, getResultCode(), getResultData(), getResultExtras(false));
+          if (handler != null) {
+            handler.post(onFinishedRunnable);
+          } else {
+            onFinishedRunnable.run();
+          }
+        }
+      };
+
+      // sendBroadcast doesn't allow passing through as many arguments as we'd like
+      savedContext.sendOrderedBroadcast(sendIntents[0], requiredPermission, finalBroadcastReceiver, null, resultCode, null, null);
+    } else if (isServiceIntent()) {
+      savedContext.startService(sendIntents[0]);
+    } else {
+      throw new IllegalStateException();
+    }
+
+    if ((flags & PendingIntent.FLAG_ONE_SHOT) != 0) {
+      cancel();
     }
   }
 
@@ -101,28 +163,40 @@ public class ShadowPendingIntent {
     return new RoboIntentSender(realPendingIntent);
   }
 
+  @Implementation
+  public synchronized void cancel() {
+    synchronized (createdIntents) {
+      canceled = true;
+      createdIntents.remove(realPendingIntent);
+    }
+  }
+
   public boolean isActivityIntent() {
-    return isActivityIntent;
+    return intentType == TYPE_ACTIVITY;
   }
 
   public boolean isBroadcastIntent() {
-    return isBroadcastIntent;
+    return intentType == TYPE_BROADCAST;
   }
 
   public boolean isServiceIntent() {
-    return isServiceIntent;
+    return intentType == TYPE_SERVICE;
   }
 
   public Context getSavedContext() {
     return savedContext;
   }
 
-  public Intent getSavedIntent() {
+  public synchronized Intent getSavedIntent() {
     return savedIntents[0];
   }
 
-  public Intent[] getSavedIntents() {
+  public synchronized Intent[] getSavedIntents() {
     return savedIntents;
+  }
+
+  public Bundle getSavedOptions() {
+    return savedOptions;
   }
 
   public int getRequestCode() {
@@ -133,15 +207,19 @@ public class ShadowPendingIntent {
     return flags;
   }
 
+  public synchronized boolean isCanceled() {
+    return canceled;
+  }
+
   @Implementation
   public String getTargetPackage() {
     return getCreatorPackage();
   }
 
-  @Implementation
+  @Implementation(minSdk = 17)
   public String getCreatorPackage() {
     return (creatorPackage == null)
-        ? RuntimeEnvironment.application.getPackageName()
+        ? savedContext.getPackageName()
         : creatorPackage;
   }
 
@@ -152,34 +230,7 @@ public class ShadowPendingIntent {
   @Override
   @Implementation
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || realPendingIntent.getClass() != o.getClass()) return false;
-    ShadowPendingIntent that = shadowOf((PendingIntent) o);
-    if (savedContext != null) {
-      String packageName = savedContext.getPackageName();
-      String thatPackageName = that.savedContext.getPackageName();
-      if (packageName != null ? !packageName.equals(thatPackageName) : thatPackageName != null) return false;
-    } else {
-      if (that.savedContext != null) return false;
-    }
-    if (this.savedIntents == null) {
-      return that.savedIntents == null;
-    }
-    if (that.savedIntents == null) {
-      return false;
-    }
-    if (this.savedIntents.length != that.savedIntents.length) {
-      return false;
-    }
-    for (int i = 0; i < this.savedIntents.length; i++) {
-      if (!this.savedIntents[i].filterEquals(that.savedIntents[i])) {
-        return false;
-      }
-    }
-    if (this.requestCode != that.requestCode) {
-      return false;
-    }
-    return true;
+    return realPendingIntent == o;
   }
 
   @Override
@@ -194,51 +245,138 @@ public class ShadowPendingIntent {
     return result;
   }
 
-  private static PendingIntent create(Context context, Intent[] intents, boolean isActivity, boolean isBroadcast, boolean isService, int requestCode, int flags) {
-    if ((flags & PendingIntent.FLAG_NO_CREATE) != 0) {
-      return getCreatedIntentFor(intents);
-    }
-
-    PendingIntent pendingIntent = ReflectionHelpers.callConstructor(PendingIntent.class);
-    ShadowPendingIntent shadowPendingIntent = Shadows.shadowOf(pendingIntent);
-    shadowPendingIntent.savedIntents = intents;
-    shadowPendingIntent.isActivityIntent = isActivity;
-    shadowPendingIntent.isBroadcastIntent = isBroadcast;
-    shadowPendingIntent.isServiceIntent = isService;
-    shadowPendingIntent.savedContext = context;
-    shadowPendingIntent.requestCode = requestCode;
-    shadowPendingIntent.flags = flags;
-
-    createdIntents.add(pendingIntent);
-    return pendingIntent;
+  @Override
+  @Implementation
+  public String toString() {
+    return "PendingIntent{"
+        + Integer.toHexString(System.identityHashCode(realPendingIntent))
+        + ": "
+        + Integer.toHexString(System.identityHashCode(this))
+        + "}";
   }
 
-  private static PendingIntent getCreatedIntentFor(Intent[] intents) {
-    for (PendingIntent createdIntent : createdIntents) {
-      ShadowPendingIntent shadowPendingIntent = Shadows.shadowOf(createdIntent);
-      if (shadowPendingIntent.savedIntents.length != intents.length) {
-        continue;
+  private static PendingIntent create(int intentType, Context context, int requestCode, Intent[] intents, int flags, Bundle options) {
+    synchronized (createdIntents) {
+      PendingIntent previousIntent = getCreatedIntentForLocked(intentType, requestCode, intents,  context.getPackageName());
+
+      if ((flags & PendingIntent.FLAG_NO_CREATE) != 0) {
+        return previousIntent;
       }
 
-      // Order matters in the framework. If I call getActivities(Activity1, Activity2), that will
-      // give me a different PendingIntent than if I call getActivities(Activity2, Activity1).
-      boolean equalIntents = true;
-      for (int i = 0; i < intents.length; i++) {
-        if (!shadowPendingIntent.savedIntents[i].filterEquals(intents[i])) {
-          equalIntents = false;
-          break;
+      if (previousIntent != null) {
+        if ((flags & PendingIntent.FLAG_UPDATE_CURRENT) != 0) {
+          ShadowPendingIntent previousIntentShadow = shadowOf(previousIntent);
+          synchronized (previousIntentShadow) {
+            for (int i = 0; i < previousIntentShadow.savedIntents.length; i++) {
+              previousIntentShadow.savedIntents[i].replaceExtras(intents[i]);
+            }
+          }
+        }
+
+        if ((flags & PendingIntent.FLAG_CANCEL_CURRENT) != 0) {
+          previousIntent.cancel();
+        } else {
+          return previousIntent;
         }
       }
 
-      if (equalIntents) {
-        return createdIntent;
+      PendingIntent pendingIntent = ReflectionHelpers.callConstructor(PendingIntent.class);
+      ShadowPendingIntent shadowPendingIntent = Shadows.shadowOf(pendingIntent);
+      shadowPendingIntent.intentType = intentType;
+      shadowPendingIntent.savedContext = context;
+      shadowPendingIntent.requestCode = requestCode;
+      shadowPendingIntent.savedIntents = copyIntents(intents);
+      shadowPendingIntent.savedOptions = (options != null ? new Bundle(options) : null);
+      shadowPendingIntent.flags = flags;
+      shadowPendingIntent.canceled = false;
+
+      createdIntents.add(pendingIntent);
+
+      return pendingIntent;
+    }
+  }
+
+  private static Intent[] copyIntents(Intent[] intents) {
+    Intent[] intentsCopy = new Intent[intents.length];
+    for (int i = 0; i < intents.length; i++) {
+      intentsCopy[i] = intents[i] != null ? new Intent(intents[i]) : null;
+    }
+    return intentsCopy;
+  }
+
+  private static boolean compareIntents(Intent[] intentsThis, Intent[] intentsThat) {
+    if (intentsThis == intentsThat) {
+      return true;
+    }
+    if (intentsThis == null || intentsThat == null) {
+      return false;
+    }
+    if (intentsThis.length != intentsThat.length) {
+      return false;
+    }
+    // Order matters in the framework. If I call getActivities(Activity1, Activity2), that will
+    // give me a different PendingIntent than if I call getActivities(Activity2, Activity1).
+    for (int i = 0; i < intentsThis.length; i++) {
+      if (intentsThis[i] == intentsThat[i]) {
+        continue;
+      }
+      if (intentsThis[i] == null || !intentsThis[i].filterEquals(intentsThat[i])) {
+        return false;
       }
     }
+
+    return true;
+  }
+
+  private static PendingIntent getCreatedIntentForLocked(int intentType, int requestCode, Intent[] intents, String packageName) {
+    for (PendingIntent createdIntent : createdIntents) {
+      ShadowPendingIntent shadowPendingIntent = Shadows.shadowOf(createdIntent);
+      synchronized (shadowPendingIntent) {
+        if (shadowPendingIntent.intentType != intentType) {
+          continue;
+        }
+        if (shadowPendingIntent.requestCode != requestCode) {
+          continue;
+        }
+        if (!compareIntents(shadowPendingIntent.savedIntents, intents)) {
+          continue;
+        }
+        if (!Objects.equals(shadowPendingIntent.getCreatorPackage(), packageName)) {
+          continue;
+        }
+      }
+
+      return createdIntent;
+    }
+
     return null;
   }
 
   @Resetter
   public static void reset() {
     createdIntents.clear();
+  }
+
+  // not an anonymous class so that the broadcast reciever can be GCed before this runs
+  private class OnFinishedRunnable implements Runnable {
+
+    private final PendingIntent.OnFinished onFinished;
+    private final Intent intent;
+    private final int resultCode;
+    private final String resultData;
+    private final Bundle resultExtras;
+
+    public OnFinishedRunnable(PendingIntent.OnFinished onFinished, Intent intent, int resultCode, String resultData, Bundle resultExtras) {
+      this.onFinished = onFinished;
+      this.intent = intent;
+      this.resultCode = resultCode;
+      this.resultData = resultData;
+      this.resultExtras = resultExtras;
+    }
+
+    @Override
+    public void run() {
+      onFinished.onSendFinished(realPendingIntent, intent, resultCode, resultData, resultExtras);
+    }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
@@ -159,7 +159,7 @@ public class ShadowNotificationBuilderTest {
     PendingIntent action = PendingIntent.getBroadcast(RuntimeEnvironment.application, 0, null, 0);
     Notification notification = builder.addAction(0, "Action", action).build();
 
-    assertThat(notification.actions[0].actionIntent).isEqualToComparingFieldByField(action);
+    assertThat(notification.actions[0].actionIntent).isEqualTo(action);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPendingIntentTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPendingIntentTest.java
@@ -1,6 +1,5 @@
 package org.robolectric.shadows;
 
-import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -9,11 +8,17 @@ import android.os.Bundle;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.eq;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.MultiApiSelfTest.class)
@@ -21,69 +26,63 @@ public class ShadowPendingIntentTest {
 
   @Test
   public void getBroadcast_shouldCreateIntentForBroadcast() throws Exception {
-    Intent intent = new Intent();
+    Intent intent = new Intent("ACTION");
     PendingIntent pendingIntent = PendingIntent.getBroadcast(RuntimeEnvironment.application, 99, intent, 100);
     ShadowPendingIntent shadow = shadowOf(pendingIntent);
     assertThat(shadow.isActivityIntent()).isFalse();
     assertThat(shadow.isBroadcastIntent()).isTrue();
     assertThat(shadow.isServiceIntent()).isFalse();
-    assertThat(intent).isEqualTo(shadow.getSavedIntent());
+    assertThat(shadow.getSavedIntent().filterEquals(intent)).isTrue();
     assertThat((Context) RuntimeEnvironment.application).isEqualTo(shadow.getSavedContext());
     assertThat(shadow.getRequestCode()).isEqualTo(99);
     assertThat(shadow.getFlags()).isEqualTo(100);
   }
 
   @Test
-  public void getActivity_shouldCreateIntentForBroadcast() throws Exception {
-    Intent intent = new Intent();
+  public void getActivity_shouldCreateIntentForActivity() throws Exception {
+    Intent intent = new Intent("ACTION");
     PendingIntent pendingIntent = PendingIntent.getActivity(RuntimeEnvironment.application, 99, intent, 100);
     ShadowPendingIntent shadow = shadowOf(pendingIntent);
     assertThat(shadow.isActivityIntent()).isTrue();
     assertThat(shadow.isBroadcastIntent()).isFalse();
     assertThat(shadow.isServiceIntent()).isFalse();
-    assertThat(intent).isEqualTo(shadow.getSavedIntent());
+    assertThat(shadow.getSavedIntent().filterEquals(intent)).isTrue();
     assertThat((Context) RuntimeEnvironment.application).isEqualTo(shadow.getSavedContext());
     assertThat(shadow.getRequestCode()).isEqualTo(99);
     assertThat(shadow.getFlags()).isEqualTo(100);
   }
 
   @Test
-  public void getActivities_shouldCreateIntentForBroadcast() throws Exception {
+  public void getActivities_shouldCreateIntentForActivity() throws Exception {
     Intent[] intents = new Intent[] {new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK)};
     PendingIntent pendingIntent = PendingIntent.getActivities(RuntimeEnvironment.application, 99, intents, 100);
 
-    ShadowPendingIntent shadow = shadowOf(pendingIntent);
-    assertThat(shadow.getSavedIntents()).isEqualTo(intents);
-
     pendingIntent.send();
     ShadowApplication application = shadowOf(RuntimeEnvironment.application);
-    assertThat(application.getNextStartedActivity()).isEqualTo(intents[0]);
-    assertThat(application.getNextStartedActivity()).isEqualTo(intents[1]);
+    assertThat(application.getNextStartedActivity().filterEquals(intents[0])).isTrue();
+    assertThat(application.getNextStartedActivity().filterEquals(intents[1])).isTrue();
   }
 
   @Test
-  public void getActivities_withBundle_shouldCreateIntentForBroadcast() throws Exception {
+  public void getActivities_withBundle_shouldCreateIntentForActivity() throws Exception {
     Intent[] intents = new Intent[] {new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK)};
     PendingIntent pendingIntent = PendingIntent.getActivities(RuntimeEnvironment.application, 99, intents, 100, new Bundle());
 
-    ShadowPendingIntent shadow = shadowOf(pendingIntent);
-    assertThat(shadow.getSavedIntents()).isEqualTo(intents);
-
     pendingIntent.send();
     ShadowApplication application = shadowOf(RuntimeEnvironment.application);
-    assertThat(application.getNextStartedActivity()).isEqualTo(intents[0]);
-    assertThat(application.getNextStartedActivity()).isEqualTo(intents[1]);
+    assertThat(application.getNextStartedActivity().filterEquals(intents[0])).isTrue();
+    assertThat(application.getNextStartedActivity().filterEquals(intents[1])).isTrue();
   }
 
   @Test
-  public void getService_shouldCreateIntentForBroadcast() throws Exception {
-    Intent intent = new Intent();
+  public void getService_shouldCreateIntentForService() throws Exception {
+    Intent intent = new Intent("ACTION");
     PendingIntent pendingIntent = PendingIntent.getService(RuntimeEnvironment.application, 99, intent, 100);
     ShadowPendingIntent shadow = shadowOf(pendingIntent);
     assertThat(shadow.isActivityIntent()).isFalse();
     assertThat(shadow.isBroadcastIntent()).isFalse();
     assertThat(shadow.isServiceIntent()).isTrue();
-    assertThat(intent).isEqualTo(shadow.getSavedIntent());
+    assertThat(shadow.getSavedIntent().filterEquals(intent)).isTrue();
     assertThat((Context) RuntimeEnvironment.application).isEqualTo(shadow.getSavedContext());
     assertThat(shadow.getRequestCode()).isEqualTo(99);
     assertThat(shadow.getFlags()).isEqualTo(100);
@@ -92,18 +91,73 @@ public class ShadowPendingIntentTest {
   @Test
   public void send_shouldFillInIntentData() throws Exception {
     Intent intent = new Intent();
-    Activity context = new Activity();
-    PendingIntent forActivity = PendingIntent.getActivity(context, 99, intent, 100);
+    PendingIntent forActivity = PendingIntent.getActivity(RuntimeEnvironment.application, 99, intent, 100);
 
-    Activity otherContext = new Activity();
     Intent fillIntent = new Intent();
     fillIntent.putExtra("TEST", 23);
-    forActivity.send(otherContext, 0, fillIntent);
+    forActivity.send(RuntimeEnvironment.application, 0, fillIntent);
 
-    Intent i = shadowOf(otherContext).getNextStartedActivity();
+    Intent i = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
     assertThat(i).isNotNull();
-    assertThat(i).isSameAs(intent);
     assertThat(i.getIntExtra("TEST", -1)).isEqualTo(23);
+  }
+
+  @Test
+  public void send_shouldBeCancelable() throws Exception {
+    Intent intent = new Intent();
+    PendingIntent forActivity = PendingIntent.getActivity(RuntimeEnvironment.application, 0, intent, 0);
+    forActivity.cancel();
+    try {
+      forActivity.send();
+      fail();
+    } catch (PendingIntent.CanceledException e) {
+      // pass
+    }
+
+    assertThat(shadowOf(RuntimeEnvironment.application).getNextStartedActivity()).isNull();
+  }
+
+  @Test
+  public void send_cannotChangeBaseIntent() throws Exception {
+    Intent intent = new Intent("ACTION");
+    PendingIntent forActivity = PendingIntent.getActivity(RuntimeEnvironment.application, 0, intent, 0);
+
+    Intent fillIntent1 = new Intent();
+    fillIntent1.putExtra("TEST1", 1);
+    forActivity.send(RuntimeEnvironment.application, 0, fillIntent1);
+
+
+    Intent fillIntent2 = new Intent();
+    fillIntent2.putExtra("TEST2", 1);
+    forActivity.send(RuntimeEnvironment.application, 0, fillIntent2);
+
+    intent.setAction("INACTION");
+
+    Intent i1 = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+    assertThat(i1).isNotNull();
+    assertThat(i1.getAction()).isEqualTo("ACTION");
+    assertThat(i1.hasExtra("TEST1")).isTrue();
+    assertThat(i1.hasExtra("TEST2")).isFalse();
+
+    Intent i2 = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+    assertThat(i2).isNotNull();
+    assertThat(i2.getAction()).isEqualTo("ACTION");
+    assertThat(i2.hasExtra("TEST1")).isFalse();
+    assertThat(i2.hasExtra("TEST2")).isTrue();
+  }
+
+
+  @Test
+  public void send_callOnFinished() throws Exception {
+    Intent intent = new Intent();
+    PendingIntent forBroadcast = PendingIntent.getBroadcast(RuntimeEnvironment.application, 99, intent, 0);
+
+    PendingIntent.OnFinished onFinished = mock(PendingIntent.OnFinished.class);
+    forBroadcast.send(101, onFinished, null);
+
+    ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
+    verify(onFinished).onSendFinished(eq(forBroadcast), intentCaptor.capture(), eq(101), Mockito.<String>isNull(), Mockito.<Bundle>isNull());
+    assertThat(intentCaptor.getValue().filterEquals(intent)).isTrue();
   }
 
   @Test
@@ -118,16 +172,11 @@ public class ShadowPendingIntentTest {
 
   @Test
   public void getActivity_withFlagNoCreate_shouldReturnExistingIntent() {
-    Intent intent = new Intent();
-
-    PendingIntent.getActivity(RuntimeEnvironment.application, 99, intent, 100);
-
-    Intent identical = new Intent();
-    PendingIntent saved = PendingIntent.getActivity(RuntimeEnvironment.application, 99, identical,
-        PendingIntent.FLAG_NO_CREATE);
+    PendingIntent saved = PendingIntent.getActivity(RuntimeEnvironment.application, 99, new Intent(), 100);
+    PendingIntent identical = PendingIntent.getActivity(RuntimeEnvironment.application, 99, new Intent(), PendingIntent.FLAG_NO_CREATE);
 
     assertThat(saved).isNotNull();
-    assertThat(intent).isEqualTo(shadowOf(saved).getSavedIntent());
+    assertThat(identical).isEqualTo(saved);
   }
 
   @Test
@@ -144,14 +193,14 @@ public class ShadowPendingIntentTest {
   public void getActivities_withFlagNoCreate_shouldReturnExistingIntent() {
     Intent[] intents = new Intent[] { new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK) };
 
-    PendingIntent.getActivities(RuntimeEnvironment.application, 99, intents, 100);
+    PendingIntent saved = PendingIntent.getActivities(RuntimeEnvironment.application, 99, intents, 100);
 
     Intent[] identicalIntents = new Intent[] { new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK) };
-    PendingIntent saved = PendingIntent.getActivities(RuntimeEnvironment.application, 99, identicalIntents,
+    PendingIntent identical = PendingIntent.getActivities(RuntimeEnvironment.application, 99, identicalIntents,
         PendingIntent.FLAG_NO_CREATE);
 
     assertThat(saved).isNotNull();
-    assertThat(intents).isEqualTo(shadowOf(saved).getSavedIntents());
+    assertThat(identical).isEqualTo(saved);
   }
 
   @Test
@@ -166,15 +215,12 @@ public class ShadowPendingIntentTest {
 
   @Test
   public void getBroadcast_withFlagNoCreate_shouldReturnExistingIntent() {
-    Intent intent = new Intent();
-
-    PendingIntent.getBroadcast(RuntimeEnvironment.application, 99, intent, 100);
-    Intent identical = new Intent();
-    PendingIntent saved = PendingIntent.getBroadcast(RuntimeEnvironment.application, 99, identical,
+    PendingIntent saved = PendingIntent.getBroadcast(RuntimeEnvironment.application, 99, new Intent(), 100);
+    PendingIntent identical = PendingIntent.getBroadcast(RuntimeEnvironment.application, 99, new Intent(),
         PendingIntent.FLAG_NO_CREATE);
 
     assertThat(saved).isNotNull();
-    assertThat(intent).isEqualTo(shadowOf(saved).getSavedIntent());
+    assertThat(identical).isEqualTo(saved);
   }
 
   @Test
@@ -189,17 +235,11 @@ public class ShadowPendingIntentTest {
 
   @Test
   public void getService_withFlagNoCreate_shouldReturnExistingIntent() {
-    Intent intent = new Intent();
-
-    PendingIntent.getService(RuntimeEnvironment.application, 99, intent, 100);
-
-    Intent identical = new Intent();
-
-    PendingIntent saved = PendingIntent.getService(RuntimeEnvironment.application, 99, identical,
-        PendingIntent.FLAG_NO_CREATE);
+    PendingIntent saved = PendingIntent.getService(RuntimeEnvironment.application, 99, new Intent(), 100);
+    PendingIntent identical = PendingIntent.getService(RuntimeEnvironment.application, 99, new Intent(), PendingIntent.FLAG_NO_CREATE);
 
     assertThat(saved).isNotNull();
-    assertThat(intent).isEqualTo(shadowOf(saved).getSavedIntent());
+    assertThat(identical).isEqualTo(saved);
   }
 
   @Test


### PR DESCRIPTION
This commit adds several bug fixes and improvements to
ShadowPendingIntent:

* Implements cancel(), previously there was no support for cancelling a
PendingIntent.
* Makes copies of intents when creating a PendingIntent so that tests
cannot inappropriately change the intents for a PendingIntent.
* Adds implementations for send() overloads with over 3 arguments.
* Correctly implements all possible PendingIntent flag values.
* Fixes bug where wrong context is used to send PendingIntent.
* Broadcast PendingIntents now correctly pass through resultCode and
requiredPermission information.
* Broadcast PendingIntents now correctly implements OnFinished behavior.
* PendingIntent comparison is now reference based.
* PendingIntent creation now takes into account Intent type and
requestCode, and respects all flag values with respect to reusing an
existing PendingIntent.

### Overview

### Proposed Changes
