### PR TITLE
Fix Parcel.readByteArray()

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelTest.java
@@ -221,6 +221,25 @@ public class ShadowParcelTest {
   }
 
   @Test
+  public void testWriteAndReadByteArray() {
+    byte[] bytes = new byte[] { -1, 2, 3, 127 };
+    parcel.writeByteArray(bytes);
+    parcel.setDataPosition(0);
+    byte[] actualBytes = new byte[bytes.length];
+    parcel.readByteArray(actualBytes);
+    assertTrue(Arrays.equals(bytes, actualBytes));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testWriteAndReadByteArray_badLength() {
+    byte[] bytes = new byte[] { -1, 2, 3, 127 };
+    parcel.writeByteArray(bytes);
+    parcel.setDataPosition(0);
+    byte[] actualBytes = new byte[0];
+    parcel.readByteArray(actualBytes);
+  }
+
+  @Test
   public void testReadWriteMultipleInts() {
     for (int i = 0; i < 10; ++i) {
       parcel.writeInt(i);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcel.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcel.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.KITKAT_WATCH;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.O_MR1;
 import static org.robolectric.RuntimeEnvironment.castNativePtr;
 
 import android.os.Parcel;
@@ -194,6 +195,11 @@ public class ShadowParcel {
     return NATIVE_PTR_TO_PARCEL.get(nativePtr).readByteArray();
   }
 
+  @Implementation(minSdk = O_MR1)
+  public static boolean nativeReadByteArray(long nativePtr, byte[] dest, int destLen) {
+    return NATIVE_PTR_TO_PARCEL.get(nativePtr).readByteArray(dest, destLen);
+  }
+
   @HiddenApi
   @Implementation(maxSdk = KITKAT_WATCH)
   public static int nativeReadInt(int nativePtr) {
@@ -369,6 +375,20 @@ public class ShadowParcel {
         array[i] = readByte();
       }
       return array;
+    }
+
+    /**
+     * Reads a byte array from the byte buffer based on the current data position
+     */
+    public boolean readByteArray(byte[] dest, int destLen) {
+      int length = readInt();
+      if (length >= 0 && length <= dataAvailable() && length == destLen) {
+        for (int i = 0; i < length; i++) {
+          dest[i] = readByte();
+        }
+        return true;
+      }
+      return false;
     }
 
     /**


### PR DESCRIPTION
API 27 reimplements readByteArray() using a new native method that needs to be implemented in the shadow:

https://android.googlesource.com/platform/frameworks/base/+/61960cec37b078c41dca1401ad537e0806aded29%5E1..61960cec37b078c41dca1401ad537e0806aded29/
