### PR TITLE
Add support to method getFromLocation on ShadowGeocoder

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowGeocoderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowGeocoderTest.java
@@ -1,11 +1,18 @@
 package org.robolectric.shadows;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.Shadows.shadowOf;
 
+import android.location.Address;
 import android.location.Geocoder;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 
 /** Unit test for {@link ShadowGeocoder}. */
 @RunWith(RobolectricTestRunner.class)
@@ -21,6 +28,30 @@ public class ShadowGeocoderTest {
     ShadowGeocoder.setIsPresent(false);
 
     assertThat(Geocoder.isPresent()).isFalse();
+  }
+
+  @Test
+  public void getFromLocationReturnsAnEmptyArrayByDefault() throws IOException {
+    Geocoder geocoder = new Geocoder(RuntimeEnvironment.application.getApplicationContext());
+    assertThat(geocoder.getFromLocation(90.0,90.0,1)).hasSize(0);
+  }
+
+  @Test
+  public void getFromLocationReturnsTheOverwrittenListLimitingByMaxResults() throws IOException {
+    Geocoder geocoder = new Geocoder(RuntimeEnvironment.application.getApplicationContext());
+    ShadowGeocoder shadowGeocoder = shadowOf(geocoder);
+
+    List<Address> list = Arrays.asList(new Address(Locale.getDefault()), new Address(Locale.CANADA));
+    shadowGeocoder.setFromLocation(list);
+
+    List<Address> result = geocoder.getFromLocation(90.0, 90.0, 1);
+    assertThat(result).hasSize(1);
+
+    result = geocoder.getFromLocation(90.0, 90.0, 2);
+    assertThat(result).hasSize(2);
+
+    result = geocoder.getFromLocation(90.0, 90.0, 3);
+    assertThat(result).hasSize(2);
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGeocoder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGeocoder.java
@@ -1,6 +1,10 @@
 package org.robolectric.shadows;
 
+import android.location.Address;
 import android.location.Geocoder;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
@@ -9,6 +13,7 @@ import org.robolectric.annotation.Resetter;
 @Implements(Geocoder.class)
 public final class ShadowGeocoder {
   private static boolean isPresent = true;
+  private List<Address> fromLocation = new ArrayList<>();
 
   /** Returns true by default, or the last value set by {@link #setIsPresent(boolean)}. */
   @Implementation
@@ -16,10 +21,25 @@ public final class ShadowGeocoder {
     return isPresent;
   }
 
+  /**
+   * Returns an empty list by default, or the last value set by {@link #setFromLocation(List)}
+   * @param latitude it's ignored by this implementation
+   * @param longitude it's ignored by this implementation
+   * @param maxResults max number of addresses to return
+   * @throws IOException - never thrown, only keeping the same signature
+   */
+  @Implementation
+  public List<Address> getFromLocation(double latitude, double longitude, int maxResults) throws IOException {
+      return fromLocation.subList(0, Math.min(maxResults, fromLocation.size()));
+  }
+
   /** Statically sets the value to be returned by {@link #isPresent()}. */
   public static void setIsPresent(boolean value) {
     isPresent = value;
   }
+
+  /** Sets the value to be returned by {@link #getFromLocation(double, double, int)} */
+  public void setFromLocation(List<Address> list) { fromLocation = list; }
 
   @Resetter
   public static void reset() {


### PR DESCRIPTION
### Overview
Related to #3677

### Proposed Changes
Add support to method `getFromLocation` on `ShadowGeocoder` as it's relying on an external service and it's resulting in a `NullPointerException` when trying to test using this method.

The the list of addresses can be defined using the static method `ShadowGeocoder.setFromLocation`