### PR TITLE
Overhaul package manager + Android manifest treatment.

### DIFF
--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -118,7 +118,7 @@ public class AndroidManifest {
       String rClassName = getRClassName();
       return Class.forName(rClassName);
     } catch (Exception e) {
-        return null;
+      return null;
     }
   }
 
@@ -168,8 +168,8 @@ public class AndroidManifest {
 
         minSdkVersion = getTagAttributeIntValue(manifestDocument, "uses-sdk", "android:minSdkVersion");
 
-        String targetSdkText = getTagAttributeText(manifestDocument, "uses-sdk",
-            "android:targetSdkVersion");
+        String targetSdkText =
+            getTagAttributeText(manifestDocument, "uses-sdk", "android:targetSdkVersion");
         if (targetSdkText != null) {
           // Support Android O Preview. This can be removed once Android O is officially launched.
           targetSdkVersion = targetSdkText.equals("O") ? 26 : Integer.parseInt(targetSdkText);
@@ -226,15 +226,15 @@ public class AndroidManifest {
       Node permissionNode = elementsByTagName.item(i);
       final MetaData metaData = new MetaData(getChildrenTags(permissionNode, "meta-data"));
       String name = getAttributeValue(permissionNode, "android:name");
-      permissions.put(name,
+      permissions.put(
+          name,
           new PermissionItemData(
               name,
               getAttributeValue(permissionNode, "android:label"),
               getAttributeValue(permissionNode, "android:description"),
               getAttributeValue(permissionNode, "android:permissionGroup"),
               getAttributeValue(permissionNode, "android:protectionLevel"),
-              metaData
-          ));
+              metaData));
     }
   }
 
@@ -255,12 +255,15 @@ public class AndroidManifest {
         ));
       }
 
-      providers.add(new ContentProviderData(resolveClassRef(name),
+      providers.add(
+          new ContentProviderData(
+              resolveClassRef(name),
               metaData,
               authorities,
               getAttributeValue(contentProviderNode, "android:readPermission"),
               getAttributeValue(contentProviderNode, "android:writePermission"),
-              pathPermissionDatas));
+              pathPermissionDatas,
+              getAttributeValue(contentProviderNode, "android:grantUriPermissions")));
     }
   }
 
@@ -687,7 +690,7 @@ public class AndroidManifest {
   public @Nullable BroadcastReceiverData getBroadcastReceiver(String className) {
     parseAndroidManifest();
     for (BroadcastReceiverData receiver : receivers) {
-      if (receiver.getClassName().equals(className)) {
+      if (receiver.getName().equals(className)) {
         return receiver;
       }
     }

--- a/resources/src/main/java/org/robolectric/manifest/ContentProviderData.java
+++ b/resources/src/main/java/org/robolectric/manifest/ContentProviderData.java
@@ -7,13 +7,22 @@ public class ContentProviderData extends PackageItemData {
   private final String readPermission;
   private final String writePermission;
   private final List<PathPermissionData> pathPermissionDatas;
+  private final boolean grantUriPermissions;
 
-  public ContentProviderData(String className, MetaData metaData, String authority, String readPermission, String writePermission, List<PathPermissionData> pathPermissionDatas) {
+  public ContentProviderData(
+      String className,
+      MetaData metaData,
+      String authority,
+      String readPermission,
+      String writePermission,
+      List<PathPermissionData> pathPermissionDatas,
+      String grantUriPermissions) {
     super(className, metaData);
     this.authority = authority;
     this.readPermission = readPermission;
     this.writePermission = writePermission;
     this.pathPermissionDatas = pathPermissionDatas;
+    this.grantUriPermissions = Boolean.parseBoolean(grantUriPermissions);
   }
 
   public String getAuthorities() {
@@ -30,5 +39,9 @@ public class ContentProviderData extends PackageItemData {
 
   public List<PathPermissionData> getPathPermissionDatas() {
     return pathPermissionDatas;
+  }
+
+  public boolean getGrantUriPermissions() {
+    return grantUriPermissions;
   }
 }

--- a/resources/src/main/java/org/robolectric/manifest/PackageItemData.java
+++ b/resources/src/main/java/org/robolectric/manifest/PackageItemData.java
@@ -1,16 +1,22 @@
 package org.robolectric.manifest;
 
 public class PackageItemData {
-  protected final String className;
+  protected final String name;
   protected final MetaData metaData;
 
-  public PackageItemData(String className, MetaData metaData) {
+  public PackageItemData(String name, MetaData metaData) {
     this.metaData = metaData;
-    this.className = className;
+    this.name = name;
   }
 
+  public String getName() {
+    return name;
+  }
+
+  /** @deprecated - Use {@link #getName()} instead. */
+  @Deprecated
   public String getClassName() {
-    return className;
+    return getName();
   }
 
   public MetaData getMetaData() {

--- a/resources/src/main/java/org/robolectric/manifest/PermissionItemData.java
+++ b/resources/src/main/java/org/robolectric/manifest/PermissionItemData.java
@@ -1,27 +1,23 @@
 package org.robolectric.manifest;
 
-public class PermissionItemData {
+/**
+ * Holds permission data from manifest.
+ */
+public class PermissionItemData extends PackageItemData {
 
-  private final String name;
   private final String label;
   private final String description;
   private final String permissionGroup;
   private final String protectionLevel;
-  private final MetaData metaData;
 
   public PermissionItemData(String name, String label, String description,
       String permissionGroup, String protectionLevel, MetaData metaData) {
+    super(name, metaData);
 
-    this.name = name;
     this.label = label;
     this.description = description;
     this.permissionGroup = permissionGroup;
     this.protectionLevel = protectionLevel;
-    this.metaData = metaData;
-  }
-
-  public String getName() {
-    return name;
   }
 
   public String getLabel() {
@@ -38,9 +34,5 @@ public class PermissionItemData {
 
   public String getProtectionLevel() {
     return protectionLevel;
-  }
-
-  public MetaData getMetaData() {
-    return metaData;
   }
 }

--- a/resources/src/main/java/org/robolectric/manifest/ServiceData.java
+++ b/resources/src/main/java/org/robolectric/manifest/ServiceData.java
@@ -1,48 +1,32 @@
 package org.robolectric.manifest;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-public class ServiceData {
+/**
+ * Holds parsed service data from manifest.
+ */
+public class ServiceData extends PackageItemData {
 
   private static final String EXPORTED = "android:exported";
   private static final String NAME = "android:name";
   private static final String PERMISSION = "android:permission";
 
   private final Map<String, String> attributes;
-  private final MetaData metaData;
   private final List<String> actions;
   private List<IntentFilterData> intentFilters;
 
   public ServiceData(
       Map<String, String> attributes, MetaData metaData, List<IntentFilterData> intentFilters) {
+    super(attributes.get(NAME), metaData);
     this.attributes = attributes;
     this.actions = new ArrayList<>();
-    this.metaData = metaData;
-    this.intentFilters = new LinkedList<>(intentFilters);
-  }
-
-  public ServiceData(String className, MetaData metaData, List<IntentFilterData> intentFilterData) {
-    this.attributes = new HashMap<>();
-    this.attributes.put(NAME, className);
-    this.actions = new ArrayList<>();
-    this.metaData = metaData;
-    intentFilters = new LinkedList<>(intentFilterData);
-  }
-
-  public String getClassName() {
-    return attributes.get(NAME);
+    this.intentFilters = new ArrayList<>(intentFilters);
   }
 
   public List<String> getActions() {
     return actions;
-  }
-
-  public MetaData getMetaData() {
-    return metaData;
   }
 
   public void addAction(String action) {

--- a/resources/src/main/java/org/robolectric/res/PackageResourceTable.java
+++ b/resources/src/main/java/org/robolectric/res/PackageResourceTable.java
@@ -25,6 +25,7 @@ public class PackageResourceTable implements ResourceTable {
     this.packageName = packageName;
   }
 
+  @Override
   public String getPackageName() {
     return packageName;
   }

--- a/resources/src/main/java/org/robolectric/res/ResourceTable.java
+++ b/resources/src/main/java/org/robolectric/res/ResourceTable.java
@@ -23,6 +23,8 @@ public interface ResourceTable {
 
   void receive(Visitor visitor);
 
+  String getPackageName();
+
   interface Visitor {
     void visit(ResName key, Iterable<TypedResource> values);
   }

--- a/resources/src/main/java/org/robolectric/res/RoutingResourceTable.java
+++ b/resources/src/main/java/org/robolectric/res/RoutingResourceTable.java
@@ -1,7 +1,7 @@
 package org.robolectric.res;
 
 import java.io.InputStream;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeSet;
 import javax.annotation.Nonnull;
@@ -13,7 +13,7 @@ public class RoutingResourceTable implements ResourceTable {
   private final Map<String, PackageResourceTable> resourceTables;
 
   public RoutingResourceTable(PackageResourceTable... resourceTables) {
-    this.resourceTables = new HashMap<>();
+    this.resourceTables = new LinkedHashMap<>();
 
     for (PackageResourceTable resourceTable : resourceTables) {
       this.resourceTables.put(resourceTable.getPackageName(), resourceTable);
@@ -57,6 +57,11 @@ public class RoutingResourceTable implements ResourceTable {
     for (PackageResourceTable resourceTable : resourceTables.values()) {
       resourceTable.receive(visitor);
     }
+  }
+
+  @Override
+  public String getPackageName() {
+    return resourceTables.keySet().iterator().next();
   }
 
   private PackageResourceTable pickFor(int resId) {

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -241,6 +241,7 @@ public class RobolectricTestRunner extends SandboxTestRunner {
       try {
         Config config = getConfig(frameworkMethod.getMethod());
         AndroidManifest appManifest = getAppManifest(config);
+
         List<SdkConfig> sdksToRun = sdkPicker.selectSdks(config, appManifest);
         RobolectricFrameworkMethod last = null;
         for (SdkConfig sdkConfig : sdksToRun) {
@@ -317,7 +318,14 @@ public class RobolectricTestRunner extends SandboxTestRunner {
     PackageResourceTable systemResourceTable = sdkEnvironment.getSystemResourceTable(getJarResolver());
     PackageResourceTable appResourceTable = getAppResourceTable(appManifest);
 
-    roboMethod.parallelUniverseInterface.setUpApplicationState(bootstrappedMethod, roboMethod.testLifecycle, appManifest, config, new RoutingResourceTable(getCompiletimeSdkResourceTable(), appResourceTable), new RoutingResourceTable(systemResourceTable, appResourceTable), new RoutingResourceTable(systemResourceTable));
+    roboMethod.parallelUniverseInterface.setUpApplicationState(
+        bootstrappedMethod,
+        roboMethod.testLifecycle,
+        appManifest,
+        config,
+        new RoutingResourceTable(appResourceTable, getCompiletimeSdkResourceTable()),
+        new RoutingResourceTable(appResourceTable, systemResourceTable),
+        new RoutingResourceTable(systemResourceTable));
     roboMethod.testLifecycle.beforeTest(bootstrappedMethod);
   }
 

--- a/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
+++ b/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
@@ -71,10 +71,13 @@ public class AndroidConfigurer {
         .doNotAcquirePackage("kotlin.")
         .doNotAcquirePackage("com.almworks.sqlite4java"); // Fix #958: SQLite native library must be loaded once.
 
-    builder.addClassNameTranslation("java.net.ExtendedResponseCache", RoboExtendedResponseCache.class.getName())
+    builder
+        .addClassNameTranslation(
+            "java.net.ExtendedResponseCache", RoboExtendedResponseCache.class.getName())
         .addClassNameTranslation("java.net.ResponseSource", RoboResponseSource.class.getName())
         .addClassNameTranslation("java.nio.charset.Charsets", RoboCharsets.class.getName())
-        .addClassNameTranslation("java.lang.UnsafeByteSequence", Object.class.getName());
+        .addClassNameTranslation("java.lang.UnsafeByteSequence", Object.class.getName())
+        .addClassNameTranslation("java.util.jar.StrictJarFile", Object.class.getName());
 
     // Instrumenting these classes causes a weird failure.
     builder.doNotInstrumentClass("android.R")

--- a/robolectric/src/test/java/org/robolectric/android/controller/ActivityControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/ActivityControllerTest.java
@@ -19,9 +19,10 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.R;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.CoreShadowsAdapter;
 import org.robolectric.shadows.ShadowLooper;
@@ -40,10 +41,10 @@ public class ActivityControllerTest {
   }
 
   @Test
-  @Config(manifest = Config.NONE)
   public void canCreateActivityNotListedInManifest() {
-    ActivityController<Activity> activityController = Robolectric.buildActivity(Activity.class);
-    assertThat(activityController.setup()).isNotNull();
+    Activity activity = Robolectric.setupActivity(Activity.class);
+    assertThat(activity).isNotNull();
+    assertThat(activity.getThemeResId()).isEqualTo(R.style.Theme_Robolectric);
   }
 
   public static class TestDelayedPostActivity extends Activity {

--- a/robolectric/src/test/java/org/robolectric/android/controller/ContentProviderControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/ContentProviderControllerTest.java
@@ -16,12 +16,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
+import org.robolectric.RuntimeEnvironment;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 23)
 public class ContentProviderControllerTest {
   private final ContentProviderController<MyContentProvider> controller = Robolectric.buildContentProvider(MyContentProvider.class);
   private ContentResolver contentResolver;
@@ -55,7 +53,9 @@ public class ContentProviderControllerTest {
   public void shouldRegisterWithContentResolver() throws Exception {
     controller.create().get();
 
-    ContentProviderClient client = contentResolver.acquireContentProviderClient("org.robolectric.authority2");
+    ContentProviderClient client =
+        contentResolver.acquireContentProviderClient(
+            "org.robolectric.my_content_provider_authority");
     client.query(Uri.parse("something"), new String[]{"title"}, "*", new String[]{}, "created");
     assertThat(controller.get().transcript).containsExactly("onCreate", "query for something");
   }

--- a/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
+++ b/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
@@ -30,10 +30,12 @@ public class AndroidManifestTest {
   public void parseManifest_shouldReadContentProviders() throws Exception {
     AndroidManifest config = newConfig("TestAndroidManifestWithContentProviders.xml");
 
-    assertThat(config.getContentProviders().get(0).getClassName()).isEqualTo("org.robolectric.tester.FullyQualifiedClassName");
+    assertThat(config.getContentProviders().get(0).getName())
+        .isEqualTo("org.robolectric.tester.FullyQualifiedClassName");
     assertThat(config.getContentProviders().get(0).getAuthorities()).isEqualTo("org.robolectric.authority1");
 
-    assertThat(config.getContentProviders().get(1).getClassName()).isEqualTo("org.robolectric.tester.PartiallyQualifiedClassName");
+    assertThat(config.getContentProviders().get(1).getName())
+        .isEqualTo("org.robolectric.tester.PartiallyQualifiedClassName");
     assertThat(config.getContentProviders().get(1).getAuthorities()).isEqualTo("org.robolectric.authority2");
   }
 
@@ -58,31 +60,38 @@ public class AndroidManifestTest {
     AndroidManifest config = newConfig("TestAndroidManifestWithReceivers.xml");
     assertThat(config.getBroadcastReceivers()).hasSize(8);
 
-    assertThat(config.getBroadcastReceivers().get(0).getClassName()).isEqualTo("org.robolectric.ConfigTestReceiver.InnerReceiver");
+    assertThat(config.getBroadcastReceivers().get(0).getName())
+        .isEqualTo("org.robolectric.ConfigTestReceiver.InnerReceiver");
     assertThat(config.getBroadcastReceivers().get(0).getActions()).contains("org.robolectric.ACTION1", "org.robolectric.ACTION2");
 
-    assertThat(config.getBroadcastReceivers().get(1).getClassName()).isEqualTo("org.robolectric.fakes.ConfigTestReceiver");
+    assertThat(config.getBroadcastReceivers().get(1).getName())
+        .isEqualTo("org.robolectric.fakes.ConfigTestReceiver");
     assertThat(config.getBroadcastReceivers().get(1).getActions()).contains("org.robolectric.ACTION_SUPERSET_PACKAGE");
 
-    assertThat(config.getBroadcastReceivers().get(2).getClassName()).isEqualTo("org.robolectric.ConfigTestReceiver");
+    assertThat(config.getBroadcastReceivers().get(2).getName())
+        .isEqualTo("org.robolectric.ConfigTestReceiver");
     assertThat(config.getBroadcastReceivers().get(2).getActions()).contains("org.robolectric.ACTION_SUBSET_PACKAGE");
 
-    assertThat(config.getBroadcastReceivers().get(3).getClassName()).isEqualTo("org.robolectric.DotConfigTestReceiver");
+    assertThat(config.getBroadcastReceivers().get(3).getName())
+        .isEqualTo("org.robolectric.DotConfigTestReceiver");
     assertThat(config.getBroadcastReceivers().get(3).getActions()).contains("org.robolectric.ACTION_DOT_PACKAGE");
 
-    assertThat(config.getBroadcastReceivers().get(4).getClassName()).isEqualTo("org.robolectric.test.ConfigTestReceiver");
+    assertThat(config.getBroadcastReceivers().get(4).getName())
+        .isEqualTo("org.robolectric.test.ConfigTestReceiver");
     assertThat(config.getBroadcastReceivers().get(4).getActions()).contains("org.robolectric.ACTION_DOT_SUBPACKAGE");
 
-    assertThat(config.getBroadcastReceivers().get(5).getClassName()).isEqualTo("com.foo.Receiver");
+    assertThat(config.getBroadcastReceivers().get(5).getName()).isEqualTo("com.foo.Receiver");
     assertThat(config.getBroadcastReceivers().get(5).getActions()).contains("org.robolectric.ACTION_DIFFERENT_PACKAGE");
     assertThat(config.getBroadcastReceivers().get(5).getIntentFilters()).hasSize(1);
     IntentFilterData filter = config.getBroadcastReceivers().get(5).getIntentFilters().get(0);
     assertThat(filter.getActions()).containsExactly("org.robolectric.ACTION_DIFFERENT_PACKAGE");
 
-    assertThat(config.getBroadcastReceivers().get(6).getClassName()).isEqualTo("com.bar.ReceiverWithoutIntentFilter");
+    assertThat(config.getBroadcastReceivers().get(6).getName())
+        .isEqualTo("com.bar.ReceiverWithoutIntentFilter");
     assertThat(config.getBroadcastReceivers().get(6).getActions()).isEmpty();
 
-    assertThat(config.getBroadcastReceivers().get(7).getClassName()).isEqualTo("org.robolectric.ConfigTestReceiverPermissionsAndActions");
+    assertThat(config.getBroadcastReceivers().get(7).getName())
+        .isEqualTo("org.robolectric.ConfigTestReceiverPermissionsAndActions");
     assertThat(config.getBroadcastReceivers().get(7).getActions()).contains("org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE");
   }
 
@@ -116,7 +125,8 @@ public class AndroidManifestTest {
   public void parseManifest_shouldReadBroadcastReceiversWithMetaData() throws Exception {
     AndroidManifest config = newConfig("TestAndroidManifestWithReceivers.xml");
 
-    assertThat(config.getBroadcastReceivers().get(4).getClassName()).isEqualTo("org.robolectric.test.ConfigTestReceiver");
+    assertThat(config.getBroadcastReceivers().get(4).getName())
+        .isEqualTo("org.robolectric.test.ConfigTestReceiver");
     assertThat(config.getBroadcastReceivers().get(4).getActions()).contains("org.robolectric.ACTION_DOT_SUBPACKAGE");
 
     Map<String, Object> meta = config.getBroadcastReceivers().get(4).getMetaData().getValueMap();
@@ -164,7 +174,8 @@ public class AndroidManifestTest {
   public void shouldReadBroadcastReceiverPermissions() throws Exception {
     AndroidManifest config = newConfig("TestAndroidManifestWithReceivers.xml");
 
-    assertThat(config.getBroadcastReceivers().get(7).getClassName()).isEqualTo("org.robolectric.ConfigTestReceiverPermissionsAndActions");
+    assertThat(config.getBroadcastReceivers().get(7).getName())
+        .isEqualTo("org.robolectric.ConfigTestReceiverPermissionsAndActions");
     assertThat(config.getBroadcastReceivers().get(7).getActions()).contains("org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE");
 
     assertEquals("org.robolectric.CUSTOM_PERM", config.getBroadcastReceivers().get(7).getPermission());

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
@@ -49,16 +49,10 @@ import android.view.Window;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.SearchView;
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
@@ -67,14 +61,11 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.manifest.AndroidManifest;
-import org.robolectric.res.Fs;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.TestRunnable;
 
 @RunWith(RobolectricTestRunner.class)
 public class ShadowActivityTest {
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private Activity activity;
 
   @Test
@@ -698,28 +689,23 @@ public class ShadowActivityTest {
 
   @Test
   public void getAndSetParentActivity_shouldWorkForTestingPurposes() throws Exception {
-    Activity parentActivity = new Activity() {
-    };
-    Activity activity = new Activity() {
-    };
+    Activity parentActivity = new Activity();
+    Activity activity = new Activity();
     shadowOf(activity).setParent(parentActivity);
     assertSame(parentActivity, activity.getParent());
   }
 
   @Test
   public void getAndSetRequestedOrientation_shouldRemember() throws Exception {
-    Activity activity = new Activity() {
-    };
+    Activity activity = new Activity();
     activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
     assertEquals(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, activity.getRequestedOrientation());
   }
 
   @Test
   public void getAndSetRequestedOrientation_shouldDelegateToParentIfPresent() throws Exception {
-    Activity parentActivity = new Activity() {
-    };
-    Activity activity = new Activity() {
-    };
+    Activity parentActivity = new Activity();
+    Activity activity = new Activity();
     shadowOf(activity).setParent(parentActivity);
     parentActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
     assertEquals(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, activity.getRequestedOrientation());
@@ -752,6 +738,8 @@ public class ShadowActivityTest {
 
   @Test public void shouldGetAttributeFromThemeSetOnActivity() throws Exception {
     ShadowThemeTest.TestActivity activity = setupActivity(ShadowThemeTest.TestActivityWithAnotherTheme.class);
+    assertThat(activity.getThemeResId()).isEqualTo(R.style.Theme_AnotherTheme);
+
     TypedArray a = activity.obtainStyledAttributes(R.styleable.AnotherTheme);
 
     assertThat(a.hasValue(R.styleable.AnotherTheme_animalStyle)).isTrue();
@@ -892,21 +880,6 @@ public class ShadowActivityTest {
   }
 
   /////////////////////////////
-
-  public AndroidManifest newConfigWith(String contents) throws IOException {
-    return newConfigWith("org.robolectric", contents);
-  }
-
-  private AndroidManifest newConfigWith(String packageName, String contents) throws IOException {
-    String fileContents = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-        "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\"\n" +
-        "          package=\"" + packageName + "\">\n" +
-        "    " + contents + "\n" +
-        "</manifest>\n";
-    File f = temporaryFolder.newFile("whatever.xml");
-    Files.write(fileContents, f, Charsets.UTF_8);
-    return new AndroidManifest(Fs.newFile(f), null, null);
-  }
 
   private static class DialogCreatingActivity extends Activity {
     @Override

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityThreadTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityThreadTest.java
@@ -2,24 +2,44 @@ package org.robolectric.shadows;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import android.content.Context;
-import android.content.pm.PackageManager;
-import org.junit.Assert;
+import android.app.ActivityThread;
+import android.content.res.CompatibilityInfo;
+import android.os.Build;
+import android.os.RemoteException;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 public class ShadowActivityThreadTest {
-    @Test
-    public void testTriggersUndeclaredThrowableException() throws Exception {
-        // createPackageContext internally calls ActivityThread.getPackageInfo which is what we'd like to test here.
-        try {
-            RuntimeEnvironment.application.createPackageContext("com.unknownpackage.ab", Context.CONTEXT_RESTRICTED);
-            Assert.fail("Should've triggered a NameNotFoundException and not UndeclaredThrowableException");
-        } catch (PackageManager.NameNotFoundException nnfe) {
-            assertThat(nnfe).hasMessageContaining("com.unknownpackage.ab");
-        }
+
+  private ActivityThread activityThread;
+
+  @Before
+  public void setUp() {
+    activityThread = (ActivityThread) RuntimeEnvironment.getActivityThread();
+  }
+
+  @Test
+  @Config(maxSdk = Build.VERSION_CODES.M)
+  public void getPackageInfo_returnsNullWhenNotFound() throws Exception {
+    assertThat(
+            activityThread.getPackageInfo(
+                "com.unknownpackage.ab", CompatibilityInfo.DEFAULT_COMPATIBILITY_INFO, 0))
+        .isNull();
+  }
+
+  @Test
+  @Config(minSdk = Build.VERSION_CODES.N_MR1)
+  public void getPackageInfo_throwsRemoteExceptionWhenNotFound() throws Exception {
+    try {
+      activityThread.getPackageInfo(
+          "com.unknownpackage.ab", CompatibilityInfo.DEFAULT_COMPATIBILITY_INFO, 0);
+    } catch (RuntimeException e) {
+      assertThat(e).hasCauseInstanceOf(RemoteException.class);
     }
+  }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
@@ -31,39 +31,29 @@ import android.os.Binder;
 import android.os.IBinder;
 import android.os.UserManager;
 import android.print.PrintManager;
-import android.view.accessibility.CaptioningManager;
 import android.telephony.SubscriptionManager;
 import android.view.Gravity;
 import android.view.accessibility.AccessibilityManager;
 import android.widget.LinearLayout;
 import android.widget.PopupWindow;
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
-import java.io.File;
-import java.io.IOException;
 import java.util.List;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.fakes.RoboVibrator;
-import org.robolectric.manifest.AndroidManifest;
-import org.robolectric.res.Fs;
 import org.robolectric.util.Scheduler;
 
 @RunWith(RobolectricTestRunner.class)
 public class ShadowApplicationTest {
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
   @Config(packageName = "override.package")
   public void shouldOverridePackageWithConfig() {
-    assertEquals("override.package", RuntimeEnvironment.application.getPackageName());
+    assertThat(RuntimeEnvironment.application.getPackageName()).isEqualTo("override.package");
   }
 
   @Test
@@ -108,7 +98,6 @@ public class ShadowApplicationTest {
   @Config(minSdk = KITKAT)
   public void shouldProvideServicesIntroducedInKitKat() throws Exception {
     checkSystemService(Context.PRINT_SERVICE, PrintManager.class);
-    checkSystemService(Context.CAPTIONING_SERVICE, CaptioningManager.class);
   }
 
   @Test
@@ -156,12 +145,6 @@ public class ShadowApplicationTest {
   public void packageManager_shouldKnowPackageName() throws Exception {
     assertThat(RuntimeEnvironment.application.getPackageManager().getApplicationInfo("org.robolectric", 0).packageName)
         .isEqualTo("org.robolectric");
-  }
-
-  @Test
-  public void packageManager_shouldKnowApplicationName() throws Exception {
-    assertThat(RuntimeEnvironment.application.getPackageManager().getApplicationInfo("org.robolectric", 0).name)
-        .isEqualTo("org.robolectric.TestApplication");
   }
 
   @Test
@@ -556,21 +539,6 @@ public class ShadowApplicationTest {
   }
 
   /////////////////////////////
-
-  public AndroidManifest newConfigWith(String contents) throws IOException {
-    return newConfigWith("org.robolectric", contents);
-  }
-
-  private AndroidManifest newConfigWith(String packageName, String contents) throws IOException {
-    String fileContents = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-        "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\"\n" +
-        "          package=\"" + packageName + "\">\n" +
-        "    " + contents + "\n" +
-        "</manifest>\n";
-    File f = temporaryFolder.newFile("whatever.xml");
-    Files.write(fileContents, f, Charsets.UTF_8);
-    return new AndroidManifest(Fs.newFile(f), null, null);
-  }
 
   private static class EmptyServiceConnection implements ServiceConnection {
     @Override

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.verify;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.accounts.Account;
-import android.app.Activity;
 import android.app.Application;
 import android.content.ContentProvider;
 import android.content.ContentProviderOperation;
@@ -50,12 +49,10 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.DefaultTestLifecycle;
 import org.robolectric.Robolectric;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.fakes.BaseCursor;
-import org.robolectric.manifest.AndroidManifest;
-import org.robolectric.manifest.ContentProviderData;
 import org.robolectric.util.ReflectionHelpers;
 
 @RunWith(RobolectricTestRunner.class)
@@ -70,7 +67,7 @@ public class ShadowContentResolverTest {
 
   @Before
   public void setUp() {
-    contentResolver = Robolectric.setupActivity(Activity.class).getContentResolver();
+    contentResolver = RuntimeEnvironment.application.getContentResolver();
     shadowContentResolver = shadowOf(contentResolver);
     uri21 = Uri.parse(EXTERNAL_CONTENT_URI.toString() + "/21");
     uri22 = Uri.parse(EXTERNAL_CONTENT_URI.toString() + "/22");
@@ -695,15 +692,18 @@ public class ShadowContentResolverTest {
   }
 
   @Test
-  public void getProvider_shouldCreateProviderFromManifest() {
-    AndroidManifest manifest = ShadowApplication.getInstance().getAppManifest();
-    ContentProviderData testProviderData = new ContentProviderData("org.robolectric.shadows.ShadowContentResolverTest$TestContentProvider", null, AUTHORITY, null, null, null);
-    try {
-      manifest.getContentProviders().add(testProviderData);
-      assertThat(ShadowContentResolver.getProvider(Uri.parse("content://" + AUTHORITY + "/shadows"))).isNotNull();
-    } finally {
-      manifest.getContentProviders().remove(testProviderData);
-    }
+  public void getProvider_shouldCreateProviderFromManifest() throws Exception {
+    Uri uri = Uri.parse("content://org.robolectric.my_content_provider_authority/shadows");
+    ContentProvider provider = ShadowContentResolver.getProvider(uri);
+    assertThat(provider).isNotNull();
+    assertThat(provider.getReadPermission()).isEqualTo("READ_PERMISSION");
+    assertThat(provider.getWritePermission()).isEqualTo("WRITE_PERMISSION");
+    assertThat(provider.getPathPermissions()).hasSize(1);
+
+    // unfortunately, there is no direct way of testing if authority is set or not
+    // however, it's checked in ContentProvider.Transport method calls (validateIncomingUri), so
+    // it's the closest we can test against
+    provider.getIContentProvider().getType(uri); // should not throw
   }
 
   @Test
@@ -713,63 +713,11 @@ public class ShadowContentResolverTest {
     assertThat(ShadowContentResolver.getProvider(Uri.parse("content://"))).isNull();
   }
 
-  @Test
-  public void getProvider_shouldSetAuthority() throws RemoteException {
-    AndroidManifest manifest = ShadowApplication.getInstance().getAppManifest();
-    ContentProviderData testProviderData = new ContentProviderData("org.robolectric.shadows.ShadowContentResolverTest$TestContentProvider", null, AUTHORITY, null, null, null);
-    try {
-      manifest.getContentProviders().add(testProviderData);
-      Uri uri = Uri.parse("content://" + AUTHORITY + "/shadows");
-      ContentProvider provider = ShadowContentResolver.getProvider(uri);
-      // unfortunately, there is no direct way of testing if authority is set or not
-      // however, it's checked in ContentProvider.Transport method calls (validateIncomingUri), so it's the closest we can test against
-      provider.getIContentProvider().getType(uri); // should not throw
-    } finally {
-      manifest.getContentProviders().remove(testProviderData);
-    }
-  }
+
 
   @Test
   public void openTypedAssetFileDescriptor_shouldOpenDescriptor() throws IOException, RemoteException {
-    final File file = new File(RuntimeEnvironment.application.getFilesDir(), "test_file");
-    file.createNewFile();
-
-    ShadowContentResolver.registerProviderInternal(AUTHORITY, new ContentProvider() {
-      @Override
-      public boolean onCreate() {
-        return true;
-      }
-
-      @Override
-      public Cursor query(Uri uri, String[] strings, String s, String[] strings1, String s1) {
-        return null;
-      }
-
-      @Override
-      public String getType(Uri uri) {
-        return null;
-      }
-
-      @Override
-      public Uri insert(Uri uri, ContentValues contentValues) {
-        return null;
-      }
-
-      @Override
-      public int delete(Uri uri, String s, String[] strings) {
-        return 0;
-      }
-
-      @Override
-      public int update(Uri uri, ContentValues contentValues, String s, String[] strings) {
-        return 0;
-      }
-
-      @Override
-      public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
-        return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
-      }
-    });
+    Robolectric.setupContentProvider(MyContentProvider.class, AUTHORITY);
 
     AssetFileDescriptor afd = contentResolver.openTypedAssetFileDescriptor(Uri.parse("content://" + AUTHORITY + "/whatever"), "*/*", null);
 
@@ -876,4 +824,51 @@ public class ShadowContentResolverTest {
       return 0;
     }
   }
+
+  /**
+   * Provider that opens a temporary file.
+   */
+  public static class MyContentProvider extends ContentProvider {
+    @Override
+    public boolean onCreate() {
+      return true;
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] strings, String s, String[] strings1, String s1) {
+      return null;
+    }
+
+    @Override
+    public String getType(Uri uri) {
+      return null;
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues contentValues) {
+      return null;
+    }
+
+    @Override
+    public int delete(Uri uri, String s, String[] strings) {
+      return 0;
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues contentValues, String s, String[] strings) {
+      return 0;
+    }
+
+    @Override
+    public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
+      final File file = new File(RuntimeEnvironment.application.getFilesDir(), "test_file");
+      try {
+        file.createNewFile();
+      } catch (IOException e) {
+        throw new RuntimeException("error creating new file", e);
+      }
+      return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
+    }
+  }
+
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
@@ -16,7 +16,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
@@ -28,17 +27,6 @@ import org.robolectric.annotation.Config;
 @RunWith(RobolectricTestRunner.class)
 public class ShadowContextTest {
   private final Context context = RuntimeEnvironment.application;
-
-  @Before
-  public void setUp() throws Exception {
-    File dataDir = new File(context.getPackageManager()
-        .getPackageInfo("org.robolectric", 0).applicationInfo.dataDir);
-
-    File[] files = dataDir.listFiles();
-    assertThat(files)
-      .isNotNull()
-      .isEmpty();
-  }
 
   @Test
   @Config(minSdk = JELLY_BEAN_MR1)

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowIntentTest.java
@@ -25,14 +25,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 public class ShadowIntentTest {
   private static final String TEST_ACTIVITY_CLASS_NAME = "org.robolectric.shadows.TestActivity";
 
   @Test
-  @Config(manifest = "TestAndroidManifestForActivities.xml")
   public void resolveActivityInfo_shouldReturnActivityInfoForExistingActivity() {
       Context context = RuntimeEnvironment.application;
       PackageManager packageManager = context.getPackageManager();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -5,10 +5,7 @@ import static android.content.pm.ApplicationInfo.FLAG_ALLOW_CLEAR_USER_DATA;
 import static android.content.pm.ApplicationInfo.FLAG_ALLOW_TASK_REPARENTING;
 import static android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE;
 import static android.content.pm.ApplicationInfo.FLAG_HAS_CODE;
-import static android.content.pm.ApplicationInfo.FLAG_KILL_AFTER_RESTORE;
-import static android.content.pm.ApplicationInfo.FLAG_PERSISTENT;
 import static android.content.pm.ApplicationInfo.FLAG_RESIZEABLE_FOR_SCREENS;
-import static android.content.pm.ApplicationInfo.FLAG_RESTORE_ANY_VERSION;
 import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_LARGE_SCREENS;
 import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_NORMAL_SCREENS;
 import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_SCREEN_DENSITIES;
@@ -30,6 +27,8 @@ import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.N;
+import static android.os.Build.VERSION_CODES.N_MR1;
+import static android.os.Build.VERSION_CODES.O;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -87,7 +86,6 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-import org.robolectric.manifest.AndroidManifest;
 
 @RunWith(RobolectricTestRunner.class)
 public class ShadowPackageManagerTest {
@@ -95,7 +93,7 @@ public class ShadowPackageManagerTest {
   private static final String TEST_PACKAGE_NAME = "com.some.other.package";
   private static final String TEST_PACKAGE_LABEL = "My Little App";
   private static final String TEST_APP_PATH = "/values/app/application.apk";
-  private ShadowPackageManager shadowPackageManager;
+  protected ShadowPackageManager shadowPackageManager;
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private PackageManager packageManager;
@@ -161,28 +159,24 @@ public class ShadowPackageManagerTest {
     assertThat(applicationInfo).isInstanceOf(ApplicationInfo.class);
     assertThat(applicationInfo.packageName).isEqualTo(TEST_PACKAGE_NAME);
     assertThat(applicationInfo.sourceDir).isEqualTo(TEST_APP_PATH);
+
   }
 
   @Test
   public void applicationFlags() throws Exception {
     int flags = packageManager.getApplicationInfo("org.robolectric", 0).flags;
-    assertThat(flags).isEqualTo(
-        FLAG_ALLOW_BACKUP
-            | FLAG_ALLOW_CLEAR_USER_DATA
-            | FLAG_ALLOW_TASK_REPARENTING
-            | FLAG_DEBUGGABLE
-            | FLAG_HAS_CODE
-            | FLAG_KILL_AFTER_RESTORE
-            | FLAG_PERSISTENT
-            | FLAG_RESIZEABLE_FOR_SCREENS
-            | FLAG_RESTORE_ANY_VERSION
-            | FLAG_SUPPORTS_LARGE_SCREENS
-            | FLAG_SUPPORTS_NORMAL_SCREENS
-            | FLAG_SUPPORTS_SCREEN_DENSITIES
-            | FLAG_SUPPORTS_SMALL_SCREENS
-            | FLAG_TEST_ONLY
-            | FLAG_VM_SAFE_MODE
-    );
+    assertThat((flags & FLAG_ALLOW_BACKUP)).isEqualTo(FLAG_ALLOW_BACKUP);
+    assertThat((flags & FLAG_ALLOW_CLEAR_USER_DATA)).isEqualTo(FLAG_ALLOW_CLEAR_USER_DATA);
+    assertThat((flags & FLAG_ALLOW_TASK_REPARENTING)).isEqualTo(FLAG_ALLOW_TASK_REPARENTING);
+    assertThat((flags & FLAG_DEBUGGABLE)).isEqualTo(FLAG_DEBUGGABLE);
+    assertThat((flags & FLAG_HAS_CODE)).isEqualTo(FLAG_HAS_CODE);
+    assertThat((flags & FLAG_RESIZEABLE_FOR_SCREENS)).isEqualTo(FLAG_RESIZEABLE_FOR_SCREENS);
+    assertThat((flags & FLAG_SUPPORTS_LARGE_SCREENS)).isEqualTo(FLAG_SUPPORTS_LARGE_SCREENS);
+    assertThat((flags & FLAG_SUPPORTS_NORMAL_SCREENS)).isEqualTo(FLAG_SUPPORTS_NORMAL_SCREENS);
+    assertThat((flags & FLAG_SUPPORTS_SCREEN_DENSITIES)).isEqualTo(FLAG_SUPPORTS_SCREEN_DENSITIES);
+    assertThat((flags & FLAG_SUPPORTS_SMALL_SCREENS)).isEqualTo(FLAG_SUPPORTS_SMALL_SCREENS);
+    assertThat((flags & FLAG_TEST_ONLY)).isEqualTo(FLAG_TEST_ONLY);
+    assertThat((flags & FLAG_VM_SAFE_MODE)).isEqualTo(FLAG_VM_SAFE_MODE);
   }
 
   @Test
@@ -202,9 +196,12 @@ public class ShadowPackageManagerTest {
 
     List<ResolveInfo> receiverInfos = packageManager.queryBroadcastReceivers(intent, PackageManager.GET_INTENT_FILTERS);
     assertThat(receiverInfos).isNotEmpty();
-    assertEquals("org.robolectric.ConfigTestReceiverPermissionsAndActions", receiverInfos.get(0).activityInfo.name);
-    assertEquals("org.robolectric.CUSTOM_PERM", receiverInfos.get(0).activityInfo.permission);
-    assertEquals("org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE", receiverInfos.get(0).filter.getAction(0));
+    assertThat(receiverInfos.get(0).activityInfo.name)
+        .isEqualTo("org.robolectric.ConfigTestReceiverPermissionsAndActions");
+    assertThat(receiverInfos.get(0).activityInfo.permission)
+        .isEqualTo("org.robolectric.CUSTOM_PERM");
+    assertThat(receiverInfos.get(0).filter.getAction(0))
+        .isEqualTo("org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE");
   }
 
   @Test
@@ -215,11 +212,16 @@ public class ShadowPackageManagerTest {
   }
 
   @Test
-  public void testQueryBroadcastReceiverFailsForMissingAction() {
+  public void testQueryBroadcastReceiver_matchAllWithoutIntentFilter() {
     Intent intent = new Intent();
     intent.setPackage(RuntimeEnvironment.application.getPackageName());
     List<ResolveInfo> receiverInfos = packageManager.queryBroadcastReceivers(intent, PackageManager.GET_INTENT_FILTERS);
-    assertTrue(receiverInfos.size() == 0);
+    assertThat(receiverInfos).hasSize(7);
+
+    for (ResolveInfo receiverInfo : receiverInfos) {
+      assertThat(receiverInfo.activityInfo.name)
+          .isNotEqualTo("com.bar.ReceiverWithoutIntentFilter");
+    }
   }
 
   @Test
@@ -240,19 +242,32 @@ public class ShadowPackageManagerTest {
     ActivityInfo activityInfo = activity.getPackageManager().getActivityInfo(activity.getComponentName(), 0);
 
     int configChanges = activityInfo.configChanges;
-    assertThat(configChanges & ActivityInfo.CONFIG_MCC).isEqualTo(ActivityInfo.CONFIG_MCC);
     assertThat(configChanges & ActivityInfo.CONFIG_SCREEN_LAYOUT).isEqualTo(ActivityInfo.CONFIG_SCREEN_LAYOUT);
     assertThat(configChanges & ActivityInfo.CONFIG_ORIENTATION).isEqualTo(ActivityInfo.CONFIG_ORIENTATION);
 
     // Spot check a few other possible values that shouldn't be in the flags.
-    assertThat(configChanges & ActivityInfo.CONFIG_MNC).isZero();
     assertThat(configChanges & ActivityInfo.CONFIG_FONT_SCALE).isZero();
     assertThat(configChanges & ActivityInfo.CONFIG_SCREEN_SIZE).isZero();
   }
 
+  /** MCC + MNC are always present in config changes since Oreo. */
+  @Test
+  @Config(minSdk = O)
+  public void getActivityMetaData_configChangesAlwaysIncludesMccAndMnc() throws Exception {
+    Activity activity = setupActivity(ShadowPackageManagerTest.ActivityWithConfigChanges.class);
+
+    ActivityInfo activityInfo =
+        activity.getPackageManager().getActivityInfo(activity.getComponentName(), 0);
+
+    int configChanges = activityInfo.configChanges;
+    assertThat(configChanges & ActivityInfo.CONFIG_MCC).isEqualTo(ActivityInfo.CONFIG_MCC);
+    assertThat(configChanges & ActivityInfo.CONFIG_MNC).isEqualTo(ActivityInfo.CONFIG_MNC);
+  }
+
   @Test
   public void getPermissionInfo_withMinimalFields() throws Exception {
-    PermissionInfo permission = packageManager.getPermissionInfo("permission_with_minimal_fields", 0);
+    PermissionInfo permission =
+        packageManager.getPermissionInfo("org.robolectric.permission_with_minimal_fields", 0);
     assertThat(permission.labelRes).isEqualTo(0);
     assertThat(permission.descriptionRes).isEqualTo(0);
     assertThat(permission.protectionLevel).isEqualTo(PermissionInfo.PROTECTION_NORMAL);
@@ -286,6 +301,7 @@ public class ShadowPackageManagerTest {
     assertThat(applicationInfo).isInstanceOf(ApplicationInfo.class);
     assertThat(applicationInfo.packageName).isEqualTo(TEST_PACKAGE_NAME);
     assertThat(applicationInfo.sourceDir).isEqualTo(TEST_APP_PATH);
+
   }
 
   @Test
@@ -385,6 +401,23 @@ public class ShadowPackageManagerTest {
   }
 
   @Test
+  public void queryIntentActivities_launcher() {
+    Intent intent = new Intent(Intent.ACTION_MAIN);
+    intent.addCategory(Intent.CATEGORY_LAUNCHER);
+
+    // TODO: make this the default and remove.
+    shadowPackageManager.setQueryIntentImplicitly(true);
+    List<ResolveInfo> resolveInfos =
+        packageManager.queryIntentActivities(intent, PackageManager.MATCH_ALL);
+    assertThat(resolveInfos).hasSize(1);
+
+    assertThat(resolveInfos.get(0).activityInfo.name)
+        .isEqualTo("org.robolectric.shadows.TestActivityAlias");
+    assertThat(resolveInfos.get(0).activityInfo.targetActivity)
+        .isEqualTo("org.robolectric.shadows.TestActivity");
+  }
+
+  @Test
   public void queryIntentActivities_MatchSystemOnly() throws Exception {
     Intent i = new Intent(Intent.ACTION_MAIN, null);
     i.addCategory(Intent.CATEGORY_LAUNCHER);
@@ -426,7 +459,8 @@ public class ShadowPackageManagerTest {
     assertThat(activities).isNotNull();
     assertThat(activities).hasSize(1);
     assertThat(activities.get(0).resolvePackageName).isEqualTo("org.robolectric");
-    assertThat(activities.get(0).activityInfo.targetActivity).isEqualTo("org.robolectric.shadows.TestActivity");
+    assertThat(activities.get(0).activityInfo.name)
+        .isEqualTo("org.robolectric.shadows.TestActivity");
   }
 
   @Test
@@ -601,22 +635,28 @@ public class ShadowPackageManagerTest {
   @Test
   public void getProviderInfo_shouldPopulatePermissionsInProviderInfos() throws Exception {
     ProviderInfo providerInfo = packageManager.getProviderInfo(new ComponentName(RuntimeEnvironment.application, "org.robolectric.android.controller.ContentProviderControllerTest$MyContentProvider"), 0);
-    assertThat(providerInfo.authority).isEqualTo("org.robolectric.authority2");
+    assertThat(providerInfo.authority).isEqualTo("org.robolectric.my_content_provider_authority");
 
     assertThat(providerInfo.readPermission).isEqualTo("READ_PERMISSION");
     assertThat(providerInfo.writePermission).isEqualTo("WRITE_PERMISSION");
 
     assertThat(providerInfo.pathPermissions).hasSize(1);
+    assertThat(providerInfo.pathPermissions[0].getType())
+        .isEqualTo(PathPermission.PATTERN_SIMPLE_GLOB);
     assertThat(providerInfo.pathPermissions[0].getPath()).isEqualTo("/path/*");
-    assertThat(providerInfo.pathPermissions[0].getType()).isEqualTo(PathPermission.PATTERN_SIMPLE_GLOB);
     assertThat(providerInfo.pathPermissions[0].getReadPermission()).isEqualTo("PATH_READ_PERMISSION");
     assertThat(providerInfo.pathPermissions[0].getWritePermission()).isEqualTo("PATH_WRITE_PERMISSION");
   }
 
   @Test
   public void getProviderInfo_shouldMetaDataInProviderInfos() throws Exception {
-    ProviderInfo providerInfo = packageManager.getProviderInfo(new ComponentName(RuntimeEnvironment.application, "org.robolectric.android.controller.ContentProviderControllerTest$MyContentProvider"), 0);
-    assertThat(providerInfo.authority).isEqualTo("org.robolectric.authority2");
+    ProviderInfo providerInfo =
+        packageManager.getProviderInfo(
+            new ComponentName(
+                RuntimeEnvironment.application,
+                "org.robolectric.android.controller.ContentProviderControllerTest$MyContentProvider"),
+            PackageManager.GET_META_DATA);
+    assertThat(providerInfo.authority).isEqualTo("org.robolectric.my_content_provider_authority");
 
     assertThat(providerInfo.metaData.getString("greeting")).isEqualTo("Hello");
   }
@@ -631,58 +671,7 @@ public class ShadowPackageManagerTest {
   @Test
   public void testReceiverInfo() throws Exception {
     ActivityInfo info = packageManager.getReceiverInfo(new ComponentName(RuntimeEnvironment.application, ".test.ConfigTestReceiver"), PackageManager.GET_META_DATA);
-    Bundle meta = info.metaData;
-    Object metaValue = meta.get("org.robolectric.metaName1");
-    assertTrue(String.class.isInstance(metaValue));
-    assertEquals("metaValue1", metaValue);
-
-    metaValue = meta.get("org.robolectric.metaName2");
-    assertTrue(String.class.isInstance(metaValue));
-    assertEquals("metaValue2", metaValue);
-
-    metaValue = meta.get("org.robolectric.metaFalse");
-    assertTrue(Boolean.class.isInstance(metaValue));
-    assertEquals(false, metaValue);
-
-    metaValue = meta.get("org.robolectric.metaTrue");
-    assertTrue(Boolean.class.isInstance(metaValue));
-    assertEquals(true, metaValue);
-
-    metaValue = meta.get("org.robolectric.metaInt");
-    assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(123, metaValue);
-
-    metaValue = meta.get("org.robolectric.metaFloat");
-    assertTrue(Float.class.isInstance(metaValue));
-    assertThat(metaValue).isEqualTo(1.23f);
-
-    metaValue = meta.get("org.robolectric.metaColor");
-    assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(Color.WHITE, metaValue);
-
-    metaValue = meta.get("org.robolectric.metaBooleanFromRes");
-    assertTrue(Boolean.class.isInstance(metaValue));
-    assertEquals(RuntimeEnvironment.application.getResources().getBoolean(R.bool.false_bool_value), metaValue);
-
-    metaValue = meta.get("org.robolectric.metaIntFromRes");
-    assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(RuntimeEnvironment.application.getResources().getInteger(R.integer.test_integer1), metaValue);
-
-    metaValue = meta.get("org.robolectric.metaColorFromRes");
-    assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(RuntimeEnvironment.application.getResources().getColor(R.color.clear), metaValue);
-
-    metaValue = meta.get("org.robolectric.metaStringFromRes");
-    assertTrue(String.class.isInstance(metaValue));
-    assertEquals(RuntimeEnvironment.application.getString(R.string.app_name), metaValue);
-
-    metaValue = meta.get("org.robolectric.metaStringOfIntFromRes");
-    assertTrue(String.class.isInstance(metaValue));
-    assertEquals(RuntimeEnvironment.application.getString(R.string.str_int), metaValue);
-
-    metaValue = meta.get("org.robolectric.metaStringRes");
-    assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(R.string.app_name, metaValue);
+    assertThat(info.metaData.getInt("numberOfSheep")).isEqualTo(42);
   }
 
   @Test(expected = PackageManager.NameNotFoundException.class)
@@ -794,6 +783,13 @@ public class ShadowPackageManagerTest {
   }
 
   @Test
+  public void shouldAssignTheApplicationClassNameFromTheManifest() throws Exception {
+    ApplicationInfo applicationInfo = packageManager.getApplicationInfo("org.robolectric", 0);
+    assertThat(applicationInfo.className).isEqualTo("org.robolectric.TestApplication");
+  }
+
+  @Test
+  @Config(minSdk = N_MR1)
   public void shouldAssignTheApplicationNameFromTheManifest() throws Exception {
     ApplicationInfo applicationInfo = packageManager.getApplicationInfo("org.robolectric", 0);
     assertThat(applicationInfo.name).isEqualTo("org.robolectric.TestApplication");
@@ -807,6 +803,7 @@ public class ShadowPackageManagerTest {
     Intent launchIntent = new Intent(Intent.ACTION_MAIN);
     launchIntent.setPackage(TEST_PACKAGE_LABEL);
     launchIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+    launchIntent.addCategory(Intent.CATEGORY_LAUNCHER);
     ResolveInfo resolveInfo = new ResolveInfo();
     resolveInfo.activityInfo = new ActivityInfo();
     resolveInfo.activityInfo.packageName = TEST_PACKAGE_LABEL;
@@ -819,62 +816,39 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void shouldAssignTheAppMetaDataFromTheManifest() throws Exception {
-    ShadowApplication app = ShadowApplication.getInstance();
-    String packageName = app.getAppManifest().getPackageName();
-    ApplicationInfo info = packageManager.getApplicationInfo(packageName, 0);
+    ApplicationInfo info =
+        packageManager.getApplicationInfo(RuntimeEnvironment.application.getPackageName(), 0);
     Bundle meta = info.metaData;
 
-    Object metaValue = meta.get("org.robolectric.metaName1");
-    assertTrue(String.class.isInstance(metaValue));
-    assertEquals("metaValue1", metaValue);
+    assertThat(meta.getString("org.robolectric.metaName1")).isEqualTo("metaValue1");
+    assertThat(meta.getString("org.robolectric.metaName2")).isEqualTo("metaValue2");
 
-    metaValue = meta.get("org.robolectric.metaName2");
-    assertTrue(String.class.isInstance(metaValue));
-    assertEquals("metaValue2", metaValue);
+    assertThat(meta.getBoolean("org.robolectric.metaFalseLiteral")).isEqualTo(false);
+    assertThat(meta.getBoolean("org.robolectric.metaTrueLiteral")).isEqualTo(true);
 
-    metaValue = meta.get("org.robolectric.metaFalse");
-    assertTrue(Boolean.class.isInstance(metaValue));
-    assertEquals(false, metaValue);
+    assertThat(meta.getInt("org.robolectric.metaInt")).isEqualTo(123);
+    assertThat(meta.getFloat("org.robolectric.metaFloat")).isEqualTo(1.23f);
 
-    metaValue = meta.get("org.robolectric.metaTrue");
-    assertTrue(Boolean.class.isInstance(metaValue));
-    assertEquals(true, metaValue);
+    assertThat(meta.getInt("org.robolectric.metaColor")).isEqualTo(Color.WHITE);
 
-    metaValue = meta.get("org.robolectric.metaInt");
-    assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(123, metaValue);
+    assertThat(meta.getBoolean("org.robolectric.metaBooleanFromRes"))
+        .isEqualTo(
+            RuntimeEnvironment.application.getResources().getBoolean(R.bool.false_bool_value));
 
-    metaValue = meta.get("org.robolectric.metaFloat");
-    assertTrue(Float.class.isInstance(metaValue));
-    assertThat(metaValue).isEqualTo(1.23f);
+    assertThat(meta.getInt("org.robolectric.metaIntFromRes"))
+        .isEqualTo(
+            RuntimeEnvironment.application.getResources().getInteger(R.integer.test_integer1));
 
-    metaValue = meta.get("org.robolectric.metaColor");
-    assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(Color.WHITE, metaValue);
+    assertThat(meta.getInt("org.robolectric.metaColorFromRes"))
+        .isEqualTo(RuntimeEnvironment.application.getResources().getColor(R.color.clear));
 
-    metaValue = meta.get("org.robolectric.metaBooleanFromRes");
-    assertTrue(Boolean.class.isInstance(metaValue));
-    assertEquals(RuntimeEnvironment.application.getResources().getBoolean(R.bool.false_bool_value), metaValue);
+    assertThat(meta.getString("org.robolectric.metaStringFromRes"))
+        .isEqualTo(RuntimeEnvironment.application.getString(R.string.app_name));
 
-    metaValue = meta.get("org.robolectric.metaIntFromRes");
-    assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(RuntimeEnvironment.application.getResources().getInteger(R.integer.test_integer1), metaValue);
+    assertThat(meta.getString("org.robolectric.metaStringOfIntFromRes"))
+        .isEqualTo(RuntimeEnvironment.application.getString(R.string.str_int));
 
-    metaValue = meta.get("org.robolectric.metaColorFromRes");
-    assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(RuntimeEnvironment.application.getResources().getColor(R.color.clear), metaValue);
-
-    metaValue = meta.get("org.robolectric.metaStringFromRes");
-    assertTrue(String.class.isInstance(metaValue));
-    assertEquals(RuntimeEnvironment.application.getString(R.string.app_name), metaValue);
-
-    metaValue = meta.get("org.robolectric.metaStringOfIntFromRes");
-    assertTrue(String.class.isInstance(metaValue));
-    assertEquals(RuntimeEnvironment.application.getString(R.string.str_int), metaValue);
-
-    metaValue = meta.get("org.robolectric.metaStringRes");
-    assertTrue(Integer.class.isInstance(metaValue));
-    assertEquals(R.string.app_name, metaValue);
+    assertThat(meta.getInt("org.robolectric.metaStringRes")).isEqualTo(R.string.app_name);
   }
 
   @Test
@@ -976,27 +950,6 @@ public class ShadowPackageManagerTest {
   }
 
   @Test
-  public void shouldAssignNonLocalizedLabelFromTheManifest() throws Exception {
-    AndroidManifest androidManifest = new AndroidManifest(null, null, null) {
-
-      @Override
-      public String getPackageName() {
-        return "package.with.label";
-      }
-
-      @Override
-      public String getLabelRef() {
-        return "App Label";
-      }
-    };
-
-    shadowPackageManager.addManifest(androidManifest);
-    ApplicationInfo applicationInfo = packageManager.getApplicationInfo("package.with.label", 0);
-    assertThat(applicationInfo.labelRes).isEqualTo(0);
-    assertThat(applicationInfo.nonLocalizedLabel).isEqualTo("App Label");
-  }
-
-  @Test
   public void getServiceInfo_shouldReturnServiceInfoIfExists() throws Exception {
     ServiceInfo serviceInfo = packageManager.getServiceInfo(new ComponentName("org.robolectric", "com.foo.Service"), PackageManager.GET_SERVICES);
     assertEquals(serviceInfo.packageName, "org.robolectric");
@@ -1081,7 +1034,13 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void getResourcesForApplication_anotherPackage() throws Exception {
-    shadowPackageManager.addPackage("another.package");
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = "another.package";
+
+    ApplicationInfo applicationInfo = new ApplicationInfo();
+    applicationInfo.packageName = "another.package";
+    packageInfo.applicationInfo = applicationInfo;
+    shadowPackageManager.addPackage(packageInfo);
 
     assertThat(packageManager.getResourcesForApplication("another.package")).isNotNull();
     assertThat(packageManager.getResourcesForApplication("another.package")).isNotEqualTo(RuntimeEnvironment.application.getResources());
@@ -1232,10 +1191,13 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void getPermissionInfo() throws Exception {
-    PermissionInfo permission = RuntimeEnvironment.application.getPackageManager().getPermissionInfo("some_permission", 0);
+    PermissionInfo permission =
+        RuntimeEnvironment.application
+            .getPackageManager()
+            .getPermissionInfo("org.robolectric.some_permission", 0);
     assertThat(permission.labelRes).isEqualTo(R.string.test_permission_label);
     assertThat(permission.descriptionRes).isEqualTo(R.string.test_permission_description);
-    assertThat(permission.name).isEqualTo("some_permission");
+    assertThat(permission.name).isEqualTo("org.robolectric.some_permission");
   }
 
   @Test
@@ -1299,9 +1261,10 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void getPermissionInfo_noMetaData() throws Exception {
-    PermissionInfo permission = packageManager.getPermissionInfo("some_permission", 0);
+    PermissionInfo permission =
+        packageManager.getPermissionInfo("org.robolectric.some_permission", 0);
     assertThat(permission.metaData).isNull();
-    assertThat(permission.name).isEqualTo("some_permission");
+    assertThat(permission.name).isEqualTo("org.robolectric.some_permission");
     assertThat(permission.descriptionRes).isEqualTo(R.string.test_permission_description);
     assertThat(permission.labelRes).isEqualTo(R.string.test_permission_label);
     assertThat(permission.nonLocalizedLabel).isNullOrEmpty();
@@ -1311,14 +1274,17 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void getPermissionInfo_withMetaData() throws Exception {
-    PermissionInfo permission = packageManager.getPermissionInfo("some_permission", PackageManager.GET_META_DATA);
+    PermissionInfo permission =
+        packageManager.getPermissionInfo(
+            "org.robolectric.some_permission", PackageManager.GET_META_DATA);
     assertThat(permission.metaData).isNotNull();
     assertThat(permission.metaData.getString("meta_data_name")).isEqualTo("meta_data_value");
   }
 
   @Test
   public void getPermissionInfo_withLiteralLabel() throws Exception {
-    PermissionInfo permission = packageManager.getPermissionInfo("permission_with_literal_label", 0);
+    PermissionInfo permission =
+        packageManager.getPermissionInfo("org.robolectric.permission_with_literal_label", 0);
     assertThat(permission.labelRes).isEqualTo(0);
     assertThat(permission.nonLocalizedLabel).isEqualTo("Literal label");
     assertThat(permission.protectionLevel).isEqualTo(PermissionInfo.PROTECTION_NORMAL);
@@ -1332,7 +1298,7 @@ public class ShadowPackageManagerTest {
     PermissionInfo permission = permissions.get(0);
 
     assertThat(permission.group).isEqualTo("my_permission_group");
-    assertThat(permission.name).isEqualTo("some_permission");
+    assertThat(permission.name).isEqualTo("org.robolectric.some_permission");
     assertThat(permission.metaData).isNull();
   }
 
@@ -1344,7 +1310,7 @@ public class ShadowPackageManagerTest {
     PermissionInfo permission = permissions.get(0);
 
     assertThat(permission.group).isEqualTo("my_permission_group");
-    assertThat(permission.name).isEqualTo("some_permission");
+    assertThat(permission.name).isEqualTo("org.robolectric.some_permission");
     assertThat(permission.metaData).isNotNull();
     assertThat(permission.metaData.getString("meta_data_name")).isEqualTo("meta_data_value");
   }
@@ -1354,7 +1320,9 @@ public class ShadowPackageManagerTest {
     List<PermissionInfo> permissions = packageManager.queryPermissionsByGroup(null, 0);
 
     assertThat(Iterables.transform(permissions, getPermissionNames()))
-        .containsExactlyInAnyOrder("permission_with_minimal_fields", "permission_with_literal_label");
+        .containsExactlyInAnyOrder(
+            "org.robolectric.permission_with_minimal_fields",
+            "org.robolectric.permission_with_literal_label");
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
@@ -911,10 +911,9 @@ public class ShadowViewTest {
     activityController.setup();
 
     Rect globalVisibleRect = new Rect();
-    assertThat(view.getGlobalVisibleRect(globalVisibleRect))
-        .isTrue();
-    assertThat(globalVisibleRect)
-        .isEqualTo(new Rect(0, 25, 480, 800));
+    assertThat(view.getGlobalVisibleRect(globalVisibleRect)).isTrue();
+    assertThat(globalVisibleRect.right).isEqualTo(480);
+    assertThat(globalVisibleRect.bottom).isEqualTo(800);
   }
 
   public static class MyActivity extends Activity {

--- a/robolectric/src/test/resources/AndroidManifest.xml
+++ b/robolectric/src/test/resources/AndroidManifest.xml
@@ -1,7 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      package="org.robolectric">
+      package="org.robolectric" android:sharedUserId="sharedUserId.robolectric"
+    android:versionCode="123"
+    android:versionName="aVersionName">
   <uses-sdk android:targetSdkVersion="23"/>
+
+  <permission android:name="some_permission"
+      android:description="@string/test_permission_description"
+      android:icon="@drawable/an_image"
+      android:label="@string/test_permission_label"
+      android:permissionGroup="my_permission_group"
+      android:protectionLevel="dangerous">
+    <meta-data android:name="meta_data_name" android:value="meta_data_value"/>
+  </permission>
+
+  <permission android:name="permission_with_literal_label"
+      android:description="@string/test_permission_description"
+      android:icon="@drawable/an_image"
+      android:label="Literal label"/>
+
+  <permission android:name="permission_with_minimal_fields"/>
+
+  <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+  <uses-permission android:name="android.permission.GET_TASKS"/>
 
   <application android:name="org.robolectric.TestApplication"
          android:theme="@style/Theme.Robolectric"
@@ -22,30 +44,10 @@
          android:testOnly="true"
          android:vmSafeMode="true">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-    <uses-permission android:name="android.permission.GET_TASKS"/>
-
-    <permission android:name="some_permission"
-                android:description="@string/test_permission_description"
-                android:icon="@drawable/an_image"
-                android:label="@string/test_permission_label"
-                android:permissionGroup="my_permission_group"
-                android:protectionLevel="dangerous">
-      <meta-data android:name="meta_data_name" android:value="meta_data_value"/>
-    </permission>
-
-    <permission android:name="permission_with_literal_label"
-                android:description="@string/test_permission_description"
-                android:icon="@drawable/an_image"
-                android:label="Literal label"/>
-
-    <permission android:name="permission_with_minimal_fields"/>
-
     <meta-data android:name="org.robolectric.metaName1" android:value="metaValue1" />
     <meta-data android:name="org.robolectric.metaName2" android:value="metaValue2" />
-    <meta-data android:name="org.robolectric.metaTrue" android:value="true" />
-    <meta-data android:name="org.robolectric.metaFalse" android:value="false" />
+    <meta-data android:name="org.robolectric.metaTrueLiteral" android:value="true" />
+    <meta-data android:name="org.robolectric.metaFalseLiteral" android:value="false" />
     <meta-data android:name="org.robolectric.metaInt" android:value="123" />
     <meta-data android:name="org.robolectric.metaFloat" android:value="1.23" />
     <meta-data android:name="org.robolectric.metaColor" android:value="#FFFFFF" />
@@ -73,7 +75,7 @@
     </activity>
 
     <activity android:name="org.robolectric.shadows.ShadowPackageManagerTest$ActivityWithConfigChanges"
-              android:configChanges="mcc|screenLayout|orientation"/>
+              android:configChanges="screenLayout|orientation"/>
 
     <activity android:name="org.robolectric.shadows.ShadowActivityTest$LabelTestActivity1" />
     <activity android:name="org.robolectric.shadows.ShadowActivityTest$LabelTestActivity2"
@@ -135,16 +137,14 @@
 
     <provider
             android:name="org.robolectric.android.controller.ContentProviderControllerTest$MyContentProvider"
-            android:authorities="org.robolectric.authority2"
+            android:authorities="org.robolectric.my_content_provider_authority"
             android:permission="PERMISSION"
             android:readPermission="READ_PERMISSION"
-            android:writePermission="WRITE_PERMISSION"
-    >
+            android:writePermission="WRITE_PERMISSION">
       <path-permission
               android:pathPattern="/path/*"
               android:readPermission="PATH_READ_PERMISSION"
-              android:writePermission="PATH_WRITE_PERMISSION"
-      />
+              android:writePermission="PATH_WRITE_PERMISSION"/>
       <meta-data android:name="greeting" android:value="@string/hello"/>
     </provider>
 
@@ -182,19 +182,7 @@
       <intent-filter>
         <action android:name="org.robolectric.ACTION_DOT_SUBPACKAGE"/>
       </intent-filter>
-      <meta-data android:name="org.robolectric.metaName1" android:value="metaValue1" />
-      <meta-data android:name="org.robolectric.metaName2" android:value="metaValue2" />
-      <meta-data android:name="org.robolectric.metaTrue" android:value="true" />
-      <meta-data android:name="org.robolectric.metaFalse" android:value="false" />
-      <meta-data android:name="org.robolectric.metaInt" android:value="123" />
-      <meta-data android:name="org.robolectric.metaFloat" android:value="1.23" />
-      <meta-data android:name="org.robolectric.metaColor" android:value="#FFFFFF" />
-      <meta-data android:name="org.robolectric.metaBooleanFromRes" android:value="@bool/false_bool_value" />
-      <meta-data android:name="org.robolectric.metaIntFromRes" android:value="@integer/test_integer1" />
-      <meta-data android:name="org.robolectric.metaColorFromRes" android:value="@color/clear" />
-      <meta-data android:name="org.robolectric.metaStringFromRes" android:value="@string/app_name" />
-      <meta-data android:name="org.robolectric.metaStringOfIntFromRes" android:value="@string/str_int" />
-      <meta-data android:name="org.robolectric.metaStringRes" android:resource="@string/app_name" />
+      <meta-data android:name="numberOfSheep" android:value="42" />
     </receiver>
 
     <receiver android:name="com.foo.Receiver">

--- a/robolectric/src/test/resources/TestAndroidManifestWithContentProviders.xml
+++ b/robolectric/src/test/resources/TestAndroidManifestWithContentProviders.xml
@@ -16,6 +16,7 @@
       android:permission="PERMISSION"
       android:readPermission="READ_PERMISSION"
       android:writePermission="WRITE_PERMISSION"
+      android:grantUriPermissions="true"
     >
       <path-permission
               android:pathPattern="/path/*"

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
@@ -92,6 +92,10 @@ public class InstrumentationConfiguration {
       return true;
     }
 
+    if (name.equals("java.util.jar.StrictJarFile")) {
+      return true;
+    }
+
     // android.R and com.android.internal.R classes must be loaded from the framework jar
     if (name.matches("(android|com\\.android\\.internal)\\.R(\\$.+)?")) {
       return true;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -3,7 +3,6 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.M;
-import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.shadow.api.Shadow.directlyOn;
 import static org.robolectric.shadow.api.Shadow.invokeConstructor;
 
@@ -47,7 +46,6 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.fakes.RoboMenuItem;
-import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.util.ReflectionHelpers;
 
 @Implements(Activity.class)
@@ -86,30 +84,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
     ReflectionHelpers.setField(realActivity, "mApplication", application);
   }
 
-  private String getActivityTitle() {
-    String title = null;
-
-    AndroidManifest appManifest = ShadowApplication.getInstance().getAppManifest();
-
-    if (appManifest == null) return null;
-    String labelRef = appManifest.getActivityLabel(realActivity.getClass().getName());
-
-    if (labelRef != null) {
-      if (labelRef.startsWith("@")) {
-        /* Label refers to a string value, get the resource identifier */
-        int labelRes = RuntimeEnvironment.application.getResources().getIdentifier(labelRef.replace("@", ""), "string", appManifest.getPackageName());
-        /* Get the resource ID, use the activity to look up the actual string */
-        title = RuntimeEnvironment.application.getString(labelRes);
-      } else {
-        title = labelRef; /* Label isn't an identifier, use it directly as the title */
-      }
-    }
-
-    return title;
-  }
-
   public void callAttach(Intent intent) {
-    String activityTitle = getActivityTitle();
     int apiLevel = RuntimeEnvironment.getApiLevel();
     Application application = RuntimeEnvironment.application;
     Context baseContext = RuntimeEnvironment.application.getBaseContext();
@@ -121,6 +96,8 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
     } catch (NameNotFoundException e) {
       throw new RuntimeException();
     }
+
+    CharSequence activityTitle = activityInfo.loadLabel(baseContext.getPackageManager());
 
     if (apiLevel <= Build.VERSION_CODES.KITKAT) {
       ReflectionHelpers.callInstanceMethod(Activity.class, realActivity, "attach",
@@ -212,7 +189,11 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
     } else {
       throw new RuntimeException("Could not find AndroidRuntimeAdapter for API level: " + apiLevel);
     }
-    setThemeFromManifest();
+
+    int theme = activityInfo.getThemeResource();
+    if (theme != 0) {
+      realActivity.setTheme(theme);
+    }
   }
 
   private Class<?> getNonConfigurationClass() {
@@ -221,21 +202,6 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  public boolean setThemeFromManifest() {
-    ShadowApplication shadowApplication = shadowOf(realActivity.getApplication());
-    AndroidManifest appManifest = shadowApplication.getAppManifest();
-    if (appManifest == null) return false;
-
-    String themeRef = appManifest.getThemeRef(realActivity.getClass().getName());
-
-    if (themeRef != null) {
-      int themeRes = realActivity.getResources().getIdentifier(themeRef.replace("@", ""), "style", appManifest.getPackageName());
-      realActivity.setTheme(themeRes);
-      return true;
-    }
-    return false;
   }
 
   public void setCallingActivity(ComponentName activityName) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
@@ -1,7 +1,9 @@
 package org.robolectric.shadows;
 
 import android.app.ActivityThread;
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.os.RemoteException;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -13,6 +15,7 @@ import org.robolectric.annotation.Implements;
 @Implements(value = ActivityThread.class, isInAndroidSdk = false)
 public class ShadowActivityThread {
   public static final String CLASS_NAME = "android.app.ActivityThread";
+  private static ApplicationInfo applicationInfo;
 
   @Implementation
   public static Object getPackageManager() {
@@ -23,29 +26,44 @@ public class ShadowActivityThread {
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e);
     }
-    return Proxy.newProxyInstance(classLoader, new Class[]{iPackageManagerClass}, new InvocationHandler() {
-      @Override
-      public Object invoke(Object proxy, @Nonnull Method method, Object[] args) throws Exception {
-        if (method.getName().equals("getApplicationInfo")) {
-          String packageName = (String) args[0];
-          int flags = (Integer) args[1];
-          try {
-            return RuntimeEnvironment.application.getPackageManager().getApplicationInfo(packageName, flags);
-          } catch (PackageManager.NameNotFoundException e) {
-            return null;
+    return Proxy.newProxyInstance(
+        classLoader,
+        new Class[] {iPackageManagerClass},
+        new InvocationHandler() {
+          @Override
+          public Object invoke(Object proxy, @Nonnull Method method, Object[] args)
+              throws Exception {
+            if (method.getName().equals("getApplicationInfo")) {
+              String packageName = (String) args[0];
+              int flags = (Integer) args[1];
+
+              if (packageName.equals(ShadowActivityThread.applicationInfo.packageName)) {
+                return ShadowActivityThread.applicationInfo;
+              }
+
+              try {
+                return RuntimeEnvironment.application
+                    .getPackageManager()
+                    .getApplicationInfo(packageName, flags);
+              } catch (PackageManager.NameNotFoundException e) {
+                throw new RemoteException(e.getMessage());
+              }
+            } else if (method.getName().equals("notifyPackageUse")) {
+              return null;
+            } else if (method.getName().equals("getPackageInstaller")) {
+              return null;
+            }
+            throw new UnsupportedOperationException("sorry, not supporting " + method + " yet!");
           }
-        } else if (method.getName().equals("notifyPackageUse")) {
-          return null;
-        } else if (method.getName().equals("getPackageInstaller")) {
-          return null;
-        }
-        throw new UnsupportedOperationException("sorry, not supporting " + method + " yet!");
-      }
-    });
+        });
   }
 
   @Implementation
   public static Object currentActivityThread() {
     return RuntimeEnvironment.getActivityThread();
+  }
+
+  public static void setApplicationInfo(ApplicationInfo applicationInfo) {
+    ShadowActivityThread.applicationInfo = applicationInfo;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -136,7 +136,7 @@ public class ShadowApplication extends ShadowContextWrapper {
       for (String action : receiver.getActions()) {
         filter.addAction(action);
       }
-      String receiverClassName = replaceLastDotWith$IfInnerStaticClass(receiver.getClassName());
+      String receiverClassName = replaceLastDotWith$IfInnerStaticClass(receiver.getName());
       registerReceiver((BroadcastReceiver) newInstanceOf(receiverClassName), filter);
     }
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -117,6 +117,7 @@ public final class ShadowAssetManager {
 
     // short-circuit Android caching of loaded resources cuz our string positions don't remain stable...
     outValue.assetCookie = Converter.getNextStringCookie();
+    outValue.changingConfigurations = 0;
 
     // TODO: Handle resource and style references
     if (attribute.isStyleReference()) {
@@ -416,11 +417,11 @@ public final class ShadowAssetManager {
 
   @Implementation
   public final XmlResourceParser openXmlResourceParser(int cookie, String fileName) throws IOException {
-    XmlBlock xmlBlock = XmlBlock.create(Fs.fileFromPath(fileName), "fixme");
+    XmlBlock xmlBlock = XmlBlock.create(Fs.fileFromPath(fileName), resourceTable.getPackageName());
     if (xmlBlock == null) {
       throw new Resources.NotFoundException(fileName);
     }
-    return getXmlResourceParser(null, xmlBlock, "fixme");
+    return getXmlResourceParser(resourceTable, xmlBlock, resourceTable.getPackageName());
   }
 
   public XmlResourceParser loadXmlResourceParser(int resId, String type) throws Resources.NotFoundException {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
@@ -17,13 +17,11 @@ import android.content.OperationApplicationException;
 import android.content.PeriodicSync;
 import android.content.UriPermission;
 import android.content.pm.ProviderInfo;
-import android.content.res.AssetFileDescriptor;
 import android.database.ContentObserver;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.CancellationSignal;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -41,8 +39,6 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
 import org.robolectric.fakes.BaseCursor;
-import org.robolectric.manifest.AndroidManifest;
-import org.robolectric.manifest.ContentProviderData;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.NamedStream;
 import org.robolectric.util.ReflectionHelpers;
@@ -597,14 +593,10 @@ public class ShadowContentResolver {
 
   synchronized private static ContentProvider getProvider(String authority) {
     if (!providers.containsKey(authority)) {
-      AndroidManifest manifest = shadowOf(RuntimeEnvironment.application).getAppManifest();
-      if (manifest != null) {
-        for (ContentProviderData providerData : manifest.getContentProviders()) {
-          // todo: handle multiple authorities
-          if (providerData.getAuthorities().equals(authority)) {
-            providers.put(providerData.getAuthorities(), createAndInitialize(providerData));
-          }
-        }
+      ProviderInfo providerInfo =
+          RuntimeEnvironment.application.getPackageManager().resolveContentProvider(authority, 0);
+      if (providerInfo != null) {
+        providers.put(providerInfo.authority, createAndInitialize(providerInfo));
       }
     }
     return providers.get(authority);
@@ -797,31 +789,15 @@ public class ShadowContentResolver {
     return observers;
   }
 
-  @Implementation
-  public final AssetFileDescriptor openTypedAssetFileDescriptor(Uri uri, String mimeType, Bundle opts) throws FileNotFoundException {
-    ContentProvider provider = getProvider(uri);
-    if (provider == null) {
-      return null;
-    }
-    return provider.openTypedAssetFile(uri, mimeType, opts);
-  }
-
-  private static ContentProvider createAndInitialize(ContentProviderData providerData) {
+  private static ContentProvider createAndInitialize(ProviderInfo providerInfo) {
     try {
-      ContentProvider provider = (ContentProvider) Class.forName(providerData.getClassName()).newInstance();
-      initialize(provider, providerData.getAuthorities());
+      ContentProvider provider = (ContentProvider) Class.forName(providerInfo.name).newInstance();
+      provider.attachInfo(RuntimeEnvironment.application, providerInfo);
+      provider.onCreate();
       return provider;
     } catch (InstantiationException | ClassNotFoundException | IllegalAccessException e) {
-      throw new RuntimeException("Error instantiating class " + providerData.getClassName());
+      throw new RuntimeException("Error instantiating class " + providerInfo.name);
     }
-  }
-
-  private static void initialize(ContentProvider provider, String authorities) {
-    ProviderInfo providerInfo = new ProviderInfo();
-    providerInfo.authority = authorities; // todo: support multiple authorities
-    providerInfo.grantUriPermissions = true;
-    provider.attachInfo(RuntimeEnvironment.application, providerInfo);
-    provider.onCreate();
   }
 
   private BaseCursor getCursor(Uri uri) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
@@ -1,22 +1,24 @@
 package org.robolectric.shadows;
 
-import static android.content.pm.ApplicationInfo.FLAG_ALLOW_BACKUP;
-import static android.content.pm.ApplicationInfo.FLAG_ALLOW_CLEAR_USER_DATA;
-import static android.content.pm.ApplicationInfo.FLAG_ALLOW_TASK_REPARENTING;
-import static android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE;
-import static android.content.pm.ApplicationInfo.FLAG_HAS_CODE;
-import static android.content.pm.ApplicationInfo.FLAG_KILL_AFTER_RESTORE;
-import static android.content.pm.ApplicationInfo.FLAG_PERSISTENT;
-import static android.content.pm.ApplicationInfo.FLAG_RESIZEABLE_FOR_SCREENS;
-import static android.content.pm.ApplicationInfo.FLAG_RESTORE_ANY_VERSION;
-import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_LARGE_SCREENS;
-import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_NORMAL_SCREENS;
-import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_SCREEN_DENSITIES;
-import static android.content.pm.ApplicationInfo.FLAG_SUPPORTS_SMALL_SCREENS;
-import static android.content.pm.ApplicationInfo.FLAG_TEST_ONLY;
-import static android.content.pm.ApplicationInfo.FLAG_VM_SAFE_MODE;
 import static android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
+import static android.content.pm.PackageManager.GET_ACTIVITIES;
+import static android.content.pm.PackageManager.GET_CONFIGURATIONS;
+import static android.content.pm.PackageManager.GET_GIDS;
+import static android.content.pm.PackageManager.GET_INSTRUMENTATION;
+import static android.content.pm.PackageManager.GET_INTENT_FILTERS;
 import static android.content.pm.PackageManager.GET_META_DATA;
+import static android.content.pm.PackageManager.GET_PERMISSIONS;
+import static android.content.pm.PackageManager.GET_PROVIDERS;
+import static android.content.pm.PackageManager.GET_RECEIVERS;
+import static android.content.pm.PackageManager.GET_RESOLVED_FILTER;
+import static android.content.pm.PackageManager.GET_SERVICES;
+import static android.content.pm.PackageManager.GET_SHARED_LIBRARY_FILES;
+import static android.content.pm.PackageManager.GET_SIGNATURES;
+import static android.content.pm.PackageManager.GET_URI_PERMISSION_PATTERNS;
+import static android.content.pm.PackageManager.MATCH_DIRECT_BOOT_AWARE;
+import static android.content.pm.PackageManager.MATCH_DIRECT_BOOT_UNAWARE;
+import static android.content.pm.PackageManager.MATCH_DISABLED_COMPONENTS;
+import static android.content.pm.PackageManager.MATCH_DISABLED_UNTIL_USED_COMPONENTS;
 import static android.content.pm.PackageManager.MATCH_UNINSTALLED_PACKAGES;
 import static android.content.pm.PackageManager.SIGNATURE_FIRST_NOT_SIGNED;
 import static android.content.pm.PackageManager.SIGNATURE_MATCH;
@@ -40,10 +42,13 @@ import android.content.pm.IPackageDeleteObserver;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.pm.PackageParser;
+import android.content.pm.PackageParser.Activity;
+import android.content.pm.PackageParser.Package;
+import android.content.pm.PackageParser.Service;
 import android.content.pm.PackageStats;
-import android.content.pm.PathPermission;
+import android.content.pm.PackageUserState;
 import android.content.pm.PermissionInfo;
-import android.content.pm.ProviderInfo;
 import android.content.pm.ResolveInfo;
 import android.content.pm.ServiceInfo;
 import android.content.pm.Signature;
@@ -51,11 +56,11 @@ import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Binder;
-import android.os.Bundle;
-import android.os.PatternMatcher;
+import android.os.Build;
 import android.os.Process;
 import android.os.RemoteException;
 import android.os.UserHandle;
+import android.util.ArraySet;
 import android.util.Pair;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
@@ -74,58 +79,16 @@ import java.util.TreeMap;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
-import org.robolectric.manifest.ActivityData;
-import org.robolectric.manifest.AndroidManifest;
-import org.robolectric.manifest.ContentProviderData;
-import org.robolectric.manifest.IntentFilterData;
-import org.robolectric.manifest.PathPermissionData;
-import org.robolectric.manifest.PermissionItemData;
-import org.robolectric.manifest.ServiceData;
-import org.robolectric.res.AttributeResource;
-import org.robolectric.res.ResName;
+import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.TempDirectory;
 
 @Implements(PackageManager.class)
 public class ShadowPackageManager {
 
-  private static final List<Pair<String, Integer>> APPLICATION_FLAGS = asList(
-      Pair.create("android:allowBackup", FLAG_ALLOW_BACKUP),
-      Pair.create("android:allowClearUserData", FLAG_ALLOW_CLEAR_USER_DATA),
-      Pair.create("android:allowTaskReparenting", FLAG_ALLOW_TASK_REPARENTING),
-      Pair.create("android:debuggable", FLAG_DEBUGGABLE),
-      Pair.create("android:hasCode", FLAG_HAS_CODE),
-      Pair.create("android:killAfterRestore", FLAG_KILL_AFTER_RESTORE),
-      Pair.create("android:persistent", FLAG_PERSISTENT),
-      Pair.create("android:resizeable", FLAG_RESIZEABLE_FOR_SCREENS),
-      Pair.create("android:restoreAnyVersion", FLAG_RESTORE_ANY_VERSION),
-      Pair.create("android:largeScreens", FLAG_SUPPORTS_LARGE_SCREENS),
-      Pair.create("android:normalScreens", FLAG_SUPPORTS_NORMAL_SCREENS),
-      Pair.create("android:anyDensity", FLAG_SUPPORTS_SCREEN_DENSITIES),
-      Pair.create("android:smallScreens", FLAG_SUPPORTS_SMALL_SCREENS),
-      Pair.create("android:testOnly", FLAG_TEST_ONLY),
-      Pair.create("android:vmSafeMode", FLAG_VM_SAFE_MODE)
-  );
-
-  private static final List<Pair<String, Integer>> CONFIG_OPTIONS = asList(
-      Pair.create("mcc", ActivityInfo.CONFIG_MCC),
-      Pair.create("mnc", ActivityInfo.CONFIG_MNC),
-      Pair.create("locale", ActivityInfo.CONFIG_LOCALE),
-      Pair.create("touchscreen", ActivityInfo.CONFIG_TOUCHSCREEN),
-      Pair.create("keyboard", ActivityInfo.CONFIG_KEYBOARD),
-      Pair.create("keyboardHidden", ActivityInfo.CONFIG_KEYBOARD_HIDDEN),
-      Pair.create("navigation", ActivityInfo.CONFIG_NAVIGATION),
-      Pair.create("screenLayout", ActivityInfo.CONFIG_SCREEN_LAYOUT),
-      Pair.create("fontScale", ActivityInfo.CONFIG_FONT_SCALE),
-      Pair.create("uiMode", ActivityInfo.CONFIG_UI_MODE),
-      Pair.create("orientation", ActivityInfo.CONFIG_ORIENTATION),
-      Pair.create("screenSize", ActivityInfo.CONFIG_SCREEN_SIZE),
-      Pair.create("smallestScreenSize", ActivityInfo.CONFIG_SMALLEST_SCREEN_SIZE)
-  );
-
-
   Map<String, Boolean> permissionRationaleMap = new HashMap<>();
   List<FeatureInfo> systemAvailableFeatures = new LinkedList<>();
   final Map<String, PackageInfo> packageInfos = new LinkedHashMap<>();
+  final Map<String, Package> packages = new LinkedHashMap<>();
   private Map<String, PackageInfo> packageArchiveInfo = new HashMap<>();
   final Map<String, PackageStats> packageStatsMap = new HashMap<>();
   final Map<String, String> packageInstallerMap = new HashMap<>();
@@ -135,7 +98,6 @@ public class ShadowPackageManager {
   final Map<Integer, Integer> verificationResults = new HashMap<>();
   final Map<Integer, Long> verificationTimeoutExtension = new HashMap<>();
   final Map<String, String> currentToCanonicalNames = new HashMap<>();
-  final Map<String, AndroidManifest> androidManifests = new LinkedHashMap<>();
   final Map<ComponentName, ComponentState> componentList = new LinkedHashMap<>();
   final Map<ComponentName, Drawable> drawableList = new LinkedHashMap<>();
   final Map<String, Drawable> applicationIcons = new HashMap<>();
@@ -150,40 +112,6 @@ public class ShadowPackageManager {
   private Set<String> deletedPackages = new HashSet<>();
   Map<String, IPackageDeleteObserver> pendingDeleteCallbacks = new HashMap<>();
 
-  public ShadowPackageManager() {
-    addManifest(RuntimeEnvironment.getAppManifest());
-  }
-
-  /**
-   * Goes through the meta data and puts each value in to a
-   * bundle as the correct type.
-   *
-   * Note that this will convert resource identifiers specified
-   * via the value attribute as well.
-   * @param meta Meta data to put in to a bundle
-   * @return bundle containing the meta data
-   */
-  static Bundle metaDataToBundle(Map<String, Object> meta) {
-    if (meta.size() == 0) {
-        return null;
-    }
-
-    Bundle bundle = new Bundle();
-
-    for (Map.Entry<String,Object> entry : meta.entrySet()) {
-      if (Boolean.class.isInstance(entry.getValue())) {
-        bundle.putBoolean(entry.getKey(), (Boolean) entry.getValue());
-      } else if (Float.class.isInstance(entry.getValue())) {
-        bundle.putFloat(entry.getKey(), (Float) entry.getValue());
-      } else if (Integer.class.isInstance(entry.getValue())) {
-        bundle.putInt(entry.getKey(), (Integer) entry.getValue());
-      } else {
-        bundle.putString(entry.getKey(), entry.getValue().toString());
-      }
-    }
-    return bundle;
-  }
-
   // From com.android.server.pm.PackageManagerService.compareSignatures().
   static int compareSignature(Signature[] signatures1, Signature[] signatures2) {
     if (signatures1 == null) {
@@ -196,8 +124,8 @@ public class ShadowPackageManager {
     if (signatures1.length != signatures2.length) {
       return SIGNATURE_NO_MATCH;
     }
-    HashSet<Signature> signatures1set = new HashSet<>(Arrays.asList(signatures1));
-    HashSet<Signature> signatures2set = new HashSet<>(Arrays.asList(signatures2));
+    HashSet<Signature> signatures1set = new HashSet<>(asList(signatures1));
+    HashSet<Signature> signatures2set = new HashSet<>(asList(signatures2));
     return signatures1set.equals(signatures2set) ? SIGNATURE_MATCH : SIGNATURE_NO_MATCH;
   }
 
@@ -212,177 +140,47 @@ public class ShadowPackageManager {
     return classString;
   }
 
-  static PathPermission[] createPathPermissions(List<PathPermissionData> pathPermissionDatas) {
-    PathPermission[] pathPermissions = new PathPermission[pathPermissionDatas.size()];
-    for (int i = 0; i < pathPermissions.length; i++) {
-      PathPermissionData data = pathPermissionDatas.get(i);
-
-      final String path;
-      final int type;
-      if (data.pathPrefix != null) {
-        path = data.pathPrefix;
-        type = PathPermission.PATTERN_PREFIX;
-      } else if (data.pathPattern != null) {
-        path = data.pathPattern;
-        type = PathPermission.PATTERN_SIMPLE_GLOB;
-      } else {
-        path = data.path;
-        type = PathPermission.PATTERN_LITERAL;
-      }
-
-      pathPermissions[i] = new PathPermission(path, type, data.readPermission, data.writePermission);
-    }
-
-    return pathPermissions;
+  static ResolveInfo getResolveInfo(Activity activity, IntentFilter intentFilter) {
+    ResolveInfo info = new ResolveInfo();
+    info.isDefault = intentFilter.hasCategory("Intent.CATEGORY_DEFAULT");
+    info.activityInfo = new ActivityInfo();
+    info.activityInfo.name = activity.info.name;
+    info.activityInfo.packageName = activity.info.packageName;
+    info.activityInfo.applicationInfo = activity.info.applicationInfo;
+    info.activityInfo.permission = activity.info.permission;
+    info.filter = new IntentFilter(intentFilter);
+    return info;
   }
 
-  static IntentFilter matchIntentFilter(Intent intent, List<IntentFilterData> intentFilters) {
-    for (IntentFilterData intentFilterData : intentFilters) {
-      List<String> actionList = intentFilterData.getActions();
-      List<String> categoryList = intentFilterData.getCategories();
-      IntentFilter intentFilter = new IntentFilter();
-
-      for (String action : actionList) {
-        intentFilter.addAction(action);
-      }
-
-      for (String category : categoryList) {
-        intentFilter.addCategory(category);
-      }
-
-      for (String scheme : intentFilterData.getSchemes()) {
-        intentFilter.addDataScheme(scheme);
-      }
-
-      for (String mimeType : intentFilterData.getMimeTypes()) {
-        try {
-          intentFilter.addDataType(mimeType);
-        } catch (IntentFilter.MalformedMimeTypeException ex) {
-          throw new RuntimeException(ex);
-        }
-      }
-
-      for (String path : intentFilterData.getPaths()) {
-        intentFilter.addDataPath(path, PatternMatcher.PATTERN_LITERAL);
-      }
-
-      for (String pathPattern : intentFilterData.getPathPatterns()) {
-        intentFilter.addDataPath(pathPattern, PatternMatcher.PATTERN_SIMPLE_GLOB);
-      }
-
-      for (String pathPrefix : intentFilterData.getPathPrefixes()) {
-        intentFilter.addDataPath(pathPrefix, PatternMatcher.PATTERN_PREFIX);
-      }
-
-      for (IntentFilterData.DataAuthority authority : intentFilterData.getAuthorities()) {
-        intentFilter.addDataAuthority(authority.getHost(), authority.getPort());
-      }
-
-      // match action
-      boolean matchActionResult = intentFilter.matchAction(intent.getAction());
-      // match category
-      String matchCategoriesResult = intentFilter.matchCategories(intent.getCategories());
-      // match data
-
-      int matchResult = intentFilter.matchData(intent.getType(),
-          (intent.getData() != null ? intent.getData().getScheme() : null),
-          intent.getData());
-      if (matchActionResult && (matchCategoriesResult == null) &&
-          (matchResult != IntentFilter.NO_MATCH_DATA && matchResult != IntentFilter.NO_MATCH_TYPE)){
-        return intentFilter;
-      }
-    }
-    return null;
-  }
-
-  static ResolveInfo getResolveInfo(ServiceData service, IntentFilter intentFilter,
-      String packageName) {
-    try {
-      ResolveInfo info = new ResolveInfo();
-      info.isDefault = intentFilter.hasCategory("Intent.CATEGORY_DEFAULT");
-      info.serviceInfo = new ServiceInfo();
-      info.serviceInfo.name = service.getClassName();
-      info.serviceInfo.packageName = packageName;
-      info.serviceInfo.applicationInfo = new ApplicationInfo();
-      info.filter = new IntentFilter();
-      Iterator<String> iterator = intentFilter.typesIterator();
-      if (iterator != null) {
-        while (iterator.hasNext()) {
-          info.filter.addDataType(iterator.next());
-        }
-      }
-      return info;
-    } catch (IntentFilter.MalformedMimeTypeException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private static int decodeProtectionLevel(String protectionLevel) {
-    if (protectionLevel == null) {
-      return PermissionInfo.PROTECTION_NORMAL;
-    }
-
-    switch (protectionLevel) {
-      case "normal":
-        return PermissionInfo.PROTECTION_NORMAL;
-      case "dangerous":
-        return PermissionInfo.PROTECTION_DANGEROUS;
-      case "signature":
-        return PermissionInfo.PROTECTION_SIGNATURE;
-      case "signatureOrSystem":
-        return PermissionInfo.PROTECTION_SIGNATURE_OR_SYSTEM;
-      default:
-        throw new IllegalArgumentException("unknown protection level " + protectionLevel);
-    }
-  }
-
-  static PermissionInfo createPermissionInfo(int flags,
-      PermissionItemData permissionItemData) throws NameNotFoundException {
-    PermissionInfo permissionInfo = new PermissionInfo();
-    String packageName = RuntimeEnvironment.getAppManifest().getPackageName();
-    permissionInfo.packageName = packageName;
-    permissionInfo.name = permissionItemData.getName();
-    permissionInfo.group = permissionItemData.getPermissionGroup();
-    permissionInfo.protectionLevel = decodeProtectionLevel(permissionItemData.getProtectionLevel());
-
-    String descriptionRef = permissionItemData.getDescription();
-    if (descriptionRef != null) {
-      ResName descResName = AttributeResource
-          .getResourceReference(descriptionRef, packageName, "string");
-      permissionInfo.descriptionRes = RuntimeEnvironment.getAppResourceTable().getResourceId(descResName);
-    }
-
-    String labelRefOrString = permissionItemData.getLabel();
-    if (labelRefOrString != null) {
-      if (AttributeResource.isResourceReference(labelRefOrString)) {
-        ResName labelResName = AttributeResource.getResourceReference(labelRefOrString, packageName, "string");
-        permissionInfo.labelRes = RuntimeEnvironment.getAppResourceTable().getResourceId(labelResName);
-      } else {
-        permissionInfo.nonLocalizedLabel = labelRefOrString;
-      }
-    }
-
-    if ((flags & GET_META_DATA) != 0) {
-      permissionInfo.metaData = metaDataToBundle(permissionItemData.getMetaData().getValueMap());
-    }
-    return permissionInfo;
-  }
-
-  private static int decodeFlags(Map<String, String> applicationAttributes) {
-    int applicationFlags = 0;
-    for (Pair<String, Integer> pair : APPLICATION_FLAGS) {
-      if ("true".equals(applicationAttributes.get(pair.first))) {
-        applicationFlags |= pair.second;
-      }
-    }
-    return applicationFlags;
+  static ResolveInfo getResolveInfo(Service service, IntentFilter intentFilter) {
+    ResolveInfo info = new ResolveInfo();
+    info.isDefault = intentFilter.hasCategory("Intent.CATEGORY_DEFAULT");
+    info.serviceInfo = new ServiceInfo();
+    info.serviceInfo.name = service.info.name;
+    info.serviceInfo.packageName = service.info.packageName;
+    info.serviceInfo.applicationInfo = service.info.applicationInfo;
+    info.serviceInfo.permission = service.info.permission;
+    info.filter = new IntentFilter(intentFilter);
+    return info;
   }
 
   private static void setUpPackageStorage(ApplicationInfo applicationInfo) {
     TempDirectory tempDirectory = RuntimeEnvironment.getTempDirectory();
-    applicationInfo.sourceDir = tempDirectory.createIfNotExists(applicationInfo.packageName + "-sourceDir").toAbsolutePath().toString();
+    if (applicationInfo.sourceDir == null) {
+      applicationInfo.sourceDir =
+          tempDirectory
+              .createIfNotExists(applicationInfo.packageName + "-sourceDir")
+              .toAbsolutePath()
+              .toString();
+    }
+    if (applicationInfo.dataDir == null) {
+      applicationInfo.dataDir =
+          tempDirectory
+              .createIfNotExists(applicationInfo.packageName + "-dataDir")
+              .toAbsolutePath()
+              .toString();
+    }
     applicationInfo.publicSourceDir = applicationInfo.sourceDir;
-    applicationInfo.dataDir = tempDirectory.createIfNotExists(applicationInfo.packageName + "-dataDir").toAbsolutePath().toString();
 
     if (RuntimeEnvironment.getApiLevel() >= N) {
       applicationInfo.credentialProtectedDataDir = tempDirectory.createIfNotExists("userDataDir").toAbsolutePath().toString();
@@ -628,7 +426,8 @@ public class ShadowPackageManager {
     return state != null ? state.flags : 0;
   }
 
-
+  /** @deprecated - use {@link #addPackage(PackageInfo)} instead */
+  @Deprecated
   public void addPackage(String packageName) {
     PackageInfo packageInfo = new PackageInfo();
     packageInfo.packageName = packageName;
@@ -660,114 +459,8 @@ public class ShadowPackageManager {
     extraPermissions.put(permissionInfo.name, permissionInfo);
   }
 
-  public void addManifest(AndroidManifest androidManifest) {
-    androidManifests.put(androidManifest.getPackageName(), androidManifest);
-
-    PackageInfo packageInfo = new PackageInfo();
-    packageInfo.packageName = androidManifest.getPackageName();
-    packageInfo.versionName = androidManifest.getVersionName();
-    packageInfo.versionCode = androidManifest.getVersionCode();
-
-    Map<String,ActivityData> activityDatas = androidManifest.getActivityDatas();
-
-    for (ActivityData data : activityDatas.values()) {
-      String name = data.getName();
-      String activityName = name.startsWith(".") ? androidManifest.getPackageName() + name : name;
-      Intent intent = new Intent(activityName);
-      List<ResolveInfo> infoList1 = resolveInfoForIntent.get(intent);
-      if (infoList1 == null) {
-        infoList1 = new ArrayList<>();
-        resolveInfoForIntent.put(intent, infoList1);
-      }
-      List<ResolveInfo> infoList = infoList1;
-      infoList.add(new ResolveInfo());
-    }
-
-    ContentProviderData[] cpdata = androidManifest.getContentProviders().toArray(new ContentProviderData[]{});
-    if (cpdata.length == 0) {
-      packageInfo.providers = null;
-    } else {
-      packageInfo.providers = new ProviderInfo[cpdata.length];
-      for (int i = 0; i < cpdata.length; i++) {
-        ProviderInfo info = new ProviderInfo();
-        info.authority = cpdata[i].getAuthorities(); // todo: support multiple authorities
-        info.name = cpdata[i].getClassName();
-        info.packageName = androidManifest.getPackageName();
-        info.metaData = metaDataToBundle(cpdata[i].getMetaData().getValueMap());
-        packageInfo.providers[i] = info;
-      }
-    }
-
-    // Populate information related to BroadcastReceivers. Broadcast receivers can be queried in two
-    // possible ways,
-    // 1. PackageManager#getPackageInfo(...),
-    // 2. PackageManager#queryBroadcastReceivers(...)
-    // The following piece of code will let you enable querying receivers through both the methods.
-    List<ActivityInfo> receiverActivityInfos = new ArrayList<>();
-    for (int i = 0; i < androidManifest.getBroadcastReceivers().size(); ++i) {
-      ActivityInfo activityInfo = new ActivityInfo();
-      activityInfo.name = androidManifest.getBroadcastReceivers().get(i).getClassName();
-      activityInfo.permission = androidManifest.getBroadcastReceivers().get(i).getPermission();
-      receiverActivityInfos.add(activityInfo);
-
-      ResolveInfo resolveInfo = new ResolveInfo();
-      resolveInfo.activityInfo = activityInfo;
-      IntentFilter filter = new IntentFilter();
-      for (String action : androidManifest.getBroadcastReceivers().get(i).getActions()) {
-        filter.addAction(action);
-      }
-      resolveInfo.filter = filter;
-
-      for (String action : androidManifest.getBroadcastReceivers().get(i).getActions()) {
-        Intent intent = new Intent(action);
-        intent.setPackage(androidManifest.getPackageName());
-        List<ResolveInfo> infoList1 = resolveInfoForIntent.get(intent);
-        if (infoList1 == null) {
-          infoList1 = new ArrayList<>();
-          resolveInfoForIntent.put(intent, infoList1);
-        }
-        List<ResolveInfo> infoList = infoList1;
-        infoList.add(resolveInfo);
-      }
-    }
-    packageInfo.receivers = receiverActivityInfos.toArray(new ActivityInfo[0]);
-
-    String[] usedPermissions = androidManifest.getUsedPermissions().toArray(new String[]{});
-    if (usedPermissions.length == 0) {
-      packageInfo.requestedPermissions = null;
-    } else {
-      packageInfo.requestedPermissions = usedPermissions;
-    }
-
-    ApplicationInfo applicationInfo = new ApplicationInfo();
-    applicationInfo.flags = decodeFlags(androidManifest.getApplicationAttributes());
-    applicationInfo.targetSdkVersion = androidManifest.getTargetSdkVersion();
-    applicationInfo.packageName = androidManifest.getPackageName();
-    applicationInfo.processName = androidManifest.getProcessName();
-    applicationInfo.name = androidManifest.getApplicationName();
-    applicationInfo.metaData = metaDataToBundle(androidManifest.getApplicationMetaData());
-    applicationInfo.uid = Process.myUid();
-    setUpPackageStorage(applicationInfo);
-
-    int labelRes = 0;
-    if (androidManifest.getLabelRef() != null) {
-      String fullyQualifiedName = ResName.qualifyResName(androidManifest.getLabelRef(), androidManifest
-          .getPackageName());
-      Integer id = fullyQualifiedName == null ? null : RuntimeEnvironment.getAppResourceTable().getResourceId(new ResName(fullyQualifiedName));
-      labelRes = id != null ? id : 0;
-    }
-
-    applicationInfo.labelRes = labelRes;
-    String labelRef = androidManifest.getLabelRef();
-    if (labelRef != null && !labelRef.startsWith("@")) {
-      applicationInfo.nonLocalizedLabel = labelRef;
-    }
-
-    packageInfo.applicationInfo = applicationInfo;
-    addPackage(packageInfo);
-  }
-
   public void removePackage(String packageName) {
+    packages.remove(packageName);
     packageInfos.remove(packageName);
   }
 
@@ -908,7 +601,7 @@ public class ShadowPackageManager {
   public void doPendingUninstallCallbacks() {
     boolean hasDeletePackagesPermission = false;
     String[] requestedPermissions =
-        packageInfos.get(RuntimeEnvironment.getAppManifest().getPackageName()).requestedPermissions;
+        packageInfos.get(RuntimeEnvironment.application.getPackageName()).requestedPermissions;
     if (requestedPermissions != null) {
       for (String permission : requestedPermissions) {
         if (Manifest.permission.DELETE_PACKAGES.equals(permission)) {
@@ -954,29 +647,81 @@ public class ShadowPackageManager {
     }
   }
 
-  protected static int getConfigChanges(ActivityData activityData) {
-    String s = activityData.getConfigChanges();
+  public void addPackage(Package appPackage) {
+    int flags =
+        GET_ACTIVITIES
+            | GET_RECEIVERS
+            | GET_SERVICES
+            | GET_PROVIDERS
+            | GET_INSTRUMENTATION
+            | GET_INTENT_FILTERS
+            | GET_SIGNATURES
+            | GET_RESOLVED_FILTER
+            | GET_META_DATA
+            | GET_GIDS
+            | MATCH_DISABLED_COMPONENTS
+            | GET_SHARED_LIBRARY_FILES
+            | GET_URI_PERMISSION_PATTERNS
+            | GET_PERMISSIONS
+            | MATCH_UNINSTALLED_PACKAGES
+            | GET_CONFIGURATIONS
+            | MATCH_DISABLED_UNTIL_USED_COMPONENTS
+            | MATCH_DIRECT_BOOT_UNAWARE
+            | MATCH_DIRECT_BOOT_AWARE;
 
-    int res = 0;
-
-    //quick sanity check.
-    if (s == null || "".equals(s)) {
-      return res;
+    packages.put(appPackage.packageName, appPackage);
+    PackageInfo packageInfo;
+    if (RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.M) {
+      packageInfo =
+          PackageParser.generatePackageInfo(
+              appPackage,
+              new int[] {0},
+              flags,
+              0,
+              0,
+              new HashSet<String>(),
+              new PackageUserState());
+    } else if (RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+      packageInfo =
+          ReflectionHelpers.callStaticMethod(
+              PackageParser.class,
+              "generatePackageInfo",
+              ReflectionHelpers.ClassParameter.from(Package.class, appPackage),
+              ReflectionHelpers.ClassParameter.from(int[].class, new int[] {0}),
+              ReflectionHelpers.ClassParameter.from(int.class, flags),
+              ReflectionHelpers.ClassParameter.from(long.class, 0L),
+              ReflectionHelpers.ClassParameter.from(long.class, 0L),
+              ReflectionHelpers.ClassParameter.from(ArraySet.class, new ArraySet<>()),
+              ReflectionHelpers.ClassParameter.from(
+                  PackageUserState.class, new PackageUserState()));
+    } else if (RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      packageInfo =
+          ReflectionHelpers.callStaticMethod(
+              PackageParser.class,
+              "generatePackageInfo",
+              ReflectionHelpers.ClassParameter.from(Package.class, appPackage),
+              ReflectionHelpers.ClassParameter.from(int[].class, new int[] {0}),
+              ReflectionHelpers.ClassParameter.from(int.class, flags),
+              ReflectionHelpers.ClassParameter.from(long.class, 0L),
+              ReflectionHelpers.ClassParameter.from(long.class, 0L),
+              ReflectionHelpers.ClassParameter.from(HashSet.class, new HashSet<>()),
+              ReflectionHelpers.ClassParameter.from(
+                  PackageUserState.class, new PackageUserState()));
+    } else {
+      packageInfo =
+          ReflectionHelpers.callStaticMethod(
+              PackageParser.class,
+              "generatePackageInfo",
+              ReflectionHelpers.ClassParameter.from(Package.class, appPackage),
+              ReflectionHelpers.ClassParameter.from(int[].class, new int[] {0}),
+              ReflectionHelpers.ClassParameter.from(int.class, flags),
+              ReflectionHelpers.ClassParameter.from(long.class, 0L),
+              ReflectionHelpers.ClassParameter.from(long.class, 0L),
+              ReflectionHelpers.ClassParameter.from(HashSet.class, new HashSet<>()));
     }
 
-    String[] pieces = s.split("\\|");
-
-    for(String s1 : pieces) {
-      s1 = s1.trim();
-
-      for (Pair<String, Integer> pair : CONFIG_OPTIONS) {
-        if (s1.equals(pair.first)) {
-          res |= pair.second;
-          break;
-        }
-      }
-    }
-    return res;
+    packageInfo.applicationInfo.uid = Process.myUid();
+    addPackage(packageInfo);
   }
 
   public static class IntentComparator implements Comparator<Intent> {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcelFileDescriptor.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcelFileDescriptor.java
@@ -1,5 +1,8 @@
 package org.robolectric.shadows;
 
+import static org.robolectric.shadow.api.Shadow.invokeConstructor;
+import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
+
 import android.os.ParcelFileDescriptor;
 import java.io.File;
 import java.io.FileDescriptor;
@@ -10,10 +13,22 @@ import java.lang.reflect.Constructor;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
 
 @Implements(ParcelFileDescriptor.class)
 public class ShadowParcelFileDescriptor {
   private RandomAccessFile file;
+
+  private @RealObject ParcelFileDescriptor realObject;
+
+  @Implementation
+  public void __constructor__(ParcelFileDescriptor wrapped) {
+    invokeConstructor(ParcelFileDescriptor.class, realObject,
+        from(ParcelFileDescriptor.class, wrapped));
+    if (wrapped != null) {
+      this.file = Shadows.shadowOf(wrapped).file;
+    }
+  }
 
   @Implementation
   public static ParcelFileDescriptor open(File file, int mode) throws FileNotFoundException {
@@ -44,6 +59,15 @@ public class ShadowParcelFileDescriptor {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Overrides framework to avoid call to FileDescriptor#getInt$ which does not exist on JVM.
+   * Returns a fixed int (0).
+   */
+  @Implementation
+  public int getFd() {
+    return 0;
   }
 
   @Implementation

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTypedArray.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTypedArray.java
@@ -1,14 +1,15 @@
 package org.robolectric.shadows;
 
 import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.shadow.api.Shadow.directlyOn;
 
+import android.annotation.StyleableRes;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.os.Build;
 import android.util.TypedValue;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import java.util.Map;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.HiddenApi;
@@ -48,6 +49,16 @@ public class ShadowTypedArray {
   @HiddenApi @Implementation
   public CharSequence loadStringValueAt(int index) {
     return stringData[index / ShadowAssetManager.STYLE_NUM_ENTRIES];
+  }
+
+  @Implementation
+  public String getNonResourceString(@StyleableRes int index) {
+    return directlyOn(realTypedArray, TypedArray.class).getString(index);
+  }
+
+  @Implementation
+  public String getNonConfigurationString(@StyleableRes int index, int allowedChangingConfigs) {
+    return directlyOn(realTypedArray, TypedArray.class).getString(index);
   }
 
   @Implementation


### PR DESCRIPTION
- Add support for using Android framework code to parse manifest if
use_framework_manifest_parser prop is true. This will become default
behavior in a future version of Robolectric.
- Remove direct references to robolectric.AndroidManifest class in
 Shadow*PackageManager, in favor of using framework PackageInfo and
 friend
  classes
  - Rework current manifest parsing (aka legacy manifest parsing) to
  populate PackageParser.Package and friends

PiperRevId: 177052824

### Overview

### Proposed Changes
