### PR TITLE
Refactor ManifestFactory implementations

### DIFF
--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -30,6 +30,7 @@ public class AndroidManifest {
   private final FsFile resDirectory;
   private final FsFile assetsDirectory;
   private final String overridePackageName;
+  private final List<AndroidManifest> libraryManifests;
 
   private boolean manifestIsParsed;
 
@@ -53,7 +54,6 @@ public class AndroidManifest {
   private final List<String> usedPermissions = new ArrayList<>();
   private final Map<String, String> applicationAttributes = new HashMap<>();
   private MetaData applicationMetaData;
-  private List<AndroidManifest> libraryManifests = new ArrayList<>();
 
   /**
    * Creates a Robolectric configuration using specified locations.
@@ -74,13 +74,31 @@ public class AndroidManifest {
    * @param assetsDirectory     Location of the assets directory.
    * @param overridePackageName Application package name.
    */
-  public AndroidManifest(FsFile androidManifestFile, FsFile resDirectory, FsFile assetsDirectory, String overridePackageName) {
+  public AndroidManifest(FsFile androidManifestFile, FsFile resDirectory, FsFile assetsDirectory,
+      String overridePackageName) {
+    this(androidManifestFile, resDirectory, assetsDirectory, Collections.emptyList(), overridePackageName);
+    this.packageName = overridePackageName;
+  }
+
+  /**
+   * Creates a Robolectric configuration using specified values.
+   *
+   * @param androidManifestFile Location of the AndroidManifest.xml file.
+   * @param resDirectory        Location of the res directory.
+   * @param assetsDirectory     Location of the assets directory.
+   * @param libraryManifests    List of dependency library manifests.
+   * @param overridePackageName Application package name.
+   */
+  public AndroidManifest(FsFile androidManifestFile, FsFile resDirectory, FsFile assetsDirectory,
+      List<AndroidManifest> libraryManifests, String overridePackageName) {
     this.androidManifestFile = androidManifestFile;
     this.resDirectory = resDirectory;
     this.assetsDirectory = assetsDirectory;
     this.overridePackageName = overridePackageName;
+    this.libraryManifests = libraryManifests;
 
     this.packageName = overridePackageName;
+
   }
 
   public String getThemeRef(String activityClassName) {
@@ -561,11 +579,6 @@ public class AndroidManifest {
   public List<ContentProviderData> getContentProviders() {
     parseAndroidManifest();
     return providers;
-  }
-
-  public void setLibraryManifests(List<AndroidManifest> libraryManifests) {
-    Preconditions.checkNotNull(libraryManifests);
-    this.libraryManifests = libraryManifests;
   }
 
   public List<AndroidManifest> getLibraryManifests() {

--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -77,7 +77,6 @@ public class AndroidManifest {
   public AndroidManifest(FsFile androidManifestFile, FsFile resDirectory, FsFile assetsDirectory,
       String overridePackageName) {
     this(androidManifestFile, resDirectory, assetsDirectory, Collections.emptyList(), overridePackageName);
-    this.packageName = overridePackageName;
   }
 
   /**
@@ -98,7 +97,6 @@ public class AndroidManifest {
     this.libraryManifests = libraryManifests;
 
     this.packageName = overridePackageName;
-
   }
 
   public String getThemeRef(String activityClassName) {

--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -188,7 +188,17 @@ public class AndroidManifest {
         ignored.printStackTrace();
       }
     } else {
-      rClassName = (packageName != null && !packageName.equals("")) ? packageName + ".R" : null;
+      if (androidManifestFile != null) {
+        System.out.println("WARNING: No manifest file found at " + androidManifestFile.getPath() + ".");
+        System.out.println("Falling back to the Android OS resources only.");
+        System.out.println("To remove this warning, annotate your test class with @Config(manifest=Config.NONE).");
+      }
+
+      if (packageName == null || packageName.equals("")) {
+        packageName = "org.robolectric.default";
+      }
+
+      rClassName = packageName + ".R";
 
       if (androidManifestFile != null) {
         System.err.println("No such manifest file: " + androidManifestFile);

--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -1,6 +1,5 @@
 package org.robolectric.manifest;
 
-import com.google.common.base.Preconditions;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -10,6 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -90,7 +90,7 @@ public class AndroidManifest {
    * @param overridePackageName Application package name.
    */
   public AndroidManifest(FsFile androidManifestFile, FsFile resDirectory, FsFile assetsDirectory,
-      List<AndroidManifest> libraryManifests, String overridePackageName) {
+      @Nonnull List<AndroidManifest> libraryManifests, String overridePackageName) {
     this.androidManifestFile = androidManifestFile;
     this.resDirectory = resDirectory;
     this.assetsDirectory = assetsDirectory;

--- a/resources/src/main/java/org/robolectric/res/FileFsFile.java
+++ b/resources/src/main/java/org/robolectric/res/FileFsFile.java
@@ -15,7 +15,6 @@ public class FileFsFile implements FsFile {
   @VisibleForTesting
   static String FILE_SEPARATOR = File.separator;
 
-  private File canonicalFile;
   private final File file;
 
   FileFsFile(File file) {
@@ -118,12 +117,12 @@ public class FileFsFile implements FsFile {
 
     FileFsFile fsFile = (FileFsFile) o;
 
-    return getCanonicalFile().equals(fsFile.getCanonicalFile());
+    return file.equals(fsFile.file);
   }
 
   @Override
   public int hashCode() {
-    return getCanonicalFile().hashCode();
+    return file.hashCode();
   }
 
   @Override
@@ -145,27 +144,6 @@ public class FileFsFile implements FsFile {
       fsFiles[i] = Fs.newFile(files[i]);
     }
     return fsFiles;
-  }
-
-  /**
-   * Canonical file queries can be expensive, so perform them lazily. In
-   * practice, this should only happen for raw resources, AndroidManifest.xml,
-   * and project.properties.
-   */
-  private synchronized File getCanonicalFile() {
-    if (canonicalFile == null) {
-      try {
-        // Android library references in project.properties are all
-        // relative paths, so using a canonical path guarantees that
-        // there won't be duplicates.
-        this.canonicalFile = file.getCanonicalFile();
-      } catch (IOException e) {
-        // In a case where file system queries are failing, it makes
-        // sense for the test to fail.
-        throw new RuntimeException(e);
-      }
-    }
-    return canonicalFile;
   }
 
   /**

--- a/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
@@ -5,15 +5,14 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashSet;
+import java.util.Collections;
 import java.util.List;
-import java.util.ListIterator;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.robolectric.annotation.Config;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.Fs;
 import org.robolectric.res.FsFile;
-import org.robolectric.res.ResourcePath;
 import org.robolectric.util.Logger;
 import org.robolectric.util.Util;
 
@@ -27,66 +26,83 @@ public class BuckManifestFactory implements ManifestFactory {
   public ManifestIdentifier identify(Config config) {
     String buckManifest = System.getProperty(BUCK_ROBOLECTRIC_MANIFEST);
     FsFile manifestFile = Fs.fileFromPath(buckManifest);
-    return new ManifestIdentifier(manifestFile, null, null, config.packageName(), null);
+
+    String buckResDirs = System.getProperty(BUCK_ROBOLECTRIC_RES_DIRECTORIES);
+    String buckAssetsDirs = System.getProperty(BUCK_ROBOLECTRIC_ASSETS_DIRECTORIES);
+    String packageName = config.packageName();
+
+    final List<FsFile> buckResources = getDirectoriesFromProperty(buckResDirs);
+    final List<FsFile> buckAssets = getDirectoriesFromProperty(buckAssetsDirs);
+
+    if (buckResources.size() != buckAssets.size()) {
+      throw new IllegalArgumentException("number of resources and assets do not match match: "
+          + buckResources.size() + " != " + buckAssets.size());
+    }
+
+    int pathCount = buckResources.size();
+    final FsFile resDir;
+    final FsFile assetsDir;
+    final List<ManifestIdentifier> libraries;
+    if (pathCount == 0) {
+      resDir = null;
+      assetsDir = null;
+      libraries = null;
+    } else {
+      resDir = buckResources.get(pathCount - 1);
+      assetsDir = buckAssets.get(pathCount - 1);
+      libraries = new ArrayList<>();
+
+      for (int i = 0; i < pathCount - 1; i++) {
+        libraries.add(new ManifestIdentifier(null, null,
+            buckResources.get(i), buckAssets.get(i), null));
+      }
+    }
+
+    return new ManifestIdentifier(packageName, manifestFile, resDir, assetsDir, libraries);
   }
 
   @Override
   public AndroidManifest create(ManifestIdentifier manifestIdentifier) {
-    String buckResDirs = System.getProperty(BUCK_ROBOLECTRIC_RES_DIRECTORIES);
-    String buckAssetsDirs = System.getProperty(BUCK_ROBOLECTRIC_ASSETS_DIRECTORIES);
-    String packageName = manifestIdentifier.getPackageName();
     FsFile manifestFile = manifestIdentifier.getManifestFile();
+    FsFile resDir = manifestIdentifier.getResDir();
+    FsFile assetsDir = manifestIdentifier.getAssetDir();
+    final String packageName = manifestIdentifier.getPackageName();
 
-    final List<String> buckResources = getDirectoriesFromProperty(buckResDirs);
-    final List<String> buckAssets = getDirectoriesFromProperty(buckAssetsDirs);
-
-    final FsFile resDir = (buckResources == null || buckResources.isEmpty()) ? null :
-            Fs.fileFromPath(buckResources.get(buckResources.size() - 1));
-    final FsFile assetsDir = (buckAssets == null || buckAssets.isEmpty()) ? null :
-            Fs.fileFromPath(buckAssets.get(buckAssets.size() - 1));
-
-    Logger.debug("Robolectric assets directory: " + (assetsDir == null ? null : assetsDir.getPath()));
-    Logger.debug("   Robolectric res directory: " + (resDir == null ? null : resDir.getPath()));
-    Logger.debug("   Robolectric manifest path: " + manifestFile.getPath());
+    Logger.debug("Robolectric assets directory: " + assetsDir);
+    Logger.debug("   Robolectric res directory: " + resDir);
+    Logger.debug("   Robolectric manifest path: " + manifestFile);
     Logger.debug("    Robolectric package name: " + packageName);
 
-    return new AndroidManifest(manifestFile, resDir, assetsDir, packageName) {
-        @Override
-        public List<ResourcePath> getIncludedResourcePaths() {
-            Collection<ResourcePath> resourcePaths = new LinkedHashSet<>(); // Needs stable ordering and no duplicates
-            resourcePaths.add(super.getResourcePath());
-
-            // Add all the buck resource folders, no duplicates as they are being added to a set.
-            if (buckResources != null) {
-                ListIterator<String> it = buckResources.listIterator(buckResources.size());
-                while (it.hasPrevious()) {
-                    resourcePaths.add(new ResourcePath(
-                            getRClass(),
-                            Fs.fileFromPath(it.previous()),
-                            getAssetsDirectory()));
-                }
-            }
-            return new ArrayList<>(resourcePaths);
-        }
-    };
+    List<ManifestIdentifier> libraries = manifestIdentifier.getLibraries();
+    List<AndroidManifest> libraryManifests = libraries == null
+        ? Collections.emptyList()
+        : libraries.stream().map(this::create).collect(Collectors.toList());
+    return new AndroidManifest(manifestFile, resDir, assetsDir, libraryManifests, packageName);
   }
 
   public static boolean isBuck() {
     return System.getProperty(BUCK_ROBOLECTRIC_MANIFEST) != null;
   }
 
-  private List<String> getDirectoriesFromProperty(String property) {
+  @Nonnull
+  private List<FsFile> getDirectoriesFromProperty(String property) {
     if (property == null) {
-      return null;
+      return Collections.emptyList();
     }
+
+    List<String> dirs;
     if (property.startsWith("@")) {
       String filename = property.substring(1);
       try {
-        return Arrays.asList(new String(Util.readBytes(new FileInputStream(filename))).split("\\n"));
+        dirs = Arrays
+            .asList(new String(Util.readBytes(new FileInputStream(filename))).split("\\n"));
       } catch (IOException e) {
         throw new RuntimeException("Cannot read file " + filename);
       }
+    } else {
+      dirs = Arrays.asList(property.split(File.pathSeparator));
     }
-    return Arrays.asList(property.split(File.pathSeparator));
+
+    return dirs.stream().map(Fs::fileFromPath).collect(Collectors.toList());
   }
 }

--- a/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/BuckManifestFactory.java
@@ -10,10 +10,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.robolectric.annotation.Config;
-import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.Fs;
 import org.robolectric.res.FsFile;
-import org.robolectric.util.Logger;
 import org.robolectric.util.Util;
 
 public class BuckManifestFactory implements ManifestFactory {
@@ -59,25 +57,6 @@ public class BuckManifestFactory implements ManifestFactory {
     }
 
     return new ManifestIdentifier(packageName, manifestFile, resDir, assetsDir, libraries);
-  }
-
-  @Override
-  public AndroidManifest create(ManifestIdentifier manifestIdentifier) {
-    FsFile manifestFile = manifestIdentifier.getManifestFile();
-    FsFile resDir = manifestIdentifier.getResDir();
-    FsFile assetsDir = manifestIdentifier.getAssetDir();
-    final String packageName = manifestIdentifier.getPackageName();
-
-    Logger.debug("Robolectric assets directory: " + assetsDir);
-    Logger.debug("   Robolectric res directory: " + resDir);
-    Logger.debug("   Robolectric manifest path: " + manifestFile);
-    Logger.debug("    Robolectric package name: " + packageName);
-
-    List<ManifestIdentifier> libraries = manifestIdentifier.getLibraries();
-    List<AndroidManifest> libraryManifests = libraries == null
-        ? Collections.emptyList()
-        : libraries.stream().map(this::create).collect(Collectors.toList());
-    return new AndroidManifest(manifestFile, resDir, assetsDir, libraryManifests, packageName);
   }
 
   public static boolean isBuck() {

--- a/robolectric/src/main/java/org/robolectric/internal/DefaultManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/DefaultManifestFactory.java
@@ -7,7 +7,6 @@ import java.net.URL;
 import java.util.List;
 import java.util.Properties;
 import org.robolectric.annotation.Config;
-import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.Fs;
 import org.robolectric.res.FsFile;
 import org.robolectric.util.Logger;
@@ -25,7 +24,6 @@ public class DefaultManifestFactory implements ManifestFactory {
     FsFile resourcesDir = getFsFileFromPath(properties.getProperty("android_merged_resources"));
     FsFile assetsDir = getFsFileFromPath(properties.getProperty("android_merged_assets"));
     String packageName = properties.getProperty("android_custom_package");
-    List<FsFile> libraryDirs = emptyList();
 
     String manifestConfig = config.manifest();
     if (Config.NONE.equals(manifestConfig)) {
@@ -44,6 +42,11 @@ public class DefaultManifestFactory implements ManifestFactory {
 
     if (!Config.DEFAULT_PACKAGE_NAME.equals(config.packageName())) {
       packageName = config.packageName();
+    }
+
+    List<FsFile> libraryDirs = emptyList();
+    if (config.libraries().length > 0) {
+      Logger.info("@Config(libraries) specified while using Build System API, ignoring");
     }
 
     return new ManifestIdentifier(manifestFile, resourcesDir, assetsDir, packageName, libraryDirs);
@@ -69,10 +72,5 @@ public class DefaultManifestFactory implements ManifestFactory {
     } else {
       return Fs.fileFromPath(property);
     }
-  }
-
-  @Override
-  public AndroidManifest create(ManifestIdentifier manifestIdentifier) {
-    return new AndroidManifest(manifestIdentifier.getManifestFile(), manifestIdentifier.getResDir(), manifestIdentifier.getAssetDir(), manifestIdentifier.getPackageName());
   }
 }

--- a/robolectric/src/main/java/org/robolectric/internal/GradleManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/GradleManifestFactory.java
@@ -6,9 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.robolectric.annotation.Config;
-import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.FileFsFile;
-import org.robolectric.res.FsFile;
 import org.robolectric.util.Logger;
 import org.robolectric.util.ReflectionHelpers;
 
@@ -69,20 +67,6 @@ public class GradleManifestFactory implements ManifestFactory {
     }
 
     return new ManifestIdentifier(manifest, res, assets, packageName, null);
-  }
-
-  @Override
-  public AndroidManifest create(ManifestIdentifier manifestIdentifier) {
-    FsFile manifestFile = manifestIdentifier.getManifestFile();
-    FsFile resDir = manifestIdentifier.getResDir();
-    FsFile assetDir = manifestIdentifier.getAssetDir();
-    final String packageName = manifestIdentifier.getPackageName();
-
-    Logger.debug("Robolectric assets directory: " + assetDir.getPath());
-    Logger.debug("   Robolectric res directory: " + resDir.getPath());
-    Logger.debug("   Robolectric manifest path: " + manifestFile.getPath());
-    Logger.debug("    Robolectric package name: " + packageName);
-    return new AndroidManifest(manifestFile, resDir, assetDir, packageName);
   }
 
   private static String getBuildOutputDir(Config config) {

--- a/robolectric/src/main/java/org/robolectric/internal/ManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ManifestFactory.java
@@ -1,5 +1,8 @@
 package org.robolectric.internal;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.robolectric.annotation.Config;
 import org.robolectric.manifest.AndroidManifest;
 
@@ -16,5 +19,20 @@ import org.robolectric.manifest.AndroidManifest;
 public interface ManifestFactory {
   ManifestIdentifier identify(Config config);
 
-  AndroidManifest create(ManifestIdentifier manifestIdentifier);
+  default AndroidManifest create(ManifestIdentifier manifestIdentifier) {
+    return createLibraryAndroidManifest(manifestIdentifier);
+  }
+
+  static AndroidManifest createLibraryAndroidManifest(ManifestIdentifier manifestIdentifier) {
+    List<ManifestIdentifier> libraries = manifestIdentifier.getLibraries();
+    List<AndroidManifest> libraryManifests = new ArrayList<>();
+    if (libraries != null) {
+      libraryManifests = libraries.stream()
+          .map(ManifestFactory::createLibraryAndroidManifest)
+          .collect(Collectors.toList());
+    }
+
+    return new AndroidManifest(manifestIdentifier.getManifestFile(), manifestIdentifier.getResDir(),
+        manifestIdentifier.getAssetDir(), libraryManifests, manifestIdentifier.getPackageName());
+  }
 }

--- a/robolectric/src/main/java/org/robolectric/internal/ManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ManifestFactory.java
@@ -1,6 +1,5 @@
 package org.robolectric.internal;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.robolectric.annotation.Config;
@@ -17,20 +16,31 @@ import org.robolectric.manifest.AndroidManifest;
  * * Buck
  */
 public interface ManifestFactory {
+
+  /**
+   * Creates a {@link ManifestIdentifier} which represents an Android app, service, or library
+   * under test, indicating its manifest file, resources and assets directories, and optionally
+   * dependency libraries and an overridden package name.
+   *
+   * @param config The merged configuration for the running test.
+   */
   ManifestIdentifier identify(Config config);
 
+  /**
+   * @deprecated This method should no longer be overridden as of Robolectric 3.5. Instead,
+   *             {@link #identify(Config)} should return a fully-specified
+   *             {@link ManifestIdentifier}.
+   */
+  @Deprecated
   default AndroidManifest create(ManifestIdentifier manifestIdentifier) {
     return createLibraryAndroidManifest(manifestIdentifier);
   }
 
   static AndroidManifest createLibraryAndroidManifest(ManifestIdentifier manifestIdentifier) {
     List<ManifestIdentifier> libraries = manifestIdentifier.getLibraries();
-    List<AndroidManifest> libraryManifests = new ArrayList<>();
-    if (libraries != null) {
-      libraryManifests = libraries.stream()
-          .map(ManifestFactory::createLibraryAndroidManifest)
-          .collect(Collectors.toList());
-    }
+    List<AndroidManifest> libraryManifests = libraries.stream()
+        .map(ManifestFactory::createLibraryAndroidManifest)
+        .collect(Collectors.toList());
 
     return new AndroidManifest(manifestIdentifier.getManifestFile(), manifestIdentifier.getResDir(),
         manifestIdentifier.getAssetDir(), libraryManifests, manifestIdentifier.getPackageName());

--- a/robolectric/src/main/java/org/robolectric/internal/ManifestIdentifier.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ManifestIdentifier.java
@@ -1,6 +1,8 @@
 package org.robolectric.internal;
 
+import java.util.ArrayList;
 import java.util.List;
+import org.robolectric.annotation.Config;
 import org.robolectric.res.FsFile;
 
 public class ManifestIdentifier {
@@ -8,15 +10,42 @@ public class ManifestIdentifier {
   private final FsFile resDir;
   private final FsFile assetDir;
   private final String packageName;
-  private final List<FsFile> libraryDirs;
+  private final List<ManifestIdentifier> libraries;
 
+  public ManifestIdentifier(String packageName,
+      FsFile manifestFile, FsFile resDir, FsFile assetDir,
+      List<ManifestIdentifier> libraries) {
+    this.manifestFile = manifestFile;
+    this.resDir = resDir;
+    this.assetDir = assetDir;
+    this.packageName = packageName;
+    this.libraries = libraries;
+  }
+
+  /**
+   * @deprecated Use {@link #ManifestIdentifier(String, FsFile, FsFile, FsFile, List)} instead.
+   */
+  @Deprecated
   public ManifestIdentifier(FsFile manifestFile, FsFile resDir, FsFile assetDir, String packageName,
                             List<FsFile> libraryDirs) {
     this.manifestFile = manifestFile;
     this.resDir = resDir;
     this.assetDir = assetDir;
     this.packageName = packageName;
-    this.libraryDirs = libraryDirs;
+
+    if (libraryDirs == null) {
+      this.libraries = null;
+    } else {
+      this.libraries = new ArrayList<>();
+      for (FsFile libraryDir : libraryDirs) {
+        this.libraries.add(new ManifestIdentifier(
+            null,
+            existsOrNull(libraryDir.join(Config.DEFAULT_MANIFEST_NAME)),
+            existsOrNull(libraryDir.join(Config.DEFAULT_RES_FOLDER)),
+            existsOrNull(libraryDir.join(Config.DEFAULT_ASSET_FOLDER)),
+            null));
+      }
+    }
   }
 
   public FsFile getManifestFile() {
@@ -35,8 +64,8 @@ public class ManifestIdentifier {
     return packageName;
   }
 
-  public List<FsFile> getLibraryDirs() {
-    return libraryDirs;
+  public List<ManifestIdentifier> getLibraries() {
+    return libraries;
   }
 
   @Override
@@ -50,7 +79,7 @@ public class ManifestIdentifier {
     if (resDir != null ? !resDir.equals(that.resDir) : that.resDir != null) return false;
     if (assetDir != null ? !assetDir.equals(that.assetDir) : that.assetDir != null) return false;
     if (packageName != null ? !packageName.equals(that.packageName) : that.packageName != null) return false;
-    return libraryDirs != null ? libraryDirs.equals(that.libraryDirs) : that.libraryDirs == null;
+    return libraries != null ? libraries.equals(that.libraries) : that.libraries == null;
 
   }
 
@@ -60,7 +89,11 @@ public class ManifestIdentifier {
     result = 31 * result + (resDir != null ? resDir.hashCode() : 0);
     result = 31 * result + (assetDir != null ? assetDir.hashCode() : 0);
     result = 31 * result + (packageName != null ? packageName.hashCode() : 0);
-    result = 31 * result + (libraryDirs != null ? libraryDirs.hashCode() : 0);
+    result = 31 * result + (libraries != null ? libraries.hashCode() : 0);
     return result;
+  }
+
+  private static FsFile existsOrNull(FsFile fsFile) {
+    return fsFile.exists() ? fsFile : null;
   }
 }

--- a/robolectric/src/main/java/org/robolectric/internal/ManifestIdentifier.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ManifestIdentifier.java
@@ -93,6 +93,17 @@ public class ManifestIdentifier {
     return result;
   }
 
+  @Override
+  public String toString() {
+    return "ManifestIdentifier{" +
+        "manifestFile=" + manifestFile +
+        ", resDir=" + resDir +
+        ", assetDir=" + assetDir +
+        ", packageName='" + packageName + '\'' +
+        ", libraries=" + libraries +
+        '}';
+  }
+
   private static FsFile existsOrNull(FsFile fsFile) {
     return fsFile.exists() ? fsFile : null;
   }

--- a/robolectric/src/main/java/org/robolectric/internal/ManifestIdentifier.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ManifestIdentifier.java
@@ -1,7 +1,9 @@
 package org.robolectric.internal;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.robolectric.annotation.Config;
 import org.robolectric.res.FsFile;
 
@@ -19,7 +21,7 @@ public class ManifestIdentifier {
     this.resDir = resDir;
     this.assetDir = assetDir;
     this.packageName = packageName;
-    this.libraries = libraries;
+    this.libraries = libraries == null ? Collections.emptyList() : libraries;
   }
 
   /**
@@ -33,12 +35,10 @@ public class ManifestIdentifier {
     this.assetDir = assetDir;
     this.packageName = packageName;
 
-    if (libraryDirs == null) {
-      this.libraries = null;
-    } else {
-      this.libraries = new ArrayList<>();
+    List<ManifestIdentifier> libraries = new ArrayList<>();
+    if (libraryDirs != null) {
       for (FsFile libraryDir : libraryDirs) {
-        this.libraries.add(new ManifestIdentifier(
+        libraries.add(new ManifestIdentifier(
             null,
             libraryDir.join(Config.DEFAULT_MANIFEST_NAME),
             libraryDir.join(Config.DEFAULT_RES_FOLDER),
@@ -46,6 +46,7 @@ public class ManifestIdentifier {
             null));
       }
     }
+    this.libraries = Collections.unmodifiableList(libraries);
   }
 
   public FsFile getManifestFile() {
@@ -64,6 +65,7 @@ public class ManifestIdentifier {
     return packageName;
   }
 
+  @Nonnull
   public List<ManifestIdentifier> getLibraries() {
     return libraries;
   }

--- a/robolectric/src/main/java/org/robolectric/internal/ManifestIdentifier.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ManifestIdentifier.java
@@ -40,9 +40,9 @@ public class ManifestIdentifier {
       for (FsFile libraryDir : libraryDirs) {
         this.libraries.add(new ManifestIdentifier(
             null,
-            existsOrNull(libraryDir.join(Config.DEFAULT_MANIFEST_NAME)),
-            existsOrNull(libraryDir.join(Config.DEFAULT_RES_FOLDER)),
-            existsOrNull(libraryDir.join(Config.DEFAULT_ASSET_FOLDER)),
+            libraryDir.join(Config.DEFAULT_MANIFEST_NAME),
+            libraryDir.join(Config.DEFAULT_RES_FOLDER),
+            libraryDir.join(Config.DEFAULT_ASSET_FOLDER),
             null));
       }
     }
@@ -102,9 +102,5 @@ public class ManifestIdentifier {
         ", packageName='" + packageName + '\'' +
         ", libraries=" + libraries +
         '}';
-  }
-
-  private static FsFile existsOrNull(FsFile fsFile) {
-    return fsFile.exists() ? fsFile : null;
   }
 }

--- a/robolectric/src/main/java/org/robolectric/internal/MavenManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/MavenManifestFactory.java
@@ -3,6 +3,7 @@ package org.robolectric.internal;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import org.robolectric.annotation.Config;
@@ -85,7 +86,8 @@ public class MavenManifestFactory implements ManifestFactory {
    * Search through an AndroidManifest's library directories to load library AppManifest files.
    * For testing, allow a parameter override of the library directories.
    * @param resDirectory
-   * @param libraries If not null, override the libraries in androidManifest.
+   * @param libraries If not null, override the libraries in androidManifest. If null, search for
+   *                  libraries in the project.properties file using {@link #findLibraries(FsFile)}.
    * @return A list of AndroidManifest objects, one for each library found.
    */
   private static List<AndroidManifest> createLibraryManifests(
@@ -99,7 +101,7 @@ public class MavenManifestFactory implements ManifestFactory {
 
       for (ManifestIdentifier library : libraries) {
         AndroidManifest libraryManifest = createLibraryAndroidManifest(library,
-            createLibraryManifests(resDirectory, null));
+            createLibraryManifests(resDirectory, Collections.emptyList()));
         libraryManifests.add(libraryManifest);
       }
     }

--- a/robolectric/src/main/java/org/robolectric/internal/MavenManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/MavenManifestFactory.java
@@ -3,14 +3,11 @@ package org.robolectric.internal;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import org.robolectric.annotation.Config;
-import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.res.Fs;
 import org.robolectric.res.FsFile;
-import org.robolectric.util.Logger;
 
 public class MavenManifestFactory implements ManifestFactory {
 
@@ -25,93 +22,28 @@ public class MavenManifestFactory implements ManifestFactory {
     FsFile resDir = baseDir.join(config.resourceDir());
     FsFile assetDir = baseDir.join(config.assetDir());
 
-    List<FsFile> libraryDirs = null;
-    if (config.libraries().length > 0) {
-      libraryDirs = new ArrayList<>();
-      for (String libraryDirName : config.libraries()) {
-        libraryDirs.add(baseDir.join(libraryDirName));
-      }
-    }
-
-    return new ManifestIdentifier(manifestFile, resDir, assetDir, config.packageName(), libraryDirs);
-  }
-
-  @Override
-  public AndroidManifest create(ManifestIdentifier manifestIdentifier) {
-    AndroidManifest appManifest;
-    FsFile manifestFile = manifestIdentifier.getManifestFile();
-    if (manifestFile == null) {
-      appManifest = createDummyManifest(manifestIdentifier.getPackageName());
-    } else if (!manifestFile.exists()) {
-      System.out.println("WARNING: No manifest file found at " + manifestFile.getPath() + ".");
-      System.out.println("Falling back to the Android OS resources only.");
-      System.out.println("To remove this warning, annotate your test class with @Config(manifest=Config.NONE).");
-      appManifest = createDummyManifest(manifestIdentifier.getPackageName());
+    List<ManifestIdentifier> libraries;
+    if (config.libraries().length == 0) {
+      // If there is no library override, look through subdirectories.
+      libraries = findLibraries(resDir);
     } else {
-      FsFile resDir = manifestIdentifier.getResDir();
-      FsFile assetDir = manifestIdentifier.getAssetDir();
-      String packageName = manifestIdentifier.getPackageName();
-
-      Logger.debug("Robolectric assets directory: " + assetDir.getPath());
-      Logger.debug("   Robolectric res directory: " + resDir.getPath());
-      Logger.debug("   Robolectric manifest path: " + manifestFile.getPath());
-      Logger.debug("    Robolectric package name: " + packageName);
-
-      List<ManifestIdentifier> libraries = manifestIdentifier.getLibraries();
-      List<AndroidManifest> libraryManifests = createLibraryManifests(resDir, libraries);
-      appManifest = new AndroidManifest(manifestFile, resDir, assetDir, libraryManifests, packageName);
-    }
-
-    return appManifest;
-  }
-
-  private AndroidManifest createDummyManifest(String packageName) {
-    if (packageName == null || packageName.equals("")) {
-      packageName = "org.robolectric.default";
-    }
-
-    return new AndroidManifest(null, null, null, packageName) {
-      @Override
-      public int getTargetSdkVersion() {
-        return SdkConfig.FALLBACK_SDK_VERSION;
+      libraries = new ArrayList<>();
+      for (String libraryDirName : config.libraries()) {
+        FsFile libDir = baseDir.join(libraryDirName);
+        libraries.add(new ManifestIdentifier(
+            null,
+            libDir.join(Config.DEFAULT_MANIFEST_NAME),
+            libDir.join(Config.DEFAULT_RES_FOLDER),
+            libDir.join(Config.DEFAULT_ASSET_FOLDER),
+            null));
       }
-    };
+    }
+
+    return new ManifestIdentifier(config.packageName(), manifestFile, resDir, assetDir, libraries);
   }
 
   FsFile getBaseDir() {
     return Fs.currentDirectory();
-  }
-
-  /**
-   * Search through an AndroidManifest's library directories to load library AppManifest files.
-   * For testing, allow a parameter override of the library directories.
-   * @param resDirectory
-   * @param libraries If not null, override the libraries in androidManifest. If null, search for
-   *                  libraries in the project.properties file using {@link #findLibraries(FsFile)}.
-   * @return A list of AndroidManifest objects, one for each library found.
-   */
-  private static List<AndroidManifest> createLibraryManifests(
-      FsFile resDirectory, List<ManifestIdentifier> libraries) {
-    List<AndroidManifest> libraryManifests = new ArrayList<>();
-    if (resDirectory != null) {
-      // If there is no library override, look through subdirectories.
-      if (libraries == null) {
-        libraries = findLibraries(resDirectory);
-      }
-
-      for (ManifestIdentifier library : libraries) {
-        AndroidManifest libraryManifest = createLibraryAndroidManifest(library,
-            createLibraryManifests(resDirectory, Collections.emptyList()));
-        libraryManifests.add(libraryManifest);
-      }
-    }
-    return libraryManifests;
-  }
-
-  private static AndroidManifest createLibraryAndroidManifest(ManifestIdentifier libraryBaseDir,
-      List<AndroidManifest> libraryManifests) {
-    return new AndroidManifest(libraryBaseDir.getManifestFile(), libraryBaseDir.getResDir(),
-        libraryBaseDir.getAssetDir(), libraryManifests, null);
   }
 
   private static Properties getProperties(FsFile propertiesFile) {
@@ -141,7 +73,7 @@ public class MavenManifestFactory implements ManifestFactory {
 
   /**
    * Find valid library AndroidManifest files referenced from an already loaded AndroidManifest's
-   * "project.properties" file.
+   * `project.properties` file, recursively.
    */
   private static List<ManifestIdentifier> findLibraries(FsFile resDirectory) {
     List<ManifestIdentifier> libraryBaseDirs = new ArrayList<>();
@@ -160,12 +92,13 @@ public class MavenManifestFactory implements ManifestFactory {
           // Ignore directories without any files
           FsFile[] libraryBaseDirFiles = libraryDir.listFiles();
           if (libraryBaseDirFiles != null && libraryBaseDirFiles.length > 0) {
+            List<ManifestIdentifier> libraries = findLibraries(libraryDir.join(Config.DEFAULT_RES_FOLDER));
             libraryBaseDirs.add(new ManifestIdentifier(
                 null,
-                existsOrNull(libraryDir.join(Config.DEFAULT_MANIFEST_NAME)),
-                existsOrNull(libraryDir.join(Config.DEFAULT_RES_FOLDER)),
-                existsOrNull(libraryDir.join(Config.DEFAULT_ASSET_FOLDER)),
-                null));
+                libraryDir.join(Config.DEFAULT_MANIFEST_NAME),
+                libraryDir.join(Config.DEFAULT_RES_FOLDER),
+                libraryDir.join(Config.DEFAULT_ASSET_FOLDER),
+                libraries));
           }
         }
 
@@ -173,9 +106,5 @@ public class MavenManifestFactory implements ManifestFactory {
       }
     }
     return libraryBaseDirs;
-  }
-
-  private static FsFile existsOrNull(FsFile fsFile) {
-    return fsFile.exists() ? fsFile : null;
   }
 }

--- a/robolectric/src/test/java/org/robolectric/ManifestFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/ManifestFactoryTest.java
@@ -77,7 +77,7 @@ public class ManifestFactoryTest {
     assertThat(manifestIdentifier.getManifestFile()).isEqualTo(Fs.fileFromPath("/path/to/MergedManifest.xml"));
     assertThat(manifestIdentifier.getResDir()).isEqualTo(Fs.fileFromPath("/path/to/merged-resources"));
     assertThat(manifestIdentifier.getAssetDir()).isEqualTo(Fs.fileFromPath("/path/to/merged-assets"));
-    assertThat(manifestIdentifier.getLibraryDirs()).isEmpty();
+    assertThat(manifestIdentifier.getLibraries()).isEmpty();
     assertThat(manifestIdentifier.getPackageName()).isNull();
 
     AndroidManifest androidManifest = manifestFactory.create(manifestIdentifier);
@@ -111,7 +111,7 @@ public class ManifestFactoryTest {
             .isEqualTo(Fs.fromURL(getClass().getClassLoader().getResource("TestAndroidManifest.xml")));
     assertThat(manifestIdentifier.getResDir()).isEqualTo(Fs.fileFromPath("/path/to/merged-resources"));
     assertThat(manifestIdentifier.getAssetDir()).isEqualTo(Fs.fileFromPath("/path/to/merged-assets"));
-    assertThat(manifestIdentifier.getLibraryDirs()).isEmpty();
+    assertThat(manifestIdentifier.getLibraries()).isEmpty();
     assertThat(manifestIdentifier.getPackageName()).isEqualTo("another.package");
   }
 

--- a/robolectric/src/test/java/org/robolectric/internal/BuckManifestFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/BuckManifestFactoryTest.java
@@ -52,20 +52,20 @@ public class BuckManifestFactoryTest {
 
   @Test public void multiple_res_dirs() throws Exception {
     System.setProperty("buck.robolectric_res_directories", "buck/res1:buck/res2");
-    System.setProperty("buck.robolectric_assets_directories", "buck/assets");
+    System.setProperty("buck.robolectric_assets_directories", "buck/assets1:buck/assets2");
 
     ManifestIdentifier manifestIdentifier = buckManifestFactory.identify(configBuilder.build());
     AndroidManifest manifest = buckManifestFactory.create(manifestIdentifier);
     assertThat(manifest.getResDirectory())
             .isEqualTo(FileFsFile.from("buck/res2"));
     assertThat(manifest.getAssetsDirectory())
-            .isEqualTo(FileFsFile.from("buck/assets"));
+            .isEqualTo(FileFsFile.from("buck/assets2"));
 
     List<ResourcePath> resourcePathList = manifest.getIncludedResourcePaths();
     assertThat(resourcePathList.size()).isEqualTo(2);
     assertThat(resourcePathList).containsExactly(
-            new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res2"), FileFsFile.from("buck/assets")),
-            new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res1"), FileFsFile.from("buck/assets"))
+            new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res2"), FileFsFile.from("buck/assets2")),
+            new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res1"), FileFsFile.from("buck/assets1"))
     );
   }
 
@@ -77,7 +77,7 @@ public class BuckManifestFactoryTest {
 
     String assetDirectoriesFileName = "asset-directories";
     File assetDirectoriesFile = tempFolder.newFile(assetDirectoriesFileName);
-    Files.write("buck/assets", assetDirectoriesFile, Charsets.UTF_8);
+    Files.write("buck/assets1\nbuck/assets2", assetDirectoriesFile, Charsets.UTF_8);
     System.setProperty("buck.robolectric_assets_directories", "@" + assetDirectoriesFile.getAbsolutePath());
 
     ManifestIdentifier manifestIdentifier = buckManifestFactory.identify(configBuilder.build());
@@ -85,13 +85,13 @@ public class BuckManifestFactoryTest {
     assertThat(manifest.getResDirectory())
         .isEqualTo(FileFsFile.from("buck/res2"));
     assertThat(manifest.getAssetsDirectory())
-        .isEqualTo(FileFsFile.from("buck/assets"));
+        .isEqualTo(FileFsFile.from("buck/assets2"));
 
     List<ResourcePath> resourcePathList = manifest.getIncludedResourcePaths();
     assertThat(resourcePathList.size()).isEqualTo(2);
     assertThat(resourcePathList).containsExactly(
-        new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res2"), FileFsFile.from("buck/assets")),
-        new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res1"), FileFsFile.from("buck/assets"))
+        new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res2"), FileFsFile.from("buck/assets2")),
+        new ResourcePath(manifest.getRClass(), FileFsFile.from("buck/res1"), FileFsFile.from("buck/assets1"))
     );
   }
 }

--- a/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
+++ b/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
@@ -270,6 +270,13 @@ public class AndroidManifestTest {
   }
 
   @Test
+  public void whenMissingManifestFile_getPackageName_shouldBeDefault() throws Exception {
+    AndroidManifest appManifest = new AndroidManifest(null, resourceFile("res"), resourceFile("assets"), null);
+    assertThat(appManifest.getPackageName()).isEqualTo("org.robolectric.default");
+    assertThat(appManifest.getRClass()).isEqualTo(null);
+  }
+
+  @Test
   public void shouldRead1IntentFilter() {
     AndroidManifest appManifest = newConfig("TestAndroidManifestForActivitiesWithIntentFilter.xml");
     appManifest.getMinSdkVersion(); // Force parsing

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -229,7 +229,7 @@ public class ShadowPackageManagerTest {
 
   public static class ActivityWithConfigChanges extends Activity { }
 
-  @Test
+  @Test @Config(sdk=25)
   public void getActivityMetaData_configChanges() throws Exception {
     Activity activity = setupActivity(ShadowPackageManagerTest.ActivityWithConfigChanges.class);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -229,7 +229,7 @@ public class ShadowPackageManagerTest {
 
   public static class ActivityWithConfigChanges extends Activity { }
 
-  @Test @Config(sdk=25)
+  @Test
   public void getActivityMetaData_configChanges() throws Exception {
     Activity activity = setupActivity(ShadowPackageManagerTest.ActivityWithConfigChanges.class);
 

--- a/shadows/framework/src/main/java/org/robolectric/RuntimeEnvironment.java
+++ b/shadows/framework/src/main/java/org/robolectric/RuntimeEnvironment.java
@@ -149,6 +149,11 @@ public class RuntimeEnvironment {
     RuntimeEnvironment.appManifest = appManifest;
   }
 
+  /**
+   * @deprecated Use {@link android.content.Context} or {@link android.content.pm.PackageManager}
+   *             instead. This method will be removed in a future version of Robolectric.
+   */
+  @Deprecated
   public static AndroidManifest getAppManifest() {
     return RuntimeEnvironment.appManifest;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -681,6 +681,11 @@ public class ShadowApplication extends ShadowContextWrapper {
     latestWakeLock = null;
   }
 
+  /**
+   * @deprecated Use {@link android.content.Context} or {@link android.content.pm.PackageManager}
+   *             instead. This method will be removed in a future version of Robolectric.
+   */
+  @Deprecated
   public AndroidManifest getAppManifest() {
     return appManifest;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -321,17 +321,17 @@ public final class ShadowAssetManager {
 
   @Implementation
   public final InputStream open(String fileName) throws IOException {
-    return ShadowApplication.getInstance().getAppManifest().getAssetsDirectory().join(fileName).getInputStream();
+    return getAssetsDirectory().join(fileName).getInputStream();
   }
 
   @Implementation
   public final InputStream open(String fileName, int accessMode) throws IOException {
-    return ShadowApplication.getInstance().getAppManifest().getAssetsDirectory().join(fileName).getInputStream();
+    return getAssetsDirectory().join(fileName).getInputStream();
   }
 
   @Implementation
   public final AssetFileDescriptor openFd(String fileName) throws IOException {
-    File file = new File(ShadowApplication.getInstance().getAppManifest().getAssetsDirectory().join(fileName).getPath());
+    File file = new File(getAssetsDirectory().join(fileName).getPath());
     if (file.getPath().startsWith("jar")) {
       file = getFileFromZip(file);
     }
@@ -382,9 +382,9 @@ public final class ShadowAssetManager {
   public final String[] list(String path) throws IOException {
     FsFile file;
     if (path.isEmpty()) {
-      file = ShadowApplication.getInstance().getAppManifest().getAssetsDirectory();
+      file = getAssetsDirectory();
     } else {
-      file = ShadowApplication.getInstance().getAppManifest().getAssetsDirectory().join(path);
+      file = getAssetsDirectory().join(path);
     }
     if (file.isDirectory()) {
       return file.listFileNames();
@@ -913,6 +913,10 @@ public final class ShadowAssetManager {
 
     // else if attr in theme, use its value
     return themeStyleSet.getAttrValue(attrName);
+  }
+
+  private FsFile getAssetsDirectory() {
+    return ShadowApplication.getInstance().getAppManifest().getAssetsDirectory();
   }
 
   @Nonnull private ResName getResName(int id) {


### PR DESCRIPTION
Toward removing `#create(ManifestIdentifier)`.

Refactor ManifestIdentifier to hold libraries' `ManifestIdentifiers` instead of paths.