### PR TITLE
Fix ShadowNotification's getContentTitle and getContentText methods for SDK >= N

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
@@ -12,6 +12,10 @@ import android.app.PendingIntent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.Icon;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.Spanned;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
@@ -172,6 +176,34 @@ public class ShadowNotificationBuilderTest {
     Notification notification = builder.setContentInfo(null).build();
 
     assertThat(shadowOf(notification).getContentInfo()).isNull();
+  }
+
+  @Test @Config(maxSdk = M)
+  public void build_handlesNonStringContentText() {
+    Notification notification = builder.setContentText(new SpannableString("Hello")).build();
+
+    assertThat(shadowOf(notification).getContentText().toString()).isEqualTo("Hello");
+  }
+
+  @Test @Config(minSdk = N)
+  public void build_handlesNonStringContentText_atLeastN() {
+    Notification notification = builder.setContentText(new SpannableString("Hello")).build();
+
+    assertThat(shadowOf(notification).getContentText().toString()).isEqualTo("Hello");
+  }
+
+  @Test @Config(maxSdk = M)
+  public void build_handlesNonStringContentTitle() {
+    Notification notification = builder.setContentText(new SpannableString("My Title")).build();
+
+    assertThat(shadowOf(notification).getContentText().toString()).isEqualTo("My Title");
+  }
+
+  @Test @Config(minSdk = N)
+  public void build_handlesNonStringContentTitle_atLeastN() {
+    Notification notification = builder.setContentTitle(new SpannableString("My Title")).build();
+
+    assertThat(shadowOf(notification).getContentTitle().toString()).isEqualTo("My Title");
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTest.java
@@ -12,9 +12,7 @@ import android.app.PendingIntent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.Icon;
-import android.text.Spannable;
 import android.text.SpannableString;
-import android.text.Spanned;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
@@ -30,13 +30,13 @@ public class ShadowNotification {
 
   public CharSequence getContentTitle() {
     return RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.N
-        ? realNotification.extras.getString(Notification.EXTRA_TITLE)
+        ? realNotification.extras.getCharSequence(Notification.EXTRA_TITLE)
         : findText(applyContentView(), "title");
   }
 
   public CharSequence getContentText() {
     return RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.N
-        ? realNotification.extras.getString(Notification.EXTRA_TEXT)
+        ? realNotification.extras.getCharSequence(Notification.EXTRA_TEXT)
         : findText(applyContentView(), "text");
   }
 


### PR DESCRIPTION
### Overview
On the Android Notifcation.Builder object, you can use any subclass of CharSequence (which includes Android classes such as Spanned/Spannables). However, because in the ShadowNotification methods getContentTitle, and getContentText use the getString method to retrieve what's been set on the notification, we can't test to verify that a given notification has been set if the content title or content text weren't set as Strings.

### Proposed Changes
replace the getString methods in the aforementioned methods with the getCharSequence method that is used for every other get* method.