### PR TITLE
Allow authentication to custom maven repo.

### DIFF
--- a/resources/src/main/java/org/robolectric/RoboSettings.java
+++ b/resources/src/main/java/org/robolectric/RoboSettings.java
@@ -7,11 +7,15 @@ public class RoboSettings {
 
   private static String mavenRepositoryId;
   private static String mavenRepositoryUrl;
+  private static String mavenRepositoryUserName;
+  private static String mavenRepositoryPassword;
   private static boolean useGlobalScheduler;
 
   static {
     mavenRepositoryId = System.getProperty("robolectric.dependency.repo.id", "sonatype");
     mavenRepositoryUrl = System.getProperty("robolectric.dependency.repo.url", "https://oss.sonatype.org/content/groups/public/");
+    mavenRepositoryUserName = System.getProperty("robolectric.dependency.repo.username");
+    mavenRepositoryPassword = System.getProperty("robolectric.dependency.repo.password");
     useGlobalScheduler = Boolean.getBoolean("robolectric.scheduling.global");
   }
 
@@ -29,6 +33,22 @@ public class RoboSettings {
 
   public static void setMavenRepositoryUrl(String mavenRepositoryUrl) {
     RoboSettings.mavenRepositoryUrl = mavenRepositoryUrl;
+  }
+
+  public static String getMavenRepositoryUserName() {
+    return mavenRepositoryUserName;
+  }
+
+  public static void setMavenRepositoryUserName(String mavenRepositoryUserName) {
+    RoboSettings.mavenRepositoryUserName = mavenRepositoryUserName;
+  }
+
+  public static String getMavenRepositoryPassword() {
+    return mavenRepositoryPassword;
+  }
+
+  public static void setMavenRepositoryPassword(String mavenRepositoryPassword) {
+    RoboSettings.mavenRepositoryPassword = mavenRepositoryPassword;
   }
 
   public static boolean isUseGlobalScheduler() {

--- a/resources/src/test/java/org/robolectric/RoboSettingsTest.java
+++ b/resources/src/test/java/org/robolectric/RoboSettingsTest.java
@@ -15,12 +15,16 @@ public class RoboSettingsTest {
 
   private String originalMavenRepositoryId;
   private String originalMavenRepositoryUrl;
+  private String originalMavenRepositoryUserName;
+  private String originalMavenRepositoryPassword;
   private boolean originalUseGlobalScheduler;
 
   @Before
   public void setUp() {
     originalMavenRepositoryId = RoboSettings.getMavenRepositoryId();
     originalMavenRepositoryUrl = RoboSettings.getMavenRepositoryUrl();
+    originalMavenRepositoryUserName = RoboSettings.getMavenRepositoryUserName();
+    originalMavenRepositoryPassword = RoboSettings.getMavenRepositoryPassword();
     originalUseGlobalScheduler = RoboSettings.isUseGlobalScheduler();
   }
 
@@ -28,6 +32,8 @@ public class RoboSettingsTest {
   public void tearDown() {
     RoboSettings.setMavenRepositoryId(originalMavenRepositoryId);
     RoboSettings.setMavenRepositoryUrl(originalMavenRepositoryUrl);
+    RoboSettings.setMavenRepositoryUserName(originalMavenRepositoryUserName);
+    RoboSettings.setMavenRepositoryPassword(originalMavenRepositoryPassword);
     RoboSettings.setUseGlobalScheduler(originalUseGlobalScheduler);
   }
 
@@ -51,6 +57,18 @@ public class RoboSettingsTest {
   public void setMavenRepositoryUrl() {
     RoboSettings.setMavenRepositoryUrl("http://local");
     assertEquals("http://local", RoboSettings.getMavenRepositoryUrl());
+  }
+
+  @Test
+  public void setMavenRepositoryUserName() {
+    RoboSettings.setMavenRepositoryUserName("username");
+    assertEquals("username", RoboSettings.getMavenRepositoryUserName());
+  }
+
+  @Test
+  public void setMavenRepositoryPassword() {
+    RoboSettings.setMavenRepositoryPassword("password");
+    assertEquals("password", RoboSettings.getMavenRepositoryPassword());
   }
 
   @Test

--- a/robolectric/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
@@ -3,6 +3,8 @@ package org.robolectric.internal.dependency;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Hashtable;
+
+import org.apache.maven.artifact.ant.Authentication;
 import org.apache.maven.artifact.ant.DependenciesTask;
 import org.apache.maven.artifact.ant.RemoteRepository;
 import org.apache.maven.model.Dependency;
@@ -14,14 +16,18 @@ public class MavenDependencyResolver implements DependencyResolver {
   private final Project project = new Project();
   private final String repositoryUrl;
   private final String repositoryId;
+  private final String repositoryUserName;
+  private final String repositoryPassword;
 
   public MavenDependencyResolver() {
-    this(RoboSettings.getMavenRepositoryUrl(), RoboSettings.getMavenRepositoryId());
+    this(RoboSettings.getMavenRepositoryUrl(), RoboSettings.getMavenRepositoryId(), RoboSettings.getMavenRepositoryUserName(), RoboSettings.getMavenRepositoryPassword());
   }
 
-  public MavenDependencyResolver(String repositoryUrl, String repositoryId) {
+  public MavenDependencyResolver(String repositoryUrl, String repositoryId, String repositoryUserName, String repositoryPassword) {
     this.repositoryUrl = repositoryUrl;
     this.repositoryId = repositoryId;
+    this.repositoryUserName = repositoryUserName;
+    this.repositoryPassword = repositoryPassword;
   }
 
   @Override
@@ -39,6 +45,12 @@ public class MavenDependencyResolver implements DependencyResolver {
     RemoteRepository remoteRepository = new RemoteRepository();
     remoteRepository.setUrl(repositoryUrl);
     remoteRepository.setId(repositoryId);
+    if (repositoryUserName != null || repositoryPassword != null) {
+      Authentication authentication = new Authentication();
+      authentication.setUserName(repositoryUserName);
+      authentication.setPassword(repositoryPassword);
+      remoteRepository.addAuthentication(authentication);
+    }
     dependenciesTask.addConfiguredRemoteRepository(remoteRepository);
     dependenciesTask.setProject(project);
     for (DependencyJar dependencyJar : dependencies) {

--- a/robolectric/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
@@ -28,6 +28,10 @@ public class MavenDependencyResolverTest {
 
   private static final String REPOSITORY_ID = "remote";
 
+  private static final String REPOSITORY_USERNAME = "username";
+
+  private static final String REPOSITORY_PASSWORD = "password";
+
   private DependenciesTask dependenciesTask;
 
   private Project project;
@@ -114,7 +118,7 @@ public class MavenDependencyResolverTest {
   }
 
   private DependencyResolver createResolver() {
-    return new MavenDependencyResolver(REPOSITORY_URL, REPOSITORY_ID) {
+    return new MavenDependencyResolver(REPOSITORY_URL, REPOSITORY_ID, REPOSITORY_USERNAME, REPOSITORY_PASSWORD) {
       @Override
       protected DependenciesTask createDependenciesTask() {
         return dependenciesTask;


### PR DESCRIPTION
Add properties robolectric.dependency.repo.username and
robolectric.dependency.repo.password to allow setting authentication
when using a custom repo url.
