### PR TITLE
Add ShadowInputEventReceiver and no-op consumeBatchedInputEvents.

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInputEventReceiver.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInputEventReceiver.java
@@ -1,0 +1,15 @@
+package org.robolectric.shadows;
+
+import android.view.InputEventReceiver;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(value = InputEventReceiver.class, isInAndroidSdk = false)
+public class ShadowInputEventReceiver {
+  @Implementation
+  public void consumeBatchedInputEvents(long frameTimeNanos) {
+    // The real implementation of this calls a JNI method, and logs a statement if the native
+    // object isn't present. Since the native object will never be present in Robolectric tests, it
+    // ends up being rather spammy in test logs, so we no-op it.
+  }
+}


### PR DESCRIPTION
Add ShadowInputEventReceiver and no-op consumeBatchedInputEvents.

This method outputs a warning log every time it's called in Robolectric tests, so the message being logged isn't actually indicative of anything other than that a ViewRootImpl traversal occurred. This change just no-ops it to keep the log a bit cleaner and more relevant to actual test failures/output.