### PR TITLE
PackageManager.getProviderInfo() improvements.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
+++ b/robolectric/src/main/java/org/robolectric/res/builder/DefaultPackageManager.java
@@ -276,23 +276,26 @@ public class DefaultPackageManager extends PackageManager implements Robolectric
     AndroidManifest androidManifest = androidManifests.get(packageName);
     String classString = resolvePackageName(packageName, className);
 
-    for (ContentProviderData contentProviderData : androidManifest.getContentProviders()) {
-      if (contentProviderData.getClassName().equals(classString)) {
-        ProviderInfo providerInfo = new ProviderInfo();
-        providerInfo.packageName = packageName;
-        providerInfo.name = contentProviderData.getClassName();
-        providerInfo.authority = contentProviderData.getAuthorities(); // todo: support multiple authorities
-        providerInfo.readPermission = contentProviderData.getReadPermission();
-        providerInfo.writePermission = contentProviderData.getWritePermission();
-        providerInfo.pathPermissions = createPathPermissions(contentProviderData.getPathPermissionDatas());
-        providerInfo.metaData = metaDataToBundle(contentProviderData.getMetaData().getValueMap());
-        if ((flags & GET_META_DATA) != 0) {
+    if (androidManifest != null) {
+      for (ContentProviderData contentProviderData : androidManifest.getContentProviders()) {
+        if (contentProviderData.getClassName().equals(classString)) {
+          ProviderInfo providerInfo = new ProviderInfo();
+          providerInfo.packageName = packageName;
+          providerInfo.name = contentProviderData.getClassName();
+          providerInfo.authority = contentProviderData.getAuthorities(); // todo: support multiple authorities
+          providerInfo.readPermission = contentProviderData.getReadPermission();
+          providerInfo.writePermission = contentProviderData.getWritePermission();
+          providerInfo.pathPermissions = createPathPermissions(contentProviderData.getPathPermissionDatas());
           providerInfo.metaData = metaDataToBundle(contentProviderData.getMetaData().getValueMap());
+          if ((flags & GET_META_DATA) != 0) {
+            providerInfo.metaData = metaDataToBundle(contentProviderData.getMetaData().getValueMap());
+          }
+          return providerInfo;
         }
-        return providerInfo;
       }
     }
-    return null;
+
+    throw new NameNotFoundException("Package not found: " + packageName);
   }
 
   private PathPermission[] createPathPermissions(List<PathPermissionData> pathPermissionDatas) {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -540,6 +540,11 @@ public class ShadowPackageManagerTest {
     assertThat(providerInfo2.authority).isEqualTo("org.robolectric.authority2");
   }
 
+  @Test(expected = NameNotFoundException.class)
+  public void getProviderInfo_packageNotFoundShouldThrowException() throws Exception {
+    packageManager.getProviderInfo(new ComponentName("non.existent.package", ".tester.FullyQualifiedClassName"), 0);
+  }
+
   @Test
   @Config(manifest = "TestAndroidManifestWithContentProviders.xml")
   public void getProviderInfo_shouldPopulatePermissionsInProviderInfos() throws Exception {


### PR DESCRIPTION
This method should throw an exception when the package name cannot be
resolved as per the Javadocs:-

https://developer.android.com/reference/android/content/pm/PackageManager.html#getProviderInfo(android.content.ComponentName,
int)
