### PR TITLE
Fix PackageManager#resolveActivity() and activity metadata.

### DIFF
--- a/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -437,6 +437,10 @@ public class AndroidManifest {
     if (applicationMetaData != null) {
       applicationMetaData.init(resourceTable, packageName);
     }
+
+    for (ActivityData activityData : activityDatas.values()) {
+      activityData.getMetaData().init(resourceTable, packageName);
+    }
     for (PackageItemData receiver : receivers) {
       receiver.getMetaData().init(resourceTable, packageName);
     }
@@ -445,6 +449,9 @@ public class AndroidManifest {
     }
     for (ContentProviderData providerData : providers) {
       providerData.getMetaData().init(resourceTable, packageName);
+    }
+    for (PermissionItemData permissionItemData : permissions.values()) {
+      permissionItemData.getMetaData().init(resourceTable, packageName);
     }
   }
 
@@ -539,10 +546,12 @@ public class AndroidManifest {
 
   public Map<String, Object> getApplicationMetaData() {
     parseAndroidManifest();
+
     if (applicationMetaData == null) {
-      applicationMetaData = new MetaData(Collections.<Node>emptyList());
+      return Collections.emptyMap();
+    } else {
+      return applicationMetaData.getValueMap();
     }
-    return applicationMetaData.getValueMap();
   }
 
   public ResourcePath getResourcePath() {

--- a/robolectric-resources/src/main/java/org/robolectric/manifest/MetaData.java
+++ b/robolectric-resources/src/main/java/org/robolectric/manifest/MetaData.java
@@ -35,14 +35,16 @@ public final class MetaData {
   public void init(ResourceTable resourceTable, String packageName) throws RoboNotFoundException {
     if (!initialised) {
       for (Map.Entry<String,VALUE_TYPE> entry : typeMap.entrySet()) {
-        String value = valueMap.get(entry.getKey()).toString();
+        String key = entry.getKey();
+        String value = valueMap.get(key).toString();
+        VALUE_TYPE type = entry.getValue();
         if (value.startsWith("@")) {
           ResName resName = ResName.qualifyResName(value.substring(1), packageName, null);
 
-          switch (entry.getValue()) {
+          switch (type) {
             case RESOURCE:
               // Was provided by resource attribute, store resource ID
-              valueMap.put(entry.getKey(), resourceTable.getResourceId(resName));
+              valueMap.put(key, resourceTable.getResourceId(resName));
               break;
             case VALUE:
               // Was provided by value attribute, need to inferFromValue it
@@ -53,16 +55,16 @@ public final class MetaData {
               }
               switch (typedRes.getResType()) {
                 case BOOLEAN: case COLOR: case INTEGER: case FLOAT:
-                  valueMap.put(entry.getKey(), parseValue(typedRes.getData().toString()));
+                  valueMap.put(key, parseValue(typedRes.getData().toString()));
                   break;
                 default:
-                  valueMap.put(entry.getKey(),typedRes.getData());
+                  valueMap.put(key,typedRes.getData());
               }
               break;
           }
-        } else if (entry.getValue() == VALUE_TYPE.VALUE) {
+        } else if (type == VALUE_TYPE.VALUE) {
           // Raw value, so inferFromValue it in to the appropriate type and store it
-          valueMap.put(entry.getKey(), parseValue(value));
+          valueMap.put(key, parseValue(value));
         }
       }
       // Finished parsing, mark as initialised
@@ -71,6 +73,7 @@ public final class MetaData {
   }
 
   public Map<String, Object> getValueMap() {
+    if (!initialised) throw new IllegalStateException();
     return valueMap;
   }
 

--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -103,7 +103,7 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
   private final Map<Integer, String> namesForUid = new HashMap<>();
   private final Map<Integer, String[]> packagesForUid = new HashMap<>();
   private final Map<String, String> packageInstallerMap = new HashMap<>();
-  private boolean queryIntentImplicitly = false;
+  private boolean queryIntentImplicitly = true;
   private PackageInstaller packageInstaller;
   private AndroidManifest applicationManifest;
   private ResourceTable appResourceTable;
@@ -843,6 +843,12 @@ public class DefaultPackageManager extends StubPackageManager implements Robolec
           resolveInfo.resolvePackageName = packageName;
           resolveInfo.activityInfo = new ActivityInfo();
           resolveInfo.activityInfo.targetActivity = activityName;
+          resolveInfo.activityInfo.packageName = packageName;
+          resolveInfo.activityInfo.name = activityName;
+          PackageInfo packageInfo = packageInfos.get(packageName);
+          if (packageInfo != null) {
+            resolveInfo.activityInfo.applicationInfo = packageInfo.applicationInfo;
+          }
 
           resolveInfoList.add(resolveInfo);
         }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentTest.java
@@ -45,6 +45,32 @@ public class ShadowIntentTest {
   }
 
   @Test
+  public void withSingleMatch_resolveActivity_shouldReturnActivityName() throws Exception {
+    Context context = RuntimeEnvironment.application;
+    PackageManager packageManager = context.getPackageManager();
+
+    Intent intent = new Intent();
+    intent.setClassName(context, TEST_ACTIVITY_CLASS_NAME);
+    ComponentName componentName = intent.resolveActivity(packageManager);
+    assertThat(componentName).isNotNull();
+  }
+
+  @Test
+  @Config(manifest = "src/test/resources/TestAndroidManifestForActivitiesWithIntentFilter.xml")
+  public void testResolveActivitySingleMatch() {
+    Context context = RuntimeEnvironment.application;
+    PackageManager packageManager = context.getPackageManager();
+
+    final Intent intent = new Intent("android.intent.action.MAIN");
+    intent.addCategory("android.intent.category.LAUNCHER");
+
+    // Should only have one activity responding to narrow category
+    final ComponentName target = intent.resolveActivity(packageManager);
+    assertEquals("org.robolectric", target.getPackageName());
+    assertEquals("org.robolectric.shadows.TestActivity", target.getClassName());
+  }
+
+  @Test
   public void testGetExtraReturnsNull_whenThereAreNoExtrasAdded() throws Exception {
     Intent intent = new Intent();
     assertEquals(intent.getExtras(), null);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -756,7 +756,7 @@ public class ShadowPackageManagerTest {
 
     metaValue = meta.get("org.robolectric.metaColor");
     assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(Color.WHITE, metaValue);
+    assertEquals(0xFFABCDEF, metaValue);
 
     metaValue = meta.get("org.robolectric.metaBooleanFromRes");
     assertTrue(Boolean.class.isInstance(metaValue));
@@ -781,6 +781,10 @@ public class ShadowPackageManagerTest {
     metaValue = meta.get("org.robolectric.metaStringRes");
     assertTrue(Integer.class.isInstance(metaValue));
     assertEquals(R.string.app_name, metaValue);
+
+    metaValue = meta.get("org.robolectric.metaColorRes");
+    assertTrue(Integer.class.isInstance(metaValue));
+    assertEquals(R.color.clear, metaValue);
   }
 
   @Test

--- a/robolectric/src/test/resources/TestAndroidManifestWithAppMetaData.xml
+++ b/robolectric/src/test/resources/TestAndroidManifestWithAppMetaData.xml
@@ -11,12 +11,13 @@
     <meta-data android:name="org.robolectric.metaFalse" android:value="false" />
     <meta-data android:name="org.robolectric.metaInt" android:value="123" />
     <meta-data android:name="org.robolectric.metaFloat" android:value="1.23" />
-    <meta-data android:name="org.robolectric.metaColor" android:value="#FFFFFF" />
+    <meta-data android:name="org.robolectric.metaColor" android:value="#ABCDEF" />
     <meta-data android:name="org.robolectric.metaBooleanFromRes" android:value="@bool/false_bool_value" />
     <meta-data android:name="org.robolectric.metaIntFromRes" android:value="@integer/test_integer1" />
     <meta-data android:name="org.robolectric.metaColorFromRes" android:value="@color/clear" />
     <meta-data android:name="org.robolectric.metaStringFromRes" android:value="@string/app_name" />
     <meta-data android:name="org.robolectric.metaStringOfIntFromRes" android:value="@string/str_int" />
     <meta-data android:name="org.robolectric.metaStringRes" android:resource="@string/app_name" />
+    <meta-data android:name="org.robolectric.metaColorRes" android:resource="@color/clear" />
   </application>
 </manifest>


### PR DESCRIPTION
* Switched DefaultPackageManager#queryIntentImplicitly to default to true, so PackageManager#resolveActivity() now matches more intents.
* Activity metadata should be resolved against resources.
* Fixes CTS `IntentTest.testParseIntent()` and `testResolveActivitySingleMatch()`.