### PR TITLE
Refactor @Implementation method resolution

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/Implements.java
+++ b/annotations/src/main/java/org/robolectric/annotation/Implements.java
@@ -47,10 +47,17 @@ public @interface Implements {
   boolean callThroughByDefault() default true;
 
   /**
-   * If true, Robolectric will invoke @Implementation methods from superclasses.
+   * If true, Robolectric will invoke `@Implementation` methods from superclasses regardless of
+   * what class the superclass `@Implement`s.
+   *
+   * This is inadvisable because Robolectric might pick an @Implementation method that's intended
+   * to implement a different class (e.g. an overridden method with the same signature from a
+   * superclass) than the one requested.
    *
    * @return True to invoke superclass methods.
+   * @deprecated Declare methods directly in your shadow class rather than relying on inheritance.
    */
+  @Deprecated
   boolean inheritImplementationMethods() default false;
 
   /**

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowInfo.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowInfo.java
@@ -7,6 +7,10 @@ public class ShadowInfo {
   public final String shadowedClassName;
   public final String shadowClassName;
   public final boolean callThroughByDefault;
+  /**
+   * @deprecated
+   */
+  @Deprecated
   public final boolean inheritImplementationMethods;
   public final boolean looseSignatures;
   private final int minSdk;
@@ -35,6 +39,10 @@ public class ShadowInfo {
 
   public boolean supportsSdk(int sdkInt) {
     return minSdk <= sdkInt && (maxSdk == -1 || maxSdk >= sdkInt);
+  }
+
+  public boolean isShadowOf(Class<?> clazz) {
+    return shadowedClassName.equals(clazz.getName());
   }
 
   @Override

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowMap.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowMap.java
@@ -73,9 +73,17 @@ public class ShadowMap {
   }
 
   public static ShadowInfo obtainShadowInfo(Class<?> clazz) {
+    return obtainShadowInfo(clazz, false);
+  }
+
+  static ShadowInfo obtainShadowInfo(Class<?> clazz, boolean mayBeNonShadow) {
     Implements annotation = clazz.getAnnotation(Implements.class);
     if (annotation == null) {
-      throw new IllegalArgumentException(clazz + " is not annotated with @Implements");
+      if (mayBeNonShadow) {
+        return null;
+      } else {
+        throw new IllegalArgumentException(clazz + " is not annotated with @Implements");
+      }
     }
 
     String className = annotation.className();

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
@@ -133,6 +133,13 @@ public class ShadowWrangler implements ClassHandler {
     try {
       Method method = pickShadowMethod(clazz,
           ShadowConstants.STATIC_INITIALIZER_METHOD_NAME, NO_ARGS);
+
+      // if we got back DO_NOTHING_METHOD that means the shadow is `callThroughByDefault = false`;
+      // for backwards compatibility we'll still perform static initialization though for now.
+      if (method == DO_NOTHING_METHOD) {
+        method = null;
+      }
+
       if (method != null) {
         if (!Modifier.isStatic(method.getModifiers())) {
           throw new RuntimeException(

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
@@ -23,9 +23,9 @@ import java.util.Map;
 import java.util.WeakHashMap;
 import javax.annotation.Nonnull;
 import org.robolectric.annotation.Implementation;
-import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.Function;
+import org.robolectric.util.Logger;
 import org.robolectric.util.PerfStatsCollector;
 import org.robolectric.util.ReflectionHelpers;
 
@@ -60,6 +60,9 @@ public class ShadowWrangler implements ClassHandler {
       throw new RuntimeException(e);
     }
   }
+
+  public static final Implementation IMPLEMENTATION_DEFAULTS =
+      ReflectionHelpers.defaultsFor(Implementation.class);
 
   private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
   private static final boolean STRIP_SHADOW_STACK_TRACES = true;
@@ -129,14 +132,17 @@ public class ShadowWrangler implements ClassHandler {
     Class<?> shadowClass = findDirectShadowClass(clazz);
     if (shadowClass != null) {
       try {
-        Method method = shadowClass.getDeclaredMethod(ShadowConstants.STATIC_INITIALIZER_METHOD_NAME);
-        if (!Modifier.isStatic(method.getModifiers())) {
-          throw new RuntimeException(shadowClass.getName() + "." + method.getName() + " is not static");
+        Method method = findShadowMethodDeclaredOnClass(shadowClass,
+            ShadowConstants.STATIC_INITIALIZER_METHOD_NAME, new Class[0]);
+        if (method != null) {
+          if (!Modifier.isStatic(method.getModifiers())) {
+            throw new RuntimeException(shadowClass.getName() + "." + method.getName() + " is not static");
+          }
+
+          method.invoke(null);
+        } else {
+          RobolectricInternals.performStaticInitialization(clazz);
         }
-        method.setAccessible(true);
-        method.invoke(null);
-      } catch (NoSuchMethodException e) {
-        RobolectricInternals.performStaticInitialization(clazz);
       } catch (InvocationTargetException | IllegalAccessException e) {
         throw new RuntimeException(e);
       }
@@ -152,11 +158,13 @@ public class ShadowWrangler implements ClassHandler {
 
   @Override
   public Plan methodInvoked(String signature, boolean isStatic, Class<?> theClass) {
+    Plan plan;
     if (planCache.containsKey(signature)) {
-      return planCache.get(signature);
+      plan = planCache.get(signature);
+    } else {
+      plan = calculatePlan(signature, isStatic, theClass);
+      planCache.put(signature, plan);
     }
-    Plan plan = calculatePlan(signature, isStatic, theClass);
-    planCache.put(signature, plan);
     return plan;
   }
 
@@ -220,88 +228,101 @@ public class ShadowWrangler implements ClassHandler {
         throw new IllegalStateException(e);
       }
 
-      Method method = findShadowMethod(shadowInfo, shadowClass, name, paramTypes);
+      Method method = findShadowMethod(definingClass, name, paramTypes, shadowInfo, shadowClass,
+          shadowInfo.inheritImplementationMethods);
       if (method == null) {
         return shadowInfo.callThroughByDefault ? CALL_REAL_CODE : DO_NOTHING_METHOD;
-      }
-
-      Class<?> declaredShadowedClass = getShadowedClass(method);
-      if (declaredShadowedClass.equals(Object.class)) {
-        // e.g. for equals(), hashCode(), toString()
-        return CALL_REAL_CODE;
-      }
-
-      boolean shadowClassMismatch = !declaredShadowedClass.equals(definingClass);
-      if (shadowClassMismatch && !shadowInfo.inheritImplementationMethods) {
-        return CALL_REAL_CODE;
       } else {
         return method;
       }
     }
   }
 
-  private Method findShadowMethod(ShadowInfo config, Class<?> shadowClass, String name, Class<?>[] types) {
-    Method method = findShadowMethodInternal(shadowClass, name, types);
+  /**
+   * Searches for an `@Implementation` method on a given shadow class.
+   *
+   * If the shadow class allows loose signatures, search for them.
+   *
+   * If the shadow class doesn't have such a method, but does hav a superclass which implements
+   * the same class as it, recursively call {@link #findShadowMethod(Class, String, Class[],
+   * ShadowInfo, Class, boolean)} with the shadow superclass.
+   *
+   * `inheritImplementationMethods` is deprecated but supported for now.
+   */
+  private Method findShadowMethod(Class<?> definingClass, String name, Class<?>[] types,
+      ShadowInfo shadowInfo, Class<?> shadowClass, boolean inheritImplementationMethods) {
+    Method method = findShadowMethodDeclaredOnClass(shadowClass, name, types);
 
-    if (method == null && config.looseSignatures) {
+    if (method == null && shadowInfo.looseSignatures) {
       Class<?>[] genericTypes = MethodType.genericMethodType(types.length).parameterArray();
-      method = findShadowMethodInternal(shadowClass, name, genericTypes);
+      method = findShadowMethodDeclaredOnClass(shadowClass, name, genericTypes);
     }
 
-    Class<?> superclass;
-    if (method == null && config.inheritImplementationMethods && (superclass = shadowClass.getSuperclass()) != null) {
-      return findShadowMethod(config, superclass, name, types);
+    if (method != null) {
+      return method;
+    } else {
+      // if the shadow's superclass shadows the same class as this shadow, then recurse.
+      // Buffalo buffalo buffalo buffalo buffalo buffalo buffalo.
+      Class<?> shadowSuperclass = shadowClass.getSuperclass();
+      if (shadowSuperclass != null && !shadowSuperclass.equals(Object.class)) {
+        ShadowInfo shadowSuperclassInfo = ShadowMap.obtainShadowInfo(shadowSuperclass, true);
+        if (inheritImplementationMethods || (
+            shadowSuperclassInfo != null
+                && shadowSuperclassInfo.isShadowOf(definingClass)
+                && shadowSuperclassInfo.supportsSdk(apiLevel))) {
+          if (inheritImplementationMethods && shadowSuperclassInfo == null) {
+            // we might inherit methods from a class with no @Implements annotation, that's okay
+            shadowSuperclassInfo = shadowInfo;
+          }
+
+          method = findShadowMethod(definingClass, name, types, shadowSuperclassInfo,
+              shadowSuperclass, inheritImplementationMethods);
+        }
+      }
     }
 
     return method;
   }
 
-  private Method findShadowMethodInternal(Class<?> shadowClass, String methodName, Class<?>[] paramClasses) {
+  private Method findShadowMethodDeclaredOnClass(
+      Class<?> shadowClass, String methodName, Class<?>[] paramClasses) {
     try {
       Method method = shadowClass.getDeclaredMethod(methodName, paramClasses);
-      method.setAccessible(true);
-      Implementation implementation = getImplementationAnnotation(method);
-      return matchesSdk(implementation) ? method : null;
 
       // todo: allow per-version overloading
-//      if (method == null) {
-//        String methodPrefix = name + "$$";
-//        for (Method candidateMethod : shadowClass.getMethods()) {
-//          if (candidateMethod.getName().startsWith(methodPrefix)) {
-//
-//          }
-//        }
-//      }
+      // if (method == null) {
+      //   String methodPrefix = name + "$$";
+      //   for (Method candidateMethod : shadowClass.getDeclaredMethods()) {
+      //     if (candidateMethod.getName().startsWith(methodPrefix)) {
+      //
+      //     }
+      //   }
+      // }
+
+      if (isValidShadowMethod(method)) {
+        method.setAccessible(true);
+        return method;
+      } else {
+        return null;
+      }
 
     } catch (NoSuchMethodException e) {
       return null;
     }
   }
 
-  private boolean matchesSdk(Implementation implementation) {
-    return implementation.minSdk() <= apiLevel && (implementation.maxSdk() == -1 || implementation.maxSdk() >= apiLevel);
+  private boolean isValidShadowMethod(Method method) {
+    int modifiers = method.getModifiers();
+    if (!Modifier.isPublic(modifiers) && !Modifier.isProtected(modifiers)) {
+      return false;
+    }
+
+    Implementation implementation = getImplementationAnnotation(method);
+    return matchesSdk(implementation);
   }
 
-  private Class<?> getShadowedClass(Method shadowMethod) {
-    Class<?> shadowingClass = shadowMethod.getDeclaringClass();
-    if (shadowingClass.equals(Object.class)) {
-      return Object.class;
-    }
-
-    Implements implementsAnnotation = shadowingClass.getAnnotation(Implements.class);
-    if (implementsAnnotation == null) {
-      throw new RuntimeException(shadowingClass + " has no @" + Implements.class.getSimpleName() + " annotation");
-    }
-    String shadowedClassName = implementsAnnotation.className();
-    if (shadowedClassName.isEmpty()) {
-      return implementsAnnotation.value();
-    } else {
-      try {
-        return shadowingClass.getClassLoader().loadClass(shadowedClassName);
-      } catch (ClassNotFoundException e) {
-        throw new RuntimeException(e);
-      }
-    }
+  private boolean matchesSdk(Implementation implementation) {
+    return implementation.minSdk() <= apiLevel && (implementation.maxSdk() == -1 || implementation.maxSdk() >= apiLevel);
   }
 
   private static Implementation getImplementationAnnotation(Method method) {
@@ -309,8 +330,11 @@ public class ShadowWrangler implements ClassHandler {
       return null;
     }
     Implementation implementation = method.getAnnotation(Implementation.class);
+    if (implementation == null) {
+      Logger.warn("No @Implementation annotation on " + method);
+    }
     return implementation == null
-        ? ReflectionHelpers.defaultsFor(Implementation.class)
+        ? IMPLEMENTATION_DEFAULTS
         : implementation;
   }
 

--- a/sandbox/src/test/java/org/robolectric/ShadowWranglerIntegrationTest.java
+++ b/sandbox/src/test/java/org/robolectric/ShadowWranglerIntegrationTest.java
@@ -23,6 +23,9 @@ import org.robolectric.testing.ShadowFoo;
 
 @RunWith(SandboxTestRunner.class)
 public class ShadowWranglerIntegrationTest {
+
+  private static boolean yes = true;
+
   private String name;
 
   @Before
@@ -404,5 +407,30 @@ public class ShadowWranglerIntegrationTest {
     static {
       initCount++;
     }
+  }
+
+  @Test @SandboxConfig(shadows = Shadow22OfAClassWithBrokenStaticInitializer.class)
+  public void staticInitializerShadowMethodsObeySameRules() throws Exception {
+    new AClassWithBrokenStaticInitializer();
+  }
+
+  @Instrument
+  public static class AClassWithBrokenStaticInitializer {
+    static {
+      if (yes) throw new RuntimeException("broken!");
+    }
+  }
+
+  @Implements(AClassWithBrokenStaticInitializer.class)
+  public static class Shadow2OfAClassWithBrokenStaticInitializer {
+    @Implementation
+    protected static void __staticInitializer__() {
+      // don't call real static initializer
+    }
+  }
+
+  @Implements(AClassWithBrokenStaticInitializer.class)
+  public static class Shadow22OfAClassWithBrokenStaticInitializer
+      extends Shadow2OfAClassWithBrokenStaticInitializer {
   }
 }

--- a/sandbox/src/test/java/org/robolectric/ShadowWranglerIntegrationTest.java
+++ b/sandbox/src/test/java/org/robolectric/ShadowWranglerIntegrationTest.java
@@ -24,7 +24,7 @@ import org.robolectric.testing.ShadowFoo;
 @RunWith(SandboxTestRunner.class)
 public class ShadowWranglerIntegrationTest {
 
-  private static boolean yes = true;
+  private static final boolean YES = true;
 
   private String name;
 
@@ -417,7 +417,7 @@ public class ShadowWranglerIntegrationTest {
   @Instrument
   public static class AClassWithBrokenStaticInitializer {
     static {
-      if (yes) throw new RuntimeException("broken!");
+      if (YES) throw new RuntimeException("broken!");
     }
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -4,7 +4,6 @@ import static android.os.Build.VERSION_CODES.JELLY_BEAN;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.M;
 import static org.robolectric.shadow.api.Shadow.directlyOn;
-import static org.robolectric.shadow.api.Shadow.invokeConstructor;
 
 import android.R;
 import android.app.Activity;
@@ -75,12 +74,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   private Menu optionsMenu;
   private ComponentName callingActivity;
 
-  @Implementation
-  public void __constructor__() {
-    invokeConstructor(Activity.class, realActivity);
-  }
-
-  public void setApplication(Application application) {
+ public void setApplication(Application application) {
     ReflectionHelpers.setField(realActivity, "mApplication", application);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -74,7 +74,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   private Menu optionsMenu;
   private ComponentName callingActivity;
 
- public void setApplication(Application application) {
+  public void setApplication(Application application) {
     ReflectionHelpers.setField(realActivity, "mApplication", application);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPhoneWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPhoneWindow.java
@@ -5,13 +5,12 @@ import static org.robolectric.shadow.api.Shadow.directlyOn;
 
 import android.graphics.drawable.Drawable;
 import android.view.Window;
-import com.android.internal.policy.PhoneWindow;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
-@Implements(value = PhoneWindow.class, isInAndroidSdk = false, minSdk = M)
+@Implements(className = "com.android.internal.policy.PhoneWindow", isInAndroidSdk = false, minSdk = M)
 public class ShadowPhoneWindow extends ShadowWindow {
   @SuppressWarnings("UnusedDeclaration")
   protected @RealObject Window realWindow;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPlayerBase.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPlayerBase.java
@@ -1,12 +1,13 @@
 package org.robolectric.shadows;
 
 import android.media.IAudioService;
-import android.media.PlayerBase;
+import android.os.Build;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.util.ReflectionHelpers;
 
-@Implements(value = PlayerBase.class, isInAndroidSdk = false)
+@Implements(className = "android.media.PlayerBase", isInAndroidSdk = false,
+    minSdk = Build.VERSION_CODES.N)
 public class ShadowPlayerBase {
 
   @Implementation

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSettings.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSettings.java
@@ -113,7 +113,7 @@ public class ShadowSettings {
     private static Map<String, Object> get(ContentResolver cr) {
       Map<String, Object> map = dataMap.get(cr);
       if (map == null) {
-        map = new HashMap<String, Object>();
+        map = new HashMap<>();
         dataMap.put(cr, map);
       }
       return map;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimePickerDialog.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimePickerDialog.java
@@ -9,7 +9,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.shadow.api.Shadow;
 
-@Implements(value = TimePickerDialog.class, inheritImplementationMethods = true)
+@Implements(value = TimePickerDialog.class)
 public class ShadowTimePickerDialog extends ShadowAlertDialog {
   @RealObject
   protected TimePickerDialog realTimePickerDialog;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWebView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWebView.java
@@ -24,7 +24,7 @@ import org.robolectric.fakes.RoboWebSettings;
 import org.robolectric.util.ReflectionHelpers;
 
 @SuppressWarnings({"UnusedDeclaration"})
-@Implements(value = WebView.class, inheritImplementationMethods = true)
+@Implements(value = WebView.class)
 public class ShadowWebView extends ShadowViewGroup {
   @RealObject
   private WebView realWebView;


### PR DESCRIPTION
* Always search up shadow class hierarchy for `@Implementation` methods. `@Implementation` methods apply to the class specified on that shadow's `@Implements` annotation.
* Deprecate `@Implements(inheritImplementationMethods)`; the default behavior now does most of what this was meant to be used for.