### PR TITLE
Close test_config.properties after reading it.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -362,6 +362,12 @@ public class RobolectricTestRunner extends SandboxTestRunner {
       return properties;
     } catch (IOException e) {
       return null;
+    } finally {
+      try {
+        resourceAsStream.close();
+      } catch (IOException e) {
+        throw new RuntimeException("couldn't close test_config.properties", e);
+      }
     }
   }
 


### PR DESCRIPTION
### Overview
Closes the test_config.properties after we are done reading it. Not closing it causes the file to remain open and leak file descriptors.