### PR TITLE
Replace truth.FailureStrategy with truth.FailureMetadata in custom

### DIFF
--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -26,5 +26,6 @@ dependencies {
     // Testing dependencies
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:2.5.4"
-    testCompile "com.google.testing.compile:compile-testing:0.8"
+    testCompile "com.google.testing.compile:compile-testing:0.12"
+    testCompile "com.google.truth:truth:0.36"
 }

--- a/processor/src/test/java/org/robolectric/annotation/processing/validator/SingleClassSubject.java
+++ b/processor/src/test/java/org/robolectric/annotation/processing/validator/SingleClassSubject.java
@@ -5,9 +5,8 @@ import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 import static org.robolectric.annotation.processing.RobolectricProcessorTest.DEFAULT_OPTS;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.truth.FailureStrategy;
+import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.Subject;
-import com.google.common.truth.SubjectFactory;
 import com.google.testing.compile.CompileTester;
 import com.google.testing.compile.CompileTester.LineClause;
 import com.google.testing.compile.CompileTester.SuccessfulCompilationClause;
@@ -18,23 +17,17 @@ import org.robolectric.annotation.processing.RobolectricProcessor;
 
 public final class SingleClassSubject extends Subject<SingleClassSubject, String> {
 
-  public static SubjectFactory<SingleClassSubject, String> singleClass() {
+  public static Subject.Factory<SingleClassSubject, String> singleClass() {
 
-    return new SubjectFactory<SingleClassSubject, String>() {
-
-      @Override
-      public SingleClassSubject getSubject(FailureStrategy failureStrategy, String source) {
-        return new SingleClassSubject(failureStrategy, source);
-      }
-    };
+    return SingleClassSubject::new;
   }
 
 
   JavaFileObject source;
   CompileTester tester;
   
-  public SingleClassSubject(FailureStrategy failureStrategy, String subject) {
-    super(failureStrategy, subject);
+  public SingleClassSubject(FailureMetadata failureMetadata, String subject) {
+    super(failureMetadata, subject);
     source = JavaFileObjects.forResource(Utils.toResourcePath(subject));
     tester = assertAbout(javaSources())
       .that(ImmutableList.of(source, Utils.ROBO_SOURCE, Utils.SHADOW_EXTRACTOR_SOURCE))


### PR DESCRIPTION
Subjects.

Also changed truth.SubjectFactory to truth.Subject.Factory (plain
renaming) and use method reference instead of anonymous class to create
the factory when applicable.

FailureMetadata, an opaque object to its users, is introduced to replace
FailureStrategy in in custom Subject in order to resolve some existing
flaws of FailureStrategy as well as enable new features to be added to
Truth.

PiperRevId: 175940858

### Overview

### Proposed Changes
