### PR TITLE
Fix asset path searches to include all transitively reachable asset paths

### DIFF
--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -5,10 +5,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.xml.parsers.DocumentBuilder;
@@ -590,6 +592,26 @@ public class AndroidManifest {
   public List<AndroidManifest> getLibraryManifests() {
     assert(libraryManifests != null);
     return Collections.unmodifiableList(libraryManifests);
+  }
+
+  /**
+   * Returns all transitively reachable manifests, including this one, in order and without
+   * duplicates.
+   */
+  public List<AndroidManifest> getAllManifests() {
+    Set<AndroidManifest> seenManifests = new HashSet<>();
+    List<AndroidManifest> uniqueManifests = new ArrayList<>();
+    addTransitiveManifests(seenManifests, uniqueManifests);
+    return uniqueManifests;
+  }
+
+  private void addTransitiveManifests(Set<AndroidManifest> unique, List<AndroidManifest> list) {
+    if (unique.add(this)) {
+      list.add(this);
+      for (AndroidManifest androidManifest : getLibraryManifests()) {
+        androidManifest.addTransitiveManifests(unique, list);
+      }
+    }
   }
 
   public FsFile getResDirectory() {

--- a/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
+++ b/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.Rule;
@@ -494,9 +495,8 @@ public class AndroidManifestTest {
   @Test
   public void getTransitiveManifests() throws Exception {
     AndroidManifest lib1 = new AndroidManifest(resourceFile("lib1/AndroidManifest.xml"), null, null);
-    List<AndroidManifest> libraryManifests = java.util.Arrays.asList(lib1);
     AndroidManifest lib2 = new AndroidManifest(resourceFile("lib2/AndroidManifest.xml"), null, null,
-        libraryManifests, null);
+        Collections.singletonList(lib1), null);
     AndroidManifest app = new AndroidManifest(
         resourceFile("TestAndroidManifestWithReceivers.xml"), null, null,
         Arrays.asList(lib1, lib2), null);

--- a/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
+++ b/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.junit.Rule;
@@ -488,6 +489,18 @@ public class AndroidManifestTest {
     BroadcastReceiverData receiverData = config.getBroadcastReceiver("com.foo.Receiver");
     assertThat(receiverData).isNotNull();
     assertThat(receiverData.isExported()).isTrue();
+  }
+
+  @Test
+  public void getTransitiveManifests() throws Exception {
+    AndroidManifest lib1 = new AndroidManifest(resourceFile("lib1/AndroidManifest.xml"), null, null);
+    List<AndroidManifest> libraryManifests = java.util.Arrays.asList(lib1);
+    AndroidManifest lib2 = new AndroidManifest(resourceFile("lib2/AndroidManifest.xml"), null, null,
+        libraryManifests, null);
+    AndroidManifest app = new AndroidManifest(
+        resourceFile("TestAndroidManifestWithReceivers.xml"), null, null,
+        Arrays.asList(lib1, lib2), null);
+    assertThat(app.getAllManifests()).containsExactly(app, lib1, lib2);
   }
 
   /////////////////////////////

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
@@ -64,7 +64,13 @@ public class ShadowAssetManagerTest {
   public void assetsPathListing() throws IOException {
     assertThat(assetManager.list(""))
         .containsExactlyInAnyOrder(
-            "assetsHome.txt", "docs", "myFont.ttf", "libFont.ttf", "file-in-lib2.txt");
+            "assetsHome.txt",   // test/resources/assets
+            "docs",             // test/resources/assets
+            "myFont.ttf",       // test/resources/assets
+            "libFont.ttf",      // test/resources/lib1/assets
+            "file-in-lib2.txt", // test/resources/lib2/assets
+            "file-in-lib2.txt"  // test/resources/lib1/../lib2/assets (yes, weird)
+            );
 
     assertThat(assetManager.list("docs"))
         .contains("extra");

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -978,7 +978,6 @@ public final class ShadowAssetManager {
 
   private List<FsFile> getAllAssetsDirectories() {
     List<FsFile> assetsDirs = new ArrayList<>();
-    assetsDirs.add(getAssetsDirectory());
     assetsDirs.addAll(getLibraryAssetsDirectories());
     return assetsDirs;
   }
@@ -989,7 +988,8 @@ public final class ShadowAssetManager {
 
   private List<FsFile> getLibraryAssetsDirectories() {
     List<FsFile> libraryAssetsDirectory = new ArrayList<>();
-    for (AndroidManifest manifest : ShadowApplication.getInstance().getAppManifest().getLibraryManifests()) {
+    AndroidManifest appManifest = ShadowApplication.getInstance().getAppManifest();
+    for (AndroidManifest manifest : appManifest.getAllManifests()) {
       if (manifest.getAssetsDirectory() != null) {
         libraryAssetsDirectory.add(manifest.getAssetsDirectory());
       }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -62,7 +62,7 @@ import org.robolectric.util.Logger;
 import org.robolectric.util.ReflectionHelpers;
 
 @Implements(AssetManager.class)
-public final class ShadowAssetManager {
+public class ShadowAssetManager {
 
   public static final int STYLE_NUM_ENTRIES = 6;
   public static final int STYLE_TYPE = 0;
@@ -976,13 +976,13 @@ public final class ShadowAssetManager {
     return themeStyleSet.getAttrValue(attrName);
   }
 
-  private List<FsFile> getAllAssetsDirectories() {
+  protected List<FsFile> getAllAssetsDirectories() {
     List<FsFile> assetsDirs = new ArrayList<>();
     assetsDirs.addAll(getLibraryAssetsDirectories());
     return assetsDirs;
   }
 
-  private FsFile getAssetsDirectory() {
+  protected FsFile getAssetsDirectory() {
     return ShadowApplication.getInstance().getAppManifest().getAssetsDirectory();
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTypeface.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTypeface.java
@@ -60,11 +60,9 @@ public class ShadowTypeface {
   public static Typeface createFromAsset(AssetManager mgr, String path) {
     AndroidManifest appManifest = Shadows.shadowOf(RuntimeEnvironment.application).getAppManifest();
     ArrayList<String> paths = new ArrayList<>();
-    paths.add(getAssetsPath(appManifest, path));
 
-    List<AndroidManifest> libraryManifests = appManifest.getLibraryManifests();
-    for (AndroidManifest libraryManifest : libraryManifests) {
-      paths.add(getAssetsPath(libraryManifest, path));
+    for (AndroidManifest depManifest : appManifest.getAllManifests()) {
+      paths.add(getAssetsPath(depManifest, path));
     }
 
     for (String assetPath : paths) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTypeface.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTypeface.java
@@ -9,7 +9,6 @@ import android.graphics.Typeface;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;


### PR DESCRIPTION
Previously, deps of deps wouldn't be searched.