### PR TITLE
activity rule launch intent fix

### DIFF
--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integration_tests/axt/ActivityTestRuleTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integration_tests/axt/ActivityTestRuleTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
@@ -120,6 +121,17 @@ public class ActivityTestRuleTest {
   public void launchActivity_bundle() {
     TranscriptActivity activity = rule.launchActivity(null);
     assertThat(activity.receivedBundle).isNull();
+  }
+
+  @Test public void launchActivity_intentExtras() {
+    Intent intent = new Intent();
+    intent.putExtra("Key", "Value");
+
+    TranscriptActivity activity = rule.launchActivity(intent);
+
+    Intent activityIntent = activity.getIntent();
+    assertThat(activityIntent.getExtras()).isNotNull();
+    assertThat(activityIntent.getStringExtra("Key")).isEqualTo("Value");
   }
 
   @Test

--- a/robolectric/src/main/java/org/robolectric/android/fakes/RoboMonitoringInstrumentation.java
+++ b/robolectric/src/main/java/org/robolectric/android/fakes/RoboMonitoringInstrumentation.java
@@ -34,7 +34,7 @@ public class RoboMonitoringInstrumentation extends MonitoringInstrumentation {
     ActivityInfo ai = intent.resolveActivityInfo(getTargetContext().getPackageManager(), 0);
     try {
       Class<? extends Activity> activityClass = Class.forName(ai.name).asSubclass(Activity.class);
-      ActivityController<? extends Activity> controller = Robolectric.buildActivity(activityClass);
+      ActivityController<? extends Activity> controller = Robolectric.buildActivity(activityClass, intent);
       Activity activity = controller.get();
       callActivityOnCreate(activity, null);
       controller.postCreate(null);


### PR DESCRIPTION
### Overview

Support for passing the Intent used when calling `ActivityTestRule.launchActivity` into the Activity that is created.

### Proposed Changes

Call to `Robolectric.buildActivity` should pass the Intent parameter in to the call.
