### PR TITLE
Use runPaused for two ViewPager methods

### DIFF
--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowViewPager.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowViewPager.java
@@ -1,0 +1,33 @@
+package org.robolectric.shadows.support.v4;
+
+import static org.robolectric.internal.Shadow.directlyOn;
+
+import android.support.v4.view.PagerAdapter;
+import android.support.v4.view.ViewPager;
+import org.robolectric.Robolectric;
+import org.robolectric.ShadowsAdapter;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.shadows.ShadowViewGroup;
+
+@Implements(ViewPager.class)
+public class ShadowViewPager extends ShadowViewGroup {
+  @RealObject ViewPager realViewPager;
+
+  @Implementation
+  public void setAdapter(final PagerAdapter adapter) {
+    ShadowsAdapter shadowsAdapter = Robolectric.getShadowsAdapter();
+    shadowsAdapter
+        .getMainLooper()
+        .runPaused(() -> directlyOn(realViewPager, ViewPager.class).setAdapter(adapter));
+  }
+
+  @Implementation
+  public void setOffscreenPageLimit(final int limit) {
+    ShadowsAdapter shadowsAdapter = Robolectric.getShadowsAdapter();
+    shadowsAdapter
+        .getMainLooper()
+        .runPaused(() -> directlyOn(realViewPager, ViewPager.class).setOffscreenPageLimit(limit));
+  }
+}

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/R.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/R.java
@@ -6,6 +6,7 @@ public final class R {
     public static final int fragment = 0x10022;
     public static final int tacos = 0x10027;
     public static final int burritos = 0x10028;
+    public static final int view_pager = 0x10029;
   }
 
   public static final class drawable {
@@ -17,5 +18,6 @@ public final class R {
     public static final int fragment = 0x10607;
     public static final int fragment_contents = 0x10609;
     public static final int activity_fragment = 0x10620;
+    public static final int activity_view_pager = 0x10621;
   }
 }

--- a/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowViewPagerTest.java
+++ b/robolectric-shadows/shadows-support-v4/src/test/java/org/robolectric/shadows/support/v4/ShadowViewPagerTest.java
@@ -1,15 +1,24 @@
 package org.robolectric.shadows.support.v4;
 
+import android.app.Activity;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.support.v4.app.*;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RuntimeEnvironment;
+import org.robolectric.*;
 import org.robolectric.util.TestRunnerWithManifest;
 
 import static junit.framework.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(TestRunnerWithManifest.class)
 public class ShadowViewPagerTest {
@@ -57,6 +66,13 @@ public class ShadowViewPagerTest {
     assertFalse(listener.onPageSelectedCalled);
   }
 
+  @Test
+  public void viewPager_withFragmentPagerAdapter_canBeCalledAsynchronously() {
+    Activity activity = Robolectric.setupActivity(TestActivity.class);
+    org.robolectric.Shadows.shadowOf(TestActivity.sHandler.getLooper()).runToEndOfTasks();
+    assertThat(((TextView) activity.findViewById(R.id.burritos)).getText()).isEqualTo("BURRITOS");
+  }
+
   private static class TestPagerAdapter extends PagerAdapter {
     @Override
     public int getCount() {
@@ -75,6 +91,63 @@ public class ShadowViewPagerTest {
     @Override
     public void onPageSelected(int position) {
       onPageSelectedCalled = true;
+    }
+  }
+
+  public static class TestActivity extends FragmentActivity {
+    static final HandlerThread sHandlerThread = new HandlerThread("handlerThread");
+    static final Handler sHandler;
+
+    private TestFragmentPagerAdapter mAdapter;
+    private ViewPager mPager;
+
+    static {
+      sHandlerThread.start();
+      sHandler = new Handler(sHandlerThread.getLooper());
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      setContentView(R.layout.activity_view_pager);
+      mAdapter = new TestFragmentPagerAdapter(getSupportFragmentManager());
+      sHandler.post(
+          () ->
+              runOnUiThread(
+                  () -> {
+                    mPager = findViewById(R.id.view_pager);
+                    mPager.setAdapter(mAdapter);
+                    mPager.setCurrentItem(0);
+                    mPager.setOffscreenPageLimit(3);
+                  }));
+    }
+  }
+
+  public static class TestFragmentPagerAdapter extends FragmentPagerAdapter {
+    public TestFragmentPagerAdapter(FragmentManager fm) {
+      super(fm);
+    }
+
+    @Override
+    public int getCount() {
+      return 5;
+    }
+
+    @Override
+    public Fragment getItem(int position) {
+      return new TestViewPagerFragment();
+    }
+  }
+
+  public static class TestViewPagerFragment extends Fragment {
+    public TestViewPagerFragment() {
+      // required empty public constructor
+    }
+
+    @Override
+    public View onCreateView(
+        LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+      return inflater.inflate(R.layout.fragment_contents, container, false);
     }
   }
 }

--- a/robolectric-shadows/shadows-support-v4/src/test/resources/res/layout/activity_view_pager.xml
+++ b/robolectric-shadows/shadows-support-v4/src/test/resources/res/layout/activity_view_pager.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/activity_main"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+    <android.support.v4.view.ViewPager
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:id="@+id/view_pager" />
+</RelativeLayout>


### PR DESCRIPTION
Two methods in support.v4.view.ViewPager, `setAdapter` and
`setOffscreenPageLimit` may produce IllegalStateExceptions when they are
invoked while flushing the Robolectric scheduler. Because these methods
perform fragment transactions, they may not always play nicely with the
scheduler. Calling them with `runPaused` seems to fix the issue.

Fixes #2871