### PR TITLE
Support the ATSL InstrumentationRegistry API on Robolectric tests.

### DIFF
--- a/integration_tests/android_support_test/build.gradle
+++ b/integration_tests/android_support_test/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id "net.ltgt.errorprone" version "0.0.13"
+}
+
+apply plugin: RoboJavaModulePlugin
+
+dependencies {
+    compile project(":robolectric")
+    compile "junit:junit:4.12"
+    compileOnly AndroidSdk.MAX_SDK.coordinates
+
+    // Testing dependencies
+    testRuntime AndroidSdk.MAX_SDK.coordinates
+    testCompile("com.android.support.test:runner:1.0.2-alpha1")
+    testCompile "com.google.truth:truth:0.36"
+}

--- a/integration_tests/android_support_test/src/test/java/org/robolectric/integration_tests/atsl/InstrumentationRegistryTest.java
+++ b/integration_tests/android_support_test/src/test/java/org/robolectric/integration_tests/atsl/InstrumentationRegistryTest.java
@@ -1,0 +1,59 @@
+package org.robolectric.integration_tests.atsl;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.app.Instrumentation;
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** {@link InstrumentationRegistry} tests. */
+@RunWith(AndroidJUnit4.class)
+public class InstrumentationRegistryTest {
+
+  private static Instrumentation priorInstrumentation = null;
+  private static Context priorContext = null;
+
+  @Test
+  public void getArguments() {
+    assertThat(InstrumentationRegistry.getArguments()).isNotNull();
+  }
+
+  @Test
+  public void getInstrumentation() {
+    assertThat(InstrumentationRegistry.getInstrumentation()).isNotNull();
+  }
+
+  @Test
+  public void getTargetContext() {
+    assertThat(InstrumentationRegistry.getTargetContext()).isNotNull();
+    assertThat(InstrumentationRegistry.getTargetContext()).isEqualTo(InstrumentationRegistry.getContext());
+  }
+
+  @Test
+  public void uniqueInstancesPerTest() {
+    checkInstances();
+  }
+
+  @Test
+  public void uniqueInstancesPerTest2() {
+    checkInstances();
+  }
+
+  /**
+   * Verifies that each test gets a new Instrumentation and Context, by comparing against instances
+   * stored by prior test.
+   */
+  private void checkInstances() {
+    if (priorInstrumentation == null) {
+      priorInstrumentation = InstrumentationRegistry.getInstrumentation();
+      priorContext = InstrumentationRegistry.getTargetContext();
+    } else {
+      assertThat(priorInstrumentation).isNotEqualTo(InstrumentationRegistry.getInstrumentation());
+      assertThat(priorContext).isNotEqualTo(InstrumentationRegistry.getTargetContext());
+    }
+  }
+
+}

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     }
     compileOnly AndroidSdk.MAX_SDK.coordinates
     compileOnly "junit:junit:4.12"
+    compile("com.android.support.test:monitor:1.0.2-alpha1")
 
     // Testing dependencies
     testCompile "junit:junit:4.12"

--- a/robolectric/src/main/java/org/robolectric/android/fakes/RoboInstrumentation.java
+++ b/robolectric/src/main/java/org/robolectric/android/fakes/RoboInstrumentation.java
@@ -1,6 +1,30 @@
 package org.robolectric.android.fakes;
 
-import android.app.Instrumentation;
+import android.content.ComponentName;
+import android.content.Context;
+import android.support.test.runner.MonitoringInstrumentation;
+import org.robolectric.util.ReflectionHelpers;
 
-public class RoboInstrumentation extends Instrumentation {
+public class RoboInstrumentation extends MonitoringInstrumentation {
+
+  public void init(
+      Class<?> activityThreadClass,
+      Object activityThread,
+      Context context,
+      ComponentName component) {
+    // TODO: Consider calling through to package-private Instrumentation.init using
+    // reflection.
+    // init(ActivityThread thread, Context instrContext, Context appContext, ComponentName
+    // component,
+    //    IInstrumentationWatcher watcher, IUiAutomationConnection uiAutomationConnection
+    ReflectionHelpers.setField(this, "mThread", activityThread);
+    ReflectionHelpers.setField(this, "mInstrContext", context);
+    ReflectionHelpers.setField(this, "mAppContext", context);
+    ReflectionHelpers.setField(this, "mComponent", component);
+  }
+
+  @Override
+  protected void specifyDexMakerCacheProperty() {
+    // ignore, unnecessary for robolectric
+  }
 }

--- a/scripts/install-dependencies.rb
+++ b/scripts/install-dependencies.rb
@@ -144,7 +144,7 @@ MULTIDEX_VERSION = "1.0.1"
 ANDROID_SUPPORT_TEST_GROUP_ID = "com.android.support.test"
 RUNNER_ARTIFACT_ID = "runner"
 MONITOR_ARTIFACT_ID = "monitor"
-ANDROID_SUPPORT_TEST_VERSION = "1.0.2-alpha"
+ANDROID_SUPPORT_TEST_VERSION = "1.0.2-alpha1"
 
 # Play Services constants
 PLAY_SERVICES_GROUP_ID = "com.google.android.gms"

--- a/scripts/install-dependencies.rb
+++ b/scripts/install-dependencies.rb
@@ -105,11 +105,15 @@ def install_stubs(api)
   install("com.google.android", "android-stubs", "#{api}", path)
 end
 
-def install_from_gmaven(artifact_id)
-  return if already_have?(ANDROID_SUPPORT_GROUP_ID, artifact_id, SUPPORT_LIBRARY_VERSION, "jar")
+def install_supportlib_from_gmaven(artifact_id)
+  install_from_gmaven(ANDROID_SUPPORT_GROUP_ID, artifact_id, SUPPORT_LIBRARY_VERSION)
+end
 
-  get_dependency(ANDROID_SUPPORT_GROUP_ID, artifact_id, SUPPORT_LIBRARY_VERSION, "aar")
-  install_aar(MVN_LOCAL, ANDROID_SUPPORT_GROUP_ID, artifact_id, SUPPORT_LIBRARY_VERSION)
+def install_from_gmaven(group_id, artifact_id, version)
+  return if already_have?(group_id, artifact_id, version, "jar")
+
+  get_dependency(group_id, artifact_id, version, "aar")
+  install_aar(MVN_LOCAL, group_id, artifact_id, version)
 end
 
 # Local repository paths
@@ -135,6 +139,12 @@ INTERNAL_IMPL_ARTIFACT_ID = "internal_impl"
 SUPPORT_LIBRARY_VERSION = "26.0.1"
 MULTIDEX_TRAILING_VERSION = "1.0.0"
 MULTIDEX_VERSION = "1.0.1"
+
+# Android Support test versions
+ANDROID_SUPPORT_TEST_GROUP_ID = "com.android.support.test"
+RUNNER_ARTIFACT_ID = "runner"
+MONITOR_ARTIFACT_ID = "monitor"
+ANDROID_SUPPORT_TEST_VERSION = "1.0.2-alpha"
 
 # Play Services constants
 PLAY_SERVICES_GROUP_ID = "com.google.android.gms"
@@ -165,7 +175,7 @@ install_aar(ANDROID_REPO, ANDROID_SUPPORT_GROUP_ID, MULTIDEX_ARTIFACT_ID, MULTID
 
 # install_aar(ANDROID_REPO, ANDROID_SUPPORT_GROUP_ID, APPCOMPAT_V7_ARTIFACT_ID, SUPPORT_LIBRARY_TRAILING_VERSION)
 
-install_from_gmaven(APPCOMPAT_V7_ARTIFACT_ID)
+install_supportlib_from_gmaven(APPCOMPAT_V7_ARTIFACT_ID)
 
 install_aar(GOOGLE_REPO, PLAY_SERVICES_GROUP_ID, PLAY_SERVICES_LEGACY, PLAY_SERVICES_VERSION_6_5_87)
 
@@ -181,9 +191,12 @@ install_aar(GOOGLE_REPO, PLAY_SERVICES_GROUP_ID, PLAY_SERVICES_BASE, PLAY_SERVIC
   # install_jar(ANDROID_SUPPORT_GROUP_ID, INTERNAL_IMPL_ARTIFACT_ID, SUPPORT_LIBRARY_TRAILING_VERSION, "#{dir}/libs/#{INTERNAL_IMPL_ARTIFACT_ID}-#{SUPPORT_LIBRARY_TRAILING_VERSION}.jar")
 # end
 
-install_from_gmaven(SUPPORT_V4_ARTIFACT_ID)
-install_from_gmaven(SUPPORT_COMPAT_ARTIFACT_ID)
-install_from_gmaven(SUPPORT_CORE_UI_ARTIFACT_ID)
-install_from_gmaven(SUPPORT_CORE_UTILS_ARTIFACT_ID)
-install_from_gmaven(SUPPORT_FRAGMENT_ARTIFACT_ID)
-install_from_gmaven('support-media-compat')
+install_supportlib_from_gmaven(SUPPORT_V4_ARTIFACT_ID)
+install_supportlib_from_gmaven(SUPPORT_COMPAT_ARTIFACT_ID)
+install_supportlib_from_gmaven(SUPPORT_CORE_UI_ARTIFACT_ID)
+install_supportlib_from_gmaven(SUPPORT_CORE_UTILS_ARTIFACT_ID)
+install_supportlib_from_gmaven(SUPPORT_FRAGMENT_ARTIFACT_ID)
+install_supportlib_from_gmaven('support-media-compat')
+
+install_from_gmaven(ANDROID_SUPPORT_TEST_GROUP_ID, MONITOR_ARTIFACT_ID, ANDROID_SUPPORT_TEST_VERSION)
+install_from_gmaven(ANDROID_SUPPORT_TEST_GROUP_ID, RUNNER_ARTIFACT_ID, ANDROID_SUPPORT_TEST_VERSION)

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,3 +18,4 @@ include ":integration_tests:libphonenumber"
 include ":integration_tests:mockito"
 include ":integration_tests:mockito-experimental"
 include ":integration_tests:powermock"
+include ':integration_tests:android_support_test'


### PR DESCRIPTION
This is done by using and initializing ATSL's MonitoringInstrumentation.

PiperRevId: 177347075

### Overview

### Proposed Changes
