### PR TITLE
Rename setup_robolectric.bzl

### DIFF
--- a/bazel/robolectric.bzl
+++ b/bazel/robolectric.bzl
@@ -471,6 +471,6 @@ def robolectric_maven_dependencies():
     )
 
 
-def setup_robolectric():
+def robolectric_repositories():
     android_all_jars()
     robolectric_maven_dependencies()


### PR DESCRIPTION
Rename setup_robolectric.bzl to conform with other external repository file names

### Overview

### Proposed Changes
