### PR TITLE
Improve the fidelity of ShadowPendingIntent

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPendingIntentTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPendingIntentTest.java
@@ -1,16 +1,25 @@
 package org.robolectric.shadows;
 
+import static android.app.PendingIntent.FLAG_CANCEL_CURRENT;
+import static android.app.PendingIntent.FLAG_IMMUTABLE;
+import static android.app.PendingIntent.FLAG_NO_CREATE;
+import static android.app.PendingIntent.FLAG_ONE_SHOT;
+import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Activity;
 import android.app.PendingIntent;
+import android.app.PendingIntent.CanceledException;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -18,38 +27,47 @@ import org.robolectric.annotation.Config;
 @RunWith(RobolectricTestRunner.class)
 public class ShadowPendingIntentTest {
 
+  private Context context;
+
+  @Before
+  public void setUp() {
+    context = RuntimeEnvironment.application;
+  }
+
   @Test
-  public void getBroadcast_shouldCreateIntentForBroadcast() throws Exception {
+  public void getBroadcast_shouldCreateIntentForBroadcast() {
     Intent intent = new Intent();
-    PendingIntent pendingIntent = PendingIntent.getBroadcast(RuntimeEnvironment.application, 99, intent, 100);
+    PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 99, intent, 100);
+
     ShadowPendingIntent shadow = shadowOf(pendingIntent);
     assertThat(shadow.isActivityIntent()).isFalse();
     assertThat(shadow.isBroadcastIntent()).isTrue();
     assertThat(shadow.isServiceIntent()).isFalse();
     assertThat(intent).isEqualTo(shadow.getSavedIntent());
-    assertThat((Context) RuntimeEnvironment.application).isEqualTo(shadow.getSavedContext());
+    assertThat(context).isEqualTo(shadow.getSavedContext());
     assertThat(shadow.getRequestCode()).isEqualTo(99);
     assertThat(shadow.getFlags()).isEqualTo(100);
   }
 
   @Test
-  public void getActivity_shouldCreateIntentForBroadcast() throws Exception {
+  public void getActivity_shouldCreateIntentForBroadcast() {
     Intent intent = new Intent();
-    PendingIntent pendingIntent = PendingIntent.getActivity(RuntimeEnvironment.application, 99, intent, 100);
+    PendingIntent pendingIntent = PendingIntent.getActivity(context, 99, intent, 100);
+
     ShadowPendingIntent shadow = shadowOf(pendingIntent);
     assertThat(shadow.isActivityIntent()).isTrue();
     assertThat(shadow.isBroadcastIntent()).isFalse();
     assertThat(shadow.isServiceIntent()).isFalse();
     assertThat(intent).isEqualTo(shadow.getSavedIntent());
-    assertThat((Context) RuntimeEnvironment.application).isEqualTo(shadow.getSavedContext());
+    assertThat(context).isEqualTo(shadow.getSavedContext());
     assertThat(shadow.getRequestCode()).isEqualTo(99);
     assertThat(shadow.getFlags()).isEqualTo(100);
   }
 
   @Test
   public void getActivities_shouldCreateIntentForBroadcast() throws Exception {
-    Intent[] intents = new Intent[] {new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK)};
-    PendingIntent pendingIntent = PendingIntent.getActivities(RuntimeEnvironment.application, 99, intents, 100);
+    Intent[] intents = {new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK)};
+    PendingIntent pendingIntent = PendingIntent.getActivities(context, 99, intents, 100);
 
     ShadowPendingIntent shadow = shadowOf(pendingIntent);
     assertThat(shadow.getSavedIntents()).isEqualTo(intents);
@@ -62,8 +80,9 @@ public class ShadowPendingIntentTest {
 
   @Test
   public void getActivities_withBundle_shouldCreateIntentForBroadcast() throws Exception {
-    Intent[] intents = new Intent[] {new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK)};
-    PendingIntent pendingIntent = PendingIntent.getActivities(RuntimeEnvironment.application, 99, intents, 100, new Bundle());
+    Intent[] intents = {new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK)};
+    PendingIntent pendingIntent =
+        PendingIntent.getActivities(context, 99, intents, 100, Bundle.EMPTY);
 
     ShadowPendingIntent shadow = shadowOf(pendingIntent);
     assertThat(shadow.getSavedIntents()).isEqualTo(intents);
@@ -75,29 +94,49 @@ public class ShadowPendingIntentTest {
   }
 
   @Test
-  public void getService_shouldCreateIntentForBroadcast() throws Exception {
+  public void getService_shouldCreateIntentForBroadcast() {
     Intent intent = new Intent();
-    PendingIntent pendingIntent = PendingIntent.getService(RuntimeEnvironment.application, 99, intent, 100);
+    PendingIntent pendingIntent = PendingIntent.getService(context, 99, intent, 100);
+
     ShadowPendingIntent shadow = shadowOf(pendingIntent);
     assertThat(shadow.isActivityIntent()).isFalse();
     assertThat(shadow.isBroadcastIntent()).isFalse();
     assertThat(shadow.isServiceIntent()).isTrue();
     assertThat(intent).isEqualTo(shadow.getSavedIntent());
-    assertThat((Context) RuntimeEnvironment.application).isEqualTo(shadow.getSavedContext());
+    assertThat(context).isEqualTo(shadow.getSavedContext());
     assertThat(shadow.getRequestCode()).isEqualTo(99);
     assertThat(shadow.getFlags()).isEqualTo(100);
   }
 
   @Test
+  public void getActivities_nullIntent() {
+    try {
+      PendingIntent.getActivities(context, 99, null, 100);
+      fail("Expected NullPointerException when creating PendingIntent with null Intent[]");
+    } catch (NullPointerException ignore) {
+      // expected
+    }
+  }
+
+  @Test
+  public void getActivities_withBundle_nullIntent() {
+    try {
+      PendingIntent.getActivities(context, 99, null, 100, Bundle.EMPTY);
+      fail("Expected NullPointerException when creating PendingIntent with null Intent[]");
+    } catch (NullPointerException ignore) {
+      // expected
+    }
+  }
+
+  @Test
   public void send_shouldFillInIntentData() throws Exception {
     Intent intent = new Intent();
-    Activity context = new Activity();
-    PendingIntent forActivity = PendingIntent.getActivity(context, 99, intent, 100);
+    Context context = Robolectric.setupActivity(Activity.class);
+    PendingIntent pendingIntent = PendingIntent.getActivity(context, 99, intent, 100);
 
-    Activity otherContext = new Activity();
-    Intent fillIntent = new Intent();
-    fillIntent.putExtra("TEST", 23);
-    forActivity.send(otherContext, 0, fillIntent);
+    Activity otherContext = Robolectric.setupActivity(Activity.class);
+    Intent fillIntent = new Intent().putExtra("TEST", 23);
+    pendingIntent.send(otherContext, 0, fillIntent);
 
     Intent i = shadowOf(otherContext).getNextStartedActivity();
     assertThat(i).isNotNull();
@@ -106,134 +145,358 @@ public class ShadowPendingIntentTest {
   }
 
   @Test
+  public void send_shouldFillInLastIntentData() throws Exception {
+    Intent[] intents = {new Intent("first"), new Intent("second")};
+    Context context = Robolectric.setupActivity(Activity.class);
+    PendingIntent pendingIntent = PendingIntent.getActivities(context, 99, intents, 100);
+
+    Activity otherContext = Robolectric.setupActivity(Activity.class);
+    Intent fillIntent = new Intent();
+    fillIntent.putExtra("TEST", 23);
+    pendingIntent.send(otherContext, 0, fillIntent);
+
+    ShadowActivity shadowActivity = shadowOf(otherContext);
+    Intent first = shadowActivity.getNextStartedActivity();
+    assertThat(first).isNotNull();
+    assertThat(first).isSameAs(intents[0]);
+    assertThat(first.hasExtra("TEST")).isFalse();
+
+    Intent second = shadowActivity.getNextStartedActivity();
+    assertThat(second).isNotNull();
+    assertThat(second).isSameAs(intents[1]);
+    assertThat(second.getIntExtra("TEST", -1)).isEqualTo(23);
+  }
+
+  @Test
+  public void send_shouldNotFillIn_whenPendingIntentIsImmutable() throws Exception {
+    Intent intent = new Intent();
+    Context context = Robolectric.setupActivity(Activity.class);
+    PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, FLAG_IMMUTABLE);
+
+    Activity otherContext = Robolectric.setupActivity(Activity.class);
+    Intent fillIntent = new Intent().putExtra("TEST", 23);
+    pendingIntent.send(otherContext, 0, fillIntent);
+
+    Intent i = shadowOf(otherContext).getNextStartedActivity();
+    assertThat(i).isNotNull();
+    assertThat(i).isSameAs(intent);
+    assertThat(i.hasExtra("TEST")).isFalse();
+  }
+
+  @Test
+  public void updatePendingIntent() {
+    Intent intent = new Intent().putExtra("whatever", 5);
+    PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
+    ShadowPendingIntent shadowPendingIntent = shadowOf(pendingIntent);
+
+    // Absent FLAG_UPDATE_CURRENT, this should fail to update the Intent extra.
+    intent = new Intent().putExtra("whatever", 77);
+    PendingIntent.getBroadcast(context, 0, intent, 0);
+    assertThat(shadowPendingIntent.getSavedIntent().getIntExtra("whatever", -1)).isEqualTo(5);
+
+    // With FLAG_UPDATE_CURRENT, this should succeed in updating the Intent extra.
+    PendingIntent.getBroadcast(context, 0, intent, FLAG_UPDATE_CURRENT);
+    assertThat(shadowPendingIntent.getSavedIntent().getIntExtra("whatever", -1)).isEqualTo(77);
+  }
+
+  @Test
   public void getActivity_withFlagNoCreate_shouldReturnNullIfNoPendingIntentExists() {
     Intent intent = new Intent();
+    assertThat(PendingIntent.getActivity(context, 99, intent, FLAG_NO_CREATE)).isNull();
+  }
 
-    PendingIntent pendingIntent = PendingIntent.getActivity(RuntimeEnvironment.application, 99, intent,
-        PendingIntent.FLAG_NO_CREATE);
-
-    assertThat(pendingIntent).isNull();
+  @Test
+  public void getActivity_withFlagNoCreate_shouldReturnNullIfRequestCodeIsUnmatched() {
+    Intent intent = new Intent();
+    PendingIntent.getActivity(context, 99, intent, 0);
+    assertThat(PendingIntent.getActivity(context, 98, intent, FLAG_NO_CREATE)).isNull();
   }
 
   @Test
   public void getActivity_withFlagNoCreate_shouldReturnExistingIntent() {
     Intent intent = new Intent();
-
-    PendingIntent.getActivity(RuntimeEnvironment.application, 99, intent, 100);
+    PendingIntent.getActivity(context, 99, intent, 100);
 
     Intent identical = new Intent();
-    PendingIntent saved = PendingIntent.getActivity(RuntimeEnvironment.application, 99, identical,
-        PendingIntent.FLAG_NO_CREATE);
-
+    PendingIntent saved = PendingIntent.getActivity(context, 99, identical, FLAG_NO_CREATE);
     assertThat(saved).isNotNull();
-    assertThat(intent).isEqualTo(shadowOf(saved).getSavedIntent());
+    assertThat(intent).isSameAs(shadowOf(saved).getSavedIntent());
+  }
+
+  @Test
+  public void getActivity_withNoFlags_shouldReturnExistingIntent() {
+    Intent intent = new Intent();
+    PendingIntent.getActivity(context, 99, intent, 100);
+
+    Intent updated = new Intent();
+    PendingIntent saved = PendingIntent.getActivity(context, 99, updated, 0);
+    assertThat(saved).isNotNull();
+    assertThat(intent).isSameAs(shadowOf(saved).getSavedIntent());
   }
 
   @Test
   public void getActivities_withFlagNoCreate_shouldReturnNullIfNoPendingIntentExists() {
-    Intent[] intents = new Intent[] { new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK) };
-
-    PendingIntent pendingIntent = PendingIntent.getActivities(RuntimeEnvironment.application, 99, intents,
-        PendingIntent.FLAG_NO_CREATE);
-
+    Intent[] intents = {new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK)};
+    PendingIntent pendingIntent = PendingIntent.getActivities(context, 99, intents, FLAG_NO_CREATE);
     assertThat(pendingIntent).isNull();
   }
 
   @Test
-  public void getActivities_withFlagNoCreate_shouldReturnExistingIntent() {
-    Intent[] intents = new Intent[] { new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK) };
+  public void getActivities_withFlagNoCreate_shouldReturnNullIfRequestCodeIsUnmatched() {
+    Intent[] intents = {new Intent()};
+    PendingIntent.getActivities(context, 99, intents, 0);
+    assertThat(PendingIntent.getActivities(context, 98, intents, FLAG_NO_CREATE)).isNull();
+  }
 
+  @Test
+  public void getActivities_withFlagNoCreate_shouldReturnExistingIntent() {
+    Intent[] intents = {new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK)};
     PendingIntent.getActivities(RuntimeEnvironment.application, 99, intents, 100);
 
-    Intent[] identicalIntents = new Intent[] { new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK) };
-    PendingIntent saved = PendingIntent.getActivities(RuntimeEnvironment.application, 99, identicalIntents,
-        PendingIntent.FLAG_NO_CREATE);
-
+    Intent[] identicalIntents = {new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK)};
+    PendingIntent saved =
+        PendingIntent.getActivities(context, 99, identicalIntents, FLAG_NO_CREATE);
     assertThat(saved).isNotNull();
-    assertThat(intents).isEqualTo(shadowOf(saved).getSavedIntents());
+    assertThat(intents).isSameAs(shadowOf(saved).getSavedIntents());
+  }
+
+  @Test
+  public void getActivities_withNoFlags_shouldReturnExistingIntent() {
+    Intent[] intents = {new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK)};
+    PendingIntent.getActivities(RuntimeEnvironment.application, 99, intents, 100);
+
+    Intent[] identicalIntents = {new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK)};
+    PendingIntent saved = PendingIntent.getActivities(context, 99, identicalIntents, 0);
+    assertThat(saved).isNotNull();
+    assertThat(intents).isSameAs(shadowOf(saved).getSavedIntents());
   }
 
   @Test
   public void getBroadcast_withFlagNoCreate_shouldReturnNullIfNoPendingIntentExists() {
     Intent intent = new Intent();
-
-    PendingIntent pendingIntent = PendingIntent.getBroadcast(RuntimeEnvironment.application, 99, intent,
-        PendingIntent.FLAG_NO_CREATE);
-
+    PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 99, intent, FLAG_NO_CREATE);
     assertThat(pendingIntent).isNull();
+  }
+
+  @Test
+  public void getBroadcast_withFlagNoCreate_shouldReturnNullIfRequestCodeIsUnmatched() {
+    Intent intent = new Intent();
+    PendingIntent.getBroadcast(context, 99, intent, 0);
+    assertThat(PendingIntent.getBroadcast(context, 98, intent, FLAG_NO_CREATE)).isNull();
   }
 
   @Test
   public void getBroadcast_withFlagNoCreate_shouldReturnExistingIntent() {
     Intent intent = new Intent();
+    PendingIntent.getBroadcast(context, 99, intent, 100);
 
-    PendingIntent.getBroadcast(RuntimeEnvironment.application, 99, intent, 100);
     Intent identical = new Intent();
-    PendingIntent saved = PendingIntent.getBroadcast(RuntimeEnvironment.application, 99, identical,
-        PendingIntent.FLAG_NO_CREATE);
-
+    PendingIntent saved = PendingIntent.getBroadcast(context, 99, identical, FLAG_NO_CREATE);
     assertThat(saved).isNotNull();
-    assertThat(intent).isEqualTo(shadowOf(saved).getSavedIntent());
+    assertThat(intent).isSameAs(shadowOf(saved).getSavedIntent());
+  }
+
+  @Test
+  public void getBroadcast_withNoFlags_shouldReturnExistingIntent() {
+    Intent intent = new Intent();
+    PendingIntent.getBroadcast(context, 99, intent, 100);
+
+    Intent identical = new Intent();
+    PendingIntent saved = PendingIntent.getBroadcast(context, 99, identical, 0);
+    assertThat(saved).isNotNull();
+    assertThat(intent).isSameAs(shadowOf(saved).getSavedIntent());
   }
 
   @Test
   public void getService_withFlagNoCreate_shouldReturnNullIfNoPendingIntentExists() {
     Intent intent = new Intent();
-
-    PendingIntent pendingIntent = PendingIntent.getService(RuntimeEnvironment.application, 99, intent,
-        PendingIntent.FLAG_NO_CREATE);
-
+    PendingIntent pendingIntent = PendingIntent.getService(context, 99, intent, FLAG_NO_CREATE);
     assertThat(pendingIntent).isNull();
+  }
+
+  @Test
+  public void getService_withFlagNoCreate_shouldReturnNullIfRequestCodeIsUnmatched() {
+    Intent intent = new Intent();
+    PendingIntent.getService(context, 99, intent, 0);
+    assertThat(PendingIntent.getService(context, 98, intent, FLAG_NO_CREATE)).isNull();
   }
 
   @Test
   public void getService_withFlagNoCreate_shouldReturnExistingIntent() {
     Intent intent = new Intent();
-
-    PendingIntent.getService(RuntimeEnvironment.application, 99, intent, 100);
+    PendingIntent.getService(context, 99, intent, 100);
 
     Intent identical = new Intent();
-
-    PendingIntent saved = PendingIntent.getService(RuntimeEnvironment.application, 99, identical,
-        PendingIntent.FLAG_NO_CREATE);
-
+    PendingIntent saved = PendingIntent.getService(context, 99, identical, FLAG_NO_CREATE);
     assertThat(saved).isNotNull();
-    assertThat(intent).isEqualTo(shadowOf(saved).getSavedIntent());
+    assertThat(intent).isSameAs(shadowOf(saved).getSavedIntent());
+  }
+
+  @Test
+  public void getService_withNoFlags_shouldReturnExistingIntent() {
+    Intent intent = new Intent();
+    PendingIntent.getService(context, 99, intent, 100);
+
+    Intent identical = new Intent();
+    PendingIntent saved = PendingIntent.getService(context, 99, identical, 0);
+    assertThat(saved).isNotNull();
+    assertThat(intent).isSameAs(shadowOf(saved).getSavedIntent());
+  }
+
+  @Test
+  public void cancel_shouldRemovePendingIntentForBroadcast() {
+    Intent intent = new Intent();
+    PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 99, intent, 100);
+    assertThat(pendingIntent).isNotNull();
+
+    pendingIntent.cancel();
+    assertThat(PendingIntent.getBroadcast(context, 99, intent, FLAG_NO_CREATE)).isNull();
+  }
+
+  @Test
+  public void cancel_shouldRemovePendingIntentForActivity() {
+    Intent intent = new Intent();
+    PendingIntent pendingIntent = PendingIntent.getActivity(context, 99, intent, 100);
+    assertThat(pendingIntent).isNotNull();
+
+    pendingIntent.cancel();
+    assertThat(PendingIntent.getActivity(context, 99, intent, FLAG_NO_CREATE)).isNull();
+  }
+
+  @Test
+  public void cancel_shouldRemovePendingIntentForActivities() {
+    Intent[] intents = {new Intent(Intent.ACTION_VIEW), new Intent(Intent.ACTION_PICK)};
+    PendingIntent pendingIntent = PendingIntent.getActivities(context, 99, intents, 100);
+    assertThat(pendingIntent).isNotNull();
+
+    pendingIntent.cancel();
+    assertThat(PendingIntent.getActivities(context, 99, intents, FLAG_NO_CREATE)).isNull();
+  }
+
+  @Test
+  public void cancel_shouldRemovePendingIntentForService() {
+    Intent intent = new Intent();
+    PendingIntent pendingIntent = PendingIntent.getService(context, 99, intent, 100);
+    assertThat(pendingIntent).isNotNull();
+
+    pendingIntent.cancel();
+    assertThat(PendingIntent.getService(context, 99, intent, FLAG_NO_CREATE)).isNull();
+  }
+
+  @Test
+  public void send_canceledPendingIntent_throwsCanceledException() throws CanceledException {
+    Intent intent = new Intent();
+    PendingIntent canceled = PendingIntent.getService(context, 99, intent, 100);
+    assertThat(canceled).isNotNull();
+
+    // Cancel the existing PendingIntent and create a new one in its place.
+    PendingIntent current = PendingIntent.getService(context, 99, intent, FLAG_CANCEL_CURRENT);
+    assertThat(current).isNotNull();
+
+    assertThat(shadowOf(canceled).isCanceled()).isTrue();
+    assertThat(shadowOf(current).isCanceled()).isFalse();
+
+    // Sending the new PendingIntent should work as expected.
+    current.send();
+
+    // Sending the canceled PendingIntent should produce a CanceledException.
+    try {
+      canceled.send();
+      fail("CanceledException expected when sending a canceled PendingIntent");
+    } catch (CanceledException ignore) {
+      // expected
+    }
+  }
+
+  @Test
+  public void send_oneShotPendingIntent_shouldCancel() throws CanceledException {
+    Intent intent = new Intent();
+    PendingIntent pendingIntent = PendingIntent.getService(context, 0, intent, FLAG_ONE_SHOT);
+    assertThat(shadowOf(pendingIntent).isCanceled()).isFalse();
+
+    pendingIntent.send();
+    assertThat(shadowOf(pendingIntent).isCanceled()).isTrue();
+    assertThat(PendingIntent.getService(context, 0, intent, FLAG_ONE_SHOT | FLAG_NO_CREATE))
+        .isNull();
+  }
+
+  @Test
+  public void oneShotFlag_differentiatesPendingIntents() {
+    Intent intent = new Intent();
+    PendingIntent oneShot = PendingIntent.getService(context, 0, intent, FLAG_ONE_SHOT);
+    PendingIntent notOneShot = PendingIntent.getService(context, 0, intent, FLAG_UPDATE_CURRENT);
+    assertThat(oneShot).isNotSameAs(notOneShot);
+  }
+
+  @Test
+  public void immutableFlag_differentiatesPendingIntents() {
+    Intent intent = new Intent();
+    PendingIntent immutable = PendingIntent.getService(context, 0, intent, FLAG_IMMUTABLE);
+    PendingIntent notImmutable = PendingIntent.getService(context, 0, intent, FLAG_UPDATE_CURRENT);
+    assertThat(immutable).isNotSameAs(notImmutable);
   }
 
   @Test
   public void testEquals() {
-    Context ctx = RuntimeEnvironment.application;
-    PendingIntent pendingIntent1 = PendingIntent.getActivity(ctx, 99, new Intent("activity"), 100);
+    PendingIntent pendingIntent =
+        PendingIntent.getActivity(context, 99, new Intent("activity"), 100);
 
-    assertThat(pendingIntent1)
-        .isEqualTo(PendingIntent.getActivity(ctx, 99, new Intent("activity"), 100));
+    // Same type, requestCode and Intent action implies equality.
+    assertThat(PendingIntent.getActivity(context, 99, new Intent("activity"), FLAG_NO_CREATE))
+        .isSameAs(pendingIntent);
 
-    assertThat(pendingIntent1)
-        .isNotEqualTo(PendingIntent.getActivity(ctx, 99, new Intent("activity2"), 100));
+    // Mismatched Intent action implies inequality.
+    assertThat(PendingIntent.getActivity(context, 99, new Intent("activity2"), FLAG_NO_CREATE))
+        .isNull();
 
-    assertThat(pendingIntent1)
-        .isNotEqualTo(PendingIntent.getActivity(ctx, 999, new Intent("activity"), 100));
+    // Mismatched requestCode implies inequality.
+    assertThat(PendingIntent.getActivity(context, 999, new Intent("activity"), FLAG_NO_CREATE))
+        .isNull();
+
+    // Mismatched types imply inequality.
+    assertThat(PendingIntent.getBroadcast(context, 99, new Intent("activity"), FLAG_NO_CREATE))
+        .isNull();
+    assertThat(PendingIntent.getService(context, 99, new Intent("activity"), FLAG_NO_CREATE))
+        .isNull();
+  }
+
+  @Test
+  public void testEquals_getActivities() {
+    Intent[] intents = {new Intent("activity"), new Intent("activity2")};
+    PendingIntent pendingIntent = PendingIntent.getActivities(context, 99, intents, 100);
+
+    Intent[] forward = {new Intent("activity"), new Intent("activity2")};
+    assertThat(PendingIntent.getActivities(context, 99, forward, FLAG_NO_CREATE))
+        .isSameAs(pendingIntent);
+
+    Intent[] irrelevant = {new Intent("irrelevant"), new Intent("activity2")};
+    assertThat(PendingIntent.getActivities(context, 99, irrelevant, FLAG_NO_CREATE))
+        .isSameAs(pendingIntent);
+
+    Intent single = new Intent("activity2");
+    assertThat(PendingIntent.getActivity(context, 99, single, FLAG_NO_CREATE))
+        .isSameAs(pendingIntent);
+
+    Intent[] backward = {new Intent("activity2"), new Intent("activity")};
+    assertThat(PendingIntent.getActivities(context, 99, backward, FLAG_NO_CREATE)).isNull();
   }
 
   @Test
   @Config(minSdk = Build.VERSION_CODES.JELLY_BEAN_MR1)
   public void testGetCreatorPackage_nothingSet() {
-    Context ctx = RuntimeEnvironment.application;
-    PendingIntent pendingIntent = PendingIntent.getActivity(ctx, 99, new Intent("activity"), 100);
-
-    assertThat(pendingIntent.getCreatorPackage()).isEqualTo(ctx.getPackageName());
-    assertThat(pendingIntent.getTargetPackage()).isEqualTo(ctx.getPackageName());
+    PendingIntent pendingIntent =
+        PendingIntent.getActivity(context, 99, new Intent("activity"), 100);
+    assertThat(pendingIntent.getCreatorPackage()).isEqualTo(context.getPackageName());
+    assertThat(pendingIntent.getTargetPackage()).isEqualTo(context.getPackageName());
   }
 
   @Test
   @Config(minSdk = Build.VERSION_CODES.JELLY_BEAN_MR1)
   public void testGetCreatorPackage_explicitlySetPackage() {
     String fakePackage = "some.fake.package";
-    Context ctx = RuntimeEnvironment.application;
-    PendingIntent pendingIntent = PendingIntent.getActivity(ctx, 99, new Intent("activity"), 100);
+    PendingIntent pendingIntent =
+        PendingIntent.getActivity(context, 99, new Intent("activity"), 100);
     shadowOf(pendingIntent).setCreatorPackage(fakePackage);
-
     assertThat(pendingIntent.getCreatorPackage()).isEqualTo(fakePackage);
     assertThat(pendingIntent.getTargetPackage()).isEqualTo(fakePackage);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
@@ -1,7 +1,13 @@
 package org.robolectric.shadows;
 
+import static android.app.PendingIntent.FLAG_CANCEL_CURRENT;
+import static android.app.PendingIntent.FLAG_IMMUTABLE;
+import static android.app.PendingIntent.FLAG_NO_CREATE;
+import static android.app.PendingIntent.FLAG_ONE_SHOT;
+import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
 import static org.robolectric.Shadows.shadowOf;
 
+import android.annotation.NonNull;
 import android.app.PendingIntent;
 import android.app.PendingIntent.CanceledException;
 import android.content.Context;
@@ -10,9 +16,10 @@ import android.content.IntentSender;
 import android.os.Bundle;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -22,48 +29,68 @@ import org.robolectric.util.ReflectionHelpers;
 
 @Implements(PendingIntent.class)
 public class ShadowPendingIntent {
+
+  private enum Type {ACTIVITY, BROADCAST, SERVICE}
+
   private static final List<PendingIntent> createdIntents = new ArrayList<>();
 
   @RealObject
-  PendingIntent realPendingIntent;
+  private PendingIntent realPendingIntent;
 
-  private Intent[] savedIntents;
+  @NonNull private Intent[] savedIntents;
   private Context savedContext;
-  private boolean isActivityIntent;
-  private boolean isBroadcastIntent;
-  private boolean isServiceIntent;
+  private Type type;
   private int requestCode;
   private int flags;
   private String creatorPackage;
+  private boolean canceled;
 
   @Implementation
-  public static PendingIntent getActivity(Context context, int requestCode, Intent intent, int flags) {
-    return create(context, new Intent[] {intent}, true, false, false, requestCode, flags);
+  public static PendingIntent getActivity(
+      Context context, int requestCode, @NonNull Intent intent, int flags) {
+    return create(context, new Intent[] {intent}, Type.ACTIVITY, requestCode, flags);
   }
 
   @Implementation
-  public static PendingIntent getActivity(Context context, int requestCode, Intent intent, int flags, Bundle options) {
-    return create(context, new Intent[] {intent}, true, false, false, requestCode, flags);
+  public static PendingIntent getActivity(
+      Context context, int requestCode, @NonNull Intent intent, int flags, Bundle options) {
+    return create(context, new Intent[] {intent}, Type.ACTIVITY, requestCode, flags);
   }
 
   @Implementation
-  public static PendingIntent getActivities(Context context, int requestCode, Intent[] intents, int flags) {
-    return create(context, intents, true, false, false, requestCode, flags);
+  public static PendingIntent getActivities(
+      Context context, int requestCode, @NonNull Intent[] intents, int flags) {
+    return create(context, intents, Type.ACTIVITY, requestCode, flags);
   }
 
   @Implementation
-  public static PendingIntent getActivities(Context context, int requestCode, Intent[] intents, int flags, Bundle options) {
-    return create(context, intents, true, false, false, requestCode, flags);
+  public static PendingIntent getActivities(
+      Context context, int requestCode, @NonNull Intent[] intents, int flags, Bundle options) {
+    return create(context, intents, Type.ACTIVITY, requestCode, flags);
   }
 
   @Implementation
-  public static PendingIntent getBroadcast(Context context, int requestCode, Intent intent, int flags) {
-    return create(context, new Intent[] {intent}, false, true, false, requestCode, flags);
+  public static PendingIntent getBroadcast(
+      Context context, int requestCode, @NonNull Intent intent, int flags) {
+    return create(context, new Intent[] {intent}, Type.BROADCAST, requestCode, flags);
   }
 
   @Implementation
-  public static PendingIntent getService(Context context, int requestCode, Intent intent, int flags) {
-    return create(context, new Intent[] {intent}, false, false, true, requestCode, flags);
+  public static PendingIntent getService(
+      Context context, int requestCode, @NonNull Intent intent, int flags) {
+    return create(context, new Intent[] {intent}, Type.SERVICE, requestCode, flags);
+  }
+
+  @Implementation
+  public void cancel() {
+    for (Iterator<PendingIntent> i = createdIntents.iterator(); i.hasNext(); ) {
+      PendingIntent pendingIntent = i.next();
+      if (pendingIntent == realPendingIntent) {
+        canceled = true;
+        i.remove();
+        break;
+      }
+    }
   }
 
   @Implementation
@@ -73,24 +100,31 @@ public class ShadowPendingIntent {
 
   @Implementation
   public void send(Context context, int code, Intent intent) throws CanceledException {
-    if (intent != null) {
-      for (Intent savedIntent : savedIntents) {
-        savedIntent.fillIn(intent, 0);
-      }
+    if (canceled) {
+      throw new CanceledException();
     }
 
-    if (isActivityIntent) {
+    // Fill in the last Intent, if it is mutable, with information now available at send-time.
+    if (intent != null && isMutable(flags)) {
+      getSavedIntent().fillIn(intent, 0);
+    }
+
+    if (isActivityIntent()) {
       for (Intent savedIntent : savedIntents) {
         context.startActivity(savedIntent);
       }
-    } else if (isBroadcastIntent) {
+    } else if (isBroadcastIntent()) {
       for (Intent savedIntent : savedIntents) {
         context.sendBroadcast(savedIntent);
       }
-    } else if (isServiceIntent) {
+    } else if (isServiceIntent()) {
       for (Intent savedIntent : savedIntents) {
         context.startService(savedIntent);
       }
+    }
+
+    if (isOneShot(flags)) {
+      cancel();
     }
   }
 
@@ -99,34 +133,80 @@ public class ShadowPendingIntent {
     return new RoboIntentSender(realPendingIntent);
   }
 
+  /**
+   * @return {@code true} iff sending this PendingIntent will start an activity
+   */
   public boolean isActivityIntent() {
-    return isActivityIntent;
+    return type == Type.ACTIVITY;
   }
 
+  /**
+   * @return {@code true} iff sending this PendingIntent will broadcast an Intent
+   */
   public boolean isBroadcastIntent() {
-    return isBroadcastIntent;
+    return type == Type.BROADCAST;
   }
 
+  /**
+   * @return {@code true} iff sending this PendingIntent will start a service
+   */
   public boolean isServiceIntent() {
-    return isServiceIntent;
+    return type == Type.SERVICE;
   }
 
+  /**
+   * @return the context in which this PendingIntent was created
+   */
   public Context getSavedContext() {
     return savedContext;
   }
 
+  /**
+   * This returns the last Intent in the Intent[] to be delivered when the PendingIntent is sent.
+   * This method is particularly useful for PendingIntents created with a single Intent:
+   * <ul>
+   *   <li>{@link #getActivity(Context, int, Intent, int)}</li>
+   *   <li>{@link #getActivity(Context, int, Intent, int, Bundle)}</li>
+   *   <li>{@link #getBroadcast(Context, int, Intent, int)}</li>
+   *   <li>{@link #getService(Context, int, Intent, int)}</li>
+   * </ul>
+   *
+   * @return the final Intent to be delivered when the PendingIntent is sent
+   */
   public Intent getSavedIntent() {
-    return savedIntents[0];
+    return savedIntents[savedIntents.length - 1];
   }
 
+  /**
+   * This method is particularly useful for PendingIntents created with multiple Intents:
+   * <ul>
+   *   <li>{@link #getActivities(Context, int, Intent[], int)}</li>
+   *   <li>{@link #getActivities(Context, int, Intent[], int, Bundle)}</li>
+   * </ul>
+   *
+   * @return all Intents to be delivered when the PendingIntent is sent
+   */
   public Intent[] getSavedIntents() {
     return savedIntents;
   }
 
+  /**
+   * @return {@true} iff this PendingIntent has been canceled
+   */
+  public boolean isCanceled() {
+    return canceled;
+  }
+
+  /**
+   * @return the request code with which this PendingIntent was created
+   */
   public int getRequestCode() {
     return requestCode;
   }
 
+  /**
+   * @return the flags with which this PendingIntent was created
+   */
   public int getFlags() {
     return flags;
   }
@@ -153,27 +233,23 @@ public class ShadowPendingIntent {
     if (this == o) return true;
     if (o == null || realPendingIntent.getClass() != o.getClass()) return false;
     ShadowPendingIntent that = shadowOf((PendingIntent) o);
-    if (savedContext != null) {
-      String packageName = savedContext.getPackageName();
-      String thatPackageName = that.savedContext.getPackageName();
-      if (packageName != null ? !packageName.equals(thatPackageName) : thatPackageName != null) return false;
-    } else {
-      if (that.savedContext != null) return false;
-    }
-    if (this.savedIntents == null) {
-      return that.savedIntents == null;
-    }
-    if (that.savedIntents == null) {
+
+    String packageName = savedContext == null ? null : savedContext.getPackageName();
+    String thatPackageName = that.savedContext == null ? null : that.savedContext.getPackageName();
+    if (!Objects.equals(packageName, thatPackageName)) {
       return false;
     }
+
     if (this.savedIntents.length != that.savedIntents.length) {
       return false;
     }
+
     for (int i = 0; i < this.savedIntents.length; i++) {
       if (!this.savedIntents[i].filterEquals(that.savedIntents[i])) {
         return false;
       }
     }
+
     if (this.requestCode != that.requestCode) {
       return false;
     }
@@ -192,47 +268,89 @@ public class ShadowPendingIntent {
     return result;
   }
 
-  private static PendingIntent create(Context context, Intent[] intents, boolean isActivity, boolean isBroadcast, boolean isService, int requestCode, int flags) {
-    if ((flags & PendingIntent.FLAG_NO_CREATE) != 0) {
-      return getCreatedIntentFor(intents);
+  private static PendingIntent create(Context context, Intent[] intents, Type type, int requestCode,
+      int flags) {
+    Objects.requireNonNull(intents, "intents may not be null");
+
+    // Search for a matching PendingIntent.
+    PendingIntent pendingIntent = getCreatedIntentFor(type, intents, requestCode, flags);
+    if ((flags & FLAG_NO_CREATE) != 0) {
+      return pendingIntent;
     }
 
-    PendingIntent pendingIntent = ReflectionHelpers.callConstructor(PendingIntent.class);
-    ShadowPendingIntent shadowPendingIntent = Shadows.shadowOf(pendingIntent);
-    shadowPendingIntent.savedIntents = intents;
-    shadowPendingIntent.isActivityIntent = isActivity;
-    shadowPendingIntent.isBroadcastIntent = isBroadcast;
-    shadowPendingIntent.isServiceIntent = isService;
-    shadowPendingIntent.savedContext = context;
-    shadowPendingIntent.requestCode = requestCode;
-    shadowPendingIntent.flags = flags;
+    // If requested, update the existing PendingIntent if one exists.
+    if (pendingIntent != null && (flags & FLAG_UPDATE_CURRENT) != 0) {
+      Intent intent = shadowOf(pendingIntent).getSavedIntent();
+      Bundle extras = intent.getExtras();
+      if (extras != null) {
+        extras.clear();
+      }
+      intent.putExtras(intents[intents.length - 1]);
+      return pendingIntent;
+    }
 
-    createdIntents.add(pendingIntent);
+    // If requested, cancel the existing PendingIntent if one exists.
+    if (pendingIntent != null && (flags & FLAG_CANCEL_CURRENT) != 0) {
+      ShadowPendingIntent toCancel = shadowOf(pendingIntent);
+      toCancel.cancel();
+      pendingIntent = null;
+    }
+
+    // Build the PendingIntent if it does not exist.
+    if (pendingIntent == null) {
+      pendingIntent = ReflectionHelpers.callConstructor(PendingIntent.class);
+      ShadowPendingIntent shadowPendingIntent = shadowOf(pendingIntent);
+      shadowPendingIntent.savedIntents = intents;
+      shadowPendingIntent.type = type;
+      shadowPendingIntent.savedContext = context;
+      shadowPendingIntent.requestCode = requestCode;
+      shadowPendingIntent.flags = flags;
+
+      createdIntents.add(pendingIntent);
+    }
+
     return pendingIntent;
   }
 
-  private static PendingIntent getCreatedIntentFor(Intent[] intents) {
+  private static PendingIntent getCreatedIntentFor(Type type, Intent[] intents, int requestCode,
+      int flags) {
     for (PendingIntent createdIntent : createdIntents) {
-      ShadowPendingIntent shadowPendingIntent = Shadows.shadowOf(createdIntent);
-      if (shadowPendingIntent.savedIntents.length != intents.length) {
+      ShadowPendingIntent shadowPendingIntent = shadowOf(createdIntent);
+
+      if (isOneShot(shadowPendingIntent.flags) != isOneShot(flags)) {
         continue;
       }
 
-      // Order matters in the framework. If I call getActivities(Activity1, Activity2), that will
-      // give me a different PendingIntent than if I call getActivities(Activity2, Activity1).
-      boolean equalIntents = true;
-      for (int i = 0; i < intents.length; i++) {
-        if (!shadowPendingIntent.savedIntents[i].filterEquals(intents[i])) {
-          equalIntents = false;
-          break;
-        }
+      if (isMutable(shadowPendingIntent.flags) != isMutable(flags)) {
+        continue;
       }
 
-      if (equalIntents) {
+      if (shadowPendingIntent.type != type) {
+        continue;
+      }
+
+      if (shadowPendingIntent.requestCode != requestCode) {
+        continue;
+      }
+
+      // The last Intent in the array acts as the "significant element" for matching as per
+      // {@link #getActivities(Context, int, Intent[], int)}.
+      Intent savedIntent = shadowPendingIntent.getSavedIntent();
+      Intent targetIntent = intents[intents.length - 1];
+
+      if (savedIntent == null ? targetIntent == null : savedIntent.filterEquals(targetIntent)) {
         return createdIntent;
       }
     }
     return null;
+  }
+
+  private static boolean isOneShot(int flags) {
+    return (flags & FLAG_ONE_SHOT) != 0;
+  }
+
+  private static boolean isMutable(int flags) {
+    return (flags & FLAG_IMMUTABLE) == 0;
   }
 
   @Resetter


### PR DESCRIPTION
- ShadowPendingIntents can no longer be created with null Intent arrays
- ShadowPendingIntent.cancel() now works
- ShadowPendingIntent.isCanceled() allows for querying of the canceled
state
- Activity, Broadcast and Service ShadowPendingIntents are now always
unequal
- ShadowPendingIntent now checks equality against the last Intent in the
Intent[]
- send() throws CanceledException when attempting to send a canceled
PendingIntent
- send() only fills in the last Intent in the Intent[]
- getSavedIntent() returns the last Intent in the Intent[] (used to
return first)
- Added support for FLAG_UPDATE_CURRENT
- Added support for FLAG_CANCEL_CURRENT
- Added support for FLAG_ONE_SHOT
- Added support for FLAG_IMMUTABLE

PiperRevId: 172932344

### Overview

### Proposed Changes
