### PR TITLE
Remove protobuf-java dependency

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -47,7 +47,6 @@ java_library(
     "@com_almworks_sqlite4java_sqlite4java//jar",
     "@com_google_android_apps_common_testing_accessibility_framework_accessibility_test_framework//jar",
     "@com_google_guava_guava//jar",
-    "@com_google_protobuf_protobuf_java//jar",
     "@com_ibm_icu_icu4j//jar",
     "@com_thoughtworks_xstream_xstream//jar",
     "@junit_junit//jar",

--- a/bazel/robolectric.bzl
+++ b/bazel/robolectric.bzl
@@ -184,13 +184,6 @@ def robolectric_maven_dependencies():
     )
     
     native.maven_jar(
-        name = "com_google_protobuf_protobuf_java",
-        artifact = "com.google.protobuf:protobuf-java:2.6.1",
-        sha1 = "d9521f2aecb909835746b7a5facf612af5e890e8",
-        repository = "http://central.maven.org/maven2/",
-    )
-    
-    native.maven_jar(
         name = "com_ibm_icu_icu4j",
         artifact = "com.ibm.icu:icu4j:53.1",
         sha1 = "786d9055d4ca8c1aab4a7d4ac8283f973fd7e41f",

--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -50,7 +50,9 @@ dependencies {
     compile "com.almworks.sqlite4java:sqlite4java:0.282"
     compileOnly(AndroidSdk.MAX_SDK.coordinates) { force = true }
     compile "com.ibm.icu:icu4j:53.1"
-    compile "com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:2.1"
+    compile ("com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:2.1") {
+        exclude group: 'com.google.protobuf', module: 'protobuf-java'
+    }
 
     jni "com.github.axet.litedb:libsqlite:0.282-3:natives-mac-x86_64"
     jni "com.github.axet.litedb:libsqlite:0.282-3:natives-linux-x86"


### PR DESCRIPTION
### Overview
Robolectric has a protobuf-java dependency which conflicts with projects with grpc-lite or protobuf-lite dependencies.

Looks like we don't necessarily need protobuf-java in Robolectric. The other transitive dependency of protobuf-java comes from `com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:2.1`

### Proposed Changes
Remove protobuf-java from bazel files and exclude the dependency from `com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:2.1`.

### Possibly Related Issue
https://github.com/robolectric/robolectric/issues/2643