### PR TITLE
KeyguardManager's isKeyguardSecure() is API 16

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowKeyguardManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowKeyguardManagerTest.java
@@ -9,8 +9,8 @@ import android.app.KeyguardManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
@@ -52,7 +52,6 @@ public class ShadowKeyguardManagerTest {
   }
 
   @Test
-  @Config(minSdk = M)
   public void isKeyguardSecure() {
     assertThat(manager.isKeyguardSecure()).isFalse();
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowKeyguardManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowKeyguardManager.java
@@ -71,18 +71,18 @@ public class ShadowKeyguardManager {
   private boolean isKeyguardSecure;
 
   /**
-   * For tests on Android >=M, returns the value set by {@link #setIsKeyguardSecure(boolean)}, or
-   * `false` by default.
+   * For tests, returns the value set by {@link #setIsKeyguardSecure(boolean)}, or `false` by
+   * default.
    *
    * @see #setIsKeyguardSecure(boolean)
    */
-  @Implementation(minSdk = M)
+  @Implementation
   public boolean isKeyguardSecure() {
     return isKeyguardSecure;
   }
 
   /**
-   * For tests on Android >=M, sets the value to be returned by {@link #isKeyguardSecure()}.
+   * Sets the value to be returned by {@link #isKeyguardSecure()}.
    *
    * @see #isKeyguardSecure()
    */


### PR DESCRIPTION
isKeyguardSecure introduced in api 16 (Jellybean), not 23 (M), see:

https://developer.android.com/reference/android/app/KeyguardManager.html#isKeyguardSecure()

PiperRevId: 178187890

### Overview

### Proposed Changes
