### PR TITLE
Remove empty shadow ShadowCursorLoader

### DIFF
--- a/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowCursorLoader.java
+++ b/robolectric-shadows/shadows-support-v4/src/main/java/org/robolectric/shadows/support/v4/ShadowCursorLoader.java
@@ -1,9 +1,0 @@
-package org.robolectric.shadows.support.v4;
-
-import android.database.Cursor;
-import android.support.v4.content.CursorLoader;
-import org.robolectric.annotation.Implements;
-
-@Implements(CursorLoader.class)
-public class ShadowCursorLoader extends ShadowAsyncTaskLoader<Cursor> {
-}


### PR DESCRIPTION
I noticed this while working on a separate pull request.
ShadowCursorLoader is completely empty. Since it has no additional
functionality, it can be removed.
