### PR TITLE
Catch exceptions thrown during filtering and return empty results.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowFilterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowFilterTest.java
@@ -82,4 +82,26 @@ public class ShadowFilterTest {
     });
     assertThat(listenerCalled.get()).isTrue();
   }
+
+  @Test
+  public void testFilter_whenExceptionThrown_ShouldReturn() throws InterruptedException {
+    final AtomicBoolean listenerCalled = new AtomicBoolean(false);
+    Filter filter = new Filter() {
+      @Override
+      protected FilterResults performFiltering(CharSequence charSequence) {
+        throw new RuntimeException("unchecked exception during filtering");
+      }
+
+      @Override
+      protected void publishResults(CharSequence charSequence, FilterResults filterResults) {}
+    };
+    filter.filter("", new Filter.FilterListener() {
+      @Override
+      public void onFilterComplete(int resultCount) {
+        assertThat(resultCount).isEqualTo(0);
+        listenerCalled.set(true);
+      }
+    });
+    assertThat(listenerCalled.get()).isTrue();
+  }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFilter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFilter.java
@@ -15,8 +15,14 @@ public class ShadowFilter {
   public void filter(CharSequence constraint, Filter.FilterListener listener) {
     try {
       Class<?> forName = Class.forName("android.widget.Filter$FilterResults");
-      Object filtering = ReflectionHelpers.callInstanceMethod(realObject, "performFiltering",
-          ClassParameter.from(CharSequence.class, constraint));
+      Object filtering;
+      try {
+        filtering = ReflectionHelpers.callInstanceMethod(realObject, "performFiltering",
+            ClassParameter.from(CharSequence.class, constraint));
+      } catch (Exception e) {
+        e.printStackTrace();
+        filtering = ReflectionHelpers.newInstance(forName);
+      }
 
       ReflectionHelpers.callInstanceMethod(realObject, "publishResults",
           ClassParameter.from(CharSequence.class, constraint),


### PR DESCRIPTION
Catch exceptions thrown during filtering and return empty results.

In contrast to the Robolectric ShadowFilter, the actual Android implementation of android.widget.Filter#filter runs asynchronously. One important difference here is that exceptions thrown during performFiltering are caught by the android.widget.Filter.RequestHandler and an empty set of results is returned.

This pull request changes the ShadowFilter to match the Android Filter and also adds a corresponding unit test.