### PR TITLE
Update RoboJavaModulePlugin to use Java 8

### DIFF
--- a/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
@@ -10,12 +10,12 @@ class RoboJavaModulePlugin implements Plugin<Project> {
 
     Closure doApply = {
         apply plugin: "java"
-        sourceCompatibility = JavaVersion.VERSION_1_7
-        targetCompatibility = JavaVersion.VERSION_1_7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
 
         tasks.withType(JavaCompile) { task ->
-            sourceCompatibility = JavaVersion.VERSION_1_7
-            targetCompatibility = JavaVersion.VERSION_1_7
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
 
             // Show all warnings except boot classpath
             configure(options) {

--- a/robolectric-sandbox/src/test/java/org/robolectric/SandboxClassLoaderTest.java
+++ b/robolectric-sandbox/src/test/java/org/robolectric/SandboxClassLoaderTest.java
@@ -105,7 +105,7 @@ public class SandboxClassLoaderTest {
     assertTrue(Modifier.isPublic(defaultCtor.getModifiers()));
     defaultCtor.setAccessible(true);
     Object instance = defaultCtor.newInstance();
-    assertThat(shadow.extract(instance)).isNotNull();
+    assertThat((Object) shadow.extract(instance)).isNotNull();
     assertThat(transcript).isEmpty();
   }
 

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/SupportFragmentControllerTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/SupportFragmentControllerTest.java
@@ -8,6 +8,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
@@ -72,7 +73,7 @@ public class SupportFragmentControllerTest {
     assertThat(fragment.getActivity()).isNotNull();
     assertThat(fragment.isAdded()).isTrue();
     assertThat(fragment.isResumed()).isFalse();
-    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+    assertThat((TextView) fragment.getView().findViewById(R.id.tacos)).isNotNull();
   }
 
   @Test
@@ -92,7 +93,7 @@ public class SupportFragmentControllerTest {
     assertThat(fragment.getActivity()).isNotNull();
     assertThat(fragment.isAdded()).isTrue();
     assertThat(fragment.isResumed()).isTrue();
-    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+    assertThat((TextView) fragment.getView().findViewById(R.id.tacos)).isNotNull();
   }
 
   @Test

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/SupportFragmentTestUtilTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/SupportFragmentTestUtilTest.java
@@ -7,6 +7,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
@@ -26,7 +27,7 @@ public class SupportFragmentTestUtilTest {
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();
-    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+    assertThat((TextView) fragment.getView().findViewById(R.id.tacos)).isNotNull();
   }
 
   @Test
@@ -36,7 +37,7 @@ public class SupportFragmentTestUtilTest {
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();
-    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+    assertThat((TextView) fragment.getView().findViewById(R.id.tacos)).isNotNull();
   }
 
   @Test
@@ -54,7 +55,7 @@ public class SupportFragmentTestUtilTest {
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();
-    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+    assertThat((TextView) fragment.getView().findViewById(R.id.tacos)).isNotNull();
     assertThat(fragment.getActivity()).isInstanceOf(LoginFragmentActivity.class);
   }
 
@@ -65,7 +66,7 @@ public class SupportFragmentTestUtilTest {
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();
-    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+    assertThat((TextView) fragment.getView().findViewById(R.id.tacos)).isNotNull();
     assertThat(fragment.getActivity()).isInstanceOf(LoginFragmentActivity.class);
   }
 

--- a/robolectric/src/test/java/org/robolectric/android/FragmentTestUtilTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/FragmentTestUtilTest.java
@@ -5,6 +5,7 @@ import static org.robolectric.util.FragmentTestUtil.startFragment;
 import static org.robolectric.util.FragmentTestUtil.startVisibleFragment;
 
 import android.widget.LinearLayout;
+import android.widget.TextView;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
@@ -26,7 +27,7 @@ public class FragmentTestUtilTest {
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();
-    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+    assertThat((TextView) fragment.getView().findViewById(R.id.tacos)).isNotNull();
   }
 
   @Test
@@ -36,7 +37,7 @@ public class FragmentTestUtilTest {
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();
-    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+    assertThat((TextView) fragment.getView().findViewById(R.id.tacos)).isNotNull();
   }
 
   @Test
@@ -54,7 +55,7 @@ public class FragmentTestUtilTest {
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();
-    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+    assertThat((TextView) fragment.getView().findViewById(R.id.tacos)).isNotNull();
     assertThat(fragment.getActivity()).isInstanceOf(LoginActivity.class);
   }
 
@@ -65,7 +66,7 @@ public class FragmentTestUtilTest {
 
     assertThat(fragment.getView()).isNotNull();
     assertThat(fragment.getActivity()).isNotNull();
-    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+    assertThat((TextView) fragment.getView().findViewById(R.id.tacos)).isNotNull();
     assertThat(fragment.getActivity()).isInstanceOf(LoginActivity.class);
   }
 

--- a/robolectric/src/test/java/org/robolectric/android/controller/FragmentControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/FragmentControllerTest.java
@@ -8,11 +8,11 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.TestRunners;
-import org.robolectric.android.controller.FragmentController;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
@@ -52,7 +52,7 @@ public class FragmentControllerTest {
     assertThat(fragment.getActivity()).isNotNull();
     assertThat(fragment.isAdded()).isTrue();
     assertThat(fragment.isResumed()).isFalse();
-    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+    assertThat((TextView) fragment.getView().findViewById(R.id.tacos)).isNotNull();
   }
 
   @Test
@@ -64,7 +64,7 @@ public class FragmentControllerTest {
     assertThat(fragment.getActivity()).isNotNull();
     assertThat(fragment.isAdded()).isTrue();
     assertThat(fragment.isResumed()).isFalse();
-    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+    assertThat((TextView) fragment.getView().findViewById(R.id.tacos)).isNotNull();
   }
 
   @Test
@@ -77,7 +77,7 @@ public class FragmentControllerTest {
     assertThat(fragment.getActivity()).isInstanceOf(LoginActivity.class);
     assertThat(fragment.isAdded()).isTrue();
     assertThat(fragment.isResumed()).isFalse();
-    assertThat(fragment.getView().findViewById(R.id.tacos)).isNotNull();
+    assertThat((TextView) fragment.getView().findViewById(R.id.tacos)).isNotNull();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
@@ -10,6 +10,7 @@ import android.accounts.OnAccountsUpdateListener;
 import android.accounts.OperationCanceledException;
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import org.junit.Before;
@@ -469,7 +470,7 @@ public class ShadowAccountManagerTest {
 
     Bundle resultBundle = result.getResult();
 
-    assertThat(resultBundle.getParcelable(AccountManager.KEY_INTENT)).isNotNull();
+    assertThat((Intent) resultBundle.getParcelable(AccountManager.KEY_INTENT)).isNotNull();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
@@ -974,7 +974,10 @@ public class ShadowActivityTest {
 
     @Override
     public void onContentChanged() {
-      transcript.add("onContentChanged was called; title is \"" + shadowOf(findViewById(R.id.title)).innerText() + "\"");
+      transcript.add(
+          "onContentChanged was called; title is \""
+              + shadowOf((View) findViewById(R.id.title)).innerText()
+              + "\"");
     }
 
     private void setTranscript(List<String> transcript) {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAlertDialogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAlertDialogTest.java
@@ -271,7 +271,7 @@ public class ShadowAlertDialogTest {
     AlertDialog dialog = new AlertDialog(RuntimeEnvironment.application) {
     };
 
-    assertThat(dialog.findViewById(99)).isNull();
+    assertThat((View) dialog.findViewById(99)).isNull();
 
     dialog.setContentView(R.layout.main);
     assertNotNull(dialog.findViewById(R.id.title));

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBundleTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBundleTest.java
@@ -90,7 +90,7 @@ public class ShadowBundleTest {
     assertThat(bundle.getStringArray("foo")).isNull();
     assertThat(bundle.getStringArrayList("foo")).isNull();
     assertThat(bundle.getBundle("foo")).isNull();
-    assertThat(bundle.getParcelable("foo")).isNull();
+    assertThat((Parcelable) bundle.getParcelable("foo")).isNull();
     assertThat(bundle.getParcelableArray("foo")).isNull();
     assertThat(bundle.getParcelableArrayList("foo")).isNull();
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentTest.java
@@ -350,7 +350,8 @@ public class ShadowIntentTest {
     Intent chooserIntent = Intent.createChooser(originalIntent, "The title");
     assertThat(chooserIntent.getAction()).isEqualTo(Intent.ACTION_CHOOSER);
     assertThat(chooserIntent.getStringExtra(Intent.EXTRA_TITLE)).isEqualTo("The title");
-    assertThat(chooserIntent.getParcelableExtra(Intent.EXTRA_INTENT)).isSameAs(originalIntent);
+    assertThat((Intent) chooserIntent.getParcelableExtra(Intent.EXTRA_INTENT))
+        .isSameAs(originalIntent);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowListViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowListViewTest.java
@@ -64,10 +64,10 @@ public class ShadowListViewTest {
     assertThat(shadowOf(listView).getHeaderViews().get(2)).isSameAs(view2);
     assertThat(shadowOf(listView).getHeaderViews().get(3)).isSameAs(view3);
 
-    assertThat(listView.findViewById(0)).isNotNull();
-    assertThat(listView.findViewById(1)).isNotNull();
-    assertThat(listView.findViewById(2)).isNotNull();
-    assertThat(listView.findViewById(3)).isNotNull();
+    assertThat((View) listView.findViewById(0)).isNotNull();
+    assertThat((View) listView.findViewById(1)).isNotNull();
+    assertThat((View) listView.findViewById(2)).isNotNull();
+    assertThat((View) listView.findViewById(3)).isNotNull();
   }
 
   @Test
@@ -77,7 +77,7 @@ public class ShadowListViewTest {
 
     listView.addHeaderView(view);
 
-    assertThat(listView.findViewById(42)).isSameAs(view);
+    assertThat((View) listView.findViewById(42)).isSameAs(view);
   }
 
   @Test
@@ -98,7 +98,7 @@ public class ShadowListViewTest {
 
     listView.addFooterView(view);
 
-    assertThat(listView.findViewById(42)).isSameAs(view);
+    assertThat((View) listView.findViewById(42)).isSameAs(view);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTest.java
@@ -36,13 +36,14 @@ public class ShadowTest {
   @Test
   public void extractor() throws Exception {
     Activity activity = new Activity();
-    assertThat(Shadow.extract(activity)).isSameAs(shadowOf(activity));
+    assertThat((ShadowActivity) Shadow.extract(activity)).isSameAs(shadowOf(activity));
   }
 
   @Test
   public void deprecated_extractor() throws Exception {
     Activity activity = new Activity();
-    assertThat(org.robolectric.internal.Shadow.extract(activity)).isSameAs(shadowOf(activity));
+    assertThat((ShadowActivity) org.robolectric.internal.Shadow.extract(activity))
+        .isSameAs(shadowOf(activity));
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewGroupTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewGroupTest.java
@@ -130,8 +130,8 @@ public class ShadowViewGroupTest {
     root.addView(child1);
     root.addView(child2);
     root.addView(child3, 1);
-    assertThat(root.findViewWithTag("tag1")).isSameAs(child1);
-    assertThat(root.findViewWithTag("tag2")).isSameAs((View) child2);
+    assertThat((View) root.findViewWithTag("tag1")).isSameAs(child1);
+    assertThat((View) root.findViewWithTag("tag2")).isSameAs((View) child2);
     assertThat((ViewGroup) root.findViewWithTag("tag3")).isSameAs(child3);
   }
 
@@ -144,8 +144,8 @@ public class ShadowViewGroupTest {
     root.addView(child1);
     root.addView(child2);
     root.addView(child3, 1);
-    assertThat(root.findViewWithTag("tag21")).isEqualTo(null);
-    assertThat((ViewGroup) root.findViewWithTag("tag23")).isEqualTo(null);
+    assertThat((View) root.findViewWithTag("tag21")).isNull();
+    assertThat((ViewGroup) root.findViewWithTag("tag23")).isNull();
   }
 
   @Test
@@ -162,13 +162,13 @@ public class ShadowViewGroupTest {
     child3b.setTag("tag2");
 
     //can find views by tag from root
-    assertThat(root.findViewWithTag("tag1")).isSameAs(child1);
-    assertThat(root.findViewWithTag("tag2")).isSameAs((View) child2);
+    assertThat((View) root.findViewWithTag("tag1")).isSameAs(child1);
+    assertThat((View) root.findViewWithTag("tag2")).isSameAs((View) child2);
     assertThat((ViewGroup) root.findViewWithTag("tag3")).isSameAs(child3);
 
     //can find views by tag from child3
-    assertThat(child3.findViewWithTag("tag1")).isSameAs(child3a);
-    assertThat(child3.findViewWithTag("tag2")).isSameAs(child3b);
+    assertThat((View) child3.findViewWithTag("tag1")).isSameAs(child3a);
+    assertThat((View) child3.findViewWithTag("tag2")).isSameAs(child3b);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
@@ -378,7 +378,7 @@ public class ShadowViewTest {
   @Test
   public void shouldFindViewWithTag() {
     view.setTag("tagged");
-    assertThat(view.findViewWithTag("tagged")).isSameAs(view);
+    assertThat((View) view.findViewWithTag("tagged")).isSameAs(view);
   }
 
   @Test

--- a/shadow-api/src/test/java/org/robolectric/util/ReflectionHelpersTest.java
+++ b/shadow-api/src/test/java/org/robolectric/util/ReflectionHelpersTest.java
@@ -15,14 +15,14 @@ public class ReflectionHelpersTest {
   public void getFieldReflectively_getsPrivateFields() {
     ExampleDescendant example = new ExampleDescendant();
     example.overridden = 5;
-    assertThat(ReflectionHelpers.getField(example, "overridden")).isEqualTo(5);
+    assertThat((int) ReflectionHelpers.getField(example, "overridden")).isEqualTo(5);
   }
 
   @Test
   public void getFieldReflectively_getsInheritedFields() {
     ExampleDescendant example = new ExampleDescendant();
     example.setNotOverridden(6);
-    assertThat(ReflectionHelpers.getField(example, "notOverridden")).isEqualTo(6);
+    assertThat((int) ReflectionHelpers.getField(example, "notOverridden")).isEqualTo(6);
   }
 
   @Test
@@ -77,7 +77,8 @@ public class ReflectionHelpersTest {
 
   @Test
   public void getStaticFieldReflectively_withFieldName_getsStaticField() {
-    assertThat(ReflectionHelpers.getStaticField(ExampleDescendant.class, "DESCENDANT")).isEqualTo(6);
+    assertThat((int) ReflectionHelpers.getStaticField(ExampleDescendant.class, "DESCENDANT"))
+        .isEqualTo(6);
   }
 
   @Test
@@ -108,20 +109,23 @@ public class ReflectionHelpersTest {
   @Test
   public void callInstanceMethodReflectively_callsPrivateMethods() {
     ExampleDescendant example = new ExampleDescendant();
-    assertThat(ReflectionHelpers.callInstanceMethod(example, "returnNumber")).isEqualTo(1337);
+    assertThat((int) ReflectionHelpers.callInstanceMethod(example, "returnNumber")).isEqualTo(1337);
   }
 
   @Test
   public void callInstanceMethodReflectively_whenMultipleSignaturesExistForAMethodName_callsMethodWithCorrectSignature() {
     ExampleDescendant example = new ExampleDescendant();
-    assertThat(ReflectionHelpers.callInstanceMethod(example, "returnNumber", ClassParameter.from(int.class, 5)))
-      .isEqualTo(5);
+    int returnNumber =
+        ReflectionHelpers.callInstanceMethod(
+            example, "returnNumber", ClassParameter.from(int.class, 5));
+    assertThat(returnNumber).isEqualTo(5);
   }
 
   @Test
   public void callInstanceMethodReflectively_callsInheritedMethods() {
     ExampleDescendant example = new ExampleDescendant();
-    assertThat(ReflectionHelpers.callInstanceMethod(example, "returnNegativeNumber")).isEqualTo(-46);
+    assertThat((int) ReflectionHelpers.callInstanceMethod(example, "returnNegativeNumber"))
+        .isEqualTo(-46);
   }
 
   @Test
@@ -174,7 +178,9 @@ public class ReflectionHelpersTest {
 
   @Test
   public void callStaticMethodReflectively_callsPrivateStaticMethodsReflectively() {
-    assertThat(ReflectionHelpers.callStaticMethod(ExampleDescendant.class, "getConstantNumber")).isEqualTo(1);
+    int constantNumber =
+        ReflectionHelpers.callStaticMethod(ExampleDescendant.class, "getConstantNumber");
+    assertThat(constantNumber).isEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION
Previously, RoboJavaModulePlugin declared VERSION_1_7 for both
sourceCompatibility and targetCompatibility. Now that Robolectric only
supports Java 8, the source and target compatibility can be updated to
8. This allows Robolectric to use Java 8 features such as lambda
expressions and method references.

The main changes involved uses of AssertJ's generic assertThat method.
Java 8 has improved type inference, so the compiler complained about
assertions where it could not infer the type.