### PR TITLE
Added support for fragment arguments

### DIFF
--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -7,12 +7,9 @@ import android.app.Service;
 import android.app.backup.BackupAgent;
 import android.content.ContentProvider;
 import android.content.Intent;
+import android.os.Bundle;
 import android.util.AttributeSet;
 import android.view.View;
-import java.util.ServiceLoader;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import org.robolectric.android.XmlResourceParserImpl;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.android.controller.BackupAgentController;
@@ -28,6 +25,11 @@ import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.Scheduler;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.util.ServiceLoader;
 
 public class Robolectric {
   private static ShadowsAdapter shadowsAdapter = null;
@@ -105,7 +107,13 @@ public class Robolectric {
     return FragmentController.of(ReflectionHelpers.callConstructor(fragmentClass));
   }
 
-  public static <T extends Fragment> FragmentController<T> buildFragment(Class<T> fragmentClass, Class<? extends Activity> activityClass) {
+  public static <T extends Fragment> FragmentController<T> buildFragment(Class<T> fragmentClass,
+                                                                         Bundle arguments) {
+    return FragmentController.of(ReflectionHelpers.callConstructor(fragmentClass), arguments);
+  }
+
+  public static <T extends Fragment> FragmentController<T> buildFragment(Class<T> fragmentClass,
+                                                                         Class<? extends Activity> activityClass) {
     return FragmentController.of(ReflectionHelpers.callConstructor(fragmentClass), activityClass);
   }
 
@@ -113,8 +121,29 @@ public class Robolectric {
     return FragmentController.of(ReflectionHelpers.callConstructor(fragmentClass), intent);
   }
 
-  public static <T extends Fragment> FragmentController<T> buildFragment(Class<T> fragmentClass, Class<? extends Activity> activityClass, Intent intent) {
+  public static <T extends Fragment> FragmentController<T> buildFragment(Class<T> fragmentClass,
+                                                                         Intent intent,
+                                                                         Bundle arguments) {
+    return FragmentController.of(ReflectionHelpers.callConstructor(fragmentClass), intent, arguments);
+  }
+
+  public static <T extends Fragment> FragmentController<T> buildFragment(Class<T> fragmentClass,
+                                                                         Class<? extends Activity> activityClass,
+                                                                         Intent intent) {
     return FragmentController.of(ReflectionHelpers.callConstructor(fragmentClass), activityClass, intent);
+  }
+
+  public static <T extends Fragment> FragmentController<T> buildFragment(Class<T> fragmentClass,
+                                                                         Class<? extends Activity> activityClass,
+                                                                         Bundle arguments) {
+    return FragmentController.of(ReflectionHelpers.callConstructor(fragmentClass), activityClass, arguments);
+  }
+
+  public static <T extends Fragment> FragmentController<T> buildFragment(Class<T> fragmentClass,
+                                                                         Class<? extends Activity> activityClass,
+                                                                         Intent intent,
+                                                                         Bundle arguments) {
+    return FragmentController.of(ReflectionHelpers.callConstructor(fragmentClass), activityClass, intent, arguments);
   }
 
   public static <T extends BackupAgent> BackupAgentController<T> buildBackupAgent(Class<T> backupAgentClass) {

--- a/robolectric/src/main/java/org/robolectric/android/controller/FragmentController.java
+++ b/robolectric/src/main/java/org/robolectric/android/controller/FragmentController.java
@@ -123,6 +123,11 @@ public class FragmentController<F extends Fragment> extends ComponentController<
     return this;
   }
 
+  public FragmentController<F> arguments(Bundle bundle) {
+    component.setArguments(bundle);
+    return this;
+  }
+
   public FragmentController<F> saveInstanceState(final Bundle outState) {
     shadowMainLooper.runPaused(new Runnable() {
       @Override

--- a/robolectric/src/main/java/org/robolectric/android/controller/FragmentController.java
+++ b/robolectric/src/main/java/org/robolectric/android/controller/FragmentController.java
@@ -16,24 +16,54 @@ public class FragmentController<F extends Fragment> extends ComponentController<
   private final ActivityController<? extends Activity> activityController;
 
   public static <F extends Fragment> FragmentController<F> of(F fragment) {
-    return of(fragment, FragmentControllerActivity.class, null);
+    return of(fragment, FragmentControllerActivity.class, null, null);
   }
 
   public static <F extends Fragment> FragmentController<F> of(F fragment, Class<? extends Activity> activityClass) {
-    return of(fragment, activityClass, null);
+    return of(fragment, activityClass, null, null);
   }
 
   public static <F extends Fragment> FragmentController<F> of(F fragment, Intent intent) {
     return new FragmentController<>(Robolectric.getShadowsAdapter(), fragment, FragmentControllerActivity.class, intent);
   }
 
+  public static <F extends Fragment> FragmentController<F> of(F fragment, Bundle arguments) {
+    return new FragmentController<>(Robolectric.getShadowsAdapter(), fragment, FragmentControllerActivity.class, arguments);
+  }
+
+  public static <F extends Fragment> FragmentController<F> of(F fragment, Intent intent, Bundle arguments) {
+    return new FragmentController<>(Robolectric.getShadowsAdapter(), fragment, FragmentControllerActivity.class, intent,
+            arguments);
+  }
+
   public static <F extends Fragment> FragmentController<F> of(F fragment, Class<? extends Activity> activityClass, Intent intent) {
     return new FragmentController<>(Robolectric.getShadowsAdapter(), fragment, activityClass, intent);
   }
 
+  public static <F extends Fragment> FragmentController<F> of(F fragment, Class<? extends Activity> activityClass, Bundle arguments) {
+    return new FragmentController<>(Robolectric.getShadowsAdapter(), fragment, activityClass, arguments);
+  }
+
+  public static <F extends Fragment> FragmentController<F> of(F fragment, Class<? extends Activity> activityClass,
+                                                              Intent intent, Bundle arguments) {
+    return new FragmentController<>(Robolectric.getShadowsAdapter(), fragment, activityClass, intent, arguments);
+  }
+
   private FragmentController(ShadowsAdapter shadowsAdapter, F fragment, Class<? extends Activity> activityClass, Intent intent) {
+    this(shadowsAdapter, fragment, activityClass, intent, null);
+  }
+
+  private FragmentController(ShadowsAdapter shadowsAdapter, F fragment, Class<? extends Activity> activityClass, Bundle arguments) {
+    this(shadowsAdapter, fragment, activityClass, null, arguments);
+  }
+
+  private FragmentController(ShadowsAdapter shadowsAdapter, F fragment, Class<? extends Activity> activityClass,
+                             Intent intent, Bundle arguments) {
     super(shadowsAdapter, fragment, intent);
     this.fragment = fragment;
+    if (arguments != null) {
+      this.fragment.setArguments(arguments);
+    }
     this.activityController = Robolectric.buildActivity(activityClass, intent);
   }
 
@@ -120,11 +150,6 @@ public class FragmentController<F extends Fragment> extends ComponentController<
         activityController.stop();
       }
     });
-    return this;
-  }
-
-  public FragmentController<F> arguments(Bundle bundle) {
-    component.setArguments(bundle);
     return this;
   }
 

--- a/robolectric/src/test/java/org/robolectric/android/controller/FragmentControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/FragmentControllerTest.java
@@ -135,6 +135,18 @@ public class FragmentControllerTest {
   }
 
   @Test
+  public void withArguments() {
+    final LoginFragment fragment = new LoginFragment();
+
+    Bundle arguments = new Bundle();
+    arguments.putString("test_argument", "test_value");
+    FragmentController<LoginFragment> controller = FragmentController.of(fragment, LoginActivity.class).arguments(arguments).create();
+
+    Bundle argumentsInFragment = controller.get().getArguments();
+    assertThat(argumentsInFragment.getString("test_argument")).isEqualTo("test_value");
+  }
+
+  @Test
   public void visible() {
     final LoginFragment fragment = new LoginFragment();
     final FragmentController<LoginFragment> controller = FragmentController.of(fragment, LoginActivity.class);

--- a/robolectric/src/test/java/org/robolectric/android/controller/FragmentControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/FragmentControllerTest.java
@@ -1,9 +1,5 @@
 package org.robolectric.android.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-
 import android.app.Activity;
 import android.app.Fragment;
 import android.content.Intent;
@@ -17,6 +13,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.RobolectricTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
 public class FragmentControllerTest {
@@ -140,7 +140,7 @@ public class FragmentControllerTest {
 
     Bundle arguments = new Bundle();
     arguments.putString("test_argument", "test_value");
-    FragmentController<LoginFragment> controller = FragmentController.of(fragment, LoginActivity.class).arguments(arguments).create();
+    FragmentController<LoginFragment> controller = FragmentController.of(fragment, LoginActivity.class, arguments).create();
 
     Bundle argumentsInFragment = controller.get().getArguments();
     assertThat(argumentsInFragment.getString("test_argument")).isEqualTo("test_value");


### PR DESCRIPTION
Fixes https://github.com/robolectric/robolectric/issues/3296

### Overview
It's not possible to specify arguments for a Fragment using the current FragmentController API.
This was possible using the old API: 

```
Fragment fragment = new FooFragment();
Bundle arguments = new Bundle();
// Add arguments... 
fragment.setArguments(arguments);
FragmentTestUtil.startFragment();
```

### Proposed Changes
Add a method, `arguments()` to `FragmentController` so that it's possible to do:

```
Bundle arguments = new Bundle();
// Add arguments... 
Robolectric.buildFragment(FooFragment.class).arguments(arguments).start();
```
