### PR TITLE
Eliminate test pollution of static Handler messages

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperTest.java
@@ -334,6 +334,19 @@ public class ShadowLooperTest {
   }
 
   @Test
+  public void resetThreadLoopers_clears_messages() {
+    HandlerThread backgroundThread = new HandlerThread("resetTest");
+    backgroundThread.start();
+    Looper backgroundLooper = backgroundThread.getLooper();
+    Handler handler = new Handler(backgroundLooper);
+    for (int i = 0; i < 5; i++) {
+      handler.sendEmptyMessageDelayed(1, 100);
+      ShadowLooper.resetThreadLoopers();
+      assertThat(handler.hasMessages(1)).isFalse();
+    }
+  }
+
+  @Test
   public void myLooper_returnsMainLooper_ifMainThreadIsSwitched() throws InterruptedException {
     final AtomicReference<Looper> myLooper = new AtomicReference<>();
     Thread t = new Thread(testName.getMethodName()) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLooper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLooper.java
@@ -59,6 +59,7 @@ public class ShadowLooper {
             // Reset the schedulers of all loopers. This prevents un-run tasks queued up in static
             // background handlers from leaking to subsequent tests.
             shadowOf(looper).getScheduler().reset();
+            shadowOf(looper.getQueue()).reset();
           }
         }
       }
@@ -125,6 +126,7 @@ public class ShadowLooper {
       quit = true;
       realObject.notifyAll();
       getScheduler().reset();
+      shadowOf(realObject.getQueue()).reset();
     }
   }
   


### PR DESCRIPTION
Messages posted to static background Handlers could leak to subsequent
tests. They were stored in the internal 'mMessages' member of
MessageQueue. In the ShadowLooper resetter, schedulers for background
Handlers were reset. However, the message queues themselves were not
reset. This could cause subsequent tests to receive false positives when
calling the 'Handler.hasMessages' variants.