### PR TITLE
Resources.getQuantityString() should throw for missing resources.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -268,6 +268,16 @@ public class ShadowResourcesTest {
   }
 
   @Test
+  public void whenResourceNotFound_getQuantityString_shouldThrow() throws Exception {
+    try {
+      resources.getQuantityString(-1, 0);
+      fail("should throw Resources.NotFoundException");
+    } catch (Resources.NotFoundException e) {
+      // cool
+    }
+  }
+
+  @Test
   public void getFraction() throws Exception {
     final int myself = 300;
     final int myParent = 600;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -116,7 +116,12 @@ public class ShadowResources {
           RuntimeEnvironment.getQualifiers(), resId);
       return resolvedTypedResource == null ? null : resolvedTypedResource.asString();
     } else {
-      return null;
+      ResName resName = shadowAssetManager.getResourceTable().getResName(resId);
+      if (resName == null) {
+        throw new Resources.NotFoundException("Unable to find resource ID #0x" + Integer.toHexString(resId));
+      } else {
+        throw new Resources.NotFoundException(resName.getFullyQualifiedName());
+      }
     }
   }
 


### PR DESCRIPTION
Fixes CTS ResourcesTest#testGetQuantityString1() etc.