### PR TITLE
Adding attributes and intent filters to BroadcastReceiverData and ServiceData

### DIFF
--- a/resources/src/main/java/org/robolectric/manifest/ActivityData.java
+++ b/resources/src/main/java/org/robolectric/manifest/ActivityData.java
@@ -86,7 +86,7 @@ public class ActivityData {
   }
 
   public boolean isExported() {
-    boolean defaultValue = false;
+    boolean defaultValue = !intentFilters.isEmpty();
     return getBooleanAttr(withXMLNS(EXPORTED), defaultValue);
   }
 

--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -246,13 +246,28 @@ public class AndroidManifest {
 
   private void parseReceivers(Node applicationNode) {
     for (Node receiverNode : getChildrenTags(applicationNode, "receiver")) {
-      Node namedItem = receiverNode.getAttributes().getNamedItem("android:name");
-      if (namedItem == null) continue;
+      final NamedNodeMap attributes = receiverNode.getAttributes();
+      final int attrCount = attributes.getLength();
+      final HashMap<String, String> receiverAttrs = new HashMap<>(attributes.getLength());
+      for(int i = 0; i < attrCount; i++) {
+        Node attr = attributes.item(i);
+        String v = attr.getNodeValue();
+        if( v != null) {
+          receiverAttrs.put(attr.getNodeName(), v);
+        }
+      }
 
-      String receiverName = resolveClassRef(namedItem.getTextContent());
+      String receiverName = resolveClassRef(receiverAttrs.get("android:name"));
+      if (receiverName == null) {
+        continue;
+      }
+      receiverAttrs.put("android:name", receiverName);
+
       MetaData metaData = new MetaData(getChildrenTags(receiverNode, "meta-data"));
 
-      BroadcastReceiverData receiver = new BroadcastReceiverData(receiverName, metaData);
+      final List<IntentFilterData> intentFilterData = parseIntentFilters(receiverNode);
+      BroadcastReceiverData receiver = new BroadcastReceiverData(receiverAttrs, metaData,
+          intentFilterData);
       List<Node> intentFilters = getChildrenTags(receiverNode, "intent-filter");
       for (Node intentFilterNode : intentFilters) {
         for (Node actionNode : getChildrenTags(intentFilterNode, "action")) {
@@ -262,12 +277,7 @@ public class AndroidManifest {
           }
         }
       }
-      
-      Node permissionItem = receiverNode.getAttributes().getNamedItem("android:permission");
-      if (permissionItem != null) {
-        receiver.setPermission(permissionItem.getTextContent());
-      }
-      
+
       receivers.add(receiver);
     }
   }
@@ -669,5 +679,22 @@ public class AndroidManifest {
   public Map<String, PermissionItemData> getPermissions() {
     parseAndroidManifest();
     return permissions;
+  }
+
+  /**
+   * Returns data for the broadcast receiver with the provided name from this manifest. If no
+   * receiver with the class name can be found, returns null.
+   *
+   * @param className the fully resolved class name of the receiver
+   * @return data for the receiver or null if it cannot be found
+   */
+  public @Nullable BroadcastReceiverData getBroadcastReceiver(String className) {
+    parseAndroidManifest();
+    for (BroadcastReceiverData receiver : receivers) {
+      if (receiver.getClassName().equals(className)) {
+        return receiver;
+      }
+    }
+    return null;
   }
 }

--- a/resources/src/main/java/org/robolectric/manifest/BroadcastReceiverData.java
+++ b/resources/src/main/java/org/robolectric/manifest/BroadcastReceiverData.java
@@ -1,15 +1,34 @@
 package org.robolectric.manifest;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 public class BroadcastReceiverData extends PackageItemData {
+
+  private static final String EXPORTED = "android:exported";
+  private static final String NAME = "android:name";
+  private static final String PERMISSION = "android:permission";
+
+  private final Map<String, String> attributes;
   private final List<String> actions;
-  private String permission;
+  private List<IntentFilterData> intentFilters;
+
+  public BroadcastReceiverData(Map<String, String> attributes, MetaData metaData,
+      List<IntentFilterData> intentFilters) {
+    super(attributes.get(NAME), metaData);
+    this.attributes = attributes;
+    this.actions = new ArrayList<>();
+    this.intentFilters = new LinkedList<>(intentFilters);
+  }
 
   public BroadcastReceiverData(String className, MetaData metaData) {
     super(className, metaData);
     this.actions = new ArrayList<>();
+    this.attributes = new HashMap<>();
+    intentFilters = new LinkedList<>();
   }
 
   public List<String> getActions() {
@@ -21,10 +40,33 @@ public class BroadcastReceiverData extends PackageItemData {
   }
 
   public void setPermission(final String permission) {
-    this.permission = permission;
+    attributes.put(PERMISSION, permission);
   }
 
-  public String getPermission() {
-    return permission;
+  public String getPermission() { return attributes.get(PERMISSION); }
+
+  /**
+   * Get the intent filters defined for the broadcast receiver.
+   * @return A list of intent filters. Not null.
+   */
+  public List<IntentFilterData> getIntentFilters() {
+    return intentFilters;
+  }
+
+  /**
+   * Get the map for all attributes defined for the broadcast receiver.
+   * @return map of attributes names to values from the manifest. Not null.
+   */
+  public Map<String, String> getAllAttributes() {
+    return attributes;
+  }
+
+  /**
+   * Returns whether this broadcast receiver is exported by checking the XML attribute.
+   * @return true if the broadcast receiver is exported
+   */
+  public boolean isExported() {
+    boolean defaultValue = !intentFilters.isEmpty();
+    return (attributes.containsKey(EXPORTED) ? Boolean.parseBoolean(attributes.get(EXPORTED)): defaultValue);
   }
 }

--- a/resources/src/main/java/org/robolectric/manifest/ServiceData.java
+++ b/resources/src/main/java/org/robolectric/manifest/ServiceData.java
@@ -1,25 +1,40 @@
 package org.robolectric.manifest;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 public class ServiceData {
-  private final String className;
+
+  private static final String EXPORTED = "android:exported";
+  private static final String NAME = "android:name";
+  private static final String PERMISSION = "android:permission";
+
+  private final Map<String, String> attributes;
   private final MetaData metaData;
   private final List<String> actions;
-  private String permission;
   private List<IntentFilterData> intentFilters;
 
-  public ServiceData(String className, MetaData metaData, List<IntentFilterData> intentFilterData) {
+  public ServiceData(Map<String, String> attributes, MetaData metaData,
+      List<IntentFilterData> intentFilters) {
+    this.attributes = attributes;
     this.actions = new ArrayList<>();
-    this.className = className;
+    this.metaData = metaData;
+    this.intentFilters = new LinkedList<>(intentFilters);
+  }
+
+  public ServiceData(String className, MetaData metaData, List<IntentFilterData> intentFilterData) {
+    this.attributes = new HashMap<>();
+    this.attributes.put(NAME, className);
+    this.actions = new ArrayList<>();
     this.metaData = metaData;
     intentFilters = new LinkedList<>(intentFilterData);
   }
 
   public String getClassName() {
-    return className;
+    return attributes.get(NAME);
   }
 
   public List<String> getActions() {
@@ -35,18 +50,34 @@ public class ServiceData {
   }
 
   public void setPermission(final String permission) {
-    this.permission = permission;
+    attributes.put(PERMISSION, permission);
   }
 
-  public String getPermission() {
-    return permission;
-  }
+  public String getPermission() { return attributes.get(PERMISSION); }
 
   /**
-   * Get the intent filters defined for activity.
+   * Get the intent filters defined for the service.
    * @return A list of intent filters. Not null.
    */
   public List<IntentFilterData> getIntentFilters() {
     return intentFilters;
   }
+
+  /**
+   * Get the map for all attributes defined for the service.
+   * @return map of attributes names to values from the manifest. Not null.
+   */
+  public Map<String, String> getAllAttributes() {
+    return attributes;
+  }
+
+  /**
+   * Returns whether this service is exported by checking the XML attribute.
+   * @return true if the service is exported
+   */
+  public boolean isExported() {
+    boolean defaultValue = !intentFilters.isEmpty();
+    return (attributes.containsKey(EXPORTED) ? Boolean.parseBoolean(attributes.get(EXPORTED)): defaultValue);
+  }
+
 }

--- a/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
+++ b/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
@@ -77,6 +77,9 @@ public class AndroidManifestTest {
 
     assertThat(config.getBroadcastReceivers().get(5).getClassName()).isEqualTo("com.foo.Receiver");
     assertThat(config.getBroadcastReceivers().get(5).getActions()).contains("org.robolectric.ACTION_DIFFERENT_PACKAGE");
+    assertThat(config.getBroadcastReceivers().get(5).getIntentFilters()).hasSize(1);
+    IntentFilterData filter = config.getBroadcastReceivers().get(5).getIntentFilters().get(0);
+    assertThat(filter.getActions()).containsExactly("org.robolectric.ACTION_DIFFERENT_PACKAGE");
 
     assertThat(config.getBroadcastReceivers().get(6).getClassName()).isEqualTo("com.bar.ReceiverWithoutIntentFilter");
     assertThat(config.getBroadcastReceivers().get(6).getActions()).isEmpty();
@@ -451,6 +454,22 @@ public class AndroidManifestTest {
     AndroidManifest config = newConfig("TestAndroidManifestWithServices.xml");
     ServiceData serviceData = config.getServiceData("com.foo.Service");
     assertThat(serviceData.isExported()).isTrue();
+  }
+
+  @Test
+  public void receiversWithoutIntentFiltersNotExportedByDefault() throws Exception {
+    AndroidManifest config = newConfig("TestAndroidManifestWithReceivers.xml");
+    BroadcastReceiverData receiverData = config.getBroadcastReceiver("com.bar.ReceiverWithoutIntentFilter");
+    assertThat(receiverData).isNotNull();
+    assertThat(receiverData.isExported()).isFalse();
+  }
+
+  @Test
+  public void receiversWithIntentFiltersExportedByDefault() throws Exception {
+    AndroidManifest config = newConfig("TestAndroidManifestWithReceivers.xml");
+    BroadcastReceiverData receiverData = config.getBroadcastReceiver("com.foo.Receiver");
+    assertThat(receiverData).isNotNull();
+    assertThat(receiverData.isExported()).isTrue();
   }
 
   /////////////////////////////

--- a/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
+++ b/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
@@ -438,6 +438,21 @@ public class AndroidManifestTest {
     ActivityData activityData = config.getActivityData("org.robolectric.shadows.TestActivity");
     assertThat(activityData.isExported()).isTrue();
   }
+
+  @Test
+  public void servicesWithoutIntentFiltersNotExportedByDefault() throws Exception {
+    AndroidManifest config = newConfig("TestAndroidManifestWithServices.xml");
+    ServiceData serviceData = config.getServiceData("com.bar.ServiceWithoutIntentFilter");
+    assertThat(serviceData.isExported()).isFalse();
+  }
+
+  @Test
+  public void servicesWithIntentFiltersExportedByDefault() throws Exception {
+    AndroidManifest config = newConfig("TestAndroidManifestWithServices.xml");
+    ServiceData serviceData = config.getServiceData("com.foo.Service");
+    assertThat(serviceData.isExported()).isTrue();
+  }
+
   /////////////////////////////
 
   private AndroidManifest newConfigWith(String fileName, String usesSdkAttrs) throws IOException {

--- a/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
+++ b/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
@@ -425,6 +425,19 @@ public class AndroidManifestTest {
     assertThat(wrongFields).isEmpty();
   }
 
+  @Test
+  public void activitiesWithoutIntentFiltersNotExportedByDefault() throws Exception {
+    AndroidManifest config = newConfig("TestAndroidManifestForActivities.xml");
+    ActivityData activityData = config.getActivityData("org.robolectric.shadows.TestActivity");
+    assertThat(activityData.isExported()).isFalse();
+  }
+
+  @Test
+  public void activitiesWithIntentFiltersExportedByDefault() throws Exception {
+    AndroidManifest config = newConfig("TestAndroidManifestForActivitiesWithIntentFilter.xml");
+    ActivityData activityData = config.getActivityData("org.robolectric.shadows.TestActivity");
+    assertThat(activityData.isExported()).isTrue();
+  }
   /////////////////////////////
 
   private AndroidManifest newConfigWith(String fileName, String usesSdkAttrs) throws IOException {


### PR DESCRIPTION
### Overview

The data parsed from the Android manifest is missing important attributes and intent filters which might be useful during testing.

### Proposed Changes

- Fixing the incorrect default value for isExported in `ActivityData` (an activity with intent filters is exported by default while an activity without intent filters is not exported by default).

- Adding attributes to `ServiceData`, including whether the service is exported etc. This is already available for `ActivityData` but missing in `ServiceData`.

- Adding attributes and intent filters to `BroadcastReceiverData`. In addition to attributes such as `android:exported`, the receiver data should also include the intent filters in the same way that `ActivityData` and `ServiceData` do.