### PR TITLE
Clean up handling of missing resources.

### DIFF
--- a/resources/src/main/java/org/robolectric/res/DrawableResourceLoader.java
+++ b/resources/src/main/java/org/robolectric/res/DrawableResourceLoader.java
@@ -6,10 +6,6 @@ package org.robolectric.res;
 public class DrawableResourceLoader {
   private final PackageResourceTable resourceTable;
 
-  public static boolean isStillHandledHere(String type) {
-    return "drawable".equals(type) || "anim".equals(type) || "mipmap".equals(type);
-  }
-
   DrawableResourceLoader(PackageResourceTable resourceTable) {
     this.resourceTable = resourceTable;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -36,7 +36,6 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
 import org.robolectric.res.AttrData;
 import org.robolectric.res.AttributeResource;
-import org.robolectric.res.DrawableResourceLoader;
 import org.robolectric.res.EmptyStyle;
 import org.robolectric.res.FileTypedResource;
 import org.robolectric.res.Fs;
@@ -126,25 +125,9 @@ public final class ShadowAssetManager {
       outValue.resourceId = resourceId;
 
       TypedResource dereferencedRef = resourceTable.getValue(resName, qualifiers);
-
       if (dereferencedRef == null) {
         Logger.strict("couldn't resolve %s from %s", resName.getFullyQualifiedName(), attribute);
-
-        if (DrawableResourceLoader.isStillHandledHere(resName.type)) {
-          // wtf. color and drawable references reference are all kinds of stupid.
-          TypedResource drawableResource = resourceTable.getValue(resName, qualifiers);
-          if (drawableResource == null) {
-            throw new Resources.NotFoundException("can't find file for " + resName);
-          } else {
-            outValue.type = TypedValue.TYPE_STRING;
-            outValue.data = 0;
-            outValue.assetCookie = Converter.getNextStringCookie();
-            outValue.string = (CharSequence) drawableResource.getData();
-            return;
-          }
-        } else {
-          return;
-        }
+        return;
       } else {
         if (dereferencedRef.isFile()) {
           outValue.type = TypedValue.TYPE_STRING;


### PR DESCRIPTION
When calling obtainAttributes() we should never throw a not found
exception, rather missing attributes should be just missing from the
results.

This code seems to be dead, the second call to ResourceLoader.getValue()
will still return the same result as the first and so this code is never
executed.