### PR TITLE
Use a constant version of errorprone as workaround for bug 711

### DIFF
--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(

--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(
@@ -11,4 +11,7 @@ dependencies {
     compile project(":shadowapi")
     compileOnly "com.google.code.findbugs:jsr305:3.0.1"
     compileOnly AndroidSdk.MAX_SDK.coordinates
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }

--- a/integration_tests/dependency-on-stubs/build.gradle
+++ b/integration_tests/dependency-on-stubs/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 apply plugin: RoboJavaModulePlugin

--- a/integration_tests/dependency-on-stubs/build.gradle
+++ b/integration_tests/dependency-on-stubs/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 apply plugin: RoboJavaModulePlugin
@@ -14,4 +14,7 @@ dependencies {
     // Testing dependencies
     testCompile "org.assertj:assertj-core:3.8.0"
     testCompile "org.mockito:mockito-core:2.5.4"
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }

--- a/integration_tests/libphonenumber/build.gradle
+++ b/integration_tests/libphonenumber/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 apply plugin: RoboJavaModulePlugin

--- a/integration_tests/libphonenumber/build.gradle
+++ b/integration_tests/libphonenumber/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 apply plugin: RoboJavaModulePlugin
@@ -13,4 +13,7 @@ dependencies {
     testRuntime AndroidSdk.MAX_SDK_FOR_THIS_JDK.coordinates
     testCompile "org.assertj:assertj-core:2.0.0"
     testCompile 'com.googlecode.libphonenumber:libphonenumber:8.0.0'
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }

--- a/integration_tests/mockito-experimental/build.gradle
+++ b/integration_tests/mockito-experimental/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 apply plugin: RoboJavaModulePlugin

--- a/integration_tests/mockito-experimental/build.gradle
+++ b/integration_tests/mockito-experimental/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 apply plugin: RoboJavaModulePlugin
@@ -14,4 +14,7 @@ dependencies {
     testCompile "org.hamcrest:hamcrest-core:1.3"
     testCompile "org.assertj:assertj-core:2.0.0"
     testCompile "org.mockito:mockito-core:2.5.4"
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }

--- a/integration_tests/mockito/build.gradle
+++ b/integration_tests/mockito/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 apply plugin: RoboJavaModulePlugin

--- a/integration_tests/mockito/build.gradle
+++ b/integration_tests/mockito/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 apply plugin: RoboJavaModulePlugin
@@ -17,4 +17,7 @@ dependencies {
     testCompile "com.android.support:support-fragment:26.0.0-alpha1"
     testCompile "org.assertj:assertj-core:3.8.0"
     testCompile "org.mockito:mockito-core:2.5.4"
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }

--- a/integration_tests/powermock/build.gradle
+++ b/integration_tests/powermock/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 apply plugin: RoboJavaModulePlugin

--- a/integration_tests/powermock/build.gradle
+++ b/integration_tests/powermock/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 apply plugin: RoboJavaModulePlugin
@@ -18,4 +18,7 @@ dependencies {
     testCompile "org.powermock:powermock-module-junit4-rule:1.6.2"
     testCompile "org.powermock:powermock-api-mockito:1.6.2"
     testCompile "org.powermock:powermock-classloading-xstream:1.6.2"
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }

--- a/junit/build.gradle
+++ b/junit/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(

--- a/junit/build.gradle
+++ b/junit/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(
@@ -14,4 +14,7 @@ dependencies {
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.1"
     compileOnly "junit:junit:4.12"
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(
@@ -23,4 +23,7 @@ dependencies {
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:2.5.4"
     testCompile "com.google.testing.compile:compile-testing:0.8"
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }

--- a/resources/build.gradle
+++ b/resources/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(
@@ -20,4 +20,7 @@ dependencies {
     testCompile "org.assertj:assertj-core:3.8.0"
     testCompile "com.google.testing.compile:compile-testing:0.6"
     testCompile "org.mockito:mockito-core:2.5.4"
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }

--- a/resources/build.gradle
+++ b/resources/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(
@@ -50,6 +50,9 @@ dependencies {
     testCompile "org.mockito:mockito-core:2.5.4"
     testCompileOnly AndroidSdk.MAX_SDK.coordinates // compile against latest Android SDK
     testRuntime AndroidSdk.MAX_SDK_FOR_THIS_JDK.coordinates // run against whatever this JDK supports
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }
 
 project.apply plugin: CheckApiChangesPlugin

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(
@@ -21,4 +21,7 @@ dependencies {
     testCompile "org.assertj:assertj-core:3.8.0"
     testCompile "org.mockito:mockito-core:2.5.4"
     testCompile project(":junit")
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(

--- a/shadowapi/build.gradle
+++ b/shadowapi/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(
@@ -14,4 +14,7 @@ dependencies {
     testCompile "junit:junit:4.12"
     testCompile "org.assertj:assertj-core:3.8.0"
     testCompile "org.mockito:mockito-core:2.5.4"
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }

--- a/shadowapi/build.gradle
+++ b/shadowapi/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(

--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(

--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(
@@ -64,4 +64,7 @@ dependencies {
     jni "com.github.axet.litedb:libsqlite:0.282-3:natives-linux-x86_64"
     jni "com.github.axet.litedb:libsqlite:0.282-3:natives-windows-x86"
     jni "com.github.axet.litedb:libsqlite:0.282-3:natives-windows-x86_64"
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }

--- a/shadows/httpclient/build.gradle
+++ b/shadows/httpclient/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(
@@ -31,6 +31,9 @@ dependencies {
     testCompile "org.assertj:assertj-core:3.8.0"
     testCompile "org.mockito:mockito-core:2.5.4"
     testRuntime AndroidSdk.LOLLIPOP_MR1.coordinates
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }
 
 // change local artifact name to match dependencies

--- a/shadows/httpclient/build.gradle
+++ b/shadows/httpclient/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(

--- a/shadows/multidex/build.gradle
+++ b/shadows/multidex/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(

--- a/shadows/multidex/build.gradle
+++ b/shadows/multidex/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(
@@ -20,6 +20,9 @@ dependencies {
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
     testCompile project(":robolectric")
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }
 
 // change local artifact name to match dependencies

--- a/shadows/playservices/build.gradle
+++ b/shadows/playservices/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(
@@ -31,6 +31,9 @@ dependencies {
     testRuntime "com.google.android.gms:play-services-basement:8.4.0"
 
     testRuntime AndroidSdk.MAX_SDK_FOR_THIS_JDK.coordinates
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }
 
 install {

--- a/shadows/playservices/build.gradle
+++ b/shadows/playservices/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(

--- a/shadows/supportv4/build.gradle
+++ b/shadows/supportv4/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(

--- a/shadows/supportv4/build.gradle
+++ b/shadows/supportv4/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(
@@ -43,6 +43,9 @@ dependencies {
     testRuntime "com.android.support:support-core-ui:26.0.0-alpha1"
     testRuntime "com.android.support:support-core-utils:26.0.0-alpha1"
     testRuntime "com.android.support:support-fragment:26.0.0-alpha1"
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }
 
 // change local artifact name to match dependencies

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    //id "net.ltgt.errorprone" version "0.0.11"
+    id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(
@@ -14,4 +14,7 @@ dependencies {
     testCompile "junit:junit:4.12"
     testCompile "org.assertj:assertj-core:3.8.0"
     testCompile "org.mockito:mockito-core:2.5.4"
+
+    // temporary workaround for https://github.com/google/error-prone/issues/711
+    errorprone 'com.google.errorprone:error_prone_core:2.0.21'
 }

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.ltgt.errorprone" version "0.0.10"
+    //id "net.ltgt.errorprone" version "0.0.11"
 }
 
 new RoboJavaModulePlugin(


### PR DESCRIPTION
### Overview
The errorprone plugin automatically uses the latest version of errorprone, which is subject to this bug  https://github.com/google/error-prone/issues/711

Fix robolectric to use the previous release of error prone (2.0.21) as a temporary workaround.

### Proposed Changes
