### PR TITLE
Enforce that __constructor__ and __staticInitializer__ methods be annotated @Implementation.

### DIFF
--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementsValidator.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementsValidator.java
@@ -16,6 +16,7 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
 import javax.tools.Diagnostic.Kind;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.processing.DocumentedMethod;
@@ -28,6 +29,9 @@ public class ImplementsValidator extends Validator {
 
   public static final String IMPLEMENTS_CLASS = "org.robolectric.annotation.Implements";
   public static final int MAX_SUPPORTED_ANDROID_SDK = 10000; // Now == Build.VERSION_CODES.O
+
+  public static final String STATIC_INITIALIZER_METHOD_NAME = "__staticInitializer__";
+  public static final String CONSTRUCTOR_METHOD_NAME = "__constructor__";
 
   private final ProcessingEnvironment env;
 
@@ -51,6 +55,8 @@ public class ImplementsValidator extends Validator {
   @Override
   public Void visitType(TypeElement elem, Element parent) {
     captureJavadoc(elem);
+
+    validateShadowMethods(elem);
 
     // Don't import nested classes because some of them have the same name.
     AnnotationMirror am = getCurrentAnnotation();
@@ -126,6 +132,20 @@ public class ImplementsValidator extends Validator {
     }
     model.addShadowType(elem, type);
     return null;
+  }
+
+  private void validateShadowMethods(TypeElement elem) {
+    for (Element memberElement : ElementFilter.methodsIn(elem.getEnclosedElements())) {
+      ExecutableElement methodElement = (ExecutableElement) memberElement;
+      Implementation implementation = memberElement.getAnnotation(Implementation.class);
+
+      String methodName = methodElement.getSimpleName().toString();
+      if (methodName.equals(CONSTRUCTOR_METHOD_NAME) || methodName.equals(STATIC_INITIALIZER_METHOD_NAME)) {
+        if (implementation == null) {
+          messager.printMessage(Kind.ERROR, "Shadow methods must be annotated @Implementation", methodElement);
+        }
+      }
+    }
   }
 
   private void captureJavadoc(TypeElement elem) {

--- a/processor/src/test/java/org/robolectric/annotation/processing/validator/ImplementsValidatorTest.java
+++ b/processor/src/test/java/org/robolectric/annotation/processing/validator/ImplementsValidatorTest.java
@@ -87,6 +87,19 @@ public class ImplementsValidatorTest {
   }
 
   @Test
+  public void constructorShadowWithoutImplementation_shouldNotCompile() {
+    final String testClass = "org.robolectric.annotation.processing.shadows.ShadowWithImplementationlessShadowMethods";
+    assertAbout(singleClass())
+      .that(testClass)
+      .failsToCompile()
+      .withErrorContaining("Shadow methods must be annotated @Implementation")
+      .onLine(9)
+      .and()
+      .withErrorContaining("Shadow methods must be annotated @Implementation")
+      .onLine(12);
+  }
+
+  @Test
   public void javadocMarkdownFormatting() throws Exception {
     DocumentedMethod documentedMethod = new DocumentedMethod("name");
     documentedMethod.setDocumentation(

--- a/processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowWithImplementationlessShadowMethods.java
+++ b/processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowWithImplementationlessShadowMethods.java
@@ -1,0 +1,14 @@
+package org.robolectric.annotation.processing.shadows;
+
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
+import com.example.objects.Dummy;
+
+@Implements(Dummy.class)
+public class ShadowWithImplementationlessShadowMethods {
+  public void __constructor__() {
+  }
+
+  public void __staticInitializer__() {
+  }
+}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityEvent.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityEvent.java
@@ -34,6 +34,7 @@ public class ShadowAccessibilityEvent extends ShadowAccessibilityRecord {
   @RealObject
   private AccessibilityEvent realAccessibilityEvent;
 
+  @Implementation
   public void __constructor__() {
     ReflectionHelpers.setStaticField(AccessibilityEvent.class, "CREATOR", ShadowAccessibilityEvent.CREATOR);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java
@@ -173,6 +173,7 @@ public class ShadowAccessibilityNodeInfo {
   @RealObject
   private AccessibilityNodeInfo realAccessibilityNodeInfo;
 
+  @Implementation
   public void __constructor__() {
     ReflectionHelpers.setStaticField(AccessibilityNodeInfo.class, "CREATOR", ShadowAccessibilityNodeInfo.CREATOR);
   }
@@ -1241,6 +1242,7 @@ public class ShadowAccessibilityNodeInfo {
     private int id;
     private CharSequence label;
 
+    @Implementation
     public void __constructor__(int id, CharSequence label) {
       if (((id & (int)ReflectionHelpers.getStaticField(AccessibilityNodeInfo.class, "ACTION_TYPE_MASK")) == 0) && Integer.bitCount(id) != 1) {
         throw new IllegalArgumentException("Invalid standard action id");

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityWindowInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityWindowInfo.java
@@ -48,6 +48,7 @@ public class ShadowAccessibilityWindowInfo {
   @RealObject
   private AccessibilityWindowInfo mRealAccessibilityWindowInfo;
 
+  @Implementation
   public void __constructor__() {}
 
   @Implementation

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
@@ -52,6 +52,7 @@ public class ShadowAccountManager {
   private Handler mainHandler;
   private RoboAccountManagerFuture pendingAddFuture;
 
+  @Implementation
   public void __constructor__(Context context, IAccountManager service) {
     mainHandler = new Handler(context.getMainLooper());
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -76,6 +76,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   private Menu optionsMenu;
   private ComponentName callingActivity;
 
+  @Implementation
   public void __constructor__() {
     invokeConstructor(Activity.class, realActivity);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppWidgetHost.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppWidgetHost.java
@@ -18,6 +18,7 @@ public class ShadowAppWidgetHost {
   private int hostId;
   private int appWidgetIdToAllocate;
 
+  @Implementation
   public void __constructor__(Context context, int hostId) {
     this.context = context;
     this.hostId = hostId;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -208,10 +208,12 @@ public final class ShadowAssetManager {
     }
   }
 
+  @Implementation
   public void __constructor__() {
     resourceTable = RuntimeEnvironment.getAppResourceTable();
   }
 
+  @Implementation
   public void __constructor__(boolean isSystem) {
     resourceTable = isSystem ? RuntimeEnvironment.getSystemResourceTable() : RuntimeEnvironment.getAppResourceTable();
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAsyncTaskLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAsyncTaskLoader.java
@@ -13,6 +13,7 @@ public class ShadowAsyncTaskLoader<D> {
   @RealObject private AsyncTaskLoader<D> realObject;
   private SimpleFuture<D> future;
 
+  @Implementation
   public void __constructor__(Context context) {
     BackgroundWorker worker = new BackgroundWorker();
     future = new SimpleFuture<D>(worker) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCamera.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCamera.java
@@ -38,6 +38,7 @@ public class ShadowCamera {
   @RealObject
   private Camera realCamera;
 
+  @Implementation
   public void __constructor__() {
     locked = true;
     previewing = false;
@@ -434,6 +435,7 @@ public class ShadowCamera {
   public static class ShadowSize {
     @RealObject private Camera.Size realCameraSize;
 
+    @Implementation
     public void __constructor__(Camera camera, int width, int height) {
       realCameraSize.width = width;
       realCameraSize.height = height;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCanvas.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCanvas.java
@@ -50,6 +50,7 @@ public class ShadowCanvas {
     return shadowOf(canvas).getDescription();
   }
 
+  @Implementation
   public void __constructor__(Bitmap bitmap) {
     this.targetBitmap = bitmap;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentProviderClient.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentProviderClient.java
@@ -26,6 +26,7 @@ public class ShadowContentProviderClient {
   private boolean released;
   private ContentProvider provider;
 
+  @Implementation
   public void __constructor__(ContentResolver contentResolver, IContentProvider contentProvider, boolean stable) {
     this.stable = stable;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentProviderResult.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentProviderResult.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import android.content.ContentProviderResult;
 import android.net.Uri;
 import java.lang.reflect.Field;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
@@ -10,12 +11,14 @@ import org.robolectric.annotation.RealObject;
 public class ShadowContentProviderResult {
   @RealObject ContentProviderResult realResult;
 
+  @Implementation
   public void __constructor__(Uri uri) throws SecurityException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
     Field field = realResult.getClass().getField("uri");
     field.setAccessible(true);
     field.set(realResult, uri);
   }
 
+  @Implementation
   public void __constructor__(int count) throws SecurityException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
     Field field = realResult.getClass().getField("count");
     field.setAccessible(true);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCornerPathEffect.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCornerPathEffect.java
@@ -1,6 +1,7 @@
 package org.robolectric.shadows;
 
 import android.graphics.CornerPathEffect;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 @SuppressWarnings({"UnusedDeclaration"})
@@ -8,6 +9,7 @@ import org.robolectric.annotation.Implements;
 public class ShadowCornerPathEffect {
   private float radius;
 
+  @Implementation
   public void __constructor__(float radius) {
     this.radius = radius;
    }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCountDownTimer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCountDownTimer.java
@@ -13,6 +13,7 @@ public class ShadowCountDownTimer {
 
   @RealObject CountDownTimer countDownTimer;
 
+  @Implementation
   public void __constructor__(long millisInFuture, long countDownInterval) {
     this.countDownInterval = countDownInterval;
     this.millisInFuture = millisInFuture;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCursorWrapper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCursorWrapper.java
@@ -18,6 +18,7 @@ import org.robolectric.annotation.Implements;
 public class ShadowCursorWrapper implements Cursor {
   private Cursor wrappedCursor;
 
+  @Implementation
   public void __constructor__(Cursor c) {
     wrappedCursor = c;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGestureDetector.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGestureDetector.java
@@ -25,6 +25,7 @@ public class ShadowGestureDetector {
   private GestureDetector.OnGestureListener listener;
   private OnDoubleTapListener onDoubleTapListener;
 
+  @Implementation
   public void __constructor__(Context context, GestureDetector.OnGestureListener listener, Handler handler) {
     Shadow.invokeConstructor(GestureDetector.class, realObject,
         from(Context.class, context),

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLinearGradient.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLinearGradient.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import android.graphics.LinearGradient;
 import android.graphics.Shader;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 @SuppressWarnings({"UnusedDeclaration"})
@@ -15,6 +16,7 @@ public class ShadowLinearGradient {
   private int color1;
   private Shader.TileMode tile;
 
+  @Implementation
   public void __constructor__(float x0, float y0, float x1, float y1, int color0, int color1, Shader.TileMode tile) {
     this.x0 = x0;
     this.y0 = y0;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMatrix.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMatrix.java
@@ -35,6 +35,7 @@ public class ShadowMatrix {
 
   private SimpleMatrix mMatrix = SimpleMatrix.IDENTITY;
 
+  @Implementation
   public void __constructor__(Matrix src) {
     set(src);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
@@ -87,6 +87,7 @@ import org.robolectric.shadows.util.DataSource;
  */
 @Implements(MediaPlayer.class)
 public class ShadowMediaPlayer extends ShadowPlayerBase {
+  @Implementation
   public static void __staticInitializer__() {
     // don't bind the JNI library
   }
@@ -529,6 +530,7 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
     return mp;
   }
 
+  @Implementation
   public void __constructor__() {
     // Contract of audioSessionId is that if it is 0 (which represents
     // the master mix) then that's an error. By default it generates

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaRecorder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaRecorder.java
@@ -9,6 +9,7 @@ import org.robolectric.annotation.Implements;
 @Implements(MediaRecorder.class)
 public class ShadowMediaRecorder {
   @SuppressWarnings("UnusedDeclaration")
+  @Implementation
   public static void __staticInitializer__() {
     // don't bind the JNI library
   }
@@ -46,6 +47,7 @@ public class ShadowMediaRecorder {
   private MediaRecorder.OnErrorListener errorListener;
   private MediaRecorder.OnInfoListener infoListener;
 
+  @Implementation
   public void __constructor__() {
     state = STATE_INITIAL;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessenger.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessenger.java
@@ -11,6 +11,7 @@ import org.robolectric.annotation.Implements;
 public class ShadowMessenger {
   private Handler handler;
 
+  @Implementation
   public void __constructor__(Handler handler) {
     this.handler = handler;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetwork.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetwork.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 
 import android.net.Network;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.shadow.api.Shadow;
 
@@ -21,6 +22,7 @@ public class ShadowNetwork {
     return network;
   }
 
+  @Implementation
   public void __constructor__(int netId) {
     this.netId = netId;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkInfo.java
@@ -14,6 +14,7 @@ public class ShadowNetworkInfo {
   private int connectionSubType;
   private NetworkInfo.DetailedState detailedState;
 
+  @Implementation
   public static void __staticInitializer__() {
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageInstaller.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageInstaller.java
@@ -156,6 +156,7 @@ public class ShadowPackageInstaller {
     private int sessionId;
     private ShadowPackageInstaller shadowPackageInstaller;
 
+    @Implementation
     public void __constructor__() {
 
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPaint.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPaint.java
@@ -40,11 +40,13 @@ public class ShadowPaint {
   private float textSize;
   private Paint.Align textAlign = Paint.Align.LEFT;
 
+  @Implementation
   public void __constructor__(int flags) {
     this.flags = flags;
     Shadow.invokeConstructor(Paint.class, paint, ClassParameter.from(int.class, flags));
   }
 
+  @Implementation
   public void __constructor__(Paint otherPaint) {
     ShadowPaint otherShadowPaint = shadowOf(otherPaint);
     this.color = otherShadowPaint.color;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPath.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPath.java
@@ -20,6 +20,7 @@ public class ShadowPath {
   private Point wasMovedTo;
   private String quadDescription = "";
 
+  @Implementation
   public void __constructor__(Path path) {
     points = new ArrayList<>(Shadows.shadowOf(path).getPoints());
     wasMovedTo = Shadows.shadowOf(path).wasMovedTo;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPicture.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPicture.java
@@ -12,15 +12,19 @@ public class ShadowPicture {
   private int width;
   private int height;
 
+  @Implementation
   public void __constructor__() {
   }
 
+  @Implementation
   public void __constructor__(long nativePicture) {
   }
 
+  @Implementation
   public void __constructor__(int nativePicture, boolean fromStream) {
   }
 
+  @Implementation
   public void __constructor__(Picture src) {
     width = src.getWidth();
     height = src.getHeight();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPorterDuffColorFilter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPorterDuffColorFilter.java
@@ -10,6 +10,7 @@ public class ShadowPorterDuffColorFilter {
   private int color;
   private PorterDuff.Mode mode;
 
+  @Implementation
   public void __constructor__(int color, PorterDuff.Mode mode) {
     this.color = color;
     this.mode = mode;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -301,9 +301,11 @@ public class ShadowResources {
 
     private String message;
 
+    @Implementation
     public void __constructor__() {
     }
 
+    @Implementation
     public void __constructor__(String name) {
       this.message = name;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStatFs.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStatFs.java
@@ -22,6 +22,7 @@ public class ShadowStatFs {
   private static Map<String, Stats> stats = new HashMap<String, Stats>();
   private Stats stat;
 
+  @Implementation
   public void __constructor__(String path) {
     restat(path);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSurface.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSurface.java
@@ -2,12 +2,14 @@ package org.robolectric.shadows;
 
 import android.graphics.SurfaceTexture;
 import android.view.Surface;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 @Implements(Surface.class)
 public class ShadowSurface {
   private SurfaceTexture surfaceTexture;
 
+  @Implementation
   public void __constructor__(SurfaceTexture surfaceTexture) {
     this.surfaceTexture = surfaceTexture;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextToSpeech.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextToSpeech.java
@@ -14,6 +14,7 @@ public class ShadowTextToSpeech {
   private boolean shutdown = false;
   private int queueMode = -1;
 
+  @Implementation
   public void __constructor__(Context context, TextToSpeech.OnInitListener listener) {
     this.context = context;
     this.listener = listener;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimePickerDialog.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimePickerDialog.java
@@ -4,6 +4,7 @@ import static org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 import android.app.TimePickerDialog;
 import android.content.Context;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.shadow.api.Shadow;
@@ -15,6 +16,7 @@ public class ShadowTimePickerDialog extends ShadowAlertDialog {
   private int hourOfDay;
   private int minute;
 
+  @Implementation
   public void __constructor__(Context context, int theme, TimePickerDialog.OnTimeSetListener callBack,
                               int hourOfDay, int minute, boolean is24HourView) {
     this.hourOfDay = hourOfDay;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowToast.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowToast.java
@@ -24,6 +24,7 @@ public class ShadowToast {
 
   @RealObject Toast toast;
 
+  @Implementation
   public void __constructor__(Context context) {
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTouchDelegate.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTouchDelegate.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import android.graphics.Rect;
 import android.view.TouchDelegate;
 import android.view.View;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
@@ -12,6 +13,7 @@ public class ShadowTouchDelegate {
   private Rect bounds;
   private View delegateView;
 
+  @Implementation
   public void __constructor__( Rect bounds, View delegateView ){
     this.bounds = bounds;
     this.delegateView = delegateView;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTypeface.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTypeface.java
@@ -30,11 +30,13 @@ public class ShadowTypeface {
   @RealObject private Typeface realTypeface;
 
   @HiddenApi
+  @Implementation
   public void __constructor__(int fontId) {
     description = findById((long) fontId);
   }
 
   @HiddenApi
+  @Implementation
   public void __constructor__(long fontId) {
     description = findById(fontId);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowView.java
@@ -110,6 +110,7 @@ public class ShadowView {
     return shadowOf(view).innerText();
   }
 
+  @Implementation
   public void __constructor__(Context context, AttributeSet attributeSet, int defStyle) {
     if (context == null) throw new NullPointerException("no context");
     this.attributeSet = attributeSet;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiConfiguration.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiConfiguration.java
@@ -10,6 +10,7 @@ import org.robolectric.annotation.RealObject;
 public class ShadowWifiConfiguration {
   @RealObject private WifiConfiguration realObject;
 
+  @Implementation
   public void __constructor__() {
     realObject.networkId = -1;
     realObject.SSID = null;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiInfo.java
@@ -9,6 +9,7 @@ import org.robolectric.annotation.Implements;
 
 @Implements(WifiInfo.class)
 public class ShadowWifiInfo {
+  @Implementation
   public static void __staticInitializer__() {
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowZoomButtonsController.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowZoomButtonsController.java
@@ -10,6 +10,7 @@ import org.robolectric.annotation.Implements;
 public class ShadowZoomButtonsController {
   private ZoomButtonsController.OnZoomListener listener;
 
+  @Implementation
   public void __constructor__(View ownerView) {
   }
 

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
@@ -53,6 +53,7 @@ public class ShadowDefaultRequestDirector {
 
   org.robolectric.shadows.httpclient.DefaultRequestDirector redirector;
 
+  @Implementation
   public void __constructor__(
       Log log,
       HttpRequestExecutor requestExec,
@@ -102,6 +103,7 @@ public class ShadowDefaultRequestDirector {
     }
   }
 
+  @Implementation
   public void __constructor__(
       HttpRequestExecutor requestExec,
       ClientConnectionManager conman,

--- a/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowAsyncTaskLoader.java
+++ b/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowAsyncTaskLoader.java
@@ -14,6 +14,7 @@ public class ShadowAsyncTaskLoader<D> {
   @RealObject private AsyncTaskLoader<D> realLoader;
   private SimpleFuture<D> future;
 
+  @Implementation
   public void __constructor__(Context context) {
     BackgroundWorker worker = new BackgroundWorker();
     future = new SimpleFuture<D>(worker) {


### PR DESCRIPTION
Constructor and static initializer `@Implementation` methods should be annotated as such. This fixes an issue that caused javadoc from those methods to be excluded from developer.android.com reference docs with Robolectric Chrome plugin.