### PR TITLE
[ShadowChoreographer] Allows customized delay to be specified by application for postCallback and postFrameCallback to avoid animation problems during test.

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowChoreographer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowChoreographer.java
@@ -26,6 +26,7 @@ public class ShadowChoreographer {
   private static final Thread MAIN_THREAD = Thread.currentThread();
   private static SoftThreadLocal<Choreographer> instance = makeThreadLocal();
   private Handler handler = new Handler(Looper.myLooper());
+  private static volatile int postCallbackDelayMillis = 0;
 
   private static SoftThreadLocal<Choreographer> makeThreadLocal() {
     return new SoftThreadLocal<Choreographer>() {
@@ -47,9 +48,23 @@ public class ShadowChoreographer {
     };
   }
 
+  /**
+   * Allows application to specify a fixed amount of delay when postFrameCallback or postCallback is
+   * invoked. The default delay value is 0. This can be used to avoid infinite animation tasks to be
+   * spawned when the Robolectric scheduler is in paused mode.
+   */
+  public static void setPostCallbackDeley(int delayMillis) {
+    postCallbackDelayMillis = delayMillis;
+  }
+
   @Implementation
   public static Choreographer getInstance() {
     return instance.get();
+  }
+
+  @Implementation
+  public void postCallback(int callbackType, Runnable action, Object token) {
+    postCallbackDelayed(callbackType, action, token, postCallbackDelayMillis);
   }
 
   @Implementation
@@ -60,6 +75,24 @@ public class ShadowChoreographer {
   @Implementation
   public void removeCallbacks(int callbackType, Runnable action, Object token) {
     handler.removeCallbacks(action, token);
+  }
+
+  /**
+   * The default implementation will call postFrameCallbackDelayed with 0 delay. AnimationHandler
+   * is calling this method to schedule animation update infinitely. Because during Robolectric
+   * test,
+   * the system time is paused and execution of event loop is invoked for each test instruction,
+   * the behavior of AnimationHandler would result in endless generation of its animation update
+   * task
+   * (the execution of the task results in a new animation task created and scheduled to the front
+   * of the event loop queue).
+   *
+   * So it makes sense to allow application to specify a small amount of delay during animation
+   * schedule in Robolectric tests to avoid the endless loop.
+   */
+  @Implementation
+  public void postFrameCallback(final Choreographer.FrameCallback callback) {
+    postFrameCallbackDelayed(callback, postCallbackDelayMillis);
   }
 
   @Implementation


### PR DESCRIPTION
[ShadowChoreographer] Allows customized delay to be specified by application for postCallback and postFrameCallback to avoid animation problems during test.