### PR TITLE
Avoid NPE in ShadowAccessibilityNodeInfo

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityNodeInfoTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityNodeInfoTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadow.api.Shadow;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
@@ -153,6 +154,20 @@ public class ShadowAccessibilityNodeInfoTest {
     assertThat(shadow.getPerformedActions().size()).isEqualTo(2);
     assertThat(shadow.getPerformedActions().get(1))
         .isEqualTo(AccessibilityNodeInfo.ACTION_LONG_CLICK);
+  }
+
+  @Test
+  public void equalsTest_avoidsNullPointerDuringParentComparison() {
+    AccessibilityNodeInfo grandparentInfo = AccessibilityNodeInfo.obtain();
+    AccessibilityNodeInfo childInfo = AccessibilityNodeInfo.obtain();
+    AccessibilityNodeInfo parentInfo = AccessibilityNodeInfo.obtain();
+    ((ShadowAccessibilityNodeInfo) Shadow.extract(grandparentInfo)).addChild(parentInfo);
+    ((ShadowAccessibilityNodeInfo) Shadow.extract(parentInfo)).addChild(childInfo);
+
+    assertThat(parentInfo.equals(childInfo)).isFalse();
+    assertThat(childInfo.equals(parentInfo)).isFalse();
+    assertThat(grandparentInfo.equals(parentInfo)).isFalse();
+    assertThat(parentInfo.equals(grandparentInfo)).isFalse();
   }
 
   @After

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java
@@ -972,7 +972,8 @@ public class ShadowAccessibilityNodeInfo {
       if (parent == null) {
         areEqual &= (otherShadow.parent == null);
       } else if (!shadowOf(parent).visitedWhenCheckingChildren){
-        areEqual &= (shadowOf(parent).equals(shadowOf(otherShadow.parent)));
+        areEqual &=
+           ((otherShadow.parent != null) && shadowOf(parent).equals(shadowOf(otherShadow.parent)));
       }
 
       while (!visitedNodes.isEmpty()) {


### PR DESCRIPTION
The logic that compares parent nodes within ShadowAccessibilityNodeInfo became prone to a NullPointerException with [this change](https://github.com/robolectric/robolectric/commit/763b60a9959bd472e54ef02b8f72846d0dbc4a22#diff-bb3c8ee8c5d15ad042da9cc7fdb6be6c), which could cause an attempt to extract a shadow from a null reference under certain conditions.