### PR TITLE
Make ShadowLog.getLogsForTag return empty list instead of null if no logs found.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
@@ -5,15 +5,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.robolectric.shadows.ShadowLog.LogItem;
 
 import android.util.Log;
+import com.google.common.collect.Iterables;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowLog.LogItem;
 
 @RunWith(RobolectricTestRunner.class)
 public class ShadowLogTest {
@@ -167,6 +168,7 @@ public class ShadowLogTest {
 
   @Test
   public void shouldLogAccordingToTag() throws Exception {
+    ShadowLog.reset();
     Log.d( "tag1", "1" );
     Log.i( "tag2", "2" );
     Log.e( "tag3", "3" );
@@ -226,7 +228,7 @@ public class ShadowLogTest {
   }
 
   private void assertLogged(int type, String tag, String msg, Throwable throwable) {
-    LogItem lastLog = ShadowLog.getLogs().get(0);
+    LogItem lastLog = Iterables.getLast(ShadowLog.getLogs());
     assertEquals(type, lastLog.type);
     assertEquals(msg, lastLog.msg);
     assertEquals(tag, lastLog.tag);
@@ -260,5 +262,10 @@ public class ShadowLogTest {
   public void getLogs_shouldReturnCopy() {
     assertThat(ShadowLog.getLogs()).isNotSameAs(ShadowLog.getLogs());
     assertThat(ShadowLog.getLogs()).isEqualTo(ShadowLog.getLogs());
+  }
+
+  @Test
+  public void getLogsForTag_empty() {
+    assertThat(ShadowLog.getLogsForTag("non_existent")).isEmpty();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLog.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLog.java
@@ -168,11 +168,11 @@ public class ShadowLog {
    * Returns ordered list of all log items for a specific tag.
    *
    * @param tag The tag to get logs for
-   * @return The list of log items for the tag
+   * @return The list of log items for the tag or an empty list if no logs for that tag exist.
    */
-  public static List<LogItem> getLogsForTag( String tag ) {
+  public static List<LogItem> getLogsForTag(String tag) {
     Queue<LogItem> logs = logsByTag.get(tag);
-    return logs == null ? null : new ArrayList<>(logs);
+    return logs == null ? Collections.emptyList() : new ArrayList<>(logs);
   }
 
   @Resetter


### PR DESCRIPTION
Also adjust unit tests to be resilient if other logs are present from
framework initialization.

PiperRevId: 176675344

### Overview

### Proposed Changes
