### PR TITLE
Xml resource string escaping

### DIFF
--- a/robolectric/src/test/java/org/robolectric/res/builder/XmlResourceParserImplTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/builder/XmlResourceParserImplTest.java
@@ -382,6 +382,30 @@ public class XmlResourceParserImplTest {
   }
 
   @Test
+  public void testGetAttributeEscapedValue() throws Exception {
+    forgeAndOpenDocument("<foo bar=\"\\'\"/>");
+    assertThat(parser.getAttributeValue(0)).isEqualTo("\'");
+  }
+
+  @Test
+  public void testGetAttributeEntityValue() throws Exception {
+    forgeAndOpenDocument("<foo bar=\"\\u201e&#34;\"/>");
+    assertThat(parser.getAttributeValue(0)).isEqualTo("„\"");
+  }
+
+  @Test
+  public void testGetNodeTextEscapedValue() throws Exception {
+    forgeAndOpenDocument("<foo>\'</foo>");
+    assertThat(parser.getText()).isEqualTo("\'");
+  }
+
+  @Test
+  public void testGetNodeTextEntityValue() throws Exception {
+    forgeAndOpenDocument("<foo>\\u201e&#34;</foo>");
+    assertThat(parser.getText()).isEqualTo("„\"");
+  }
+
+  @Test
   public void testGetAttributeType() {
     // Hardcoded to always return CDATA
     assertThat(parser.getAttributeType(attributeIndexOutOfIndex())).isEqualTo("CDATA");

--- a/shadows/framework/src/main/java/org/robolectric/android/XmlResourceParserImpl.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/XmlResourceParserImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.robolectric.res.AttributeResource;
 import org.robolectric.res.ResName;
 import org.robolectric.res.ResourceTable;
+import org.robolectric.res.StringResources;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -167,7 +168,7 @@ public class XmlResourceParserImpl implements XmlResourceParser {
     if (currentNode == null) {
       return "";
     }
-    return currentNode.getTextContent();
+    return StringResources.processStringResources(currentNode.getTextContent());
   }
 
   @Override
@@ -326,7 +327,7 @@ public class XmlResourceParserImpl implements XmlResourceParser {
     } else if (AttributeResource.isStyleReference(value)) {
       return "?" + ResName.qualifyResourceName(value.substring(1), packageName, "attr");
     } else {
-      return value;
+      return StringResources.processStringResources(value);
     }
   }
 


### PR DESCRIPTION
### Overview
According to https://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling (and real devices), when ready values from XML resource, the HTML entities and escape characters are honored. This is not the case with Robolectric.

### Proposed Changes
Calling `StringResources.processStringResources` at the right places.
I believe that once Robolectric switches to the Android's native resource parsing (and AAPT), this issue will go away, but even then, the unit-tests are super important.