### PR TITLE
Implement PackageManager.queryPermissionsByGroup()

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -1213,6 +1213,69 @@ public class ShadowPackageManagerTest {
   }
 
   @Test
+  @Config(manifest = "TestAndroidManifestWithPermissions.xml")
+  public void queryPermissionsByGroup_noMetaData() throws Exception {
+    List<PermissionInfo> permissions = packageManager.queryPermissionsByGroup("my_permission_group", 0);
+    assertThat(permissions).hasSize(1);
+
+    PermissionInfo permission = permissions.get(0);
+
+    assertThat(permission.group).isEqualTo("my_permission_group");
+    assertThat(permission.name).isEqualTo("some_permission");
+    assertThat(permission.metaData).isNull();
+  }
+
+  @Test
+  @Config(manifest = "TestAndroidManifestWithPermissions.xml")
+  public void queryPermissionsByGroup_withMetaData() throws Exception {
+    List<PermissionInfo> permissions = packageManager.queryPermissionsByGroup("my_permission_group", PackageManager.GET_META_DATA);
+    assertThat(permissions).hasSize(1);
+
+    PermissionInfo permission = permissions.get(0);
+
+    assertThat(permission.group).isEqualTo("my_permission_group");
+    assertThat(permission.name).isEqualTo("some_permission");
+    assertThat(permission.metaData).isNotNull();
+    assertThat(permission.metaData.getString("meta_data_name")).isEqualTo("meta_data_value");
+  }
+
+  @Test
+  @Config(manifest = "TestAndroidManifestWithPermissions.xml")
+  public void queryPermissionsByGroup_nullMatchesPermissionsNotAssociatedWithGroup() throws Exception {
+    List<PermissionInfo> permissions = packageManager.queryPermissionsByGroup(null, 0);
+    assertThat(permissions).hasSize(2);
+
+    assertThat(permissions.get(0).name).isEqualTo("permission_with_minimal_fields");
+    assertThat(permissions.get(1).name).isEqualTo("permission_with_literal_label");
+  }
+
+  @Test
+  public void queryPermissionsByGroup_nullMatchesPermissionsNotAssociatedWithGroup_with_addPermissionInfo() throws Exception {
+    PermissionInfo permissionInfo = new PermissionInfo();
+    permissionInfo.name = "some_name";
+    shadowPackageManager.addPermissionInfo(permissionInfo);
+
+    List<PermissionInfo> permissions = packageManager.queryPermissionsByGroup(null, 0);
+    assertThat(permissions).hasSize(1);
+
+    assertThat(permissions.get(0).name).isEqualTo(permissionInfo.name);
+  }
+
+  @Test
+  public void queryPermissionsByGroup_with_addPermissionInfo() throws Exception {
+    PermissionInfo permissionInfo = new PermissionInfo();
+    permissionInfo.name = "some_name";
+    permissionInfo.group = "some_group";
+    shadowPackageManager.addPermissionInfo(permissionInfo);
+
+    List<PermissionInfo> permissions = packageManager.queryPermissionsByGroup(permissionInfo.group, 0);
+    assertThat(permissions).hasSize(1);
+
+    assertThat(permissions.get(0).name).isEqualTo(permissionInfo.name);
+    assertThat(permissions.get(0).group).isEqualTo(permissionInfo.group);
+  }
+
+  @Test
   public void getDefaultActivityIcon() {
     assertThat(packageManager.getDefaultActivityIcon()).isNotNull();
   }


### PR DESCRIPTION
Both for the manifest case and the ShadowPackageManager.addPermission()
override.

Support the null case which returns permissions not associated
with a group.

Support META_DATA flag.
