### PR TITLE
Update support for the Android O developer preview

### DIFF
--- a/buildSrc/src/main/groovy/AndroidSdk.groovy
+++ b/buildSrc/src/main/groovy/AndroidSdk.groovy
@@ -8,7 +8,7 @@ class AndroidSdk implements Comparable<AndroidSdk> {
     static final M = new AndroidSdk(23, "6.0.1_r3", 0, "1.7")
     static final N = new AndroidSdk(24, "7.0.0_r1", 0, "1.8")
     static final N_MR1 = new AndroidSdk(25, "7.1.0_r7", 0, "1.8")
-    static final O = new AndroidSdk(26, "o-preview-1", 0, "1.8")
+    static final O = new AndroidSdk(26, "o-preview-2", 0, "1.8")
 
     private static final double jdkVersion = Double.parseDouble(System.getProperty("java.specification.version"));
 

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/android/StubPackageManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/android/StubPackageManager.java
@@ -56,6 +56,45 @@ import java.util.List;
 public class StubPackageManager extends PackageManager {
 
   @Override
+  public int getInstantAppCookieMaxBytes() {
+    return -1;
+  }
+
+  @Override
+  public void clearInstantAppCookie() {
+
+  }
+
+  @Override
+  public void updateInstantAppCookie(byte[] cookie) {
+
+  }
+
+  @Override
+  public void setUpdateAvailable(String packageName, boolean updateAvaialble) {
+  }
+
+  @Override
+  public ComponentName getInstantAppResolverSettingsComponent() {
+    return null;
+  }
+
+  @Override
+  public ComponentName getInstantAppInstallerComponent() {
+    return null;
+  }
+
+  @Override
+  public String getInstantAppAndroidId(String s, UserHandle u) {
+    return null;
+  }
+
+  @Override
+  public boolean isInstantApp(String packageName) {
+    return false;
+  }
+
+  @Override
   public PackageInfo getPackageInfo(String packageName, int flags) throws NameNotFoundException {
     return null;
   }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboVibrator.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboVibrator.java
@@ -1,6 +1,7 @@
 package org.robolectric.fakes;
 
 import android.os.Vibrator;
+import android.os.VibrationEffect;
 
 import android.media.AudioAttributes;
 import org.robolectric.annotation.internal.DoNotInstrument;
@@ -31,13 +32,16 @@ public class RoboVibrator extends Vibrator {
     this.repeat = repeat;
   }
 
-  @Override
   public void vibrate(int i, String s, long l, AudioAttributes audioAttributes) {
 
   }
 
-  @Override
   public void vibrate(int i, String s, long[] longs, int i1, AudioAttributes audioAttributes) {
+
+  }
+
+  @Override
+  public void vibrate(int i, String s, VibrationEffect effect, AudioAttributes audioAttributes) {
 
   }
 
@@ -72,5 +76,10 @@ public class RoboVibrator extends Vibrator {
 
   public int getRepeat() {
     return repeat;
+  }
+
+  @Override
+  public boolean hasAmplitudeControl() {
+    return false;
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboWebSettings.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/fakes/RoboWebSettings.java
@@ -634,4 +634,14 @@ public class RoboWebSettings extends WebSettings {
   }
 
   // End API 24.
+
+  public boolean getSafeBrowsingEnabled() {
+    return false;
+  }
+
+  public void setSafeBrowsingEnabled(boolean enabled) {
+
+  }
+
+  // End API 26
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLinux.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLinux.java
@@ -1,0 +1,36 @@
+package org.robolectric.shadows;
+
+import android.os.Build;
+import android.system.ErrnoException;
+import android.system.StructStat;
+import libcore.io.Linux;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+import java.io.File;
+
+@Implements(value = Linux.class, minSdk = Build.VERSION_CODES.O, isInAndroidSdk = false)
+public class ShadowLinux {
+  @Implementation
+  public static void mkdir(String path, int mode) throws ErrnoException {
+    new File(path).mkdirs();
+  }
+
+  @Implementation
+  public StructStat stat(String path) throws ErrnoException {
+    return new StructStat(0, // st_dev
+        0, // st_ino
+        0, // st_mode
+        0, // st_nlink
+        0, // st_uid
+        0, // st_gid
+        0, // st_rdev
+        0, // st_size
+        0, // st_atime
+        0, // st_mtime
+        0, // st_ctime,
+        0, // st_blksize
+        0 // st_blocks
+    );
+  }
+}

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLoadedApk.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowLoadedApk.java
@@ -3,12 +3,19 @@ package org.robolectric.shadows;
 import android.app.LoadedApk;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.os.Build.VERSION_CODES;
 
 @Implements(value = LoadedApk.class, isInAndroidSdk = false)
 public class ShadowLoadedApk {
 
   @Implementation
   public ClassLoader getClassLoader() {
+    return this.getClass().getClassLoader();
+  }
+
+  @Implementation(minSdk = VERSION_CODES.CUR_DEVELOPMENT)
+  public ClassLoader getSplitClassLoader(String splitName) throws NameNotFoundException {
     return this.getClass().getClassLoader();
   }
 }

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
@@ -24,7 +24,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.android.StubPackageManager;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.manifest.AndroidManifest;

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPosix.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowPosix.java
@@ -3,7 +3,6 @@ package org.robolectric.shadows;
 import android.os.Build;
 import android.system.ErrnoException;
 import android.system.StructStat;
-import libcore.io.Posix;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -11,7 +10,7 @@ import org.robolectric.util.ReflectionHelpers;
 
 import java.io.File;
 
-@Implements(value = Posix.class, isInAndroidSdk = false)
+@Implements(className = "libcore.io.Posix", maxSdk = Build.VERSION_CODES.N_MR1, isInAndroidSdk = false)
 public class ShadowPosix {
   @Implementation
   public static void mkdir(String path, int mode) throws ErrnoException {

--- a/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
+++ b/robolectric-shadows/shadows-core/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
@@ -70,7 +70,7 @@ public class ShadowSensorManager {
     return ReflectionHelpers.callConstructor(SensorDirectChannel.class,
         ClassParameter.from(SensorManager.class, realObject),
         ClassParameter.from(int.class, 0),
-        ClassParameter.from(int.class, SensorDirectChannel.TYPE_ASHMEM),
+        ClassParameter.from(int.class, SensorDirectChannel.TYPE_MEMORY_FILE),
         ClassParameter.from(long.class, mem.length()));
   }
 }

--- a/robolectric/src/main/java/org/robolectric/android/runtime/Api26RuntimeAdapter.java
+++ b/robolectric/src/main/java/org/robolectric/android/runtime/Api26RuntimeAdapter.java
@@ -10,7 +10,9 @@ import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.os.IBinder;
 import android.view.ViewRootImpl;
+import android.view.ViewRootImpl.ActivityConfigCallback;
 import android.view.Window;
+import android.util.MergedConfiguration;
 import com.android.internal.app.IVoiceInteractor;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.fakes.RoboInstrumentation;
@@ -37,7 +39,8 @@ class Api26RuntimeAdapter implements RuntimeAdapter {
         ClassParameter.from(Configuration.class, application.getResources().getConfiguration()),
         ClassParameter.from(String.class, "referrer"),
         ClassParameter.from(IVoiceInteractor.class, null),
-        ClassParameter.from(Window.class, null)
+        ClassParameter.from(Window.class, null),
+        ClassParameter.from(ActivityConfigCallback.class, null)
     );
   }
 
@@ -53,7 +56,7 @@ class Api26RuntimeAdapter implements RuntimeAdapter {
         ClassParameter.from(Rect.class, stableInsets),
         ClassParameter.from(Rect.class, outsets),
         ClassParameter.from(boolean.class, reportDraw),
-        ClassParameter.from(Configuration.class, newConfig),
+        ClassParameter.from(MergedConfiguration.class, null),
         ClassParameter.from(Rect.class, frame),
         ClassParameter.from(boolean.class, false),
         ClassParameter.from(boolean.class, false),

--- a/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
@@ -26,7 +26,7 @@ public class SdkConfig implements Comparable<SdkConfig> {
       addSdk(Build.VERSION_CODES.M, "6.0.1_r3", "0", "1.7", "REL");
       addSdk(Build.VERSION_CODES.N, "7.0.0_r1", "0", "1.8", "REL");
       addSdk(Build.VERSION_CODES.N_MR1, "7.1.0_r7", "0", "1.8", "REL");
-      addSdk(Build.VERSION_CODES.CUR_DEVELOPMENT, "o-preview-1", "0", "1.8", "O");
+      addSdk(Build.VERSION_CODES.CUR_DEVELOPMENT, "o-preview-2", "0", "1.8", "O");
     }
 
     private void addSdk(int sdkVersion, String androidVersion, String frameworkSdkBuildVersion, String minJdkVersion, String codeName) {


### PR DESCRIPTION
An updated version of Android O developer preview has been released.
Update Robolectric to support this new version. The following items
changed:

* Implement additional methods in StubPackageManager
* Update`vibrate` methods in RoboVibrator
* Implement additional methods in RoboWebSettings
* Add shadow for Linux class
* Add shadow for LoadedApk#getSplitClassLoader(String)
* Set maxSdk=25 in ShadowPosix
* Update ShadowSensorManager compatibility
* Update Api26RuntimeAdapter compatibility
