### PR TITLE
Add startForegroundService to Context & Application

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
@@ -5,24 +5,24 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.res.Configuration;
 import android.content.res.TypedArray;
+import android.os.Build.VERSION_CODES;
 import android.util.AttributeSet;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
@@ -44,6 +44,14 @@ public class ShadowContextTest {
   @Config(minSdk = JELLY_BEAN_MR1)
   public void createConfigurationContext() {
     assertThat(RuntimeEnvironment.application.createConfigurationContext(new Configuration())).isNotNull();
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.O)
+  public void startForegroundService() {
+    Intent intent = new Intent();
+    RuntimeEnvironment.application.startForegroundService(intent);
+    assertThat(ShadowApplication.getInstance().getNextStartedService()).isEqualTo(intent);
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
@@ -221,6 +221,11 @@ public class ShadowContextImpl {
     return ShadowApplication.getInstance().startService(service);
   }
 
+  @Implementation(minSdk = O)
+  public ComponentName startForegroundService(Intent service) {
+    return ShadowApplication.getInstance().startService(service);
+  }
+
   @Implementation
   public void startActivity(Intent intent) {
     ShadowApplication.getInstance().startActivity(intent);


### PR DESCRIPTION
O added this method. It behaves the same as startService, but the system
will kill it if it does not immediately go foreground.

