### PR TITLE
Handle receiver class names with no leading '.'

### DIFF
--- a/robolectric/src/main/java/org/robolectric/android/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/ParallelUniverse.java
@@ -387,7 +387,8 @@ public class ParallelUniverse implements ParallelUniverseInterface {
   private static String replaceLastDotWith$IfInnerStaticClass(String receiverClassName) {
     String[] splits = receiverClassName.split("\\.");
     String staticInnerClassRegex = "[A-Z][a-zA-Z]*";
-    if (splits[splits.length - 1].matches(staticInnerClassRegex)
+    if (splits.length > 1
+        && splits[splits.length - 1].matches(staticInnerClassRegex)
         && splits[splits.length - 2].matches(staticInnerClassRegex)) {
       int lastDotIndex = receiverClassName.lastIndexOf(".");
       StringBuilder buffer = new StringBuilder(receiverClassName);


### PR DESCRIPTION
PiperRevId: 184713262

### Overview

### Proposed Changes
