### PR TITLE
Load SharedPreferences from disk synchronously.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSharedPreferencesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSharedPreferencesTest.java
@@ -16,9 +16,8 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
+import org.robolectric.RuntimeEnvironment;
 
 @RunWith(RobolectricTestRunner.class)
 public class ShadowSharedPreferencesTest {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSharedPreferencesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSharedPreferencesTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -17,6 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 public class ShadowSharedPreferencesTest {
@@ -196,5 +198,16 @@ public class ShadowSharedPreferencesTest {
     anotherSharedPreferences.edit().putString(testKey, "bar").commit();
 
     assertThat(transcript).containsExactly(testKey+ " called");
+  }
+
+  @Test
+  public void defaultSharedPreferences() throws Exception {
+    SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+    sharedPreferences.edit().putString("foo", "bar").commit();
+
+    SharedPreferences anotherSharedPreferences = PreferenceManager
+        .getDefaultSharedPreferences(context);
+    String restored = anotherSharedPreferences.getString("foo", null);
+    assertThat(restored).isEqualTo("bar");
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSharedPreferencesImpl.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSharedPreferencesImpl.java
@@ -1,0 +1,33 @@
+package org.robolectric.shadows;
+
+import static org.robolectric.shadow.api.Shadow.directlyOn;
+
+import android.os.Build;
+import android.os.Build.VERSION_CODES;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+
+@Implements(className = "android.app.SharedPreferencesImpl",
+    isInAndroidSdk = false)
+public class ShadowSharedPreferencesImpl {
+  @RealObject private Object realSharedPreferencesImpl;
+
+
+  /**
+   * Override to load from disk synchronously, to prevent cross-test collisions where one test has
+   * finished but thread to load from disk is still active.
+   */
+  @Implementation
+  public void startLoadFromDisk() {
+    if (RuntimeEnvironment.getApiLevel() >= VERSION_CODES.N) {
+      directlyOn(realSharedPreferencesImpl, "android.app.SharedPreferencesImpl", "loadFromDisk");
+    } else {
+      synchronized (realSharedPreferencesImpl) {
+        directlyOn(realSharedPreferencesImpl, "android.app.SharedPreferencesImpl",
+            "loadFromDiskLocked");
+      }
+    }
+  }
+}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSharedPreferencesImpl.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSharedPreferencesImpl.java
@@ -8,6 +8,7 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
+import org.robolectric.util.ReflectionHelpers;
 
 @Implements(className = "android.app.SharedPreferencesImpl",
     isInAndroidSdk = false)
@@ -22,6 +23,9 @@ public class ShadowSharedPreferencesImpl {
   @Implementation
   public void startLoadFromDisk() {
     if (RuntimeEnvironment.getApiLevel() >= VERSION_CODES.N) {
+      synchronized(realSharedPreferencesImpl) {
+        ReflectionHelpers.setField(realSharedPreferencesImpl, "mLoaded", false);
+      }
       directlyOn(realSharedPreferencesImpl, "android.app.SharedPreferencesImpl", "loadFromDisk");
     } else {
       synchronized (realSharedPreferencesImpl) {


### PR DESCRIPTION
The Android framework will fork a thread to read SharedPreferences from
disk on construction.

There is a potential race condition, where this thread might still be
active when test finishes, causing collisions betweem tests.

