### PR TITLE
Use CircleCI instead of Travis for builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,5 +33,21 @@ task aggregateTestReports(type: TestReport) {
     }
 }
 
+task prefetchSdks() {
+    def sdkConfigurations = []
+    AndroidSdk.ALL_SDKS.each { androidSdk ->
+        sdkConfigurations << configurations.create("sdk${androidSdk.apiLevel}")
+        dependencies.add("sdk${androidSdk.apiLevel}", androidSdk.coordinates)
+    }
+
+    sdkConfigurations.each { sdkConfiguration ->
+        println sdkConfiguration.files
+    }
+}
+
+task prefetchDependencies(dependsOn: allprojects.collect { p -> "${p.path}:dependencies" }) {
+    dependsOn "prefetchSdks"
+}
+
 // for use of external initialization scripts...
 project.ext.allSdks = AndroidSdk.ALL_SDKS

--- a/build.gradle
+++ b/build.gradle
@@ -39,10 +39,6 @@ task prefetchSdks() {
         sdkConfigurations << configurations.create("sdk${androidSdk.apiLevel}")
         dependencies.add("sdk${androidSdk.apiLevel}", androidSdk.coordinates)
     }
-
-    sdkConfigurations.each { sdkConfiguration ->
-        println sdkConfiguration.files
-    }
 }
 
 task prefetchDependencies(dependsOn: allprojects.collect { p -> "${p.path}:dependencies" }) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,16 @@
+buildscript {
+    repositories { jcenter() }
+
+    dependencies {
+        classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:2.2.+'
+        classpath 'ch.raffael.pegdown-doclet:pegdown-doclet:1.3'
+    }
+}
+
+plugins {
+    id "net.ltgt.apt" version "0.12" // automatic annotation processing
+}
+
 allprojects {
     repositories {
         mavenLocal()
@@ -8,12 +21,13 @@ allprojects {
     version = thisVersion
 }
 
-buildscript {
-    repositories { jcenter() }
+apply plugin: 'idea'
+apply plugin: 'net.ltgt.apt-idea'
 
-    dependencies {
-        classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:2.2.+'
-        classpath 'ch.raffael.pegdown-doclet:pegdown-doclet:1.3'
+idea {
+    project {
+        // experimental: whether annotation processing will be configured in the IDE; only actually used with the 'idea' task.
+        configureAnnotationProcessing = true
     }
 }
 

--- a/buildSrc/src/main/groovy/AndroidSdk.groovy
+++ b/buildSrc/src/main/groovy/AndroidSdk.groovy
@@ -28,8 +28,20 @@ class AndroidSdk implements Comparable<AndroidSdk> {
         this.frameworkSdkBuildVersion = frameworkSdkBuildVersion
     }
 
+    String getGroupId() {
+        return "org.robolectric"
+    }
+
+    String getArtifactId() {
+        return "android-all"
+    }
+
+    String getVersion() {
+        return "${androidVersion}-robolectric-${frameworkSdkBuildVersion}"
+    }
+
     String getCoordinates() {
-        return "org.robolectric:android-all:${androidVersion}-robolectric-${frameworkSdkBuildVersion}"
+        return "${groupId}:${artifactId}:${version}"
     }
 
     String getJarFileName() {

--- a/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
@@ -61,7 +61,7 @@ class RoboJavaModulePlugin implements Plugin<Project> {
             }
 
             minHeapSize = "1024m"
-            maxHeapSize = "2048m"
+            maxHeapSize = "3172m"
 
             def forwardedSystemProperties = System.properties
                     .findAll { k,v -> k.startsWith("robolectric.") }

--- a/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
@@ -60,8 +60,8 @@ class RoboJavaModulePlugin implements Plugin<Project> {
                 events = ["failed", "skipped"]
             }
 
-            minHeapSize = "2048m"
-            maxHeapSize = "4096m"
+            minHeapSize = "1024m"
+            maxHeapSize = "2048m"
 
             def forwardedSystemProperties = System.properties
                     .findAll { k,v -> k.startsWith("robolectric.") }

--- a/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
@@ -37,6 +37,8 @@ class RoboJavaModulePlugin implements Plugin<Project> {
 
         // it's weird that compileOnly deps aren't included for test compilation; fix that:
         project.sourceSets {
+            generated
+
             test.compileClasspath += project.configurations.compileOnly
         }
 
@@ -89,10 +91,13 @@ class RoboJavaModulePlugin implements Plugin<Project> {
 
             task('sourcesJar', type: Jar, dependsOn: classes) {
                 classifier "sources"
-                from sourceSets.main.allJava
+                from sourceSets.main.allJava + sourceSets.generated.allJava
             }
 
-            javadoc.failOnError = false
+            javadoc {
+                failOnError = false
+                source = sourceSets.main.allJava + sourceSets.generated.allJava
+            }
 
             task('javadocJar', type: Jar, dependsOn: javadoc) {
                 classifier "javadoc"

--- a/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
@@ -63,6 +63,10 @@ class RoboJavaModulePlugin implements Plugin<Project> {
             minHeapSize = "1024m"
             maxHeapSize = "3172m"
 
+            if (System.env['GRADLE_MAX_PARALLEL_FORKS'] != null) {
+                maxParallelForks = Integer.parseInt(System.env['GRADLE_MAX_PARALLEL_FORKS'])
+            }
+
             def forwardedSystemProperties = System.properties
                     .findAll { k,v -> k.startsWith("robolectric.") }
                     .collect { k,v -> "-D$k=$v" }
@@ -153,8 +157,8 @@ class RoboJavaModulePlugin implements Plugin<Project> {
                                 "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
                         repository(url: url) {
                             authentication(
-                                    userName: System.properties["sonatype-login"],
-                                    password: System.properties["sonatype-password"]
+                                    userName: System.properties["sonatype-login"] || System.env['sonatypeLogin'],
+                                    password: System.properties["sonatype-password"] || System.env['sonatypePassword']
                             )
                         }
 

--- a/buildSrc/src/main/groovy/ShadowsPlugin.groovy
+++ b/buildSrc/src/main/groovy/ShadowsPlugin.groovy
@@ -31,22 +31,16 @@ class ShadowsPlugin implements Plugin<Project> {
             }
         }
 
-        project.task('checkAssembly', description: "Check that jars have required contents") {
-            def jars = [:]
-            project.configurations.archives.artifacts.each {
-                if (it.extension == 'jar') {
-                    jars["${it.classifier}.${it.extension}"] = it.file
-                }
-            }
-
-            project.tasks['checkAssembly'].doLast {
-                def shadowPackageNameDir = project.shadows.packageName.replaceAll(/\./, '/')
-                checkForFile(jars['javadoc.jar'], "${shadowPackageNameDir}/Shadows.html")
-                checkForFile(jars['sources.jar'], "${shadowPackageNameDir}/Shadows.java")
-            }
+        // verify that we have the apt-generated files in our javadoc and sources jars
+        project.tasks['javadocJar'].doLast { task ->
+            def shadowPackageNameDir = project.shadows.packageName.replaceAll(/\./, '/')
+            checkForFile(task.archivePath, "${shadowPackageNameDir}/Shadows.html")
         }
 
-        project.tasks['assemble'].finalizedBy 'checkAssembly'
+        project.tasks['sourcesJar'].doLast { task ->
+            def shadowPackageNameDir = project.shadows.packageName.replaceAll(/\./, '/')
+            checkForFile(task.archivePath, "${shadowPackageNameDir}/Shadows.java")
+        }
 
         project.idea {
             module {

--- a/buildSrc/src/main/groovy/ShadowsPlugin.groovy
+++ b/buildSrc/src/main/groovy/ShadowsPlugin.groovy
@@ -7,50 +7,37 @@ import org.gradle.util.GFileUtils
 class ShadowsPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
+        project.apply plugin: "idea"
+        project.apply plugin: "net.ltgt.apt-idea"
+
         project.extensions.create("shadows", ShadowsPluginExtension)
 
-        project.configurations {
-            robolectricProcessor
-        }
-
         project.dependencies {
-            robolectricProcessor project.project(":processor")
-        }
-
-        def generatedSourcesDir = "${project.buildDir}/generated-shadows"
-
-        project.sourceSets.main.java.srcDirs += project.file(generatedSourcesDir)
-
-        project.task("generateShadowProvider", type: JavaCompile, description: "Generate Shadows.shadowOf()s class") { task ->
-            classpath = project.configurations.robolectricProcessor
-            source = project.sourceSets.main.java
-            destinationDir = project.file(generatedSourcesDir)
-
-            doFirst {
-                logger.info "Generating Shadows.java for ${project.name}…"
-
-                // reset our classpath at the last minute, since other plugins might mutate
-                //   compileJava's classpath and we want to pick up any changes…
-                classpath = project.tasks['compileJava'].classpath + project.configurations.robolectricProcessor
-
-                options.compilerArgs.addAll(
-                        "-proc:only",
-                        "-processor", "org.robolectric.annotation.processing.RobolectricProcessor",
-                        "-Aorg.robolectric.annotation.processing.shadowPackage=${project.shadows.packageName}"
-                )
-            }
-
-            doLast {
-                def src = project.file("$generatedSourcesDir/META-INF/services/org.robolectric.internal.ShadowProvider")
-                def dest = project.file("${project.buildDir}/resources/main/META-INF/services/org.robolectric.internal.ShadowProvider")
-
-                GFileUtils.mkdirs(dest.getParentFile());
-                GFileUtils.copyFile(src, dest);
-            }
+            apt project.project(":processor")
         }
 
         def compileJavaTask = project.tasks["compileJava"]
-        compileJavaTask.dependsOn("generateShadowProvider")
+        compileJavaTask.doFirst {
+            options.compilerArgs.add("-Aorg.robolectric.annotation.processing.shadowPackage=${project.shadows.packageName}")
+        }
+
+        project.idea {
+            module {
+                apt {
+                    // whether generated sources dirs are added as generated sources root
+                    addGeneratedSourcesDirs = true
+                    // whether the apt and testApt dependencies are added as module dependencies
+                    addAptDependencies = true
+
+                    // The following are mostly internal details; you shouldn't ever need to configure them.
+                    // whether the compileOnly and testCompileOnly dependencies are added as module dependencies
+                    addCompileOnlyDependencies = false // defaults to true in Gradle < 2.12
+                    // the dependency scope used for apt and/or compileOnly dependencies (when enabled above)
+                    mainDependenciesScope = "PROVIDED" // defaults to "COMPILE" in Gradle < 3.4, or when using the Gradle integration in IntelliJ IDEA
+                }
+            }
+
+        }
     }
 
     static class ShadowsPluginExtension {

--- a/circle.yml
+++ b/circle.yml
@@ -21,12 +21,14 @@ jobs:
       - run:
           name: Download Dependencies
           command: |
+            sdkmanager --install 'platforms;android-27'
             ./scripts/install-dependencies.rb
             ./gradlew prefetchDependencies
       - save_cache:
           paths:
             - ~/.gradle
             - ~/.m2
+            - /opt/android/sdk/platforms/android-27
           key: cache-{{ checksum ".cache-hash" }}
       - run:
           name: Build and Test

--- a/circle.yml
+++ b/circle.yml
@@ -7,12 +7,14 @@ jobs:
     resource_class: large
     environment:
       JVM_OPTS: -Xmx3172m
-      GRADLE_MAX_PARALLEL_FORKS: 3
+      GRADLE_MAX_PARALLEL_FORKS: 2
     steps:
       - checkout
       - run:
           name: Calculate Cache Hash
-          command: find . \( -name \*.gradle -or -name \*.groovy -or -name \*.sh -or -name \*.rb -or -name circle.yml \) -exec shasum {} \; > .cache-hash
+          command: |
+            find . \( -name \*.gradle -or -name \*.groovy -or -name \*.sh -or -name \*.rb -or -name circle.yml \) -exec shasum {} \; > .cache-hash
+            cat .cache-hash
       - run:
           name: Install Maven
           command: sudo apt-get update; sudo apt-get install maven

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: ~/code
     docker:
       - image: circleci/android:api-26-alpha
-    resource_class: large
+    resource_class: xlarge
     environment:
       JVM_OPTS: -Xmx3172m
       GRADLE_MAX_PARALLEL_FORKS: 2

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ jobs:
     resource_class: large
     environment:
       JVM_OPTS: -Xmx3172m
+      GRADLE_MAX_PARALLEL_FORKS: 3
     steps:
       - checkout
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -4,24 +4,43 @@ jobs:
     working_directory: ~/code
     docker:
       - image: circleci/android:api-26-alpha
+    resource_class: large
     environment:
       JVM_OPTS: -Xmx3200m
     steps:
       - checkout
+      - run:
+          name: Calculate Cache Hash
+          command: find . \( -name \*.gradle -or -name \*.groovy -or -name \*.sh -or -name \*.rb -or -name circle.yml \) -exec shasum {} \; > .cache-hash
+      - run:
+          name: Install Maven
+          command: sudo apt-get update; sudo apt-get install maven
       - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}
+          key: cache-{{ checksum ".cache-hash" }}
       - run:
           name: Download Dependencies
-          command: ./scripts/install-dependencies.rb
+          command: |
+            ./scripts/install-dependencies.rb
+            ./gradlew prefetchDependencies
       - save_cache:
           paths:
             - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}
+            - ~/.m2
+          key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Run Tests
-          command: ./gradlew test
+          name: Build and Test
+          command: SKIP_JAVADOC=true ./gradlew clean assemble test --info --stacktrace --continue
+      - run:
+          name: Collect Test Results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
       - store_artifacts:
           path: build/reports
           destination: reports
-      - store_test_results:
-          path: build/test-results
+      - run:
+          name: Upload Snapshot
+          command: SKIP_JAVADOC=true ./gradlew upload --no-rebuild

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Calculate Cache Hash
           command: |
-            find . \( -name \*.gradle -or -name \*.groovy -or -name \*.sh -or -name \*.rb -or -name circle.yml \) -exec shasum {} \; > .cache-hash
+            find . \( -name \*.gradle -or -name \*.groovy -or -name \*.sh -or -name \*.rb -or -name circle.yml \) -exec shasum {} \; | sort > .cache-hash
             cat .cache-hash
       - run:
           name: Install Maven

--- a/circle.yml
+++ b/circle.yml
@@ -44,4 +44,7 @@ jobs:
           destination: reports
       - run:
           name: Upload Snapshot
-          command: SKIP_JAVADOC=true ./gradlew upload --no-rebuild
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              ./gradlew upload --no-rebuild
+            fi

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ jobs:
       - image: circleci/android:api-26-alpha
     resource_class: large
     environment:
-      JVM_OPTS: -Xmx3200m
+      JVM_OPTS: -Xmx3172m
     steps:
       - checkout
       - run:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -6,6 +6,10 @@ new RoboJavaModulePlugin(
         deploy: true
 ).apply(project)
 
+// Disable annotation processor for tests
+compileTestJava {
+    options.compilerArgs.add("-proc:none")
+}
 
 dependencies {
     // Project dependencies

--- a/processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
@@ -1,5 +1,6 @@
 package org.robolectric.annotation.processing;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -57,7 +58,8 @@ public class RobolectricProcessor extends AbstractProcessor {
    * @param options simulated options that would ordinarily
    *                be passed in the {@link ProcessingEnvironment}.
    */
-  RobolectricProcessor(Map<String, String> options) {
+  @VisibleForTesting
+  public RobolectricProcessor(Map<String, String> options) {
     processOptions(options);
   }
 
@@ -108,6 +110,10 @@ public class RobolectricProcessor extends AbstractProcessor {
       this.shadowPackage = options.get(PACKAGE_OPT);
       this.shouldInstrumentPackages =
           !"false".equalsIgnoreCase(options.get(SHOULD_INSTRUMENT_PKG_OPT));
+
+      if (this.shadowPackage == null) {
+        throw new IllegalArgumentException("no package specified for " + PACKAGE_OPT);
+      }
     }
   }
 

--- a/processor/src/test/java/org/robolectric/annotation/processing/RobolectricProcessorTest.java
+++ b/processor/src/test/java/org/robolectric/annotation/processing/RobolectricProcessorTest.java
@@ -32,21 +32,19 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class RobolectricProcessorTest {
-  private static final Map<String,String> DEFAULT_OPTS = new HashMap<>();
-
-  static {
-    DEFAULT_OPTS.put(PACKAGE_OPT, "org.robolectric");
-  }
+  public static final Map<String,String> DEFAULT_OPTS = new HashMap<String, String>() {{
+    put(PACKAGE_OPT, "org.robolectric");
+  }};
 
   @Test
   public void robolectricProcessor_supportsPackageOption() {
-    assertThat(new RobolectricProcessor().getSupportedOptions()).contains(PACKAGE_OPT);
+    assertThat(new RobolectricProcessor(DEFAULT_OPTS).getSupportedOptions()).contains(PACKAGE_OPT);
   }
 
   @Test
   public void robolectricProcessor_supportsShouldInstrumentPackageOption() {
     assertThat(
-        new RobolectricProcessor().getSupportedOptions()).contains(SHOULD_INSTRUMENT_PKG_OPT);
+        new RobolectricProcessor(DEFAULT_OPTS).getSupportedOptions()).contains(SHOULD_INSTRUMENT_PKG_OPT);
   }
 
   @Test
@@ -57,7 +55,7 @@ public class RobolectricProcessorTest {
           SHADOW_PROVIDER_SOURCE,
           SHADOW_EXTRACTOR_SOURCE,
           forSourceString("HelloWorld", "final class HelloWorld {}")))
-      .processedWith(new RobolectricProcessor())
+      .processedWith(new RobolectricProcessor(DEFAULT_OPTS))
       .compilesWithoutError();
     //.and().generatesNoSources(); Should add this assertion onces
     // it becomes available in compile-testing
@@ -190,7 +188,7 @@ public class RobolectricProcessorTest {
           SHADOW_PROVIDER_SOURCE,
           SHADOW_EXTRACTOR_SOURCE,
           forResource("org/robolectric/annotation/TestWithUnrecognizedAnnotation.java")))
-      .processedWith(new RobolectricProcessor())
+      .processedWith(new RobolectricProcessor(DEFAULT_OPTS))
       .compilesWithoutError();
   }
 
@@ -198,7 +196,7 @@ public class RobolectricProcessorTest {
   public void shouldGracefullyHandleNoAnythingClass_withNoRealObject() {
     assertAbout(javaSource())
       .that(forResource("org/robolectric/annotation/processing/shadows/ShadowAnything.java"))
-      .processedWith(new RobolectricProcessor())
+      .processedWith(new RobolectricProcessor(DEFAULT_OPTS))
       .failsToCompile();
   }
 
@@ -209,7 +207,7 @@ public class RobolectricProcessorTest {
           SHADOW_PROVIDER_SOURCE,
           SHADOW_EXTRACTOR_SOURCE,
           forResource("org/robolectric/annotation/processing/shadows/ShadowRealObjectWithCorrectAnything.java")))
-      .processedWith(new RobolectricProcessor())
+      .processedWith(new RobolectricProcessor(DEFAULT_OPTS))
       .failsToCompile();
   }
 
@@ -253,7 +251,7 @@ public class RobolectricProcessorTest {
         .that(ImmutableList.of(
             ROBO_SOURCE,
             forResource("org/robolectric/annotation/processing/shadows/DocumentedObjectShadow.java")))
-        .processedWith(new RobolectricProcessor())
+        .processedWith(new RobolectricProcessor(DEFAULT_OPTS))
         .compilesWithoutError();
     JsonParser jsonParser = new JsonParser();
     String jsonFile = "build/docs/json/org.robolectric.Robolectric.DocumentedObject.json";

--- a/processor/src/test/java/org/robolectric/annotation/processing/validator/RealObjectValidatorTest.java
+++ b/processor/src/test/java/org/robolectric/annotation/processing/validator/RealObjectValidatorTest.java
@@ -3,6 +3,7 @@ package org.robolectric.annotation.processing.validator;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaFileObjects.forResource;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static org.robolectric.annotation.processing.RobolectricProcessorTest.DEFAULT_OPTS;
 import static org.robolectric.annotation.processing.validator.SingleClassSubject.singleClass;
 import static org.robolectric.annotation.processing.validator.Utils.SHADOW_EXTRACTOR_SOURCE;
 
@@ -102,7 +103,7 @@ public class RealObjectValidatorTest {
     .that(ImmutableList.of(
         SHADOW_EXTRACTOR_SOURCE,
         forResource("org/robolectric/annotation/processing/shadows/ShadowRealObjectWithCorrectType.java")))
-    .processedWith(new RobolectricProcessor())
+    .processedWith(new RobolectricProcessor(DEFAULT_OPTS))
       .compilesWithoutError();
   }
 
@@ -120,7 +121,7 @@ public class RealObjectValidatorTest {
       .that(ImmutableList.of(
           SHADOW_EXTRACTOR_SOURCE,
           forResource("org/robolectric/annotation/processing/shadows/ShadowRealObjectWithCorrectClassName.java")))
-      .processedWith(new RobolectricProcessor())
+      .processedWith(new RobolectricProcessor(DEFAULT_OPTS))
       .compilesWithoutError();
   }
   

--- a/processor/src/test/java/org/robolectric/annotation/processing/validator/SingleClassSubject.java
+++ b/processor/src/test/java/org/robolectric/annotation/processing/validator/SingleClassSubject.java
@@ -2,6 +2,7 @@ package org.robolectric.annotation.processing.validator;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static org.robolectric.annotation.processing.RobolectricProcessorTest.DEFAULT_OPTS;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.truth.FailureStrategy;
@@ -37,7 +38,7 @@ public final class SingleClassSubject extends Subject<SingleClassSubject, String
     source = JavaFileObjects.forResource(Utils.toResourcePath(subject));
     tester = assertAbout(javaSources())
       .that(ImmutableList.of(source, Utils.ROBO_SOURCE, Utils.SHADOW_EXTRACTOR_SOURCE))
-      .processedWith(new RobolectricProcessor());
+      .processedWith(new RobolectricProcessor(DEFAULT_OPTS));
   }
 
   public SuccessfulCompilationClause compilesWithoutError() {


### PR DESCRIPTION
Looks like it'll be much faster, makes test failures easier to read, etc.

Also switched gradle build to use `net.ltgt.apt` gradle plugin to enable annotation processing.

Still need to:
- [x] get `javadoc` jar to include generated source
- [x] get `sources` jar to include generated source
- [ ] prefetch `android-all` artifacts into `~/.m2` or switch to using gradle cache