### PR TITLE
Fix ShadowAccessibilityManager to keep a static instance

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
@@ -31,7 +31,7 @@ public class ShadowAccessibilityManagerTest {
   }
 
   @Test
-  public void shouldReturnTrueWhenEnabled() {
+  public void shouldReturnTrueWhenEnabled() throws Exception {
     shadowAccessibilityManager.setEnabled(true);
     assertThat(accessibilityManager.isEnabled()).isTrue();
     assertThat(getAccessibilityManagerInstance().isEnabled()).isTrue();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
@@ -34,7 +34,7 @@ public class ShadowAccessibilityManagerTest {
   public void shouldReturnTrueWhenEnabled() {
     shadowAccessibilityManager.setEnabled(true);
     assertThat(accessibilityManager.isEnabled()).isTrue();
-    assertThat(getAccessibilityManagerInstance.isEnabled()).isTrue();
+    assertThat(getAccessibilityManagerInstance().isEnabled()).isTrue();
   }
 
   // Emulates Android framework behavior, e.g.,

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.accessibilityservice.AccessibilityServiceInfo;
+import android.content.Context;
 import android.content.pm.ServiceInfo;
 import android.view.accessibility.AccessibilityManager;
 import java.util.ArrayList;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
@@ -36,33 +36,33 @@ public class ShadowAccessibilityManagerTest {
   }
 
   @Test
-  public void shouldReturnTrueWhenEnabled() {
+  public void shouldReturnTrueWhenEnabled() throws Exception {
     shadowAccessibilityManager.setEnabled(true);
     assertThat(getAccessibilityManager().isEnabled()).isTrue();
   }
 
   @Test
-  public void shouldReturnTrueForTouchExplorationWhenEnabled() {
+  public void shouldReturnTrueForTouchExplorationWhenEnabled() throws Exception {
     shadowAccessibilityManager.setTouchExplorationEnabled(true);
     assertThat(getAccessibilityManager().isTouchExplorationEnabled()).isTrue();
   }
 
   @Test
-  public void shouldReturnExpectedEnabledServiceList() {
+  public void shouldReturnExpectedEnabledServiceList() throws Exception {
     List<AccessibilityServiceInfo> expected = new ArrayList<>(Arrays.asList(new AccessibilityServiceInfo()));
     shadowAccessibilityManager.setEnabledAccessibilityServiceList(expected);
     assertThat(getAccessibilityManager().getEnabledAccessibilityServiceList(0)).isEqualTo(expected);
   }
 
   @Test
-  public void shouldReturnExpectedInstalledServiceList() {
+  public void shouldReturnExpectedInstalledServiceList() throws Exception {
     List<AccessibilityServiceInfo> expected = new ArrayList<>(Arrays.asList(new AccessibilityServiceInfo()));
     shadowAccessibilityManager.setInstalledAccessibilityServiceList(expected);
     assertThat(getAccessibilityManager().getInstalledAccessibilityServiceList()).isEqualTo(expected);
   }
 
   @Test
-  public void shouldReturnExpectedAccessibilityServiceList() {
+  public void shouldReturnExpectedAccessibilityServiceList() throws Exception {
     List<ServiceInfo> expected = new ArrayList<>(Arrays.asList(new ServiceInfo()));
     shadowAccessibilityManager.setAccessibilityServiceList(expected);
     assertThat(getAccessibilityManager().getAccessibilityServiceList()).isEqualTo(expected);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
@@ -39,7 +39,7 @@ public class ShadowAccessibilityManagerTest {
 
   // Emulates Android framework behavior, e.g.,
   // AccessibilityManager.getInstance(context).isEnabled().
-  private AccessibilityManager getAccessibilityManagerInstance() throws Exception {
+  private static AccessibilityManager getAccessibilityManagerInstance() throws Exception {
     return ReflectionHelpers.callStaticMethod(AccessibilityManager.class, "getInstance",
             ReflectionHelpers.ClassParameter.from(Context.class, RuntimeEnvironment.application));
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
@@ -21,50 +21,53 @@ import org.robolectric.util.ReflectionHelpers;
 @RunWith(TestRunners.MultiApiSelfTest.class)
 public class ShadowAccessibilityManagerTest {
 
+  private AccessibilityManager accessibilityManager;
   private ShadowAccessibilityManager shadowAccessibilityManager;
 
   @Before
   public void setUp() throws Exception {
-    shadowAccessibilityManager = shadowOf(getAccessibilityManager());
+    accessibilityManager = (AccessibilityManager) RuntimeEnvironment.application.getSystemService(ACCESSIBILITY_SERVICE);
+    shadowAccessibilityManager = shadowOf(accessibilityManager);
+  }
+
+  @Test
+  public void shouldReturnTrueWhenEnabled() {
+    shadowAccessibilityManager.setEnabled(true);
+    assertThat(accessibilityManager.isEnabled()).isTrue();
+    assertThat(getAccessibilityManagerInstance.isEnabled()).isTrue();
   }
 
   // Emulates Android framework behavior, e.g.,
   // AccessibilityManager.getInstance(context).isEnabled().
-  private AccessibilityManager getAccessibilityManager() throws Exception {
+  private AccessibilityManager getAccessibilityManagerInstance() throws Exception {
     return ReflectionHelpers.callStaticMethod(AccessibilityManager.class, "getInstance",
             ReflectionHelpers.ClassParameter.from(Context.class, RuntimeEnvironment.application));
   }
 
   @Test
-  public void shouldReturnTrueWhenEnabled() throws Exception {
-    shadowAccessibilityManager.setEnabled(true);
-    assertThat(getAccessibilityManager().isEnabled()).isTrue();
-  }
-
-  @Test
-  public void shouldReturnTrueForTouchExplorationWhenEnabled() throws Exception {
+  public void shouldReturnTrueForTouchExplorationWhenEnabled() {
     shadowAccessibilityManager.setTouchExplorationEnabled(true);
-    assertThat(getAccessibilityManager().isTouchExplorationEnabled()).isTrue();
+    assertThat(accessibilityManager.isTouchExplorationEnabled()).isTrue();
   }
 
   @Test
-  public void shouldReturnExpectedEnabledServiceList() throws Exception {
+  public void shouldReturnExpectedEnabledServiceList() {
     List<AccessibilityServiceInfo> expected = new ArrayList<>(Arrays.asList(new AccessibilityServiceInfo()));
     shadowAccessibilityManager.setEnabledAccessibilityServiceList(expected);
-    assertThat(getAccessibilityManager().getEnabledAccessibilityServiceList(0)).isEqualTo(expected);
+    assertThat(accessibilityManager.getEnabledAccessibilityServiceList(0)).isEqualTo(expected);
   }
 
   @Test
-  public void shouldReturnExpectedInstalledServiceList() throws Exception {
+  public void shouldReturnExpectedInstalledServiceList() {
     List<AccessibilityServiceInfo> expected = new ArrayList<>(Arrays.asList(new AccessibilityServiceInfo()));
     shadowAccessibilityManager.setInstalledAccessibilityServiceList(expected);
-    assertThat(getAccessibilityManager().getInstalledAccessibilityServiceList()).isEqualTo(expected);
+    assertThat(accessibilityManager.getInstalledAccessibilityServiceList()).isEqualTo(expected);
   }
 
   @Test
-  public void shouldReturnExpectedAccessibilityServiceList() throws Exception {
+  public void shouldReturnExpectedAccessibilityServiceList() {
     List<ServiceInfo> expected = new ArrayList<>(Arrays.asList(new ServiceInfo()));
     shadowAccessibilityManager.setAccessibilityServiceList(expected);
-    assertThat(getAccessibilityManager().getAccessibilityServiceList()).isEqualTo(expected);
+    assertThat(accessibilityManager.getAccessibilityServiceList()).isEqualTo(expected);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
@@ -15,49 +15,55 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.TestRunners;
+import org.robolectric.util.ReflectionHelpers;
 
 @RunWith(TestRunners.MultiApiSelfTest.class)
 public class ShadowAccessibilityManagerTest {
 
-  private AccessibilityManager accessibilityManager;
   private ShadowAccessibilityManager shadowAccessibilityManager;
 
   @Before
   public void setUp() throws Exception {
-    accessibilityManager = (AccessibilityManager) RuntimeEnvironment.application.getSystemService(ACCESSIBILITY_SERVICE);
-    shadowAccessibilityManager = shadowOf(accessibilityManager);
+    shadowAccessibilityManager = shadowOf(getAccessibilityManager());
+  }
+
+  // Emulates Android framework behavior, e.g.,
+  // AccessibilityManager.getInstance(context).isEnabled().
+  private AccessibilityManager getAccessibilityManager() throws Exception {
+    return ReflectionHelpers.callStaticMethod(AccessibilityManager.class, "getInstance",
+            ReflectionHelpers.ClassParameter.from(Context.class, RuntimeEnvironment.application));
   }
 
   @Test
   public void shouldReturnTrueWhenEnabled() {
     shadowAccessibilityManager.setEnabled(true);
-    assertThat(accessibilityManager.isEnabled()).isTrue();
+    assertThat(getAccessibilityManager().isEnabled()).isTrue();
   }
 
   @Test
   public void shouldReturnTrueForTouchExplorationWhenEnabled() {
     shadowAccessibilityManager.setTouchExplorationEnabled(true);
-    assertThat(accessibilityManager.isTouchExplorationEnabled()).isTrue();
+    assertThat(getAccessibilityManager().isTouchExplorationEnabled()).isTrue();
   }
 
   @Test
   public void shouldReturnExpectedEnabledServiceList() {
     List<AccessibilityServiceInfo> expected = new ArrayList<>(Arrays.asList(new AccessibilityServiceInfo()));
     shadowAccessibilityManager.setEnabledAccessibilityServiceList(expected);
-    assertThat(accessibilityManager.getEnabledAccessibilityServiceList(0)).isEqualTo(expected);
+    assertThat(getAccessibilityManager().getEnabledAccessibilityServiceList(0)).isEqualTo(expected);
   }
 
   @Test
   public void shouldReturnExpectedInstalledServiceList() {
     List<AccessibilityServiceInfo> expected = new ArrayList<>(Arrays.asList(new AccessibilityServiceInfo()));
     shadowAccessibilityManager.setInstalledAccessibilityServiceList(expected);
-    assertThat(accessibilityManager.getInstalledAccessibilityServiceList()).isEqualTo(expected);
+    assertThat(getAccessibilityManager().getInstalledAccessibilityServiceList()).isEqualTo(expected);
   }
 
   @Test
   public void shouldReturnExpectedAccessibilityServiceList() {
     List<ServiceInfo> expected = new ArrayList<>(Arrays.asList(new ServiceInfo()));
     shadowAccessibilityManager.setAccessibilityServiceList(expected);
-    assertThat(accessibilityManager.getAccessibilityServiceList()).isEqualTo(expected);
+    assertThat(getAccessibilityManager().getAccessibilityServiceList()).isEqualTo(expected);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
@@ -16,12 +16,15 @@ import java.util.List;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 @Implements(AccessibilityManager.class)
 public class ShadowAccessibilityManager {
+  private static AccessibilityManager sInstance;
+  private static final Object sInstanceSync = new Object();
 
   private boolean enabled;
   private List<AccessibilityServiceInfo> installedAccessibilityServiceList;
@@ -29,9 +32,25 @@ public class ShadowAccessibilityManager {
   private List<ServiceInfo> accessibilityServiceList;
   private boolean touchExplorationEnabled;
 
+  @Resetter
+  public static void reset() {
+      synchronized (sInstanceSync) {
+          sInstance = null;
+      }
+  }
+
   @HiddenApi
   @Implementation
   public static AccessibilityManager getInstance(Context context) throws Exception {
+    synchronized (sInstanceSync) {
+      if (sInstance == null) {
+          sInstance = createInstance(context);
+      }
+    }
+    return sInstance;
+  }
+
+  private static AccessibilityManager createInstance(Context context) throws Exception {
     if (getApiLevel() >= KITKAT) {
       AccessibilityManager accessibilityManager = Shadow.newInstance(AccessibilityManager.class,
           new Class[]{Context.class, IAccessibilityManager.class, int.class},

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
@@ -34,9 +34,9 @@ public class ShadowAccessibilityManager {
 
   @Resetter
   public static void reset() {
-      synchronized (sInstanceSync) {
-          sInstance = null;
-      }
+    synchronized (sInstanceSync) {
+      sInstance = null;
+    }
   }
 
   @HiddenApi


### PR DESCRIPTION
1) Shadows.shadowOf(mAccessibilityManager).setEnabled(true)
2) AccessibilityManager.getInstance(mContext).isEnabled()

Calling 1) does not make 2) return true, and 2) is the common pattern
that can be found in the Android framework, so we are not enabling
accessibility in robolectric tests correctly.

The reason is that AccessibilityManager.getInstance(...) calls
ShadowAccessibilityManager.getInstance(...) and it in turn creates new
instance each time, while setEnabled() and other methods only apply to
the previous instance. This can be fixed by keeping a static instance, an
approach similar to the implementation of
AccessibilityManager.getInstance() itself.

https://github.com/robolectric/robolectric/issues/3364
