### PR TITLE
Enhance Robolectric's detection of color types.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/R.java
+++ b/robolectric/src/test/java/org/robolectric/R.java
@@ -166,6 +166,9 @@ public final class R {
     public static final int list_separator = 0x7f05000c;
     public static final int custom_state_view_text_color = 0x7f05000d;
     public static final int typed_array_orange = 0x7f05000e;
+    public static final int test_ARGB8=0x7f05000f;
+    public static final int test_RGB4=0x7f050010;
+    public static final int test_RGB8=0x7f050011;
   }
 
   public static final class drawable {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
@@ -8,13 +8,17 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.robolectric.R.color.test_ARGB8;
+import static org.robolectric.R.color.test_RGB8;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Activity;
 import android.content.res.AssetFileDescriptor;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
+import android.graphics.Color;
 import android.util.AttributeSet;
+import android.util.TypedValue;
 import com.google.common.io.CharStreams;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -326,5 +330,21 @@ public class ShadowAssetManagerTest {
     assertThat(
             shadowOf(assetManager).getResourceIdentifier("raw_resource", "raw", "org.robolectric"))
         .isEqualTo(R.raw.raw_resource);
+  }
+
+  @Test
+  public void getResourceValue_colorARGB8() {
+    TypedValue outValue = new TypedValue();
+    resources.getValue(test_ARGB8, outValue, false);
+    assertThat(outValue.type).isEqualTo(TypedValue.TYPE_INT_COLOR_ARGB8);
+    assertThat(Color.blue(outValue.data)).isEqualTo(2);
+  }
+
+  @Test
+  public void getResourceValue_colorRGB8() {
+    TypedValue outValue = new TypedValue();
+    resources.getValue(test_RGB8, outValue, false);
+    assertThat(outValue.type).isEqualTo(TypedValue.TYPE_INT_COLOR_RGB8);
+    assertThat(Color.blue(outValue.data)).isEqualTo(4);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -837,7 +837,7 @@ public class ShadowResourcesTest {
     assertThat(outValue.assetCookie).isNotEqualTo(0);
 
     resources.getValue(R.color.blue, outValue, true);
-    assertThat(outValue.type).isEqualTo(TypedValue.TYPE_INT_COLOR_ARGB8);
+    assertThat(outValue.type).isEqualTo(TypedValue.TYPE_INT_COLOR_RGB8);
     assertThat(outValue.data).isEqualTo(ResourceHelper.getColor("#0000ff"));
     assertThat(outValue.string).isNull();
     assertThat(outValue.assetCookie).isEqualTo(TypedValue.DATA_NULL_UNDEFINED);

--- a/robolectric/src/test/resources/res/values/colors.xml
+++ b/robolectric/src/test/resources/res/values/colors.xml
@@ -17,4 +17,9 @@
   <color name="list_separator">#111111</color>
 
   <color name="typed_array_orange">#FF5C00</color>
+
+  <color name="test_ARGB4">#0001</color>
+  <color name="test_ARGB8">#00000002</color>
+  <color name="test_RGB4">#00f</color>
+  <color name="test_RGB8">#000004</color>
 </resources>

--- a/shadows/framework/src/main/java/org/robolectric/shadows/Converter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/Converter.java
@@ -134,7 +134,7 @@ public class Converter<T> {
     @Override
     public boolean fillTypedValue(String data, TypedValue typedValue) {
       try {
-        typedValue.type = TypedValue.TYPE_INT_COLOR_ARGB8;
+        typedValue.type =  ResourceHelper.getColorType(data);
         typedValue.data = ResourceHelper.getColor(data);
         typedValue.assetCookie = 0;
         typedValue.string = null;
@@ -149,8 +149,6 @@ public class Converter<T> {
       return ResourceHelper.getColor(typedResource.asString().trim());
     }
   }
-
-
 
   public static class FromFilePath extends Converter<String> {
     @Override

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper.java
@@ -34,6 +34,7 @@ public final class ResourceHelper {
 
   /**
    * Returns the color value represented by the given string value
+   *
    * @param value the color value
    * @return the color as an int
    * @throws NumberFormatException if the conversion failed.
@@ -82,6 +83,29 @@ public final class ResourceHelper {
     }
 
     throw new NumberFormatException();
+  }
+
+  /**
+   * Returns the TypedValue color type represented by the given string value
+   *
+   * @param value the color value
+   * @return the color as an int. For backwards compatibility, will return a default of ARGB8 if
+   *   value format is unrecognized.
+   */
+  public static int getColorType(String value) {
+    if (value != null && value.startsWith("#")) {
+      switch (value.length()) {
+        case 4:
+          return TypedValue.TYPE_INT_COLOR_RGB4;
+        case 5:
+          return TypedValue.TYPE_INT_COLOR_ARGB4;
+        case 7:
+          return TypedValue.TYPE_INT_COLOR_RGB8;
+        case 9:
+          return TypedValue.TYPE_INT_COLOR_ARGB8;
+      }
+    }
+    return TypedValue.TYPE_INT_COLOR_ARGB8;
   }
 
   public static int getInternalResourceId(String idName) {


### PR DESCRIPTION
Previously Robolectric would hardcode all resource colors as
TYPE_INT_COLOR_ARGB8.
With this commit Robolectric will return the appropriate type
based on format.

PiperRevId: 174753119

### Overview

### Proposed Changes
