### PR TITLE
Extend BuckManifestFactory to support passing directories in files

### DIFF
--- a/robolectric/src/test/java/org/robolectric/internal/BuckManifestFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/BuckManifestFactoryTest.java
@@ -2,10 +2,16 @@ package org.robolectric.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
 import java.util.List;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.robolectric.annotation.Config;
@@ -16,6 +22,9 @@ import org.robolectric.res.ResourcePath;
 @RunWith(JUnit4.class)
 public class BuckManifestFactoryTest {
 
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
   private Config.Builder configBuilder;
   private BuckManifestFactory buckManifestFactory;
 
@@ -23,8 +32,6 @@ public class BuckManifestFactoryTest {
   public void setUp() throws Exception {
     configBuilder = Config.Builder.defaults().setPackageName("com.robolectric.buck");
     System.setProperty("buck.robolectric_manifest", "buck/AndroidManifest.xml");
-    System.setProperty("buck.robolectric_res_directories", "buck/res1:buck/res2");
-    System.setProperty("buck.robolectric_assets_directories", "buck/assets");
     buckManifestFactory = new BuckManifestFactory();
   }
 
@@ -44,6 +51,9 @@ public class BuckManifestFactoryTest {
   }
 
   @Test public void multiple_res_dirs() throws Exception {
+    System.setProperty("buck.robolectric_res_directories", "buck/res1:buck/res2");
+    System.setProperty("buck.robolectric_assets_directories", "buck/assets");
+
     ManifestIdentifier manifestIdentifier = buckManifestFactory.identify(configBuilder.build());
     AndroidManifest manifest = buckManifestFactory.create(manifestIdentifier);
     assertThat(manifest.getResDirectory())
@@ -56,6 +66,32 @@ public class BuckManifestFactoryTest {
     assertThat(resourcePathList).containsExactly(
             new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res2"), FileFsFile.from("buck/assets")),
             new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res1"), FileFsFile.from("buck/assets"))
+    );
+  }
+
+  @Test public void pass_multiple_res_dirs_in_file() throws Exception {
+    String resDirectoriesFileName = "res-directories";
+    File resDirectoriesFile = tempFolder.newFile(resDirectoriesFileName);
+    Files.write("buck/res1\nbuck/res2", resDirectoriesFile, Charsets.UTF_8);
+    System.setProperty("buck.robolectric_res_directories", "@" + resDirectoriesFile.getAbsolutePath());
+
+    String assetDirectoriesFileName = "asset-directories";
+    File assetDirectoriesFile = tempFolder.newFile(assetDirectoriesFileName);
+    Files.write("buck/assets", assetDirectoriesFile, Charsets.UTF_8);
+    System.setProperty("buck.robolectric_assets_directories", "@" + assetDirectoriesFile.getAbsolutePath());
+
+    ManifestIdentifier manifestIdentifier = buckManifestFactory.identify(configBuilder.build());
+    AndroidManifest manifest = buckManifestFactory.create(manifestIdentifier);
+    assertThat(manifest.getResDirectory())
+        .isEqualTo(FileFsFile.from("buck/res2"));
+    assertThat(manifest.getAssetsDirectory())
+        .isEqualTo(FileFsFile.from("buck/assets"));
+
+    List<ResourcePath> resourcePathList = manifest.getIncludedResourcePaths();
+    assertThat(resourcePathList.size()).isEqualTo(2);
+    assertThat(resourcePathList).containsExactly(
+        new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res2"), FileFsFile.from("buck/assets")),
+        new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res1"), FileFsFile.from("buck/assets"))
     );
   }
 }


### PR DESCRIPTION
Buck passes resource and asset directories to test runners in JVM command-line parameters . When the lists of directories are too big the command line is hitting the system limit.

The solution is to extend the Buck runner to accept a list of directories stored in a file. When a value passing in a JVM parameter starts with `@` the rest of the value is the name of the file with directories., otherwise the value is handled using the old logic (i.e. it contains a list of directories separated by path separator).

Related change in Buck: https://github.com/facebook/buck/commit/999d21dff654cf5d303d548cce7aa77fe10b4881