### PR TITLE
Handle parsing float attribute values with no leading numbers.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ResourceHelperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ResourceHelperTest.java
@@ -1,0 +1,29 @@
+package org.robolectric.shadows;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+import android.util.TypedValue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/**
+ * Unit tests for {@link ResourceHelper}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ResourceHelperTest {
+
+  @Test
+  @Config(sdk = Config.NEWEST_SDK)
+  public void parseFloatAttribute() {
+    TypedValue out = new TypedValue();
+    ResourceHelper.parseFloatAttribute(null, "0.16", out, false);
+    assertThat(out.getFloat()).isEqualTo(0.16f);
+
+    out = new TypedValue();
+    ResourceHelper.parseFloatAttribute(null, ".16", out, false);
+    assertThat(out.getFloat()).isEqualTo(0.16f);
+  }
+}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper.java
@@ -27,7 +27,7 @@ import org.robolectric.res.ResName;
  */
 public final class ResourceHelper {
 
-  private final static Pattern sFloatPattern = Pattern.compile("(-?[0-9]+(?:\\.[0-9]+)?)(.*)");
+  private final static Pattern sFloatPattern = Pattern.compile("(-?[0-9]*(?:\\.[0-9]+)?)(.*)");
   private final static float[] sFloatOut = new float[1];
 
   private final static TypedValue mValue = new TypedValue();


### PR DESCRIPTION
eg ".12"

PiperRevId: 182833658

### Overview

### Proposed Changes
