### PR TITLE
Adding support for Paint.hasGlyph

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPaintTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPaintTest.java
@@ -1,5 +1,6 @@
 package org.robolectric.shadows;
 
+import static android.os.Build.VERSION_CODES.M;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -10,6 +11,7 @@ import android.graphics.Paint;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
 @RunWith(RobolectricTestRunner.class)
@@ -77,5 +79,18 @@ public class ShadowPaintTest {
   public void createPaintFromPaint() throws Exception {
     Paint origPaint = new Paint();
     assertThat(new Paint(origPaint).getTextLocale()).isSameAs(origPaint.getTextLocale());
+  }
+
+  @Test
+  @Config(minSdk = M)
+  public void hasGlyph() throws Exception {
+    Paint origPaint = new Paint();
+    assertThat(origPaint.hasGlyph("M")).isTrue();
+    assertThat(origPaint.hasGlyph("\uD83D\uDC75")).isTrue();
+    assertThat(origPaint.hasGlyph("text")).isTrue();
+
+    ShadowPaint shadowPaint = shadowOf(paint);
+    shadowPaint.addStringWithoutGlyph("\uD83D\uDC75");
+    assertThat(origPaint.hasGlyph("\uD83D\uDC75")).isFalse();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPaint.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPaint.java
@@ -7,6 +7,9 @@ import android.graphics.Paint;
 import android.graphics.PathEffect;
 import android.graphics.Shader;
 import android.graphics.Typeface;
+import android.os.Build;
+import java.util.HashSet;
+import java.util.Set;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -38,6 +41,8 @@ public class ShadowPaint {
   private Typeface typeface;
   private float textSize;
   private Paint.Align textAlign = Paint.Align.LEFT;
+
+  private final Set<String> stringsWithoutGlyph = new HashSet<>();
 
   @Implementation
   public void __constructor__(int flags) {
@@ -294,5 +299,14 @@ public class ShadowPaint {
   @Implementation
   public float measureText(char[] text, int index, int count) {
     return count;
+  }
+
+  @Implementation(minSdk = Build.VERSION_CODES.M)
+  public boolean hasGlyph(String string) {
+    return false;
+  }
+
+  public void addStringWithoutGlyph(String string) {
+    stringsWithoutGlyph.add(string);
   }
 }


### PR DESCRIPTION
### Overview
Support for `Paint.hasGlyph` which was introduced in Android M.

### Proposed Changes
hasGlyph should return `true` always unless the string-to-test is added to a `Set<String>` of unrenderable strings (which will be added to `ShadowPaint`).