### PR TITLE
Fix './gradlew install' for new 'framework' artifact

### DIFF
--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -42,7 +42,7 @@ jar {
 // change local artifact name to match dependencies
 install {
     repositories.mavenInstaller {
-        pom.artifactId = 'shadows-core'
+        pom.artifactId = 'framework'
     }
 }
 


### PR DESCRIPTION
In #3186 the `shadows-core` artifact was renamed `framework`.
Update its build.gradle file to use the new `framework` artifact
id when performing a `gradlew install`.