### PR TITLE
Set default locale from configured qualifiers.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/android/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/ParallelUniverse.java
@@ -10,11 +10,13 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.os.Build.VERSION_CODES;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.DisplayMetrics;
 import java.lang.reflect.Method;
 import java.security.Security;
+import java.util.Locale;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
@@ -83,6 +85,11 @@ public class ParallelUniverse implements ParallelUniverseInterface {
     DisplayMetrics displayMetrics = new DisplayMetrics();
     String qualifiers = Bootstrap.applyQualifiers(config.qualifiers(),
         sdkConfig.getApiLevel(), configuration, displayMetrics);
+
+    Locale locale = sdkConfig.getApiLevel() >= VERSION_CODES.N
+        ? configuration.getLocales().get(0)
+        : configuration.locale;
+    Locale.setDefault(locale);
 
     systemResources.updateConfiguration(configuration, displayMetrics);
     RuntimeEnvironment.setQualifiers(qualifiers);

--- a/robolectric/src/test/java/org/robolectric/android/internal/ParallelUniverseTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/ParallelUniverseTest.java
@@ -11,6 +11,7 @@ import android.os.Build;
 import java.lang.reflect.Method;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Before;
@@ -188,5 +189,12 @@ public class ParallelUniverseTest {
     public void initMetaData(ResourceTable resourceTable) throws RoboNotFoundException {
       throw new RoboNotFoundException("This is just a test");
     }
+  }
+
+  @Test @Config(qualifiers = "b+fr+Cyrl+UK")
+  public void localeIsSet() throws Exception {
+    assertThat(Locale.getDefault().getLanguage()).isEqualTo("fr");
+    assertThat(Locale.getDefault().getScript()).isEqualTo("Cyrl");
+    assertThat(Locale.getDefault().getCountry()).isEqualTo("UK");
   }
 }


### PR DESCRIPTION
Currently the Java default locale (`Locale.getDefault()`) is never set by Robolectric.

Set the default locale based on `@Config(qualifiers = ...)`.