### PR TITLE
Make some @Implementation methods protected.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -408,7 +408,8 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void getApplicationInfo_uninstalledApplication_includeUninstalled() throws Exception {
-    shadowPackageManager.setApplicationEnabledSetting(RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
+    packageManager.setApplicationEnabledSetting(
+        RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
     ApplicationInfo info = packageManager.getApplicationInfo(RuntimeEnvironment.application.getPackageName(), MATCH_UNINSTALLED_PACKAGES);
     assertThat(info).isNotNull();
     assertThat(info.packageName).isEqualTo(RuntimeEnvironment.application.getPackageName());
@@ -416,7 +417,8 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void getApplicationInfo_uninstalledApplication_dontIncludeUninstalled() throws Exception {
-    shadowPackageManager.setApplicationEnabledSetting(RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
+    packageManager.setApplicationEnabledSetting(
+        RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
 
     try {
       packageManager.getApplicationInfo(RuntimeEnvironment.application.getPackageName(), 0);
@@ -428,7 +430,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void getApplicationInfo_disabledApplication_includeDisabled() throws Exception {
-    shadowPackageManager.setApplicationEnabledSetting(
+    packageManager.setApplicationEnabledSetting(
         RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
     ApplicationInfo info = packageManager.getApplicationInfo(
         RuntimeEnvironment.application.getPackageName(), MATCH_DISABLED_COMPONENTS);
@@ -751,8 +753,8 @@ public class ShadowPackageManagerTest {
 
     shadowPackageManager.addActivityIcon(i, d);
 
-    assertThat(shadowPackageManager.getActivityIcon(i)).isSameAs(d);
-    assertThat(shadowPackageManager.getActivityIcon(i.getComponent())).isSameAs(d);
+    assertThat(packageManager.getActivityIcon(i)).isSameAs(d);
+    assertThat(packageManager.getActivityIcon(i.getComponent())).isSameAs(d);
   }
 
   @Test
@@ -884,7 +886,8 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void getPackageInfo_uninstalledPackage_includeUninstalled() throws Exception {
-    shadowPackageManager.setApplicationEnabledSetting(RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
+    packageManager.setApplicationEnabledSetting(
+        RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
     PackageInfo info = packageManager.getPackageInfo(RuntimeEnvironment.application.getPackageName(), MATCH_UNINSTALLED_PACKAGES);
     assertThat(info).isNotNull();
     assertThat(info.packageName).isEqualTo(RuntimeEnvironment.application.getPackageName());
@@ -892,7 +895,8 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void getPackageInfo_uninstalledPackage_dontIncludeUninstalled() {
-    shadowPackageManager.setApplicationEnabledSetting(RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
+    packageManager.setApplicationEnabledSetting(
+        RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
 
     try {
       packageManager.getPackageInfo(RuntimeEnvironment.application.getPackageName(), 0);
@@ -904,7 +908,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void getPackageInfo_disabledPackage_includeDisabled() throws Exception {
-    shadowPackageManager.setApplicationEnabledSetting(
+    packageManager.setApplicationEnabledSetting(
         RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
     PackageInfo info = packageManager.getPackageInfo(
         RuntimeEnvironment.application.getPackageName(), MATCH_DISABLED_COMPONENTS);
@@ -914,7 +918,8 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void getInstalledPackages_uninstalledPackage_includeUninstalled() throws Exception {
-    shadowPackageManager.setApplicationEnabledSetting(RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
+    packageManager.setApplicationEnabledSetting(
+        RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
 
     assertThat(packageManager.getInstalledPackages(MATCH_UNINSTALLED_PACKAGES)).isNotEmpty();
     assertThat(packageManager.getInstalledPackages(MATCH_UNINSTALLED_PACKAGES).get(0).packageName).isEqualTo(RuntimeEnvironment.application.getPackageName());
@@ -922,14 +927,15 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void getInstalledPackages_uninstalledPackage_dontIncludeUninstalled() throws Exception {
-    shadowPackageManager.setApplicationEnabledSetting(RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
+    packageManager.setApplicationEnabledSetting(
+        RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
 
     assertThat(packageManager.getInstalledPackages(0)).isEmpty();
   }
 
   @Test
   public void getInstalledPackages_disabledPackage_includeDisabled() throws Exception {
-    shadowPackageManager.setApplicationEnabledSetting(
+    packageManager.setApplicationEnabledSetting(
         RuntimeEnvironment.application.getPackageName(), COMPONENT_ENABLED_STATE_DISABLED, 0);
 
     assertThat(packageManager.getInstalledPackages(MATCH_DISABLED_COMPONENTS)).isNotEmpty();
@@ -972,7 +978,7 @@ public class ShadowPackageManagerTest {
   public void canResolveDrawableGivenPackageAndResourceId() throws Exception {
     Drawable drawable = ShadowDrawable.createFromStream(new ByteArrayInputStream(new byte[0]), "my_source");
     shadowPackageManager.addDrawableResolution("com.example.foo", 4334, drawable);
-    Drawable actual = shadowPackageManager.getDrawable("com.example.foo", 4334, null);
+    Drawable actual = packageManager.getDrawable("com.example.foo", 4334, null);
     assertThat(actual).isSameAs(drawable);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -87,7 +87,8 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public ActivityInfo getActivityInfo(ComponentName component, int flags) throws NameNotFoundException {
+  protected ActivityInfo getActivityInfo(ComponentName component, int flags)
+      throws NameNotFoundException {
     String activityName = component.getClassName();
     String packageName = component.getPackageName();
     PackageInfo packageInfo = packageInfos.get(packageName);
@@ -125,23 +126,23 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public boolean hasSystemFeature(String name) {
+  protected boolean hasSystemFeature(String name) {
     return systemFeatureList.containsKey(name) ? systemFeatureList.get(name) : false;
   }
 
   @Implementation
-  public int getComponentEnabledSetting(ComponentName componentName) {
+  protected int getComponentEnabledSetting(ComponentName componentName) {
     ComponentState state = componentList.get(componentName);
     return state != null ? state.newState : PackageManager.COMPONENT_ENABLED_STATE_DEFAULT;
   }
 
   @Implementation
-  public @Nullable String getNameForUid(int uid) {
+  protected @Nullable String getNameForUid(int uid) {
     return namesForUid.get(uid);
   }
 
   @Implementation
-  public @Nullable String[] getPackagesForUid(int uid) {
+  protected @Nullable String[] getPackagesForUid(int uid) {
     String[] packageNames = packagesForUid.get(uid);
     if (packageNames != null) {
       return packageNames;
@@ -160,7 +161,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public int getApplicationEnabledSetting(String packageName) {
+  protected int getApplicationEnabledSetting(String packageName) {
     try {
         getPackageInfo(packageName, -1);
     } catch (NameNotFoundException e) {
@@ -171,7 +172,8 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public ProviderInfo getProviderInfo(ComponentName component, int flags) throws NameNotFoundException {
+  protected ProviderInfo getProviderInfo(ComponentName component, int flags)
+      throws NameNotFoundException {
     String packageName = component.getPackageName();
 
     PackageInfo packageInfo = packageInfos.get(packageName);
@@ -198,23 +200,23 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public void setComponentEnabledSetting(ComponentName componentName, int newState, int flags) {
+  protected void setComponentEnabledSetting(ComponentName componentName, int newState, int flags) {
     componentList.put(componentName, new ComponentState(newState, flags));
   }
 
-  @Override @Implementation
-  public void setApplicationEnabledSetting(String packageName, int newState, int flags) {
+  @Implementation
+  protected void setApplicationEnabledSetting(String packageName, int newState, int flags) {
     applicationEnabledSettingMap.put(packageName, newState);
   }
 
   @Implementation
-  public ResolveInfo resolveActivity(Intent intent, int flags) {
+  protected ResolveInfo resolveActivity(Intent intent, int flags) {
     List<ResolveInfo> candidates = queryIntentActivities(intent, flags);
     return candidates.isEmpty() ? null : candidates.get(0);
   }
 
   @Implementation
-  public ProviderInfo resolveContentProvider(String name, int flags) {
+  protected ProviderInfo resolveContentProvider(String name, int flags) {
     if (name == null) {
       return null;
     }
@@ -231,12 +233,13 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public ProviderInfo resolveContentProviderAsUser(String name, int flags, @UserIdInt int userId) {
+  protected ProviderInfo resolveContentProviderAsUser(
+      String name, int flags, @UserIdInt int userId) {
     return null;
   }
 
   @Implementation
-  public PackageInfo getPackageInfo(String packageName, int flags) throws NameNotFoundException {
+  protected PackageInfo getPackageInfo(String packageName, int flags) throws NameNotFoundException {
     PackageInfo info = packageInfos.get(packageName);
     if (info != null) {
       if (applicationEnabledSettingMap.get(packageName) == COMPONENT_ENABLED_STATE_DISABLED
@@ -251,7 +254,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public List<ResolveInfo> queryIntentServices(Intent intent, int flags) {
+  protected List<ResolveInfo> queryIntentServices(Intent intent, int flags) {
     // Check the manually added resolve infos first.
     List<ResolveInfo> resolveInfoList = queryOverriddenIntents(intent, flags);
     if (!resolveInfoList.isEmpty()) {
@@ -293,16 +296,14 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
     return resolveInfoList;
   }
 
-  /**
-   * Behaves as {@link #queryIntentServices(Intent, int)} and currently ignores userId.
-   */
+  /** Behaves as {@link #queryIntentServices(Intent, int)} and currently ignores userId. */
   @Implementation(minSdk = JELLY_BEAN_MR1)
-  public List<ResolveInfo> queryIntentServicesAsUser(Intent intent, int flags, int userId) {
+  protected List<ResolveInfo> queryIntentServicesAsUser(Intent intent, int flags, int userId) {
     return queryIntentServices(intent, flags);
   }
 
   @Implementation
-  public List<ResolveInfo> queryIntentActivities(Intent intent, int flags) {
+  protected List<ResolveInfo> queryIntentActivities(Intent intent, int flags) {
     // Check the manually added resolve infos first.
     List<ResolveInfo> resolveInfoList = queryOverriddenIntents(intent, flags);
     if (!resolveInfoList.isEmpty()) {
@@ -491,7 +492,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public int checkPermission(String permName, String pkgName) {
+  protected int checkPermission(String permName, String pkgName) {
     PackageInfo permissionsInfo = packageInfos.get(pkgName);
     if (permissionsInfo == null || permissionsInfo.requestedPermissions == null) {
       return PackageManager.PERMISSION_DENIED;
@@ -505,7 +506,8 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public ActivityInfo getReceiverInfo(ComponentName className, int flags) throws NameNotFoundException {
+  protected ActivityInfo getReceiverInfo(ComponentName className, int flags)
+      throws NameNotFoundException {
     String packageName = className.getPackageName();
 
     PackageInfo packageInfo = packageInfos.get(packageName);
@@ -527,7 +529,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public List<ResolveInfo> queryBroadcastReceivers(Intent intent, int flags) {
+  protected List<ResolveInfo> queryBroadcastReceivers(Intent intent, int flags) {
     // Check the manually added resolve infos first.
     List<ResolveInfo> resolveInfoList = queryOverriddenIntents(intent, flags);
     if (!resolveInfoList.isEmpty()) {
@@ -564,13 +566,14 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public ResolveInfo resolveService(Intent intent, int flags) {
+  protected ResolveInfo resolveService(Intent intent, int flags) {
     List<ResolveInfo> candidates = queryIntentServices(intent, flags);
     return candidates.isEmpty() ? null : candidates.get(0);
   }
 
   @Implementation
-  public ServiceInfo getServiceInfo(ComponentName className, int flags) throws NameNotFoundException {
+  protected ServiceInfo getServiceInfo(ComponentName className, int flags)
+      throws NameNotFoundException {
     String packageName = className.getPackageName();
     PackageInfo packageInfo = packageInfos.get(packageName);
 
@@ -597,12 +600,13 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public Resources getResourcesForApplication(@NonNull ApplicationInfo applicationInfo) throws PackageManager.NameNotFoundException {
+  protected Resources getResourcesForApplication(@NonNull ApplicationInfo applicationInfo)
+      throws PackageManager.NameNotFoundException {
     return getResourcesForApplication(applicationInfo.packageName);
   }
 
   @Implementation
-  public List<ApplicationInfo> getInstalledApplications(int flags) {
+  protected List<ApplicationInfo> getInstalledApplications(int flags) {
     List<ApplicationInfo> result = new ArrayList<>();
 
     for (PackageInfo packageInfo : packageInfos.values()) {
@@ -612,12 +616,12 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public String getInstallerPackageName(String packageName) {
+  protected String getInstallerPackageName(String packageName) {
     return packageInstallerMap.get(packageName);
   }
 
   @Implementation
-  public PermissionInfo getPermissionInfo(String name, int flags) throws NameNotFoundException {
+  protected PermissionInfo getPermissionInfo(String name, int flags) throws NameNotFoundException {
     PermissionInfo permissionInfo = extraPermissions.get(name);
     if (permissionInfo != null) {
       return permissionInfo;
@@ -637,17 +641,17 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation(minSdk = M)
-  public boolean shouldShowRequestPermissionRationale(String permission) {
+  protected boolean shouldShowRequestPermissionRationale(String permission) {
     return permissionRationaleMap.containsKey(permission) ? permissionRationaleMap.get(permission) : false;
   }
 
   @Implementation
-  public FeatureInfo[] getSystemAvailableFeatures() {
+  protected FeatureInfo[] getSystemAvailableFeatures() {
     return systemAvailableFeatures.isEmpty() ? null : systemAvailableFeatures.toArray(new FeatureInfo[systemAvailableFeatures.size()]);
   }
 
   @Implementation
-  public void verifyPendingInstall(int id, int verificationCode) {
+  protected void verifyPendingInstall(int id, int verificationCode) {
     if (verificationResults.containsKey(id)) {
       throw new IllegalStateException("Multiple verifications for id=" + id);
     }
@@ -655,41 +659,42 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public void extendVerificationTimeout(int id, int verificationCodeAtTimeout, long millisecondsToDelay) {
+  protected void extendVerificationTimeout(
+      int id, int verificationCodeAtTimeout, long millisecondsToDelay) {
     verificationTimeoutExtension.put(id, millisecondsToDelay);
   }
 
   @Implementation
   @Override
-  public void freeStorageAndNotify(long freeStorageSize, IPackageDataObserver observer) {
-  }
+  protected void freeStorageAndNotify(long freeStorageSize, IPackageDataObserver observer) {}
 
   @Implementation
-  public void freeStorageAndNotify(String volumeUuid, long freeStorageSize, IPackageDataObserver observer) {
-  }
+  protected void freeStorageAndNotify(
+      String volumeUuid, long freeStorageSize, IPackageDataObserver observer) {}
 
   @Implementation
-  public void setInstallerPackageName(String targetPackage, String installerPackageName) {
+  protected void setInstallerPackageName(String targetPackage, String installerPackageName) {
     packageInstallerMap.put(targetPackage, installerPackageName);
   }
 
   @Implementation
-  public List<ResolveInfo> queryIntentContentProviders(Intent intent, int flags) {
+  protected List<ResolveInfo> queryIntentContentProviders(Intent intent, int flags) {
     return Collections.emptyList();
   }
 
   @Implementation
-  public List<ResolveInfo> queryIntentContentProvidersAsUser(Intent intent, int flags, int userId) {
+  protected List<ResolveInfo> queryIntentContentProvidersAsUser(
+      Intent intent, int flags, int userId) {
     return Collections.emptyList();
   }
 
   @Implementation
-  public String getPermissionControllerPackageName() {
+  protected String getPermissionControllerPackageName() {
     return null;
   }
 
   @Implementation(maxSdk = JELLY_BEAN)
-  public void getPackageSizeInfo(Object pkgName, Object observer) {
+  protected void getPackageSizeInfo(Object pkgName, Object observer) {
     final PackageStats packageStats = packageStatsMap.get((String) pkgName);
     new Handler(Looper.getMainLooper()).post(() -> {
       try {
@@ -701,7 +706,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR1, maxSdk = M)
-  public void getPackageSizeInfo(Object pkgName, Object uid, final Object observer) {
+  protected void getPackageSizeInfo(Object pkgName, Object uid, final Object observer) {
     final PackageStats packageStats = packageStatsMap.get((String) pkgName);
     new Handler(Looper.getMainLooper()).post(() -> {
       try {
@@ -713,7 +718,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation(minSdk = N)
-  public void getPackageSizeInfoAsUser(Object pkgName, Object uid, final Object observer) {
+  protected void getPackageSizeInfoAsUser(Object pkgName, Object uid, final Object observer) {
     final PackageStats packageStats = packageStatsMap.get((String) pkgName);
     new Handler(Looper.getMainLooper()).post(() -> {
       try {
@@ -725,12 +730,12 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public void deletePackage(String packageName, IPackageDeleteObserver observer, int flags) {
+  protected void deletePackage(String packageName, IPackageDeleteObserver observer, int flags) {
     pendingDeleteCallbacks.put(packageName, observer);
   }
 
   @Implementation
-  public String[] currentToCanonicalPackageNames(String[] names) {
+  protected String[] currentToCanonicalPackageNames(String[] names) {
     String[] out = new String[names.length];
     for (int i = names.length - 1; i >= 0; i--) {
       if (currentToCanonicalNames.containsKey(names[i])) {
@@ -743,27 +748,27 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public boolean isSafeMode() {
+  protected boolean isSafeMode() {
     return false;
   }
 
   @Implementation
-  public Drawable getApplicationIcon(String packageName) throws NameNotFoundException {
+  protected Drawable getApplicationIcon(String packageName) throws NameNotFoundException {
     return applicationIcons.get(packageName);
   }
 
   @Implementation
-  public Drawable getApplicationIcon(ApplicationInfo info) {
+  protected Drawable getApplicationIcon(ApplicationInfo info) {
     return null;
   }
 
   @Implementation
-  public Drawable getUserBadgeForDensity(UserHandle userHandle, int i) {
+  protected Drawable getUserBadgeForDensity(UserHandle userHandle, int i) {
     return null;
   }
 
   @Implementation
-  public int checkSignatures(String pkg1, String pkg2) {
+  protected int checkSignatures(String pkg1, String pkg2) {
     try {
       PackageInfo packageInfo1 = getPackageInfo(pkg1, GET_SIGNATURES);
       PackageInfo packageInfo2 = getPackageInfo(pkg2, GET_SIGNATURES);
@@ -774,12 +779,13 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public int checkSignatures(int uid1, int uid2) {
+  protected int checkSignatures(int uid1, int uid2) {
     return 0;
   }
 
   @Implementation
-  public List<PermissionInfo> queryPermissionsByGroup(String group, int flags) throws NameNotFoundException {
+  protected List<PermissionInfo> queryPermissionsByGroup(String group, int flags)
+      throws NameNotFoundException {
     List<PermissionInfo> result = new ArrayList<>();
     for (PermissionInfo permissionInfo : extraPermissions.values()) {
       if (Objects.equals(permissionInfo.group, group)) {
@@ -809,7 +815,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public Intent getLaunchIntentForPackage(String packageName) {
+  protected Intent getLaunchIntentForPackage(String packageName) {
     Intent intentToResolve = new Intent(Intent.ACTION_MAIN);
     intentToResolve.addCategory(Intent.CATEGORY_INFO);
     intentToResolve.setPackage(packageName);
@@ -833,33 +839,33 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   ////////////////////////////
 
   @Implementation
-  public PackageInfo getPackageInfoAsUser(String packageName, int flags, int userId)
+  protected PackageInfo getPackageInfoAsUser(String packageName, int flags, int userId)
       throws NameNotFoundException {
     return null;
   }
 
   @Implementation
-  public String[] canonicalToCurrentPackageNames(String[] names) {
+  protected String[] canonicalToCurrentPackageNames(String[] names) {
     return new String[0];
   }
 
   @Implementation
-  public Intent getLeanbackLaunchIntentForPackage(String packageName) {
+  protected Intent getLeanbackLaunchIntentForPackage(String packageName) {
     return null;
   }
 
   @Implementation
-  public int[] getPackageGids(String packageName) throws NameNotFoundException {
+  protected int[] getPackageGids(String packageName) throws NameNotFoundException {
     return new int[0];
   }
 
   @Implementation
-  public int[] getPackageGids(String packageName, int flags) throws NameNotFoundException {
+  protected int[] getPackageGids(String packageName, int flags) throws NameNotFoundException {
     return null;
   }
 
   @Implementation
-  public int getPackageUid(String packageName, int flags) throws NameNotFoundException {
+  protected int getPackageUid(String packageName, int flags) throws NameNotFoundException {
     Integer uid = uidForPackage.get(packageName);
     if (uid == null) {
       throw new NameNotFoundException(packageName);
@@ -868,18 +874,18 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public int getPackageUidAsUser(String packageName, int userId) throws NameNotFoundException {
+  protected int getPackageUidAsUser(String packageName, int userId) throws NameNotFoundException {
     return 0;
   }
 
   @Implementation
-  public int getPackageUidAsUser(String packageName, int flags, int userId)
+  protected int getPackageUidAsUser(String packageName, int flags, int userId)
       throws NameNotFoundException {
     return 0;
   }
 
   @Implementation
-  public PermissionGroupInfo getPermissionGroupInfo(String name, int flags)
+  protected PermissionGroupInfo getPermissionGroupInfo(String name, int flags)
       throws NameNotFoundException {
     if (extraPermissionGroups.containsKey(name)) {
       return new PermissionGroupInfo(extraPermissionGroups.get(name));
@@ -897,7 +903,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public List<PermissionGroupInfo> getAllPermissionGroups(int flags) {
+  protected List<PermissionGroupInfo> getAllPermissionGroups(int flags) {
     ArrayList<PermissionGroupInfo> allPermissionGroups = new ArrayList<PermissionGroupInfo>();
     // To be consistent with Android's implementation, return at most one PermissionGroupInfo object
     // per permission group string
@@ -923,7 +929,8 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public ApplicationInfo getApplicationInfo(String packageName, int flags) throws NameNotFoundException {
+  protected ApplicationInfo getApplicationInfo(String packageName, int flags)
+      throws NameNotFoundException {
     PackageInfo info = packageInfos.get(packageName);
     if (info != null) {
       try {
@@ -944,203 +951,199 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public String[] getSystemSharedLibraryNames() {
+  protected String[] getSystemSharedLibraryNames() {
     return new String[0];
   }
 
   @Implementation
-  public
-  @NonNull
-  String getServicesSystemSharedLibraryPackageName() {
+  protected @NonNull String getServicesSystemSharedLibraryPackageName() {
     return null;
   }
 
   @Implementation
-  public
-  @NonNull
-  String getSharedSystemSharedLibraryPackageName() {
+  protected @NonNull String getSharedSystemSharedLibraryPackageName() {
     return "";
   }
 
   @Implementation
-  public boolean hasSystemFeature(String name, int version) {
+  protected boolean hasSystemFeature(String name, int version) {
     return false;
   }
 
   @Implementation
-  public boolean isPermissionRevokedByPolicy(String permName, String pkgName) {
+  protected boolean isPermissionRevokedByPolicy(String permName, String pkgName) {
     return false;
   }
 
   @Implementation
-  public boolean addPermission(PermissionInfo info) {
+  protected boolean addPermission(PermissionInfo info) {
     return false;
   }
 
   @Implementation
-  public boolean addPermissionAsync(PermissionInfo info) {
+  protected boolean addPermissionAsync(PermissionInfo info) {
     return false;
   }
 
   @Implementation
-  public void removePermission(String name) {
-  }
+  protected void removePermission(String name) {}
 
   @Implementation
-  public void grantRuntimePermission(String packageName, String permissionName, UserHandle user) {
-  }
+  protected void grantRuntimePermission(
+      String packageName, String permissionName, UserHandle user) {}
 
   @Implementation
-  public void revokeRuntimePermission(String packageName, String permissionName, UserHandle user) {
-  }
+  protected void revokeRuntimePermission(
+      String packageName, String permissionName, UserHandle user) {}
 
   @Implementation
-  public int getPermissionFlags(String permissionName, String packageName, UserHandle user) {
+  protected int getPermissionFlags(String permissionName, String packageName, UserHandle user) {
     return 0;
   }
 
   @Implementation
-  public void updatePermissionFlags(String permissionName, String packageName, int flagMask,
-      int flagValues, UserHandle user) {
-  }
+  protected void updatePermissionFlags(
+      String permissionName, String packageName, int flagMask, int flagValues, UserHandle user) {}
 
   @Implementation
-  public int getUidForSharedUser(String sharedUserName) throws NameNotFoundException {
+  protected int getUidForSharedUser(String sharedUserName) throws NameNotFoundException {
     return 0;
   }
 
   @Implementation
-  public List<PackageInfo> getInstalledPackagesAsUser(int flags, int userId) {
+  protected List<PackageInfo> getInstalledPackagesAsUser(int flags, int userId) {
     return null;
   }
 
   @Implementation
-  public List<PackageInfo> getPackagesHoldingPermissions(String[] permissions, int flags) {
+  protected List<PackageInfo> getPackagesHoldingPermissions(String[] permissions, int flags) {
     return null;
   }
 
   @Implementation
-  public ResolveInfo resolveActivityAsUser(Intent intent, int flags, int userId) {
+  protected ResolveInfo resolveActivityAsUser(Intent intent, int flags, int userId) {
     return null;
   }
 
   @Implementation
-  public List<ResolveInfo> queryIntentActivitiesAsUser(Intent intent, int flags, int userId) {
+  protected List<ResolveInfo> queryIntentActivitiesAsUser(Intent intent, int flags, int userId) {
     return null;
   }
 
   @Implementation
-  public List<ResolveInfo> queryIntentActivityOptions(ComponentName caller, Intent[] specifics, Intent intent, int flags) {
+  protected List<ResolveInfo> queryIntentActivityOptions(
+      ComponentName caller, Intent[] specifics, Intent intent, int flags) {
     return null;
   }
 
   @Implementation
-  public List<ResolveInfo> queryBroadcastReceiversAsUser(Intent intent, int flags, int userId) {
+  protected List<ResolveInfo> queryBroadcastReceiversAsUser(Intent intent, int flags, int userId) {
     return null;
   }
 
   @Implementation
-  public List<ProviderInfo> queryContentProviders(String processName, int uid, int flags) {
+  protected List<ProviderInfo> queryContentProviders(String processName, int uid, int flags) {
     return null;
   }
 
   @Implementation
-  public InstrumentationInfo getInstrumentationInfo(ComponentName className, int flags) throws NameNotFoundException {
+  protected InstrumentationInfo getInstrumentationInfo(ComponentName className, int flags)
+      throws NameNotFoundException {
     return null;
   }
 
   @Implementation
-  public List<InstrumentationInfo> queryInstrumentation(String targetPackage, int flags) {
+  protected List<InstrumentationInfo> queryInstrumentation(String targetPackage, int flags) {
     return null;
   }
 
-  @Override @Nullable
+  @Nullable
   @Implementation
-  public Drawable getDrawable(String packageName, @DrawableRes int resId, @Nullable ApplicationInfo appInfo) {
+  protected Drawable getDrawable(
+      String packageName, @DrawableRes int resId, @Nullable ApplicationInfo appInfo) {
     return drawables.get(new Pair<>(packageName, resId));
   }
 
-  @Override @Implementation
-  public Drawable getActivityIcon(ComponentName activityName) throws NameNotFoundException {
+  @Implementation
+  protected Drawable getActivityIcon(ComponentName activityName) throws NameNotFoundException {
     return drawableList.get(activityName);
   }
 
-  @Override public Drawable getActivityIcon(Intent intent) throws NameNotFoundException {
-    return drawableList.get(intent.getComponent());
-  }
-
   @Implementation
-  public Drawable getDefaultActivityIcon() {
+  protected Drawable getDefaultActivityIcon() {
     return Resources.getSystem().getDrawable(com.android.internal.R.drawable.sym_def_app_icon);
   }
 
   @Implementation
-  public Drawable getActivityBanner(ComponentName activityName) throws NameNotFoundException {
+  protected Drawable getActivityBanner(ComponentName activityName) throws NameNotFoundException {
     return null;
   }
 
   @Implementation
-  public Drawable getActivityBanner(Intent intent) throws NameNotFoundException {
+  protected Drawable getActivityBanner(Intent intent) throws NameNotFoundException {
     return null;
   }
 
   @Implementation
-  public Drawable getApplicationBanner(ApplicationInfo info) {
+  protected Drawable getApplicationBanner(ApplicationInfo info) {
     return null;
   }
 
   @Implementation
-  public Drawable getApplicationBanner(String packageName) throws NameNotFoundException {
+  protected Drawable getApplicationBanner(String packageName) throws NameNotFoundException {
     return null;
   }
 
   @Implementation
-  public Drawable getActivityLogo(ComponentName activityName) throws NameNotFoundException {
+  protected Drawable getActivityLogo(ComponentName activityName) throws NameNotFoundException {
     return null;
   }
 
   @Implementation
-  public Drawable getActivityLogo(Intent intent) throws NameNotFoundException {
+  protected Drawable getActivityLogo(Intent intent) throws NameNotFoundException {
     return null;
   }
 
   @Implementation
-  public Drawable getApplicationLogo(ApplicationInfo info) {
+  protected Drawable getApplicationLogo(ApplicationInfo info) {
     return null;
   }
 
   @Implementation
-  public Drawable getApplicationLogo(String packageName) throws NameNotFoundException {
+  protected Drawable getApplicationLogo(String packageName) throws NameNotFoundException {
     return null;
   }
 
   @Implementation
-  public Drawable getUserBadgedIcon(Drawable icon, UserHandle user) {
+  protected Drawable getUserBadgedIcon(Drawable icon, UserHandle user) {
     return null;
   }
 
   @Implementation
-  public Drawable getUserBadgedDrawableForDensity(Drawable drawable, UserHandle user, Rect badgeLocation, int badgeDensity) {
+  protected Drawable getUserBadgedDrawableForDensity(
+      Drawable drawable, UserHandle user, Rect badgeLocation, int badgeDensity) {
     return null;
   }
 
   @Implementation
-  public Drawable getUserBadgeForDensityNoBackground(UserHandle user, int density) {
+  protected Drawable getUserBadgeForDensityNoBackground(UserHandle user, int density) {
     return null;
   }
 
   @Implementation
-  public CharSequence getUserBadgedLabel(CharSequence label, UserHandle user) {
+  protected CharSequence getUserBadgedLabel(CharSequence label, UserHandle user) {
     return null;
   }
 
   @Implementation
-  public Resources getResourcesForActivity(ComponentName activityName) throws NameNotFoundException {
+  protected Resources getResourcesForActivity(ComponentName activityName)
+      throws NameNotFoundException {
     return null;
   }
 
   @Implementation
-  public Resources getResourcesForApplication(String appPackageName) throws NameNotFoundException {
+  protected Resources getResourcesForApplication(String appPackageName)
+      throws NameNotFoundException {
     if (RuntimeEnvironment.application.getPackageName().equals(appPackageName)) {
       return RuntimeEnvironment.application.getResources();
     } else if (packageInfos.containsKey(appPackageName)) {
@@ -1155,149 +1158,143 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public Resources getResourcesForApplicationAsUser(String appPackageName, int userId) throws NameNotFoundException {
+  protected Resources getResourcesForApplicationAsUser(String appPackageName, int userId)
+      throws NameNotFoundException {
     return null;
   }
 
   @Implementation
-  public void addOnPermissionsChangeListener(Object listener) {
-  }
+  protected void addOnPermissionsChangeListener(Object listener) {}
 
   @Implementation
-  public void removeOnPermissionsChangeListener(Object listener) {
-  }
+  protected void removeOnPermissionsChangeListener(Object listener) {}
 
   @Implementation
-  public void installPackage(Object packageURI, Object observer, Object flags, Object installerPackageName) {
-  }
+  protected void installPackage(
+      Object packageURI, Object observer, Object flags, Object installerPackageName) {}
 
   @Implementation
-  public int installExistingPackage(String packageName) throws NameNotFoundException {
+  protected int installExistingPackage(String packageName) throws NameNotFoundException {
     return 0;
   }
 
   @Implementation
-  public int installExistingPackageAsUser(String packageName, int userId) throws NameNotFoundException {
+  protected int installExistingPackageAsUser(String packageName, int userId)
+      throws NameNotFoundException {
     return 0;
   }
 
   @Implementation
-  public void verifyIntentFilter(int id, int verificationCode, List<String> failedDomains) {
-  }
+  protected void verifyIntentFilter(int id, int verificationCode, List<String> failedDomains) {}
 
   @Implementation
-  public int getIntentVerificationStatusAsUser(String packageName, int userId) {
+  protected int getIntentVerificationStatusAsUser(String packageName, int userId) {
     return 0;
   }
 
   @Implementation
-  public boolean updateIntentVerificationStatusAsUser(String packageName, int status, int userId) {
+  protected boolean updateIntentVerificationStatusAsUser(
+      String packageName, int status, int userId) {
     return false;
   }
 
   @Implementation
-  public List<IntentFilterVerificationInfo> getIntentFilterVerifications(String packageName) {
+  protected List<IntentFilterVerificationInfo> getIntentFilterVerifications(String packageName) {
     return null;
   }
 
   @Implementation
-  public List<IntentFilter> getAllIntentFilters(String packageName) {
+  protected List<IntentFilter> getAllIntentFilters(String packageName) {
     return null;
   }
 
   @Implementation
-  public String getDefaultBrowserPackageNameAsUser(int userId) {
+  protected String getDefaultBrowserPackageNameAsUser(int userId) {
     return null;
   }
 
   @Implementation
-  public boolean setDefaultBrowserPackageNameAsUser(String packageName, int userId) {
+  protected boolean setDefaultBrowserPackageNameAsUser(String packageName, int userId) {
     return false;
   }
 
   @Implementation
-  public int getMoveStatus(int moveId) {
+  protected int getMoveStatus(int moveId) {
     return 0;
   }
 
   @Implementation
-  public void registerMoveCallback(Object callback, Object handler) {
-  }
+  protected void registerMoveCallback(Object callback, Object handler) {}
 
   @Implementation
-  public void unregisterMoveCallback(Object callback) {
-  }
+  protected void unregisterMoveCallback(Object callback) {}
 
   @Implementation
-  public Object movePackage(Object packageName, Object vol) {
+  protected Object movePackage(Object packageName, Object vol) {
     return 0;
   }
 
   @Implementation
-  public Object getPackageCurrentVolume(Object app) {
+  protected Object getPackageCurrentVolume(Object app) {
     return null;
   }
 
   @Implementation
-  public List<VolumeInfo> getPackageCandidateVolumes(ApplicationInfo app) {
+  protected List<VolumeInfo> getPackageCandidateVolumes(ApplicationInfo app) {
     return null;
   }
 
   @Implementation
-  public Object movePrimaryStorage(Object vol) {
+  protected Object movePrimaryStorage(Object vol) {
     return 0;
   }
 
   @Implementation
-  public @Nullable Object getPrimaryStorageCurrentVolume() {
+  protected @Nullable Object getPrimaryStorageCurrentVolume() {
     return null;
   }
 
   @Implementation
-  public @NonNull List<VolumeInfo> getPrimaryStorageCandidateVolumes() {
+  protected @NonNull List<VolumeInfo> getPrimaryStorageCandidateVolumes() {
     return null;
   }
 
   @Implementation
-  public void deletePackageAsUser(String packageName, IPackageDeleteObserver observer, int flags, int userId) {
-  }
+  protected void deletePackageAsUser(
+      String packageName, IPackageDeleteObserver observer, int flags, int userId) {}
 
   @Implementation
-  public void clearApplicationUserData(String packageName, IPackageDataObserver observer) {
-  }
+  protected void clearApplicationUserData(String packageName, IPackageDataObserver observer) {}
 
   @Implementation
-  public void deleteApplicationCacheFiles(String packageName, IPackageDataObserver observer) {
-  }
+  protected void deleteApplicationCacheFiles(String packageName, IPackageDataObserver observer) {}
 
   @Implementation
-  public void deleteApplicationCacheFilesAsUser(String packageName, int userId, IPackageDataObserver observer) {
-  }
+  protected void deleteApplicationCacheFilesAsUser(
+      String packageName, int userId, IPackageDataObserver observer) {}
 
   @Implementation
-  public void freeStorage(String volumeUuid, long freeStorageSize, IntentSender pi) {
-  }
+  protected void freeStorage(String volumeUuid, long freeStorageSize, IntentSender pi) {}
 
   @Implementation
-  public String[] setPackagesSuspendedAsUser(String[] packageNames, boolean suspended, int userId) {
+  protected String[] setPackagesSuspendedAsUser(
+      String[] packageNames, boolean suspended, int userId) {
     return null;
   }
 
   @Implementation
-  public boolean isPackageSuspendedForUser(String packageName, int userId) {
+  protected boolean isPackageSuspendedForUser(String packageName, int userId) {
     return false;
   }
 
   @Implementation
-  public void addPackageToPreferred(String packageName) {
-  }
+  protected void addPackageToPreferred(String packageName) {}
 
   @Implementation
-  public void removePackageFromPreferred(String packageName) {
-  }
+  protected void removePackageFromPreferred(String packageName) {}
 
   @Implementation
-  public List<PackageInfo> getPreferredPackages(int flags) {
+  protected List<PackageInfo> getPreferredPackages(int flags) {
     return null;
   }
 
@@ -1306,12 +1303,11 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public void replacePreferredActivity(IntentFilter filter, int match, ComponentName[] set, ComponentName activity) {
-  }
+  protected void replacePreferredActivity(
+      IntentFilter filter, int match, ComponentName[] set, ComponentName activity) {}
 
   @Implementation
-  public void clearPackagePreferredActivities(String packageName) {
-  }
+  protected void clearPackagePreferredActivities(String packageName) {}
 
   @Override public int getPreferredActivities(List<IntentFilter> outFilters,
       List<ComponentName> outActivities, String packageName) {
@@ -1356,74 +1352,73 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   }
 
   @Implementation
-  public ComponentName getHomeActivities(List<ResolveInfo> outActivities) {
+  protected ComponentName getHomeActivities(List<ResolveInfo> outActivities) {
     return null;
   }
 
   @Implementation
-  public void flushPackageRestrictionsAsUser(int userId) {
-  }
+  protected void flushPackageRestrictionsAsUser(int userId) {}
 
   @Implementation
-  public boolean setApplicationHiddenSettingAsUser(String packageName, boolean hidden, UserHandle user) {
+  protected boolean setApplicationHiddenSettingAsUser(
+      String packageName, boolean hidden, UserHandle user) {
     return false;
   }
 
   @Implementation
-  public boolean getApplicationHiddenSettingAsUser(String packageName, UserHandle user) {
+  protected boolean getApplicationHiddenSettingAsUser(String packageName, UserHandle user) {
     return false;
   }
 
   @Implementation
-  public Object getKeySetByAlias(String packageName, String alias) {
+  protected Object getKeySetByAlias(String packageName, String alias) {
     return null;
   }
 
   @Implementation
-  public Object getSigningKeySet(String packageName) {
+  protected Object getSigningKeySet(String packageName) {
     return null;
   }
 
   @Implementation
-  public boolean isSignedBy(String packageName, Object ks) {
+  protected boolean isSignedBy(String packageName, Object ks) {
     return false;
   }
 
   @Implementation
-  public boolean isSignedByExactly(String packageName, Object ks) {
+  protected boolean isSignedByExactly(String packageName, Object ks) {
     return false;
   }
 
   @Implementation
-  public VerifierDeviceIdentity getVerifierDeviceIdentity() {
+  protected VerifierDeviceIdentity getVerifierDeviceIdentity() {
     return null;
   }
 
   @Implementation
-  public boolean isUpgrade() {
+  protected boolean isUpgrade() {
     return false;
   }
 
   @Implementation
-  public boolean isPackageAvailable(String packageName) {
+  protected boolean isPackageAvailable(String packageName) {
     return false;
   }
 
   @Implementation
-  public void addCrossProfileIntentFilter(IntentFilter filter, int sourceUserId, int targetUserId, int flags) {
-  }
+  protected void addCrossProfileIntentFilter(
+      IntentFilter filter, int sourceUserId, int targetUserId, int flags) {}
 
   @Implementation
-  public void clearCrossProfileIntentFilters(int sourceUserId) {
-  }
+  protected void clearCrossProfileIntentFilters(int sourceUserId) {}
 
   @Implementation
-  public Drawable loadItemIcon(PackageItemInfo itemInfo, ApplicationInfo appInfo) {
+  protected Drawable loadItemIcon(PackageItemInfo itemInfo, ApplicationInfo appInfo) {
     return null;
   }
 
   @Implementation
-  public Drawable loadUnbadgedItemIcon(PackageItemInfo itemInfo, ApplicationInfo appInfo) {
+  protected Drawable loadUnbadgedItemIcon(PackageItemInfo itemInfo, ApplicationInfo appInfo) {
     return null;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFingerprintManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFingerprintManager.java
@@ -8,7 +8,6 @@ import android.hardware.fingerprint.FingerprintManager.AuthenticationCallback;
 import android.hardware.fingerprint.FingerprintManager.AuthenticationResult;
 import android.hardware.fingerprint.FingerprintManager.CryptoObject;
 import android.os.CancellationSignal;
-import android.os.CancellationSignal.OnCancelListener;
 import android.os.Handler;
 import android.util.Log;
 import org.robolectric.RuntimeEnvironment;
@@ -65,8 +64,12 @@ public class ShadowFingerprintManager {
   }
 
   @Implementation
-  public void authenticate(CryptoObject crypto, CancellationSignal cancel,
-      int flags, AuthenticationCallback callback, Handler handler) {
+  protected void authenticate(
+      CryptoObject crypto,
+      CancellationSignal cancel,
+      int flags,
+      AuthenticationCallback callback,
+      Handler handler) {
     if (callback == null) {
       throw new IllegalArgumentException("Must supply an authentication callback");
     }
@@ -95,7 +98,7 @@ public class ShadowFingerprintManager {
   }
 
   @Implementation
-  public boolean hasEnrolledFingerprints() {
+  protected boolean hasEnrolledFingerprints() {
     return this.hasEnrolledFingerprints;
   }
 
@@ -107,7 +110,7 @@ public class ShadowFingerprintManager {
   }
 
   @Implementation
-  public boolean isHardwareDetected() {
+  protected boolean isHardwareDetected() {
     return this.isHardwareDetected;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowKeyguardManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowKeyguardManager.java
@@ -33,12 +33,12 @@ public class ShadowKeyguardManager {
    * @see #setinRestrictedInputMode(boolean)
    */
   @Implementation
-  public boolean inKeyguardRestrictedInputMode() {
+  protected boolean inKeyguardRestrictedInputMode() {
     return inRestrictedInputMode;
   }
 
   @Implementation(minSdk = O)
-  public void requestDismissKeyguard(
+  protected void requestDismissKeyguard(
       Activity activity, KeyguardManager.KeyguardDismissCallback callback) {
     if (isKeyguardLocked) {
       if (this.callback != null) {
@@ -57,7 +57,7 @@ public class ShadowKeyguardManager {
    * @see #setKeyguardLocked(boolean)
    */
   @Implementation
-  public boolean isKeyguardLocked() {
+  protected boolean isKeyguardLocked() {
     return isKeyguardLocked;
   }
 
@@ -89,7 +89,7 @@ public class ShadowKeyguardManager {
    * @see ShadowKeyguardLock
    */
   @Implementation
-  public KeyguardManager.KeyguardLock newKeyguardLock(String tag) {
+  protected KeyguardManager.KeyguardLock newKeyguardLock(String tag) {
     return keyguardLock;
   }
 
@@ -109,7 +109,7 @@ public class ShadowKeyguardManager {
    * @see #setIsKeyguardSecure(boolean)
    */
   @Implementation
-  public boolean isKeyguardSecure() {
+  protected boolean isKeyguardSecure() {
     return isKeyguardSecure;
   }
 
@@ -129,7 +129,7 @@ public class ShadowKeyguardManager {
    * @see #setIsDeviceSecure(boolean)
    */
   @Implementation(minSdk = M)
-  public boolean isDeviceSecure() {
+  protected boolean isDeviceSecure() {
     return isDeviceSecure;
   }
 
@@ -152,7 +152,7 @@ public class ShadowKeyguardManager {
   }
 
   @Implementation(minSdk = LOLLIPOP_MR1)
-  public boolean isDeviceLocked() {
+  protected boolean isDeviceLocked() {
     return isDeviceLocked;
   }
 
@@ -167,7 +167,7 @@ public class ShadowKeyguardManager {
      * @see #isEnabled()
      */
     @Implementation
-    public void disableKeyguard() {
+    protected void disableKeyguard() {
       keyguardEnabled = false;
     }
 
@@ -177,7 +177,7 @@ public class ShadowKeyguardManager {
      * @see #isEnabled()
      */
     @Implementation
-    public void reenableKeyguard() {
+    protected void reenableKeyguard() {
       keyguardEnabled = true;
     }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
@@ -205,14 +205,6 @@ public class ShadowPackageManager {
         "Could not find package name for ResolveInfo " + resolveInfo.toString());
   }
 
-  public Drawable getActivityIcon(Intent intent) throws NameNotFoundException {
-    return drawableList.get(intent.getComponent());
-  }
-
-  public Drawable getActivityIcon(ComponentName componentName) throws NameNotFoundException {
-    return drawableList.get(componentName);
-  }
-
   public void addActivityIcon(ComponentName component, Drawable drawable) {
     drawableList.put(component, drawable);
   }
@@ -223,10 +215,6 @@ public class ShadowPackageManager {
 
   public void setApplicationIcon(String packageName, Drawable drawable) {
     applicationIcons.put(packageName, drawable);
-  }
-
-  public void setApplicationEnabledSetting(String packageName, int newState, int flags) {
-    applicationEnabledSettingMap.put(packageName, newState);
   }
 
   public void addPreferredActivity(IntentFilter filter, int match, ComponentName[] set, ComponentName activity) {
@@ -345,10 +333,6 @@ public class ShadowPackageManager {
     drawables.put(new Pair(packageName, resourceId), drawable);
   }
 
-  public Drawable getDrawable(String packageName, int resourceId, ApplicationInfo applicationInfo) {
-    return drawables.get(new Pair(packageName, resourceId));
-  }
-
   public void setNameForUid(int uid, String name) {
     namesForUid.put(uid, name);
   }
@@ -406,17 +390,19 @@ public class ShadowPackageManager {
   }
 
   @Implementation
-  public List<ResolveInfo> queryBroadcastReceiversAsUser(Intent intent, int flags, UserHandle userHandle) {
+  protected List<ResolveInfo> queryBroadcastReceiversAsUser(
+      Intent intent, int flags, UserHandle userHandle) {
     return null;
   }
 
   @Implementation
-  public List<ResolveInfo> queryBroadcastReceivers(Intent intent, int flags, @UserIdInt int userId) {
+  protected List<ResolveInfo> queryBroadcastReceivers(
+      Intent intent, int flags, @UserIdInt int userId) {
     return null;
   }
 
   @Implementation
-  public PackageInfo getPackageArchiveInfo(String archiveFilePath, int flags) {
+  protected PackageInfo getPackageArchiveInfo(String archiveFilePath, int flags) {
     List<PackageInfo> result = new ArrayList<>();
     for (PackageInfo packageInfo : packageInfos.values()) {
       if (applicationEnabledSettingMap.get(packageInfo.packageName)
@@ -437,12 +423,10 @@ public class ShadowPackageManager {
   }
 
   @Implementation
-  public void freeStorageAndNotify(long freeStorageSize, IPackageDataObserver observer) {
-  }
+  protected void freeStorageAndNotify(long freeStorageSize, IPackageDataObserver observer) {}
 
   @Implementation
-  public void freeStorage(long freeStorageSize, IntentSender pi) {
-  }
+  protected void freeStorage(long freeStorageSize, IntentSender pi) {}
 
   /**
    * Runs the callbacks pending from calls to {@link PackageManager#deletePackage(String, IPackageDeleteObserver, int)}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRestrictionsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRestrictionsManager.java
@@ -20,7 +20,7 @@ public class ShadowRestrictionsManager {
   }
 
   @Implementation
-  public Bundle getApplicationRestrictions() {
+  protected Bundle getApplicationRestrictions() {
     return applicationRestrictions;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSearchManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSearchManager.java
@@ -10,7 +10,7 @@ import org.robolectric.annotation.Implements;
 public class ShadowSearchManager {
 
   @Implementation
-  public SearchableInfo getSearchableInfo(ComponentName componentName) {
+  protected SearchableInfo getSearchableInfo(ComponentName componentName) {
     // Prevent Robolectric from calling through
     return null;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowShortcutManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowShortcutManager.java
@@ -29,7 +29,7 @@ public class ShadowShortcutManager {
   private boolean isRequestPinShortcutSupported = true;
 
   @Implementation
-  public boolean addDynamicShortcuts(List<ShortcutInfo> shortcutInfoList) {
+  protected boolean addDynamicShortcuts(List<ShortcutInfo> shortcutInfoList) {
     for (ShortcutInfo shortcutInfo : shortcutInfoList) {
       if (activePinnedShortcuts.containsKey(shortcutInfo.getId())) {
         ShortcutInfo previousShortcut = activePinnedShortcuts.get(shortcutInfo.getId());
@@ -54,7 +54,7 @@ public class ShadowShortcutManager {
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public Intent createShortcutResultIntent(ShortcutInfo shortcut) {
+  protected Intent createShortcutResultIntent(ShortcutInfo shortcut) {
     if (disabledPinnedShortcuts.containsKey(shortcut.getId())) {
       throw new IllegalArgumentException();
     }
@@ -62,12 +62,12 @@ public class ShadowShortcutManager {
   }
 
   @Implementation
-  public void disableShortcuts(List<String> shortcutIds) {
+  protected void disableShortcuts(List<String> shortcutIds) {
     disableShortcuts(shortcutIds, "Shortcut is disabled.");
   }
 
   @Implementation
-  public void disableShortcuts(List<String> shortcutIds, CharSequence unused) {
+  protected void disableShortcuts(List<String> shortcutIds, CharSequence unused) {
     for (String shortcutId : shortcutIds) {
       ShortcutInfo shortcut = activePinnedShortcuts.remove(shortcutId);
       if (shortcut != null) {
@@ -77,7 +77,7 @@ public class ShadowShortcutManager {
   }
 
   @Implementation
-  public void enableShortcuts(List<String> shortcutIds) {
+  protected void enableShortcuts(List<String> shortcutIds) {
     for (String shortcutId : shortcutIds) {
       ShortcutInfo shortcut = disabledPinnedShortcuts.remove(shortcutId);
       if (shortcut != null) {
@@ -87,32 +87,32 @@ public class ShadowShortcutManager {
   }
 
   @Implementation
-  public List<ShortcutInfo> getDynamicShortcuts() {
+  protected List<ShortcutInfo> getDynamicShortcuts() {
     return ImmutableList.copyOf(dynamicShortcuts.values());
   }
 
   @Implementation
-  public int getIconMaxHeight() {
+  protected int getIconMaxHeight() {
     return MAX_ICON_DIMENSION;
   }
 
   @Implementation
-  public int getIconMaxWidth() {
+  protected int getIconMaxWidth() {
     return MAX_ICON_DIMENSION;
   }
 
   @Implementation
-  public List<ShortcutInfo> getManifestShortcuts() {
+  protected List<ShortcutInfo> getManifestShortcuts() {
     return ImmutableList.of();
   }
 
   @Implementation
-  public int getMaxShortcutCountPerActivity() {
+  protected int getMaxShortcutCountPerActivity() {
     return MAX_NUM_SHORTCUTS_PER_ACTIVITY;
   }
 
   @Implementation
-  public List<ShortcutInfo> getPinnedShortcuts() {
+  protected List<ShortcutInfo> getPinnedShortcuts() {
     ImmutableList.Builder<ShortcutInfo> pinnedShortcuts = ImmutableList.builder();
     pinnedShortcuts.addAll(activePinnedShortcuts.values());
     pinnedShortcuts.addAll(disabledPinnedShortcuts.values());
@@ -120,12 +120,12 @@ public class ShadowShortcutManager {
   }
 
   @Implementation
-  public boolean isRateLimitingActive() {
+  protected boolean isRateLimitingActive() {
     return false;
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public boolean isRequestPinShortcutSupported() {
+  protected boolean isRequestPinShortcutSupported() {
     return isRequestPinShortcutSupported;
   }
 
@@ -134,22 +134,22 @@ public class ShadowShortcutManager {
   }
 
   @Implementation
-  public void removeAllDynamicShortcuts() {
+  protected void removeAllDynamicShortcuts() {
     dynamicShortcuts.clear();
   }
 
   @Implementation
-  public void removeDynamicShortcuts(List<String> shortcutIds) {
+  protected void removeDynamicShortcuts(List<String> shortcutIds) {
     for (String shortcutId : shortcutIds) {
       dynamicShortcuts.remove(shortcutId);
     }
   }
 
   @Implementation
-  public void reportShortcutUsed(String shortcutId) {}
+  protected void reportShortcutUsed(String shortcutId) {}
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public boolean requestPinShortcut(ShortcutInfo shortcut, IntentSender resultIntent) {
+  protected boolean requestPinShortcut(ShortcutInfo shortcut, IntentSender resultIntent) {
     if (disabledPinnedShortcuts.containsKey(shortcut.getId())) {
       throw new IllegalArgumentException(
           "Shortcut with ID [" + shortcut.getId() + "] already exists and is disabled.");
@@ -170,13 +170,13 @@ public class ShadowShortcutManager {
   }
 
   @Implementation
-  public boolean setDynamicShortcuts(List<ShortcutInfo> shortcutInfoList) {
+  protected boolean setDynamicShortcuts(List<ShortcutInfo> shortcutInfoList) {
     dynamicShortcuts.clear();
     return addDynamicShortcuts(shortcutInfoList);
   }
 
   @Implementation
-  public boolean updateShortcuts(List<ShortcutInfo> shortcutInfoList) {
+  protected boolean updateShortcuts(List<ShortcutInfo> shortcutInfoList) {
     List<ShortcutInfo> existingShortcutsToUpdate = new ArrayList<>();
     for (ShortcutInfo shortcutInfo : shortcutInfoList) {
       if (dynamicShortcuts.containsKey(shortcutInfo.getId())

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsbManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsbManager.java
@@ -19,7 +19,7 @@ public class ShadowUsbManager {
 
   /** Returns true if the caller has permission to access the device. */
   @Implementation
-  public boolean hasPermission(UsbDevice device) {
+  protected boolean hasPermission(UsbDevice device) {
     return usbDevicesPermissionMap.containsKey(device)
         ? usbDevicesPermissionMap.get(device)
         : false;
@@ -31,7 +31,7 @@ public class ShadowUsbManager {
    * is inactive or unsupported.
    */
   @Implementation
-  public HashMap<String, UsbDevice> getDeviceList() {
+  protected HashMap<String, UsbDevice> getDeviceList() {
     HashMap<String, UsbDevice> usbDeviceMap = new HashMap<>();
     for (UsbDevice usbDevice : usbDevicesPermissionMap.keySet()) {
       usbDeviceMap.put(usbDevice.getDeviceName(), usbDevice);
@@ -60,11 +60,9 @@ public class ShadowUsbManager {
     usbDevicesPermissionMap.remove(usbDevice);
   }
 
-  /**
-   * Opens a file descriptor from a temporary file.
-   */
+  /** Opens a file descriptor from a temporary file. */
   @Implementation
-  public ParcelFileDescriptor openAccessory(UsbAccessory accessory) {
+  protected ParcelFileDescriptor openAccessory(UsbAccessory accessory) {
     try {
       File tmpUsbDir =
           RuntimeEnvironment.getTempDirectory().createIfNotExists("usb-accessory").toFile();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUserManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUserManager.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
@@ -43,7 +42,7 @@ public class ShadowUserManager {
   private boolean enforcePermissions;
 
   @Implementation
-  public void __constructor__(Context context, IUserManager service) {
+  protected void __constructor__(Context context, IUserManager service) {
     this.context = context;
   }
 
@@ -60,7 +59,7 @@ public class ShadowUserManager {
    * package name and the method returns instantly.
    */
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public Bundle getApplicationRestrictions(String packageName) {
+  protected Bundle getApplicationRestrictions(String packageName) {
     Bundle bundle = applicationRestrictions.get(packageName);
     return bundle != null ? bundle : new Bundle();
   }
@@ -80,12 +79,12 @@ public class ShadowUserManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public List<UserHandle> getUserProfiles(){
+  protected List<UserHandle> getUserProfiles() {
     return ImmutableList.copyOf(userProfiles.keySet());
   }
 
   @Implementation(minSdk = N)
-  public boolean isUserUnlocked() {
+  protected boolean isUserUnlocked() {
     return userUnlocked;
   }
 
@@ -97,7 +96,7 @@ public class ShadowUserManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean isManagedProfile() {
+  protected boolean isManagedProfile() {
     if (enforcePermissions && !hasManageUsersPermission()) {
       throw new SecurityException(
           "You need MANAGE_USERS permission to: check if specified user a " +
@@ -114,7 +113,7 @@ public class ShadowUserManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean hasUserRestriction(String restrictionKey, UserHandle userHandle) {
+  protected boolean hasUserRestriction(String restrictionKey, UserHandle userHandle) {
     Bundle bundle = userRestrictions.get(userHandle);
     return bundle != null && bundle.getBoolean(restrictionKey);
   }
@@ -134,7 +133,7 @@ public class ShadowUserManager {
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public Bundle getUserRestrictions(UserHandle userHandle) {
+  protected Bundle getUserRestrictions(UserHandle userHandle) {
     return getUserRestrictionsForUser(userHandle);
   }
 
@@ -148,7 +147,7 @@ public class ShadowUserManager {
   }
 
   @Implementation
-  public long getSerialNumberForUser(UserHandle userHandle) {
+  protected long getSerialNumberForUser(UserHandle userHandle) {
     Long result = userProfiles.get(userHandle);
     return result == null ? -1L : result;
   }
@@ -165,7 +164,7 @@ public class ShadowUserManager {
   }
 
   @Implementation
-  public UserHandle getUserForSerialNumber(long serialNumber) {
+  protected UserHandle getUserForSerialNumber(long serialNumber) {
     return userProfiles.inverse().get(serialNumber);
   }
 
@@ -181,7 +180,7 @@ public class ShadowUserManager {
   }
 
   @Implementation(minSdk = N_MR1)
-  public boolean isDemoUser() {
+  protected boolean isDemoUser() {
     return isDemoUser;
   }
 
@@ -194,7 +193,7 @@ public class ShadowUserManager {
   }
 
   @Implementation
-  public boolean isUserRunning(UserHandle handle) {
+  protected boolean isUserRunning(UserHandle handle) {
     checkPermissions();
     UserState state = userState.get(handle);
 
@@ -208,7 +207,7 @@ public class ShadowUserManager {
   }
 
   @Implementation
-  public boolean isUserRunningOrStopping(UserHandle handle) {
+  protected boolean isUserRunningOrStopping(UserHandle handle) {
     checkPermissions();
     UserState state = userState.get(handle);
 
@@ -250,7 +249,7 @@ public class ShadowUserManager {
   }
 
   @Implementation
-  public List<UserInfo> getUsers() {
+  protected List<UserInfo> getUsers() {
     // Implement this - return empty list to avoid NPE from call to getUserCount()
     return ImmutableList.of();
   }


### PR DESCRIPTION
Switch whitelisted (custom-banned) shadows @Implementation methods from
public
to protected to narrow our API surface area. Shadow implementations
should be
hidden from the API. Test writers should prefer to call the equivalent
method
on the actual Android API.
