### PR TITLE
Support overridden packages with AGP3.0

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/DefaultManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/DefaultManifestFactory.java
@@ -60,6 +60,6 @@ public class DefaultManifestFactory implements ManifestFactory {
 
   @Override
   public AndroidManifest create(ManifestIdentifier manifestIdentifier) {
-    return new AndroidManifest(manifestIdentifier.getManifestFile(), manifestIdentifier.getResDir(), manifestIdentifier.getAssetDir());
+    return new AndroidManifest(manifestIdentifier.getManifestFile(), manifestIdentifier.getResDir(), manifestIdentifier.getAssetDir(), manifestIdentifier.getPackageName());
   }
 }

--- a/robolectric/src/test/java/org/robolectric/internal/DefaultManifestFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/DefaultManifestFactoryTest.java
@@ -1,0 +1,53 @@
+package org.robolectric.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.robolectric.annotation.Config.Builder;
+import org.robolectric.manifest.AndroidManifest;
+import org.robolectric.res.FileFsFile;
+
+@RunWith(JUnit4.class)
+public class DefaultManifestFactoryTest {
+
+  @Test
+  public void identify() {
+    Properties properties = new Properties();
+    properties.put("android_merged_manifest", "gradle/AndroidManifest.xml");
+    properties.put("android_merged_resources", "gradle/res");
+    properties.put("android_merged_assets", "gradle/assets");
+    DefaultManifestFactory factory = new DefaultManifestFactory(properties);
+    ManifestIdentifier identifier = factory.identify(Builder.defaults().build());
+    AndroidManifest manifest = factory.create(identifier);
+
+    assertThat(manifest.getAndroidManifestFile())
+        .isEqualTo(FileFsFile.from("gradle/AndroidManifest.xml"));
+    assertThat(manifest.getResDirectory())
+        .isEqualTo(FileFsFile.from("gradle/res"));
+    assertThat(manifest.getAssetsDirectory())
+        .isEqualTo(FileFsFile.from("gradle/assets"));
+  }
+
+  @Test
+  public void identify_packageCanBeOverridenFromConfig() throws Exception {
+    Properties properties = new Properties();
+    properties.put("android_merged_manifest", "gradle/AndroidManifest.xml");
+    properties.put("android_merged_resources", "gradle/res");
+    properties.put("android_merged_assets", "gradle/assets");
+    DefaultManifestFactory factory = new DefaultManifestFactory(properties);
+    ManifestIdentifier identifier = factory.identify(Builder.defaults().setPackageName("overridden.package").build());
+    AndroidManifest manifest = factory.create(identifier);
+
+    assertThat(manifest.getAndroidManifestFile())
+        .isEqualTo(FileFsFile.from("gradle/AndroidManifest.xml"));
+    assertThat(manifest.getResDirectory())
+        .isEqualTo(FileFsFile.from("gradle/res"));
+    assertThat(manifest.getAssetsDirectory())
+        .isEqualTo(FileFsFile.from("gradle/assets"));
+    assertThat(manifest.getRClassName())
+        .isEqualTo("overridden.package.R");
+  }
+}


### PR DESCRIPTION
Allows package name to be overridden in @Config(packageName = ) which is
necessary when R classes are generated in packages other than that
defined in the manifest.

This is still necessary while we parse R classes to obtain the resource
IDs.

When we switch to ARSC files we will no longer need to read R classes
and this can be removed.