### PR TITLE
Work around test failure caused by Travis host update.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTimeTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTimeTest.java
@@ -371,7 +371,9 @@ public class ShadowTimeTest {
   @Test
   public void shouldFormat2445() throws Exception {
     Time t = new Time();
+    t.timezone = "PST";
     assertEquals("19700101T000000", t.format2445());
+    
     t.timezone = Time.TIMEZONE_UTC;
     //2445 formatted date should hava a Z postfix
     assertEquals("19700101T000000Z",t.format2445());


### PR DESCRIPTION
Fixes [failures](https://travis-ci.org/robolectric/robolectric/jobs/254995438) probably related to:

` This job ran on our Trusty environment, which was updated on Wednesday, July 12th. Read all about it in the docs and take note that you can add group: deprecated-2017Q3 in your .travis.yml file to use the previous version.`

i.e.:

```
org.robolectric.shadows.ShadowTimeTest > shouldFormat2445[18] FAILED
    org.junit.ComparisonFailure: expected:<19700101T000000[]> but was:<19700101T000000[Z]>
        at org.junit.Assert.assertEquals(Assert.java:115)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at org.robolectric.shadows.ShadowTimeTest.shouldFormat2445(ShadowTimeTest.java:374)
org.robolectric.shadows.ShadowTimeTest > shouldFormat2445[19] FAILED
    org.junit.ComparisonFailure: expected:<19700101T000000[]> but was:<19700101T000000[Z]>
        at org.junit.Assert.assertEquals(Assert.java:115)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at org.robolectric.shadows.ShadowTimeTest.shouldFormat2445(ShadowTimeTest.java:374)
org.robolectric.shadows.ShadowTimeTest > shouldFormat2445 FAILED
    org.junit.ComparisonFailure: expected:<19700101T000000[]> but was:<19700101T000000[Z]>
        at org.junit.Assert.assertEquals(Assert.java:115)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at org.robolectric.shadows.ShadowTimeTest.shouldFormat2445(ShadowTimeTest.java:374)
```