### PR TITLE
Create ShadowShortcutManager

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowShortcutManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowShortcutManagerTest.java
@@ -1,0 +1,183 @@
+package org.robolectric.shadows;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.content.pm.ShortcutInfo;
+import android.content.pm.ShortcutManager;
+import android.os.Build;
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.TestRunners;
+import org.robolectric.annotation.Config;
+
+/** Unit tests for ShadowShortcutManager. */
+@Config(minSdk = Build.VERSION_CODES.N_MR1)
+@RunWith(TestRunners.MultiApiSelfTest.class)
+public final class ShadowShortcutManagerTest {
+  private ShortcutManager shortcutManager;
+
+  @Before
+  public void setUp() {
+    shortcutManager =
+        (ShortcutManager) RuntimeEnvironment.application.getSystemService(Context.SHORTCUT_SERVICE);
+  }
+
+  @Test
+  public void testDynamicShortcuts_twoAdded() throws Exception {
+    shortcutManager.addDynamicShortcuts(
+        ImmutableList.of(createShortcut("id1"), createShortcut("id2")));
+    assertThat(shortcutManager.getDynamicShortcuts()).hasSize(2);
+  }
+
+  @Test
+  public void testDynamicShortcuts_duplicateGetsDeduped() throws Exception {
+    shortcutManager.addDynamicShortcuts(
+        ImmutableList.of(createShortcut("id1"), createShortcut("id1")));
+    assertThat(shortcutManager.getDynamicShortcuts()).hasSize(1);
+  }
+
+  @Test
+  public void testDynamicShortcuts_immutableShortcutDoesntGetUpdated() throws Exception {
+    ShortcutInfo shortcut1 = createShortcut("id1", true /* isImmutable */);
+    when(shortcut1.getLongLabel()).thenReturn("original");
+    ShortcutInfo shortcut2 = createShortcut("id1", true /* isImmutable */);
+    when(shortcut2.getLongLabel()).thenReturn("updated");
+
+    shortcutManager.addDynamicShortcuts(ImmutableList.of(shortcut1));
+    assertThat(shortcutManager.getDynamicShortcuts()).hasSize(1);
+    shortcutManager.addDynamicShortcuts(ImmutableList.of(shortcut2));
+    assertThat(shortcutManager.getDynamicShortcuts()).hasSize(1);
+    assertThat(shortcutManager.getDynamicShortcuts().get(0).getLongLabel()).isEqualTo("original");
+  }
+
+  @Test
+  public void testShortcutWithIdenticalIdGetsUpdated() throws Exception {
+    ShortcutInfo shortcut1 = createShortcut("id1");
+    when(shortcut1.getLongLabel()).thenReturn("original");
+    ShortcutInfo shortcut2 = createShortcut("id1");
+    when(shortcut2.getLongLabel()).thenReturn("updated");
+
+    shortcutManager.addDynamicShortcuts(ImmutableList.of(shortcut1));
+    assertThat(shortcutManager.getDynamicShortcuts()).hasSize(1);
+    shortcutManager.addDynamicShortcuts(ImmutableList.of(shortcut2));
+    assertThat(shortcutManager.getDynamicShortcuts()).hasSize(1);
+    assertThat(shortcutManager.getDynamicShortcuts().get(0).getLongLabel()).isEqualTo("updated");
+  }
+
+  @Test
+  public void testRemoveAllDynamicShortcuts() throws Exception {
+    shortcutManager.addDynamicShortcuts(
+        ImmutableList.of(createShortcut("id1"), createShortcut("id2")));
+    assertThat(shortcutManager.getDynamicShortcuts()).hasSize(2);
+
+    shortcutManager.removeAllDynamicShortcuts();
+    assertThat(shortcutManager.getDynamicShortcuts()).isEmpty();
+  }
+
+  @Test
+  public void testRemoveDynamicShortcuts() throws Exception {
+    ShortcutInfo shortcut1 = createShortcut("id1");
+    ShortcutInfo shortcut2 = createShortcut("id2");
+    shortcutManager.addDynamicShortcuts(
+        ImmutableList.of(shortcut1, shortcut2));
+    assertThat(shortcutManager.getDynamicShortcuts()).hasSize(2);
+
+    shortcutManager.removeDynamicShortcuts(ImmutableList.of("id1"));
+    assertThat(shortcutManager.getDynamicShortcuts()).containsExactlyInAnyOrder(shortcut2);
+  }
+
+  @Test
+  public void testSetDynamicShortcutsClearOutOldList() throws Exception {
+    ShortcutInfo shortcut1 = createShortcut("id1");
+    ShortcutInfo shortcut2 = createShortcut("id2");
+    ShortcutInfo shortcut3 = createShortcut("id3");
+    ShortcutInfo shortcut4 = createShortcut("id4");
+
+    shortcutManager.addDynamicShortcuts(ImmutableList.of(shortcut1, shortcut2));
+    assertThat(shortcutManager.getDynamicShortcuts()).containsExactlyInAnyOrder(shortcut1, shortcut2);
+    shortcutManager.setDynamicShortcuts(ImmutableList.of(shortcut3, shortcut4));
+    assertThat(shortcutManager.getDynamicShortcuts()).containsExactlyInAnyOrder(shortcut3, shortcut4);
+  }
+
+  @Test
+  public void testUpdateShortcut_dynamic() throws Exception {
+    ShortcutInfo shortcut1 = createShortcut("id1");
+    when(shortcut1.getLongLabel()).thenReturn("original");
+    ShortcutInfo shortcutUpdated = createShortcut("id1");
+    when(shortcutUpdated.getLongLabel()).thenReturn("updated");
+    shortcutManager.addDynamicShortcuts(
+        ImmutableList.of(shortcut1));
+    assertThat(shortcutManager.getDynamicShortcuts()).containsExactly(shortcut1);
+
+    shortcutManager.updateShortcuts(ImmutableList.of(shortcutUpdated));
+    assertThat(shortcutManager.getDynamicShortcuts()).containsExactly(shortcutUpdated);
+  }
+
+  @Test
+  @Config(minSdk = Build.VERSION_CODES.O)
+  public void testUpdateShortcut_pinned() throws Exception {
+    ShortcutInfo shortcut1 = createShortcut("id1");
+    when(shortcut1.getLongLabel()).thenReturn("original");
+    ShortcutInfo shortcutUpdated = createShortcut("id1");
+    when(shortcutUpdated.getLongLabel()).thenReturn("updated");
+    shortcutManager.requestPinShortcut(
+        shortcut1, null /* resultIntent */);
+    assertThat(shortcutManager.getPinnedShortcuts()).containsExactly(shortcut1);
+
+    shortcutManager.updateShortcuts(ImmutableList.of(shortcutUpdated));
+    assertThat(shortcutManager.getPinnedShortcuts()).containsExactly(shortcutUpdated);
+  }
+
+  @Test
+  public void testUpdateShortcutsOnlyUpdatesExistingShortcuts() throws Exception {
+    ShortcutInfo shortcut1 = createShortcut("id1");
+    when(shortcut1.getLongLabel()).thenReturn("original");
+    ShortcutInfo shortcutUpdated = createShortcut("id1");
+    when(shortcutUpdated.getLongLabel()).thenReturn("updated");
+    ShortcutInfo shortcut2 = createShortcut("id2");
+
+    shortcutManager.addDynamicShortcuts(ImmutableList.of(shortcut1));
+    assertThat(shortcutManager.getDynamicShortcuts()).containsExactlyInAnyOrder(shortcut1);
+    shortcutManager.updateShortcuts(ImmutableList.of(shortcutUpdated, shortcut2));
+    assertThat(shortcutManager.getDynamicShortcuts()).containsExactlyInAnyOrder(shortcutUpdated);
+    assertThat(shortcutManager.getDynamicShortcuts().get(0).getLongLabel()).isEqualTo("updated");
+  }
+
+  @Test
+  @Config(minSdk = Build.VERSION_CODES.O)
+  public void testPinningExistingDynamicShortcut() throws Exception {
+    ShortcutInfo shortcut1 = createShortcut("id1");
+    ShortcutInfo shortcut2 = createShortcut("id2");
+    shortcutManager.addDynamicShortcuts(ImmutableList.of(shortcut1, shortcut2));
+    assertThat(shortcutManager.getDynamicShortcuts()).hasSize(2);
+
+    shortcutManager.requestPinShortcut(shortcut1, null /* resultIntent */);
+    assertThat(shortcutManager.getDynamicShortcuts()).containsExactlyInAnyOrder(shortcut2);
+    assertThat(shortcutManager.getPinnedShortcuts()).containsExactlyInAnyOrder(shortcut1);
+  }
+
+  @Test
+  @Config(minSdk = Build.VERSION_CODES.O)
+  public void testPinningNewShortcut() throws Exception {
+    ShortcutInfo shortcut1 = createShortcut("id1");
+    shortcutManager.requestPinShortcut(shortcut1, null /* resultIntent */);
+    assertThat(shortcutManager.getPinnedShortcuts()).containsExactlyInAnyOrder(shortcut1);
+  }
+
+  private static ShortcutInfo createShortcut(String id) {
+    return createShortcut(id, false /* isImmutable */);
+  }
+
+  private static ShortcutInfo createShortcut(String id, boolean isImmutable) {
+    ShortcutInfo shortcut = mock(ShortcutInfo.class);
+    when(shortcut.getId()).thenReturn(id);
+    when(shortcut.isImmutable()).thenReturn(isImmutable);
+    return shortcut;
+  }
+}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
@@ -1,5 +1,9 @@
 package org.robolectric.shadows;
 
+import static android.os.Build.VERSION_CODES.*;
+import static org.robolectric.RuntimeEnvironment.getApiLevel;
+import static org.robolectric.shadow.api.Shadow.newInstanceOf;
+
 import android.accounts.IAccountManager;
 import android.app.admin.IDevicePolicyManager;
 import android.content.BroadcastReceiver;
@@ -21,6 +25,9 @@ import android.os.Looper;
 import android.os.UserHandle;
 import android.view.Display;
 import android.view.accessibility.AccessibilityManager;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -28,14 +35,6 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
-
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-
-import static android.os.Build.VERSION_CODES.*;
-import static org.robolectric.RuntimeEnvironment.getApiLevel;
-import static org.robolectric.shadow.api.Shadow.newInstanceOf;
 
 @Implements(className = ShadowContextImpl.CLASS_NAME)
 public class ShadowContextImpl {
@@ -99,6 +98,9 @@ public class ShadowContextImpl {
     }
     if (getApiLevel() >= LOLLIPOP_MR1) {
       SYSTEM_SERVICE_MAP.put(Context.TELEPHONY_SUBSCRIPTION_SERVICE, "android.telephony.SubscriptionManager");
+    }
+    if (getApiLevel() >= N_MR1) {
+      SYSTEM_SERVICE_MAP.put(Context.SHORTCUT_SERVICE, "android.content.pm.ShortcutManager");
     }
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowShortcutManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowShortcutManager.java
@@ -1,0 +1,190 @@
+package org.robolectric.shadows;
+
+import android.content.Intent;
+import android.content.IntentSender;
+import android.content.IntentSender.SendIntentException;
+import android.content.pm.ShortcutInfo;
+import android.content.pm.ShortcutManager;
+import android.os.Build;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/** */
+@Implements(value = ShortcutManager.class, minSdk = Build.VERSION_CODES.N_MR1)
+public class ShadowShortcutManager {
+
+  private static final int MAX_ICON_DIMENSION = 128;
+  private static final int MAX_NUM_SHORTCUTS_PER_ACTIVITY = 16;
+
+  private final Map<String, ShortcutInfo> dynamicShortcuts = new HashMap<>();
+  private final Map<String, ShortcutInfo> activePinnedShortcuts = new HashMap<>();
+  private final Map<String, ShortcutInfo> disabledPinnedShortcuts = new HashMap<>();
+
+  private boolean isRequestPinShortcutSupported = true;
+
+  @Implementation
+  public boolean addDynamicShortcuts(List<ShortcutInfo> shortcutInfoList) {
+    for (ShortcutInfo shortcutInfo : shortcutInfoList) {
+      if (activePinnedShortcuts.containsKey(shortcutInfo.getId())) {
+        ShortcutInfo previousShortcut = activePinnedShortcuts.get(shortcutInfo.getId());
+        if (!previousShortcut.isImmutable()) {
+          activePinnedShortcuts.put(shortcutInfo.getId(), shortcutInfo);
+        }
+      } else if (disabledPinnedShortcuts.containsKey(shortcutInfo.getId())) {
+        ShortcutInfo previousShortcut = disabledPinnedShortcuts.get(shortcutInfo.getId());
+        if (!previousShortcut.isImmutable()) {
+          disabledPinnedShortcuts.put(shortcutInfo.getId(), shortcutInfo);
+        }
+      } else if (dynamicShortcuts.containsKey(shortcutInfo.getId())) {
+        ShortcutInfo previousShortcut = dynamicShortcuts.get(shortcutInfo.getId());
+        if (!previousShortcut.isImmutable()) {
+          dynamicShortcuts.put(shortcutInfo.getId(), shortcutInfo);
+        }
+      } else {
+        dynamicShortcuts.put(shortcutInfo.getId(), shortcutInfo);
+      }
+    }
+    return true;
+  }
+
+  @Implementation(minSdk = Build.VERSION_CODES.O)
+  public Intent createShortcutResultIntent(ShortcutInfo shortcut) {
+    if (disabledPinnedShortcuts.containsKey(shortcut.getId())) {
+      throw new IllegalArgumentException();
+    }
+    return new Intent();
+  }
+
+  @Implementation
+  public void disableShortcuts(List<String> shortcutIds) {
+    disableShortcuts(shortcutIds, "Shortcut is disabled.");
+  }
+
+  @Implementation
+  public void disableShortcuts(List<String> shortcutIds, CharSequence unused) {
+    for (String shortcutId : shortcutIds) {
+      ShortcutInfo shortcut = activePinnedShortcuts.remove(shortcutId);
+      if (shortcut != null) {
+        disabledPinnedShortcuts.put(shortcutId, shortcut);
+      }
+    }
+  }
+
+  @Implementation
+  public void enableShortcuts(List<String> shortcutIds) {
+    for (String shortcutId : shortcutIds) {
+      ShortcutInfo shortcut = disabledPinnedShortcuts.remove(shortcutId);
+      if (shortcut != null) {
+        activePinnedShortcuts.put(shortcutId, shortcut);
+      }
+    }
+  }
+
+  @Implementation
+  public List<ShortcutInfo> getDynamicShortcuts() {
+    return ImmutableList.copyOf(dynamicShortcuts.values());
+  }
+
+  @Implementation
+  public int getIconMaxHeight() {
+    return MAX_ICON_DIMENSION;
+  }
+
+  @Implementation
+  public int getIconMaxWidth() {
+    return MAX_ICON_DIMENSION;
+  }
+
+  @Implementation
+  public List<ShortcutInfo> getManifestShortcuts() {
+    return ImmutableList.of();
+  }
+
+  @Implementation
+  public int getMaxShortcutCountPerActivity() {
+    return MAX_NUM_SHORTCUTS_PER_ACTIVITY;
+  }
+
+  @Implementation
+  public List<ShortcutInfo> getPinnedShortcuts() {
+    ImmutableList.Builder<ShortcutInfo> pinnedShortcuts = ImmutableList.builder();
+    pinnedShortcuts.addAll(activePinnedShortcuts.values());
+    pinnedShortcuts.addAll(disabledPinnedShortcuts.values());
+    return pinnedShortcuts.build();
+  }
+
+  @Implementation
+  public boolean isRateLimitingActive() {
+    return false;
+  }
+
+  @Implementation(minSdk = Build.VERSION_CODES.O)
+  public boolean isRequestPinShortcutSupported() {
+    return isRequestPinShortcutSupported;
+  }
+
+  public void setIsRequestPinShortcutSupported(boolean isRequestPinShortcutSupported) {
+    this.isRequestPinShortcutSupported = isRequestPinShortcutSupported;
+  }
+
+  @Implementation
+  public void removeAllDynamicShortcuts() {
+    dynamicShortcuts.clear();
+  }
+
+  @Implementation
+  public void removeDynamicShortcuts(List<String> shortcutIds) {
+    for (String shortcutId : shortcutIds) {
+      dynamicShortcuts.remove(shortcutId);
+    }
+  }
+
+  @Implementation
+  public void reportShortcutUsed(String shortcutId) {}
+
+  @Implementation(minSdk = Build.VERSION_CODES.O)
+  public boolean requestPinShortcut(ShortcutInfo shortcut, IntentSender resultIntent) {
+    if (disabledPinnedShortcuts.containsKey(shortcut.getId())) {
+      throw new IllegalArgumentException(
+          "Shortcut with ID [" + shortcut.getId() + "] already exists and is disabled.");
+    }
+    if (dynamicShortcuts.containsKey(shortcut.getId())) {
+      activePinnedShortcuts.put(shortcut.getId(), dynamicShortcuts.remove(shortcut.getId()));
+    } else {
+      activePinnedShortcuts.put(shortcut.getId(), shortcut);
+    }
+    if (resultIntent != null) {
+      try {
+        resultIntent.sendIntent(RuntimeEnvironment.application, 0, null, null, null);
+      } catch (SendIntentException e) {
+        throw new IllegalStateException();
+      }
+    }
+    return true;
+  }
+
+  @Implementation
+  public boolean setDynamicShortcuts(List<ShortcutInfo> shortcutInfoList) {
+    dynamicShortcuts.clear();
+    return addDynamicShortcuts(shortcutInfoList);
+  }
+
+  @Implementation
+  public boolean updateShortcuts(List<ShortcutInfo> shortcutInfoList) {
+    List<ShortcutInfo> existingShortcutsToUpdate = new ArrayList<>();
+    for (ShortcutInfo shortcutInfo : shortcutInfoList) {
+      if (dynamicShortcuts.containsKey(shortcutInfo.getId())
+          || activePinnedShortcuts.containsKey(shortcutInfo.getId())
+          || disabledPinnedShortcuts.containsKey(shortcutInfo.getId())) {
+        existingShortcutsToUpdate.add(shortcutInfo);
+      }
+    }
+    return addDynamicShortcuts(existingShortcutsToUpdate);
+  }
+}


### PR DESCRIPTION
Add a new ShadowShortcutManager (originally introduced in N_MR1) to give robolectric tests (especially those using the O ShortcutManagerCompat) to test shortcut creation.