### PR TITLE
Remove bogus directory that causes an error with Bazel's android_library

### DIFF
--- a/robolectric/src/test/resources/res/layout/.bogus_hidden_dir_for_tests/bad.xml
+++ b/robolectric/src/test/resources/res/layout/.bogus_hidden_dir_for_tests/bad.xml
@@ -1,1 +1,0 @@
-this is not a valid XML file


### PR DESCRIPTION
rule.

PiperRevId: 168844614

### Overview

### Proposed Changes
