### PR TITLE
@Deprecate queryIntentImplicitly.

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
@@ -799,10 +799,20 @@ public class ShadowPackageManager {
     return 0;
   }
 
+  /**
+   * @deprecated - this will be the default behaviour in Robolectric 3.7 and bring behaviour into line with that of
+   * other Android components (note this method only affects Activities)
+   */
+  @Deprecated
   public boolean isQueryIntentImplicitly() {
     return queryIntentImplicitly;
   }
 
+  /**
+   * @deprecated - this will be the default behaviour in Robolectric 3.7 and bring behaviour into line with that of
+   * other Android components (note this method only affects Activities)
+   */
+  @Deprecated
   public void setQueryIntentImplicitly(boolean queryIntentImplicitly) {
     this.queryIntentImplicitly = queryIntentImplicitly;
   }


### PR DESCRIPTION
This switched Robolectric to check for Activities in the Manifest, was
false by default. Switching it to true by default will be the behaviour going forwards from Robolectric 3.7. matching the same logic as for other Android components like Services etc.

