### PR TITLE
Add equals() and hashCode() to ShadowDisplay

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayTest.java
@@ -3,18 +3,22 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
 
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.hardware.display.DisplayManagerGlobal;
 import android.util.DisplayMetrics;
 import android.view.Display;
+import android.view.DisplayInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadow.api.Shadow;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(minSdk = JELLY_BEAN_MR1)
@@ -27,6 +31,32 @@ public class ShadowDisplayTest {
   public void setUp() throws Exception {
     display = DisplayManagerGlobal.getInstance().getRealDisplay(Display.DEFAULT_DISPLAY);
     shadow = Shadows.shadowOf(display);
+  }
+
+  @Test
+  public void testEquals() {
+    final DisplayManagerGlobal displayManagerGlobal = DisplayManagerGlobal.getInstance();
+    Display equalDisplay = displayManagerGlobal.getRealDisplay(Display.DEFAULT_DISPLAY);
+    assertNotSame(display, equalDisplay);
+    assertEquals(display, equalDisplay);
+
+    ShadowDisplayManagerGlobal shadow = Shadow.extract(displayManagerGlobal);
+    final int displayId = shadow.addDisplay(new DisplayInfo());
+    Display otherDisplay = displayManagerGlobal.getRealDisplay(displayId);
+    assertNotEquals(display, otherDisplay);
+  }
+
+  @Test
+  public void testHashCode() {
+    final DisplayManagerGlobal displayManagerGlobal = DisplayManagerGlobal.getInstance();
+    Display equalDisplay = displayManagerGlobal.getRealDisplay(Display.DEFAULT_DISPLAY);
+    assertNotSame(display, equalDisplay);
+    assertEquals(display.hashCode(), equalDisplay.hashCode());
+
+    ShadowDisplayManagerGlobal shadow = Shadow.extract(displayManagerGlobal);
+    final int displayId = shadow.addDisplay(new DisplayInfo());
+    Display otherDisplay = displayManagerGlobal.getRealDisplay(displayId);
+    assertNotEquals(display.hashCode(), otherDisplay.hashCode());
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplay.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplay.java
@@ -392,6 +392,16 @@ public class ShadowDisplay {
     }
   }
 
+  @Override
+  public boolean equals(Object object) {
+    return object instanceof Display && ((Display) object).getDisplayId() == getDisplayId();
+  }
+
+  @Override
+  public int hashCode() {
+    return getDisplayId();
+  }
+
   private boolean isJB() {
     return RuntimeEnvironment.getApiLevel() == JELLY_BEAN;
   }


### PR DESCRIPTION
`ShadowWindowManagerImpl` uses `Display` as a key in a multimap of views. The `Display` class, however, doesn't implement `hashCode()`, and `getDefaultDisplay()` returns a new instance of `Display` in each call. As a result, adding views to views always creates a new key, and looking up views doesn't work at all.

This patch adds `equals()` and `hashCode()` to `ShadowDisplay` and fixes #3932.
