### PR TITLE
Avoid NPE in ShadowAccessibilityNodeInfo

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityNodeInfoTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityNodeInfoTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadow.api.Shadow;
 
 @RunWith(RobolectricTestRunner.class)
 public class ShadowAccessibilityNodeInfoTest {
@@ -153,6 +154,20 @@ public class ShadowAccessibilityNodeInfoTest {
     assertThat(shadow.getPerformedActions().size()).isEqualTo(2);
     assertThat(shadow.getPerformedActions().get(1))
         .isEqualTo(AccessibilityNodeInfo.ACTION_LONG_CLICK);
+  }
+
+  @Test
+  public void equalsTest_avoidsNullPointerDuringParentComparison() {
+    AccessibilityNodeInfo grandparentInfo = AccessibilityNodeInfo.obtain();
+    AccessibilityNodeInfo childInfo = AccessibilityNodeInfo.obtain();
+    AccessibilityNodeInfo parentInfo = AccessibilityNodeInfo.obtain();
+    ((ShadowAccessibilityNodeInfo) Shadow.extract(grandparentInfo)).addChild(parentInfo);
+    ((ShadowAccessibilityNodeInfo) Shadow.extract(parentInfo)).addChild(childInfo);
+
+    assertThat(parentInfo.equals(childInfo)).isFalse();
+    assertThat(childInfo.equals(parentInfo)).isFalse();
+    assertThat(grandparentInfo.equals(parentInfo)).isFalse();
+    assertThat(parentInfo.equals(grandparentInfo)).isFalse();
   }
 
   @After

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java
@@ -972,7 +972,8 @@ public class ShadowAccessibilityNodeInfo {
       if (parent == null) {
         areEqual &= (otherShadow.parent == null);
       } else if (!shadowOf(parent).visitedWhenCheckingChildren){
-        areEqual &= (shadowOf(parent).equals(shadowOf(otherShadow.parent)));
+        areEqual &=
+            ((otherShadow.parent != null) && shadowOf(parent).equals(shadowOf(otherShadow.parent)));
       }
 
       while (!visitedNodes.isEmpty()) {


### PR DESCRIPTION
The logic that compares parent nodes within ShadowAccessibilityNodeInfo
became prone to a NullPointerException, which could cause an attempt to
extract a shadow from a null reference under certain conditions.
