### PR TITLE
Add looseSignatures=true to ShadowNotificationManager

### DIFF
--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -1,15 +1,14 @@
 package org.robolectric.shadows;
 
 import android.app.Notification;
-import android.app.NotificationChannel;
-import android.app.NotificationChannelGroup;
 import android.app.NotificationManager;
 import android.os.Build;
 import android.service.notification.StatusBarNotification;
 import com.google.common.collect.ImmutableList;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
-import org.robolectric.RuntimeEnvironment;
+import org.robolectric.util.ReflectionHelpers;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -17,11 +16,11 @@ import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings({"UnusedDeclaration"})
-@Implements(NotificationManager.class)
+@Implements(value = NotificationManager.class, looseSignatures = true)
 public class ShadowNotificationManager {
   private Map<Key, Notification> notifications = new HashMap<>();
-  private final Map<String, NotificationChannel> notificationChannels = new HashMap<>();
-  private final Map<String, NotificationChannelGroup> notificationChannelGroups = new HashMap<>();
+  private final Map<String, Object> notificationChannels = new HashMap<>();
+  private final Map<String, Object> notificationChannelGroups = new HashMap<>();
 
   @Implementation
   public void notify(int id, Notification notification) {
@@ -73,31 +72,33 @@ public class ShadowNotificationManager {
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public NotificationChannel getNotificationChannel(String channelId) {
+  public Object /*NotificationChannel*/ getNotificationChannel(String channelId) {
     return notificationChannels.get(channelId);
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public void createNotificationChannelGroup(NotificationChannelGroup group) {
-    notificationChannelGroups.put(group.getId(), group);
+  public void createNotificationChannelGroup(Object /*NotificationChannelGroup*/ group) {
+    String id = ReflectionHelpers.callInstanceMethod(group, "getId");
+    notificationChannelGroups.put(id, group);
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public List<NotificationChannelGroup> getNotificationChannelGroups() {
+  public List<Object /*NotificationChannelGroup*/> getNotificationChannelGroups() {
     return ImmutableList.copyOf(notificationChannelGroups.values());
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public void createNotificationChannel(NotificationChannel channel) {
-    notificationChannels.put(channel.getId(), channel);
+  public void createNotificationChannel(Object /*NotificationChannel*/ channel) {
+    String id = ReflectionHelpers.callInstanceMethod(channel, "getId");
+    notificationChannels.put(id, channel);
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public List<NotificationChannel> getNotificationChannels() {
+  public List<Object /*NotificationChannel*/> getNotificationChannels() {
     return ImmutableList.copyOf(notificationChannels.values());
   }
 
-  public NotificationChannelGroup getNotificationChannelGroup(String id) {
+  public Object /*NotificationChannelGroup*/ getNotificationChannelGroup(String id) {
     return notificationChannelGroups.get(id);
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
@@ -35,8 +35,10 @@ public class ShadowNotificationManagerTest {
     notificationManager.createNotificationChannel(new NotificationChannel("id", "name", 1));
 
     assertThat(shadowOf(notificationManager).getNotificationChannels()).hasSize(1);
-    assertThat(shadowOf(notificationManager).getNotificationChannel("id").getName()).isEqualTo("name");
-    assertThat(shadowOf(notificationManager).getNotificationChannel("id").getImportance()).isEqualTo(1);
+    NotificationChannel channel = (NotificationChannel)shadowOf(notificationManager)
+        .getNotificationChannel("id");
+    assertThat(channel.getName()).isEqualTo("name");
+    assertThat(channel.getImportance()).isEqualTo(1);
   }
 
   @Test
@@ -45,7 +47,9 @@ public class ShadowNotificationManagerTest {
     notificationManager.createNotificationChannelGroup(new NotificationChannelGroup("id", "name"));
 
     assertThat(shadowOf(notificationManager).getNotificationChannelGroups()).hasSize(1);
-    assertThat(shadowOf(notificationManager).getNotificationChannelGroup("id").getName()).isEqualTo("name");
+    NotificationChannelGroup group = (NotificationChannelGroup)shadowOf(notificationManager)
+        .getNotificationChannelGroup("id");
+    assertThat(group.getName()).isEqualTo("name");
   }
 
   @Test


### PR DESCRIPTION
ShadowNotificationManager was importing NotificationChannel and
NotificationChannelGroup. These classes are only available starting in
Android O. If an app that targets SDK 25 below attempted to use
Robolectric 3.4-rc1's ShadowNotificationManager, a
java.lang.NoClassDefFoundError would be thrown.

To fix this, add looseSignatures = true to ShadowNotificationManager,
and convert all the methods that reference NotificationChannel and
NotificationChannelGroup to use Object.

Thanks to xian for the suggestion.

Fixes #3098

