### PR TITLE
Do not leak assertj into compile scope

### DIFF
--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -12,6 +12,6 @@ dependencies {
 
     // Testing dependencies
     testCompile "junit:junit:4.12"
-    compile "org.assertj:assertj-core:3.8.0"
+    testCompile "org.assertj:assertj-core:3.8.0"
     testCompile "org.mockito:mockito-core:2.5.4"
 }


### PR DESCRIPTION
robolectric 3.4-rc4 is leaking assertj 3.8 transitively, it should be a test only dependency