### PR TITLE
Add ability to get the DropDownViewResourceId

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArrayAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArrayAdapter.java
@@ -17,4 +17,8 @@ public class ShadowArrayAdapter<T> extends ShadowBaseAdapter {
   public int getResourceId() {
     return ReflectionHelpers.getField(realArrayAdapter, "mResource");
   }
+  
+  public int getDropDownViewResourceId() {
+    return ReflectionHelpers.getField(realArrayAdapter, "mDropDownResource");
+  }
 }


### PR DESCRIPTION
### Overview

When unit testing, a view that has a Spinner, and you use setDropDownResourceId method on the ArrayAdapter, there is no current way to make sure that the appropriate Resource was set.

### Proposed Changes

This adds the ability to get the DropDownViewResource id that is set on the ArrayAdapter, so that it can be verified during a unit test that it was set to the expected resource Id.

