### PR TITLE
Filter out disabled components in PackageManager query/resolve method…

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -603,8 +603,7 @@ public class ShadowPackageManagerTest {
         PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
 
     List<ResolveInfo> resolveInfos = packageManager.queryIntentActivities(i, 0);
-    assertThat(resolveInfos).isNotNull();
-    assertThat(resolveInfos).hasSize(0);
+    assertThat(resolveInfos).isEmpty();
   }
 
   @Test
@@ -620,8 +619,7 @@ public class ShadowPackageManagerTest {
         PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
 
     List<ResolveInfo> resolveInfos = packageManager.queryIntentActivities(i, 0);
-    assertThat(resolveInfos).isNotNull();
-    assertThat(resolveInfos).hasSize(0);
+    assertThat(resolveInfos).isEmpty();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -597,10 +597,12 @@ public class ShadowPackageManagerTest {
     Intent i = new Intent();
     i.setClassName(RuntimeEnvironment.application, "org.robolectric.shadows.TestActivity");
 
-    ComponentName componentToDisable = new ComponentName(RuntimeEnvironment.application,
-        "org.robolectric.shadows.TestActivity");
-    packageManager.setComponentEnabledSetting(componentToDisable,
-        PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
+    ComponentName componentToDisable =
+        new ComponentName(RuntimeEnvironment.application, "org.robolectric.shadows.TestActivity");
+    packageManager.setComponentEnabledSetting(
+        componentToDisable,
+        PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+        PackageManager.DONT_KILL_APP);
 
     List<ResolveInfo> resolveInfos = packageManager.queryIntentActivities(i, 0);
     assertThat(resolveInfos).isEmpty();
@@ -613,10 +615,12 @@ public class ShadowPackageManagerTest {
     i.addCategory(Intent.CATEGORY_DEFAULT);
     i.setDataAndType(uri, "image/jpeg");
 
-    ComponentName componentToDisable = new ComponentName(RuntimeEnvironment.application,
-        "org.robolectric.shadows.TestActivity");
-    packageManager.setComponentEnabledSetting(componentToDisable,
-        PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
+    ComponentName componentToDisable =
+        new ComponentName(RuntimeEnvironment.application, "org.robolectric.shadows.TestActivity");
+    packageManager.setComponentEnabledSetting(
+        componentToDisable,
+        PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+        PackageManager.DONT_KILL_APP);
 
     List<ResolveInfo> resolveInfos = packageManager.queryIntentActivities(i, 0);
     assertThat(resolveInfos).isEmpty();
@@ -629,12 +633,15 @@ public class ShadowPackageManagerTest {
     i.addCategory(Intent.CATEGORY_DEFAULT);
     i.setDataAndType(uri, "image/jpeg");
 
-    ComponentName componentToDisable = new ComponentName(RuntimeEnvironment.application,
-        "org.robolectric.shadows.TestActivity");
-    packageManager.setComponentEnabledSetting(componentToDisable,
-        PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
+    ComponentName componentToDisable =
+        new ComponentName(RuntimeEnvironment.application, "org.robolectric.shadows.TestActivity");
+    packageManager.setComponentEnabledSetting(
+        componentToDisable,
+        PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+        PackageManager.DONT_KILL_APP);
 
-    List<ResolveInfo> resolveInfos = packageManager.queryIntentActivities(i, PackageManager.MATCH_DISABLED_COMPONENTS);
+    List<ResolveInfo> resolveInfos =
+        packageManager.queryIntentActivities(i, PackageManager.MATCH_DISABLED_COMPONENTS);
     assertThat(resolveInfos).isNotNull();
     assertThat(resolveInfos).hasSize(1);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -593,6 +593,55 @@ public class ShadowPackageManagerTest {
   }
 
   @Test
+  public void queryIntentActivities_DisabledComponentExplicitIntent() throws Exception {
+    Intent i = new Intent();
+    i.setClassName(RuntimeEnvironment.application, "org.robolectric.shadows.TestActivity");
+
+    ComponentName componentToDisable = new ComponentName(RuntimeEnvironment.application,
+        "org.robolectric.shadows.TestActivity");
+    packageManager.setComponentEnabledSetting(componentToDisable,
+        PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
+
+    List<ResolveInfo> resolveInfos = packageManager.queryIntentActivities(i, 0);
+    assertThat(resolveInfos).isNotNull();
+    assertThat(resolveInfos).hasSize(0);
+  }
+
+  @Test
+  public void queryIntentActivities_DisabledComponentImplicitIntent() throws Exception {
+    Uri uri = Uri.parse("content://testhost1.com:1/testPath/test.jpeg");
+    Intent i = new Intent(Intent.ACTION_VIEW);
+    i.addCategory(Intent.CATEGORY_DEFAULT);
+    i.setDataAndType(uri, "image/jpeg");
+
+    ComponentName componentToDisable = new ComponentName(RuntimeEnvironment.application,
+        "org.robolectric.shadows.TestActivity");
+    packageManager.setComponentEnabledSetting(componentToDisable,
+        PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
+
+    List<ResolveInfo> resolveInfos = packageManager.queryIntentActivities(i, 0);
+    assertThat(resolveInfos).isNotNull();
+    assertThat(resolveInfos).hasSize(0);
+  }
+
+  @Test
+  public void queryIntentActivities_MatchDisabledComponents() throws Exception {
+    Uri uri = Uri.parse("content://testhost1.com:1/testPath/test.jpeg");
+    Intent i = new Intent(Intent.ACTION_VIEW);
+    i.addCategory(Intent.CATEGORY_DEFAULT);
+    i.setDataAndType(uri, "image/jpeg");
+
+    ComponentName componentToDisable = new ComponentName(RuntimeEnvironment.application,
+        "org.robolectric.shadows.TestActivity");
+    packageManager.setComponentEnabledSetting(componentToDisable,
+        PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
+
+    List<ResolveInfo> resolveInfos = packageManager.queryIntentActivities(i, PackageManager.MATCH_DISABLED_COMPONENTS);
+    assertThat(resolveInfos).isNotNull();
+    assertThat(resolveInfos).hasSize(1);
+  }
+
+  @Test
   public void resolveActivity_Match() throws Exception {
     Intent i = new Intent(Intent.ACTION_MAIN, null).addCategory(Intent.CATEGORY_LAUNCHER);
     ResolveInfo info = new ResolveInfo();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -282,7 +282,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
 
     for (Iterator<ResolveInfo> iterator = resolveInfoList.iterator(); iterator.hasNext();) {
       ResolveInfo resolveInfo = iterator.next();
-       if ((flags & PackageManager.MATCH_SYSTEM_ONLY) == PackageManager.MATCH_SYSTEM_ONLY) {
+       if (isFlagSet(flags, PackageManager.MATCH_SYSTEM_ONLY)) {
          if (resolveInfo.serviceInfo == null || resolveInfo.serviceInfo.applicationInfo == null) {
            // TODO: for backwards compatibility just skip filtering. In future should just remove
            // invalid resolve infos from list
@@ -293,7 +293,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
              iterator.remove();
            }
          }
-      } else if (((flags & PackageManager.MATCH_DISABLED_COMPONENTS) != PackageManager.MATCH_DISABLED_COMPONENTS)
+      } else if (!isFlagSet(flags, PackageManager.MATCH_DISABLED_COMPONENTS)
            && isValidComponentInfo(resolveInfo.serviceInfo)) {
         ComponentName componentName = new ComponentName(
             resolveInfo.serviceInfo.applicationInfo.packageName,
@@ -306,7 +306,11 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
     return resolveInfoList;
   }
 
-  private boolean isValidComponentInfo(ComponentInfo componentInfo) {
+  private static boolean isFlagSet(int flags, int matchFlag) {
+    return (flags & matchFlag) == matchFlag;
+  }
+
+  private static boolean isValidComponentInfo(ComponentInfo componentInfo) {
     return componentInfo != null
         && componentInfo.applicationInfo != null
         && componentInfo.applicationInfo.packageName != null

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -274,31 +274,33 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
 
   private List<ResolveInfo> filterResolvedServices(List<ResolveInfo> resolveInfoList, int flags) {
     // If the flag is set, no further filtering will happen.
-    if ((flags & PackageManager.MATCH_ALL) == PackageManager.MATCH_ALL) {
+    if (isFlagSet(flags, PackageManager.MATCH_ALL)) {
       return resolveInfoList;
     }
     // Create a copy of the list for filtering
     resolveInfoList = new ArrayList<>(resolveInfoList);
 
-    for (Iterator<ResolveInfo> iterator = resolveInfoList.iterator(); iterator.hasNext();) {
+    for (Iterator<ResolveInfo> iterator = resolveInfoList.iterator(); iterator.hasNext(); ) {
       ResolveInfo resolveInfo = iterator.next();
-       if (isFlagSet(flags, PackageManager.MATCH_SYSTEM_ONLY)) {
-         if (resolveInfo.serviceInfo == null || resolveInfo.serviceInfo.applicationInfo == null) {
-           // TODO: for backwards compatibility just skip filtering. In future should just remove
-           // invalid resolve infos from list
-           iterator.remove();
-         } else {
-           final int applicationFlags = resolveInfo.serviceInfo.applicationInfo.flags;
-           if ((applicationFlags & ApplicationInfo.FLAG_SYSTEM) != ApplicationInfo.FLAG_SYSTEM) {
-             iterator.remove();
-           }
-         }
+      if (isFlagSet(flags, PackageManager.MATCH_SYSTEM_ONLY)) {
+        if (resolveInfo.serviceInfo == null || resolveInfo.serviceInfo.applicationInfo == null) {
+          // TODO: for backwards compatibility just skip filtering. In future should just remove
+          // invalid resolve infos from list
+          iterator.remove();
+        } else {
+          final int applicationFlags = resolveInfo.serviceInfo.applicationInfo.flags;
+          if ((applicationFlags & ApplicationInfo.FLAG_SYSTEM) != ApplicationInfo.FLAG_SYSTEM) {
+            iterator.remove();
+          }
+        }
       } else if (!isFlagSet(flags, PackageManager.MATCH_DISABLED_COMPONENTS)
-           && isValidComponentInfo(resolveInfo.serviceInfo)) {
-        ComponentName componentName = new ComponentName(
-            resolveInfo.serviceInfo.applicationInfo.packageName,
-            resolveInfo.serviceInfo.name);
-        if ((getComponentEnabledSetting(componentName) & PackageManager.COMPONENT_ENABLED_STATE_DISABLED) != 0) {
+          && resolveInfo != null && isValidComponentInfo(resolveInfo.serviceInfo)) {
+        ComponentName componentName =
+            new ComponentName(
+                resolveInfo.serviceInfo.applicationInfo.packageName, resolveInfo.serviceInfo.name);
+        if ((getComponentEnabledSetting(componentName)
+                & PackageManager.COMPONENT_ENABLED_STATE_DISABLED)
+            != 0) {
           iterator.remove();
         }
       }
@@ -345,38 +347,39 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
 
   private List<ResolveInfo> filterResolvedActivities(List<ResolveInfo> resolveInfoList, int flags) {
     // If the flag is set, no further filtering will happen.
-    if ((flags & PackageManager.MATCH_ALL) == PackageManager.MATCH_ALL) {
+    if (isFlagSet(flags, PackageManager.MATCH_ALL)) {
       return resolveInfoList;
     }
     // Create a copy of the list for filtering
     resolveInfoList = new ArrayList<>(resolveInfoList);
 
-    for (Iterator<ResolveInfo> iterator = resolveInfoList.iterator(); iterator.hasNext();) {
+    for (Iterator<ResolveInfo> iterator = resolveInfoList.iterator(); iterator.hasNext(); ) {
       ResolveInfo resolveInfo = iterator.next();
 
-      if ((flags & PackageManager.MATCH_SYSTEM_ONLY) == PackageManager.MATCH_SYSTEM_ONLY) {
+      if (isFlagSet(flags, PackageManager.MATCH_SYSTEM_ONLY)) {
         // TODO: for backwards compatibility only remove invalid components when MATCH_SYSTEM_ONLY
         // In future should just remove all invalid resolve infos from list
         if (resolveInfo.activityInfo == null || resolveInfo.activityInfo.applicationInfo == null) {
           iterator.remove();
         } else {
           final int applicationFlags = resolveInfo.activityInfo.applicationInfo.flags;
-          if ((applicationFlags & ApplicationInfo.FLAG_SYSTEM) != ApplicationInfo.FLAG_SYSTEM) {
+          if (!isFlagSet(applicationFlags, ApplicationInfo.FLAG_SYSTEM)) {
             iterator.remove();
           }
         }
-      } else if (((flags & PackageManager.MATCH_DISABLED_COMPONENTS) != PackageManager.MATCH_DISABLED_COMPONENTS)
-          && isValidComponentInfo(resolveInfo.activityInfo)) {
-          ComponentName componentName = new ComponentName(
-              resolveInfo.activityInfo.applicationInfo.packageName,
-              resolveInfo.activityInfo.name);
-          if ((getComponentEnabledSetting(componentName)
-              & PackageManager.COMPONENT_ENABLED_STATE_DISABLED) != 0) {
-            iterator.remove();
-          }
+      } else if (!isFlagSet(flags, PackageManager.MATCH_DISABLED_COMPONENTS)
+          && resolveInfo != null && isValidComponentInfo(resolveInfo.activityInfo)) {
+        ComponentName componentName =
+            new ComponentName(
+                resolveInfo.activityInfo.applicationInfo.packageName,
+                resolveInfo.activityInfo.name);
+        if ((getComponentEnabledSetting(componentName)
+                & PackageManager.COMPONENT_ENABLED_STATE_DISABLED)
+            != 0) {
+          iterator.remove();
         }
       }
-
+    }
 
     return resolveInfoList;
   }


### PR DESCRIPTION
…s unless MATCH_DISABLED_COMPONENTS is specified.

Fixes #3748

This commit attempts to add this support while retaining backwards compatibilty wrt the quirks of the existing implementation.
