### PR TITLE
Fix ShadowAccountManager's implementation of AccountManagerFuture such

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
@@ -530,6 +530,7 @@ public class ShadowAccountManagerTest {
     } catch(AuthenticatorException e) {
       // Expected
     }
+    assertThat(future.isDone()).isTrue();
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
@@ -581,7 +581,7 @@ public class ShadowAccountManager {
 
     @Override
     public boolean isDone() {
-      return result != null;
+      return result != null || exception != null || isCancelled();
     }
 
     @Override


### PR DESCRIPTION
that the failure case still causes isDone() to return true.

See
https://developer.android.com/reference/android/accounts/AccountManagerFuture.html#isDone()

