### PR TITLE
Fixing the ShadowAccountManager so that it appropriately returns a value in getResult(). Currently the implementation is bugged in that because it posts a runnable to the scheduler. However, the implementation of getResult() doesn't block to ensure that actually works.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
@@ -1,5 +1,12 @@
 package org.robolectric.shadows;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
+import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.robolectric.Shadows.shadowOf;
+
 import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.accounts.AccountManagerCallback;
@@ -13,6 +20,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
+import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,15 +29,6 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.Scheduler;
-
-import java.io.IOException;
-
-import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
-import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(TestRunners.MultiApiSelfTest.class)
 public class ShadowAccountManagerTest {
@@ -511,13 +510,10 @@ public class ShadowAccountManagerTest {
     TestAccountManagerCallback<Bundle> callback = new TestAccountManagerCallback<>();
     AccountManagerFuture<Bundle> result = am.addAccount("google.com", "auth_token_type", null, null, activity, callback, new Handler());
     assertThat(callback.hasBeenCalled()).isFalse();
-    assertThat(result.isDone()).isFalse();
 
     shadowOf(am).addAccount(new Account("thebomb@google.com", "google.com"));
 
     scheduler.unPause();
-
-    assertThat(result.isDone()).isTrue();
     assertThat(callback.hasBeenCalled()).isTrue();
 
     Bundle resultBundle = callback.getResult();
@@ -618,27 +614,6 @@ public class ShadowAccountManagerTest {
   }
 
   @Test
-  public void whenPaused_getAuthToken() throws Exception {
-    scheduler.pause();
-    Account account = new Account("name", "google.com");
-    shadowOf(am).addAccount(account);
-    shadowOf(am).addAuthenticator("google.com");
-
-    am.setAuthToken(account, "auth_token_type", "token1");
-
-    TestAccountManagerCallback<Bundle> callback = new TestAccountManagerCallback<>();
-    AccountManagerFuture<Bundle> future = am.getAuthToken(account, "auth_token_type", new Bundle(), activity, callback, new Handler());
-
-    assertThat(future.isDone()).isFalse();
-    assertThat(callback.hasBeenCalled()).isFalse();
-
-    scheduler.unPause();
-
-    assertThat(future.isDone()).isTrue();
-    assertThat(callback.hasBeenCalled()).isTrue();
-  }
-
-  @Test
   public void getHasFeatures_returnsTrueWhenAllFeaturesSatisfied() throws Exception {
     Account account = new Account("name", "google.com");
     shadowOf(am).addAccount(account);
@@ -650,27 +625,6 @@ public class ShadowAccountManagerTest {
     assertThat(future.isDone()).isTrue();
     assertThat(future.getResult().booleanValue()).isEqualTo(true);
 
-    assertThat(callback.hasBeenCalled()).isTrue();
-  }
-
-  @Test
-  public void whenSchedulerPaused_getHasFeatures_returnsTrueWhenAllFeaturesSatisfied() throws Exception {
-    scheduler.pause();
-
-    Account account = new Account("name", "google.com");
-    shadowOf(am).addAccount(account);
-    shadowOf(am).setFeatures(account, new String[] { "FEATURE_1", "FEATURE_2" });
-
-    TestAccountManagerCallback<Boolean> callback = new TestAccountManagerCallback<>();
-    AccountManagerFuture<Boolean> future = am.hasFeatures(account, new String[] { "FEATURE_1", "FEATURE_2" }, callback, new Handler());
-
-    assertThat(future.isDone()).isFalse();
-    assertThat(callback.hasBeenCalled()).isFalse();
-    assertThat(future.getResult()).isNull();
-
-    scheduler.unPause();
-    assertThat(future.getResult().booleanValue()).isEqualTo(true);
-    assertThat(future.isDone()).isTrue();
     assertThat(callback.hasBeenCalled()).isTrue();
   }
 
@@ -711,28 +665,6 @@ public class ShadowAccountManagerTest {
     assertThat(future.isDone()).isTrue();
     assertThat(future.getResult()).containsOnly(accountWithCorrectTypeAndFeatures);
 
-    assertThat(callback.hasBeenCalled()).isTrue();
-  }
-
-  @Test
-  public void whenSchedulerPaused_getAccountsByTypeAndFeatures() throws Exception {
-    scheduler.pause();
-
-    Account accountWithCorrectTypeAndFeatures = new Account("account_1", "google.com");
-    shadowOf(am).addAccount(accountWithCorrectTypeAndFeatures);
-    shadowOf(am).setFeatures(accountWithCorrectTypeAndFeatures, new String[] { "FEATURE_1", "FEATURE_2" });
-
-    TestAccountManagerCallback<Account[]> callback = new TestAccountManagerCallback<>();
-
-    AccountManagerFuture<Account[]> future = am.getAccountsByTypeAndFeatures("google.com", new String[] { "FEATURE_1", "FEATURE_2" }, callback, new Handler());
-
-    assertThat(future.isDone()).isFalse();
-    assertThat(callback.hasBeenCalled()).isFalse();
-
-    scheduler.unPause();
-    assertThat(future.getResult()).containsOnly(accountWithCorrectTypeAndFeatures);
-
-    assertThat(future.isDone()).isTrue();
     assertThat(callback.hasBeenCalled()).isTrue();
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
@@ -1,23 +1,22 @@
 package org.robolectric.shadows;
 
+import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
+import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
+
 import android.accounts.*;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
-import org.robolectric.annotation.Implementation;
-import org.robolectric.annotation.Implements;
-
 import java.io.IOException;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
 import org.robolectric.util.Scheduler.IdleState;
-
-import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
-import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
 
 @Implements(AccountManager.class)
 public class ShadowAccountManager {
@@ -100,20 +99,20 @@ public class ShadowAccountManager {
         return false;
       }
     }
-    
+
     if (!accounts.add(account)) {
-    	return false;
+      return false;
     }
-    
+
     setPassword(account, password);
-    
+
     if(userdata != null) {
       for (String key : userdata.keySet()) {
         setUserData(account, key, userdata.get(key).toString());
       }
     }
-    
-    return true;    
+
+    return true;
   }
 
   @Implementation
@@ -145,12 +144,14 @@ public class ShadowAccountManager {
       throw new IllegalArgumentException("account is null");
     }
 
-	  return start(new BaseRoboAccountManagerFuture<Boolean>(callback, handler) {
-      @Override
-      public Boolean doWork() throws OperationCanceledException, IOException, AuthenticatorException {
-        return removeAccountExplicitly(account);
-      }
-    });
+    return start(
+        new BaseRoboAccountManagerFuture<Boolean>(callback, handler) {
+          @Override
+          public Boolean doWork()
+              throws OperationCanceledException, IOException, AuthenticatorException {
+            return removeAccountExplicitly(account);
+          }
+        });
   }
 
   @Implementation(minSdk = LOLLIPOP_MR1)
@@ -203,53 +204,53 @@ public class ShadowAccountManager {
     if (!userData.containsKey(account)) {
       return null;
     }
-    
+
     Map<String, String> userDataMap = userData.get(account);
     if (userDataMap.containsKey(key)) {
       return userDataMap.get(key);
     }
 
-	return null;
+    return null;
   }
-  
+
   @Implementation
   public void setUserData(Account account, String key, String value) {
     if (account == null) {
       throw new IllegalArgumentException("account is null");
     }
-    
+
     if (!userData.containsKey(account)) {
       userData.put(account, new HashMap<String, String>());
     }
-    
+
     Map<String, String> userDataMap = userData.get(account);
-    
+
     if (value == null) {
       userDataMap.remove(key);
     } else {
       userDataMap.put(key, value);
     }
   }
-  
+
   @Implementation
   public void setPassword (Account account, String password) {
     if (account == null) {
       throw new IllegalArgumentException("account is null");
     }
-    
+
     if (password == null) {
       passwords.remove(account);
     } else {
       passwords.put(account, password);
     }
   }
-  
+
   @Implementation
   public String getPassword (Account account) {
     if (account == null) {
       throw new IllegalArgumentException("account is null");
     }
-	
+
     if (passwords.containsKey(account)) {
       return passwords.get(account);
     } else {
@@ -507,19 +508,21 @@ public class ShadowAccountManager {
       if (started) return;
       started = true;
 
-      handler.post(new Runnable() {
-        @Override
-        public void run() {
-          try {
-            result = doWork();
-          } catch (OperationCanceledException | IOException | AuthenticatorException e) {
-            exception = e;
-          }
-          if (callback != null) {
-            callback.run(BaseRoboAccountManagerFuture.this);
-          }
-        }
-      });
+      try {
+        result = doWork();
+      } catch (OperationCanceledException | IOException | AuthenticatorException e) {
+        exception = e;
+      }
+
+      if (callback != null) {
+        handler.post(
+            new Runnable() {
+              @Override
+              public void run() {
+                callback.run(BaseRoboAccountManagerFuture.this);
+              }
+            });
+      }
     }
 
     @Override


### PR DESCRIPTION
Fixing the ShadowAccountManager so that it appropriately returns a value in getResult(). Currently the implementation is bugged in that because it posts a runnable to the scheduler. However, the implementation of getResult() doesn't block to ensure that actually works.

Per documentation at https://developer.android.com/reference/android/accounts/AccountManagerFuture.html#getResult(): "This call will block until the result is available.", which means if you try to access the result right away, the shadow will return null and can cause NPEs in correct existing code.
