### PR TITLE
Fix the build-resources.rb script and regenerate resource ids

### DIFF
--- a/robolectric/src/test/java/org/robolectric/R.java
+++ b/robolectric/src/test/java/org/robolectric/R.java
@@ -37,272 +37,272 @@ public final class R {
     public static final int grey_text_view_hint = 0x7f010019;
 
     public static final int textStyle = 0x7f01001a;
-    public static final int test_menu_1 = 0x7f01001d;
-    public static final int test_menu_2 = 0x7f01001e;
-    public static final int test_menu_3 = 0x7f01001f;
+    public static final int test_menu_1 = 0x7f01001b;
+    public static final int test_menu_2 = 0x7f01001c;
+    public static final int test_menu_3 = 0x7f01001d;
 
-    public static final int group_id_1 = 0x7f010020;
+    public static final int group_id_1 = 0x7f01001e;
 
-    public static final int test_submenu_1 = 0x7f010021;
+    public static final int test_submenu_1 = 0x7f01001f;
 
-    public static final int fragment = 0x7f010022;
-    public static final int dynamic_fragment_container = 0x7f010023;
-    public static final int content_view = 0x7f010024;
+    public static final int fragment = 0x7f010020;
+    public static final int dynamic_fragment_container = 0x7f010021;
+    public static final int content_view = 0x7f010022;
 
-    public static final int portrait = 0x7f010025;
-    public static final int landscape = 0x7f010026;
-    public static final int tacos = 0x7f010027;
-    public static final int burritos = 0x7f010028;
-    public static final int lam_container = 0x7f010029;
-    public static final int lam_inner_contents = 0x7f01002a;
-    public static final int my_fragment = 0x7f01002b;
-    public static final int my_landscape_text = 0x7f01002c;
+    public static final int portrait = 0x7f010023;
+    public static final int landscape = 0x7f010024;
+    public static final int tacos = 0x7f010025;
+    public static final int burritos = 0x7f010026;
+    public static final int lam_container = 0x7f010027;
+    public static final int lam_inner_contents = 0x7f010028;
+    public static final int my_fragment = 0x7f010029;
+    public static final int my_landscape_text = 0x7f01002a;
 
-    public static final int itemType = 0x7f01002d;
-    public static final int scrollBars = 0x7f01002e;
-    public static final int keycode = 0x7f01002f;
-    public static final int aspectRatio = 0x7f010030;
-    public static final int aspectRatioEnabled = 0x7f010031;
+    public static final int itemType = 0x7f01002b;
+    public static final int scrollBars = 0x7f01002c;
+    public static final int keycode = 0x7f01002d;
+    public static final int aspectRatio = 0x7f01002e;
+    public static final int aspectRatioEnabled = 0x7f01002f;
 
-    public static final int marsupial = 0x7f010032;
-    public static final int ungulate = 0x7f010033;
+    public static final int marsupial = 0x7f010030;
+    public static final int ungulate = 0x7f010031;
 
-    public static final int custom_view = 0x7f010034;
+    public static final int custom_view = 0x7f010032;
 
-    public static final int custom_title_text = 0x7f010035;
+    public static final int custom_title_text = 0x7f010033;
 
-    public static final int remote_view_1 = 0x7f010036;
-    public static final int remote_view_2 = 0x7f010037;
-    public static final int remote_view_3 = 0x7f010038;
+    public static final int remote_view_1 = 0x7f010034;
+    public static final int remote_view_2 = 0x7f010035;
+    public static final int remote_view_3 = 0x7f010036;
 
-    public static final int hello = 0x7f010039;
-    public static final int world = 0x7f01003a;
+    public static final int hello = 0x7f010037;
+    public static final int world = 0x7f010038;
 
-    public static final int list_view_with_enum_scrollbar = 0x7f01003b;
-    public static final int action_search = 0x7f01003c;
+    public static final int list_view_with_enum_scrollbar = 0x7f010039;
+    public static final int action_search = 0x7f01003a;
 
-    public static final int id_declared_in_layout = 0x7f01003d;
-    public static final int id_declared_in_item_tag = 0x7f01003e;
-    public static final int id_with_string_value = 0x7f010042;
-    public static final int lib_button = 0x7f01003f;
-    public static final int lib3_button = 0x7f010040;
+    public static final int id_declared_in_layout = 0x7f01003b;
+    public static final int id_declared_in_item_tag = 0x7f01003c;
+    public static final int id_with_string_value = 0x7f01003d;
+    public static final int lib_button = 0x7f01003e;
+    public static final int lib3_button = 0x7f01003f;
   }
 
   public static final class string {
-    public static final int howdy = 0x7f020100;
-    public static final int hello = 0x7f020101;
-    public static final int some_html = 0x7f020102;
-    public static final int greeting = 0x7f020103;
-    public static final int copy = 0x7f020104;
-    public static final int ok = 0x7f020105;
-    public static final int ok2 = 0x7f020106;
-    public static final int only_in_main = 0x7f020107;
-    public static final int only_in_lib1 = 0x7f020108;
-    public static final int only_in_lib2 = 0x7f020109;
-    public static final int only_in_lib3 = 0x7f02010a;
-    public static final int in_all_libs = 0x7f02010b;
-    public static final int in_lib2_and_lib3 = 0x7f02010c;
-    public static final int in_lib1_and_lib3 = 0x7f02010d;
-    public static final int in_main_and_lib1 = 0x7f02010e;
-    public static final int interpolate = 0x7f02010f;
-    public static final int app_name = 0x7f020110;
-    public static final int activity_name = 0x7f020111;
-    public static final int minute_singular = 0x7f020112;
-    public static final int minute_plural = 0x7f020113;
-    public static final int str_int = 0x7f020114;
-    public static final int preference_resource_key = 0x7f020115;
-    public static final int preference_resource_title = 0x7f020116;
-    public static final int preference_resource_summary = 0x7f020117;
-    public static final int preference_resource_default_value = 0x7f020118;
-    public static final int surrounding_quotes = 0x7f020119;
-    public static final int escaped_apostrophe = 0x7f02011a;
-    public static final int escaped_quotes = 0x7f02011b;
-    public static final int leading_and_trailing_new_lines = 0x7f02011c;
-    public static final int non_breaking_space = 0x7f02011d;
-    public static final int new_lines_and_tabs = 0x7f02011e;
-    public static final int space = 0x7f02011f;
-    public static final int say_it_with_item = 0x7f020120;
-    public static final int test_menu_2 = 0x7f020121;
-    public static final int also_in_all_libs = 0x7f020122;
-    public static final int typed_array_a = 0x7f020123;
-    public static final int typed_array_b = 0x7f020124;
-    public static final int test_permission_description = 0x7f020125;
-    public static final int test_permission_label = 0x7f020126;
-    public static final int string_with_spaces = 0x7f020127;
+    public static final int howdy = 0x7f020000;
+    public static final int hello = 0x7f020001;
+    public static final int some_html = 0x7f020002;
+    public static final int greeting = 0x7f020003;
+    public static final int copy = 0x7f020004;
+    public static final int ok = 0x7f020005;
+    public static final int ok2 = 0x7f020006;
+    public static final int only_in_main = 0x7f020007;
+    public static final int only_in_lib1 = 0x7f020008;
+    public static final int only_in_lib2 = 0x7f020009;
+    public static final int only_in_lib3 = 0x7f02000a;
+    public static final int in_all_libs = 0x7f02000b;
+    public static final int in_lib2_and_lib3 = 0x7f02000c;
+    public static final int in_lib1_and_lib3 = 0x7f02000d;
+    public static final int in_main_and_lib1 = 0x7f02000e;
+    public static final int interpolate = 0x7f02000f;
+    public static final int app_name = 0x7f020010;
+    public static final int activity_name = 0x7f020011;
+    public static final int minute_singular = 0x7f020012;
+    public static final int minute_plural = 0x7f020013;
+    public static final int str_int = 0x7f020014;
+    public static final int preference_resource_key = 0x7f020015;
+    public static final int preference_resource_title = 0x7f020016;
+    public static final int preference_resource_summary = 0x7f020017;
+    public static final int preference_resource_default_value = 0x7f020018;
+    public static final int surrounding_quotes = 0x7f020019;
+    public static final int escaped_apostrophe = 0x7f02001a;
+    public static final int escaped_quotes = 0x7f02001b;
+    public static final int leading_and_trailing_new_lines = 0x7f02001c;
+    public static final int non_breaking_space = 0x7f02001d;
+    public static final int new_lines_and_tabs = 0x7f02001e;
+    public static final int space = 0x7f02001f;
+    public static final int say_it_with_item = 0x7f020020;
+    public static final int test_menu_2 = 0x7f020021;
+    public static final int also_in_all_libs = 0x7f020022;
+    public static final int typed_array_a = 0x7f020023;
+    public static final int typed_array_b = 0x7f020024;
+    public static final int test_permission_description = 0x7f020025;
+    public static final int test_permission_label = 0x7f020026;
+    public static final int string_with_spaces = 0x7f020027;
   }
 
   public static final class plurals {
-    public static final int beer = 0x7f030200;
-    public static final int minute = 0x7f030201;
+    public static final int beer = 0x7f030000;
+    public static final int minute = 0x7f030001;
   }
 
   public static final class array {
-    public static final int items = 0x7f040300;
-    public static final int greetings = 0x7f040301;
-    public static final int alertDialogTestItems = 0x7f040302;
-    public static final int emailAddressTypes = 0x7f040303;
-    public static final int zero_to_four_int_array = 0x7f040304;
-    public static final int empty_int_array = 0x7f040305;
-    public static final int with_references_int_array = 0x7f040306;
-    public static final int referenced_colors_int_array = 0x7f040307;
-    public static final int typed_array_values = 0x7f040308;
-    public static final int typed_array_references = 0x7f040309;
-    public static final int typed_array_with_resource_id = 0x7f04030A;
+    public static final int items = 0x7f040000;
+    public static final int greetings = 0x7f040001;
+    public static final int alertDialogTestItems = 0x7f040002;
+    public static final int emailAddressTypes = 0x7f040003;
+    public static final int zero_to_four_int_array = 0x7f040004;
+    public static final int empty_int_array = 0x7f040005;
+    public static final int with_references_int_array = 0x7f040006;
+    public static final int referenced_colors_int_array = 0x7f040007;
+    public static final int typed_array_values = 0x7f040008;
+    public static final int typed_array_references = 0x7f040009;
+    public static final int typed_array_with_resource_id = 0x7f04000a;
   }
 
   public static final class color {
-    public static final int background = 0x7f050400;
-    public static final int foreground = 0x7f050401;
-    public static final int grey42 = 0x7f050402;
-    public static final int black = 0x7f050403;
-    public static final int blue = 0x7f050404;
-    public static final int white = 0x7f050405;
-    public static final int clear = 0x7f050406;
-    public static final int color_with_alpha = 0x7f050407;
-    public static final int android_namespaced_black = 0x7f050408;
-    public static final int android_namespaced_transparent = 0x7f050409;
-    public static final int test_color_1 = 0x7f05040b;
-    public static final int color_state_list = 0x7f05040c;
-    public static final int list_separator = 0x7f05040d;
-    public static final int custom_state_view_text_color = 0x7f05040e;
-    public static final int typed_array_orange = 0x7f05040f;
+    public static final int background = 0x7f050000;
+    public static final int foreground = 0x7f050001;
+    public static final int grey42 = 0x7f050002;
+    public static final int black = 0x7f050003;
+    public static final int blue = 0x7f050004;
+    public static final int white = 0x7f050005;
+    public static final int clear = 0x7f050006;
+    public static final int color_with_alpha = 0x7f050007;
+    public static final int android_namespaced_black = 0x7f050008;
+    public static final int android_namespaced_transparent = 0x7f050009;
+    public static final int test_color_1 = 0x7f05000a;
+    public static final int color_state_list = 0x7f05000b;
+    public static final int list_separator = 0x7f05000c;
+    public static final int custom_state_view_text_color = 0x7f05000d;
+    public static final int typed_array_orange = 0x7f05000e;
   }
 
   public static final class drawable {
-    public static final int an_image = 0x7f060500;
-    public static final int an_other_image = 0x7f060501;
-    public static final int third_image = 0x7f060502;
-    public static final int fourth_image = 0x7f060503;
-    public static final int image_background = 0x7f060504;
-    public static final int l0_red = 0x7f060505;
-    public static final int l1_orange = 0x7f060506;
-    public static final int l2_yellow = 0x7f060507;
-    public static final int l3_green = 0x7f060508;
-    public static final int l4_blue = 0x7f060509;
-    public static final int l5_indigo = 0x7f06050a;
-    public static final int l6_violet = 0x7f06050b;
-    public static final int l7_white = 0x7f06050c;
-    public static final int rainbow = 0x7f06050d;
-    public static final int state_drawable = 0x7f06050e;
-    public static final int nine_patch_drawable = 0x7f06050f;
-    public static final int drawable_with_nine_patch = 0x7f060510;
-    public static final int robolectric = 0x7f060511;
-    public static final int an_image_or_vector = 0x7f060512;
-    public static final int vector = 0x7f060513;
-    public static final int text_file_posing_as_image = 0x7f060514;
+    public static final int an_image = 0x7f060000;
+    public static final int an_other_image = 0x7f060001;
+    public static final int third_image = 0x7f060002;
+    public static final int fourth_image = 0x7f060003;
+    public static final int image_background = 0x7f060004;
+    public static final int l0_red = 0x7f060005;
+    public static final int l1_orange = 0x7f060006;
+    public static final int l2_yellow = 0x7f060007;
+    public static final int l3_green = 0x7f060008;
+    public static final int l4_blue = 0x7f060009;
+    public static final int l5_indigo = 0x7f06000a;
+    public static final int l6_violet = 0x7f06000b;
+    public static final int l7_white = 0x7f06000c;
+    public static final int rainbow = 0x7f06000d;
+    public static final int state_drawable = 0x7f06000e;
+    public static final int nine_patch_drawable = 0x7f06000f;
+    public static final int drawable_with_nine_patch = 0x7f060010;
+    public static final int robolectric = 0x7f060011;
+    public static final int an_image_or_vector = 0x7f060012;
+    public static final int vector = 0x7f060013;
+    public static final int text_file_posing_as_image = 0x7f060014;
   }
 
   public static final class layout {
-    public static final int activity_list_item = 0x7f070600;
-    public static final int custom_layout = 0x7f070601;
-    public static final int custom_layout2 = 0x7f070602;
-    public static final int custom_layout3 = 0x7f070603;
-    public static final int custom_layout4 = 0x7f070604;
-    public static final int different_screen_sizes = 0x7f070605;
-    public static final int edit_text = 0x7f070606;
-    public static final int fragment = 0x7f070607;
-    public static final int fragment_activity = 0x7f070608;
-    public static final int fragment_contents = 0x7f070609;
-    public static final int included_layout_parent = 0x7f07060a;
-    public static final int included_linear_layout = 0x7f07060b;
-    public static final int inner_merge = 0x7f07060c;
-    public static final int lam_inner = 0x7f07060d;
-    public static final int lam_outer = 0x7f07060e;
-    public static final int main = 0x7f07060f;
-    public static final int mapview = 0x7f070610;
-    public static final int media = 0x7f070611;
-    public static final int multi_orientation = 0x7f070612;
-    public static final int outer = 0x7f070613;
-    public static final int override_include = 0x7f070614;
-    public static final int request_focus = 0x7f070615;
-    public static final int request_focus_with_two_edit_texts = 0x7f070616;
-    public static final int snippet = 0x7f070617;
-    public static final int styles_button_layout = 0x7f070618;
-    public static final int tab_activity = 0x7f070619;
-    public static final int text_views = 0x7f07061a;
-    public static final int text_views_hints = 0x7f07061b;
-    public static final int toplevel_merge = 0x7f07061c;
-    public static final int webview_holder = 0x7f07061d;
-    public static final int with_invalid_onclick = 0x7f07061e;
-    public static final int styles_button_with_style_layout = 0x7f07061f;
-    public static final int custom_title = 0x7f070620;
-    public static final int remote_views = 0x7f070621;
-    public static final int main_layout = 0x7f070622;
-    public static final int activity_main = 0x7f070623;
-    public static final int activity_main_1 = 0x7f070624;
-    public static final int ordinal_scrollbar = 0x7f070625;
-    public static final int custom_layout5 = 0x7f070626;
-    public static final int custom_layout6 = 0x7f070627;
-    public static final int layout_smallest_width = 0x7f070628;
+    public static final int activity_list_item = 0x7f070000;
+    public static final int custom_layout = 0x7f070001;
+    public static final int custom_layout2 = 0x7f070002;
+    public static final int custom_layout3 = 0x7f070003;
+    public static final int custom_layout4 = 0x7f070004;
+    public static final int different_screen_sizes = 0x7f070005;
+    public static final int edit_text = 0x7f070006;
+    public static final int fragment = 0x7f070007;
+    public static final int fragment_activity = 0x7f070008;
+    public static final int fragment_contents = 0x7f070009;
+    public static final int included_layout_parent = 0x7f07000a;
+    public static final int included_linear_layout = 0x7f07000b;
+    public static final int inner_merge = 0x7f07000c;
+    public static final int lam_inner = 0x7f07000d;
+    public static final int lam_outer = 0x7f07000e;
+    public static final int main = 0x7f07000f;
+    public static final int mapview = 0x7f070010;
+    public static final int media = 0x7f070011;
+    public static final int multi_orientation = 0x7f070012;
+    public static final int outer = 0x7f070013;
+    public static final int override_include = 0x7f070014;
+    public static final int request_focus = 0x7f070015;
+    public static final int request_focus_with_two_edit_texts = 0x7f070016;
+    public static final int snippet = 0x7f070017;
+    public static final int styles_button_layout = 0x7f070018;
+    public static final int tab_activity = 0x7f070019;
+    public static final int text_views = 0x7f07001a;
+    public static final int text_views_hints = 0x7f07001b;
+    public static final int toplevel_merge = 0x7f07001c;
+    public static final int webview_holder = 0x7f07001d;
+    public static final int with_invalid_onclick = 0x7f07001e;
+    public static final int styles_button_with_style_layout = 0x7f07001f;
+    public static final int custom_title = 0x7f070020;
+    public static final int remote_views = 0x7f070021;
+    public static final int main_layout = 0x7f070022;
+    public static final int activity_main = 0x7f070023;
+    public static final int activity_main_1 = 0x7f070024;
+    public static final int ordinal_scrollbar = 0x7f070025;
+    public static final int custom_layout5 = 0x7f070026;
+    public static final int custom_layout6 = 0x7f070027;
+    public static final int layout_smallest_width = 0x7f070028;
   }
 
   public static final class anim {
-    public static final int test_anim_1 = 0x7f080700;
-    public static final int animation_list = 0x7f080701;
+    public static final int test_anim_1 = 0x7f080000;
+    public static final int animation_list = 0x7f080001;
   }
 
   public static final class animator {
-    public static final int spinning = 0x7f090800;
-    public static final int fade = 0x7f090801;
+    public static final int spinning = 0x7f090000;
+    public static final int fade = 0x7f090001;
   }
 
   public static final class raw {
-    public static final int raw_resource = 0x7f0a0900;
-    public static final int raw_no_ext = 0x7f0a0901;
-    public static final int lib_raw_resource = 0x7f0a0902;
-    public static final int lib_raw_resource_from_2 = 0x7f0a0903;
-    public static final int lib_raw_resource_from_3 = 0x7f0a0904;
+    public static final int raw_resource = 0x7f0a0000;
+    public static final int raw_no_ext = 0x7f0a0001;
+    public static final int lib_raw_resource = 0x7f0a0002;
+    public static final int lib_raw_resource_from_2 = 0x7f0a0003;
+    public static final int lib_raw_resource_from_3 = 0x7f0a0004;
   }
 
   public static final class attr {
-    public static final int isSugary = 0x7f0b0a00;
-    public static final int itemType = 0x7f0b0a01;
-    public static final int scrollBars = 0x7f0b0a02;
-    public static final int gravity = 0x7f0b0a03;
-    public static final int keycode = 0x7f0b0a04;
-    public static final int aspectRatio = 0x7f0b0a05;
-    public static final int aspectRatioEnabled = 0x7f0b0a06;
-    public static final int items = 0x7f0b0a07;
-    public static final int logoHeight = 0x7f0b0a08;
-    public static final int quitKeyCombo = 0x7f0b0a09;
-    public static final int responses = 0x7f0b0a0a;
-    public static final int animalStyle = 0x7f0b0a0b;
-    public static final int stateFoo = 0x7f0b0a0c;
-    public static final int someLayoutOne = 0x7f0b0a0d;
-    public static final int someLayoutTwo = 0x7f0b0a0e;
-    public static final int message = 0x7f0b0a0f;
-    public static final int sugarinessPercent = 0x7f0b0a10;
-    public static final int numColumns = 0x7f0b0a11;
-    public static final int sugaryScale = 0x7f0b0a12;
-    public static final int selectableItemBackground = 0x7f0b0a13;
-    public static final int attrFromLib1 = 0x7f0b0a14;
-    public static final int buttonStyle = 0x7f0b0a15;
-    public static final int logoWidth = 0x7f0b0a16;
-    public static final int averageSheepWidth = 0x7f0b0a17;
-    public static final int typeface = 0x7f0b0a18;
-    public static final int string1 = 0x7f0b0a19;
-    public static final int string2 = 0x7f0b0a1a;
-    public static final int string3 = 0x7f0b0a1b;
-    public static final int parentStyleReference = 0x7f0b0a1c;
-    public static final int styleReference = 0x7f0b0a1d;
-    public static final int styleReferenceWithoutExplicitType = 0x7f0b0a1e;
-    public static final int styleNotSpecifiedInAnyTheme = 0x7f0b0a1f;
-    public static final int offsetX = 0x7f0b0a20;
-    public static final int offsetY = 0x7f0b0a21;
-    public static final int textStyle2 = 0x7f0b0a22;
-    public static final int textStyle3 = 0x7f0b0a23;
+    public static final int isSugary = 0x7f0b0000;
+    public static final int itemType = 0x7f0b0001;
+    public static final int scrollBars = 0x7f0b0002;
+    public static final int gravity = 0x7f0b0003;
+    public static final int keycode = 0x7f0b0004;
+    public static final int aspectRatio = 0x7f0b0005;
+    public static final int aspectRatioEnabled = 0x7f0b0006;
+    public static final int items = 0x7f0b0007;
+    public static final int logoHeight = 0x7f0b0008;
+    public static final int quitKeyCombo = 0x7f0b0009;
+    public static final int responses = 0x7f0b000a;
+    public static final int animalStyle = 0x7f0b000b;
+    public static final int stateFoo = 0x7f0b000c;
+    public static final int someLayoutOne = 0x7f0b000d;
+    public static final int someLayoutTwo = 0x7f0b000e;
+    public static final int message = 0x7f0b000f;
+    public static final int sugarinessPercent = 0x7f0b0010;
+    public static final int numColumns = 0x7f0b0011;
+    public static final int sugaryScale = 0x7f0b0012;
+    public static final int selectableItemBackground = 0x7f0b0013;
+    public static final int attrFromLib1 = 0x7f0b0014;
+    public static final int buttonStyle = 0x7f0b0015;
+    public static final int logoWidth = 0x7f0b0016;
+    public static final int averageSheepWidth = 0x7f0b0017;
+    public static final int typeface = 0x7f0b0018;
+    public static final int string1 = 0x7f0b0019;
+    public static final int string2 = 0x7f0b001a;
+    public static final int string3 = 0x7f0b001b;
+    public static final int parentStyleReference = 0x7f0b001c;
+    public static final int styleReference = 0x7f0b001d;
+    public static final int styleReferenceWithoutExplicitType = 0x7f0b001e;
+    public static final int styleNotSpecifiedInAnyTheme = 0x7f0b001f;
+    public static final int offsetX = 0x7f0b0020;
+    public static final int offsetY = 0x7f0b0021;
+    public static final int textStyle2 = 0x7f0b0022;
+    public static final int textStyle3 = 0x7f0b0023;
   }
 
   public static final class menu {
-    public static final int test = 0x7f0c0b00;
-    public static final int test_withchilds = 0x7f0c0b01;
-    public static final int action_menu = 0x7f0c0b02;
-    public static final int test_withorder = 0x7f0c0b03;
+    public static final int test = 0x7f0c0000;
+    public static final int test_withchilds = 0x7f0c0001;
+    public static final int action_menu = 0x7f0c0002;
+    public static final int test_withorder = 0x7f0c0003;
   }
 
   public static final class xml {
-    public static final int preferences = 0x7f0d0c00;
-    public static final int dialog_preferences = 0x7f0d0c01;
+    public static final int preferences = 0x7f0d0000;
+    public static final int dialog_preferences = 0x7f0d0001;
   }
 
   public static final class styleable {
@@ -351,78 +351,78 @@ public final class R {
   }
 
   public static final class dimen {
-    public static final int test_dp_dimen = 0x7f0e0d00;
-    public static final int test_dip_dimen = 0x7f0e0d01;
-    public static final int test_pt_dimen = 0x7f0e0d02;
-    public static final int test_px_dimen = 0x7f0e0d03;
-    public static final int test_sp_dimen = 0x7f0e0d04;
-    public static final int test_mm_dimen = 0x7f0e0d05;
-    public static final int test_in_dimen = 0x7f0e0d06;
-    public static final int ref_to_px_dimen = 0x7f0e0d07;
+    public static final int test_dp_dimen = 0x7f0f0000;
+    public static final int test_dip_dimen = 0x7f0f0001;
+    public static final int test_pt_dimen = 0x7f0f0002;
+    public static final int test_px_dimen = 0x7f0f0003;
+    public static final int test_sp_dimen = 0x7f0f0004;
+    public static final int test_mm_dimen = 0x7f0f0005;
+    public static final int test_in_dimen = 0x7f0f0006;
+    public static final int ref_to_px_dimen = 0x7f0f0007;
   }
 
   public static final class integer {
-    public static final int test_non_integer = 0x7f0f0e00;
-    public static final int test_integer1 = 0x7f0f0e01;
-    public static final int test_integer2 = 0x7f0f0e02;
-    public static final int test_large_hex = 0x7f0f0e03;
-    public static final int meaning_of_life = 0x7f0f0e04;
-    public static final int loneliest_number = 0x7f0f0e05;
-    public static final int there_can_be_only = 0x7f0f0e06;
-    public static final int hex_int = 0x7f0f0e07;
-    public static final int test_value_with_zero = 0x7f0f0e08;
-    public static final int reference_to_meaning_of_life = 0x7f0f0e09;
-    public static final int meaning_of_life_as_item = 0x7f0f0e0a;
-    public static final int scrollbar_style_ordinal_outside_overlay = 0x7f0f0e0b;
-    public static final int typed_array_5 = 0x7f0f0e0c;
+    public static final int test_non_integer = 0x7f100000;
+    public static final int test_integer1 = 0x7f100001;
+    public static final int test_integer2 = 0x7f100002;
+    public static final int test_large_hex = 0x7f100003;
+    public static final int meaning_of_life = 0x7f100004;
+    public static final int loneliest_number = 0x7f100005;
+    public static final int there_can_be_only = 0x7f100006;
+    public static final int hex_int = 0x7f100007;
+    public static final int test_value_with_zero = 0x7f100008;
+    public static final int reference_to_meaning_of_life = 0x7f100009;
+    public static final int meaning_of_life_as_item = 0x7f10000a;
+    public static final int scrollbar_style_ordinal_outside_overlay = 0x7f10000b;
+    public static final int typed_array_5 = 0x7f10000c;
   }
 
   public static final class bool {
-    public static final int false_bool_value = 0x7f100f00;
-    public static final int true_bool_value = 0x7f100f01;
-    public static final int reference_to_true = 0x7f100f04;
-    public static final int true_as_item = 0x7f100f05;
-    public static final int different_resource_boolean=0x7f100f06;
-    public static final int value_only_present_in_w320dp=0x7f100f07;
-    public static final int typed_array_true=0x7f100f08;
+    public static final int false_bool_value = 0x7f110000;
+    public static final int true_bool_value = 0x7f110001;
+    public static final int reference_to_true = 0x7f110002;
+    public static final int true_as_item = 0x7f110003;
+    public static final int different_resource_boolean=0x7f110004;
+    public static final int value_only_present_in_w320dp=0x7f110005;
+    public static final int typed_array_true=0x7f110006;
   }
 
   public static final class style {
-    public static final int FancyStyle = 0x7f111000;
-    public static final int Theme_Robolectric = 0x7f111001;
-    public static final int Theme_Robolectric_ImplicitChild = 0x7f111002;
-    public static final int Theme_Robolectric_EmptyParent = 0x7f111003;
-    public static final int Theme_AnotherTheme = 0x7f111005;
-    public static final int MyCustomView = 0x7f111006;
-    public static final int Widget_Robolectric_Button = 0x7f111007;
-    public static final int Widget_AnotherTheme_Button = 0x7f111008;
-    public static final int Widget_AnotherTheme_Button_Blarf = 0x7f111009;
-    public static final int Sized = 0x7f11100a;
-    public static final int Gastropod = 0x7f11100b;
-    public static final int Theme_ThirdTheme = 0x7f11100c;
-    public static final int Theme_ThemeReferredToByParentAttrReference = 0x7f11100d;
-    public static final int Theme_ThemeContainingStyleReferences = 0x7f11100e;
-    public static final int StyleReferredToByParentAttrReference = 0x7f11100f;
-    public static final int Theme_ThemeWithAttrReferenceAsParent = 0x7f111010;
-    public static final int MyBlackTheme = 0x7f111011;
-    public static final int MyBlueTheme = 0x7f111012;
-    public static final int ThemeWithSelfReferencingTextAttr = 0x7f111013;
+    public static final int FancyStyle = 0x7f120000;
+    public static final int Theme_Robolectric = 0x7f120001;
+    public static final int Theme_Robolectric_ImplicitChild = 0x7f120002;
+    public static final int Theme_Robolectric_EmptyParent = 0x7f120003;
+    public static final int Theme_AnotherTheme = 0x7f120004;
+    public static final int MyCustomView = 0x7f120005;
+    public static final int Widget_Robolectric_Button = 0x7f120006;
+    public static final int Widget_AnotherTheme_Button = 0x7f120007;
+    public static final int Widget_AnotherTheme_Button_Blarf = 0x7f120008;
+    public static final int Sized = 0x7f120009;
+    public static final int Gastropod = 0x7f12000a;
+    public static final int Theme_ThirdTheme = 0x7f12000b;
+    public static final int Theme_ThemeReferredToByParentAttrReference = 0x7f12000c;
+    public static final int Theme_ThemeContainingStyleReferences = 0x7f12000d;
+    public static final int StyleReferredToByParentAttrReference = 0x7f12000e;
+    public static final int Theme_ThemeWithAttrReferenceAsParent = 0x7f12000f;
+    public static final int MyBlackTheme = 0x7f120010;
+    public static final int MyBlueTheme = 0x7f120011;
+    public static final int ThemeWithSelfReferencingTextAttr = 0x7f120012;
 
-    public static final int IndirectButtonStyle = 0x7f111014;
+    public static final int IndirectButtonStyle = 0x7f120013;
   }
 
   public static final class fraction {
-    public static final int half = 0x7f121100;
-    public static final int half_of_parent = 0x7f121101;
-    public static final int quarter_as_item = 0x7f121102;
-    public static final int quarter_of_parent_as_item = 0x7f121103;
-    public static final int fifth = 0x7f121104;
-    public static final int fifth_as_reference = 0x7f121105;
-    public static final int fifth_of_parent = 0x7f121106;
-    public static final int fifth_of_parent_as_reference = 0x7f121107;
+    public static final int half = 0x7f130000;
+    public static final int half_of_parent = 0x7f130001;
+    public static final int quarter_as_item = 0x7f130002;
+    public static final int quarter_of_parent_as_item = 0x7f130003;
+    public static final int fifth = 0x7f130004;
+    public static final int fifth_as_reference = 0x7f130005;
+    public static final int fifth_of_parent = 0x7f130006;
+    public static final int fifth_of_parent_as_reference = 0x7f130007;
   }
 
   public static final class mipmap {
-    public static final int robolectric = 0x7f121200;
+    public static final int robolectric = 0x7f140000;
   }
 }


### PR DESCRIPTION
1) Add some comments explaining this script does not generate resource
ids that are consistent with the Android aapt tool.

2) Make the script agnostic from the location where it is run.

3) Fix the start offset to be consistent with the values in R.java. I'm
honestly not sure how this script ever worked.

Also, run this script to regenerate the resource ids.