### PR TITLE
Allow @Implementation methods to be protected instead of public

### DIFF
--- a/processor/src/main/java/org/robolectric/annotation/processing/RobolectricModel.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/RobolectricModel.java
@@ -164,7 +164,7 @@ public class RobolectricModel {
   };
 
   public static AnnotationValue getAnnotationValue(AnnotationMirror annotationMirror, String key) {
-    for (Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : annotationMirror.getElementValues().entrySet() ) {
+    for (Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : annotationMirror.getElementValues().entrySet()) {
       if (entry.getKey().getSimpleName().toString().equals(key)) {
         return entry.getValue();
       }

--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementationValidator.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementationValidator.java
@@ -1,20 +1,39 @@
 package org.robolectric.annotation.processing.validator;
 
+import com.google.common.collect.ImmutableSet;
+import javax.lang.model.element.Name;
+import org.robolectric.annotation.processing.RobolectricModel;
+
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
-import org.robolectric.annotation.processing.RobolectricModel;
+import javax.tools.Diagnostic.Kind;
+import java.util.Set;
 
 /**
  * Validator that checks usages of {@link org.robolectric.annotation.Implementation}.
  */
 public class ImplementationValidator extends FoundOnImplementsValidator {
+  public static final Set<String> METHODS_ALLOWED_TO_BE_PUBLIC = ImmutableSet.of(
+      "toString",
+      "hashCode",
+      "equals"
+  );
+
   public ImplementationValidator(RobolectricModel model, ProcessingEnvironment env) {
     super(model, env, "org.robolectric.annotation.Implementation");
   }
 
   @Override
   public Void visitExecutable(ExecutableElement elem, TypeElement parent) {
+    Set<Modifier> modifiers = elem.getModifiers();
+    if (!METHODS_ALLOWED_TO_BE_PUBLIC.contains(elem.getSimpleName().toString())) {
+      if (!modifiers.contains(Modifier.PUBLIC) && !modifiers.contains(Modifier.PROTECTED)) {
+        message(Kind.ERROR, "@Implementation methods should be protected (preferred) or public (deprecated)");
+      }
+    }
+
     // TODO: Check that it has the right signature
     return null;
   }

--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementationValidator.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementationValidator.java
@@ -1,15 +1,13 @@
 package org.robolectric.annotation.processing.validator;
 
 import com.google.common.collect.ImmutableSet;
-import javax.lang.model.element.Name;
-import org.robolectric.annotation.processing.RobolectricModel;
-
+import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic.Kind;
-import java.util.Set;
+import org.robolectric.annotation.processing.RobolectricModel;
 
 /**
  * Validator that checks usages of {@link org.robolectric.annotation.Implementation}.

--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementsValidator.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementsValidator.java
@@ -54,6 +54,16 @@ public class ImplementsValidator extends Validator {
 
   @Override
   public Void visitType(TypeElement elem, Element parent) {
+    for (Element memberElement : ElementFilter.methodsIn(elem.getEnclosedElements())) {
+      String methodName = memberElement.getSimpleName().toString();
+      if (methodName.equals("__constructor__") || methodName.equals("__staticInitializer__")) {
+        Implementation implementation = memberElement.getAnnotation(Implementation.class);
+        if (implementation == null) {
+          messager.printMessage(Kind.ERROR, "Shadow methods must be annotated @Implementation", memberElement);
+        }
+      }
+    }
+
     captureJavadoc(elem);
 
     // inner class shadows must be static

--- a/processor/src/test/java/org/robolectric/annotation/processing/validator/ImplementationValidatorTest.java
+++ b/processor/src/test/java/org/robolectric/annotation/processing/validator/ImplementationValidatorTest.java
@@ -6,13 +6,34 @@ import static org.robolectric.annotation.processing.validator.SingleClassSubject
 import org.junit.Test;
 
 public class ImplementationValidatorTest {
+
   @Test
   public void implementationWithoutImplements_shouldNotCompile() {
     final String testClass = "org.robolectric.annotation.processing.shadows.ShadowImplementationWithoutImplements";
     assertAbout(singleClass())
-      .that(testClass)
-      .failsToCompile()
-      .withErrorContaining("@Implementation without @Implements")
-      .onLine(7);
+        .that(testClass)
+        .failsToCompile()
+        .withErrorContaining("@Implementation without @Implements")
+        .onLine(7);
+  }
+
+  @Test
+  public void implementationWithIncorrectVisibility_shouldNotCompile() {
+    final String testClass = "org.robolectric.annotation.processing.shadows.ShadowImplementationWithIncorrectVisibility";
+    assertAbout(singleClass())
+        .that(testClass)
+        .failsToCompile()
+        .withErrorContaining("@Implementation methods should be protected (preferred) or public (deprecated)")
+        .onLine(17)
+        .and()
+        .withErrorContaining("@Implementation methods should be protected (preferred) or public (deprecated)")
+        .onLine(21)
+        .and()
+        .withErrorContaining("@Implementation methods should be protected (preferred) or public (deprecated)")
+        .onLine(31)
+        .and()
+        .withErrorContaining("@Implementation methods should be protected (preferred) or public (deprecated)")
+        .onLine(34)
+    ;
   }
 }

--- a/processor/src/test/resources/org/robolectric/annotation/processing/shadows/DocumentedObjectShadow.java
+++ b/processor/src/test/resources/org/robolectric/annotation/processing/shadows/DocumentedObjectShadow.java
@@ -16,7 +16,7 @@ public class DocumentedObjectShadow {
    * Docs for shadow method go here!
    */
   @Implementation
-  public String getSomething(int index, Map<String, String> defaultValue) {
+  protected String getSomething(int index, Map<String, String> defaultValue) {
     return null;
   }
 

--- a/processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementationWithIncorrectVisibility.java
+++ b/processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementationWithIncorrectVisibility.java
@@ -1,0 +1,36 @@
+package org.robolectric.annotation.processing.shadows;
+
+import com.example.objects.Dummy;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(Dummy.class)
+public class ShadowImplementationWithIncorrectVisibility {
+  @Implementation
+  public void __constructor__(int i0) {
+  }
+
+  @Implementation
+  protected void __constructor__(int i0, int i1) {
+  }
+
+  @Implementation
+  void __constructor__(int i0, int i1, int i2) {
+  }
+
+  @Implementation
+  private void __constructor__(int i0, int i1, int i2, int i3) {
+  }
+
+  @Implementation
+  public static void publicMethod() {}
+
+  @Implementation
+  protected static void protectedMethod() {}
+
+  @Implementation
+  static void packageMethod() {}
+
+  @Implementation
+  private static void privateMethod() {}
+}

--- a/processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementationWithoutImplements.java
+++ b/processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowImplementationWithoutImplements.java
@@ -5,5 +5,5 @@ import org.robolectric.annotation.Implementation;
 public class ShadowImplementationWithoutImplements {
 
   @Implementation
-  public static void implementation_method() {}
+  protected static void implementation_method() {}
 }

--- a/robolectric/src/test/java/org/robolectric/InvokeDynamicTest.java
+++ b/robolectric/src/test/java/org/robolectric/InvokeDynamicTest.java
@@ -79,7 +79,7 @@ public class InvokeDynamicTest {
     public int x = -2;
 
     @Implementation
-    public void setX(int x) {
+    protected void setX(int x) {
       this.x = x;
       real.x = -x;
     }
@@ -90,7 +90,7 @@ public class InvokeDynamicTest {
     @RealObject RealCopy real;
 
     @Implementation
-    public void setX(int x) {
+    protected void setX(int x) {
       real.x = 1;
     }
   }
@@ -100,7 +100,7 @@ public class InvokeDynamicTest {
     @RealObject RealCopy real;
 
     @Implementation
-    public void setX(int x) {
+    protected void setX(int x) {
       real.x = 2;
     }
   }

--- a/robolectric/src/test/java/org/robolectric/RobolectricTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTest.java
@@ -159,7 +159,7 @@ public class RobolectricTest {
   @Implements(View.class)
   public static class TestShadowView {
     @Implementation
-    public Context getContext() {
+    protected Context getContext() {
       return null;
     }
   }

--- a/robolectric/src/test/java/org/robolectric/android/AndroidTranslatorClassInstrumentedTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/AndroidTranslatorClassInstrumentedTest.java
@@ -64,7 +64,7 @@ public class AndroidTranslatorClassInstrumentedTest {
   @Implements(ClassWithPrivateConstructor.class)
   public static class ShadowClassWithPrivateConstructor {
     @Implementation
-    public int getInt() {
+    protected int getInt() {
       return 42;
     }
   }
@@ -74,12 +74,12 @@ public class AndroidTranslatorClassInstrumentedTest {
     private int color;
 
     @Implementation
-    public void setColor(int color) {
+    protected void setColor(int color) {
       this.color = color;
     }
 
     @Implementation
-    public int getColor() {
+    protected int getColor() {
       return color;
     }
   }
@@ -104,12 +104,12 @@ public class AndroidTranslatorClassInstrumentedTest {
 
     @Override
     @Implementation
-    public int getColor() {
+    protected int getColor() {
       return 10;
     }
 
     @Implementation
-    public String getColorName() {
+    protected String getColorName() {
       return "rainbow";
     }
   }

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowWranglerUnitTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowWranglerUnitTest.java
@@ -151,23 +151,23 @@ public class ShadowWranglerUnitTest {
   @Implements(value = DummyClass.class, minSdk = 19, maxSdk = 21)
   public static class ShadowDummyClass {
     @Implementation(minSdk = 20, maxSdk = 20)
-    public void __constructor__() {
+    protected void __constructor__() {
     }
     
     @Implementation
-    public void methodWithoutRange() {
+    protected void methodWithoutRange() {
     }
 
     @Implementation(minSdk = 20, maxSdk = 20)
-    public void methodFor20() {
+    protected void methodFor20() {
     }
 
     @Implementation(minSdk = 20)
-    public void methodMin20() {
+    protected void methodMin20() {
     }
 
     @Implementation(maxSdk = 20)
-    public void methodMax20() {
+    protected void methodMax20() {
     }
   }
 
@@ -177,7 +177,7 @@ public class ShadowWranglerUnitTest {
   @Implements(value = ChildOfDummyClass.class, minSdk = 20, maxSdk = 21)
   public static class ShadowChildOfDummyClass {
     @Implementation
-    public void methodWithoutRange() {
+    protected void methodWithoutRange() {
     }
   }
 

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
@@ -108,7 +108,7 @@ public class ShadowWrangler implements ClassHandler {
     Class<?> shadowClass = findDirectShadowClass(clazz);
     if (shadowClass != null) {
       try {
-        Method method = shadowClass.getMethod(ShadowConstants.STATIC_INITIALIZER_METHOD_NAME);
+        Method method = shadowClass.getDeclaredMethod(ShadowConstants.STATIC_INITIALIZER_METHOD_NAME);
         if (!Modifier.isStatic(method.getModifiers())) {
           throw new RuntimeException(shadowClass.getName() + "." + method.getName() + " is not static");
         }
@@ -210,18 +210,30 @@ public class ShadowWrangler implements ClassHandler {
   }
 
   private Method findShadowMethod(ClassLoader classLoader, ShadowConfig config, String name, Class<?>[] types) {
+    Class<?> shadowClass;
     try {
-      Class<?> shadowClass = Class.forName(config.shadowClassName, false, classLoader);
-      Method method = findShadowMethodInternal(shadowClass, name, types);
-      if (method == null && config.looseSignatures) {
-        Class<?>[] genericTypes = MethodType.genericMethodType(types.length).parameterArray();
-        method = findShadowMethodInternal(shadowClass, name, genericTypes);
-      }
-
-      return method;
+      shadowClass = Class.forName(config.shadowClassName, false, classLoader);
     } catch (ClassNotFoundException e) {
       throw new IllegalStateException(e);
     }
+
+    return findShadowMethod(config, shadowClass, name, types);
+  }
+
+  private Method findShadowMethod(ShadowConfig config, Class<?> shadowClass, String name, Class<?>[] types) {
+    Method method = findShadowMethodInternal(shadowClass, name, types);
+
+    if (method == null && config.looseSignatures) {
+      Class<?>[] genericTypes = MethodType.genericMethodType(types.length).parameterArray();
+      method = findShadowMethodInternal(shadowClass, name, genericTypes);
+    }
+
+    Class<?> superclass;
+    if (method == null && config.inheritImplementationMethods && (superclass = shadowClass.getSuperclass()) != null) {
+      return findShadowMethod(config, superclass, name, types);
+    }
+
+    return method;
   }
 
   @SuppressWarnings("ReferenceEquality")
@@ -244,9 +256,10 @@ public class ShadowWrangler implements ClassHandler {
     return isAndroidSupport(invocationProfile) || invocationProfile.isDeclaredOnObject();
   }
 
-  private Method findShadowMethodInternal(Class<?> shadowClass, String methodName, Class<?>[] paramClasses) throws ClassNotFoundException {
+  private Method findShadowMethodInternal(Class<?> shadowClass, String methodName, Class<?>[] paramClasses) {
     try {
-      Method method = shadowClass.getMethod(methodName, paramClasses);
+      Method method = shadowClass.getDeclaredMethod(methodName, paramClasses);
+      method.setAccessible(true);
       Implementation implementation = getImplementationAnnotation(method);
       return matchesSdk(implementation) ? method : null;
 

--- a/sandbox/src/test/java/org/robolectric/RobolectricInternalsTest.java
+++ b/sandbox/src/test/java/org/robolectric/RobolectricInternalsTest.java
@@ -128,23 +128,23 @@ public class RobolectricInternalsTest {
     public Long   shadowParam33 = null;
     
     @Implementation
-    public void __constructor__() {
+    protected void __constructor__() {
       shadowConstructorCalled = true;
     }
 
     @Implementation
-    public void __constructor__(String param) {
+    protected void __constructor__(String param) {
       shadowParam11 = param;
     }
 
     @Implementation
-    public void __constructor__(String param1, Byte param2) {
+    protected void __constructor__(String param1, Byte param2) {
       shadowParam21 = param1;
       shadowParam22 = param2;
     }
 
     @Implementation
-    public void __constructor__(String param1, Byte param2, Long param3) {
+    protected void __constructor__(String param1, Byte param2, Long param3) {
       shadowParam31 = param1;
       shadowParam32 = param2;
       shadowParam33 = param3;

--- a/sandbox/src/test/java/org/robolectric/ShadowWranglerIntegrationTest.java
+++ b/sandbox/src/test/java/org/robolectric/ShadowWranglerIntegrationTest.java
@@ -219,7 +219,7 @@ public class ShadowWranglerIntegrationTest {
   @Implements(Parent.class)
   public static class ShadowOfParent {
     @Implementation
-    public String get() {
+    protected String get() {
       return "from shadow of parent";
     }
   }
@@ -242,8 +242,8 @@ public class ShadowWranglerIntegrationTest {
 
   @Implements(Foo.class)
   public static class WithEquals {
-    @SuppressWarnings("UnusedDeclaration")
-    public void __constructor__(String s) {
+    @Implementation
+    protected void __constructor__(String s) {
     }
 
     @Override
@@ -261,8 +261,8 @@ public class ShadowWranglerIntegrationTest {
 
   @Implements(Foo.class)
   public static class WithToString {
-    @SuppressWarnings("UnusedDeclaration")
-    public void __constructor__(String s) {
+    @Implementation
+    protected void __constructor__(String s) {
     }
 
     @Override
@@ -288,7 +288,8 @@ public class ShadowWranglerIntegrationTest {
     private Foo realFoo;
     public Foo realFooInParentConstructor;
 
-    public void __constructor__(String name) {
+    @Implementation
+    protected void __constructor__(String name) {
       realFooInParentConstructor = realFoo;
     }
   }
@@ -314,7 +315,7 @@ public class ShadowWranglerIntegrationTest {
   @Implements(value = AClassWithDifficultArgs.class, looseSignatures = true)
   public static class ShadowAClassWithDifficultArgs {
     @Implementation
-    public Object aMethod(Object s) {
+    protected Object aMethod(Object s) {
       return "a" + s;
     }
   }

--- a/sandbox/src/test/java/org/robolectric/ShadowingTest.java
+++ b/sandbox/src/test/java/org/robolectric/ShadowingTest.java
@@ -65,7 +65,7 @@ public class ShadowingTest {
   @Implements(ClassWithProtectedMethod.class)
   public static class ShadowClassWithProtectedMethod {
     @Implementation
-    public String getName() {
+    protected String getName() {
       return "shadow name";
     }
   }
@@ -97,12 +97,12 @@ public class ShadowingTest {
     private int color;
 
     @Implementation
-    public void setColor(int color) {
+    protected void setColor(int color) {
       this.color = color;
     }
 
     @Implementation
-    public int getColor() {
+    protected int getColor() {
       return color;
     }
   }
@@ -116,7 +116,8 @@ public class ShadowingTest {
       this.shadowDefaultConstructorCalled = true;
     }
 
-    public void __constructor__() {
+    @Implementation
+    protected void __constructor__() {
       shadowDefaultConstructorImplementorCalled = true;
     }
   }
@@ -185,8 +186,8 @@ public class ShadowingTest {
 
   @Implements(ClassWithSomeConstructors.class)
   public static class ShadowOfClassWithSomeConstructors {
-    @SuppressWarnings("UnusedDeclaration")
-    public void __constructor__(String s) {
+    @Implementation
+    protected void __constructor__(String s) {
     }
   }
 
@@ -230,7 +231,7 @@ public class ShadowingTest {
   @Implements(NonInstrumentedClass.class)
   public static class ShadowNonInstrumentedClass {
     @Implementation
-    public int plus(int x) {
+    protected int plus(int x) {
       return x + 2;
     }
   }

--- a/sandbox/src/test/java/org/robolectric/StaticInitializerTest.java
+++ b/sandbox/src/test/java/org/robolectric/StaticInitializerTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.internal.Instrument;
 import org.robolectric.internal.SandboxTestRunner;
@@ -60,8 +61,8 @@ public class StaticInitializerTest {
   public static class ShadowClassWithStaticInitializerOverride {
     public static boolean initialized = false;
 
-    @SuppressWarnings("UnusedDeclaration")
-    public static void __staticInitializer__() {
+    @Implementation
+    protected static void __staticInitializer__() {
       initialized = true;
     }
   }

--- a/sandbox/src/test/java/org/robolectric/ThreadSafetyTest.java
+++ b/sandbox/src/test/java/org/robolectric/ThreadSafetyTest.java
@@ -46,7 +46,7 @@ public class ThreadSafetyTest {
   public static class InstrumentedThreadShadow {
     @RealObject InstrumentedThread realObject;
     @Implementation
-    public void run() {
+    protected void run() {
       Shadow.directlyOn(realObject, InstrumentedThread.class, "run");
     }
   }

--- a/sandbox/src/test/java/org/robolectric/testing/Pony.java
+++ b/sandbox/src/test/java/org/robolectric/testing/Pony.java
@@ -29,7 +29,7 @@ public class Pony {
     }
 
     @Implementation
-    public static String prance(String where) {
+    protected static String prance(String where) {
       return "I'm shadily prancing to " + where + "!";
     }
   }

--- a/sandbox/src/test/java/org/robolectric/testing/ShadowFoo.java
+++ b/sandbox/src/test/java/org/robolectric/testing/ShadowFoo.java
@@ -1,6 +1,7 @@
 package org.robolectric.testing;
 
 import org.robolectric.ShadowWranglerIntegrationTest;
+import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
@@ -11,8 +12,8 @@ public class ShadowFoo extends ShadowWranglerIntegrationTest.ShadowFooParent {
   public String name;
 
   @Override
-  @SuppressWarnings({"UnusedDeclaration"})
-  public void __constructor__(String name) {
+  @Implementation
+  protected void __constructor__(String name) {
     super.__constructor__(name);
     this.name = name;
     realFooInConstructor = realFooField;

--- a/shadows/framework/src/main/java/org/robolectric/android/internal/DisplayConfig.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/internal/DisplayConfig.java
@@ -16,12 +16,8 @@
 
 package org.robolectric.android.internal;
 
-import android.content.res.CompatibilityInfo;
-import android.content.res.Configuration;
 import android.util.ArraySet;
-import android.util.DisplayMetrics;
 import android.view.Display;
-import android.view.DisplayAdjustments;
 import android.view.DisplayInfo;
 import android.view.Surface;
 import java.util.Arrays;
@@ -413,134 +409,6 @@ public final class DisplayConfig {
         other.ownerUid = ownerUid;
         other.ownerPackageName = ownerPackageName;
         other.removeMode = removeMode;
-    }
-
-
-    public Display.Mode getMode() {
-        return findMode(modeId);
-    }
-
-    public Display.Mode getDefaultMode() {
-        return findMode(defaultModeId);
-    }
-
-    private Display.Mode findMode(int id) {
-        for (int i = 0; i < supportedModes.length; i++) {
-            if (supportedModes[i].getModeId() == id) {
-                return supportedModes[i];
-            }
-        }
-        throw new IllegalStateException("Unable to locate mode " + id);
-    }
-
-    /**
-     * Returns the id of the "default" mode with the given refresh rate, or {@code 0} if no suitable
-     * mode could be found.
-     */
-    public int findDefaultModeByRefreshRate(float refreshRate) {
-        Display.Mode[] modes = supportedModes;
-        Display.Mode defaultMode = getDefaultMode();
-        for (int i = 0; i < modes.length; i++) {
-            if (modes[i].matches(
-                    defaultMode.getPhysicalWidth(), defaultMode.getPhysicalHeight(), refreshRate)) {
-                return modes[i].getModeId();
-            }
-        }
-        return 0;
-    }
-
-    /**
-     * Returns the list of supported refresh rates in the default mode.
-     */
-    public float[] getDefaultRefreshRates() {
-        Display.Mode[] modes = supportedModes;
-        ArraySet<Float> rates = new ArraySet<>();
-        Display.Mode defaultMode = getDefaultMode();
-        for (int i = 0; i < modes.length; i++) {
-            Display.Mode mode = modes[i];
-            if (mode.getPhysicalWidth() == defaultMode.getPhysicalWidth()
-                    && mode.getPhysicalHeight() == defaultMode.getPhysicalHeight()) {
-                rates.add(mode.getRefreshRate());
-            }
-        }
-        float[] result = new float[rates.size()];
-        int i = 0;
-        for (Float rate : rates) {
-            result[i++] = rate;
-        }
-        return result;
-    }
-
-    public void getAppMetrics(DisplayMetrics outMetrics) {
-        getAppMetrics(outMetrics, CompatibilityInfo.DEFAULT_COMPATIBILITY_INFO, null);
-    }
-
-    public void getAppMetrics(DisplayMetrics outMetrics, DisplayAdjustments displayAdjustments) {
-        getMetricsWithSize(outMetrics, displayAdjustments.getCompatibilityInfo(),
-                displayAdjustments.getConfiguration(), appWidth, appHeight);
-    }
-
-    public void getAppMetrics(DisplayMetrics outMetrics, CompatibilityInfo ci,
-            Configuration configuration) {
-        getMetricsWithSize(outMetrics, ci, configuration, appWidth, appHeight);
-    }
-
-    public void getLogicalMetrics(DisplayMetrics outMetrics, CompatibilityInfo compatInfo,
-            Configuration configuration) {
-        getMetricsWithSize(outMetrics, compatInfo, configuration, logicalWidth, logicalHeight);
-    }
-
-    public int getNaturalWidth() {
-        return rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180 ?
-                logicalWidth : logicalHeight;
-    }
-
-    public int getNaturalHeight() {
-        return rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180 ?
-                logicalHeight : logicalWidth;
-    }
-
-    public boolean isHdr() {
-        int[] types = hdrCapabilities != null ? hdrCapabilities.getSupportedHdrTypes() : null;
-        return types != null && types.length > 0;
-    }
-
-    public boolean isWideColorGamut() {
-        for (int colorMode : supportedColorModes) {
-            if (colorMode == Display.COLOR_MODE_DCI_P3 || colorMode > Display.COLOR_MODE_SRGB) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Returns true if the specified UID has access to this display.
-     */
-    public boolean hasAccess(int uid) {
-        return Display.hasAccess(uid, flags, ownerUid);
-    }
-
-    private void getMetricsWithSize(DisplayMetrics outMetrics, CompatibilityInfo compatInfo,
-            Configuration configuration, int width, int height) {
-        outMetrics.densityDpi = outMetrics.noncompatDensityDpi = logicalDensityDpi;
-        outMetrics.density = outMetrics.noncompatDensity =
-                logicalDensityDpi * DisplayMetrics.DENSITY_DEFAULT_SCALE;
-        outMetrics.scaledDensity = outMetrics.noncompatScaledDensity = outMetrics.density;
-        outMetrics.xdpi = outMetrics.noncompatXdpi = physicalXDpi;
-        outMetrics.ydpi = outMetrics.noncompatYdpi = physicalYDpi;
-
-        width = configuration != null && configuration.appBounds != null
-                ? configuration.appBounds.width() : width;
-        height = configuration != null && configuration.appBounds != null
-                ? configuration.appBounds.height() : height;
-
-        outMetrics.noncompatWidthPixels  = outMetrics.widthPixels = width;
-        outMetrics.noncompatHeightPixels = outMetrics.heightPixels = height;
-
-        if (!compatInfo.equals(CompatibilityInfo.DEFAULT_COMPATIBILITY_INFO)) {
-            compatInfo.applyToDisplayMetrics(outMetrics);
-        }
     }
 
     // For debugging purposes

--- a/shadows/framework/src/main/java/org/robolectric/android/internal/DisplayConfig.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/internal/DisplayConfig.java
@@ -1,0 +1,647 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.robolectric.android.internal;
+
+import android.content.res.CompatibilityInfo;
+import android.content.res.Configuration;
+import android.util.ArraySet;
+import android.util.DisplayMetrics;
+import android.view.Display;
+import android.view.DisplayAdjustments;
+import android.view.DisplayInfo;
+import android.view.Surface;
+import java.util.Arrays;
+import libcore.util.Objects;
+
+/**
+ * Describes the characteristics of a particular logical display.
+ *
+ * Robolectric internal (for now), do not use.
+ */
+public final class DisplayConfig {
+    /**
+     * The surface flinger layer stack associated with this logical display.
+     */
+    public int layerStack;
+
+    /**
+     * Display flags.
+     */
+    public int flags;
+
+    /**
+     * Display type.
+     */
+    public int type;
+
+    /**
+     * Display address, or null if none.
+     * Interpretation varies by display type.
+     */
+    public String address;
+
+    /**
+     * The human-readable name of the display.
+     */
+    public String name;
+
+    /**
+     * Unique identifier for the display. Shouldn't be displayed to the user.
+     */
+    public String uniqueId;
+
+    /**
+     * The width of the portion of the display that is available to applications, in pixels.
+     * Represents the size of the display minus any system decorations.
+     */
+    public int appWidth;
+
+    /**
+     * The height of the portion of the display that is available to applications, in pixels.
+     * Represents the size of the display minus any system decorations.
+     */
+    public int appHeight;
+
+    /**
+     * The smallest value of {@link #appWidth} that an application is likely to encounter,
+     * in pixels, excepting cases where the width may be even smaller due to the presence
+     * of a soft keyboard, for example.
+     */
+    public int smallestNominalAppWidth;
+
+    /**
+     * The smallest value of {@link #appHeight} that an application is likely to encounter,
+     * in pixels, excepting cases where the height may be even smaller due to the presence
+     * of a soft keyboard, for example.
+     */
+    public int smallestNominalAppHeight;
+
+    /**
+     * The largest value of {@link #appWidth} that an application is likely to encounter,
+     * in pixels, excepting cases where the width may be even larger due to system decorations
+     * such as the status bar being hidden, for example.
+     */
+    public int largestNominalAppWidth;
+
+    /**
+     * The largest value of {@link #appHeight} that an application is likely to encounter,
+     * in pixels, excepting cases where the height may be even larger due to system decorations
+     * such as the status bar being hidden, for example.
+     */
+    public int largestNominalAppHeight;
+
+    /**
+     * The logical width of the display, in pixels.
+     * Represents the usable size of the display which may be smaller than the
+     * physical size when the system is emulating a smaller display.
+     */
+    public int logicalWidth;
+
+    /**
+     * The logical height of the display, in pixels.
+     * Represents the usable size of the display which may be smaller than the
+     * physical size when the system is emulating a smaller display.
+     */
+    public int logicalHeight;
+
+    /**
+     * @hide
+     * Number of overscan pixels on the left side of the display.
+     */
+    public int overscanLeft;
+
+    /**
+     * @hide
+     * Number of overscan pixels on the top side of the display.
+     */
+    public int overscanTop;
+
+    /**
+     * @hide
+     * Number of overscan pixels on the right side of the display.
+     */
+    public int overscanRight;
+
+    /**
+     * @hide
+     * Number of overscan pixels on the bottom side of the display.
+     */
+    public int overscanBottom;
+
+    /**
+     * The rotation of the display relative to its natural orientation.
+     * May be one of {@link Surface#ROTATION_0},
+     * {@link Surface#ROTATION_90}, {@link Surface#ROTATION_180},
+     * {@link Surface#ROTATION_270}.
+     * <p>
+     * The value of this field is indeterminate if the logical display is presented on
+     * more than one physical display.
+     * </p>
+     */
+    @Surface.Rotation
+    public int rotation;
+
+    /**
+     * The active display mode.
+     */
+    public int modeId;
+
+    /**
+     * The default display mode.
+     */
+    public int defaultModeId;
+
+    /**
+     * The supported modes of this display.
+     */
+    public Display.Mode[] supportedModes = Display.Mode.EMPTY_ARRAY;
+
+    /** The active color mode. */
+    public int colorMode;
+
+    /** The list of supported color modes */
+    public int[] supportedColorModes = { Display.COLOR_MODE_DEFAULT };
+
+    /** The display's HDR capabilities */
+    public Display.HdrCapabilities hdrCapabilities;
+
+    /**
+     * The logical display density which is the basis for density-independent
+     * pixels.
+     */
+    public int logicalDensityDpi;
+
+    /**
+     * The exact physical pixels per inch of the screen in the X dimension.
+     * <p>
+     * The value of this field is indeterminate if the logical display is presented on
+     * more than one physical display.
+     * </p>
+     */
+    public float physicalXDpi;
+
+    /**
+     * The exact physical pixels per inch of the screen in the Y dimension.
+     * <p>
+     * The value of this field is indeterminate if the logical display is presented on
+     * more than one physical display.
+     * </p>
+     */
+    public float physicalYDpi;
+
+    /**
+     * This is a positive value indicating the phase offset of the VSYNC events provided by
+     * Choreographer relative to the display refresh.  For example, if Choreographer reports
+     * that the refresh occurred at time N, it actually occurred at (N - appVsyncOffsetNanos).
+     */
+    public long appVsyncOffsetNanos;
+
+    /**
+     * This is how far in advance a buffer must be queued for presentation at
+     * a given time.  If you want a buffer to appear on the screen at
+     * time N, you must submit the buffer before (N - bufferDeadlineNanos).
+     */
+    public long presentationDeadlineNanos;
+
+    /**
+     * The state of the display, such as {@link Display#STATE_ON}.
+     */
+    public int state;
+
+    /**
+     * The UID of the application that owns this display, or zero if it is owned by the system.
+     * <p>
+     * If the display is private, then only the owner can use it.
+     * </p>
+     */
+    public int ownerUid;
+
+    /**
+     * The package name of the application that owns this display, or null if it is
+     * owned by the system.
+     * <p>
+     * If the display is private, then only the owner can use it.
+     * </p>
+     */
+    public String ownerPackageName;
+
+    /**
+     * @hide
+     * Get current remove mode of the display - what actions should be performed with the display's
+     * content when it is removed.
+     *
+     * @see Display#getRemoveMode()
+     */
+    public int removeMode = Display.REMOVE_MODE_MOVE_CONTENT_TO_PRIMARY;
+
+    public DisplayConfig() {
+    }
+
+    public DisplayConfig(DisplayConfig other) {
+        copyFrom(other);
+    }
+
+    public DisplayConfig(DisplayInfo other) {
+        layerStack = other.layerStack;
+        flags = other.flags;
+        type = other.type;
+        address = other.address;
+        name = other.name;
+        uniqueId = other.uniqueId;
+        appWidth = other.appWidth;
+        appHeight = other.appHeight;
+        smallestNominalAppWidth = other.smallestNominalAppWidth;
+        smallestNominalAppHeight = other.smallestNominalAppHeight;
+        largestNominalAppWidth = other.largestNominalAppWidth;
+        largestNominalAppHeight = other.largestNominalAppHeight;
+        logicalWidth = other.logicalWidth;
+        logicalHeight = other.logicalHeight;
+        overscanLeft = other.overscanLeft;
+        overscanTop = other.overscanTop;
+        overscanRight = other.overscanRight;
+        overscanBottom = other.overscanBottom;
+        rotation = other.rotation;
+        modeId = other.modeId;
+        defaultModeId = other.defaultModeId;
+        supportedModes = Arrays.copyOf(other.supportedModes, other.supportedModes.length);
+        colorMode = other.colorMode;
+        supportedColorModes = Arrays.copyOf(
+            other.supportedColorModes, other.supportedColorModes.length);
+        hdrCapabilities = other.hdrCapabilities;
+        logicalDensityDpi = other.logicalDensityDpi;
+        physicalXDpi = other.physicalXDpi;
+        physicalYDpi = other.physicalYDpi;
+        appVsyncOffsetNanos = other.appVsyncOffsetNanos;
+        presentationDeadlineNanos = other.presentationDeadlineNanos;
+        state = other.state;
+        ownerUid = other.ownerUid;
+        ownerPackageName = other.ownerPackageName;
+        removeMode = other.removeMode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof DisplayConfig && equals((DisplayConfig)o);
+    }
+
+    public boolean equals(DisplayConfig other) {
+        return other != null
+                && layerStack == other.layerStack
+                && flags == other.flags
+                && type == other.type
+                && Objects.equal(address, other.address)
+                && Objects.equal(uniqueId, other.uniqueId)
+                && appWidth == other.appWidth
+                && appHeight == other.appHeight
+                && smallestNominalAppWidth == other.smallestNominalAppWidth
+                && smallestNominalAppHeight == other.smallestNominalAppHeight
+                && largestNominalAppWidth == other.largestNominalAppWidth
+                && largestNominalAppHeight == other.largestNominalAppHeight
+                && logicalWidth == other.logicalWidth
+                && logicalHeight == other.logicalHeight
+                && overscanLeft == other.overscanLeft
+                && overscanTop == other.overscanTop
+                && overscanRight == other.overscanRight
+                && overscanBottom == other.overscanBottom
+                && rotation == other.rotation
+                && modeId == other.modeId
+                && defaultModeId == other.defaultModeId
+                && colorMode == other.colorMode
+                && Arrays.equals(supportedColorModes, other.supportedColorModes)
+                && Objects.equal(hdrCapabilities, other.hdrCapabilities)
+                && logicalDensityDpi == other.logicalDensityDpi
+                && physicalXDpi == other.physicalXDpi
+                && physicalYDpi == other.physicalYDpi
+                && appVsyncOffsetNanos == other.appVsyncOffsetNanos
+                && presentationDeadlineNanos == other.presentationDeadlineNanos
+                && state == other.state
+                && ownerUid == other.ownerUid
+                && Objects.equal(ownerPackageName, other.ownerPackageName)
+                && removeMode == other.removeMode;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0; // don't care
+    }
+
+    public void copyFrom(DisplayConfig other) {
+        layerStack = other.layerStack;
+        flags = other.flags;
+        type = other.type;
+        address = other.address;
+        name = other.name;
+        uniqueId = other.uniqueId;
+        appWidth = other.appWidth;
+        appHeight = other.appHeight;
+        smallestNominalAppWidth = other.smallestNominalAppWidth;
+        smallestNominalAppHeight = other.smallestNominalAppHeight;
+        largestNominalAppWidth = other.largestNominalAppWidth;
+        largestNominalAppHeight = other.largestNominalAppHeight;
+        logicalWidth = other.logicalWidth;
+        logicalHeight = other.logicalHeight;
+        overscanLeft = other.overscanLeft;
+        overscanTop = other.overscanTop;
+        overscanRight = other.overscanRight;
+        overscanBottom = other.overscanBottom;
+        rotation = other.rotation;
+        modeId = other.modeId;
+        defaultModeId = other.defaultModeId;
+        supportedModes = Arrays.copyOf(other.supportedModes, other.supportedModes.length);
+        colorMode = other.colorMode;
+        supportedColorModes = Arrays.copyOf(
+                other.supportedColorModes, other.supportedColorModes.length);
+        hdrCapabilities = other.hdrCapabilities;
+        logicalDensityDpi = other.logicalDensityDpi;
+        physicalXDpi = other.physicalXDpi;
+        physicalYDpi = other.physicalYDpi;
+        appVsyncOffsetNanos = other.appVsyncOffsetNanos;
+        presentationDeadlineNanos = other.presentationDeadlineNanos;
+        state = other.state;
+        ownerUid = other.ownerUid;
+        ownerPackageName = other.ownerPackageName;
+        removeMode = other.removeMode;
+    }
+
+    public void copyTo(DisplayInfo other) {
+        other.layerStack = layerStack;
+        other.flags = flags;
+        other.type = type;
+        other.address = address;
+        other.name = name;
+        other.uniqueId = uniqueId;
+        other.appWidth = appWidth;
+        other.appHeight = appHeight;
+        other.smallestNominalAppWidth = smallestNominalAppWidth;
+        other.smallestNominalAppHeight = smallestNominalAppHeight;
+        other.largestNominalAppWidth = largestNominalAppWidth;
+        other.largestNominalAppHeight = largestNominalAppHeight;
+        other.logicalWidth = logicalWidth;
+        other.logicalHeight = logicalHeight;
+        other.overscanLeft = overscanLeft;
+        other.overscanTop = overscanTop;
+        other.overscanRight = overscanRight;
+        other.overscanBottom = overscanBottom;
+        other.rotation = rotation;
+        other.modeId = modeId;
+        other.defaultModeId = defaultModeId;
+        other.supportedModes = Arrays.copyOf(supportedModes, supportedModes.length);
+        other.colorMode = colorMode;
+        other.supportedColorModes = Arrays.copyOf(
+            supportedColorModes, supportedColorModes.length);
+        other.hdrCapabilities = hdrCapabilities;
+        other.logicalDensityDpi = logicalDensityDpi;
+        other.physicalXDpi = physicalXDpi;
+        other.physicalYDpi = physicalYDpi;
+        other.appVsyncOffsetNanos = appVsyncOffsetNanos;
+        other.presentationDeadlineNanos = presentationDeadlineNanos;
+        other.state = state;
+        other.ownerUid = ownerUid;
+        other.ownerPackageName = ownerPackageName;
+        other.removeMode = removeMode;
+    }
+
+
+    public Display.Mode getMode() {
+        return findMode(modeId);
+    }
+
+    public Display.Mode getDefaultMode() {
+        return findMode(defaultModeId);
+    }
+
+    private Display.Mode findMode(int id) {
+        for (int i = 0; i < supportedModes.length; i++) {
+            if (supportedModes[i].getModeId() == id) {
+                return supportedModes[i];
+            }
+        }
+        throw new IllegalStateException("Unable to locate mode " + id);
+    }
+
+    /**
+     * Returns the id of the "default" mode with the given refresh rate, or {@code 0} if no suitable
+     * mode could be found.
+     */
+    public int findDefaultModeByRefreshRate(float refreshRate) {
+        Display.Mode[] modes = supportedModes;
+        Display.Mode defaultMode = getDefaultMode();
+        for (int i = 0; i < modes.length; i++) {
+            if (modes[i].matches(
+                    defaultMode.getPhysicalWidth(), defaultMode.getPhysicalHeight(), refreshRate)) {
+                return modes[i].getModeId();
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Returns the list of supported refresh rates in the default mode.
+     */
+    public float[] getDefaultRefreshRates() {
+        Display.Mode[] modes = supportedModes;
+        ArraySet<Float> rates = new ArraySet<>();
+        Display.Mode defaultMode = getDefaultMode();
+        for (int i = 0; i < modes.length; i++) {
+            Display.Mode mode = modes[i];
+            if (mode.getPhysicalWidth() == defaultMode.getPhysicalWidth()
+                    && mode.getPhysicalHeight() == defaultMode.getPhysicalHeight()) {
+                rates.add(mode.getRefreshRate());
+            }
+        }
+        float[] result = new float[rates.size()];
+        int i = 0;
+        for (Float rate : rates) {
+            result[i++] = rate;
+        }
+        return result;
+    }
+
+    public void getAppMetrics(DisplayMetrics outMetrics) {
+        getAppMetrics(outMetrics, CompatibilityInfo.DEFAULT_COMPATIBILITY_INFO, null);
+    }
+
+    public void getAppMetrics(DisplayMetrics outMetrics, DisplayAdjustments displayAdjustments) {
+        getMetricsWithSize(outMetrics, displayAdjustments.getCompatibilityInfo(),
+                displayAdjustments.getConfiguration(), appWidth, appHeight);
+    }
+
+    public void getAppMetrics(DisplayMetrics outMetrics, CompatibilityInfo ci,
+            Configuration configuration) {
+        getMetricsWithSize(outMetrics, ci, configuration, appWidth, appHeight);
+    }
+
+    public void getLogicalMetrics(DisplayMetrics outMetrics, CompatibilityInfo compatInfo,
+            Configuration configuration) {
+        getMetricsWithSize(outMetrics, compatInfo, configuration, logicalWidth, logicalHeight);
+    }
+
+    public int getNaturalWidth() {
+        return rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180 ?
+                logicalWidth : logicalHeight;
+    }
+
+    public int getNaturalHeight() {
+        return rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180 ?
+                logicalHeight : logicalWidth;
+    }
+
+    public boolean isHdr() {
+        int[] types = hdrCapabilities != null ? hdrCapabilities.getSupportedHdrTypes() : null;
+        return types != null && types.length > 0;
+    }
+
+    public boolean isWideColorGamut() {
+        for (int colorMode : supportedColorModes) {
+            if (colorMode == Display.COLOR_MODE_DCI_P3 || colorMode > Display.COLOR_MODE_SRGB) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the specified UID has access to this display.
+     */
+    public boolean hasAccess(int uid) {
+        return Display.hasAccess(uid, flags, ownerUid);
+    }
+
+    private void getMetricsWithSize(DisplayMetrics outMetrics, CompatibilityInfo compatInfo,
+            Configuration configuration, int width, int height) {
+        outMetrics.densityDpi = outMetrics.noncompatDensityDpi = logicalDensityDpi;
+        outMetrics.density = outMetrics.noncompatDensity =
+                logicalDensityDpi * DisplayMetrics.DENSITY_DEFAULT_SCALE;
+        outMetrics.scaledDensity = outMetrics.noncompatScaledDensity = outMetrics.density;
+        outMetrics.xdpi = outMetrics.noncompatXdpi = physicalXDpi;
+        outMetrics.ydpi = outMetrics.noncompatYdpi = physicalYDpi;
+
+        width = configuration != null && configuration.appBounds != null
+                ? configuration.appBounds.width() : width;
+        height = configuration != null && configuration.appBounds != null
+                ? configuration.appBounds.height() : height;
+
+        outMetrics.noncompatWidthPixels  = outMetrics.widthPixels = width;
+        outMetrics.noncompatHeightPixels = outMetrics.heightPixels = height;
+
+        if (!compatInfo.equals(CompatibilityInfo.DEFAULT_COMPATIBILITY_INFO)) {
+            compatInfo.applyToDisplayMetrics(outMetrics);
+        }
+    }
+
+    // For debugging purposes
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("DisplayConfig{\"");
+        sb.append(name);
+        sb.append("\", uniqueId \"");
+        sb.append(uniqueId);
+        sb.append("\", app ");
+        sb.append(appWidth);
+        sb.append(" x ");
+        sb.append(appHeight);
+        sb.append(", real ");
+        sb.append(logicalWidth);
+        sb.append(" x ");
+        sb.append(logicalHeight);
+        if (overscanLeft != 0 || overscanTop != 0 || overscanRight != 0 || overscanBottom != 0) {
+            sb.append(", overscan (");
+            sb.append(overscanLeft);
+            sb.append(",");
+            sb.append(overscanTop);
+            sb.append(",");
+            sb.append(overscanRight);
+            sb.append(",");
+            sb.append(overscanBottom);
+            sb.append(")");
+        }
+        sb.append(", largest app ");
+        sb.append(largestNominalAppWidth);
+        sb.append(" x ");
+        sb.append(largestNominalAppHeight);
+        sb.append(", smallest app ");
+        sb.append(smallestNominalAppWidth);
+        sb.append(" x ");
+        sb.append(smallestNominalAppHeight);
+        sb.append(", mode ");
+        sb.append(modeId);
+        sb.append(", defaultMode ");
+        sb.append(defaultModeId);
+        sb.append(", modes ");
+        sb.append(Arrays.toString(supportedModes));
+        sb.append(", colorMode ");
+        sb.append(colorMode);
+        sb.append(", supportedColorModes ");
+        sb.append(Arrays.toString(supportedColorModes));
+        sb.append(", hdrCapabilities ");
+        sb.append(hdrCapabilities);
+        sb.append(", rotation ");
+        sb.append(rotation);
+        sb.append(", density ");
+        sb.append(logicalDensityDpi);
+        sb.append(" (");
+        sb.append(physicalXDpi);
+        sb.append(" x ");
+        sb.append(physicalYDpi);
+        sb.append(") dpi, layerStack ");
+        sb.append(layerStack);
+        sb.append(", appVsyncOff ");
+        sb.append(appVsyncOffsetNanos);
+        sb.append(", presDeadline ");
+        sb.append(presentationDeadlineNanos);
+        sb.append(", type ");
+        sb.append(Display.typeToString(type));
+        if (address != null) {
+            sb.append(", address ").append(address);
+        }
+        sb.append(", state ");
+        sb.append(Display.stateToString(state));
+        if (ownerUid != 0 || ownerPackageName != null) {
+            sb.append(", owner ").append(ownerPackageName);
+            sb.append(" (uid ").append(ownerUid).append(")");
+        }
+        sb.append(flagsToString(flags));
+        sb.append(", removeMode ");
+        sb.append(removeMode);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private static String flagsToString(int flags) {
+        StringBuilder result = new StringBuilder();
+        if ((flags & Display.FLAG_SECURE) != 0) {
+            result.append(", FLAG_SECURE");
+        }
+        if ((flags & Display.FLAG_SUPPORTS_PROTECTED_BUFFERS) != 0) {
+            result.append(", FLAG_SUPPORTS_PROTECTED_BUFFERS");
+        }
+        if ((flags & Display.FLAG_PRIVATE) != 0) {
+            result.append(", FLAG_PRIVATE");
+        }
+        if ((flags & Display.FLAG_PRESENTATION) != 0) {
+            result.append(", FLAG_PRESENTATION");
+        }
+        if ((flags & Display.FLAG_SCALING_DISABLED) != 0) {
+            result.append(", FLAG_SCALING_DISABLED");
+        }
+        if ((flags & Display.FLAG_ROUND) != 0) {
+            result.append(", FLAG_ROUND");
+        }
+        return result.toString();
+    }
+}

--- a/shadows/framework/src/main/java/org/robolectric/android/internal/DisplayConfig.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/internal/DisplayConfig.java
@@ -16,12 +16,22 @@
 
 package org.robolectric.android.internal;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
+import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
+import static android.os.Build.VERSION_CODES.M;
+import static android.os.Build.VERSION_CODES.N;
+import static android.os.Build.VERSION_CODES.N_MR1;
+import static android.os.Build.VERSION_CODES.O;
+
 import android.util.ArraySet;
 import android.view.Display;
 import android.view.DisplayInfo;
 import android.view.Surface;
 import java.util.Arrays;
 import libcore.util.Objects;
+import org.robolectric.RuntimeEnvironment;
 
 /**
  * Describes the characteristics of a particular logical display.
@@ -29,487 +39,519 @@ import libcore.util.Objects;
  * Robolectric internal (for now), do not use.
  */
 public final class DisplayConfig {
-    /**
-     * The surface flinger layer stack associated with this logical display.
-     */
-    public int layerStack;
+  /**
+   * The surface flinger layer stack associated with this logical display.
+   */
+  public int layerStack;
 
-    /**
-     * Display flags.
-     */
-    public int flags;
+  /**
+   * Display flags.
+   */
+  public int flags;
 
-    /**
-     * Display type.
-     */
-    public int type;
+  /**
+   * Display type.
+   */
+  public int type;
 
-    /**
-     * Display address, or null if none.
-     * Interpretation varies by display type.
-     */
-    public String address;
+  /**
+   * Display address, or null if none.
+   * Interpretation varies by display type.
+   */
+  public String address;
 
-    /**
-     * The human-readable name of the display.
-     */
-    public String name;
+  /**
+   * The human-readable name of the display.
+   */
+  public String name;
 
-    /**
-     * Unique identifier for the display. Shouldn't be displayed to the user.
-     */
-    public String uniqueId;
+  /**
+   * Unique identifier for the display. Shouldn't be displayed to the user.
+   */
+  public String uniqueId;
 
-    /**
-     * The width of the portion of the display that is available to applications, in pixels.
-     * Represents the size of the display minus any system decorations.
-     */
-    public int appWidth;
+  /**
+   * The width of the portion of the display that is available to applications, in pixels.
+   * Represents the size of the display minus any system decorations.
+   */
+  public int appWidth;
 
-    /**
-     * The height of the portion of the display that is available to applications, in pixels.
-     * Represents the size of the display minus any system decorations.
-     */
-    public int appHeight;
+  /**
+   * The height of the portion of the display that is available to applications, in pixels.
+   * Represents the size of the display minus any system decorations.
+   */
+  public int appHeight;
 
-    /**
-     * The smallest value of {@link #appWidth} that an application is likely to encounter,
-     * in pixels, excepting cases where the width may be even smaller due to the presence
-     * of a soft keyboard, for example.
-     */
-    public int smallestNominalAppWidth;
+  /**
+   * The smallest value of {@link #appWidth} that an application is likely to encounter,
+   * in pixels, excepting cases where the width may be even smaller due to the presence
+   * of a soft keyboard, for example.
+   */
+  public int smallestNominalAppWidth;
 
-    /**
-     * The smallest value of {@link #appHeight} that an application is likely to encounter,
-     * in pixels, excepting cases where the height may be even smaller due to the presence
-     * of a soft keyboard, for example.
-     */
-    public int smallestNominalAppHeight;
+  /**
+   * The smallest value of {@link #appHeight} that an application is likely to encounter,
+   * in pixels, excepting cases where the height may be even smaller due to the presence
+   * of a soft keyboard, for example.
+   */
+  public int smallestNominalAppHeight;
 
-    /**
-     * The largest value of {@link #appWidth} that an application is likely to encounter,
-     * in pixels, excepting cases where the width may be even larger due to system decorations
-     * such as the status bar being hidden, for example.
-     */
-    public int largestNominalAppWidth;
+  /**
+   * The largest value of {@link #appWidth} that an application is likely to encounter,
+   * in pixels, excepting cases where the width may be even larger due to system decorations
+   * such as the status bar being hidden, for example.
+   */
+  public int largestNominalAppWidth;
 
-    /**
-     * The largest value of {@link #appHeight} that an application is likely to encounter,
-     * in pixels, excepting cases where the height may be even larger due to system decorations
-     * such as the status bar being hidden, for example.
-     */
-    public int largestNominalAppHeight;
+  /**
+   * The largest value of {@link #appHeight} that an application is likely to encounter,
+   * in pixels, excepting cases where the height may be even larger due to system decorations
+   * such as the status bar being hidden, for example.
+   */
+  public int largestNominalAppHeight;
 
-    /**
-     * The logical width of the display, in pixels.
-     * Represents the usable size of the display which may be smaller than the
-     * physical size when the system is emulating a smaller display.
-     */
-    public int logicalWidth;
+  /**
+   * The logical width of the display, in pixels.
+   * Represents the usable size of the display which may be smaller than the
+   * physical size when the system is emulating a smaller display.
+   */
+  public int logicalWidth;
 
-    /**
-     * The logical height of the display, in pixels.
-     * Represents the usable size of the display which may be smaller than the
-     * physical size when the system is emulating a smaller display.
-     */
-    public int logicalHeight;
+  /**
+   * The logical height of the display, in pixels.
+   * Represents the usable size of the display which may be smaller than the
+   * physical size when the system is emulating a smaller display.
+   */
+  public int logicalHeight;
 
-    /**
-     * @hide
-     * Number of overscan pixels on the left side of the display.
-     */
-    public int overscanLeft;
+  /**
+   * @hide
+   * Number of overscan pixels on the left side of the display.
+   */
+  public int overscanLeft;
 
-    /**
-     * @hide
-     * Number of overscan pixels on the top side of the display.
-     */
-    public int overscanTop;
+  /**
+   * @hide
+   * Number of overscan pixels on the top side of the display.
+   */
+  public int overscanTop;
 
-    /**
-     * @hide
-     * Number of overscan pixels on the right side of the display.
-     */
-    public int overscanRight;
+  /**
+   * @hide
+   * Number of overscan pixels on the right side of the display.
+   */
+  public int overscanRight;
 
-    /**
-     * @hide
-     * Number of overscan pixels on the bottom side of the display.
-     */
-    public int overscanBottom;
+  /**
+   * @hide
+   * Number of overscan pixels on the bottom side of the display.
+   */
+  public int overscanBottom;
 
-    /**
-     * The rotation of the display relative to its natural orientation.
-     * May be one of {@link Surface#ROTATION_0},
-     * {@link Surface#ROTATION_90}, {@link Surface#ROTATION_180},
-     * {@link Surface#ROTATION_270}.
-     * <p>
-     * The value of this field is indeterminate if the logical display is presented on
-     * more than one physical display.
-     * </p>
-     */
-    @Surface.Rotation
-    public int rotation;
+  /**
+   * The rotation of the display relative to its natural orientation.
+   * May be one of {@link Surface#ROTATION_0},
+   * {@link Surface#ROTATION_90}, {@link Surface#ROTATION_180},
+   * {@link Surface#ROTATION_270}.
+   * <p>
+   * The value of this field is indeterminate if the logical display is presented on
+   * more than one physical display.
+   * </p>
+   */
+  @Surface.Rotation
+  public int rotation;
 
-    /**
-     * The active display mode.
-     */
-    public int modeId;
+  /**
+   * The active display mode.
+   */
+  public int modeId;
 
-    /**
-     * The default display mode.
-     */
-    public int defaultModeId;
+  /**
+   * The default display mode.
+   */
+  public int defaultModeId;
 
-    /**
-     * The supported modes of this display.
-     */
-    public Display.Mode[] supportedModes = Display.Mode.EMPTY_ARRAY;
+  /**
+   * The supported modes of this display.
+   */
+  public Display.Mode[] supportedModes = Display.Mode.EMPTY_ARRAY;
 
-    /** The active color mode. */
-    public int colorMode;
+  /** The active color mode. */
+  public int colorMode;
 
-    /** The list of supported color modes */
-    public int[] supportedColorModes = { Display.COLOR_MODE_DEFAULT };
+  /** The list of supported color modes */
+  public int[] supportedColorModes = { Display.COLOR_MODE_DEFAULT };
 
-    /** The display's HDR capabilities */
-    public Display.HdrCapabilities hdrCapabilities;
+  /** The display's HDR capabilities */
+  public Display.HdrCapabilities hdrCapabilities;
 
-    /**
-     * The logical display density which is the basis for density-independent
-     * pixels.
-     */
-    public int logicalDensityDpi;
+  /**
+   * The logical display density which is the basis for density-independent
+   * pixels.
+   */
+  public int logicalDensityDpi;
 
-    /**
-     * The exact physical pixels per inch of the screen in the X dimension.
-     * <p>
-     * The value of this field is indeterminate if the logical display is presented on
-     * more than one physical display.
-     * </p>
-     */
-    public float physicalXDpi;
+  /**
+   * The exact physical pixels per inch of the screen in the X dimension.
+   * <p>
+   * The value of this field is indeterminate if the logical display is presented on
+   * more than one physical display.
+   * </p>
+   */
+  public float physicalXDpi;
 
-    /**
-     * The exact physical pixels per inch of the screen in the Y dimension.
-     * <p>
-     * The value of this field is indeterminate if the logical display is presented on
-     * more than one physical display.
-     * </p>
-     */
-    public float physicalYDpi;
+  /**
+   * The exact physical pixels per inch of the screen in the Y dimension.
+   * <p>
+   * The value of this field is indeterminate if the logical display is presented on
+   * more than one physical display.
+   * </p>
+   */
+  public float physicalYDpi;
 
-    /**
-     * This is a positive value indicating the phase offset of the VSYNC events provided by
-     * Choreographer relative to the display refresh.  For example, if Choreographer reports
-     * that the refresh occurred at time N, it actually occurred at (N - appVsyncOffsetNanos).
-     */
-    public long appVsyncOffsetNanos;
+  /**
+   * This is a positive value indicating the phase offset of the VSYNC events provided by
+   * Choreographer relative to the display refresh.  For example, if Choreographer reports
+   * that the refresh occurred at time N, it actually occurred at (N - appVsyncOffsetNanos).
+   */
+  public long appVsyncOffsetNanos;
 
-    /**
-     * This is how far in advance a buffer must be queued for presentation at
-     * a given time.  If you want a buffer to appear on the screen at
-     * time N, you must submit the buffer before (N - bufferDeadlineNanos).
-     */
-    public long presentationDeadlineNanos;
+  /**
+   * This is how far in advance a buffer must be queued for presentation at
+   * a given time.  If you want a buffer to appear on the screen at
+   * time N, you must submit the buffer before (N - bufferDeadlineNanos).
+   */
+  public long presentationDeadlineNanos;
 
-    /**
-     * The state of the display, such as {@link Display#STATE_ON}.
-     */
-    public int state;
+  /**
+   * The state of the display, such as {@link Display#STATE_ON}.
+   */
+  public int state;
 
-    /**
-     * The UID of the application that owns this display, or zero if it is owned by the system.
-     * <p>
-     * If the display is private, then only the owner can use it.
-     * </p>
-     */
-    public int ownerUid;
+  /**
+   * The UID of the application that owns this display, or zero if it is owned by the system.
+   * <p>
+   * If the display is private, then only the owner can use it.
+   * </p>
+   */
+  public int ownerUid;
 
-    /**
-     * The package name of the application that owns this display, or null if it is
-     * owned by the system.
-     * <p>
-     * If the display is private, then only the owner can use it.
-     * </p>
-     */
-    public String ownerPackageName;
+  /**
+   * The package name of the application that owns this display, or null if it is
+   * owned by the system.
+   * <p>
+   * If the display is private, then only the owner can use it.
+   * </p>
+   */
+  public String ownerPackageName;
 
-    /**
-     * @hide
-     * Get current remove mode of the display - what actions should be performed with the display's
-     * content when it is removed.
-     *
-     * @see Display#getRemoveMode()
-     */
-    public int removeMode = Display.REMOVE_MODE_MOVE_CONTENT_TO_PRIMARY;
+  /**
+   * @hide
+   * Get current remove mode of the display - what actions should be performed with the display's
+   * content when it is removed.
+   *
+   * @see Display#getRemoveMode()
+   */
+  public int removeMode = Display.REMOVE_MODE_MOVE_CONTENT_TO_PRIMARY;
 
-    public DisplayConfig() {
+  public DisplayConfig() {
+  }
+
+  public DisplayConfig(DisplayConfig other) {
+    copyFrom(other);
+  }
+
+  public DisplayConfig(DisplayInfo other) {
+    layerStack = other.layerStack;
+    flags = other.flags;
+    type = other.type;
+    address = other.address;
+    name = other.name;
+    if (RuntimeEnvironment.getApiLevel() >= LOLLIPOP_MR1) {
+      uniqueId = other.uniqueId;
     }
-
-    public DisplayConfig(DisplayConfig other) {
-        copyFrom(other);
+    appWidth = other.appWidth;
+    appHeight = other.appHeight;
+    smallestNominalAppWidth = other.smallestNominalAppWidth;
+    smallestNominalAppHeight = other.smallestNominalAppHeight;
+    largestNominalAppWidth = other.largestNominalAppWidth;
+    largestNominalAppHeight = other.largestNominalAppHeight;
+    logicalWidth = other.logicalWidth;
+    logicalHeight = other.logicalHeight;
+    if (RuntimeEnvironment.getApiLevel() >= JELLY_BEAN_MR2) {
+      overscanLeft = other.overscanLeft;
+      overscanTop = other.overscanTop;
+      overscanRight = other.overscanRight;
+      overscanBottom = other.overscanBottom;
     }
-
-    public DisplayConfig(DisplayInfo other) {
-        layerStack = other.layerStack;
-        flags = other.flags;
-        type = other.type;
-        address = other.address;
-        name = other.name;
-        uniqueId = other.uniqueId;
-        appWidth = other.appWidth;
-        appHeight = other.appHeight;
-        smallestNominalAppWidth = other.smallestNominalAppWidth;
-        smallestNominalAppHeight = other.smallestNominalAppHeight;
-        largestNominalAppWidth = other.largestNominalAppWidth;
-        largestNominalAppHeight = other.largestNominalAppHeight;
-        logicalWidth = other.logicalWidth;
-        logicalHeight = other.logicalHeight;
-        overscanLeft = other.overscanLeft;
-        overscanTop = other.overscanTop;
-        overscanRight = other.overscanRight;
-        overscanBottom = other.overscanBottom;
-        rotation = other.rotation;
-        modeId = other.modeId;
-        defaultModeId = other.defaultModeId;
-        supportedModes = Arrays.copyOf(other.supportedModes, other.supportedModes.length);
-        colorMode = other.colorMode;
-        supportedColorModes = Arrays.copyOf(
-            other.supportedColorModes, other.supportedColorModes.length);
-        hdrCapabilities = other.hdrCapabilities;
-        logicalDensityDpi = other.logicalDensityDpi;
-        physicalXDpi = other.physicalXDpi;
-        physicalYDpi = other.physicalYDpi;
-        appVsyncOffsetNanos = other.appVsyncOffsetNanos;
-        presentationDeadlineNanos = other.presentationDeadlineNanos;
-        state = other.state;
-        ownerUid = other.ownerUid;
-        ownerPackageName = other.ownerPackageName;
-        removeMode = other.removeMode;
+    rotation = other.rotation;
+    if (RuntimeEnvironment.getApiLevel() >= M) {
+      modeId = other.modeId;
+      defaultModeId = other.defaultModeId;
+      supportedModes = Arrays.copyOf(other.supportedModes, other.supportedModes.length);
     }
-
-    @Override
-    public boolean equals(Object o) {
-        return o instanceof DisplayConfig && equals((DisplayConfig)o);
+    if (RuntimeEnvironment.getApiLevel() >= N_MR1) {
+      colorMode = other.colorMode;
+      supportedColorModes = Arrays.copyOf(
+          other.supportedColorModes, other.supportedColorModes.length);
     }
-
-    public boolean equals(DisplayConfig other) {
-        return other != null
-                && layerStack == other.layerStack
-                && flags == other.flags
-                && type == other.type
-                && Objects.equal(address, other.address)
-                && Objects.equal(uniqueId, other.uniqueId)
-                && appWidth == other.appWidth
-                && appHeight == other.appHeight
-                && smallestNominalAppWidth == other.smallestNominalAppWidth
-                && smallestNominalAppHeight == other.smallestNominalAppHeight
-                && largestNominalAppWidth == other.largestNominalAppWidth
-                && largestNominalAppHeight == other.largestNominalAppHeight
-                && logicalWidth == other.logicalWidth
-                && logicalHeight == other.logicalHeight
-                && overscanLeft == other.overscanLeft
-                && overscanTop == other.overscanTop
-                && overscanRight == other.overscanRight
-                && overscanBottom == other.overscanBottom
-                && rotation == other.rotation
-                && modeId == other.modeId
-                && defaultModeId == other.defaultModeId
-                && colorMode == other.colorMode
-                && Arrays.equals(supportedColorModes, other.supportedColorModes)
-                && Objects.equal(hdrCapabilities, other.hdrCapabilities)
-                && logicalDensityDpi == other.logicalDensityDpi
-                && physicalXDpi == other.physicalXDpi
-                && physicalYDpi == other.physicalYDpi
-                && appVsyncOffsetNanos == other.appVsyncOffsetNanos
-                && presentationDeadlineNanos == other.presentationDeadlineNanos
-                && state == other.state
-                && ownerUid == other.ownerUid
-                && Objects.equal(ownerPackageName, other.ownerPackageName)
-                && removeMode == other.removeMode;
+    if (RuntimeEnvironment.getApiLevel() >= N) {
+      hdrCapabilities = other.hdrCapabilities;
     }
-
-    @Override
-    public int hashCode() {
-        return 0; // don't care
+    logicalDensityDpi = other.logicalDensityDpi;
+    physicalXDpi = other.physicalXDpi;
+    physicalYDpi = other.physicalYDpi;
+    if (RuntimeEnvironment.getApiLevel() >= LOLLIPOP) {
+      appVsyncOffsetNanos = other.appVsyncOffsetNanos;
+      presentationDeadlineNanos = other.presentationDeadlineNanos;
+      state = other.state;
     }
-
-    public void copyFrom(DisplayConfig other) {
-        layerStack = other.layerStack;
-        flags = other.flags;
-        type = other.type;
-        address = other.address;
-        name = other.name;
-        uniqueId = other.uniqueId;
-        appWidth = other.appWidth;
-        appHeight = other.appHeight;
-        smallestNominalAppWidth = other.smallestNominalAppWidth;
-        smallestNominalAppHeight = other.smallestNominalAppHeight;
-        largestNominalAppWidth = other.largestNominalAppWidth;
-        largestNominalAppHeight = other.largestNominalAppHeight;
-        logicalWidth = other.logicalWidth;
-        logicalHeight = other.logicalHeight;
-        overscanLeft = other.overscanLeft;
-        overscanTop = other.overscanTop;
-        overscanRight = other.overscanRight;
-        overscanBottom = other.overscanBottom;
-        rotation = other.rotation;
-        modeId = other.modeId;
-        defaultModeId = other.defaultModeId;
-        supportedModes = Arrays.copyOf(other.supportedModes, other.supportedModes.length);
-        colorMode = other.colorMode;
-        supportedColorModes = Arrays.copyOf(
-                other.supportedColorModes, other.supportedColorModes.length);
-        hdrCapabilities = other.hdrCapabilities;
-        logicalDensityDpi = other.logicalDensityDpi;
-        physicalXDpi = other.physicalXDpi;
-        physicalYDpi = other.physicalYDpi;
-        appVsyncOffsetNanos = other.appVsyncOffsetNanos;
-        presentationDeadlineNanos = other.presentationDeadlineNanos;
-        state = other.state;
-        ownerUid = other.ownerUid;
-        ownerPackageName = other.ownerPackageName;
-        removeMode = other.removeMode;
+    if (RuntimeEnvironment.getApiLevel() >= KITKAT) {
+      ownerUid = other.ownerUid;
+      ownerPackageName = other.ownerPackageName;
     }
-
-    public void copyTo(DisplayInfo other) {
-        other.layerStack = layerStack;
-        other.flags = flags;
-        other.type = type;
-        other.address = address;
-        other.name = name;
-        other.uniqueId = uniqueId;
-        other.appWidth = appWidth;
-        other.appHeight = appHeight;
-        other.smallestNominalAppWidth = smallestNominalAppWidth;
-        other.smallestNominalAppHeight = smallestNominalAppHeight;
-        other.largestNominalAppWidth = largestNominalAppWidth;
-        other.largestNominalAppHeight = largestNominalAppHeight;
-        other.logicalWidth = logicalWidth;
-        other.logicalHeight = logicalHeight;
-        other.overscanLeft = overscanLeft;
-        other.overscanTop = overscanTop;
-        other.overscanRight = overscanRight;
-        other.overscanBottom = overscanBottom;
-        other.rotation = rotation;
-        other.modeId = modeId;
-        other.defaultModeId = defaultModeId;
-        other.supportedModes = Arrays.copyOf(supportedModes, supportedModes.length);
-        other.colorMode = colorMode;
-        other.supportedColorModes = Arrays.copyOf(
-            supportedColorModes, supportedColorModes.length);
-        other.hdrCapabilities = hdrCapabilities;
-        other.logicalDensityDpi = logicalDensityDpi;
-        other.physicalXDpi = physicalXDpi;
-        other.physicalYDpi = physicalYDpi;
-        other.appVsyncOffsetNanos = appVsyncOffsetNanos;
-        other.presentationDeadlineNanos = presentationDeadlineNanos;
-        other.state = state;
-        other.ownerUid = ownerUid;
-        other.ownerPackageName = ownerPackageName;
-        other.removeMode = removeMode;
+    if (RuntimeEnvironment.getApiLevel() >= O) {
+      removeMode = other.removeMode;
     }
+  }
 
-    // For debugging purposes
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("DisplayConfig{\"");
-        sb.append(name);
-        sb.append("\", uniqueId \"");
-        sb.append(uniqueId);
-        sb.append("\", app ");
-        sb.append(appWidth);
-        sb.append(" x ");
-        sb.append(appHeight);
-        sb.append(", real ");
-        sb.append(logicalWidth);
-        sb.append(" x ");
-        sb.append(logicalHeight);
-        if (overscanLeft != 0 || overscanTop != 0 || overscanRight != 0 || overscanBottom != 0) {
-            sb.append(", overscan (");
-            sb.append(overscanLeft);
-            sb.append(",");
-            sb.append(overscanTop);
-            sb.append(",");
-            sb.append(overscanRight);
-            sb.append(",");
-            sb.append(overscanBottom);
-            sb.append(")");
-        }
-        sb.append(", largest app ");
-        sb.append(largestNominalAppWidth);
-        sb.append(" x ");
-        sb.append(largestNominalAppHeight);
-        sb.append(", smallest app ");
-        sb.append(smallestNominalAppWidth);
-        sb.append(" x ");
-        sb.append(smallestNominalAppHeight);
-        sb.append(", mode ");
-        sb.append(modeId);
-        sb.append(", defaultMode ");
-        sb.append(defaultModeId);
-        sb.append(", modes ");
-        sb.append(Arrays.toString(supportedModes));
-        sb.append(", colorMode ");
-        sb.append(colorMode);
-        sb.append(", supportedColorModes ");
-        sb.append(Arrays.toString(supportedColorModes));
-        sb.append(", hdrCapabilities ");
-        sb.append(hdrCapabilities);
-        sb.append(", rotation ");
-        sb.append(rotation);
-        sb.append(", density ");
-        sb.append(logicalDensityDpi);
-        sb.append(" (");
-        sb.append(physicalXDpi);
-        sb.append(" x ");
-        sb.append(physicalYDpi);
-        sb.append(") dpi, layerStack ");
-        sb.append(layerStack);
-        sb.append(", appVsyncOff ");
-        sb.append(appVsyncOffsetNanos);
-        sb.append(", presDeadline ");
-        sb.append(presentationDeadlineNanos);
-        sb.append(", type ");
-        sb.append(Display.typeToString(type));
-        if (address != null) {
-            sb.append(", address ").append(address);
-        }
-        sb.append(", state ");
-        sb.append(Display.stateToString(state));
-        if (ownerUid != 0 || ownerPackageName != null) {
-            sb.append(", owner ").append(ownerPackageName);
-            sb.append(" (uid ").append(ownerUid).append(")");
-        }
-        sb.append(flagsToString(flags));
-        sb.append(", removeMode ");
-        sb.append(removeMode);
-        sb.append("}");
-        return sb.toString();
-    }
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof DisplayConfig && equals((DisplayConfig)o);
+  }
 
-    private static String flagsToString(int flags) {
-        StringBuilder result = new StringBuilder();
-        if ((flags & Display.FLAG_SECURE) != 0) {
-            result.append(", FLAG_SECURE");
-        }
-        if ((flags & Display.FLAG_SUPPORTS_PROTECTED_BUFFERS) != 0) {
-            result.append(", FLAG_SUPPORTS_PROTECTED_BUFFERS");
-        }
-        if ((flags & Display.FLAG_PRIVATE) != 0) {
-            result.append(", FLAG_PRIVATE");
-        }
-        if ((flags & Display.FLAG_PRESENTATION) != 0) {
-            result.append(", FLAG_PRESENTATION");
-        }
-        if ((flags & Display.FLAG_SCALING_DISABLED) != 0) {
-            result.append(", FLAG_SCALING_DISABLED");
-        }
-        if ((flags & Display.FLAG_ROUND) != 0) {
-            result.append(", FLAG_ROUND");
-        }
-        return result.toString();
+  public boolean equals(DisplayConfig other) {
+    return other != null
+        && layerStack == other.layerStack
+        && flags == other.flags
+        && type == other.type
+        && Objects.equal(address, other.address)
+        && Objects.equal(uniqueId, other.uniqueId)
+        && appWidth == other.appWidth
+        && appHeight == other.appHeight
+        && smallestNominalAppWidth == other.smallestNominalAppWidth
+        && smallestNominalAppHeight == other.smallestNominalAppHeight
+        && largestNominalAppWidth == other.largestNominalAppWidth
+        && largestNominalAppHeight == other.largestNominalAppHeight
+        && logicalWidth == other.logicalWidth
+        && logicalHeight == other.logicalHeight
+        && overscanLeft == other.overscanLeft
+        && overscanTop == other.overscanTop
+        && overscanRight == other.overscanRight
+        && overscanBottom == other.overscanBottom
+        && rotation == other.rotation
+        && modeId == other.modeId
+        && defaultModeId == other.defaultModeId
+        && colorMode == other.colorMode
+        && Arrays.equals(supportedColorModes, other.supportedColorModes)
+        && Objects.equal(hdrCapabilities, other.hdrCapabilities)
+        && logicalDensityDpi == other.logicalDensityDpi
+        && physicalXDpi == other.physicalXDpi
+        && physicalYDpi == other.physicalYDpi
+        && appVsyncOffsetNanos == other.appVsyncOffsetNanos
+        && presentationDeadlineNanos == other.presentationDeadlineNanos
+        && state == other.state
+        && ownerUid == other.ownerUid
+        && Objects.equal(ownerPackageName, other.ownerPackageName)
+        && removeMode == other.removeMode;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0; // don't care
+  }
+
+  public void copyFrom(DisplayConfig other) {
+    layerStack = other.layerStack;
+    flags = other.flags;
+    type = other.type;
+    address = other.address;
+    name = other.name;
+    uniqueId = other.uniqueId;
+    appWidth = other.appWidth;
+    appHeight = other.appHeight;
+    smallestNominalAppWidth = other.smallestNominalAppWidth;
+    smallestNominalAppHeight = other.smallestNominalAppHeight;
+    largestNominalAppWidth = other.largestNominalAppWidth;
+    largestNominalAppHeight = other.largestNominalAppHeight;
+    logicalWidth = other.logicalWidth;
+    logicalHeight = other.logicalHeight;
+    overscanLeft = other.overscanLeft;
+    overscanTop = other.overscanTop;
+    overscanRight = other.overscanRight;
+    overscanBottom = other.overscanBottom;
+    rotation = other.rotation;
+    modeId = other.modeId;
+    defaultModeId = other.defaultModeId;
+    supportedModes = Arrays.copyOf(other.supportedModes, other.supportedModes.length);
+    colorMode = other.colorMode;
+    supportedColorModes = Arrays.copyOf(
+        other.supportedColorModes, other.supportedColorModes.length);
+    hdrCapabilities = other.hdrCapabilities;
+    logicalDensityDpi = other.logicalDensityDpi;
+    physicalXDpi = other.physicalXDpi;
+    physicalYDpi = other.physicalYDpi;
+    appVsyncOffsetNanos = other.appVsyncOffsetNanos;
+    presentationDeadlineNanos = other.presentationDeadlineNanos;
+    state = other.state;
+    ownerUid = other.ownerUid;
+    ownerPackageName = other.ownerPackageName;
+    removeMode = other.removeMode;
+  }
+
+  public void copyTo(DisplayInfo other) {
+    other.layerStack = layerStack;
+    other.flags = flags;
+    other.type = type;
+    other.address = address;
+    other.name = name;
+    if (RuntimeEnvironment.getApiLevel() >= LOLLIPOP_MR1) {
+      other.uniqueId = uniqueId;
     }
+    other.appWidth = appWidth;
+    other.appHeight = appHeight;
+    other.smallestNominalAppWidth = smallestNominalAppWidth;
+    other.smallestNominalAppHeight = smallestNominalAppHeight;
+    other.largestNominalAppWidth = largestNominalAppWidth;
+    other.largestNominalAppHeight = largestNominalAppHeight;
+    other.logicalWidth = logicalWidth;
+    other.logicalHeight = logicalHeight;
+    if (RuntimeEnvironment.getApiLevel() >= JELLY_BEAN_MR2) {
+      other.overscanLeft = overscanLeft;
+      other.overscanTop = overscanTop;
+      other.overscanRight = overscanRight;
+      other.overscanBottom = overscanBottom;
+    }
+    other.rotation = rotation;
+    if (RuntimeEnvironment.getApiLevel() >= M) {
+      other.modeId = modeId;
+      other.defaultModeId = defaultModeId;
+      other.supportedModes = Arrays.copyOf(supportedModes, supportedModes.length);
+    }
+    if (RuntimeEnvironment.getApiLevel() >= N_MR1) {
+      other.colorMode = colorMode;
+      other.supportedColorModes = Arrays.copyOf(
+          supportedColorModes, supportedColorModes.length);
+    }
+    if (RuntimeEnvironment.getApiLevel() >= N) {
+      other.hdrCapabilities = hdrCapabilities;
+    }
+    other.logicalDensityDpi = logicalDensityDpi;
+    other.physicalXDpi = physicalXDpi;
+    other.physicalYDpi = physicalYDpi;
+    if (RuntimeEnvironment.getApiLevel() >= LOLLIPOP) {
+      other.appVsyncOffsetNanos = appVsyncOffsetNanos;
+      other.presentationDeadlineNanos = presentationDeadlineNanos;
+      other.state = state;
+    }
+    if (RuntimeEnvironment.getApiLevel() >= KITKAT) {
+      other.ownerUid = ownerUid;
+      other.ownerPackageName = ownerPackageName;
+    }
+    if (RuntimeEnvironment.getApiLevel() >= O) {
+      other.removeMode = removeMode;
+    }
+  }
+
+  // For debugging purposes
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("DisplayConfig{\"");
+    sb.append(name);
+    sb.append("\", uniqueId \"");
+    sb.append(uniqueId);
+    sb.append("\", app ");
+    sb.append(appWidth);
+    sb.append(" x ");
+    sb.append(appHeight);
+    sb.append(", real ");
+    sb.append(logicalWidth);
+    sb.append(" x ");
+    sb.append(logicalHeight);
+    if (overscanLeft != 0 || overscanTop != 0 || overscanRight != 0 || overscanBottom != 0) {
+      sb.append(", overscan (");
+      sb.append(overscanLeft);
+      sb.append(",");
+      sb.append(overscanTop);
+      sb.append(",");
+      sb.append(overscanRight);
+      sb.append(",");
+      sb.append(overscanBottom);
+      sb.append(")");
+    }
+    sb.append(", largest app ");
+    sb.append(largestNominalAppWidth);
+    sb.append(" x ");
+    sb.append(largestNominalAppHeight);
+    sb.append(", smallest app ");
+    sb.append(smallestNominalAppWidth);
+    sb.append(" x ");
+    sb.append(smallestNominalAppHeight);
+    sb.append(", mode ");
+    sb.append(modeId);
+    sb.append(", defaultMode ");
+    sb.append(defaultModeId);
+    sb.append(", modes ");
+    sb.append(Arrays.toString(supportedModes));
+    sb.append(", colorMode ");
+    sb.append(colorMode);
+    sb.append(", supportedColorModes ");
+    sb.append(Arrays.toString(supportedColorModes));
+    sb.append(", hdrCapabilities ");
+    sb.append(hdrCapabilities);
+    sb.append(", rotation ");
+    sb.append(rotation);
+    sb.append(", density ");
+    sb.append(logicalDensityDpi);
+    sb.append(" (");
+    sb.append(physicalXDpi);
+    sb.append(" x ");
+    sb.append(physicalYDpi);
+    sb.append(") dpi, layerStack ");
+    sb.append(layerStack);
+    sb.append(", appVsyncOff ");
+    sb.append(appVsyncOffsetNanos);
+    sb.append(", presDeadline ");
+    sb.append(presentationDeadlineNanos);
+    sb.append(", type ");
+    sb.append(Display.typeToString(type));
+    if (address != null) {
+      sb.append(", address ").append(address);
+    }
+    sb.append(", state ");
+    sb.append(Display.stateToString(state));
+    if (ownerUid != 0 || ownerPackageName != null) {
+      sb.append(", owner ").append(ownerPackageName);
+      sb.append(" (uid ").append(ownerUid).append(")");
+    }
+    sb.append(flagsToString(flags));
+    sb.append(", removeMode ");
+    sb.append(removeMode);
+    sb.append("}");
+    return sb.toString();
+  }
+
+  private static String flagsToString(int flags) {
+    StringBuilder result = new StringBuilder();
+    if ((flags & Display.FLAG_SECURE) != 0) {
+      result.append(", FLAG_SECURE");
+    }
+    if ((flags & Display.FLAG_SUPPORTS_PROTECTED_BUFFERS) != 0) {
+      result.append(", FLAG_SUPPORTS_PROTECTED_BUFFERS");
+    }
+    if ((flags & Display.FLAG_PRIVATE) != 0) {
+      result.append(", FLAG_PRIVATE");
+    }
+    if ((flags & Display.FLAG_PRESENTATION) != 0) {
+      result.append(", FLAG_PRESENTATION");
+    }
+    if ((flags & Display.FLAG_SCALING_DISABLED) != 0) {
+      result.append(", FLAG_SCALING_DISABLED");
+    }
+    if ((flags & Display.FLAG_ROUND) != 0) {
+      result.append(", FLAG_ROUND");
+    }
+    return result.toString();
+  }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManager.java
@@ -12,6 +12,7 @@ import android.view.DisplayInfo;
 import android.view.Surface;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.Bootstrap;
+import org.robolectric.android.internal.DisplayConfig;
 import org.robolectric.annotation.Implements;
 import org.robolectric.res.Qualifiers;
 import org.robolectric.shadow.api.Shadow;
@@ -143,10 +144,12 @@ public class ShadowDisplayManager {
    * @param displayId the display id to change
    * @param consumer a function which modifies the display properties
    */
-  static void changeDisplay(int displayId, Consumer<DisplayInfo> consumer) {
+  static void changeDisplay(int displayId, Consumer<DisplayConfig> consumer) {
     DisplayInfo displayInfo = DisplayManagerGlobal.getInstance().getDisplayInfo(displayId);
     if (displayInfo != null) {
-      consumer.accept(displayInfo);
+      DisplayConfig displayConfig = new DisplayConfig(displayInfo);
+      consumer.accept(displayConfig);
+      displayConfig.copyTo(displayInfo);
       fixNominalDimens(displayInfo);
     }
 


### PR DESCRIPTION
`@Implementation` methods may be `protected` or `public`. This is transitional; in the future they'll be required to be `protected`. Test authors should use Android SDK methods instead of `@Implementation` methods when available.