### PR TITLE
Ensure attribute types are parsed in correct order

### DIFF
--- a/robolectric/src/test/java/org/robolectric/R.java
+++ b/robolectric/src/test/java/org/robolectric/R.java
@@ -294,6 +294,7 @@ public final class R {
     public static final int offsetY = 0x7f0b0021;
     public static final int textStyle2 = 0x7f0b0022;
     public static final int textStyle3 = 0x7f0b0023;
+    public static final int multiformat = 0x7f0b0024;
   }
 
   public static final class menu {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
@@ -16,6 +16,7 @@ import android.app.Activity;
 import android.content.res.AssetFileDescriptor;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.util.AttributeSet;
 import android.util.TypedValue;
@@ -24,7 +25,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
@@ -35,8 +35,8 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
@@ -181,6 +181,50 @@ public class ShadowAssetManagerTest {
 
     ByteArrayInputStream byteArrayInputStream = (ByteArrayInputStream) inputStream;
     assertThat(byteArrayInputStream.available()).isEqualTo(23447);
+  }
+
+  @Test
+  public void multiFormatAttributes_integerDecimalValue() {
+    AttributeSet attributeSet =
+        Robolectric.buildAttributeSet().addAttribute(R.attr.multiformat, "16").build();
+    TypedArray typedArray =
+        resources.obtainAttributes(attributeSet, new int[] {R.attr.multiformat});
+    TypedValue outValue = new TypedValue();
+    typedArray.getValue(0, outValue);
+    assertThat(outValue.type).isEqualTo(TypedValue.TYPE_INT_DEC);
+  }
+
+  @Test
+  public void multiFormatAttributes_integerHexValue() {
+    AttributeSet attributeSet =
+        Robolectric.buildAttributeSet().addAttribute(R.attr.multiformat, "0x10").build();
+    TypedArray typedArray =
+        resources.obtainAttributes(attributeSet, new int[] {R.attr.multiformat});
+    TypedValue outValue = new TypedValue();
+    typedArray.getValue(0, outValue);
+    assertThat(outValue.type).isEqualTo(TypedValue.TYPE_INT_HEX);
+  }
+
+  @Test
+  public void multiFormatAttributes_stringValue() {
+    AttributeSet attributeSet =
+        Robolectric.buildAttributeSet().addAttribute(R.attr.multiformat, "Hello World").build();
+    TypedArray typedArray =
+        resources.obtainAttributes(attributeSet, new int[] {R.attr.multiformat});
+    TypedValue outValue = new TypedValue();
+    typedArray.getValue(0, outValue);
+    assertThat(outValue.type).isEqualTo(TypedValue.TYPE_STRING);
+  }
+
+  @Test
+  public void multiFormatAttributes_booleanValue() {
+    AttributeSet attributeSet =
+        Robolectric.buildAttributeSet().addAttribute(R.attr.multiformat, "true").build();
+    TypedArray typedArray =
+        resources.obtainAttributes(attributeSet, new int[] {R.attr.multiformat});
+    TypedValue outValue = new TypedValue();
+    typedArray.getValue(0, outValue);
+    assertThat(outValue.type).isEqualTo(TypedValue.TYPE_INT_BOOLEAN);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -23,7 +23,6 @@ import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.util.Xml;
-import android.view.Display;
 import java.io.File;
 import java.io.InputStream;
 import org.assertj.core.data.Offset;
@@ -33,12 +32,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.XmlResourceParserImpl;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.TestUtil;
 import org.xmlpull.v1.XmlPullParser;
 
@@ -842,7 +840,7 @@ public class ShadowResourcesTest {
     assertThat(outValue.assetCookie).isEqualTo(TypedValue.DATA_NULL_UNDEFINED);
 
     resources.getValue(R.integer.loneliest_number, outValue, true);
-    assertThat(outValue.type).isEqualTo(TypedValue.TYPE_INT_HEX);
+    assertThat(outValue.type).isEqualTo(TypedValue.TYPE_INT_DEC);
     assertThat(outValue.data).isEqualTo(1);
     assertThat(outValue.string).isNull();
     assertThat(outValue.assetCookie).isEqualTo(TypedValue.DATA_NULL_UNDEFINED);

--- a/robolectric/src/test/resources/res/values/attrs.xml
+++ b/robolectric/src/test/resources/res/values/attrs.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <declare-styleable name="CustomView">
+    <attr name="multiformat" format="integer|string|boolean"/>
+
     <attr name="itemType" format="enum">
       <enum name="marsupial" value="0"/>
       <enum name="ungulate" value="1"/>

--- a/shadows/framework/src/main/java/org/robolectric/shadows/Converter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/Converter.java
@@ -172,7 +172,11 @@ public class Converter<T> {
     @Override
     public boolean fillTypedValue(String data, TypedValue typedValue) {
       try {
-        typedValue.type = TypedValue.TYPE_INT_HEX;
+        if (data.startsWith("0x")) {
+          typedValue.type = TypedValue.TYPE_INT_HEX;
+        } else {
+          typedValue.type = TypedValue.TYPE_INT_DEC;
+        }
         typedValue.data = convertInt(data);
         typedValue.assetCookie = 0;
         typedValue.string = null;
@@ -222,17 +226,12 @@ public class Converter<T> {
 
       if ("true".equalsIgnoreCase(data)) {
         typedValue.data = 1;
+        return true;
       } else if ("false".equalsIgnoreCase(data)) {
         typedValue.data = 0;
-      } else {
-        try {
-          int intValue = Integer.parseInt(data);
-          typedValue.data = intValue == 0 ? 0 : 1;
-        } catch (NumberFormatException e) {
-          return false;
-        }
+        return true;
       }
-      return true;
+      return false;
     }
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -15,6 +15,7 @@ import android.os.ParcelFileDescriptor;
 import android.util.AttributeSet;
 import android.util.SparseArray;
 import android.util.TypedValue;
+import com.google.common.collect.Ordering;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -22,6 +23,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +59,7 @@ import org.robolectric.util.ReflectionHelpers;
 
 @Implements(AssetManager.class)
 public final class ShadowAssetManager {
+
   public static final int STYLE_NUM_ENTRIES = 6;
   public static final int STYLE_TYPE = 0;
   public static final int STYLE_DATA = 1;
@@ -64,6 +67,19 @@ public final class ShadowAssetManager {
   public static final int STYLE_RESOURCE_ID = 3;
   public static final int STYLE_CHANGING_CONFIGURATIONS = 4;
   public static final int STYLE_DENSITY = 5;
+
+  public static final Ordering<String> ATTRIBUTE_TYPE_PRECIDENCE =
+      Ordering.explicit(
+          "reference",
+          "color",
+          "boolean",
+          "integer",
+          "fraction",
+          "dimension",
+          "float",
+          "enum",
+          "flag",
+          "string");
 
   boolean strictErrors = false;
 
@@ -163,6 +179,7 @@ public final class ShadowAssetManager {
       AttrData attrData = (AttrData) attrTypeData.getData();
       String format = attrData.getFormat();
       String[] types = format.split("\\|");
+      Arrays.sort(types, ATTRIBUTE_TYPE_PRECIDENCE);
       for (String type : types) {
         if ("reference".equals(type)) continue; // already handled above
         Converter converter = Converter.getConverterFor(attrData, type);


### PR DESCRIPTION
If the attribute types are declared in the wrong order, e.g:

format="string|boolean" they processed in that wrong order and a boolean
"true" value would be considered a String "true" rather than a boolean
true.

### Overview

### Proposed Changes
