### PR TITLE
Change @Implementation methods to be protected rather than public.

### DIFF
--- a/errorprone/src/test/java/org/robolectric/errorprone/bugpatterns/ShadowUsageCheckTest.java
+++ b/errorprone/src/test/java/org/robolectric/errorprone/bugpatterns/ShadowUsageCheckTest.java
@@ -753,7 +753,7 @@ public class ShadowUsageCheckTest {
             "  }",
             "",
             "  boolean moreTasks() {",
-            "    return theShadowLooper.getScheduler().areAnyRunnable();",
+            "    return theShadowLooper.getSchedule().isEmpty();",
             "  }",
             "}")
         .addOutputLines(
@@ -771,7 +771,7 @@ public class ShadowUsageCheckTest {
             "  }",
             "",
             "  boolean moreTasks() {",
-            "    return shadowOf(looper).getScheduler().areAnyRunnable();",
+            "    return shadowOf(looper).getSchedule().isEmpty();",
             "  }",
             "}")
         .doTest();

--- a/errorprone/src/test/java/org/robolectric/errorprone/bugpatterns/ShadowUsageCheckTest.java
+++ b/errorprone/src/test/java/org/robolectric/errorprone/bugpatterns/ShadowUsageCheckTest.java
@@ -27,19 +27,19 @@ public class ShadowUsageCheckTest {
             "in/SomeTest.java",
             "import android.os.Looper;",
             "import org.junit.Test;",
-            "import org.robolectric.shadows.ShadowLooper;",
+            "import xxx.XShadowLooper;",
             "",
             "public class SomeTest {",
             "  @Test void theTest() {",
             "    Looper.getMainLooper();",
-            "    ShadowLooper.getMainLooper();",
+            "    XShadowLooper.getMainLooper();",
             "  }",
             "}")
         .addOutputLines(
             "in/SomeTest.java",
             "import android.os.Looper;",
             "import org.junit.Test;",
-            "import org.robolectric.shadows.ShadowLooper;", // removable
+            "import xxx.XShadowLooper;", // removable
             "",
             "public class SomeTest {",
             "  @Test void theTest() {",
@@ -563,35 +563,35 @@ public class ShadowUsageCheckTest {
     testHelper
         .addInputLines(
             "in/SomeTest.java",
-            "import static org.robolectric.Shadows.shadowOf;",
+            "import static xxx.XShadows.shadowOf;",
             "",
             "import android.os.Looper;",
             "import org.junit.Before;",
             "import org.junit.Test;",
             "import org.robolectric.RuntimeEnvironment;",
-            "import org.robolectric.shadows.ShadowLooper;",
+            "import xxx.XShadowLooper;",
             "",
             "public class SomeTest {",
-            "  private ShadowLooper shadowLooper;",
+            "  private XShadowLooper XShadowLooper;",
             "",
             "  @Before void setUp() {",
             "    Looper looper = RuntimeEnvironment.application.getMainLooper();",
-            "    shadowLooper = shadowOf(looper);",
+            "    XShadowLooper = shadowOf(looper);",
             "  }",
             "",
             "  @Test void theTest() {",
-            "    shadowLooper.runToEndOfTasks();",
+            "    XShadowLooper.runToEndOfTasks();",
             "  }",
             "}")
         .addOutputLines(
             "out/SomeTest.java",
-            "import static org.robolectric.Shadows.shadowOf;",
+            "import static xxx.XShadows.shadowOf;",
             "",
             "import android.os.Looper;",
             "import org.junit.Before;",
             "import org.junit.Test;",
             "import org.robolectric.RuntimeEnvironment;",
-            "import org.robolectric.shadows.ShadowLooper;",
+            "import xxx.XShadowLooper;",
             "",
             "public class SomeTest {",
             "  private Looper looper;",
@@ -740,13 +740,13 @@ public class ShadowUsageCheckTest {
     testHelper
         .addInputLines(
             "in/SomeTestHelper.java",
-            "import static org.robolectric.Shadows.shadowOf;",
+            "import static xxx.XShadows.shadowOf;",
             "",
             "import android.os.Looper;",
-            "import org.robolectric.shadows.ShadowLooper;",
+            "import xxx.XShadowLooper;",
             "",
             "public class SomeTestHelper {",
-            "  private final ShadowLooper theShadowLooper;",
+            "  private final XShadowLooper theShadowLooper;",
             "",
             "  SomeTestHelper(Looper looper) {",
             "    this.theShadowLooper = shadowOf(looper);",
@@ -758,10 +758,10 @@ public class ShadowUsageCheckTest {
             "}")
         .addOutputLines(
             "in/SomeTestHelper.java",
-            "import static org.robolectric.Shadows.shadowOf;",
+            "import static xxx.XShadows.shadowOf;",
             "",
             "import android.os.Looper;",
-            "import org.robolectric.shadows.ShadowLooper;",
+            "import xxx.XShadowLooper;",
             "",
             "public class SomeTestHelper {",
             "  private final Looper looper;",
@@ -782,36 +782,36 @@ public class ShadowUsageCheckTest {
     testHelper
         .addInputLines(
             "in/SomeTest.java",
-            "import static org.robolectric.Shadows.shadowOf;",
+            "import static xxx.XShadows.shadowOf;",
             "",
             "import android.content.Context;",
             "import android.net.ConnectivityManager;",
             "import android.net.NetworkInfo;",
             "import org.junit.Test;",
             "import org.robolectric.RuntimeEnvironment;",
-            "import org.robolectric.shadows.ShadowConnectivityManager;",
-            "import org.robolectric.shadows.ShadowNetworkInfo;",
+            "import xxx.XShadowConnectivityManager;",
+            "import xxx.XShadowNetworkInfo;",
             "",
             "public class SomeTest {",
             "  @Test void theTest() {",
-            "    ShadowConnectivityManager shadowConnectivityManager =",
+            "    XShadowConnectivityManager shadowConnectivityManager =",
             "        shadowOf((ConnectivityManager) RuntimeEnvironment.application.getSystemService(Context.CONNECTIVITY_SERVICE));",
-            "    ShadowNetworkInfo shadowActiveNetworkInfo =",
+            "    XShadowNetworkInfo shadowActiveNetworkInfo =",
             "        shadowOf(shadowConnectivityManager.getActiveNetworkInfo());",
             "    shadowActiveNetworkInfo.setConnectionType(ConnectivityManager.TYPE_MOBILE);",
             "  }",
             "}")
         .addOutputLines(
             "out/SomeTest.java",
-            "import static org.robolectric.Shadows.shadowOf;",
+            "import static xxx.XShadows.shadowOf;",
             "",
             "import android.content.Context;",
             "import android.net.ConnectivityManager;",
             "import android.net.NetworkInfo;",
             "import org.junit.Test;",
             "import org.robolectric.RuntimeEnvironment;",
-            "import org.robolectric.shadows.ShadowConnectivityManager;",
-            "import org.robolectric.shadows.ShadowNetworkInfo;",
+            "import xxx.XShadowConnectivityManager;",
+            "import xxx.XShadowNetworkInfo;",
             "",
             "public class SomeTest {",
             "  @Test void theTest() {",
@@ -911,13 +911,13 @@ public class ShadowUsageCheckTest {
             "import android.os.Looper;",
             "import org.robolectric.annotation.Implementation;",
             "import org.robolectric.annotation.Implements;",
-            "import org.robolectric.shadows.ShadowLooper;",
+            "import xxx.XShadowLooper;",
             "",
             "@Implements(Looper.class)",
-            "public class SomeShadow extends ShadowLooper {",
+            "public class SomeShadow extends XShadowLooper {",
             "  @Implementation",
             "  public static Looper getMainLooper() {",
-            "    return ShadowLooper.getMainLooper();",
+            "    return XShadowLooper.getMainLooper();",
             "  }",
             "}")
         .addOutputLines(
@@ -925,13 +925,13 @@ public class ShadowUsageCheckTest {
             "import android.os.Looper;",
             "import org.robolectric.annotation.Implementation;",
             "import org.robolectric.annotation.Implements;",
-            "import org.robolectric.shadows.ShadowLooper;",
+            "import xxx.XShadowLooper;",
             "",
             "@Implements(Looper.class)",
-            "public class SomeShadow extends ShadowLooper {",
+            "public class SomeShadow extends XShadowLooper {",
             "  @Implementation",
             "  public static Looper getMainLooper() {",
-            "    return ShadowLooper.getMainLooper();",
+            "    return XShadowLooper.getMainLooper();",
             "  }",
             "}")
         .doTest();
@@ -1269,7 +1269,7 @@ public class ShadowUsageCheckTest {
   @Test
   @Ignore
   public void handleStaticMethodRefs() throws IOException {
-    // shadowLooper::idle -> looper::idle
+    // XShadowLooper::idle -> looper::idle
   }
 
   @Test

--- a/errorprone/src/test/java/xxx/XShadowConnectivityManager.java
+++ b/errorprone/src/test/java/xxx/XShadowConnectivityManager.java
@@ -1,0 +1,17 @@
+package xxx;
+
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Fake shadow for testing {@link org.robolectric.errorprone.bugpatterns.DeprecatedMethodsCheck}.
+ */
+@Implements(ConnectivityManager.class)
+public class XShadowConnectivityManager {
+  @Implementation
+  public NetworkInfo getActiveNetworkInfo() {
+    return null;
+  }
+}

--- a/errorprone/src/test/java/xxx/XShadowLooper.java
+++ b/errorprone/src/test/java/xxx/XShadowLooper.java
@@ -3,7 +3,6 @@ package xxx;
 import android.os.Looper;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
-import org.robolectric.util.Scheduler;
 
 /**
  * Fake shadow for testing {@link org.robolectric.errorprone.bugpatterns.DeprecatedMethodsCheck}.
@@ -15,7 +14,7 @@ public class XShadowLooper {
     return null;
   }
 
-  public Scheduler getScheduler() {
+  public String getSchedule() {
     return null;
   }
 

--- a/errorprone/src/test/java/xxx/XShadowLooper.java
+++ b/errorprone/src/test/java/xxx/XShadowLooper.java
@@ -1,0 +1,24 @@
+package xxx;
+
+import android.os.Looper;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.util.Scheduler;
+
+/**
+ * Fake shadow for testing {@link org.robolectric.errorprone.bugpatterns.DeprecatedMethodsCheck}.
+ */
+@Implements(Looper.class)
+public class XShadowLooper {
+  @Implementation
+  public static Looper getMainLooper() {
+    return null;
+  }
+
+  public Scheduler getScheduler() {
+    return null;
+  }
+
+  public void runToEndOfTasks() {
+  }
+}

--- a/errorprone/src/test/java/xxx/XShadowNetworkInfo.java
+++ b/errorprone/src/test/java/xxx/XShadowNetworkInfo.java
@@ -1,0 +1,13 @@
+package xxx;
+
+import android.net.ConnectivityManager;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Fake shadow for testing {@link org.robolectric.errorprone.bugpatterns.DeprecatedMethodsCheck}.
+ */
+@Implements(ConnectivityManager.class)
+public class XShadowNetworkInfo {
+  public void setConnectionType(int connectionType) {
+  }
+}

--- a/errorprone/src/test/java/xxx/XShadows.java
+++ b/errorprone/src/test/java/xxx/XShadows.java
@@ -2,6 +2,9 @@ package xxx;
 
 import android.app.Application;
 import android.graphics.drawable.Drawable;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.os.Looper;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 
@@ -14,15 +17,27 @@ public class XShadows implements org.robolectric.internal.ShadowProvider {
     return null;
   }
 
+  public static XShadowConnectivityManager shadowOf(ConnectivityManager actual) {
+    return null;
+  }
+
   public static XShadowDrawable shadowOf(Drawable actual) {
     return null;
   }
 
-  public static XShadowViewGroup shadowOf(ViewGroup actual) {
+  public static XShadowLooper shadowOf(Looper actual) {
     return null;
   }
 
   public static XShadowLinearLayout shadowOf(LinearLayout actual) {
+    return null;
+  }
+
+  public static XShadowNetworkInfo shadowOf(NetworkInfo actual) {
+    return null;
+  }
+
+  public static XShadowViewGroup shadowOf(ViewGroup actual) {
     return null;
   }
 

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
@@ -209,6 +209,7 @@ public class ShadowWrangler implements ClassHandler {
         return DO_NOTHING;
       }
 
+      shadowMethod.setAccessible(true);
       MethodHandle mh = LOOKUP.unreflect(shadowMethod);
 
       // Robolectric doesn't actually look for static, this for example happens

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAbsListView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAbsListView.java
@@ -12,17 +12,17 @@ public class ShadowAbsListView extends ShadowAdapterView {
   private int lastSmoothScrollByDuration;
 
   @Implementation
-  public void setOnScrollListener(AbsListView.OnScrollListener l) {
+  protected void setOnScrollListener(AbsListView.OnScrollListener l) {
     onScrollListener = l;
   }
 
   @Implementation
-  public void smoothScrollToPosition(int position) {
+  protected void smoothScrollToPosition(int position) {
     smoothScrolledPosition = position;
   }
 
   @Implementation
-  public void smoothScrollBy(int distance, int duration) {
+  protected void smoothScrollBy(int distance, int duration) {
     this.lastSmoothScrollByDistance = distance;
     this.lastSmoothScrollByDuration = duration;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAbsSpinner.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAbsSpinner.java
@@ -16,13 +16,13 @@ public class ShadowAbsSpinner extends ShadowAdapterView {
   private boolean animatedTransition;
 
   @Implementation
-  public void setSelection(int position, boolean animate) {
+  protected void setSelection(int position, boolean animate) {
     directlyOn(realAbsSpinner, AbsSpinner.class, "setSelection", ClassParameter.from(int.class, position), ClassParameter.from(boolean.class, animate));
     animatedTransition = animate;
   }
 
   @Implementation
-  public void setSelection(int position) {
+  protected void setSelection(int position) {
     directlyOn(realAbsSpinner, AbsSpinner.class, "setSelection", ClassParameter.from(int.class, position));
     SpinnerAdapter adapter = realAbsSpinner.getAdapter();
     if (getItemSelectedListener() != null && adapter != null) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
@@ -71,17 +71,19 @@ public class ShadowAccessibilityManager {
   }
 
   @Implementation
-  public boolean addAccessibilityStateChangeListener(AccessibilityManager.AccessibilityStateChangeListener listener) {
+  protected boolean addAccessibilityStateChangeListener(
+      AccessibilityManager.AccessibilityStateChangeListener listener) {
     return true;
   }
 
   @Implementation
-  public boolean removeAccessibilityStateChangeListener(AccessibilityManager.AccessibilityStateChangeListener listener) {
+  protected boolean removeAccessibilityStateChangeListener(
+      AccessibilityManager.AccessibilityStateChangeListener listener) {
     return true;
   }
 
   @Implementation
-  public List<ServiceInfo> getAccessibilityServiceList () {
+  protected List<ServiceInfo> getAccessibilityServiceList() {
     return accessibilityServiceList;
   }
 
@@ -90,7 +92,8 @@ public class ShadowAccessibilityManager {
   }
 
   @Implementation
-  public List<AccessibilityServiceInfo> getEnabledAccessibilityServiceList (int feedbackTypeFlags) {
+  protected List<AccessibilityServiceInfo> getEnabledAccessibilityServiceList(
+      int feedbackTypeFlags) {
     return enabledAccessibilityServiceList;
   }
 
@@ -99,7 +102,7 @@ public class ShadowAccessibilityManager {
   }
 
   @Implementation
-  public List<AccessibilityServiceInfo> getInstalledAccessibilityServiceList () {
+  protected List<AccessibilityServiceInfo> getInstalledAccessibilityServiceList() {
     return installedAccessibilityServiceList;
   }
 
@@ -108,7 +111,7 @@ public class ShadowAccessibilityManager {
   }
 
   @Implementation
-  public boolean isEnabled () {
+  protected boolean isEnabled() {
     return enabled;
   }
 
@@ -118,7 +121,7 @@ public class ShadowAccessibilityManager {
   }
 
   @Implementation
-  public boolean isTouchExplorationEnabled () {
+  protected boolean isTouchExplorationEnabled() {
     return touchExplorationEnabled;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java
@@ -184,12 +184,12 @@ public class ShadowAccessibilityNodeInfo {
   private AccessibilityNodeInfo realAccessibilityNodeInfo;
 
   @Implementation
-  public void __constructor__() {
+  protected void __constructor__() {
     ReflectionHelpers.setStaticField(AccessibilityNodeInfo.class, "CREATOR", ShadowAccessibilityNodeInfo.CREATOR);
   }
 
   @Implementation
-  public static AccessibilityNodeInfo obtain(AccessibilityNodeInfo info) {
+  protected static AccessibilityNodeInfo obtain(AccessibilityNodeInfo info) {
     final ShadowAccessibilityNodeInfo shadowInfo = Shadow.extract(info);
     final AccessibilityNodeInfo obtainedInstance = shadowInfo.getClone();
 
@@ -204,7 +204,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public static AccessibilityNodeInfo obtain(View view) {
+  protected static AccessibilityNodeInfo obtain(View view) {
     // We explicitly avoid allocating the AccessibilityNodeInfo from the actual pool by using the
     // private constructor. Not doing so affects test suites which use both shadow and
     // non-shadow objects.
@@ -235,12 +235,12 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public static AccessibilityNodeInfo obtain() {
+  protected static AccessibilityNodeInfo obtain() {
     return obtain(new View(RuntimeEnvironment.application.getApplicationContext()));
   }
 
   @Implementation
-  public static AccessibilityNodeInfo obtain(View root, int virtualDescendantId) {
+  protected static AccessibilityNodeInfo obtain(View root, int virtualDescendantId) {
     AccessibilityNodeInfo node = obtain(root);
     return node;
   }
@@ -281,7 +281,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public void recycle() {
+  protected void recycle() {
     final StrictEqualityNodeWrapper wrapper =
         new StrictEqualityNodeWrapper(realAccessibilityNodeInfo);
     if (!obtainedInstances.containsKey(wrapper)) {
@@ -318,7 +318,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public int getChildCount() {
+  protected int getChildCount() {
     if (children == null) {
       return 0;
     }
@@ -327,7 +327,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public AccessibilityNodeInfo getChild(int index) {
+  protected AccessibilityNodeInfo getChild(int index) {
     if (children == null) {
       return null;
     }
@@ -341,7 +341,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public AccessibilityNodeInfo getParent() {
+  protected AccessibilityNodeInfo getParent() {
     if (parent == null) {
       return null;
     }
@@ -350,7 +350,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public boolean refresh() {
+  protected boolean refresh() {
       return refreshReturnValue;
   }
 
@@ -359,32 +359,32 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public boolean isClickable() {
+  protected boolean isClickable() {
     return ((propertyFlags & CLICKABLE_MASK) != 0);
   }
 
   @Implementation
-  public boolean isLongClickable() {
+  protected boolean isLongClickable() {
     return ((propertyFlags & LONGCLICKABLE_MASK) != 0);
   }
 
   @Implementation
-  public boolean isFocusable() {
+  protected boolean isFocusable() {
     return ((propertyFlags & FOCUSABLE_MASK) != 0);
   }
 
   @Implementation
-  public boolean isFocused() {
+  protected boolean isFocused() {
     return ((propertyFlags & FOCUSED_MASK) != 0);
   }
 
   @Implementation
-  public boolean isVisibleToUser() {
+  protected boolean isVisibleToUser() {
     return ((propertyFlags & VISIBLE_TO_USER_MASK) != 0);
   }
 
   @Implementation
-  public boolean isScrollable() {
+  protected boolean isScrollable() {
     return ((propertyFlags & SCROLLABLE_MASK) != 0);
   }
 
@@ -393,7 +393,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public boolean isEditable() {
+  protected boolean isEditable() {
     return ((propertyFlags & EDITABLE_MASK) != 0);
   }
 
@@ -402,112 +402,112 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public boolean isCheckable() {
+  protected boolean isCheckable() {
     return ((propertyFlags & CHECKABLE_MASK) != 0);
   }
 
   @Implementation
-  public void setCheckable(boolean checkable) {
+  protected void setCheckable(boolean checkable) {
     propertyFlags = (propertyFlags & ~CHECKABLE_MASK) |
         (checkable ? CHECKABLE_MASK : 0);
   }
 
   @Implementation
-  public void setChecked(boolean checked) {
+  protected void setChecked(boolean checked) {
     propertyFlags = (propertyFlags & ~CHECKED_MASK) |
         (checked ? CHECKED_MASK : 0);
   }
 
   @Implementation
-  public boolean isChecked() {
+  protected boolean isChecked() {
     return ((propertyFlags & CHECKED_MASK) != 0);
   }
 
   @Implementation
-  public void setEnabled(boolean enabled) {
+  protected void setEnabled(boolean enabled) {
     propertyFlags = (propertyFlags & ~ENABLED_MASK) |
         (enabled ? ENABLED_MASK : 0);
   }
 
   @Implementation
-  public boolean isEnabled() {
+  protected boolean isEnabled() {
     return ((propertyFlags & ENABLED_MASK) != 0);
   }
 
   @Implementation
-  public void setPassword(boolean password) {
+  protected void setPassword(boolean password) {
     propertyFlags = (propertyFlags & ~PASSWORD_MASK) |
         (password ? PASSWORD_MASK : 0);
   }
 
   @Implementation
-  public boolean isPassword() {
+  protected boolean isPassword() {
     return ((propertyFlags & PASSWORD_MASK) != 0);
   }
 
   @Implementation
-  public void setSelected(boolean selected) {
+  protected void setSelected(boolean selected) {
     propertyFlags = (propertyFlags & ~SELECTED_MASK) |
         (selected ? SELECTED_MASK : 0);
   }
 
   @Implementation
-  public boolean isSelected() {
+  protected boolean isSelected() {
     return ((propertyFlags & SELECTED_MASK) != 0);
   }
 
   @Implementation
-  public void setAccessibilityFocused(boolean focused) {
+  protected void setAccessibilityFocused(boolean focused) {
     propertyFlags = (propertyFlags & ~A11YFOCUSED_MASK) |
         (focused ? A11YFOCUSED_MASK : 0);
   }
 
   @Implementation
-  public boolean isAccessibilityFocused() {
+  protected boolean isAccessibilityFocused() {
     return ((propertyFlags & A11YFOCUSED_MASK) != 0);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void setMultiLine(boolean multiLine) {
+  protected void setMultiLine(boolean multiLine) {
     propertyFlags = (propertyFlags & ~MULTILINE_MASK) |
         (multiLine ? MULTILINE_MASK : 0);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean isMultiLine() {
+  protected boolean isMultiLine() {
     return ((propertyFlags & MULTILINE_MASK) != 0);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void setContentInvalid(boolean contentInvalid) {
+  protected void setContentInvalid(boolean contentInvalid) {
     propertyFlags = (propertyFlags & ~CONTENT_INVALID_MASK) |
         (contentInvalid ? CONTENT_INVALID_MASK : 0);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean isContentInvalid() {
+  protected boolean isContentInvalid() {
     return ((propertyFlags & CONTENT_INVALID_MASK) != 0);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void setDismissable(boolean dismissable) {
+  protected void setDismissable(boolean dismissable) {
     propertyFlags = (propertyFlags & ~DISMISSABLE_MASK) |
         (dismissable ? DISMISSABLE_MASK : 0);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean isDismissable() {
+  protected boolean isDismissable() {
     return ((propertyFlags & DISMISSABLE_MASK) != 0);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void setCanOpenPopup(boolean opensPopup) {
+  protected void setCanOpenPopup(boolean opensPopup) {
     propertyFlags = (propertyFlags & ~CAN_OPEN_POPUP_MASK) |
         (opensPopup ? CAN_OPEN_POPUP_MASK : 0);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean canOpenPopup() {
+  protected boolean canOpenPopup() {
     return ((propertyFlags & CAN_OPEN_POPUP_MASK) != 0);
   }
 
@@ -517,28 +517,28 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public void setClickable(boolean isClickable) {
+  protected void setClickable(boolean isClickable) {
     propertyFlags = (propertyFlags & ~CLICKABLE_MASK) | (isClickable ? CLICKABLE_MASK : 0);
   }
 
   @Implementation
-  public void setLongClickable(boolean isLongClickable) {
+  protected void setLongClickable(boolean isLongClickable) {
     propertyFlags =
         (propertyFlags & ~LONGCLICKABLE_MASK) | (isLongClickable ? LONGCLICKABLE_MASK : 0);
   }
 
   @Implementation
-  public void setFocusable(boolean isFocusable) {
+  protected void setFocusable(boolean isFocusable) {
     propertyFlags = (propertyFlags & ~FOCUSABLE_MASK) | (isFocusable ? FOCUSABLE_MASK : 0);
   }
 
   @Implementation
-  public void setFocused(boolean isFocused) {
+  protected void setFocused(boolean isFocused) {
     propertyFlags = (propertyFlags & ~FOCUSED_MASK) | (isFocused ? FOCUSED_MASK : 0);
   }
 
   @Implementation
-  public void setScrollable(boolean isScrollable) {
+  protected void setScrollable(boolean isScrollable) {
     propertyFlags = (propertyFlags & ~SCROLLABLE_MASK) | (isScrollable ? SCROLLABLE_MASK : 0);
   }
 
@@ -547,48 +547,48 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public void setEditable(boolean isEditable) {
+  protected void setEditable(boolean isEditable) {
     propertyFlags = (propertyFlags & ~EDITABLE_MASK) | (isEditable ? EDITABLE_MASK : 0);
   }
 
   @Implementation
-  public void setVisibleToUser(boolean isVisibleToUser) {
+  protected void setVisibleToUser(boolean isVisibleToUser) {
     propertyFlags =
         (propertyFlags & ~VISIBLE_TO_USER_MASK) | (isVisibleToUser ? VISIBLE_TO_USER_MASK : 0);
   }
 
   @Implementation
-  public void setContentDescription(CharSequence description) {
+  protected void setContentDescription(CharSequence description) {
     contentDescription = description;
   }
 
   @Implementation
-  public CharSequence getContentDescription() {
+  protected CharSequence getContentDescription() {
     return contentDescription;
   }
 
   @Implementation
-  public void setClassName(CharSequence name) {
+  protected void setClassName(CharSequence name) {
     className = name;
   }
 
   @Implementation
-  public CharSequence getClassName() {
+  protected CharSequence getClassName() {
     return className;
   }
 
   @Implementation
-  public void setText(CharSequence t) {
+  protected void setText(CharSequence t) {
     text = t;
   }
 
   @Implementation
-  public CharSequence getText() {
+  protected CharSequence getText() {
     return text;
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public void setTextSelection(int start, int end) {
+  protected void setTextSelection(int start, int end) {
       textSelectionStart = start;
       textSelectionEnd = end;
   }
@@ -599,7 +599,7 @@ public class ShadowAccessibilityNodeInfo {
    * @return The text selection start if there is selection or UNDEFINED_SELECTION_INDEX.
    */
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public int getTextSelectionStart() {
+  protected int getTextSelectionStart() {
       return textSelectionStart;
   }
 
@@ -609,12 +609,12 @@ public class ShadowAccessibilityNodeInfo {
    * @return The text selection end if there is selection or UNDEFINED_SELECTION_INDEX.
    */
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public int getTextSelectionEnd() {
+  protected int getTextSelectionEnd() {
       return textSelectionEnd;
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public AccessibilityNodeInfo getLabelFor() {
+  protected AccessibilityNodeInfo getLabelFor() {
     if (labelFor == null) {
       return null;
     }
@@ -631,7 +631,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR1)
-  public AccessibilityNodeInfo getLabeledBy() {
+  protected AccessibilityNodeInfo getLabeledBy() {
     if (labeledBy == null) {
       return null;
     }
@@ -648,107 +648,107 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public int getMovementGranularities() {
+  protected int getMovementGranularities() {
     return movementGranularities;
   }
 
   @Implementation
-  public void setMovementGranularities(int movementGranularities) {
+  protected void setMovementGranularities(int movementGranularities) {
     this.movementGranularities = movementGranularities;
   }
 
   @Implementation
-  public CharSequence getPackageName() {
+  protected CharSequence getPackageName() {
     return packageName;
   }
 
   @Implementation
-  public void setPackageName(CharSequence packageName) {
+  protected void setPackageName(CharSequence packageName) {
     this.packageName = packageName;
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public String getViewIdResourceName() {
+  protected String getViewIdResourceName() {
     return viewIdResourceName;
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public void setViewIdResourceName(String viewIdResourceName) {
+  protected void setViewIdResourceName(String viewIdResourceName) {
     this.viewIdResourceName = viewIdResourceName;
   }
 
   @Implementation(minSdk = KITKAT)
-  public CollectionInfo getCollectionInfo() {
+  protected CollectionInfo getCollectionInfo() {
     return collectionInfo;
   }
 
   @Implementation(minSdk = KITKAT)
-  public void setCollectionInfo(CollectionInfo collectionInfo) {
+  protected void setCollectionInfo(CollectionInfo collectionInfo) {
     this.collectionInfo = collectionInfo;
   }
 
   @Implementation(minSdk = KITKAT)
-  public CollectionItemInfo getCollectionItemInfo() {
+  protected CollectionItemInfo getCollectionItemInfo() {
     return collectionItemInfo;
   }
 
   @Implementation(minSdk = KITKAT)
-  public void setCollectionItemInfo(CollectionItemInfo collectionItemInfo) {
+  protected void setCollectionItemInfo(CollectionItemInfo collectionItemInfo) {
     this.collectionItemInfo = collectionItemInfo;
   }
 
   @Implementation(minSdk = KITKAT)
-  public int getInputType() {
+  protected int getInputType() {
     return inputType;
   }
 
   @Implementation(minSdk = KITKAT)
-  public void setInputType(int inputType) {
+  protected void setInputType(int inputType) {
     this.inputType = inputType;
   }
 
   @Implementation(minSdk = KITKAT)
-  public int getLiveRegion() {
+  protected int getLiveRegion() {
     return liveRegion;
   }
 
   @Implementation(minSdk = KITKAT)
-  public void setLiveRegion(int liveRegion) {
+  protected void setLiveRegion(int liveRegion) {
     this.liveRegion = liveRegion;
   }
 
   @Implementation(minSdk = KITKAT)
-  public RangeInfo getRangeInfo() {
+  protected RangeInfo getRangeInfo() {
     return rangeInfo;
   }
 
   @Implementation(minSdk = KITKAT)
-  public void setRangeInfo(RangeInfo rangeInfo) {
+  protected void setRangeInfo(RangeInfo rangeInfo) {
     this.rangeInfo = rangeInfo;
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public int getMaxTextLength() {
+  protected int getMaxTextLength() {
     return maxTextLength;
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void setMaxTextLength(int maxTextLength) {
+  protected void setMaxTextLength(int maxTextLength) {
     this.maxTextLength = maxTextLength;
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public CharSequence getError() {
+  protected CharSequence getError() {
     return error;
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void setError(CharSequence error) {
+  protected void setError(CharSequence error) {
     this.error = error;
   }
 
   @Implementation(minSdk = LOLLIPOP_MR1)
-  public AccessibilityNodeInfo getTraversalAfter() {
+  protected AccessibilityNodeInfo getTraversalAfter() {
     if (traversalAfter == null) {
       return null;
     }
@@ -783,7 +783,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation(minSdk = LOLLIPOP_MR1)
-  public AccessibilityNodeInfo getTraversalBefore() {
+  protected AccessibilityNodeInfo getTraversalBefore() {
     if (traversalBefore == null) {
       return null;
     }
@@ -818,17 +818,17 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public void setSource (View source) {
+  protected void setSource(View source) {
     this.view = source;
   }
 
   @Implementation
-  public void setSource (View root, int virtualDescendantId) {
+  protected void setSource(View root, int virtualDescendantId) {
     this.view = root;
   }
 
   @Implementation
-  public void getBoundsInScreen(Rect outBounds) {
+  protected void getBoundsInScreen(Rect outBounds) {
     if (boundsInScreen == null) {
       boundsInScreen = new Rect();
     }
@@ -836,7 +836,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public void getBoundsInParent(Rect outBounds) {
+  protected void getBoundsInParent(Rect outBounds) {
     if (boundsInParent == null) {
       boundsInParent = new Rect();
     }
@@ -844,7 +844,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public void setBoundsInScreen(Rect b) {
+  protected void setBoundsInScreen(Rect b) {
     if (boundsInScreen == null) {
       boundsInScreen = new Rect(b);
     } else {
@@ -853,7 +853,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public void setBoundsInParent(Rect b) {
+  protected void setBoundsInParent(Rect b) {
     if (boundsInParent == null) {
       boundsInParent = new Rect(b);
     } else {
@@ -862,7 +862,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public void addAction(int action) {
+  protected void addAction(int action) {
     if (getApiLevel() >= LOLLIPOP) {
       if ((action & getActionTypeMaskFromFramework()) != 0) {
         throw new IllegalArgumentException("Action is not a combination of the standard " +
@@ -881,7 +881,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void addAction(AccessibilityAction action) {
+  protected void addAction(AccessibilityAction action) {
     if (action == null) {
       return;
     }
@@ -894,13 +894,13 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void removeAction(int action) {
+  protected void removeAction(int action) {
     AccessibilityAction convertedAction = getActionFromIdFromFrameWork(action);
     removeAction(convertedAction);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean removeAction(AccessibilityAction action) {
+  protected boolean removeAction(AccessibilityAction action) {
     if (action == null || actionsArray == null) {
       return false;
     }
@@ -908,20 +908,17 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   /**
-   * Obtain flags for actions supported. Currently only supports
-   * {@link AccessibilityNodeInfo#ACTION_CLICK},
-   * {@link AccessibilityNodeInfo#ACTION_LONG_CLICK},
-   * {@link AccessibilityNodeInfo#ACTION_SCROLL_FORWARD},
-   * {@link AccessibilityNodeInfo#ACTION_PASTE},
-   * {@link AccessibilityNodeInfo#ACTION_FOCUS},
-   * {@link AccessibilityNodeInfo#ACTION_SET_SELECTION},
-   * {@link AccessibilityNodeInfo#ACTION_SCROLL_BACKWARD}
-   * Returned value is derived from the getters.
+   * Obtain flags for actions supported. Currently only supports {@link
+   * AccessibilityNodeInfo#ACTION_CLICK}, {@link AccessibilityNodeInfo#ACTION_LONG_CLICK}, {@link
+   * AccessibilityNodeInfo#ACTION_SCROLL_FORWARD}, {@link AccessibilityNodeInfo#ACTION_PASTE},
+   * {@link AccessibilityNodeInfo#ACTION_FOCUS}, {@link AccessibilityNodeInfo#ACTION_SET_SELECTION},
+   * {@link AccessibilityNodeInfo#ACTION_SCROLL_BACKWARD} Returned value is derived from the
+   * getters.
    *
    * @return Action mask. 0 if no actions supported.
    */
   @Implementation
-  public int getActions() {
+  protected int getActions() {
     if (getApiLevel() >= LOLLIPOP) {
       int returnValue = 0;
       if (actionsArray == null) {
@@ -955,7 +952,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public AccessibilityWindowInfo getWindow() {
+  protected AccessibilityWindowInfo getWindow() {
     return accessibilityWindowInfo;
   }
 
@@ -970,7 +967,7 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public List<AccessibilityAction> getActionList() {
+  protected List<AccessibilityAction> getActionList() {
     if (actionsArray == null) {
       return Collections.emptyList();
     }
@@ -979,12 +976,12 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public boolean performAction(int action) {
+  protected boolean performAction(int action) {
     return performAction(action, null);
   }
 
   @Implementation
-  public boolean performAction(int action, Bundle arguments) {
+  protected boolean performAction(int action, Bundle arguments) {
     if (performedActionAndArgsList == null) {
       performedActionAndArgsList = new ArrayList<>();
     }
@@ -1043,13 +1040,13 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public void addChild(View child) {
+  protected void addChild(View child) {
     AccessibilityNodeInfo node = AccessibilityNodeInfo.obtain(child);
     addChild(node);
   }
 
   @Implementation
-  public void addChild(View root, int virtualDescendantId) {
+  protected void addChild(View root, int virtualDescendantId) {
     AccessibilityNodeInfo node = AccessibilityNodeInfo.obtain(root, virtualDescendantId);
     addChild(node);
   }
@@ -1194,7 +1191,7 @@ public class ShadowAccessibilityNodeInfo {
     private CharSequence label;
 
     @Implementation
-    public void __constructor__(int id, CharSequence label) {
+    protected void __constructor__(int id, CharSequence label) {
       if (((id & (int)ReflectionHelpers.getStaticField(AccessibilityNodeInfo.class, "ACTION_TYPE_MASK")) == 0) && Integer.bitCount(id) != 1) {
         throw new IllegalArgumentException("Invalid standard action id");
       }
@@ -1203,12 +1200,12 @@ public class ShadowAccessibilityNodeInfo {
     }
 
     @Implementation
-    public int getId() {
+    protected int getId() {
       return id;
     }
 
     @Implementation
-    public CharSequence getLabel() {
+    protected CharSequence getLabel() {
       return label;
     }
 
@@ -1240,12 +1237,12 @@ public class ShadowAccessibilityNodeInfo {
   }
 
   @Implementation
-  public int describeContents() {
+  protected int describeContents() {
     return 0;
   }
 
   @Implementation
-  public void writeToParcel(Parcel dest, int flags) {
+  protected void writeToParcel(Parcel dest, int flags) {
     StrictEqualityNodeWrapper wrapper = new StrictEqualityNodeWrapper(realAccessibilityNodeInfo);
     int keyOfWrapper = -1;
     for (int i = 0; i < orderedInstances.size(); i++) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityRecord.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityRecord.java
@@ -25,7 +25,7 @@ public class ShadowAccessibilityRecord {
   private int windowId = -1;
 
   @Implementation
-  public void setSource(View root, int virtualDescendantId) {
+  protected void setSource(View root, int virtualDescendantId) {
     this.sourceRoot = root;
     this.virtualDescendantId = virtualDescendantId;
     Shadow.directlyOn(realRecord, AccessibilityRecord.class, "setSource",
@@ -34,7 +34,7 @@ public class ShadowAccessibilityRecord {
   }
 
   @Implementation
-  public void setSource(View root) {
+  protected void setSource(View root) {
     this.sourceRoot = root;
     this.virtualDescendantId = NO_VIRTUAL_ID;
     Shadow.directlyOn(realRecord, AccessibilityRecord.class, "setSource",

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityService.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityService.java
@@ -14,8 +14,8 @@ public class ShadowAccessibilityService extends ShadowService {
 
   private final List<Integer> globalActionsPerformed = new ArrayList<>();
 
-    @Implementation
-    public final boolean performGlobalAction(int action) {
+  @Implementation
+  protected final boolean performGlobalAction(int action) {
       globalActionsPerformed.add(action);
       return true;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityWindowInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityWindowInfo.java
@@ -52,10 +52,10 @@ public class ShadowAccessibilityWindowInfo {
   private AccessibilityWindowInfo mRealAccessibilityWindowInfo;
 
   @Implementation
-  public void __constructor__() {}
+  protected void __constructor__() {}
 
   @Implementation
-  public static AccessibilityWindowInfo obtain() {
+  protected static AccessibilityWindowInfo obtain() {
     final AccessibilityWindowInfo obtainedInstance =
         ReflectionHelpers.callConstructor(AccessibilityWindowInfo.class);
     StrictEqualityWindowWrapper wrapper = new StrictEqualityWindowWrapper(obtainedInstance);
@@ -64,7 +64,7 @@ public class ShadowAccessibilityWindowInfo {
   }
 
   @Implementation
-  public static AccessibilityWindowInfo obtain(AccessibilityWindowInfo window) {
+  protected static AccessibilityWindowInfo obtain(AccessibilityWindowInfo window) {
     final ShadowAccessibilityWindowInfo shadowInfo = Shadow.extract(window);
     final AccessibilityWindowInfo obtainedInstance = shadowInfo.getClone();
     StrictEqualityWindowWrapper wrapper = new StrictEqualityWindowWrapper(obtainedInstance);
@@ -160,12 +160,12 @@ public class ShadowAccessibilityWindowInfo {
   }
 
   @Implementation
-  public int getType() {
+  protected int getType() {
     return type;
   }
 
   @Implementation
-  public int getChildCount() {
+  protected int getChildCount() {
     if (children == null) {
       return 0;
     }
@@ -174,7 +174,7 @@ public class ShadowAccessibilityWindowInfo {
   }
 
   @Implementation
-  public AccessibilityWindowInfo getChild(int index) {
+  protected AccessibilityWindowInfo getChild(int index) {
     if (children == null) {
       return null;
     }
@@ -183,27 +183,27 @@ public class ShadowAccessibilityWindowInfo {
   }
 
   @Implementation
-  public AccessibilityWindowInfo getParent() {
+  protected AccessibilityWindowInfo getParent() {
     return parent;
   }
 
   @Implementation
-  public AccessibilityNodeInfo getRoot() {
+  protected AccessibilityNodeInfo getRoot() {
     return (rootNode == null) ? null : AccessibilityNodeInfo.obtain(rootNode);
   }
 
   @Implementation
-  public boolean isActive() {
+  protected boolean isActive() {
     return isActive;
   }
 
   @Implementation
-  public int getId() {
+  protected int getId() {
     return id;
   }
 
   @Implementation
-  public void getBoundsInScreen(Rect outBounds) {
+  protected void getBoundsInScreen(Rect outBounds) {
     if (boundsInScreen == null) {
       outBounds.setEmpty();
     } else {
@@ -212,7 +212,7 @@ public class ShadowAccessibilityWindowInfo {
   }
 
   @Implementation
-  public int getLayer() {
+  protected int getLayer() {
     return layer;
   }
 
@@ -223,17 +223,17 @@ public class ShadowAccessibilityWindowInfo {
   }
 
   @Implementation
-  public boolean isFocused() {
+  protected boolean isFocused() {
     return isFocused;
   }
 
   @Implementation
-  public boolean isAccessibilityFocused() {
+  protected boolean isAccessibilityFocused() {
     return isAccessibilityFocused;
   }
 
   @Implementation
-  public void recycle() {
+  protected void recycle() {
     // This shadow does not track recycling of windows.
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
@@ -53,26 +53,27 @@ public class ShadowAccountManager {
   private boolean authenticationErrorOnNextResponse = false;
 
   @Implementation
-  public void __constructor__(Context context, IAccountManager service) {
+  protected void __constructor__(Context context, IAccountManager service) {
     mainHandler = new Handler(context.getMainLooper());
   }
 
   /**
-   * @deprecated This method will be removed in Robolectric 3.4 Use {@link AccountManager#get(Context)} instead.
+   * @deprecated This method will be removed in Robolectric 3.4 Use {@link
+   *     AccountManager#get(Context)} instead.
    */
   @Deprecated
   @Implementation
-  public static AccountManager get(Context context) {
+  protected static AccountManager get(Context context) {
     return (AccountManager) context.getSystemService(Context.ACCOUNT_SERVICE);
   }
 
   @Implementation
-  public Account[] getAccounts() {
+  protected Account[] getAccounts() {
     return accounts.toArray(new Account[accounts.size()]);
   }
 
   @Implementation
-  public Account[] getAccountsByType(String type) {
+  protected Account[] getAccountsByType(String type) {
     if (type == null) {
       return getAccounts();
     }
@@ -88,7 +89,7 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public synchronized void setAuthToken(Account account, String tokenType, String authToken) {
+  protected synchronized void setAuthToken(Account account, String tokenType, String authToken) {
     if(accounts.contains(account)) {
       Map<String, String> tokenMap = authTokens.get(account);
       if(tokenMap == null) {
@@ -100,7 +101,7 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public String peekAuthToken(Account account, String tokenType) {
+  protected String peekAuthToken(Account account, String tokenType) {
     Map<String, String> tokenMap = authTokens.get(account);
     if(tokenMap != null) {
       return tokenMap.get(tokenType);
@@ -109,7 +110,7 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public boolean addAccountExplicitly(Account account, String password, Bundle userdata) {
+  protected boolean addAccountExplicitly(Account account, String password, Bundle userdata) {
     if (account == null) {
       throw new IllegalArgumentException("account is null");
     }
@@ -137,8 +138,8 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public String blockingGetAuthToken(Account account, String authTokenType,
-                                     boolean notifyAuthFailure) {
+  protected String blockingGetAuthToken(
+      Account account, String authTokenType, boolean notifyAuthFailure) {
     if (account == null) {
       throw new IllegalArgumentException("account is null");
     }
@@ -154,13 +155,12 @@ public class ShadowAccountManager {
   }
 
   /**
-   * The remove operation is posted to the given {@code handler}, and will be
-   * executed according to the {@link IdleState} of the corresponding {@link org.robolectric.util.Scheduler}.
+   * The remove operation is posted to the given {@code handler}, and will be executed according to
+   * the {@link IdleState} of the corresponding {@link org.robolectric.util.Scheduler}.
    */
   @Implementation
-  public AccountManagerFuture<Boolean> removeAccount(final Account account,
-                                                      AccountManagerCallback<Boolean> callback,
-                                                      Handler handler) {
+  protected AccountManagerFuture<Boolean> removeAccount(
+      final Account account, AccountManagerCallback<Boolean> callback, Handler handler) {
     if (account == null) {
       throw new IllegalArgumentException("account is null");
     }
@@ -176,7 +176,7 @@ public class ShadowAccountManager {
   }
 
   @Implementation(minSdk = LOLLIPOP_MR1)
-  public boolean removeAccountExplicitly(Account account) {
+  protected boolean removeAccountExplicitly(Account account) {
     passwords.remove(account);
     userData.remove(account);
     if (accounts.remove(account)) {
@@ -196,13 +196,13 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public AuthenticatorDescription[] getAuthenticatorTypes() {
+  protected AuthenticatorDescription[] getAuthenticatorTypes() {
     return authenticators.values().toArray(new AuthenticatorDescription[authenticators.size()]);
   }
 
   @Implementation
-  public void addOnAccountsUpdatedListener(final OnAccountsUpdateListener listener,
-      Handler handler, boolean updateImmediately) {
+  protected void addOnAccountsUpdatedListener(
+      final OnAccountsUpdateListener listener, Handler handler, boolean updateImmediately) {
 
     if (listeners.contains(listener)) {
       return;
@@ -216,12 +216,12 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public void removeOnAccountsUpdatedListener(OnAccountsUpdateListener listener) {
+  protected void removeOnAccountsUpdatedListener(OnAccountsUpdateListener listener) {
     listeners.remove(listener);
   }
 
   @Implementation
-  public String getUserData(Account account, String key) {
+  protected String getUserData(Account account, String key) {
     if (account == null) {
       throw new IllegalArgumentException("account is null");
     }
@@ -239,7 +239,7 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public void setUserData(Account account, String key, String value) {
+  protected void setUserData(Account account, String key, String value) {
     if (account == null) {
       throw new IllegalArgumentException("account is null");
     }
@@ -258,7 +258,7 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public void setPassword (Account account, String password) {
+  protected void setPassword(Account account, String password) {
     if (account == null) {
       throw new IllegalArgumentException("account is null");
     }
@@ -271,7 +271,7 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public String getPassword (Account account) {
+  protected String getPassword(Account account) {
     if (account == null) {
       throw new IllegalArgumentException("account is null");
     }
@@ -284,7 +284,7 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public void invalidateAuthToken(final String accountType, final String authToken) {
+  protected void invalidateAuthToken(final String accountType, final String authToken) {
     Account[] accountsByType = getAccountsByType(accountType);
     for (Account account : accountsByType) {
       Map<String, String> tokenMap = authTokens.get(account);
@@ -396,7 +396,14 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public AccountManagerFuture<Bundle> addAccount(final String accountType, String authTokenType, String[] requiredFeatures, Bundle addAccountOptions, Activity activity, AccountManagerCallback<Bundle> callback, Handler handler) {
+  protected AccountManagerFuture<Bundle> addAccount(
+      final String accountType,
+      String authTokenType,
+      String[] requiredFeatures,
+      Bundle addAccountOptions,
+      Activity activity,
+      AccountManagerCallback<Bundle> callback,
+      Handler handler) {
     addAccountOptionsList.add(addAccountOptions);
     pendingAddFuture = new RoboAccountManagerFuture(callback, handler, accountType, activity);
     return pendingAddFuture;
@@ -431,18 +438,20 @@ public class ShadowAccountManager {
     previousNames.put(account, previousName);
   }
 
-  /**
-   * @see #setPreviousAccountName(Account, String)
-   */
+  /** @see #setPreviousAccountName(Account, String) */
   @Implementation(minSdk = LOLLIPOP)
-  public String getPreviousName(Account account) {
+  protected String getPreviousName(Account account) {
     return previousNames.get(account);
   }
 
   @Implementation
-  public AccountManagerFuture<Bundle> getAuthToken(
-      final Account account, final String authTokenType, final Bundle options,
-      final Activity activity, final AccountManagerCallback<Bundle> callback, Handler handler) {
+  protected AccountManagerFuture<Bundle> getAuthToken(
+      final Account account,
+      final String authTokenType,
+      final Bundle options,
+      final Activity activity,
+      final AccountManagerCallback<Bundle> callback,
+      Handler handler) {
 
     return start(
         new BaseRoboAccountManagerFuture<Bundle>(callback, handler) {
@@ -461,7 +470,7 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public AccountManagerFuture<Bundle> getAuthToken(
+  protected AccountManagerFuture<Bundle> getAuthToken(
       final Account account,
       final String authTokenType,
       final Bundle options,
@@ -484,9 +493,11 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public AccountManagerFuture<Boolean> hasFeatures(final Account account,
-                                                   final String[] features,
-                                                   AccountManagerCallback<Boolean> callback, Handler handler) {
+  protected AccountManagerFuture<Boolean> hasFeatures(
+      final Account account,
+      final String[] features,
+      AccountManagerCallback<Boolean> callback,
+      Handler handler) {
     return start(new BaseRoboAccountManagerFuture<Boolean>(callback, handler) {
       @Override
       public Boolean doWork() throws OperationCanceledException, IOException, AuthenticatorException {
@@ -502,9 +513,11 @@ public class ShadowAccountManager {
   }
 
   @Implementation
-  public AccountManagerFuture<Account[]> getAccountsByTypeAndFeatures(
-      final String type, final String[] features,
-      AccountManagerCallback<Account[]> callback, Handler handler) {
+  protected AccountManagerFuture<Account[]> getAccountsByTypeAndFeatures(
+      final String type,
+      final String[] features,
+      AccountManagerCallback<Account[]> callback,
+      Handler handler) {
     return start(
         new BaseRoboAccountManagerFuture<Account[]>(callback, handler) {
           @Override
@@ -536,7 +549,7 @@ public class ShadowAccountManager {
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public Account[] getAccountsByTypeForPackage (String type, String packageName) {
+  protected Account[] getAccountsByTypeForPackage(String type, String packageName) {
     List<Account> result = new ArrayList<>();
 
     Account[] accountsByType = getAccountsByType(type);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -231,12 +231,12 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public ComponentName getCallingActivity() {
+  protected ComponentName getCallingActivity() {
     return callingActivity;
   }
 
   @Implementation
-  public void setDefaultKeyMode(int keyMode) {
+  protected void setDefaultKeyMode(int keyMode) {
     mDefaultKeyMode = keyMode;
 
     // Some modes use a SpannableStringBuilder to track & dispatch input events
@@ -262,23 +262,23 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public final void setResult(int resultCode) {
+  protected final void setResult(int resultCode) {
     this.resultCode = resultCode;
   }
 
   @Implementation
-  public final void setResult(int resultCode, Intent data) {
+  protected final void setResult(int resultCode, Intent data) {
     this.resultCode = resultCode;
     this.resultIntent = data;
   }
 
   @Implementation
-  public LayoutInflater getLayoutInflater() {
+  protected LayoutInflater getLayoutInflater() {
     return LayoutInflater.from(realActivity);
   }
 
   @Implementation
-  public MenuInflater getMenuInflater() {
+  protected MenuInflater getMenuInflater() {
     return new MenuInflater(realActivity);
   }
 
@@ -290,12 +290,12 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
    * @throws RuntimeException if the {@code contentView} has not been called first
    */
   @Implementation
-  public View findViewById(int id) {
+  protected View findViewById(int id) {
     return getWindow().findViewById(id);
   }
 
   @Implementation
-  public final Activity getParent() {
+  protected final Activity getParent() {
     return parent;
   }
 
@@ -310,24 +310,24 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public void onBackPressed() {
+  protected void onBackPressed() {
     finish();
   }
 
   @Implementation
-  public void finish() {
+  protected void finish() {
     // Sets the mFinished field in the real activity so NoDisplay activities can be tested.
     ReflectionHelpers.setField(Activity.class, realActivity, "mFinished", true);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void finishAndRemoveTask() {
+  protected void finishAndRemoveTask() {
     // Sets the mFinished field in the real activity so NoDisplay activities can be tested.
     ReflectionHelpers.setField(Activity.class, realActivity, "mFinished", true);
   }
 
   @Implementation(minSdk = JELLY_BEAN)
-  public void finishAffinity() {
+  protected void finishAffinity() {
     // Sets the mFinished field in the real activity so NoDisplay activities can be tested.
     ReflectionHelpers.setField(Activity.class, realActivity, "mFinished", true);
   }
@@ -347,13 +347,13 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   /**
-   * Constructs a new Window (a {@link com.android.internal.policy.impl.PhoneWindow}) if no window has previously been
-   * set.
+   * Constructs a new Window (a {@link com.android.internal.policy.impl.PhoneWindow}) if no window
+   * has previously been set.
    *
    * @return the window associated with this Activity
    */
   @Implementation
-  public Window getWindow()  {
+  protected Window getWindow() {
     Window window = directlyOn(realActivity, Activity.class).getWindow();
 
     if (window == null) {
@@ -373,12 +373,12 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public void runOnUiThread(Runnable action) {
+  protected void runOnUiThread(Runnable action) {
     ShadowApplication.getInstance().getForegroundThreadScheduler().post(action);
   }
 
   @Implementation
-  public void setRequestedOrientation(int requestedOrientation) {
+  protected void setRequestedOrientation(int requestedOrientation) {
     if (getParent() != null) {
       getParent().setRequestedOrientation(requestedOrientation);
     } else {
@@ -387,7 +387,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public int getRequestedOrientation() {
+  protected int getRequestedOrientation() {
     if (getParent() != null) {
       return getParent().getRequestedOrientation();
     } else {
@@ -396,7 +396,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public int getTaskId() {
+  protected int getTaskId() {
     return 0;
   }
 
@@ -448,7 +448,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public Object getLastNonConfigurationInstance() {
+  protected Object getLastNonConfigurationInstance() {
     return lastNonConfigurationInstance;
   }
 
@@ -464,7 +464,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public View getCurrentFocus() {
+  protected View getCurrentFocus() {
     return currentFocus;
   }
 
@@ -477,7 +477,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public boolean onCreateOptionsMenu(Menu menu) {
+  protected boolean onCreateOptionsMenu(Menu menu) {
     optionsMenu = menu;
     return directlyOn(realActivity, Activity.class).onCreateOptionsMenu(menu);
   }
@@ -541,12 +541,12 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public final void showDialog(int id) {
+  protected final void showDialog(int id) {
     showDialog(id, null);
   }
 
   @Implementation
-  public final void dismissDialog(int id) {
+  protected final void dismissDialog(int id) {
     final Dialog dialog = dialogForId.get(id);
     if (dialog == null) {
       throw new IllegalArgumentException();
@@ -556,12 +556,12 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public final void removeDialog(int id) {
+  protected final void removeDialog(int id) {
     dialogForId.remove(id);
   }
 
   @Implementation
-  public final boolean showDialog(int id, Bundle bundle) {
+  protected final boolean showDialog(int id, Bundle bundle) {
     this.lastShownDialogId = id;
     Dialog dialog = dialogForId.get(id);
 
@@ -589,7 +589,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public final boolean isTaskRoot() {
+  protected final boolean isTaskRoot() {
     return mIsTaskRoot;
   }
 
@@ -606,7 +606,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public void overridePendingTransition(int enterAnim, int exitAnim) {
+  protected void overridePendingTransition(int enterAnim, int exitAnim) {
     pendingTransitionEnterAnimResId = enterAnim;
     pendingTransitionExitAnimResId = exitAnim;
   }
@@ -616,7 +616,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public void recreate() {
+  protected void recreate() {
     Bundle outState = new Bundle();
     final ActivityInvoker invoker = new ActivityInvoker();
 
@@ -635,12 +635,12 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public void startManagingCursor(Cursor c) {
+  protected void startManagingCursor(Cursor c) {
     managedCursors.add(c);
   }
 
   @Implementation
-  public void stopManagingCursor(Cursor c) {
+  protected void stopManagingCursor(Cursor c) {
     managedCursors.remove(c);
   }
 
@@ -649,19 +649,17 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   @Implementation
-  public final void setVolumeControlStream(int streamType) {
+  protected final void setVolumeControlStream(int streamType) {
     this.streamType = streamType;
   }
 
   @Implementation
-  public final int getVolumeControlStream() {
+  protected final int getVolumeControlStream() {
     return streamType;
   }
 
-
   @Implementation(minSdk = M)
-  public final void requestPermissions(String[] permissions, int requestCode) {
-  }
+  protected final void requestPermissions(String[] permissions, int requestCode) {}
 
   /**
    * Starts a lock task.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityGroup.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityGroup.java
@@ -10,7 +10,7 @@ public class ShadowActivityGroup extends ShadowActivity {
   private Activity currentActivity;
 
   @Implementation
-  public android.app.Activity getCurrentActivity() {
+  protected android.app.Activity getCurrentActivity() {
     return currentActivity;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
@@ -42,17 +42,17 @@ public class ShadowActivityManager {
   }
 
   @Implementation
-  public int getMemoryClass() {
+  protected int getMemoryClass() {
     return memoryClass;
   }
 
   @Implementation
-  public static boolean isUserAMonkey() {
+  protected static boolean isUserAMonkey() {
     return false;
   }
 
   @Implementation
-  public List<ActivityManager.RunningTaskInfo> getRunningTasks(int maxNum) {
+  protected List<ActivityManager.RunningTaskInfo> getRunningTasks(int maxNum) {
     return tasks;
   }
 
@@ -69,12 +69,12 @@ public class ShadowActivityManager {
   }
 
   @Implementation
-  public List<ActivityManager.RunningServiceInfo> getRunningServices(int maxNum) {
+  protected List<ActivityManager.RunningServiceInfo> getRunningServices(int maxNum) {
     return services;
   }
 
   @Implementation
-  public List<ActivityManager.RunningAppProcessInfo> getRunningAppProcesses() {
+  protected List<ActivityManager.RunningAppProcessInfo> getRunningAppProcesses() {
     // This method is explicitly documented not to return an empty list
     if (processes.isEmpty()) {
       return null;
@@ -105,12 +105,12 @@ public class ShadowActivityManager {
   }
 
   @Implementation
-  public void killBackgroundProcesses(String packageName) {
+  protected void killBackgroundProcesses(String packageName) {
     backgroundPackage = packageName;
   }
 
   @Implementation
-  public void getMemoryInfo(ActivityManager.MemoryInfo outInfo) {
+  protected void getMemoryInfo(ActivityManager.MemoryInfo outInfo) {
     if (memoryInfo != null) {
       outInfo.availMem = memoryInfo.availMem;
       outInfo.lowMemory = memoryInfo.lowMemory;
@@ -120,7 +120,7 @@ public class ShadowActivityManager {
   }
 
   @Implementation
-  public android.content.pm.ConfigurationInfo getDeviceConfigurationInfo() {
+  protected android.content.pm.ConfigurationInfo getDeviceConfigurationInfo() {
     return new ConfigurationInfo();
   }
 
@@ -181,12 +181,12 @@ public class ShadowActivityManager {
   }
 
   @Implementation(minSdk = O)
-  public static IActivityManager getService() {
+  protected static IActivityManager getService() {
     return ReflectionHelpers.createNullProxy(IActivityManager.class);
   }
 
   @Implementation(minSdk = KITKAT)
-  public boolean isLowRamDevice() {
+  protected boolean isLowRamDevice() {
     if (isLowRamDeviceOverride != null) {
       return isLowRamDeviceOverride;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAdapterView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAdapterView.java
@@ -23,7 +23,8 @@ public class ShadowAdapterView<T extends Adapter> extends ShadowViewGroup {
   private AdapterView.OnItemSelectedListener itemSelectedListener;
 
   @Implementation
-  public void setOnItemSelectedListener(AdapterView.OnItemSelectedListener itemSelectedListener) {
+  protected void setOnItemSelectedListener(
+      AdapterView.OnItemSelectedListener itemSelectedListener) {
     this.itemSelectedListener = itemSelectedListener;
     directlyOn(realAdapterView, AdapterView.class, "setOnItemSelectedListener", ClassParameter.from(AdapterView.OnItemSelectedListener.class, itemSelectedListener));
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAlarmManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAlarmManager.java
@@ -39,7 +39,7 @@ public class ShadowAlarmManager {
   }
 
   @Implementation
-  public void setTimeZone(String timeZone) {
+  protected void setTimeZone(String timeZone) {
     // Do the real check first
     Shadow.directlyOn(realObject, AlarmManager.class).setTimeZone(timeZone);
     // Then do the right side effect
@@ -47,7 +47,7 @@ public class ShadowAlarmManager {
   }
 
   @Implementation
-  public void set(int type, long triggerAtTime, PendingIntent operation) {
+  protected void set(int type, long triggerAtTime, PendingIntent operation) {
     internalSet(type, triggerAtTime, 0L, operation, null);
   }
 
@@ -58,7 +58,7 @@ public class ShadowAlarmManager {
   }
 
   @Implementation(minSdk = KITKAT)
-  public void setExact(int type, long triggerAtTime, PendingIntent operation) {
+  protected void setExact(int type, long triggerAtTime, PendingIntent operation) {
     internalSet(type, triggerAtTime, 0L, operation, null);
   }
 
@@ -69,8 +69,8 @@ public class ShadowAlarmManager {
   }
 
   @Implementation(minSdk = KITKAT)
-  public void setWindow(int type, long windowStartMillis, long windowLengthMillis,
-      PendingIntent operation) {
+  protected void setWindow(
+      int type, long windowStartMillis, long windowLengthMillis, PendingIntent operation) {
     internalSet(type, windowStartMillis, 0L, operation, null);
   }
 
@@ -86,33 +86,34 @@ public class ShadowAlarmManager {
   }
 
   @Implementation(minSdk = M)
-  public void setAndAllowWhileIdle(int type, long triggerAtTime, PendingIntent operation) {
+  protected void setAndAllowWhileIdle(int type, long triggerAtTime, PendingIntent operation) {
     internalSet(type, triggerAtTime, 0L, operation, null);
   }
 
   @Implementation(minSdk = M)
-  public void setExactAndAllowWhileIdle(int type, long triggerAtTime, PendingIntent operation) {
+  protected void setExactAndAllowWhileIdle(int type, long triggerAtTime, PendingIntent operation) {
     internalSet(type, triggerAtTime, 0L, operation, null);
   }
 
   @Implementation
-  public void setRepeating(int type, long triggerAtTime, long interval, PendingIntent operation) {
+  protected void setRepeating(
+      int type, long triggerAtTime, long interval, PendingIntent operation) {
     internalSet(type, triggerAtTime, interval, operation, null);
   }
 
   @Implementation
-  public void setInexactRepeating(int type, long triggerAtMillis, long intervalMillis,
-      PendingIntent operation) {
+  protected void setInexactRepeating(
+      int type, long triggerAtMillis, long intervalMillis, PendingIntent operation) {
     internalSet(type, triggerAtMillis, intervalMillis, operation, null);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void setAlarmClock(AlarmClockInfo info, PendingIntent operation) {
+  protected void setAlarmClock(AlarmClockInfo info, PendingIntent operation) {
     internalSet(RTC_WAKEUP, info.getTriggerTime(), 0L, operation, info.getShowIntent());
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public AlarmClockInfo getNextAlarmClock() {
+  protected AlarmClockInfo getNextAlarmClock() {
     for (ScheduledAlarm scheduledAlarm : scheduledAlarms) {
       AlarmClockInfo alarmClockInfo = scheduledAlarm.getAlarmClockInfo();
       if (alarmClockInfo != null) {
@@ -166,7 +167,7 @@ public class ShadowAlarmManager {
   }
 
   @Implementation
-  public void cancel(PendingIntent operation) {
+  protected void cancel(PendingIntent operation) {
     ShadowPendingIntent shadowPendingIntent = Shadow.extract(operation);
     final Intent toRemove = shadowPendingIntent.getSavedIntent();
     final int requestCode = shadowPendingIntent.getRequestCode();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAnimationUtils.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAnimationUtils.java
@@ -16,12 +16,12 @@ import org.robolectric.shadow.api.Shadow;
 public class ShadowAnimationUtils {
 
   @Implementation
-  public static Interpolator loadInterpolator(Context context, int id) {
+  protected static Interpolator loadInterpolator(Context context, int id) {
     return new LinearInterpolator();
   }
 
   @Implementation
-  public static LayoutAnimationController loadLayoutAnimation(Context context, int id) {
+  protected static LayoutAnimationController loadLayoutAnimation(Context context, int id) {
     Animation anim = new TranslateAnimation(0, 0, 30, 0);
     LayoutAnimationController layoutAnim = new LayoutAnimationController(anim);
     ShadowLayoutAnimationController shadowLayoutAnimationController = Shadow.extract(layoutAnim);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppWidgetHost.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppWidgetHost.java
@@ -19,7 +19,7 @@ public class ShadowAppWidgetHost {
   private int appWidgetIdToAllocate;
 
   @Implementation
-  public void __constructor__(Context context, int hostId) {
+  protected void __constructor__(Context context, int hostId) {
     this.context = context;
     this.hostId = hostId;
   }
@@ -37,13 +37,13 @@ public class ShadowAppWidgetHost {
   }
 
   @Implementation
-  public int allocateAppWidgetId() {
+  protected int allocateAppWidgetId() {
     return appWidgetIdToAllocate;
   }
 
   @Implementation
-  public AppWidgetHostView createView(Context context, int appWidgetId,
-                    AppWidgetProviderInfo appWidget) {
+  protected AppWidgetHostView createView(
+      Context context, int appWidgetId, AppWidgetProviderInfo appWidget) {
     AppWidgetHostView hostView = new AppWidgetHostView(context);
     hostView.setAppWidget(appWidgetId, appWidget);
     ShadowAppWidgetHostView shadowAppWidgetHostView = Shadow.extract(hostView);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppWidgetHostView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppWidgetHostView.java
@@ -14,18 +14,18 @@ public class ShadowAppWidgetHostView extends ShadowViewGroup {
   private AppWidgetHost host;
 
   @Implementation
-  public void setAppWidget(int appWidgetId, AppWidgetProviderInfo info) {
+  protected void setAppWidget(int appWidgetId, AppWidgetProviderInfo info) {
     this.appWidgetId = appWidgetId;
     this.appWidgetInfo = info;
   }
 
   @Implementation
-  public int getAppWidgetId() {
+  protected int getAppWidgetId() {
     return appWidgetId;
   }
 
   @Implementation
-  public AppWidgetProviderInfo getAppWidgetInfo() {
+  protected AppWidgetProviderInfo getAppWidgetInfo() {
     return appWidgetInfo;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppWidgetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppWidgetManager.java
@@ -60,7 +60,6 @@ public class ShadowAppWidgetManager {
     // todo: implement
   }
 
-
   /**
    * Finds or creates an {@code AppWidgetManager} for the given {@code context}
    *
@@ -68,12 +67,12 @@ public class ShadowAppWidgetManager {
    * @return the {@code AppWidgetManager} associated with the given {@code context}
    */
   @Implementation
-  public static AppWidgetManager getInstance(Context context) {
+  protected static AppWidgetManager getInstance(Context context) {
     return instances.getInstance(context);
   }
 
   @Implementation
-  public void updateAppWidget(int[] appWidgetIds, RemoteViews views) {
+  protected void updateAppWidget(int[] appWidgetIds, RemoteViews views) {
     for (int appWidgetId : appWidgetIds) {
       updateAppWidget(appWidgetId, views);
     }
@@ -83,10 +82,10 @@ public class ShadowAppWidgetManager {
    * Simulates updating an {@code AppWidget} with a new set of views
    *
    * @param appWidgetId id of widget
-   * @param views       views to update
+   * @param views views to update
    */
   @Implementation
-  public void updateAppWidget(int appWidgetId, RemoteViews views) {
+  protected void updateAppWidget(int appWidgetId, RemoteViews views) {
     WidgetInfo widgetInfo = widgetInfos.get(appWidgetId);
     int layoutId = views.getLayoutId();
     if (widgetInfo.layoutId != layoutId || alwaysRecreateViewsDuringUpdate) {
@@ -98,7 +97,7 @@ public class ShadowAppWidgetManager {
   }
 
   @Implementation
-  public int[] getAppWidgetIds(ComponentName provider) {
+  protected int[] getAppWidgetIds(ComponentName provider) {
     List<Integer> idList = new ArrayList<>();
     for (int id : widgetInfos.keySet()) {
       WidgetInfo widgetInfo = widgetInfos.get(id);
@@ -114,7 +113,7 @@ public class ShadowAppWidgetManager {
   }
 
   @Implementation
-  public List<AppWidgetProviderInfo> getInstalledProviders() {
+  protected List<AppWidgetProviderInfo> getInstalledProviders() {
     return new ArrayList<>(installedProviders);
   }
 
@@ -134,7 +133,7 @@ public class ShadowAppWidgetManager {
   }
 
   @Implementation
-  public AppWidgetProviderInfo getAppWidgetInfo(int appWidgetId) {
+  protected AppWidgetProviderInfo getAppWidgetInfo(int appWidgetId) {
     WidgetInfo widgetInfo = widgetInfos.get(appWidgetId);
     if (widgetInfo == null) return null;
     return widgetInfo.info;
@@ -152,7 +151,7 @@ public class ShadowAppWidgetManager {
   }
 
   @Implementation
-  public boolean bindAppWidgetIdIfAllowed(int appWidgetId, ComponentName provider) {
+  protected boolean bindAppWidgetIdIfAllowed(int appWidgetId, ComponentName provider) {
     if (validWidgetProviderComponentName) {
       bindAppWidgetId(appWidgetId, provider);
       return allowedToBindWidgets;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -239,6 +239,10 @@ public class ShadowApplication extends ShadowContextWrapper {
     return appWidgetManager;
   }
 
+  /**
+   * @deprecated Use {@link ShadowAlertDialog#getLatestAlertDialog()} instead.
+   */
+  @Deprecated
   public ShadowAlertDialog getLatestAlertDialog() {
     return latestAlertDialog;
   }
@@ -247,6 +251,10 @@ public class ShadowApplication extends ShadowContextWrapper {
     this.latestAlertDialog = latestAlertDialog;
   }
 
+  /**
+   * @deprecated Use {@link ShadowDialog#getLatestDialog()} instead.
+   */
+  @Deprecated
   public ShadowDialog getLatestDialog() {
     return latestDialog;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager.java
@@ -15,7 +15,6 @@ import static org.robolectric.res.android.Errors.BAD_INDEX;
 import static org.robolectric.res.android.Errors.NO_ERROR;
 import static org.robolectric.res.android.Util.ALOGV;
 import static org.robolectric.res.android.Util.isTruthy;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
 
 import android.content.res.AssetManager;
 import android.os.Build.VERSION_CODES;
@@ -89,7 +88,7 @@ public class ShadowArscAssetManager extends ShadowAssetManager.ArscBase {
   }
 
   @Implementation
-  public final String[] list(String path) throws IOException {
+  protected final String[] list(String path) throws IOException {
     CppAssetManager am = assetManagerForJavaObject();
 
     String fileName8 = path;
@@ -190,7 +189,7 @@ public class ShadowArscAssetManager extends ShadowAssetManager.ArscBase {
   }
 
   @Implementation
-  public String getResourceName(int resid) {
+  protected String getResourceName(int resid) {
     CppAssetManager am = assetManagerForJavaObject();
 
     ResourceName name = new ResourceName();
@@ -220,7 +219,7 @@ public class ShadowArscAssetManager extends ShadowAssetManager.ArscBase {
   }
 
   @Implementation
-  public String getResourcePackageName(int resid) {
+  protected String getResourcePackageName(int resid) {
     CppAssetManager cppAssetManager = assetManagerForJavaObject();
 
     ResourceName name = new ResourceName();
@@ -232,7 +231,7 @@ public class ShadowArscAssetManager extends ShadowAssetManager.ArscBase {
   }
 
   @Implementation
-  public String getResourceTypeName(int resid) {
+  protected String getResourceTypeName(int resid) {
     CppAssetManager cppAssetManager = assetManagerForJavaObject();
 
     ResourceName name = new ResourceName();
@@ -244,7 +243,7 @@ public class ShadowArscAssetManager extends ShadowAssetManager.ArscBase {
   }
 
   @Implementation
-  public String getResourceEntryName(int resid) {
+  protected String getResourceEntryName(int resid) {
     CppAssetManager cppAssetManager = assetManagerForJavaObject();
 
     ResourceName name = new ResourceName();
@@ -955,7 +954,7 @@ public class ShadowArscAssetManager extends ShadowAssetManager.ArscBase {
   }
 
   @Implementation
-  public final SparseArray<String> getAssignedPackageIdentifiers() {
+  protected final SparseArray<String> getAssignedPackageIdentifiers() {
     CppAssetManager am = assetManagerForJavaObject();
     final ResTable res = am.getResources();
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAsyncTask.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAsyncTask.java
@@ -60,27 +60,28 @@ public class ShadowAsyncTask<Params, Progress, Result> {
   }
 
   @Implementation
-  public boolean isCancelled() {
+  protected boolean isCancelled() {
     return future.isCancelled();
   }
 
   @Implementation
-  public boolean cancel(boolean mayInterruptIfRunning) {
+  protected boolean cancel(boolean mayInterruptIfRunning) {
     return future.cancel(mayInterruptIfRunning);
   }
 
   @Implementation
-  public Result get() throws InterruptedException, ExecutionException {
+  protected Result get() throws InterruptedException, ExecutionException {
     return future.get();
   }
 
   @Implementation
-  public Result get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+  protected Result get(long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
     return future.get(timeout, unit);
   }
 
   @Implementation
-  public AsyncTask<Params, Progress, Result> execute(final Params... params) {
+  protected AsyncTask<Params, Progress, Result> execute(final Params... params) {
     status = AsyncTask.Status.RUNNING;
     getBridge().onPreExecute();
 
@@ -97,7 +98,8 @@ public class ShadowAsyncTask<Params, Progress, Result> {
   }
 
   @Implementation
-  public AsyncTask<Params, Progress, Result> executeOnExecutor(Executor executor, Params... params) {
+  protected AsyncTask<Params, Progress, Result> executeOnExecutor(
+      Executor executor, Params... params) {
     status = AsyncTask.Status.RUNNING;
     getBridge().onPreExecute();
 
@@ -113,19 +115,19 @@ public class ShadowAsyncTask<Params, Progress, Result> {
   }
 
   @Implementation
-  public AsyncTask.Status getStatus() {
+  protected AsyncTask.Status getStatus() {
     return status;
   }
 
   /**
-   * Enqueue a call to {@link AsyncTask#onProgressUpdate(Object[])} on UI looper (or run it immediately
-   * if the looper it is not paused).
+   * Enqueue a call to {@link AsyncTask#onProgressUpdate(Object[])} on UI looper (or run it
+   * immediately if the looper it is not paused).
    *
    * @param values The progress values to update the UI with.
    * @see AsyncTask#publishProgress(Object[])
    */
   @Implementation
-  public void publishProgress(final Progress... values) {
+  protected void publishProgress(final Progress... values) {
     ShadowApplication.getInstance().getForegroundThreadScheduler().post(new Runnable() {
       @Override
       public void run() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAsyncTaskLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAsyncTaskLoader.java
@@ -15,12 +15,12 @@ public class ShadowAsyncTaskLoader<D> {
   private BackgroundWorker worker;
 
   @Implementation
-  public void __constructor__(Context context) {
+  protected void __constructor__(Context context) {
     worker = new BackgroundWorker();
   }
 
   @Implementation
-  public void onForceLoad() {
+  protected void onForceLoad() {
     FutureTask<D> future = new FutureTask<D>(worker) {
       @Override
       protected void done() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioEffect.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioEffect.java
@@ -17,7 +17,7 @@ public class ShadowAudioEffect {
   }
 
   @Implementation
-  public static AudioEffect.Descriptor[] queryEffects() {
+  protected static AudioEffect.Descriptor[] queryEffects() {
     return DESCRIPTORS.toArray(new AudioEffect.Descriptor[DESCRIPTORS.size()]);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
@@ -58,19 +58,19 @@ public class ShadowAudioManager {
   }
 
   @Implementation
-  public int getStreamMaxVolume(int streamType) {
+  protected int getStreamMaxVolume(int streamType) {
     AudioStream stream = streamStatus.get(streamType);
     return (stream != null) ? stream.getMaxVolume() : INVALID_VOLUME;
   }
 
   @Implementation
-  public int getStreamVolume(int streamType) {
+  protected int getStreamVolume(int streamType) {
     AudioStream stream = streamStatus.get(streamType);
     return (stream != null) ? stream.getCurrentVolume() : INVALID_VOLUME;
   }
 
   @Implementation
-  public void setStreamVolume(int streamType, int index, int flags) {
+  protected void setStreamVolume(int streamType, int index, int flags) {
     AudioStream stream = streamStatus.get(streamType);
     if (stream != null) {
       stream.setCurrentVolume(index);
@@ -79,7 +79,8 @@ public class ShadowAudioManager {
   }
 
   @Implementation
-  public int requestAudioFocus(android.media.AudioManager.OnAudioFocusChangeListener l, int streamType, int durationHint) {
+  protected int requestAudioFocus(
+      android.media.AudioManager.OnAudioFocusChangeListener l, int streamType, int durationHint) {
     lastAudioFocusRequest = new AudioFocusRequest(l, streamType, durationHint);
     return nextResponseValue;
   }
@@ -95,7 +96,7 @@ public class ShadowAudioManager {
   }
 
   @Implementation
-  public int abandonAudioFocus(AudioManager.OnAudioFocusChangeListener l) {
+  protected int abandonAudioFocus(AudioManager.OnAudioFocusChangeListener l) {
     lastAbandonedAudioFocusListener = l;
     return nextResponseValue;
   }
@@ -112,12 +113,12 @@ public class ShadowAudioManager {
   }
 
   @Implementation
-  public int getRingerMode() {
+  protected int getRingerMode() {
     return ringerMode;
   }
 
   @Implementation
-  public void setRingerMode(int ringerMode) {
+  protected void setRingerMode(int ringerMode) {
     if (!AudioManager.isValidRingerMode(ringerMode)) {
       return;
     }
@@ -132,12 +133,12 @@ public class ShadowAudioManager {
   }
 
   @Implementation
-  public void setMode(int mode) {
+  protected void setMode(int mode) {
     this.mode = mode;
   }
 
   @Implementation
-  public int getMode() {
+  protected int getMode() {
     return this.mode;
   }
 
@@ -154,57 +155,57 @@ public class ShadowAudioManager {
   }
 
   @Implementation
-  public void setWiredHeadsetOn(boolean on) {
+  protected void setWiredHeadsetOn(boolean on) {
     wiredHeadsetOn = on;
   }
 
   @Implementation
-  public boolean isWiredHeadsetOn() {
+  protected boolean isWiredHeadsetOn() {
     return wiredHeadsetOn;
   }
 
   @Implementation
-  public void setBluetoothA2dpOn(boolean on) {
+  protected void setBluetoothA2dpOn(boolean on) {
     bluetoothA2dpOn = on;
   }
 
   @Implementation
-  public boolean isBluetoothA2dpOn() {
+  protected boolean isBluetoothA2dpOn() {
     return bluetoothA2dpOn;
   }
 
   @Implementation
-  public void setSpeakerphoneOn(boolean on) {
+  protected void setSpeakerphoneOn(boolean on) {
     isSpeakerphoneOn = on;
   }
 
   @Implementation
-  public boolean isSpeakerphoneOn() {
+  protected boolean isSpeakerphoneOn() {
     return isSpeakerphoneOn;
   }
 
   @Implementation
-  public void setMicrophoneMute(boolean on) {
+  protected void setMicrophoneMute(boolean on) {
     isMicrophoneMuted = on;
   }
 
   @Implementation
-  public boolean isMicrophoneMute() {
+  protected boolean isMicrophoneMute() {
     return isMicrophoneMuted;
   }
 
   @Implementation
-  public boolean isBluetoothScoOn() {
+  protected boolean isBluetoothScoOn() {
     return isBluetoothScoOn;
   }
 
   @Implementation
-  public void setBluetoothScoOn(boolean isBluetoothScoOn) {
+  protected void setBluetoothScoOn(boolean isBluetoothScoOn) {
     this.isBluetoothScoOn = isBluetoothScoOn;
   }
 
   @Implementation
-  public boolean isMusicActive() {
+  protected boolean isMusicActive() {
     return isMusicActive;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBaseAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBaseAdapter.java
@@ -14,7 +14,7 @@ public class ShadowBaseAdapter {
   private boolean wasNotifyDataSetChangedCalled;
 
   @Implementation
-  public void notifyDataSetChanged() {
+  protected void notifyDataSetChanged() {
     wasNotifyDataSetChangedCalled = true;
     directlyOn(realBaseAdapter, BaseAdapter.class, "notifyDataSetChanged");
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBatteryManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBatteryManager.java
@@ -16,7 +16,7 @@ public class ShadowBatteryManager {
   private final Map<Integer, Integer> intProperties = new HashMap<>();
 
   @Implementation(minSdk = M)
-  public boolean isCharging() {
+  protected boolean isCharging() {
     return isCharging;
   }
 
@@ -25,7 +25,7 @@ public class ShadowBatteryManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public int getIntProperty(int id) {
+  protected int getIntProperty(int id) {
     return intProperties.containsKey(id) ? intProperties.get(id) : Integer.MIN_VALUE;
   }
 
@@ -34,7 +34,7 @@ public class ShadowBatteryManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public long getLongProperty(int id) {
+  protected long getLongProperty(int id) {
     return longProperties.containsKey(id) ? longProperties.get(id) : Long.MIN_VALUE;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBinder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBinder.java
@@ -17,7 +17,8 @@ public class ShadowBinder {
   private static Integer callingPid;
 
   @Implementation
-  public boolean transact(int code, Parcel data, Parcel reply, int flags) throws RemoteException {
+  protected boolean transact(int code, Parcel data, Parcel reply, int flags)
+      throws RemoteException {
    if (data != null) {
      data.setDataPosition(0);
    }
@@ -39,7 +40,7 @@ public class ShadowBinder {
   }
 
   @Implementation
-  public static final int getCallingPid() {
+  protected static final int getCallingPid() {
     if (callingPid != null) {
       return callingPid;
     }
@@ -47,7 +48,7 @@ public class ShadowBinder {
   }
 
   @Implementation
-  public static final int getCallingUid() {
+  protected static final int getCallingUid() {
     if (callingUid != null) {
       return callingUid;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmap.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmap.java
@@ -183,7 +183,7 @@ public class ShadowBitmap {
   }
 
   @Implementation
-  public boolean compress(Bitmap.CompressFormat format, int quality, OutputStream stream) {
+  protected boolean compress(Bitmap.CompressFormat format, int quality, OutputStream stream) {
     try {
       stream.write((description + " compressed as " + format + " with quality " + quality).getBytes(UTF_8));
     } catch (IOException e) {
@@ -194,17 +194,23 @@ public class ShadowBitmap {
   }
 
   @Implementation
-  public static Bitmap createBitmap(int width, int height, Bitmap.Config config) {
+  protected static Bitmap createBitmap(int width, int height, Bitmap.Config config) {
     return createBitmap((DisplayMetrics) null, width, height, config);
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR1)
-  public static Bitmap createBitmap(DisplayMetrics displayMetrics, int width, int height, Bitmap.Config config, boolean hasAlpha) {
+  protected static Bitmap createBitmap(
+      DisplayMetrics displayMetrics,
+      int width,
+      int height,
+      Bitmap.Config config,
+      boolean hasAlpha) {
     return createBitmap((DisplayMetrics) null, width, height, config);
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR1)
-  public static Bitmap createBitmap(DisplayMetrics displayMetrics, int width, int height, Bitmap.Config config) {
+  protected static Bitmap createBitmap(
+      DisplayMetrics displayMetrics, int width, int height, Bitmap.Config config) {
     if (width <= 0 || height <= 0) {
       throw new IllegalArgumentException("width and height must be > 0");
     }
@@ -224,14 +230,15 @@ public class ShadowBitmap {
   }
 
   @Implementation
-  public static Bitmap createBitmap(Bitmap src) {
+  protected static Bitmap createBitmap(Bitmap src) {
     ShadowBitmap shadowBitmap = Shadow.extract(src);
     shadowBitmap.appendDescription(" created from Bitmap object");
     return src;
   }
 
   @Implementation
-  public static Bitmap createScaledBitmap(Bitmap src, int dstWidth, int dstHeight, boolean filter) {
+  protected static Bitmap createScaledBitmap(
+      Bitmap src, int dstWidth, int dstHeight, boolean filter) {
     if (dstWidth == src.getWidth() && dstHeight == src.getHeight() && !filter) {
       return src; // Return the original.
     }
@@ -255,7 +262,7 @@ public class ShadowBitmap {
   }
 
   @Implementation
-  public static Bitmap createBitmap(Bitmap src, int x, int y, int width, int height) {
+  protected static Bitmap createBitmap(Bitmap src, int x, int y, int width, int height) {
     if (x == 0 && y == 0 && width == src.getWidth() && height == src.getHeight()) {
       return src; // Return the original.
     }
@@ -279,13 +286,14 @@ public class ShadowBitmap {
   }
 
   @Implementation
-  public void setPixels(int[] pixels, int offset, int stride,
-                        int x, int y, int width, int height) {
+  protected void setPixels(
+      int[] pixels, int offset, int stride, int x, int y, int width, int height) {
     this.colors = pixels;
   }
 
   @Implementation
-  public static Bitmap createBitmap(Bitmap src, int x, int y, int width, int height, Matrix matrix, boolean filter) {
+  protected static Bitmap createBitmap(
+      Bitmap src, int x, int y, int width, int height, Matrix matrix, boolean filter) {
     if (x == 0 && y == 0 && width == src.getWidth() && height == src.getHeight() && (matrix == null || matrix.isIdentity())) {
       return src; // Return the original.
     }
@@ -335,7 +343,7 @@ public class ShadowBitmap {
   }
 
   @Implementation
-  public static Bitmap createBitmap(int[] colors, int width, int height, Bitmap.Config config) {
+  protected static Bitmap createBitmap(int[] colors, int width, int height, Bitmap.Config config) {
     if (colors.length != width * height) {
       throw new IllegalArgumentException("array length (" + colors.length + ") did not match width * height (" + (width * height) + ")");
     }
@@ -351,7 +359,7 @@ public class ShadowBitmap {
   }
 
   @Implementation
-  public int getPixel(int x, int y) {
+  protected int getPixel(int x, int y) {
     internalCheckPixelAccess(x, y);
     if (colors != null) {
       // Note that getPixel() returns a non-premultiplied ARGB value; if
@@ -365,7 +373,7 @@ public class ShadowBitmap {
   }
 
   @Implementation
-  public void setPixel(int x, int y, int color) {
+  protected void setPixel(int x, int y, int color) {
     if (isRecycled()) {
       throw new IllegalStateException("Can't call setPixel() on a recycled bitmap");
     } else if (!isMutable()) {
@@ -379,14 +387,13 @@ public class ShadowBitmap {
   }
 
   /**
-   * Note that this method will return a RuntimeException unless:
-   * - {@code pixels} has the same length as the number of pixels of the bitmap.
-   * - {@code x = 0}
-   * - {@code y = 0}
-   * - {@code width} and {@code height} height match the current bitmap's dimensions.
+   * Note that this method will return a RuntimeException unless: - {@code pixels} has the same
+   * length as the number of pixels of the bitmap. - {@code x = 0} - {@code y = 0} - {@code width}
+   * and {@code height} height match the current bitmap's dimensions.
    */
   @Implementation
-  public void getPixels(int[] pixels, int offset, int stride, int x, int y, int width, int height) {
+  protected void getPixels(
+      int[] pixels, int offset, int stride, int x, int y, int width, int height) {
     if (x != 0 ||
         y != 0 ||
         width != getWidth() ||
@@ -403,27 +410,27 @@ public class ShadowBitmap {
   }
 
   @Implementation
-  public int getRowBytes() {
+  protected int getRowBytes() {
     return getBytesPerPixel(config) * getWidth();
   }
 
   @Implementation
-  public int getByteCount() {
+  protected int getByteCount() {
     return getRowBytes() * getHeight();
   }
 
   @Implementation
-  public void recycle() {
+  protected void recycle() {
     recycled = true;
   }
 
   @Implementation
-  public final boolean isRecycled() {
+  protected final boolean isRecycled() {
     return recycled;
   }
 
   @Implementation
-  public Bitmap copy(Bitmap.Config config, boolean isMutable) {
+  protected Bitmap copy(Bitmap.Config config, boolean isMutable) {
     Bitmap newBitmap = ReflectionHelpers.callConstructor(Bitmap.class);
     ShadowBitmap shadowBitmap = Shadow.extract(newBitmap);
     shadowBitmap.createdFromBitmap = realBitmap;
@@ -433,22 +440,22 @@ public class ShadowBitmap {
   }
 
   @Implementation(minSdk = KITKAT)
-  public final int getAllocationByteCount() {
+  protected final int getAllocationByteCount() {
     return getRowBytes() * getHeight();
   }
 
   @Implementation
-  public final Bitmap.Config getConfig() {
+  protected final Bitmap.Config getConfig() {
     return config;
   }
 
   @Implementation(minSdk = KITKAT)
-  public void setConfig(Bitmap.Config config) {
+  protected void setConfig(Bitmap.Config config) {
     this.config = config;
   }
 
   @Implementation
-  public final boolean isMutable() {
+  protected final boolean isMutable() {
     return mutable;
   }
 
@@ -469,72 +476,70 @@ public class ShadowBitmap {
   }
 
   @Implementation
-  public final boolean hasAlpha() {
+  protected final boolean hasAlpha() {
     return hasAlpha;
   }
 
   @Implementation
-  public void setHasAlpha(boolean hasAlpha) {
+  protected void setHasAlpha(boolean hasAlpha) {
     this.hasAlpha = hasAlpha;
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR1)
-  public final boolean hasMipMap() {
+  protected final boolean hasMipMap() {
     return hasMipMap;
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR1)
-  public final void setHasMipMap(boolean hasMipMap) {
+  protected final void setHasMipMap(boolean hasMipMap) {
     this.hasMipMap = hasMipMap;
   }
 
   @Implementation(minSdk = KITKAT)
-  public void setWidth(int width) {
+  protected void setWidth(int width) {
     this.width = width;
   }
 
   @Implementation
-  public int getWidth() {
+  protected int getWidth() {
     return width;
   }
 
   @Implementation(minSdk = KITKAT)
-  public void setHeight(int height) {
+  protected void setHeight(int height) {
     this.height = height;
   }
 
   @Implementation
-  public int getHeight() {
+  protected int getHeight() {
     return height;
   }
 
   @Implementation
-  public void setDensity(int density) {
+  protected void setDensity(int density) {
     this.density = density;
   }
 
   @Implementation
-  public int getDensity() {
+  protected int getDensity() {
     return density;
   }
 
   @Implementation
-  public int getGenerationId() {
+  protected int getGenerationId() {
     return 0;
   }
 
   @Implementation(minSdk = M)
-  public Bitmap createAshmemBitmap() {
+  protected Bitmap createAshmemBitmap() {
     return realBitmap;
   }
 
   @Implementation
-  public void eraseColor(int c) {
-
-  }
+  protected void eraseColor(int c) {}
 
   @Implementation
-  public void writeToParcel(Parcel p, int flags) {
+  protected void writeToParcel(Parcel p, int flags) {
     p.writeInt(width);
     p.writeInt(height);
     p.writeSerializable(config);
@@ -542,7 +547,7 @@ public class ShadowBitmap {
   }
 
   @Implementation
-  public static Bitmap nativeCreateFromParcel(Parcel p) {
+  protected static Bitmap nativeCreateFromParcel(Parcel p) {
     int parceledWidth = p.readInt();
     int parceledHeight = p.readInt();
     Bitmap.Config parceledConfig = (Bitmap.Config) p.readSerializable();
@@ -554,7 +559,7 @@ public class ShadowBitmap {
   }
 
   @Implementation
-  public void copyPixelsFromBuffer(Buffer dst) {
+  protected void copyPixelsFromBuffer(Buffer dst) {
     if (isRecycled()) {
       throw new IllegalStateException("Can't call copyPixelsFromBuffer() on a recycled bitmap");
     }
@@ -579,7 +584,7 @@ public class ShadowBitmap {
   }
 
   @Implementation
-  public void copyPixelsToBuffer(Buffer dst) {
+  protected void copyPixelsToBuffer(Buffer dst) {
     // Ensure that the Bitmap uses 4 bytes per pixel, since we always use 4 bytes per pixels
     // internally. Clients of this API probably expect that the buffer size must be >=
     // getByteCount(), but if we don't enforce this restriction then for RGB_4444 and other

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapDrawable.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapDrawable.java
@@ -30,14 +30,14 @@ public class ShadowBitmapDrawable extends ShadowDrawable {
    * @param canvas the canvas to draw on
    */
   @Implementation
-  public void draw(Canvas canvas) {
+  protected void draw(Canvas canvas) {
     Paint paint = new Paint();
     paint.setColorFilter(colorFilter);
     canvas.drawBitmap(realBitmapDrawable.getBitmap(), 0, 0, paint);
   }
 
   @Implementation
-  public Drawable mutate() {
+  protected Drawable mutate() {
     Bitmap bitmap = realBitmapDrawable.getBitmap();
     BitmapDrawable real = ReflectionHelpers.callConstructor(BitmapDrawable.class, ClassParameter.from(Bitmap.class, bitmap));
     ShadowBitmapDrawable shadow = Shadow.extract(real);
@@ -47,7 +47,7 @@ public class ShadowBitmapDrawable extends ShadowDrawable {
   }
 
   @Implementation
-  public void setColorFilter(ColorFilter colorFilter) {
+  protected void setColorFilter(ColorFilter colorFilter) {
     this.colorFilter = colorFilter;
     directlyOn(realBitmapDrawable, BitmapDrawable.class).setColorFilter(colorFilter);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -37,7 +37,8 @@ public class ShadowBitmapFactory {
   private static Map<String, Point> widthAndHeightMap = new HashMap<>();
 
   @Implementation
-  public static Bitmap decodeResourceStream(Resources res, TypedValue value, InputStream is, Rect pad, BitmapFactory.Options opts) {
+  protected static Bitmap decodeResourceStream(
+      Resources res, TypedValue value, InputStream is, Rect pad, BitmapFactory.Options opts) {
     Bitmap bitmap = directlyOn(BitmapFactory.class, "decodeResourceStream",
         ClassParameter.from(Resources.class, res),
         ClassParameter.from(TypedValue.class, value),
@@ -53,7 +54,7 @@ public class ShadowBitmapFactory {
   }
 
   @Implementation
-  public static Bitmap decodeResource(Resources res, int id, BitmapFactory.Options options) {
+  protected static Bitmap decodeResource(Resources res, int id, BitmapFactory.Options options) {
     if (id == 0) {
       return null;
     }
@@ -64,17 +65,17 @@ public class ShadowBitmapFactory {
   }
 
   @Implementation
-  public static Bitmap decodeResource(Resources res, int id) {
+  protected static Bitmap decodeResource(Resources res, int id) {
     return decodeResource(res, id, null);
   }
 
   @Implementation
-  public static Bitmap decodeFile(String pathName) {
+  protected static Bitmap decodeFile(String pathName) {
     return decodeFile(pathName, null);
   }
 
   @Implementation
-  public static Bitmap decodeFile(String pathName, BitmapFactory.Options options) {
+  protected static Bitmap decodeFile(String pathName, BitmapFactory.Options options) {
     Bitmap bitmap = create("file:" + pathName, options);
     ShadowBitmap shadowBitmap = Shadow.extract(bitmap);
     shadowBitmap.createdFromPath = pathName;
@@ -82,7 +83,8 @@ public class ShadowBitmapFactory {
   }
 
   @Implementation
-  public static Bitmap decodeFileDescriptor(FileDescriptor fd, Rect outPadding, BitmapFactory.Options opts) {
+  protected static Bitmap decodeFileDescriptor(
+      FileDescriptor fd, Rect outPadding, BitmapFactory.Options opts) {
     Bitmap bitmap = create("fd:" + fd, opts);
     ShadowBitmap shadowBitmap = Shadow.extract(bitmap);
     shadowBitmap.createdFromFileDescriptor = fd;
@@ -90,12 +92,13 @@ public class ShadowBitmapFactory {
   }
 
   @Implementation
-  public static Bitmap decodeStream(InputStream is) {
+  protected static Bitmap decodeStream(InputStream is) {
     return decodeStream(is, null, null);
   }
 
   @Implementation
-  public static Bitmap decodeStream(InputStream is, Rect outPadding, BitmapFactory.Options opts) {
+  protected static Bitmap decodeStream(
+      InputStream is, Rect outPadding, BitmapFactory.Options opts) {
     byte[] ninePatchChunk = null;
 
     if (is instanceof AssetInputStream) {
@@ -130,7 +133,7 @@ public class ShadowBitmapFactory {
   }
 
   @Implementation
-  public static Bitmap decodeByteArray(byte[] data, int offset, int length) {
+  protected static Bitmap decodeByteArray(byte[] data, int offset, int length) {
     Bitmap bitmap = decodeByteArray(data, offset, length, new BitmapFactory.Options());
     ShadowBitmap shadowBitmap = Shadow.extract(bitmap);
     shadowBitmap.createdFromBytes = data;
@@ -138,7 +141,8 @@ public class ShadowBitmapFactory {
   }
 
   @Implementation
-  public static Bitmap decodeByteArray(byte[] data, int offset, int length, BitmapFactory.Options opts) {
+  protected static Bitmap decodeByteArray(
+      byte[] data, int offset, int length, BitmapFactory.Options opts) {
     String desc = new String(data, UTF_8);
     if (!Charset.forName("US-ASCII").newEncoder().canEncode(desc)) {
       Checksum checksumEngine = new CRC32();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapRegionDecoder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapRegionDecoder.java
@@ -24,22 +24,26 @@ public class ShadowBitmapRegionDecoder {
   private int height;
 
   @Implementation
-  public static BitmapRegionDecoder newInstance(byte[] data, int offset, int length, boolean isShareable) throws IOException {
+  protected static BitmapRegionDecoder newInstance(
+      byte[] data, int offset, int length, boolean isShareable) throws IOException {
     return fillWidthAndHeight(newInstance(), new ByteArrayInputStream(data));
   }
 
   @Implementation
-  public static BitmapRegionDecoder newInstance(FileDescriptor fd, boolean isShareable) throws IOException {
+  protected static BitmapRegionDecoder newInstance(FileDescriptor fd, boolean isShareable)
+      throws IOException {
     return fillWidthAndHeight(newInstance(), new FileInputStream(fd));
   }
 
   @Implementation
-  public static BitmapRegionDecoder newInstance(InputStream is, boolean isShareable) throws IOException {
+  protected static BitmapRegionDecoder newInstance(InputStream is, boolean isShareable)
+      throws IOException {
     return fillWidthAndHeight(newInstance(), is);
   }
 
   @Implementation
-  public static BitmapRegionDecoder newInstance(String pathName, boolean isShareable) throws IOException {
+  protected static BitmapRegionDecoder newInstance(String pathName, boolean isShareable)
+      throws IOException {
     return fillWidthAndHeight(newInstance(), new FileInputStream(pathName));
   }
 
@@ -54,17 +58,17 @@ public class ShadowBitmapRegionDecoder {
   }
 
   @Implementation
-  public int getWidth() {
+  protected int getWidth() {
     return width;
   }
 
   @Implementation
-  public int getHeight() {
+  protected int getHeight() {
     return height;
   }
 
   @Implementation
-  public Bitmap decodeRegion(Rect rect, BitmapFactory.Options options) {
+  protected Bitmap decodeRegion(Rect rect, BitmapFactory.Options options) {
     return Bitmap.createBitmap(rect.width(), rect.height(),
         options.inPreferredConfig != null ? options.inPreferredConfig : Bitmap.Config.ARGB_8888);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
@@ -36,12 +36,12 @@ public class ShadowBluetoothAdapter {
   private Map<Integer, Integer> profileConnectionStateData = new HashMap<>();
 
   @Implementation
-  public static BluetoothAdapter getDefaultAdapter() {
+  protected static BluetoothAdapter getDefaultAdapter() {
     return (BluetoothAdapter) ShadowApplication.getInstance().getBluetoothAdapter();
   }
 
   @Implementation
-  public Set<BluetoothDevice> getBondedDevices() {
+  protected Set<BluetoothDevice> getBondedDevices() {
     return Collections.unmodifiableSet(bondedDevices);
   }
 
@@ -57,31 +57,31 @@ public class ShadowBluetoothAdapter {
   }
 
   @Implementation
-  public boolean startDiscovery() {
+  protected boolean startDiscovery() {
     isDiscovering = true;
     return true;
   }
 
   @Implementation
-  public boolean cancelDiscovery() {
+  protected boolean cancelDiscovery() {
     isDiscovering = false;
     return true;
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public boolean startLeScan(LeScanCallback callback) {
+  protected boolean startLeScan(LeScanCallback callback) {
     return startLeScan(null, callback);
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public boolean startLeScan(UUID[] serviceUuids, LeScanCallback callback) {
+  protected boolean startLeScan(UUID[] serviceUuids, LeScanCallback callback) {
     // Ignoring the serviceUuids param for now.
     leScanCallbacks.add(callback);
     return true;
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public void stopLeScan(LeScanCallback callback) {
+  protected void stopLeScan(LeScanCallback callback) {
     leScanCallbacks.remove(callback);
   }
 
@@ -97,34 +97,34 @@ public class ShadowBluetoothAdapter {
   }
 
   @Implementation
-  public boolean isDiscovering() {
+  protected boolean isDiscovering() {
     return isDiscovering;
   }
 
   @Implementation
-  public boolean isEnabled() {
+  protected boolean isEnabled() {
     return enabled;
   }
 
   @Implementation
-  public boolean enable() {
+  protected boolean enable() {
     enabled = true;
     return true;
   }
 
   @Implementation
-  public boolean disable() {
+  protected boolean disable() {
     enabled = false;
     return true;
   }
 
   @Implementation
-  public String getAddress() {
+  protected String getAddress() {
     return this.address;
   }
 
   @Implementation
-  public int getState() {
+  protected int getState() {
     return state;
   }
 
@@ -162,15 +162,14 @@ public class ShadowBluetoothAdapter {
   }
 
   /**
-   * Validate a Bluetooth address, such as "00:43:A8:23:10:F0"
-   * Alphabetic characters must be uppercase to be valid.
+   * Validate a Bluetooth address, such as "00:43:A8:23:10:F0" Alphabetic characters must be
+   * uppercase to be valid.
    *
-   * @param address
-   *         Bluetooth address as string
+   * @param address Bluetooth address as string
    * @return true if the address is valid, false otherwise
    */
   @Implementation
-  public static boolean checkBluetoothAddress(String address) {
+  protected static boolean checkBluetoothAddress(String address) {
     if (address == null || address.length() != ADDRESS_LENGTH) {
       return false;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothDevice.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothDevice.java
@@ -36,7 +36,7 @@ public class ShadowBluetoothDevice {
    * from invoking {@link android.bluetooth.BluetoothAdapter#getBluetoothService}.
    */
   @Implementation
-  public static IBluetooth getService() {
+  protected static IBluetooth getService() {
     // Attempt to call the underlying getService method, but ignore any Exceptions. This allows us
     // to easily create BluetoothDevices for testing purposes without having any actual Bluetooth
     // capability.
@@ -53,7 +53,7 @@ public class ShadowBluetoothDevice {
   }
 
   @Implementation
-  public String getName() {
+  protected String getName() {
     return name;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothManager.java
@@ -10,8 +10,8 @@ import org.robolectric.annotation.Implements;
 @Implements(value = BluetoothManager.class, minSdk = JELLY_BEAN_MR2)
 public class ShadowBluetoothManager {
 
-    @Implementation
-    public BluetoothAdapter getAdapter() {
+  @Implementation
+  protected BluetoothAdapter getAdapter() {
       return BluetoothAdapter.getDefaultAdapter();
     }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBroadcastPendingResult.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBroadcastPendingResult.java
@@ -123,7 +123,7 @@ public final class ShadowBroadcastPendingResult {
   private final SettableFuture<BroadcastReceiver.PendingResult> finished = SettableFuture.create();
 
   @Implementation
-  public final void finish() {
+  protected final void finish() {
     Preconditions.checkState(finished.set(pendingResult), "Broadcast already finished");
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBroadcastReceiver.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBroadcastReceiver.java
@@ -15,13 +15,13 @@ public class ShadowBroadcastReceiver {
   private AtomicBoolean abort; // The abort state of the currently processed broadcast
 
   @Implementation
-  public void abortBroadcast() {
+  protected void abortBroadcast() {
     // TODO probably needs a check to prevent calling this method from ordinary Broadcasts
     abort.set(true);
   }
 
   @Implementation
-  public void onReceive(Context context, Intent intent) {
+  protected void onReceive(Context context, Intent intent) {
     if (abort == null || !abort.get()) {
       receiver.onReceive(context, intent);
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBuild.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBuild.java
@@ -126,7 +126,7 @@ public class ShadowBuild {
   }
 
   @Implementation
-  public static String getRadioVersion() {
+  protected static String getRadioVersion() {
     if (radioVersionOverride != null) {
       return radioVersionOverride;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCamera.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCamera.java
@@ -39,14 +39,14 @@ public class ShadowCamera {
   @RealObject private Camera realCamera;
 
   @Implementation
-  public void __constructor__() {
+  protected void __constructor__() {
     locked = true;
     previewing = false;
     released = false;
   }
 
   @Implementation
-  public static Camera open() {
+  protected static Camera open() {
     lastOpenedCameraId = 0;
     Camera camera = newInstanceOf(Camera.class);
     ShadowCamera shadowCamera = Shadow.extract(camera);
@@ -55,7 +55,7 @@ public class ShadowCamera {
   }
 
   @Implementation
-  public static Camera open(int cameraId) {
+  protected static Camera open(int cameraId) {
     lastOpenedCameraId = cameraId;
     Camera camera = newInstanceOf(Camera.class);
     ShadowCamera shadowCamera = Shadow.extract(camera);
@@ -68,17 +68,17 @@ public class ShadowCamera {
   }
 
   @Implementation
-  public void unlock() {
+  protected void unlock() {
     locked = false;
   }
 
   @Implementation
-  public void reconnect() {
+  protected void reconnect() {
     locked = true;
   }
 
   @Implementation
-  public Camera.Parameters getParameters() {
+  protected Camera.Parameters getParameters() {
     if (null == parameters) {
       parameters = newInstanceOf(Camera.Parameters.class);
     }
@@ -86,42 +86,42 @@ public class ShadowCamera {
   }
 
   @Implementation
-  public void setParameters(Camera.Parameters params) {
+  protected void setParameters(Camera.Parameters params) {
     parameters = params;
   }
 
   @Implementation
-  public void setPreviewDisplay(SurfaceHolder holder) {
+  protected void setPreviewDisplay(SurfaceHolder holder) {
     surfaceHolder = holder;
   }
 
   @Implementation
-  public void startPreview() {
+  protected void startPreview() {
     previewing = true;
   }
 
   @Implementation
-  public void stopPreview() {
+  protected void stopPreview() {
     previewing = false;
   }
 
   @Implementation
-  public void release() {
+  protected void release() {
     released = true;
   }
 
   @Implementation
-  public void setPreviewCallback(Camera.PreviewCallback cb) {
+  protected void setPreviewCallback(Camera.PreviewCallback cb) {
     previewCallback = cb;
   }
 
   @Implementation
-  public void setOneShotPreviewCallback(Camera.PreviewCallback cb) {
+  protected void setOneShotPreviewCallback(Camera.PreviewCallback cb) {
     previewCallback = cb;
   }
 
   @Implementation
-  public void setPreviewCallbackWithBuffer(Camera.PreviewCallback cb) {
+  protected void setPreviewCallbackWithBuffer(Camera.PreviewCallback cb) {
     previewCallback = cb;
   }
 
@@ -137,7 +137,7 @@ public class ShadowCamera {
   }
 
   @Implementation
-  public void addCallbackBuffer(byte[] callbackBuffer) {
+  protected void addCallbackBuffer(byte[] callbackBuffer) {
     callbackBuffers.add(callbackBuffer);
   }
 
@@ -146,7 +146,7 @@ public class ShadowCamera {
   }
 
   @Implementation
-  public void setDisplayOrientation(int degrees) {
+  protected void setDisplayOrientation(int degrees) {
     displayOrientation = degrees;
     if (cameras.containsKey(id)) {
       cameras.get(id).orientation = degrees;
@@ -158,13 +158,13 @@ public class ShadowCamera {
   }
 
   @Implementation
-  public void autoFocus(Camera.AutoFocusCallback callback) {
+  protected void autoFocus(Camera.AutoFocusCallback callback) {
     autoFocusCallback = callback;
     autoFocusing = true;
   }
 
   @Implementation
-  public void cancelAutoFocus() {
+  protected void cancelAutoFocus() {
     autoFocusCallback = null;
     autoFocusing = false;
   }
@@ -186,14 +186,14 @@ public class ShadowCamera {
   }
 
   @Implementation
-  public static void getCameraInfo(int cameraId, Camera.CameraInfo cameraInfo) {
+  protected static void getCameraInfo(int cameraId, Camera.CameraInfo cameraInfo) {
     Camera.CameraInfo foundCam = cameras.get(cameraId);
     cameraInfo.facing = foundCam.facing;
     cameraInfo.orientation = foundCam.orientation;
   }
 
   @Implementation
-  public static int getNumberOfCameras() {
+  protected static int getNumberOfCameras() {
     return cameras.size();
   }
 
@@ -276,7 +276,7 @@ public class ShadowCamera {
     }
 
     @Implementation
-    public Camera.Size getPictureSize() {
+    protected Camera.Size getPictureSize() {
       Camera.Size pictureSize = newInstanceOf(Camera.class).new Size(0, 0);
       pictureSize.width = pictureWidth;
       pictureSize.height = pictureHeight;
@@ -284,23 +284,23 @@ public class ShadowCamera {
     }
 
     @Implementation
-    public int getPreviewFormat() {
+    protected int getPreviewFormat() {
       return previewFormat;
     }
 
     @Implementation
-    public void getPreviewFpsRange(int[] range) {
+    protected void getPreviewFpsRange(int[] range) {
       range[0] = previewFpsMin;
       range[1] = previewFpsMax;
     }
 
     @Implementation
-    public int getPreviewFrameRate() {
+    protected int getPreviewFrameRate() {
       return previewFps;
     }
 
     @Implementation
-    public Camera.Size getPreviewSize() {
+    protected Camera.Size getPreviewSize() {
       Camera.Size previewSize = newInstanceOf(Camera.class).new Size(0, 0);
       previewSize.width = previewWidth;
       previewSize.height = previewHeight;
@@ -308,7 +308,7 @@ public class ShadowCamera {
     }
 
     @Implementation
-    public List<Camera.Size> getSupportedPictureSizes() {
+    protected List<Camera.Size> getSupportedPictureSizes() {
       List<Camera.Size> supportedSizes = new ArrayList<>();
       addSize(supportedSizes, 320, 240);
       addSize(supportedSizes, 640, 480);
@@ -317,7 +317,7 @@ public class ShadowCamera {
     }
 
     @Implementation
-    public List<Integer> getSupportedPictureFormats() {
+    protected List<Integer> getSupportedPictureFormats() {
       List<Integer> formats = new ArrayList<>();
       formats.add(ImageFormat.NV21);
       formats.add(ImageFormat.JPEG);
@@ -325,7 +325,7 @@ public class ShadowCamera {
     }
 
     @Implementation
-    public List<Integer> getSupportedPreviewFormats() {
+    protected List<Integer> getSupportedPreviewFormats() {
       List<Integer> formats = new ArrayList<>();
       formats.add(ImageFormat.NV21);
       formats.add(ImageFormat.JPEG);
@@ -333,7 +333,7 @@ public class ShadowCamera {
     }
 
     @Implementation
-    public List<int[]> getSupportedPreviewFpsRange() {
+    protected List<int[]> getSupportedPreviewFpsRange() {
       List<int[]> supportedRanges = new ArrayList<>();
       addRange(supportedRanges, 15000, 15000);
       addRange(supportedRanges, 10000, 30000);
@@ -341,7 +341,7 @@ public class ShadowCamera {
     }
 
     @Implementation
-    public List<Integer> getSupportedPreviewFrameRates() {
+    protected List<Integer> getSupportedPreviewFrameRates() {
       List<Integer> supportedRates = new ArrayList<>();
       supportedRates.add(10);
       supportedRates.add(15);
@@ -350,7 +350,7 @@ public class ShadowCamera {
     }
 
     @Implementation
-    public List<Camera.Size> getSupportedPreviewSizes() {
+    protected List<Camera.Size> getSupportedPreviewSizes() {
       if (supportedPreviewSizes == null) {
         initSupportedPreviewSizes();
         addSupportedPreviewSize(320, 240);
@@ -364,80 +364,80 @@ public class ShadowCamera {
     }
 
     @Implementation
-    public List<String> getSupportedFocusModes() {
+    protected List<String> getSupportedFocusModes() {
       return supportedFocusModes;
     }
 
     @Implementation
-    public String getFocusMode() {
+    protected String getFocusMode() {
       return focusMode;
     }
 
     @Implementation
-    public void setFocusMode(String focusMode) {
+    protected void setFocusMode(String focusMode) {
       this.focusMode = focusMode;
     }
 
     @Implementation
-    public void setPictureSize(int width, int height) {
+    protected void setPictureSize(int width, int height) {
       pictureWidth = width;
       pictureHeight = height;
     }
 
     @Implementation
-    public void setPreviewFormat(int pixel_format) {
+    protected void setPreviewFormat(int pixel_format) {
       previewFormat = pixel_format;
     }
 
     @Implementation
-    public void setPreviewFpsRange(int min, int max) {
+    protected void setPreviewFpsRange(int min, int max) {
       previewFpsMin = min;
       previewFpsMax = max;
     }
 
     @Implementation
-    public void setPreviewFrameRate(int fps) {
+    protected void setPreviewFrameRate(int fps) {
       previewFps = fps;
     }
 
     @Implementation
-    public void setPreviewSize(int width, int height) {
+    protected void setPreviewSize(int width, int height) {
       previewWidth = width;
       previewHeight = height;
     }
 
     @Implementation
-    public void setRecordingHint(boolean recordingHint) {
+    protected void setRecordingHint(boolean recordingHint) {
       // Do nothing - this prevents an NPE in the SDK code
     }
 
     @Implementation
-    public void setRotation(int rotation) {
+    protected void setRotation(int rotation) {
       // Do nothing - this prevents an NPE in the SDK code
     }
 
     @Implementation
-    public int getMinExposureCompensation() {
+    protected int getMinExposureCompensation() {
       return -6;
     }
 
     @Implementation
-    public int getMaxExposureCompensation() {
+    protected int getMaxExposureCompensation() {
       return 6;
     }
 
     @Implementation
-    public float getExposureCompensationStep() {
+    protected float getExposureCompensationStep() {
       return 0.5f;
     }
 
     @Implementation
-    public int getExposureCompensation() {
+    protected int getExposureCompensation() {
       return exposureCompensation;
     }
 
     @Implementation
-    public void setExposureCompensation(int compensation) {
+    protected void setExposureCompensation(int compensation) {
       exposureCompensation = compensation;
     }
 
@@ -477,7 +477,7 @@ public class ShadowCamera {
     @RealObject private Camera.Size realCameraSize;
 
     @Implementation
-    public void __constructor__(Camera camera, int width, int height) {
+    protected void __constructor__(Camera camera, int width, int height) {
       realCameraSize.width = width;
       realCameraSize.height = height;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCanvas.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCanvas.java
@@ -54,7 +54,7 @@ public class ShadowCanvas {
   }
 
   @Implementation
-  public void __constructor__(Bitmap bitmap) {
+  protected void __constructor__(Bitmap bitmap) {
     this.targetBitmap = bitmap;
   }
 
@@ -69,12 +69,12 @@ public class ShadowCanvas {
   }
 
   @Implementation
-  public void setBitmap(Bitmap bitmap) {
+  protected void setBitmap(Bitmap bitmap) {
     targetBitmap = bitmap;
   }
 
   @Implementation
-  public void drawText(String text, float x, float y, Paint paint) {
+  protected void drawText(String text, float x, float y, Paint paint) {
     drawnTextEventHistory.add(new TextHistoryEvent(x, y, paint, text));
   }
 
@@ -95,35 +95,35 @@ public class ShadowCanvas {
   }
 
   @Implementation
-  public void translate(float x, float y) {
+  protected void translate(float x, float y) {
     this.translateX = x;
     this.translateY = y;
   }
 
   @Implementation
-  public void scale(float sx, float sy) {
+  protected void scale(float sx, float sy) {
     this.scaleX = sx;
     this.scaleY = sy;
   }
 
   @Implementation
-  public void scale(float sx, float sy, float px, float py) {
+  protected void scale(float sx, float sy, float px, float py) {
     this.scaleX = sx;
     this.scaleY = sy;
   }
 
   @Implementation
-  public void drawPaint(Paint paint) {
+  protected void drawPaint(Paint paint) {
     drawnPaint = paint;
   }
 
   @Implementation
-  public void drawColor(int color) {
+  protected void drawColor(int color) {
     appendDescription("draw color " + color);
   }
 
   @Implementation
-  public void drawBitmap(Bitmap bitmap, float left, float top, Paint paint) {
+  protected void drawBitmap(Bitmap bitmap, float left, float top, Paint paint) {
     describeBitmap(bitmap, paint);
 
     int x = (int) (left + translateX);
@@ -138,7 +138,7 @@ public class ShadowCanvas {
   }
 
   @Implementation
-  public void drawBitmap(Bitmap bitmap, Rect src, Rect dst, Paint paint) {
+  protected void drawBitmap(Bitmap bitmap, Rect src, Rect dst, Paint paint) {
     describeBitmap(bitmap, paint);
 
     StringBuilder descriptionBuilder = new StringBuilder();
@@ -154,7 +154,7 @@ public class ShadowCanvas {
   }
 
   @Implementation
-  public void drawBitmap(Bitmap bitmap, Rect src, RectF dst, Paint paint) {
+  protected void drawBitmap(Bitmap bitmap, Rect src, RectF dst, Paint paint) {
     describeBitmap(bitmap, paint);
 
     StringBuilder descriptionBuilder = new StringBuilder();
@@ -170,7 +170,7 @@ public class ShadowCanvas {
   }
 
   @Implementation
-  public void drawBitmap(Bitmap bitmap, Matrix matrix, Paint paint) {
+  protected void drawBitmap(Bitmap bitmap, Matrix matrix, Paint paint) {
     describeBitmap(bitmap, paint);
 
     ShadowMatrix shadowMatrix = Shadow.extract(matrix);
@@ -178,7 +178,7 @@ public class ShadowCanvas {
   }
 
   @Implementation
-  public void drawPath(Path path, Paint paint) {
+  protected void drawPath(Path path, Paint paint) {
     pathPaintEvents.add(new PathPaintHistoryEvent(new Path(path), new Paint(paint)));
 
     separateLines();
@@ -187,33 +187,33 @@ public class ShadowCanvas {
   }
 
   @Implementation
-  public void drawCircle(float cx, float cy, float radius, Paint paint) {
+  protected void drawCircle(float cx, float cy, float radius, Paint paint) {
     circlePaintEvents.add(new CirclePaintHistoryEvent(cx, cy, radius, paint));
   }
 
   @Implementation
-  public void drawArc(RectF oval, float startAngle, float sweepAngle, boolean useCenter, Paint paint) {
+  protected void drawArc(
+      RectF oval, float startAngle, float sweepAngle, boolean useCenter, Paint paint) {
     arcPaintEvents.add(new ArcPaintHistoryEvent(oval, startAngle, sweepAngle, useCenter, paint));
   }
 
   @Implementation
-  public void drawRect(float left, float top, float right, float bottom, Paint paint) {
+  protected void drawRect(float left, float top, float right, float bottom, Paint paint) {
     rectPaintEvents.add(new RectPaintHistoryEvent(left, top, right, bottom, paint));
   }
 
   @Implementation
-  public void drawLine(float startX, float startY, float stopX, float stopY, Paint paint) {
+  protected void drawLine(float startX, float startY, float stopX, float stopY, Paint paint) {
     linePaintEvents.add(new LinePaintHistoryEvent(startX, startY, stopX, stopY, paint));
   }
 
   @Implementation
-  public void drawOval(RectF oval, Paint paint) {
+  protected void drawOval(RectF oval, Paint paint) {
     ovalPaintEvents.add(new OvalPaintHistoryEvent(oval, paint));
   }
 
   @Implementation
-  public void restore() {
-  }
+  protected void restore() {}
 
   private void describeBitmap(Bitmap bitmap, Paint paint) {
     separateLines();
@@ -313,12 +313,12 @@ public class ShadowCanvas {
   }
 
   @Implementation
-  public int getWidth() {
+  protected int getWidth() {
     return width;
   }
 
   @Implementation
-  public int getHeight() {
+  protected int getHeight() {
     return height;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowChoreographer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowChoreographer.java
@@ -70,7 +70,7 @@ public class ShadowChoreographer {
   }
 
   @Implementation
-  public static Choreographer getInstance() {
+  protected static Choreographer getInstance() {
     return instance.get();
   }
 
@@ -82,23 +82,24 @@ public class ShadowChoreographer {
    * AnimationHandler would result in endless looping (the execution of the task results in a new
    * animation task created and scheduled to the front of the event loop queue).
    *
-   * To prevent endless looping, a test may call {@link #setPostCallbackDelay(int)} to specify a
+   * <p>To prevent endless looping, a test may call {@link #setPostCallbackDelay(int)} to specify a
    * small delay when animation is scheduled.
    *
    * @see #setPostCallbackDelay(int)
    */
   @Implementation
-  public void postCallback(int callbackType, Runnable action, Object token) {
+  protected void postCallback(int callbackType, Runnable action, Object token) {
     postCallbackDelayed(callbackType, action, token, postCallbackDelayMillis);
   }
 
   @Implementation
-  public void postCallbackDelayed(int callbackType, Runnable action, Object token, long delayMillis) {
+  protected void postCallbackDelayed(
+      int callbackType, Runnable action, Object token, long delayMillis) {
     handler.postDelayed(action, delayMillis);
   }
 
   @Implementation
-  public void removeCallbacks(int callbackType, Runnable action, Object token) {
+  protected void removeCallbacks(int callbackType, Runnable action, Object token) {
     handler.removeCallbacks(action, token);
   }
 
@@ -110,18 +111,18 @@ public class ShadowChoreographer {
    * AnimationHandler would result in endless looping (the execution of the task results in a new
    * animation task created and scheduled to the front of the event loop queue).
    *
-   * To prevent endless looping, a test may call {@link #setPostFrameCallbackDelay(int)} to
+   * <p>To prevent endless looping, a test may call {@link #setPostFrameCallbackDelay(int)} to
    * specify a small delay when animation is scheduled.
    *
    * @see #setPostCallbackDelay(int)
    */
   @Implementation
-  public void postFrameCallback(final FrameCallback callback) {
+  protected void postFrameCallback(final FrameCallback callback) {
     postFrameCallbackDelayed(callback, postFrameCallbackDelayMillis);
   }
 
   @Implementation
-  public void postFrameCallbackDelayed(final FrameCallback callback, long delayMillis) {
+  protected void postFrameCallbackDelayed(final FrameCallback callback, long delayMillis) {
     handler.postAtTime(new Runnable() {
       @Override public void run() {
         callback.doFrame(getFrameTimeNanos());
@@ -130,12 +131,12 @@ public class ShadowChoreographer {
   }
 
   @Implementation
-  public void removeFrameCallback(FrameCallback callback) {
+  protected void removeFrameCallback(FrameCallback callback) {
     handler.removeCallbacksAndMessages(callback);
   }
 
   @Implementation
-  public long getFrameTimeNanos() {
+  protected long getFrameTimeNanos() {
     final long now = nanoTime;
     nanoTime += ShadowChoreographer.FRAME_INTERVAL;
     return now;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowClipboardManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowClipboardManager.java
@@ -24,7 +24,7 @@ public class ShadowClipboardManager {
   private ClipData clip;
 
   @Implementation
-  public void setPrimaryClip(ClipData clip) {
+  protected void setPrimaryClip(ClipData clip) {
     if (getApiLevel() >= N) {
       if (clip != null) {
         clip.prepareToLeaveProcess(true);
@@ -43,37 +43,37 @@ public class ShadowClipboardManager {
   }
 
   @Implementation
-  public ClipData getPrimaryClip() {
+  protected ClipData getPrimaryClip() {
     return clip;
   }
 
   @Implementation
-  public ClipDescription getPrimaryClipDescription() {
+  protected ClipDescription getPrimaryClipDescription() {
     return clip == null ? null : clip.getDescription();
   }
 
   @Implementation
-  public boolean hasPrimaryClip() {
+  protected boolean hasPrimaryClip() {
     return clip != null;
   }
 
   @Implementation
-  public void addPrimaryClipChangedListener(OnPrimaryClipChangedListener listener) {
+  protected void addPrimaryClipChangedListener(OnPrimaryClipChangedListener listener) {
     listeners.add(listener);
   }
 
   @Implementation
-  public void removePrimaryClipChangedListener(OnPrimaryClipChangedListener listener) {
+  protected void removePrimaryClipChangedListener(OnPrimaryClipChangedListener listener) {
     listeners.remove(listener);
   }
 
   @Implementation
-  public void setText(CharSequence text) {
+  protected void setText(CharSequence text) {
     setPrimaryClip(ClipData.newPlainText(null, text));
   }
 
   @Implementation
-  public boolean hasText() {
+  protected boolean hasText() {
     CharSequence text = directlyOn(realClipboardManager, ClipboardManager.class).getText();
     return text != null && text.length() > 0;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowColor.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowColor.java
@@ -9,12 +9,12 @@ public class ShadowColor {
   /**
    * This is implemented in native code in the Android SDK.
    *
-   * Since HSV == HSB then the implementation from {@link java.awt.Color} can be used,
-   * with a small adjustment to the representation of the hue.
+   * <p>Since HSV == HSB then the implementation from {@link java.awt.Color} can be used, with a
+   * small adjustment to the representation of the hue.
    *
-   * {@link java.awt.Color} represents hue as 0..1 (where 1 == 100% == 360 degrees),
-   * while {@link android.graphics.Color} represents hue as 0..360 degrees. The correct hue
-   * can be calculated by multiplying with 360.
+   * <p>{@link java.awt.Color} represents hue as 0..1 (where 1 == 100% == 360 degrees), while {@link
+   * android.graphics.Color} represents hue as 0..360 degrees. The correct hue can be calculated by
+   * multiplying with 360.
    *
    * @param red Red component
    * @param green Green component
@@ -22,13 +22,13 @@ public class ShadowColor {
    * @param hsv Array to store HSV components
    */
   @Implementation
-  public static void RGBToHSV(int red, int green, int blue, float hsv[]) {
+  protected static void RGBToHSV(int red, int green, int blue, float hsv[]) {
     java.awt.Color.RGBtoHSB(red, green, blue, hsv);
     hsv[0] = hsv[0] * 360;
   }
 
   @Implementation
-  public static int HSVToColor(int alpha, float hsv[]) {
+  protected static int HSVToColor(int alpha, float hsv[]) {
     int rgb = java.awt.Color.HSBtoRGB(hsv[0] / 360, hsv[1], hsv[2]);
     return Color.argb(alpha, Color.red(rgb), Color.green(rgb), Color.blue(rgb));
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowColorMatrixColorFilter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowColorMatrixColorFilter.java
@@ -11,12 +11,12 @@ public class ShadowColorMatrixColorFilter {
   private ColorMatrix matrix;
 
   @Implementation
-  public void __constructor__(ColorMatrix matrix) {
+  protected void __constructor__(ColorMatrix matrix) {
     this.matrix = matrix;
   }
 
   @Implementation
-  public void __constructor__(float[] array) {
+  protected void __constructor__(float[] array) {
     this.matrix = new ColorMatrix(array);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCompoundButton.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCompoundButton.java
@@ -17,13 +17,13 @@ public class ShadowCompoundButton extends ShadowTextView {
   private Drawable buttonDrawable;
 
   @Implementation
-  public void setButtonDrawable(int buttonDrawableId) {
+  protected void setButtonDrawable(int buttonDrawableId) {
     this.buttonDrawableId = buttonDrawableId;
     directlyOn(realObject, CompoundButton.class, "setButtonDrawable", from(int.class, buttonDrawableId));
   }
 
   @Implementation
-  public void setButtonDrawable(Drawable buttonDrawable) {
+  protected void setButtonDrawable(Drawable buttonDrawable) {
     this.buttonDrawable = buttonDrawable;
     directlyOn(realObject, CompoundButton.class, "setButtonDrawable", from(Drawable.class, buttonDrawable));
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowConnectivityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowConnectivityManager.java
@@ -96,7 +96,7 @@ public class ShadowConnectivityManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void unregisterNetworkCallback (ConnectivityManager.NetworkCallback networkCallback) {
+  protected void unregisterNetworkCallback(ConnectivityManager.NetworkCallback networkCallback) {
     if (networkCallback == null) {
       throw new IllegalArgumentException("Invalid NetworkCallback");
     }
@@ -106,7 +106,7 @@ public class ShadowConnectivityManager {
   }
 
   @Implementation
-  public NetworkInfo getActiveNetworkInfo() {
+  protected NetworkInfo getActiveNetworkInfo() {
     return activeNetworkInfo;
   }
 
@@ -115,7 +115,7 @@ public class ShadowConnectivityManager {
    * @see #setNetworkInfo(int, NetworkInfo)
    */
   @Implementation(minSdk = M)
-  public Network getActiveNetwork() {
+  protected Network getActiveNetwork() {
     if (defaultNetworkActive) {
       return netIdToNetwork.get(getActiveNetworkInfo().getType());
     }
@@ -127,7 +127,7 @@ public class ShadowConnectivityManager {
    * @see #setNetworkInfo(int, NetworkInfo)
    */
   @Implementation
-  public NetworkInfo[] getAllNetworkInfo() {
+  protected NetworkInfo[] getAllNetworkInfo() {
     // todo(xian): is `defaultNetworkActive` really relevant here?
     if (defaultNetworkActive) {
       return networkTypeToNetworkInfo
@@ -138,12 +138,12 @@ public class ShadowConnectivityManager {
   }
 
   @Implementation
-  public NetworkInfo getNetworkInfo(int networkType) {
+  protected NetworkInfo getNetworkInfo(int networkType) {
     return networkTypeToNetworkInfo.get(networkType);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public NetworkInfo getNetworkInfo(Network network) {
+  protected NetworkInfo getNetworkInfo(Network network) {
     if (network == null) {
       return null;
     }
@@ -152,35 +152,35 @@ public class ShadowConnectivityManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public Network[] getAllNetworks() {
+  protected Network[] getAllNetworks() {
     return netIdToNetwork.values().toArray(new Network[netIdToNetwork.size()]);
   }
 
   @Implementation
-  public boolean getBackgroundDataSetting() {
+  protected boolean getBackgroundDataSetting() {
     return backgroundDataSetting;
   }
 
   @Implementation
-  public void setNetworkPreference(int preference) {
+  protected void setNetworkPreference(int preference) {
     networkPreference = preference;
   }
 
   @Implementation
-  public int getNetworkPreference() {
+  protected int getNetworkPreference() {
     return networkPreference;
   }
 
   /**
-   * Counts {@link ConnectivityManager#TYPE_MOBILE} networks as metered.
-   * Other types will be considered unmetered.
+   * Counts {@link ConnectivityManager#TYPE_MOBILE} networks as metered. Other types will be
+   * considered unmetered.
    *
    * @return `true` if the active network is metered, otherwise `false`.
    * @see #setActiveNetworkInfo(NetworkInfo)
    * @see #setDefaultNetworkActive(boolean)
    */
   @Implementation
-  public boolean isActiveNetworkMetered() {
+  protected boolean isActiveNetworkMetered() {
     if (defaultNetworkActive && activeNetworkInfo != null) {
       return activeNetworkInfo.getType() == ConnectivityManager.TYPE_MOBILE;
     } else {
@@ -189,13 +189,13 @@ public class ShadowConnectivityManager {
   }
 
   @Implementation(minSdk = M)
-  public boolean bindProcessToNetwork(Network network) {
+  protected boolean bindProcessToNetwork(Network network) {
     processBoundNetwork = network;
     return true;
   }
 
   @Implementation(minSdk = M)
-  public Network getBoundNetworkForProcess() {
+  protected Network getBoundNetworkForProcess() {
     return processBoundNetwork;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentObserver.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentObserver.java
@@ -13,12 +13,12 @@ public class ShadowContentObserver {
   private ContentObserver realObserver;
 
   @Implementation
-  public void dispatchChange(boolean selfChange, Uri uri) {
+  protected void dispatchChange(boolean selfChange, Uri uri) {
     realObserver.onChange(selfChange, uri);
   }
 
   @Implementation
-  public void dispatchChange(boolean selfChange) {
+  protected void dispatchChange(boolean selfChange) {
     realObserver.onChange(selfChange);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentProvider.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentProvider.java
@@ -19,7 +19,7 @@ public class ShadowContentProvider {
   }
 
   @Implementation(minSdk = KITKAT)
-  public String getCallingPackage() {
+  protected String getCallingPackage() {
     if (callingPackage != null) {
       return callingPackage;
     } else {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentProviderClient.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentProviderClient.java
@@ -6,9 +6,7 @@ import android.content.ContentProvider;
 import android.content.ContentProviderClient;
 import android.content.ContentProviderOperation;
 import android.content.ContentProviderResult;
-import android.content.ContentResolver;
 import android.content.ContentValues;
-import android.content.IContentProvider;
 import android.content.OperationApplicationException;
 import android.content.res.AssetFileDescriptor;
 import android.database.Cursor;
@@ -32,80 +30,86 @@ public class ShadowContentProviderClient {
   private ContentProvider provider;
 
   @Implementation(minSdk = JELLY_BEAN_MR1)
-  public Bundle call(String method, String arg, Bundle extras) throws RemoteException {
+  protected Bundle call(String method, String arg, Bundle extras) throws RemoteException {
     return provider.call(method, arg, extras);
   }
 
   @Implementation
-  public String getType(Uri uri) throws RemoteException {
+  protected String getType(Uri uri) throws RemoteException {
     return provider.getType(uri);
   }
 
   @Implementation
-  public String[] getStreamTypes(Uri uri, String mimeTypeFilter) {
+  protected String[] getStreamTypes(Uri uri, String mimeTypeFilter) {
     return provider.getStreamTypes(uri, mimeTypeFilter);
   }
 
   @Implementation
-  public Cursor query(Uri url, String[] projection, String selection, String[] selectionArgs,
-                      String sortOrder) throws RemoteException {
+  protected Cursor query(
+      Uri url, String[] projection, String selection, String[] selectionArgs, String sortOrder)
+      throws RemoteException {
     return provider.query(url, projection, selection, selectionArgs, sortOrder);
   }
 
   @Implementation
-  public Cursor query(Uri url, String[] projection, String selection, String[] selectionArgs,
-                      String sortOrder, CancellationSignal cancellationSignal) throws RemoteException {
+  protected Cursor query(
+      Uri url,
+      String[] projection,
+      String selection,
+      String[] selectionArgs,
+      String sortOrder,
+      CancellationSignal cancellationSignal)
+      throws RemoteException {
     return provider.query(url, projection, selection, selectionArgs, sortOrder, cancellationSignal);
   }
 
   @Implementation
-  public Uri insert(Uri url, ContentValues initialValues) throws RemoteException {
+  protected Uri insert(Uri url, ContentValues initialValues) throws RemoteException {
     return provider.insert(url, initialValues);
   }
 
   @Implementation
-  public int bulkInsert(Uri url, ContentValues[] initialValues) throws RemoteException {
+  protected int bulkInsert(Uri url, ContentValues[] initialValues) throws RemoteException {
     return provider.bulkInsert(url, initialValues);
   }
 
   @Implementation
-  public int delete(Uri url, String selection, String[] selectionArgs)
-      throws RemoteException {
+  protected int delete(Uri url, String selection, String[] selectionArgs) throws RemoteException {
     return provider.delete(url, selection, selectionArgs);
   }
 
   @Implementation
-  public int update(Uri url, ContentValues values, String selection, String[] selectionArgs)
+  protected int update(Uri url, ContentValues values, String selection, String[] selectionArgs)
       throws RemoteException {
     return provider.update(url, values, selection, selectionArgs);
   }
 
   @Implementation
-  public ParcelFileDescriptor openFile(Uri url, String mode)
+  protected ParcelFileDescriptor openFile(Uri url, String mode)
       throws RemoteException, FileNotFoundException {
     return provider.openFile(url, mode);
   }
 
   @Implementation
-  public AssetFileDescriptor openAssetFile(Uri url, String mode)
+  protected AssetFileDescriptor openAssetFile(Uri url, String mode)
       throws RemoteException, FileNotFoundException {
     return provider.openAssetFile(url, mode);
   }
 
   @Implementation
-  public final AssetFileDescriptor openTypedAssetFileDescriptor(Uri uri,
-                                                                String mimeType, Bundle opts) throws RemoteException, FileNotFoundException {
+  protected final AssetFileDescriptor openTypedAssetFileDescriptor(
+      Uri uri, String mimeType, Bundle opts) throws RemoteException, FileNotFoundException {
     return provider.openTypedAssetFile(uri, mimeType, opts);
   }
 
   @Implementation
-  public ContentProviderResult[] applyBatch(ArrayList<ContentProviderOperation> operations)
+  protected ContentProviderResult[] applyBatch(ArrayList<ContentProviderOperation> operations)
       throws RemoteException, OperationApplicationException {
     return provider.applyBatch(operations);
   }
 
   @Implementation
-  public boolean release() {
+  protected boolean release() {
     synchronized (this) {
       if (released) {
         throw new IllegalStateException("Already released");
@@ -116,7 +120,7 @@ public class ShadowContentProviderClient {
   }
 
   @Implementation
-  public ContentProvider getLocalContentProvider() {
+  protected ContentProvider getLocalContentProvider() {
     return ContentProvider.coerceToLocalContentProvider(provider.getIContentProvider());
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentProviderResult.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentProviderResult.java
@@ -12,7 +12,7 @@ public class ShadowContentProviderResult {
   @RealObject ContentProviderResult realResult;
 
   @Implementation
-  public void __constructor__(Uri uri)
+  protected void __constructor__(Uri uri)
       throws SecurityException, NoSuchFieldException, IllegalArgumentException,
           IllegalAccessException {
     Field field = realResult.getClass().getField("uri");
@@ -21,7 +21,7 @@ public class ShadowContentProviderResult {
   }
 
   @Implementation
-  public void __constructor__(int count)
+  protected void __constructor__(int count)
       throws SecurityException, NoSuchFieldException, IllegalArgumentException,
           IllegalAccessException {
     Field field = realResult.getClass().getField("count");

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
@@ -145,7 +145,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public final InputStream openInputStream(final Uri uri) {
+  protected final InputStream openInputStream(final Uri uri) {
     InputStream inputStream = inputStreamMap.get(uri);
     if (inputStream != null) {
       return inputStream;
@@ -155,7 +155,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public final OutputStream openOutputStream(final Uri uri) {
+  protected final OutputStream openOutputStream(final Uri uri) {
     OutputStream outputStream = outputStreamMap.get(uri);
     if (outputStream != null) {
       return outputStream;
@@ -174,18 +174,18 @@ public class ShadowContentResolver {
   }
 
   /**
-   * If a {@link ContentProvider} is registered for the given {@link Uri}, its
-   * {@link ContentProvider#insert(Uri, ContentValues)} method will be invoked.
+   * If a {@link ContentProvider} is registered for the given {@link Uri}, its {@link
+   * ContentProvider#insert(Uri, ContentValues)} method will be invoked.
    *
-   * Tests can verify that this method was called using {@link #getStatements()} or
-   * {@link #getInsertStatements()}.
+   * <p>Tests can verify that this method was called using {@link #getStatements()} or {@link
+   * #getInsertStatements()}.
    *
-   * If no appropriate {@link ContentProvider} is found, no action will be taken and
-   * a {@link Uri} including the incremented value set with
-   * {@link #setNextDatabaseIdForInserts(int)} will returned.
+   * <p>If no appropriate {@link ContentProvider} is found, no action will be taken and a {@link
+   * Uri} including the incremented value set with {@link #setNextDatabaseIdForInserts(int)} will
+   * returned.
    */
   @Implementation
-  public final Uri insert(Uri url, ContentValues values) {
+  protected final Uri insert(Uri url, ContentValues values) {
     ContentProvider provider = getProvider(url);
     ContentValues valuesCopy = (values == null) ? null : new ContentValues(values);
     InsertStatement insertStatement = new InsertStatement(url, provider, valuesCopy);
@@ -200,20 +200,20 @@ public class ShadowContentResolver {
   }
 
   /**
-   * If a {@link ContentProvider} is registered for the given {@link Uri}, its
-   * {@link ContentProvider#update(Uri, ContentValues, String, String[])} method will be invoked.
+   * If a {@link ContentProvider} is registered for the given {@link Uri}, its {@link
+   * ContentProvider#update(Uri, ContentValues, String, String[])} method will be invoked.
    *
-   * Tests can verify that this method was called using {@link #getStatements()} or
-   * {@link #getUpdateStatements()}.
+   * <p>Tests can verify that this method was called using {@link #getStatements()} or {@link
+   * #getUpdateStatements()}.
    *
-   * If no appropriate {@link ContentProvider} is found, no action will be taken and
-   * the value set with {@link #setNextDatabaseIdForUpdates(int)} will be incremented and returned.
+   * <p>If no appropriate {@link ContentProvider} is found, no action will be taken and the value
+   * set with {@link #setNextDatabaseIdForUpdates(int)} will be incremented and returned.
    *
-   * *Note:* the return value in this case will be changed to {@code 1} in a future release of
+   * <p>*Note:* the return value in this case will be changed to {@code 1} in a future release of
    * Robolectric.
    */
   @Implementation
-  public int update(Uri uri, ContentValues values, String where, String[] selectionArgs) {
+  protected int update(Uri uri, ContentValues values, String where, String[] selectionArgs) {
     ContentProvider provider = getProvider(uri);
     ContentValues valuesCopy = (values == null) ? null : new ContentValues(values);
     UpdateStatement updateStatement =
@@ -229,7 +229,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public final Cursor query(
+  protected final Cursor query(
       Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
     ContentProvider provider = getProvider(uri);
     if (provider != null) {
@@ -246,7 +246,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public Cursor query(
+  protected Cursor query(
       Uri uri,
       String[] projection,
       String selection,
@@ -269,7 +269,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public String getType(Uri uri) {
+  protected String getType(Uri uri) {
     ContentProvider provider = getProvider(uri);
     if (provider != null) {
       return provider.getType(uri);
@@ -279,7 +279,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public Bundle call(Uri uri, String method, String arg, Bundle extras) {
+  protected Bundle call(Uri uri, String method, String arg, Bundle extras) {
     ContentProvider cp = getProvider(uri);
     if (cp != null) {
       return cp.call(method, arg, extras);
@@ -289,7 +289,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public final ContentProviderClient acquireContentProviderClient(String name) {
+  protected final ContentProviderClient acquireContentProviderClient(String name) {
     ContentProvider provider = getProvider(name);
     if (provider == null) {
       return null;
@@ -298,7 +298,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public final ContentProviderClient acquireContentProviderClient(Uri uri) {
+  protected final ContentProviderClient acquireContentProviderClient(Uri uri) {
     ContentProvider provider = getProvider(uri);
     if (provider == null) {
       return null;
@@ -307,7 +307,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public final ContentProviderClient acquireUnstableContentProviderClient(String name) {
+  protected final ContentProviderClient acquireUnstableContentProviderClient(String name) {
     ContentProvider provider = getProvider(name);
     if (provider == null) {
       return null;
@@ -316,7 +316,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public final ContentProviderClient acquireUnstableContentProviderClient(Uri uri) {
+  protected final ContentProviderClient acquireUnstableContentProviderClient(Uri uri) {
     ContentProvider provider = getProvider(uri);
     if (provider == null) {
       return null;
@@ -337,17 +337,17 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public final IContentProvider acquireProvider(String name) {
+  protected final IContentProvider acquireProvider(String name) {
     return acquireUnstableProvider(name);
   }
 
   @Implementation
-  public final IContentProvider acquireProvider(Uri uri) {
+  protected final IContentProvider acquireProvider(Uri uri) {
     return acquireUnstableProvider(uri);
   }
 
   @Implementation
-  public final IContentProvider acquireUnstableProvider(String name) {
+  protected final IContentProvider acquireUnstableProvider(String name) {
     ContentProvider cp = getProvider(name);
     if (cp != null) {
       return cp.getIContentProvider();
@@ -356,7 +356,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public final IContentProvider acquireUnstableProvider(Uri uri) {
+  protected final IContentProvider acquireUnstableProvider(Uri uri) {
     ContentProvider cp = getProvider(uri);
     if (cp != null) {
       return cp.getIContentProvider();
@@ -365,17 +365,17 @@ public class ShadowContentResolver {
   }
 
   /**
-   * If a {@link ContentProvider} is registered for the given {@link Uri}, its
-   * {@link ContentProvider#delete(Uri, String, String[])} method will be invoked.
+   * If a {@link ContentProvider} is registered for the given {@link Uri}, its {@link
+   * ContentProvider#delete(Uri, String, String[])} method will be invoked.
    *
-   * Tests can verify that this method was called using {@link #getDeleteStatements()}
-   * or {@link #getDeletedUris()}.
+   * <p>Tests can verify that this method was called using {@link #getDeleteStatements()} or {@link
+   * #getDeletedUris()}.
    *
-   * If no appropriate {@link ContentProvider} is found, no action will be taken and
-   * {@code 1} will be returned.
+   * <p>If no appropriate {@link ContentProvider} is found, no action will be taken and {@code 1}
+   * will be returned.
    */
   @Implementation
-  public final int delete(Uri url, String where, String[] selectionArgs) {
+  protected final int delete(Uri url, String where, String[] selectionArgs) {
     ContentProvider provider = getProvider(url);
 
     DeleteStatement deleteStatement = new DeleteStatement(url, provider, where, selectionArgs);
@@ -390,17 +390,17 @@ public class ShadowContentResolver {
   }
 
   /**
-   * If a {@link ContentProvider} is registered for the given {@link Uri}, its
-   * {@link ContentProvider#bulkInsert(Uri, ContentValues[])} method will be invoked.
+   * If a {@link ContentProvider} is registered for the given {@link Uri}, its {@link
+   * ContentProvider#bulkInsert(Uri, ContentValues[])} method will be invoked.
    *
-   * Tests can verify that this method was called using {@link #getStatements()} or
-   * {@link #getInsertStatements()}.
+   * <p>Tests can verify that this method was called using {@link #getStatements()} or {@link
+   * #getInsertStatements()}.
    *
-   * If no appropriate {@link ContentProvider} is found, no action will be taken and
-   * the number of rows in {@code values} will be returned.
+   * <p>If no appropriate {@link ContentProvider} is found, no action will be taken and the number
+   * of rows in {@code values} will be returned.
    */
   @Implementation
-  public final int bulkInsert(Uri url, ContentValues[] values) {
+  protected final int bulkInsert(Uri url, ContentValues[] values) {
     ContentProvider provider = getProvider(url);
 
     InsertStatement insertStatement = new InsertStatement(url, provider, values);
@@ -415,7 +415,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public void notifyChange(Uri uri, ContentObserver observer, boolean syncToNetwork) {
+  protected void notifyChange(Uri uri, ContentObserver observer, boolean syncToNetwork) {
     notifiedUris.add(new NotifiedUri(uri, observer, syncToNetwork));
 
     for (ContentObserverEntry entry : contentObservers) {
@@ -429,12 +429,12 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public void notifyChange(Uri uri, ContentObserver observer) {
+  protected void notifyChange(Uri uri, ContentObserver observer) {
     notifyChange(uri, observer, false);
   }
 
   @Implementation
-  public ContentProviderResult[] applyBatch(
+  protected ContentProviderResult[] applyBatch(
       String authority, ArrayList<ContentProviderOperation> operations)
       throws OperationApplicationException {
     ContentProvider provider = getProvider(authority);
@@ -447,7 +447,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public static void requestSync(Account account, String authority, Bundle extras) {
+  protected static void requestSync(Account account, String authority, Bundle extras) {
     validateSyncExtrasBundle(extras);
     Status status = getStatus(account, authority, true);
     status.syncRequests++;
@@ -455,7 +455,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public static void cancelSync(Account account, String authority) {
+  protected static void cancelSync(Account account, String authority) {
     Status status = getStatus(account, authority);
     if (status != null) {
       status.syncRequests = 0;
@@ -470,34 +470,34 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public static boolean isSyncActive(Account account, String authority) {
+  protected static boolean isSyncActive(Account account, String authority) {
     ShadowContentResolver.Status status = getStatus(account, authority);
     // TODO: this means a sync is *perpetually* active after one request
     return status != null && status.syncRequests > 0;
   }
 
   @Implementation
-  public static void setIsSyncable(Account account, String authority, int syncable) {
+  protected static void setIsSyncable(Account account, String authority, int syncable) {
     getStatus(account, authority, true).state = syncable;
   }
 
   @Implementation
-  public static int getIsSyncable(Account account, String authority) {
+  protected static int getIsSyncable(Account account, String authority) {
     return getStatus(account, authority, true).state;
   }
 
   @Implementation
-  public static boolean getSyncAutomatically(Account account, String authority) {
+  protected static boolean getSyncAutomatically(Account account, String authority) {
     return getStatus(account, authority, true).syncAutomatically;
   }
 
   @Implementation
-  public static void setSyncAutomatically(Account account, String authority, boolean sync) {
+  protected static void setSyncAutomatically(Account account, String authority, boolean sync) {
     getStatus(account, authority, true).syncAutomatically = sync;
   }
 
   @Implementation
-  public static void addPeriodicSync(
+  protected static void addPeriodicSync(
       Account account, String authority, Bundle extras, long pollFrequency) {
     validateSyncExtrasBundle(extras);
     removePeriodicSync(account, authority, extras);
@@ -507,7 +507,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public static void removePeriodicSync(Account account, String authority, Bundle extras) {
+  protected static void removePeriodicSync(Account account, String authority, Bundle extras) {
     validateSyncExtrasBundle(extras);
     Status status = getStatus(account, authority);
     if (status != null) {
@@ -521,12 +521,12 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public static List<PeriodicSync> getPeriodicSyncs(Account account, String authority) {
+  protected static List<PeriodicSync> getPeriodicSyncs(Account account, String authority) {
     return getStatus(account, authority, true).syncs;
   }
 
   @Implementation
-  public static void validateSyncExtrasBundle(Bundle extras) {
+  protected static void validateSyncExtrasBundle(Bundle extras) {
     for (String key : extras.keySet()) {
       Object value = extras.get(key);
       if (value == null
@@ -545,17 +545,17 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public static void setMasterSyncAutomatically(boolean sync) {
+  protected static void setMasterSyncAutomatically(boolean sync) {
     masterSyncAutomatically = sync;
   }
 
   @Implementation
-  public static boolean getMasterSyncAutomatically() {
+  protected static boolean getMasterSyncAutomatically() {
     return masterSyncAutomatically;
   }
 
   @Implementation(minSdk = KITKAT)
-  public void takePersistableUriPermission(@NonNull Uri uri, int modeFlags) {
+  protected void takePersistableUriPermission(@NonNull Uri uri, int modeFlags) {
     Objects.requireNonNull(uri, "uri may not be null");
     modeFlags &= (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
 
@@ -583,7 +583,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation(minSdk = KITKAT)
-  public void releasePersistableUriPermission(@NonNull Uri uri, int modeFlags) {
+  protected void releasePersistableUriPermission(@NonNull Uri uri, int modeFlags) {
     Objects.requireNonNull(uri, "uri may not be null");
     modeFlags &= (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
 
@@ -617,7 +617,8 @@ public class ShadowContentResolver {
   }
 
   @Implementation(minSdk = KITKAT)
-  public @NonNull List<UriPermission> getPersistedUriPermissions() {
+  @NonNull
+  protected List<UriPermission> getPersistedUriPermissions() {
     return uriPermissions;
   }
 
@@ -789,7 +790,7 @@ public class ShadowContentResolver {
   }
 
   @Implementation
-  public void registerContentObserver(
+  protected void registerContentObserver(
       Uri uri, boolean notifyForDescendents, ContentObserver observer) {
     if (uri == null || observer == null) {
       throw new NullPointerException();
@@ -798,13 +799,13 @@ public class ShadowContentResolver {
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR1)
-  public void registerContentObserver(
+  protected void registerContentObserver(
       Uri uri, boolean notifyForDescendents, ContentObserver observer, int userHandle) {
     registerContentObserver(uri, notifyForDescendents, observer);
   }
 
   @Implementation
-  public void unregisterContentObserver(ContentObserver observer) {
+  protected void unregisterContentObserver(ContentObserver observer) {
     synchronized (contentObservers) {
       for (ContentObserverEntry entry : contentObservers) {
         if (entry.observer == observer) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentUris.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentUris.java
@@ -9,12 +9,12 @@ import org.robolectric.annotation.Implements;
 public class ShadowContentUris {
 
   @Implementation
-  public static Uri withAppendedId(Uri contentUri, long id) {
+  protected static Uri withAppendedId(Uri contentUri, long id) {
     return Uri.withAppendedPath(contentUri, String.valueOf(id));
   }
 
   @Implementation
-  public static long parseId(Uri contentUri) {
+  protected static long parseId(Uri contentUri) {
     if (!contentUri.isHierarchical()) {
       throw new UnsupportedOperationException();
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextImpl.java
@@ -51,7 +51,7 @@ public class ShadowContextImpl {
 
   @Implementation
   @Nullable
-  public Object getSystemService(String name) {
+  protected Object getSystemService(String name) {
     if (removedSystemServices.contains(name)) {
       return null;
     }
@@ -78,7 +78,7 @@ public class ShadowContextImpl {
   }
 
   @Implementation
-  public void startIntentSender(
+  protected void startIntentSender(
       IntentSender intent,
       Intent fillInIntent,
       int flagsMask,
@@ -90,22 +90,22 @@ public class ShadowContextImpl {
   }
 
   @Implementation
-  public ClassLoader getClassLoader() {
+  protected ClassLoader getClassLoader() {
     return this.getClass().getClassLoader();
   }
 
   @Implementation
-  public int checkCallingPermission(String permission) {
+  protected int checkCallingPermission(String permission) {
     return checkPermission(permission, -1, -1);
   }
 
   @Implementation
-  public int checkCallingOrSelfPermission(String permission) {
+  protected int checkCallingOrSelfPermission(String permission) {
     return checkPermission(permission, -1, -1);
   }
 
   @Implementation
-  public ContentResolver getContentResolver() {
+  protected ContentResolver getContentResolver() {
     if (contentResolver == null) {
       contentResolver =
           new ContentResolver(realContextImpl) {
@@ -137,24 +137,24 @@ public class ShadowContextImpl {
   }
 
   @Implementation
-  public void sendBroadcast(Intent intent) {
+  protected void sendBroadcast(Intent intent) {
     getShadowInstrumentation().sendBroadcastWithPermission(intent, null, realContextImpl);
   }
 
   @Implementation
-  public void sendBroadcast(Intent intent, String receiverPermission) {
+  protected void sendBroadcast(Intent intent, String receiverPermission) {
     getShadowInstrumentation()
         .sendBroadcastWithPermission(intent, receiverPermission, realContextImpl);
   }
 
   @Implementation
-  public void sendOrderedBroadcast(Intent intent, String receiverPermission) {
+  protected void sendOrderedBroadcast(Intent intent, String receiverPermission) {
     getShadowInstrumentation()
         .sendOrderedBroadcastWithPermission(intent, receiverPermission, realContextImpl);
   }
 
   @Implementation
-  public void sendOrderedBroadcast(
+  protected void sendOrderedBroadcast(
       Intent intent,
       String receiverPermission,
       BroadcastReceiver resultReceiver,
@@ -175,22 +175,22 @@ public class ShadowContextImpl {
   }
 
   @Implementation
-  public void sendStickyBroadcast(Intent intent) {
+  protected void sendStickyBroadcast(Intent intent) {
     getShadowInstrumentation().sendStickyBroadcast(intent, realContextImpl);
   }
 
   @Implementation
-  public int checkPermission(String permission, int pid, int uid) {
+  protected int checkPermission(String permission, int pid, int uid) {
     return getShadowInstrumentation().checkPermission(permission, pid, uid);
   }
 
   @Implementation
-  public Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter) {
+  protected Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter) {
     return getShadowInstrumentation().registerReceiver(receiver, filter, realContextImpl);
   }
 
   @Implementation
-  public Intent registerReceiver(
+  protected Intent registerReceiver(
       BroadcastReceiver receiver,
       IntentFilter filter,
       String broadcastPermission,
@@ -200,7 +200,7 @@ public class ShadowContextImpl {
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR1)
-  public Intent registerReceiverAsUser(
+  protected Intent registerReceiverAsUser(
       BroadcastReceiver receiver,
       UserHandle user,
       IntentFilter filter,
@@ -212,27 +212,27 @@ public class ShadowContextImpl {
   }
 
   @Implementation
-  public void unregisterReceiver(BroadcastReceiver broadcastReceiver) {
+  protected void unregisterReceiver(BroadcastReceiver broadcastReceiver) {
     getShadowInstrumentation().unregisterReceiver(broadcastReceiver);
   }
 
   @Implementation
-  public ComponentName startService(Intent service) {
+  protected ComponentName startService(Intent service) {
     return getShadowInstrumentation().startService(service);
   }
 
   @Implementation(minSdk = O)
-  public ComponentName startForegroundService(Intent service) {
+  protected ComponentName startForegroundService(Intent service) {
     return getShadowInstrumentation().startService(service);
   }
 
   @Implementation
-  public boolean stopService(Intent name) {
+  protected boolean stopService(Intent name) {
     return getShadowInstrumentation().stopService(name);
   }
 
   @Implementation
-  public boolean bindService(Intent intent, final ServiceConnection serviceConnection, int i) {
+  protected boolean bindService(Intent intent, final ServiceConnection serviceConnection, int i) {
     return getShadowInstrumentation().bindService(intent, serviceConnection, i);
   }
 
@@ -244,27 +244,27 @@ public class ShadowContextImpl {
   }
 
   @Implementation
-  public void unbindService(final ServiceConnection serviceConnection) {
+  protected void unbindService(final ServiceConnection serviceConnection) {
     getShadowInstrumentation().unbindService(serviceConnection);
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR1)
-  public int getUserId() {
+  protected int getUserId() {
     return 0;
   }
 
   @Implementation
-  public File getExternalCacheDir() {
+  protected File getExternalCacheDir() {
     return Environment.getExternalStorageDirectory();
   }
 
   @Implementation(maxSdk = JELLY_BEAN_MR2)
-  public File getExternalFilesDir(String type) {
+  protected File getExternalFilesDir(String type) {
     return Environment.getExternalStoragePublicDirectory(type);
   }
 
   @Implementation(minSdk = KITKAT)
-  public File[] getExternalFilesDirs(String type) {
+  protected File[] getExternalFilesDirs(String type) {
     return new File[] {Environment.getExternalStoragePublicDirectory(type)};
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCookieManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCookieManager.java
@@ -17,7 +17,7 @@ public class ShadowCookieManager {
   }
 
   @Implementation
-  public static CookieManager getInstance() {
+  protected static CookieManager getInstance() {
     if (cookieManager == null) {
       cookieManager = new RoboCookieManager();
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCookieSyncManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCookieSyncManager.java
@@ -12,7 +12,7 @@ public class ShadowCookieSyncManager extends ShadowWebSyncManager {
   private static CookieSyncManager sRef;
 
   @Implementation
-  public static synchronized CookieSyncManager createInstance(Context ctx) {
+  protected static synchronized CookieSyncManager createInstance(Context ctx) {
     if (sRef == null) {
       sRef = Shadow.newInstanceOf(CookieSyncManager.class);
     }
@@ -20,7 +20,7 @@ public class ShadowCookieSyncManager extends ShadowWebSyncManager {
   }
 
   @Implementation
-  public static CookieSyncManager getInstance() {
+  protected static CookieSyncManager getInstance() {
     if (sRef == null) {
       throw new IllegalStateException("createInstance must be called first");
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCornerPathEffect.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCornerPathEffect.java
@@ -10,7 +10,7 @@ public class ShadowCornerPathEffect {
   private float radius;
 
   @Implementation
-  public void __constructor__(float radius) {
+  protected void __constructor__(float radius) {
     this.radius = radius;
    }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCountDownTimer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCountDownTimer.java
@@ -14,20 +14,20 @@ public class ShadowCountDownTimer {
   @RealObject CountDownTimer countDownTimer;
 
   @Implementation
-  public void __constructor__(long millisInFuture, long countDownInterval) {
+  protected void __constructor__(long millisInFuture, long countDownInterval) {
     this.countDownInterval = countDownInterval;
     this.millisInFuture = millisInFuture;
     this.started = false;
   }
 
   @Implementation
-  public final synchronized CountDownTimer start() {
+  protected final synchronized CountDownTimer start() {
     started = true;
     return countDownTimer;
   }
 
   @Implementation
-  public final void cancel() {
+  protected final void cancel() {
     started = false;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCursorWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCursorWindow.java
@@ -23,27 +23,27 @@ public class ShadowCursorWindow {
   private static final WindowData WINDOW_DATA = new WindowData();
 
   @Implementation
-  public static Number nativeCreate(String name, int cursorWindowSize) {
+  protected static Number nativeCreate(String name, int cursorWindowSize) {
     return castNativePtr(WINDOW_DATA.create(name, cursorWindowSize));
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static void nativeDispose(int windowPtr) {
+  protected static void nativeDispose(int windowPtr) {
     nativeDispose((long) windowPtr);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeDispose(long windowPtr) {
+  protected static void nativeDispose(long windowPtr) {
     WINDOW_DATA.close(windowPtr);
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static byte[] nativeGetBlob(int windowPtr, int row, int column) {
+  protected static byte[] nativeGetBlob(int windowPtr, int row, int column) {
     return nativeGetBlob((long) windowPtr, row, column);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static byte[] nativeGetBlob(long windowPtr, int row, int column) {
+  protected static byte[] nativeGetBlob(long windowPtr, int row, int column) {
     Value value = WINDOW_DATA.get(windowPtr).value(row, column);
 
     switch (value.type) {
@@ -61,12 +61,12 @@ public class ShadowCursorWindow {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static String nativeGetString(int windowPtr, int row, int column) {
+  protected static String nativeGetString(int windowPtr, int row, int column) {
     return nativeGetString((long) windowPtr, row, column);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static String nativeGetString(long windowPtr, int row, int column) {
+  protected static String nativeGetString(long windowPtr, int row, int column) {
     Value val = WINDOW_DATA.get(windowPtr).value(row, column);
     if (val.type == Cursor.FIELD_TYPE_BLOB) {
       throw new android.database.sqlite.SQLiteException("Getting string when column is blob. Row " + row + ", col " + column);
@@ -76,132 +76,132 @@ public class ShadowCursorWindow {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static long nativeGetLong(int windowPtr, int row, int column) {
+  protected static long nativeGetLong(int windowPtr, int row, int column) {
     return nativeGetLong((long) windowPtr, row, column);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static long nativeGetLong(long windowPtr, int row, int column) {
+  protected static long nativeGetLong(long windowPtr, int row, int column) {
     return nativeGetNumber(windowPtr, row, column).longValue();
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static double nativeGetDouble(int windowPtr, int row, int column) {
+  protected static double nativeGetDouble(int windowPtr, int row, int column) {
     return nativeGetDouble((long) windowPtr, row, column);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static double nativeGetDouble(long windowPtr, int row, int column) {
+  protected static double nativeGetDouble(long windowPtr, int row, int column) {
     return nativeGetNumber(windowPtr, row, column).doubleValue();
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static int nativeGetType(int windowPtr, int row, int column) {
+  protected static int nativeGetType(int windowPtr, int row, int column) {
     return nativeGetType((long) windowPtr, row, column);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static int nativeGetType(long windowPtr, int row, int column) {
+  protected static int nativeGetType(long windowPtr, int row, int column) {
     return WINDOW_DATA.get(windowPtr).value(row, column).type;
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static void nativeClear(int windowPtr) {
+  protected static void nativeClear(int windowPtr) {
     nativeClear((long) windowPtr);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeClear(long windowPtr) {
+  protected static void nativeClear(long windowPtr) {
     WINDOW_DATA.clear(windowPtr);
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static int nativeGetNumRows(int windowPtr) {
+  protected static int nativeGetNumRows(int windowPtr) {
     return nativeGetNumRows((long) windowPtr);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static int nativeGetNumRows(long windowPtr) {
+  protected static int nativeGetNumRows(long windowPtr) {
     return WINDOW_DATA.get(windowPtr).numRows();
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static boolean nativePutBlob(int windowPtr, byte[] value, int row, int column) {
+  protected static boolean nativePutBlob(int windowPtr, byte[] value, int row, int column) {
     return nativePutBlob((long) windowPtr, value, row, column);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static boolean nativePutBlob(long windowPtr, byte[] value, int row, int column) {
+  protected static boolean nativePutBlob(long windowPtr, byte[] value, int row, int column) {
     return WINDOW_DATA.get(windowPtr).putValue(new Value(value, Cursor.FIELD_TYPE_BLOB), row, column);
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static boolean nativePutString(int windowPtr, String value, int row, int column) {
+  protected static boolean nativePutString(int windowPtr, String value, int row, int column) {
     return nativePutString((long) windowPtr, value, row, column);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static boolean nativePutString(long windowPtr, String value, int row, int column) {
+  protected static boolean nativePutString(long windowPtr, String value, int row, int column) {
     return WINDOW_DATA.get(windowPtr).putValue(new Value(value, Cursor.FIELD_TYPE_STRING), row, column);
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static boolean nativePutLong(int windowPtr, long value, int row, int column) {
+  protected static boolean nativePutLong(int windowPtr, long value, int row, int column) {
     return nativePutLong((long) windowPtr, value, row, column);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static boolean nativePutLong(long windowPtr, long value, int row, int column) {
+  protected static boolean nativePutLong(long windowPtr, long value, int row, int column) {
     return WINDOW_DATA.get(windowPtr).putValue(new Value(value, Cursor.FIELD_TYPE_INTEGER), row, column);
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static boolean nativePutDouble(int windowPtr, double value, int row, int column) {
+  protected static boolean nativePutDouble(int windowPtr, double value, int row, int column) {
     return nativePutDouble((long) windowPtr, value, row, column);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static boolean nativePutDouble(long windowPtr, double value, int row, int column) {
+  protected static boolean nativePutDouble(long windowPtr, double value, int row, int column) {
     return WINDOW_DATA.get(windowPtr).putValue(new Value(value, Cursor.FIELD_TYPE_FLOAT), row, column);
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static boolean nativePutNull(int windowPtr, int row, int column) {
+  protected static boolean nativePutNull(int windowPtr, int row, int column) {
     return nativePutNull((long) windowPtr, row, column);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static boolean nativePutNull(long windowPtr, int row, int column) {
+  protected static boolean nativePutNull(long windowPtr, int row, int column) {
     return WINDOW_DATA.get(windowPtr).putValue(new Value(null, Cursor.FIELD_TYPE_NULL), row, column);
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static boolean nativeAllocRow(int windowPtr) {
+  protected static boolean nativeAllocRow(int windowPtr) {
     return nativeAllocRow((long) windowPtr);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static boolean nativeAllocRow(long windowPtr) {
+  protected static boolean nativeAllocRow(long windowPtr) {
     return WINDOW_DATA.get(windowPtr).allocRow();
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static boolean nativeSetNumColumns(int windowPtr, int columnNum) {
+  protected static boolean nativeSetNumColumns(int windowPtr, int columnNum) {
     return nativeSetNumColumns((long) windowPtr, columnNum);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static boolean nativeSetNumColumns(long windowPtr, int columnNum) {
+  protected static boolean nativeSetNumColumns(long windowPtr, int columnNum) {
     return WINDOW_DATA.get(windowPtr).setNumColumns(columnNum);
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static String nativeGetName(int windowPtr) {
+  protected static String nativeGetName(int windowPtr) {
     return nativeGetName((long) windowPtr);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static String nativeGetName(long windowPtr) {
+  protected static String nativeGetName(long windowPtr) {
     return WINDOW_DATA.get(windowPtr).getName();
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCursorWrapper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCursorWrapper.java
@@ -19,7 +19,7 @@ public class ShadowCursorWrapper implements Cursor {
   private Cursor wrappedCursor;
 
   @Implementation
-  public void __constructor__(Cursor c) {
+  protected void __constructor__(Cursor c) {
     wrappedCursor = c;
   }
 
@@ -229,7 +229,7 @@ public class ShadowCursorWrapper implements Cursor {
   }
 
   @Implementation
-  public Cursor getWrappedCursor() {
+  protected Cursor getWrappedCursor() {
     return wrappedCursor;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDateFormat.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDateFormat.java
@@ -10,17 +10,17 @@ import org.robolectric.annotation.Implements;
 public class ShadowDateFormat {
 
   @Implementation
-  public static java.text.DateFormat getDateFormat(Context context) {
+  protected static java.text.DateFormat getDateFormat(Context context) {
     return new java.text.SimpleDateFormat("MMM-dd-yyyy", Locale.ROOT);
   }
 
   @Implementation
-  public static java.text.DateFormat getLongDateFormat(Context context) {
+  protected static java.text.DateFormat getLongDateFormat(Context context) {
     return new java.text.SimpleDateFormat("MMMM dd, yyyy", Locale.ROOT);
   }
 
   @Implementation
-  public static java.text.DateFormat getTimeFormat(Context context) {
+  protected static java.text.DateFormat getTimeFormat(Context context) {
     return new java.text.SimpleDateFormat("HH:mm:ss", Locale.ROOT);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDatePickerDialog.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDatePickerDialog.java
@@ -23,8 +23,13 @@ public class ShadowDatePickerDialog extends ShadowAlertDialog {
   private DatePickerDialog.OnDateSetListener callBack;
 
   @Implementation(maxSdk = M)
-  public void __constructor__(Context context, int theme, DatePickerDialog.OnDateSetListener callBack,
-                              int year, int monthOfYear, int dayOfMonth) {
+  protected void __constructor__(
+      Context context,
+      int theme,
+      DatePickerDialog.OnDateSetListener callBack,
+      int year,
+      int monthOfYear,
+      int dayOfMonth) {
     this.year = year;
     this.monthOfYear = monthOfYear;
     this.dayOfMonth = dayOfMonth;
@@ -40,8 +45,14 @@ public class ShadowDatePickerDialog extends ShadowAlertDialog {
   }
 
   @Implementation(minSdk = N)
-  public void __constructor__(Context context, int theme, DatePickerDialog.OnDateSetListener callBack,
-                              Calendar calendar, int year, int monthOfYear, int dayOfMonth) {
+  protected void __constructor__(
+      Context context,
+      int theme,
+      DatePickerDialog.OnDateSetListener callBack,
+      Calendar calendar,
+      int year,
+      int monthOfYear,
+      int dayOfMonth) {
     this.calendar = calendar;
     this.year = year;
     this.monthOfYear = monthOfYear;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDebug.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDebug.java
@@ -22,7 +22,7 @@ public class ShadowDebug {
   private static String tracingFilename;
 
   @Implementation
-  public static void __staticInitializer__() {
+  protected static void __staticInitializer__() {
     // Avoid calling Environment.getLegacyExternalStorageDirectory()
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
@@ -150,39 +150,39 @@ public class ShadowDevicePolicyManager {
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public boolean isDeviceOwnerApp(String packageName) {
+  protected boolean isDeviceOwnerApp(String packageName) {
     return deviceOwner != null && deviceOwner.getPackageName().equals(packageName);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean isProfileOwnerApp(String packageName) {
+  protected boolean isProfileOwnerApp(String packageName) {
     return profileOwner != null && profileOwner.getPackageName().equals(packageName);
   }
 
   @Implementation
-  public boolean isAdminActive(ComponentName who) {
+  protected boolean isAdminActive(ComponentName who) {
     return who != null && deviceAdmins.contains(who);
   }
 
   @Implementation
-  public List<ComponentName> getActiveAdmins() {
+  protected List<ComponentName> getActiveAdmins() {
     return deviceAdmins;
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void addUserRestriction(ComponentName admin, String key) {
+  protected void addUserRestriction(ComponentName admin, String key) {
     enforceActiveAdmin(admin);
     getShadowUserManager().setUserRestriction(Process.myUserHandle(), key, true);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void clearUserRestriction(ComponentName admin, String key) {
+  protected void clearUserRestriction(ComponentName admin, String key) {
     enforceActiveAdmin(admin);
     getShadowUserManager().setUserRestriction(Process.myUserHandle(), key, false);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean setApplicationHidden(ComponentName admin, String packageName, boolean hidden) {
+  protected boolean setApplicationHidden(ComponentName admin, String packageName, boolean hidden) {
     enforceActiveAdmin(admin);
     if (packagesToFailForSetApplicationHidden.contains(packageName)) {
       return false;
@@ -207,7 +207,7 @@ public class ShadowDevicePolicyManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean isApplicationHidden(ComponentName admin, String packageName) {
+  protected boolean isApplicationHidden(ComponentName admin, String packageName) {
     enforceActiveAdmin(admin);
     return applicationPackageManager.getApplicationHiddenSettingAsUser(
         packageName, Process.myUserHandle());
@@ -219,7 +219,7 @@ public class ShadowDevicePolicyManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public int enableSystemApp(ComponentName admin, String packageName) {
+  protected int enableSystemApp(ComponentName admin, String packageName) {
     enforceActiveAdmin(admin);
     systemAppsEnabled.add(packageName);
     return 1;
@@ -231,7 +231,7 @@ public class ShadowDevicePolicyManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void setUninstallBlocked(
+  protected void setUninstallBlocked(
       ComponentName admin, String packageName, boolean uninstallBlocked) {
     enforceActiveAdmin(admin);
     if (uninstallBlocked) {
@@ -242,7 +242,7 @@ public class ShadowDevicePolicyManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean isUninstallBlocked(ComponentName admin, String packageName) {
+  protected boolean isUninstallBlocked(ComponentName admin, String packageName) {
     enforceActiveAdmin(admin);
     return uninstallBlockedPackages.contains(packageName);
   }
@@ -289,12 +289,12 @@ public class ShadowDevicePolicyManager {
   }
 
   @Implementation
-  public void removeActiveAdmin(ComponentName admin) {
+  protected void removeActiveAdmin(ComponentName admin) {
     deviceAdmins.remove(admin);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void clearProfileOwner(ComponentName admin) {
+  protected void clearProfileOwner(ComponentName admin) {
     profileOwner = null;
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
       removeActiveAdmin(admin);
@@ -302,7 +302,7 @@ public class ShadowDevicePolicyManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public Bundle getApplicationRestrictions(ComponentName admin, String packageName) {
+  protected Bundle getApplicationRestrictions(ComponentName admin, String packageName) {
     enforceDeviceOwnerOrProfileOwner(admin);
     return getApplicationRestrictions(packageName);
   }
@@ -315,7 +315,7 @@ public class ShadowDevicePolicyManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void setApplicationRestrictions(
+  protected void setApplicationRestrictions(
       ComponentName admin, String packageName, Bundle applicationRestrictions) {
     enforceDeviceOwnerOrProfileOwner(admin);
     setApplicationRestrictions(packageName, applicationRestrictions);
@@ -355,7 +355,7 @@ public class ShadowDevicePolicyManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void setAccountManagementDisabled(
+  protected void setAccountManagementDisabled(
       ComponentName admin, String accountType, boolean disabled) {
     enforceDeviceOwnerOrProfileOwner(admin);
     if (disabled) {
@@ -366,7 +366,7 @@ public class ShadowDevicePolicyManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public String[] getAccountTypesWithManagementDisabled() {
+  protected String[] getAccountTypesWithManagementDisabled() {
     return accountTypesWithManagementDisabled.toArray(new String[0]);
   }
 
@@ -377,7 +377,7 @@ public class ShadowDevicePolicyManager {
    * profile owner and device owner since Android O.
    */
   @Implementation(minSdk = N)
-  public void setOrganizationName(ComponentName admin, @Nullable CharSequence name) {
+  protected void setOrganizationName(ComponentName admin, @Nullable CharSequence name) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       enforceDeviceOwnerOrProfileOwner(admin);
     } else {
@@ -430,7 +430,7 @@ public class ShadowDevicePolicyManager {
   }
 
   @Implementation(minSdk = N)
-  public void setOrganizationColor(ComponentName admin, int color) {
+  protected void setOrganizationColor(ComponentName admin, int color) {
     enforceProfileOwner(admin);
     organizationColor = color;
   }
@@ -447,7 +447,7 @@ public class ShadowDevicePolicyManager {
    */
   @Implementation(minSdk = N)
   @Nullable
-  public CharSequence getOrganizationName(ComponentName admin) {
+  protected CharSequence getOrganizationName(ComponentName admin) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       enforceDeviceOwnerOrProfileOwner(admin);
     } else {
@@ -458,19 +458,19 @@ public class ShadowDevicePolicyManager {
   }
 
   @Implementation(minSdk = N)
-  public int getOrganizationColor(ComponentName admin) {
+  protected int getOrganizationColor(ComponentName admin) {
     enforceProfileOwner(admin);
     return organizationColor;
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void setAutoTimeRequired(ComponentName admin, boolean required) {
+  protected void setAutoTimeRequired(ComponentName admin, boolean required) {
     enforceDeviceOwnerOrProfileOwner(admin);
     isAutoTimeRequired = required;
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean getAutoTimeRequired() {
+  protected boolean getAutoTimeRequired() {
     return isAutoTimeRequired;
   }
 
@@ -483,7 +483,8 @@ public class ShadowDevicePolicyManager {
    * set the restriction and return true.
    */
   @Implementation(minSdk = LOLLIPOP)
-  public boolean setPermittedAccessibilityServices(ComponentName admin, List<String> packageNames) {
+  protected boolean setPermittedAccessibilityServices(
+      ComponentName admin, List<String> packageNames) {
     enforceDeviceOwnerOrProfileOwner(admin);
     permittedAccessibilityServices = packageNames;
     return true;
@@ -491,7 +492,7 @@ public class ShadowDevicePolicyManager {
 
   @Implementation(minSdk = LOLLIPOP)
   @Nullable
-  public List<String> getPermittedAccessibilityServices(ComponentName admin) {
+  protected List<String> getPermittedAccessibilityServices(ComponentName admin) {
     enforceDeviceOwnerOrProfileOwner(admin);
     return permittedAccessibilityServices;
   }
@@ -505,7 +506,7 @@ public class ShadowDevicePolicyManager {
    * restriction and return true.
    */
   @Implementation(minSdk = LOLLIPOP)
-  public boolean setPermittedInputMethods(ComponentName admin, List<String> packageNames) {
+  protected boolean setPermittedInputMethods(ComponentName admin, List<String> packageNames) {
     enforceDeviceOwnerOrProfileOwner(admin);
     permittedInputMethods = packageNames;
     return true;
@@ -513,7 +514,7 @@ public class ShadowDevicePolicyManager {
 
   @Implementation(minSdk = LOLLIPOP)
   @Nullable
-  public List<String> getPermittedInputMethods(ComponentName admin) {
+  protected List<String> getPermittedInputMethods(ComponentName admin) {
     enforceDeviceOwnerOrProfileOwner(admin);
     return permittedInputMethods;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDialog.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDialog.java
@@ -58,14 +58,14 @@ public class ShadowDialog {
   }
 
   @Implementation
-  public void show() {
+  protected void show() {
     setLatestDialog(this);
     shownDialogs.add(realDialog);
     directlyOn(realDialog, Dialog.class).show();
   }
 
   @Implementation
-  public void dismiss() {
+  protected void dismiss() {
     directlyOn(realDialog, Dialog.class).dismiss();
     hasBeenDismissed = true;
   }
@@ -75,7 +75,7 @@ public class ShadowDialog {
   }
 
   @Implementation
-  public void setCanceledOnTouchOutside(boolean flag) {
+  protected void setCanceledOnTouchOutside(boolean flag) {
     isCancelableOnTouchOutside = flag;
     directlyOn(realDialog, Dialog.class).setCanceledOnTouchOutside(flag);
   }
@@ -93,7 +93,7 @@ public class ShadowDialog {
   }
 
   @Implementation
-  public void setOnCancelListener(DialogInterface.OnCancelListener listener) {
+  protected void setOnCancelListener(DialogInterface.OnCancelListener listener) {
     this.onCancelListener = listener;
     directlyOn(realDialog, Dialog.class).setOnCancelListener(listener);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplay.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplay.java
@@ -57,14 +57,14 @@ public class ShadowDisplay {
   private Integer pixelFormat;
 
   /**
-   * If {@link #setScaledDensity(float)} has been called, {@link DisplayMetrics#scaledDensity}
-   * will be modified to reflect the value specified. Note that this is not a realistic state.
+   * If {@link #setScaledDensity(float)} has been called, {@link DisplayMetrics#scaledDensity} will
+   * be modified to reflect the value specified. Note that this is not a realistic state.
    *
    * @deprecated This behavior is deprecated and will be removed in Robolectric 3.7.
    */
   @Deprecated
   @Implementation
-  public void getMetrics(DisplayMetrics outMetrics) {
+  protected void getMetrics(DisplayMetrics outMetrics) {
     if (isJB()) {
       outMetrics.density = densityDpi * DisplayMetrics.DENSITY_DEFAULT_SCALE;
       outMetrics.densityDpi = densityDpi;
@@ -82,14 +82,14 @@ public class ShadowDisplay {
   }
 
   /**
-   * If {@link #setScaledDensity(float)} has been called, {@link DisplayMetrics#scaledDensity}
-   * will be modified to reflect the value specified. Note that this is not a realistic state.
+   * If {@link #setScaledDensity(float)} has been called, {@link DisplayMetrics#scaledDensity} will
+   * be modified to reflect the value specified. Note that this is not a realistic state.
    *
    * @deprecated This behavior is deprecated and will be removed in Robolectric 3.7.
    */
   @Deprecated
   @Implementation
-  public void getRealMetrics(DisplayMetrics outMetrics) {
+  protected void getRealMetrics(DisplayMetrics outMetrics) {
     if (isJB()) {
       getMetrics(outMetrics);
       outMetrics.widthPixels = realWidth;
@@ -109,7 +109,7 @@ public class ShadowDisplay {
    */
   @Deprecated
   @Implementation
-  public int getDisplayId() {
+  protected int getDisplayId() {
     return displayId == null
         ? directlyOn(realObject, Display.class).getDisplayId()
         : displayId;
@@ -122,7 +122,7 @@ public class ShadowDisplay {
    */
   @Deprecated
   @Implementation
-  public float getRefreshRate() {
+  protected float getRefreshRate() {
     return refreshRate == null
         ? directlyOn(realObject, Display.class).getRefreshRate()
         : refreshRate;
@@ -135,20 +135,20 @@ public class ShadowDisplay {
    */
   @Deprecated
   @Implementation
-  public int getPixelFormat() {
+  protected int getPixelFormat() {
     return pixelFormat == null
         ? directlyOn(realObject, Display.class).getPixelFormat()
         : pixelFormat;
   }
 
   @Implementation(maxSdk = JELLY_BEAN)
-  public void getSizeInternal(Point outSize, boolean doCompat) {
+  protected void getSizeInternal(Point outSize, boolean doCompat) {
     outSize.x = width;
     outSize.y = height;
   }
 
   @Implementation(maxSdk = JELLY_BEAN)
-  public void getCurrentSizeRange(Point outSmallestSize, Point outLargestSize) {
+  protected void getCurrentSizeRange(Point outSmallestSize, Point outLargestSize) {
     int minimum = Math.min(width, height);
     int maximum = Math.max(width, height);
     outSmallestSize.set(minimum, minimum);
@@ -156,7 +156,7 @@ public class ShadowDisplay {
   }
 
   @Implementation(maxSdk = JELLY_BEAN)
-  public void getRealSize(Point outSize) {
+  protected void getRealSize(Point outSize) {
     outSize.set(realWidth, realHeight);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDownloadManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDownloadManager.java
@@ -22,14 +22,14 @@ public class ShadowDownloadManager {
   private Map<Long, DownloadManager.Request> requestMap = new TreeMap<>();
 
   @Implementation
-  public long enqueue(DownloadManager.Request request) {
+  protected long enqueue(DownloadManager.Request request) {
     queueCounter++;
     requestMap.put(queueCounter, request);
     return queueCounter;
   }
 
   @Implementation
-  public int remove(long... ids) {
+  protected int remove(long... ids) {
     int removeCount = 0;
     for (long id : ids) {
       if (requestMap.remove(id) != null) {
@@ -40,7 +40,7 @@ public class ShadowDownloadManager {
   }
 
   @Implementation
-  public Cursor query(DownloadManager.Query query) {
+  protected Cursor query(DownloadManager.Query query) {
     ResultCursor result = new ResultCursor();
     ShadowQuery shadow = Shadow.extract(query);
     long[] ids = shadow.getIds();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDrawable.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDrawable.java
@@ -41,7 +41,7 @@ public class ShadowDrawable {
   private boolean wasInvalidated;
 
   @Implementation
-  public static Drawable createFromStream(InputStream is, String srcName) {
+  protected static Drawable createFromStream(InputStream is, String srcName) {
     if (corruptStreamSources.contains(srcName)) {
       return null;
     }
@@ -54,8 +54,8 @@ public class ShadowDrawable {
   }
 
   @Implementation // todo: this sucks, it's all just so we can detect 9-patches
-  public static Drawable createFromResourceStream(Resources res, TypedValue value,
-                          InputStream is, String srcName, BitmapFactory.Options opts) {
+  protected static Drawable createFromResourceStream(
+      Resources res, TypedValue value, InputStream is, String srcName, BitmapFactory.Options opts) {
     if (is == null) {
       return null;
     }
@@ -86,7 +86,7 @@ public class ShadowDrawable {
   }
 
   @Implementation
-  public static Drawable createFromPath(String pathName) {
+  protected static Drawable createFromPath(String pathName) {
     BitmapDrawable drawable = new BitmapDrawable(ReflectionHelpers.callConstructor(Bitmap.class));
     ShadowBitmapDrawable shadowBitmapDrawable = Shadow.extract(drawable);
     shadowBitmapDrawable.drawableCreateFromPath = pathName;
@@ -106,12 +106,12 @@ public class ShadowDrawable {
   }
 
   @Implementation
-  public int getIntrinsicWidth() {
+  protected int getIntrinsicWidth() {
     return intrinsicWidth;
   }
 
   @Implementation
-  public int getIntrinsicHeight() {
+  protected int getIntrinsicHeight() {
     return intrinsicHeight;
   }
 
@@ -145,19 +145,19 @@ public class ShadowDrawable {
   }
 
   @Implementation
-  public void setAlpha(int alpha) {
+  protected void setAlpha(int alpha) {
     this.alpha = alpha;
     Shadow.directlyOn(realDrawable, Drawable.class).setAlpha(alpha);
   }
 
   @Implementation
-  public void invalidateSelf() {
+  protected void invalidateSelf() {
     wasInvalidated = true;
     Shadow.directlyOn(realDrawable, Drawable.class, "invalidateSelf");
   }
 
   @Implementation(minSdk = KITKAT)
-  public int getAlpha() {
+  protected int getAlpha() {
     return alpha;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowEnvironment.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowEnvironment.java
@@ -34,7 +34,7 @@ public class ShadowEnvironment {
   static Path EXTERNAL_FILES_DIR;
 
   @Implementation
-  public static String getExternalStorageState() {
+  protected static String getExternalStorageState() {
     return externalStorageState;
   }
 
@@ -57,13 +57,13 @@ public class ShadowEnvironment {
   }
 
   @Implementation
-  public static File getExternalStorageDirectory() {
+  protected static File getExternalStorageDirectory() {
     if (!exists(EXTERNAL_CACHE_DIR)) EXTERNAL_CACHE_DIR = RuntimeEnvironment.getTempDirectory().create("external-cache");
     return EXTERNAL_CACHE_DIR.toFile();
   }
 
   @Implementation
-  public static File getExternalStoragePublicDirectory(String type) {
+  protected static File getExternalStoragePublicDirectory(String type) {
     if (!exists(EXTERNAL_FILES_DIR)) EXTERNAL_FILES_DIR = RuntimeEnvironment.getTempDirectory().create("external-files");
     if (type == null) return EXTERNAL_FILES_DIR.toFile();
     Path path = EXTERNAL_FILES_DIR.resolve(type);
@@ -95,13 +95,13 @@ public class ShadowEnvironment {
   }
 
   @Implementation
-  public static boolean isExternalStorageRemovable() {
+  protected static boolean isExternalStorageRemovable() {
     final Boolean exists = STORAGE_REMOVABLE.get(getExternalStorageDirectory());
     return exists != null ? exists : false;
   }
 
   @Implementation(minSdk = KITKAT)
-  public static String getStorageState(File directory) {
+  protected static String getStorageState(File directory) {
     Path directoryPath = directory.toPath();
     for (Map.Entry<Path, String> entry : storageState.entrySet()) {
       if (directoryPath.startsWith(entry.getKey())) {
@@ -112,7 +112,7 @@ public class ShadowEnvironment {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static String getExternalStorageState(File directory) {
+  protected static String getExternalStorageState(File directory) {
     Path directoryPath = directory.toPath();
     for (Map.Entry<Path, String> entry : storageState.entrySet()) {
       if (directoryPath.startsWith(entry.getKey())) {
@@ -122,21 +122,20 @@ public class ShadowEnvironment {
     return null;
   }
 
-
   @Implementation(minSdk = LOLLIPOP)
-  public static boolean isExternalStorageRemovable(File path) {
+  protected static boolean isExternalStorageRemovable(File path) {
     final Boolean exists = STORAGE_REMOVABLE.get(path);
     return exists != null ? exists : false;
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static boolean isExternalStorageEmulated(File path) {
+  protected static boolean isExternalStorageEmulated(File path) {
     final Boolean emulated = STORAGE_EMULATED.get(path);
     return emulated != null ? emulated : false;
   }
 
   @Implementation
-  public static boolean isExternalStorageEmulated() {
+  protected static boolean isExternalStorageEmulated() {
     return sIsExternalStorageEmulated;
   }
 
@@ -220,7 +219,7 @@ public class ShadowEnvironment {
   public static class ShadowUserEnvironment {
 
     @Implementation(minSdk = M)
-    public File[] getExternalDirs() {
+    protected File[] getExternalDirs() {
       return externalDirs.toArray(new File[externalDirs.size()]);
     }
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFilter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFilter.java
@@ -12,7 +12,7 @@ public class ShadowFilter {
   @RealObject private Filter realObject;
 
   @Implementation
-  public void filter(CharSequence constraint, Filter.FilterListener listener) {
+  protected void filter(CharSequence constraint, Filter.FilterListener listener) {
     try {
       Class<?> forName = Class.forName("android.widget.Filter$FilterResults");
       Object filtering;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFloatMath.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFloatMath.java
@@ -24,27 +24,27 @@ import org.robolectric.annotation.Implements;
 @Implements(FloatMath.class)
 public class ShadowFloatMath {
   @Implementation
-  public static float floor(float value) {
+  protected static float floor(float value) {
     return (float) Math.floor(value);
   }
 
   @Implementation
-  public static float ceil(float value) {
+  protected static float ceil(float value) {
     return (float) Math.ceil(value);
   }
 
   @Implementation
-  public static float sin(float angle) {
+  protected static float sin(float angle) {
     return (float) Math.sin(angle);
   }
 
   @Implementation
-  public static float cos(float angle) {
+  protected static float cos(float angle) {
     return (float) Math.cos(angle);
   }
 
   @Implementation
-  public static float sqrt(float value) {
+  protected static float sqrt(float value) {
     return (float) Math.sqrt(value);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGeocoder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGeocoder.java
@@ -16,11 +16,9 @@ public final class ShadowGeocoder {
   private static boolean isPresent = true;
   private List<Address> fromLocation = new ArrayList<>();
 
-  /**
-   * @return `true` by default, or the value specified via {@link #setIsPresent(boolean)}
-   */
+  /** @return `true` by default, or the value specified via {@link #setIsPresent(boolean)} */
   @Implementation
-  public static boolean isPresent() {
+  protected static boolean isPresent() {
     return isPresent;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGestureDetector.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGestureDetector.java
@@ -26,7 +26,7 @@ public class ShadowGestureDetector {
   private OnDoubleTapListener onDoubleTapListener;
 
   @Implementation
-  public void __constructor__(
+  protected void __constructor__(
       Context context, GestureDetector.OnGestureListener listener, Handler handler) {
     Shadow.invokeConstructor(GestureDetector.class, realObject,
         from(Context.class, context),
@@ -36,7 +36,7 @@ public class ShadowGestureDetector {
   }
 
   @Implementation
-  public boolean onTouchEvent(MotionEvent ev) {
+  protected boolean onTouchEvent(MotionEvent ev) {
     lastActiveGestureDetector = realObject;
     onTouchEventMotionEvent = ev;
 
@@ -44,7 +44,7 @@ public class ShadowGestureDetector {
   }
 
   @Implementation
-  public void setOnDoubleTapListener(OnDoubleTapListener onDoubleTapListener) {
+  protected void setOnDoubleTapListener(OnDoubleTapListener onDoubleTapListener) {
     directlyOn(realObject, GestureDetector.class).setOnDoubleTapListener(onDoubleTapListener);
     this.onDoubleTapListener = onDoubleTapListener;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGradientDrawable.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGradientDrawable.java
@@ -16,7 +16,7 @@ public class ShadowGradientDrawable extends ShadowDrawable {
   private int color;
 
   @Implementation
-  public void setColor(int color) {
+  protected void setColor(int color) {
     this.color = color;
     directlyOn(realGradientDrawable, GradientDrawable.class).setColor(color);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowHttpResponseCache.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowHttpResponseCache.java
@@ -28,7 +28,7 @@ public class ShadowHttpResponseCache {
   private int networkCount = 0;
 
   @Implementation
-  public static HttpResponseCache install(File directory, long maxSize) {
+  protected static HttpResponseCache install(File directory, long maxSize) {
     HttpResponseCache cache = newInstanceOf(HttpResponseCache.class);
     ShadowHttpResponseCache shadowCache = Shadow.extract(cache);
     shadowCache.originalObject = cache;
@@ -41,58 +41,59 @@ public class ShadowHttpResponseCache {
   }
 
   @Implementation
-  public static HttpResponseCache getInstalled() {
+  protected static HttpResponseCache getInstalled() {
     synchronized (LOCK) {
       return (installed != null) ? installed.originalObject : null;
     }
   }
 
   @Implementation
-  public long maxSize() {
+  protected long maxSize() {
     return maxSize;
   }
 
   @Implementation
-  public long size() {
+  protected long size() {
     return 0;
   }
 
   @Implementation
-  public void close() {
+  protected void close() {
     synchronized (LOCK) {
       installed = null;
     }
   }
 
   @Implementation
-  public void delete() {
+  protected void delete() {
     close();
   }
 
   @Implementation
-  public int getHitCount() {
+  protected int getHitCount() {
     return hitCount;
   }
 
   @Implementation
-  public int getNetworkCount() {
+  protected int getNetworkCount() {
     return networkCount;
   }
 
   @Implementation
-  public int getRequestCount() {
+  protected int getRequestCount() {
     return requestCount;
   }
 
   @Implementation
-  public CacheResponse get(URI uri, String requestMethod, Map<String, List<String>> requestHeaders) {
+  protected CacheResponse get(
+      URI uri, String requestMethod, Map<String, List<String>> requestHeaders) {
     requestCount += 1;
     networkCount += 1; // Always pretend we had a cache miss and had to fall back to the network.
     return null;
   }
 
   @Implementation
-  public CacheResponse put(URI uri, URLConnection urlConnection) {
+  protected CacheResponse put(URI uri, URLConnection urlConnection) {
     // Do not cache any data. All requests will be a miss.
     return null;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInputDevice.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInputDevice.java
@@ -17,7 +17,7 @@ public class ShadowInputDevice {
   }
 
   @Implementation
-  public String getName() {
+  protected String getName() {
     return deviceName;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInputEvent.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInputEvent.java
@@ -10,7 +10,7 @@ public class ShadowInputEvent {
   protected InputDevice device;
 
   @Implementation
-  public InputDevice getDevice() {
+  protected InputDevice getDevice() {
     return device;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInputMethodManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInputMethodManager.java
@@ -40,30 +40,30 @@ public class ShadowInputMethodManager {
   private Optional<SoftInputVisibilityChangeHandler> visibilityChangeHandler = Optional.absent();
 
   @Implementation
-  public boolean showSoftInput(View view, int flags) {
+  protected boolean showSoftInput(View view, int flags) {
     return showSoftInput(view, flags, null);
   }
 
   @Implementation
-  public boolean showSoftInput(View view, int flags, ResultReceiver resultReceiver) {
+  protected boolean showSoftInput(View view, int flags, ResultReceiver resultReceiver) {
     setSoftInputVisibility(true);
     return true;
   }
 
   @Implementation
-  public boolean hideSoftInputFromWindow(IBinder windowToken, int flags) {
+  protected boolean hideSoftInputFromWindow(IBinder windowToken, int flags) {
     return hideSoftInputFromWindow(windowToken, flags, null);
   }
 
   @Implementation
-  public boolean hideSoftInputFromWindow(
+  protected boolean hideSoftInputFromWindow(
       IBinder windowToken, int flags, ResultReceiver resultReceiver) {
     setSoftInputVisibility(false);
     return true;
   }
 
   @Implementation
-  public void toggleSoftInput(int showFlags, int hideFlags) {
+  protected void toggleSoftInput(int showFlags, int hideFlags) {
     setSoftInputVisibility(!isSoftInputVisible());
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
@@ -79,12 +79,12 @@ public class ShadowInstrumentation {
   private boolean checkActivities;
 
   @Implementation(minSdk = P)
-  public Activity startActivitySync(Intent intent, Bundle options) {
+  protected Activity startActivitySync(Intent intent, Bundle options) {
     throw new UnsupportedOperationException("Implement me!!");
   }
 
   @Implementation
-  public ActivityResult execStartActivity(
+  protected ActivityResult execStartActivity(
       Context who,
       IBinder contextThread,
       IBinder token,
@@ -97,7 +97,7 @@ public class ShadowInstrumentation {
   }
 
   @Implementation(maxSdk = LOLLIPOP_MR1)
-  public ActivityResult execStartActivity(
+  protected ActivityResult execStartActivity(
       Context who,
       IBinder contextThread,
       IBinder token,
@@ -124,7 +124,7 @@ public class ShadowInstrumentation {
   }
 
   @Implementation
-  public void execStartActivities(
+  protected void execStartActivities(
       Context who,
       IBinder contextThread,
       IBinder token,
@@ -137,13 +137,13 @@ public class ShadowInstrumentation {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public void execStartActivityFromAppTask(
+  protected void execStartActivityFromAppTask(
       Context who, IBinder contextThread, Object appTask, Intent intent, Bundle options) {
     throw new UnsupportedOperationException("Implement me!!");
   }
 
   @Implementation(minSdk = M)
-  public ActivityResult execStartActivity(
+  protected ActivityResult execStartActivity(
       Context who,
       IBinder contextThread,
       IBinder token,
@@ -156,7 +156,7 @@ public class ShadowInstrumentation {
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR1)
-  public ActivityResult execStartActivity(
+  protected ActivityResult execStartActivity(
       Context who,
       IBinder contextThread,
       IBinder token,
@@ -169,7 +169,7 @@ public class ShadowInstrumentation {
   }
 
   @Implementation(minSdk = M)
-  public ActivityResult execStartActivityAsCaller(
+  protected ActivityResult execStartActivityAsCaller(
       Context who,
       IBinder contextThread,
       IBinder token,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowIntentService.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowIntentService.java
@@ -20,7 +20,7 @@ public class ShadowIntentService extends ShadowService {
   }
 
   @Implementation
-  public void setIntentRedelivery(boolean enabled) {
+  protected void setIntentRedelivery(boolean enabled) {
     mRedelivery = enabled;
     directlyOn(realIntentService, IntentService.class, "setIntentRedelivery", ClassParameter.from(boolean.class, enabled));
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowJobScheduler.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowJobScheduler.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
@@ -21,22 +22,23 @@ import org.robolectric.annotation.Implements;
 public abstract class ShadowJobScheduler {
 
   @Implementation
-  public abstract int schedule(JobInfo job);
+  protected abstract int schedule(JobInfo job);
 
   @Implementation
-  public abstract void cancel(int jobId);
+  protected abstract void cancel(int jobId);
 
   @Implementation
-  public abstract void cancelAll();
+  protected abstract void cancelAll();
 
   @Implementation
-  public abstract List<JobInfo> getAllPendingJobs();
+  protected abstract List<JobInfo> getAllPendingJobs();
 
   @Implementation(minSdk = N)
+  @HiddenApi
   public abstract JobInfo getPendingJob(int jobId);
 
   @Implementation(minSdk = O)
-  public abstract int enqueue(JobInfo job, JobWorkItem work);
+  protected abstract int enqueue(JobInfo job, JobWorkItem work);
 
   public abstract void failOnJob(int jobId);
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowJsResult.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowJsResult.java
@@ -10,7 +10,7 @@ public class ShadowJsResult {
   private boolean wasCancelled;
 
   @Implementation
-  public void cancel() {
+  protected void cancel() {
     wasCancelled = true;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowKeyCharacterMap.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowKeyCharacterMap.java
@@ -92,12 +92,12 @@ public class ShadowKeyCharacterMap {
   }
 
   @Implementation
-  public static KeyCharacterMap load(int deviceId) {
+  protected static KeyCharacterMap load(int deviceId) {
     return ReflectionHelpers.callConstructor(KeyCharacterMap.class);
   }
 
   @Implementation
-  public KeyEvent[] getEvents(char[] charArray) {
+  protected KeyEvent[] getEvents(char[] charArray) {
     int eventsPerChar = 2;
     KeyEvent[] events = new KeyEvent[charArray.length * eventsPerChar];
 
@@ -110,12 +110,12 @@ public class ShadowKeyCharacterMap {
   }
 
   @Implementation
-  public int getKeyboardType() {
+  protected int getKeyboardType() {
     return KeyCharacterMap.FULL;
   }
 
   @Implementation
-  public int get(int keyCode, int metaState) {
+  protected int get(int keyCode, int metaState) {
     return Character.toLowerCase(KEY_CODE_TO_CHAR.get(keyCode));
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAssetManager.java
@@ -80,7 +80,6 @@ import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowAssetManager.Picker;
 import org.robolectric.util.Logger;
 import org.robolectric.util.ReflectionHelpers;
-import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 @SuppressLint("NewApi")
 @Implements(value = AssetManager.class, /* this one works for P too... maxSdk = VERSION_CODES.O_MR1,*/
@@ -370,17 +369,17 @@ public class ShadowLegacyAssetManager extends ShadowAssetManager {
   }
 
   @Implementation
-  public final InputStream open(String fileName) throws IOException {
+  protected final InputStream open(String fileName) throws IOException {
     return findAssetFile(fileName).getInputStream();
   }
 
   @Implementation
-  public final InputStream open(String fileName, int accessMode) throws IOException {
+  protected final InputStream open(String fileName, int accessMode) throws IOException {
     return findAssetFile(fileName).getInputStream();
   }
 
   @Implementation
-  public final AssetFileDescriptor openFd(String fileName) throws IOException {
+  protected final AssetFileDescriptor openFd(String fileName) throws IOException {
     File file = new File(findAssetFile(fileName).getPath());
     if (file.getPath().startsWith("jar")) {
       file = getFileFromZip(file);
@@ -440,7 +439,7 @@ public class ShadowLegacyAssetManager extends ShadowAssetManager {
   }
 
   @Implementation
-  public final String[] list(String path) throws IOException {
+  protected final String[] list(String path) throws IOException {
     List<String> assetFiles = new ArrayList<>();
 
     for (FsFile assetsDir : getAllAssetDirs()) {
@@ -530,7 +529,8 @@ public class ShadowLegacyAssetManager extends ShadowAssetManager {
   }
 
   @Implementation
-  public final XmlResourceParser openXmlResourceParser(int cookie, String fileName) throws IOException {
+  protected final XmlResourceParser openXmlResourceParser(int cookie, String fileName)
+      throws IOException {
     XmlBlock xmlBlock = XmlBlock.create(Fs.fileFromPath(fileName), resourceTable.getPackageName());
     if (xmlBlock == null) {
       throw new Resources.NotFoundException(fileName);
@@ -651,7 +651,7 @@ public class ShadowLegacyAssetManager extends ShadowAssetManager {
   }
 
   @Implementation
-  public String[] getLocales() {
+  protected String[] getLocales() {
     return new String[0]; // todo
   }
 
@@ -1278,22 +1278,22 @@ public class ShadowLegacyAssetManager extends ShadowAssetManager {
   }
 
   @Implementation
-  public String getResourceName(int resid) {
+  protected String getResourceName(int resid) {
     return getResName(resid).getFullyQualifiedName();
   }
 
   @Implementation
-  public String getResourcePackageName(int resid) {
+  protected String getResourcePackageName(int resid) {
     return getResName(resid).packageName;
   }
 
   @Implementation
-  public String getResourceTypeName(int resid) {
+  protected String getResourceTypeName(int resid) {
     return getResName(resid).type;
   }
 
   @Implementation
-  public String getResourceEntryName(int resid) {
+  protected String getResourceEntryName(int resid) {
     return getResName(resid).name;
   }
 
@@ -1313,7 +1313,7 @@ public class ShadowLegacyAssetManager extends ShadowAssetManager {
   }
 
   @Implementation(minSdk = LOLLIPOP, maxSdk = O_MR1)
-  public final SparseArray<String> getAssignedPackageIdentifiers() {
+  protected final SparseArray<String> getAssignedPackageIdentifiers() {
     return new SparseArray<>();
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLinearGradient.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLinearGradient.java
@@ -17,7 +17,7 @@ public class ShadowLinearGradient {
   private Shader.TileMode tile;
 
   @Implementation
-  public void __constructor__(
+  protected void __constructor__(
       float x0, float y0, float x1, float y1, int color0, int color1, Shader.TileMode tile) {
     this.x0 = x0;
     this.y0 = y0;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLinkMovementMethod.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLinkMovementMethod.java
@@ -9,7 +9,7 @@ import org.robolectric.annotation.Implements;
 @Implements(LinkMovementMethod.class)
 public class ShadowLinkMovementMethod {
   @Implementation
-  public static MovementMethod getInstance() {
+  protected static MovementMethod getInstance() {
     return new LinkMovementMethod();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowListPopupWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowListPopupWindow.java
@@ -16,7 +16,7 @@ public class ShadowListPopupWindow {
   private ListPopupWindow realListPopupWindow;
 
   @Implementation
-  public void show() {
+  protected void show() {
     ShadowApplication shadowApplication = Shadow.extract(RuntimeEnvironment.application);
     shadowApplication.setLatestListPopupWindow(realListPopupWindow);
     directlyOn(realListPopupWindow, ListPopupWindow.class).show();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocationManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocationManager.java
@@ -70,7 +70,7 @@ public class ShadowLocationManager {
       new HashMap<>();
 
   @Implementation
-  public boolean isProviderEnabled(String provider) {
+  protected boolean isProviderEnabled(String provider) {
     LocationProviderEntry map = providersEnabled.get(provider);
     if (map != null) {
       Boolean isEnabled = map.getKey();
@@ -80,7 +80,7 @@ public class ShadowLocationManager {
   }
 
   @Implementation
-  public List<String> getAllProviders() {
+  protected List<String> getAllProviders() {
     Set<String> allKnownProviders = new LinkedHashSet<>(providersEnabled.keySet());
     allKnownProviders.add(LocationManager.GPS_PROVIDER);
     allKnownProviders.add(LocationManager.NETWORK_PROVIDER);
@@ -138,7 +138,7 @@ public class ShadowLocationManager {
   }
 
   @Implementation
-  public List<String> getProviders(boolean enabledOnly) {
+  protected List<String> getProviders(boolean enabledOnly) {
     ArrayList<String> enabledProviders = new ArrayList<>();
     for (String provider : getAllProviders()) {
       if (!enabledOnly || providersEnabled.get(provider) != null) {
@@ -149,12 +149,12 @@ public class ShadowLocationManager {
   }
 
   @Implementation
-  public Location getLastKnownLocation(String provider) {
+  protected Location getLastKnownLocation(String provider) {
     return lastKnownLocations.get(provider);
   }
 
   @Implementation
-  public boolean addGpsStatusListener(Listener listener) {
+  protected boolean addGpsStatusListener(Listener listener) {
     if (!gpsStatusListeners.contains(listener)) {
       gpsStatusListeners.add(listener);
     }
@@ -162,12 +162,12 @@ public class ShadowLocationManager {
   }
 
   @Implementation
-  public void removeGpsStatusListener(Listener listener) {
+  protected void removeGpsStatusListener(Listener listener) {
     gpsStatusListeners.remove(listener);
   }
 
   @Implementation
-  public String getBestProvider(Criteria criteria, boolean enabled) {
+  protected String getBestProvider(Criteria criteria, boolean enabled) {
     lastBestProviderCriteria = criteria;
     lastBestProviderEnabled = enabled;
 
@@ -231,20 +231,21 @@ public class ShadowLocationManager {
 
   // @SystemApi
   @Implementation(minSdk = P)
-  public void setLocationEnabledForUser(boolean enabled, UserHandle userHandle) {
+  protected void setLocationEnabledForUser(boolean enabled, UserHandle userHandle) {
     getContext().checkCallingPermission(android.Manifest.permission.WRITE_SECURE_SETTINGS);
     locationEnabledForUser.put(userHandle, enabled);
   }
 
   // @SystemApi
   @Implementation(minSdk = P)
-  public boolean isLocationEnabledForUser(UserHandle userHandle) {
+  protected boolean isLocationEnabledForUser(UserHandle userHandle) {
     Boolean result = locationEnabledForUser.get(userHandle);
     return result == null ? false : result;
   }
 
   @Implementation
-  public void requestLocationUpdates(String provider, long minTime, float minDistance, LocationListener listener) {
+  protected void requestLocationUpdates(
+      String provider, long minTime, float minDistance, LocationListener listener) {
     addLocationListener(provider, listener, minTime, minDistance);
   }
 
@@ -271,13 +272,14 @@ public class ShadowLocationManager {
   }
 
   @Implementation
-  public void requestLocationUpdates(String provider, long minTime, float minDistance, LocationListener listener,
-      Looper looper) {
+  protected void requestLocationUpdates(
+      String provider, long minTime, float minDistance, LocationListener listener, Looper looper) {
     addLocationListener(provider, listener, minTime, minDistance);
   }
 
   @Implementation
-  public void requestLocationUpdates(long minTime, float minDistance, Criteria criteria, PendingIntent pendingIntent) {
+  protected void requestLocationUpdates(
+      long minTime, float minDistance, Criteria criteria, PendingIntent pendingIntent) {
     if (pendingIntent == null) {
       throw new IllegalStateException("Intent must not be null");
     }
@@ -288,8 +290,8 @@ public class ShadowLocationManager {
   }
 
   @Implementation
-  public void requestLocationUpdates(String provider, long minTime, float minDistance,
-      PendingIntent pendingIntent) {
+  protected void requestLocationUpdates(
+      String provider, long minTime, float minDistance, PendingIntent pendingIntent) {
     if (pendingIntent == null) {
       throw new IllegalStateException("Intent must not be null");
     }
@@ -301,7 +303,7 @@ public class ShadowLocationManager {
   }
 
   @Implementation
-  public void removeUpdates(LocationListener listener) {
+  protected void removeUpdates(LocationListener listener) {
     removedLocationListeners.add(listener);
   }
 
@@ -318,7 +320,7 @@ public class ShadowLocationManager {
   }
 
   @Implementation
-  public void removeUpdates(PendingIntent pendingIntent) {
+  protected void removeUpdates(PendingIntent pendingIntent) {
     while (requestLocationUdpateCriteriaPendingIntents.remove(pendingIntent) != null);
     while (requestLocationUdpateProviderPendingIntents.remove(pendingIntent) != null);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLog.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLog.java
@@ -33,68 +33,67 @@ public class ShadowLog {
   private static boolean wtfIsFatal = false;
 
   @Implementation
-  public static void e(String tag, String msg) {
+  protected static void e(String tag, String msg) {
     e(tag, msg, null);
   }
 
   @Implementation
-  public static void e(String tag, String msg, Throwable throwable) {
+  protected static void e(String tag, String msg, Throwable throwable) {
     addLog(Log.ERROR, tag, msg, throwable);
   }
 
   @Implementation
-  public static void d(String tag, String msg) {
+  protected static void d(String tag, String msg) {
     d(tag, msg, null);
   }
 
   @Implementation
-  public static void d(String tag, String msg, Throwable throwable) {
+  protected static void d(String tag, String msg, Throwable throwable) {
     addLog(Log.DEBUG, tag, msg, throwable);
   }
 
   @Implementation
-  public static void i(String tag, String msg) {
+  protected static void i(String tag, String msg) {
     i(tag, msg, null);
   }
 
   @Implementation
-  public static void i(String tag, String msg, Throwable throwable) {
+  protected static void i(String tag, String msg, Throwable throwable) {
     addLog(Log.INFO, tag, msg, throwable);
   }
 
   @Implementation
-  public static void v(String tag, String msg) {
+  protected static void v(String tag, String msg) {
     v(tag, msg, null);
   }
 
   @Implementation
-  public static void v(String tag, String msg, Throwable throwable) {
+  protected static void v(String tag, String msg, Throwable throwable) {
     addLog(Log.VERBOSE, tag, msg, throwable);
   }
 
   @Implementation
-  public static void w(String tag, String msg) {
+  protected static void w(String tag, String msg) {
     w(tag, msg, null);
   }
 
   @Implementation
-  public static void w(String tag, Throwable throwable) {
+  protected static void w(String tag, Throwable throwable) {
     w(tag, null, throwable);
   }
 
-
   @Implementation
-  public static void w(String tag, String msg, Throwable throwable) {
+  protected static void w(String tag, String msg, Throwable throwable) {
     addLog(Log.WARN, tag, msg, throwable);
   }
 
   @Implementation
-  public static void wtf(String tag, String msg) {
+  protected static void wtf(String tag, String msg) {
     wtf(tag, msg, null);
   }
 
   @Implementation
-  public static void wtf(String tag, String msg, Throwable throwable) {
+  protected static void wtf(String tag, String msg, Throwable throwable) {
     addLog(Log.ASSERT, tag, msg, throwable);
     if (wtfIsFatal) {
       throw new TerribleFailure(msg, throwable);
@@ -107,7 +106,7 @@ public class ShadowLog {
   }
 
   @Implementation
-  public static boolean isLoggable(String tag, int level) {
+  protected static boolean isLoggable(String tag, int level) {
     synchronized (tagToLevel) {
       if (tagToLevel.containsKey(tag)) {
         return level >= tagToLevel.get(tag);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLooper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLooper.java
@@ -30,6 +30,7 @@ import org.robolectric.util.Scheduler;
 @Implements(Looper.class)
 @SuppressWarnings("SynchronizeOnNonFinalField")
 public class ShadowLooper {
+
   // Replaced SoftThreadLocal with a WeakHashMap, because ThreadLocal make it impossible to access their contents from other
   // threads, but we need to be able to access the loopers for all threads so that we can shut them down when resetThreadLoopers()
   // is called. This also allows us to implement the useful getLooperForThread() method.
@@ -73,7 +74,7 @@ public class ShadowLooper {
   }
 
   @Implementation
-  public void __constructor__(boolean quitAllowed) {
+  protected void __constructor__(boolean quitAllowed) {
     invokeConstructor(Looper.class, realObject, from(boolean.class, quitAllowed));
     if (isMainThread()) {
       mainLooper = realObject;
@@ -84,17 +85,17 @@ public class ShadowLooper {
   }
 
   @Implementation
-  public static Looper getMainLooper() {
+  protected static Looper getMainLooper() {
     return mainLooper;
   }
 
   @Implementation
-  public static Looper myLooper() {
+  protected static Looper myLooper() {
     return getLooperForThread(Thread.currentThread());
   }
 
   @Implementation
-  public static void loop() {
+  protected static void loop() {
     shadowOf(Looper.myLooper()).doLoop();
   }
 
@@ -112,13 +113,13 @@ public class ShadowLooper {
   }
 
   @Implementation
-  public void quit() {
+  protected void quit() {
     if (realObject == Looper.getMainLooper()) throw new RuntimeException("Main thread not allowed to quit");
     quitUnchecked();
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public void quitSafely() {
+  protected void quitSafely() {
     quit();
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMatrix.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMatrix.java
@@ -39,7 +39,7 @@ public class ShadowMatrix {
   private SimpleMatrix mMatrix = SimpleMatrix.IDENTITY;
 
   @Implementation
-  public void __constructor__(Matrix src) {
+  protected void __constructor__(Matrix src) {
     set(src);
   }
 
@@ -70,32 +70,32 @@ public class ShadowMatrix {
   }
 
   @Implementation
-  public boolean isIdentity() {
+  protected boolean isIdentity() {
     return mMatrix.equals(SimpleMatrix.IDENTITY);
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean isAffine() {
+  protected boolean isAffine() {
     return mMatrix.isAffine();
   }
 
   @Implementation
-  public boolean rectStaysRect() {
+  protected boolean rectStaysRect() {
     return mMatrix.rectStaysRect();
   }
 
   @Implementation
-  public void getValues(float[] values) {
+  protected void getValues(float[] values) {
     mMatrix.getValues(values);
   }
 
   @Implementation
-  public void setValues(float[] values) {
+  protected void setValues(float[] values) {
     mMatrix = new SimpleMatrix(values);
   }
 
   @Implementation
-  public void set(Matrix src) {
+  protected void set(Matrix src) {
     reset();
     if (src != null) {
       ShadowMatrix shadowMatrix = Shadow.extract(src);
@@ -107,7 +107,7 @@ public class ShadowMatrix {
   }
 
   @Implementation
-  public void reset() {
+  protected void reset() {
     preOps.clear();
     postOps.clear();
     setOps.clear();
@@ -115,163 +115,163 @@ public class ShadowMatrix {
   }
 
   @Implementation
-  public void setTranslate(float dx, float dy) {
+  protected void setTranslate(float dx, float dy) {
     setOps.put(TRANSLATE, dx + " " + dy);
     mMatrix = SimpleMatrix.translate(dx, dy);
   }
 
   @Implementation
-  public void setScale(float sx, float sy, float px, float py) {
+  protected void setScale(float sx, float sy, float px, float py) {
     setOps.put(SCALE, sx + " " + sy + " " + px + " " + py);
     mMatrix = SimpleMatrix.scale(sx, sy, px, py);
   }
 
   @Implementation
-  public void setScale(float sx, float sy) {
+  protected void setScale(float sx, float sy) {
     setOps.put(SCALE, sx + " " + sy);
     mMatrix = SimpleMatrix.scale(sx, sy);
   }
 
   @Implementation
-  public void setRotate(float degrees, float px, float py) {
+  protected void setRotate(float degrees, float px, float py) {
     setOps.put(ROTATE, degrees + " " + px + " " + py);
     mMatrix = SimpleMatrix.rotate(degrees, px, py);
   }
 
   @Implementation
-  public void setRotate(float degrees) {
+  protected void setRotate(float degrees) {
     setOps.put(ROTATE, Float.toString(degrees));
     mMatrix = SimpleMatrix.rotate(degrees);
   }
 
   @Implementation
-  public void setSinCos(float sinValue, float cosValue, float px, float py) {
+  protected void setSinCos(float sinValue, float cosValue, float px, float py) {
     setOps.put(SINCOS, sinValue + " " + cosValue + " " + px + " " + py);
     mMatrix = SimpleMatrix.sinCos(sinValue, cosValue, px, py);
   }
 
   @Implementation
-  public void setSinCos(float sinValue, float cosValue) {
+  protected void setSinCos(float sinValue, float cosValue) {
     setOps.put(SINCOS, sinValue + " " + cosValue);
     mMatrix = SimpleMatrix.sinCos(sinValue, cosValue);
   }
 
   @Implementation
-  public void setSkew(float kx, float ky, float px, float py) {
+  protected void setSkew(float kx, float ky, float px, float py) {
     setOps.put(SKEW, kx + " " + ky + " " + px + " " + py);
     mMatrix = SimpleMatrix.skew(kx, ky, px, py);
   }
 
   @Implementation
-  public void setSkew(float kx, float ky) {
+  protected void setSkew(float kx, float ky) {
     setOps.put(SKEW, kx + " " + ky);
     mMatrix = SimpleMatrix.skew(kx, ky);
   }
 
   @Implementation
-  public boolean setConcat(Matrix a, Matrix b) {
+  protected boolean setConcat(Matrix a, Matrix b) {
     mMatrix = getSimpleMatrix(a).multiply(getSimpleMatrix(b));
     return true;
   }
 
   @Implementation
-  public boolean preTranslate(float dx, float dy) {
+  protected boolean preTranslate(float dx, float dy) {
     preOps.addFirst(TRANSLATE + " " + dx + " " + dy);
     return preConcat(SimpleMatrix.translate(dx, dy));
   }
 
   @Implementation
-  public boolean preScale(float sx, float sy, float px, float py) {
+  protected boolean preScale(float sx, float sy, float px, float py) {
     preOps.addFirst(SCALE + " " + sx + " " + sy + " " + px + " " + py);
     return preConcat(SimpleMatrix.scale(sx, sy, px, py));
   }
 
   @Implementation
-  public boolean preScale(float sx, float sy) {
+  protected boolean preScale(float sx, float sy) {
     preOps.addFirst(SCALE + " " + sx + " " + sy);
     return preConcat(SimpleMatrix.scale(sx, sy));
   }
 
   @Implementation
-  public boolean preRotate(float degrees, float px, float py) {
+  protected boolean preRotate(float degrees, float px, float py) {
     preOps.addFirst(ROTATE + " " + degrees + " " + px + " " + py);
     return preConcat(SimpleMatrix.rotate(degrees, px, py));
   }
 
   @Implementation
-  public boolean preRotate(float degrees) {
+  protected boolean preRotate(float degrees) {
     preOps.addFirst(ROTATE + " " + Float.toString(degrees));
     return preConcat(SimpleMatrix.rotate(degrees));
   }
 
   @Implementation
-  public boolean preSkew(float kx, float ky, float px, float py) {
+  protected boolean preSkew(float kx, float ky, float px, float py) {
     preOps.addFirst(SKEW + " " + kx + " " + ky + " " + px + " " + py);
     return preConcat(SimpleMatrix.skew(kx, ky, px, py));
   }
 
   @Implementation
-  public boolean preSkew(float kx, float ky) {
+  protected boolean preSkew(float kx, float ky) {
     preOps.addFirst(SKEW + " " + kx + " " + ky);
     return preConcat(SimpleMatrix.skew(kx, ky));
   }
 
   @Implementation
-  public boolean preConcat(Matrix other) {
+  protected boolean preConcat(Matrix other) {
     preOps.addFirst(MATRIX + " " + other);
     return preConcat(getSimpleMatrix(other));
   }
 
   @Implementation
-  public boolean postTranslate(float dx, float dy) {
+  protected boolean postTranslate(float dx, float dy) {
     postOps.addLast(TRANSLATE + " " + dx + " " + dy);
     return postConcat(SimpleMatrix.translate(dx, dy));
   }
 
   @Implementation
-  public boolean postScale(float sx, float sy, float px, float py) {
+  protected boolean postScale(float sx, float sy, float px, float py) {
     postOps.addLast(SCALE + " " + sx + " " + sy + " " + px + " " + py);
     return postConcat(SimpleMatrix.scale(sx, sy, px, py));
   }
 
   @Implementation
-  public boolean postScale(float sx, float sy) {
+  protected boolean postScale(float sx, float sy) {
     postOps.addLast(SCALE + " " + sx + " " + sy);
     return postConcat(SimpleMatrix.scale(sx, sy));
   }
 
   @Implementation
-  public boolean postRotate(float degrees, float px, float py) {
+  protected boolean postRotate(float degrees, float px, float py) {
     postOps.addLast(ROTATE + " " + degrees + " " + px + " " + py);
     return postConcat(SimpleMatrix.rotate(degrees, px, py));
   }
 
   @Implementation
-  public boolean postRotate(float degrees) {
+  protected boolean postRotate(float degrees) {
     postOps.addLast(ROTATE + " " + Float.toString(degrees));
     return postConcat(SimpleMatrix.rotate(degrees));
   }
 
   @Implementation
-  public boolean postSkew(float kx, float ky, float px, float py) {
+  protected boolean postSkew(float kx, float ky, float px, float py) {
     postOps.addLast(SKEW + " " + kx + " " + ky + " " + px + " " + py);
     return postConcat(SimpleMatrix.skew(kx, ky, px, py));
   }
 
   @Implementation
-  public boolean postSkew(float kx, float ky) {
+  protected boolean postSkew(float kx, float ky) {
     postOps.addLast(SKEW + " " + kx + " " + ky);
     return postConcat(SimpleMatrix.skew(kx, ky));
   }
 
   @Implementation
-  public boolean postConcat(Matrix other) {
+  protected boolean postConcat(Matrix other) {
     postOps.addLast(MATRIX + " " + other);
     return postConcat(getSimpleMatrix(other));
   }
 
   @Implementation
-  public boolean invert(Matrix inverse) {
+  protected boolean invert(Matrix inverse) {
     final SimpleMatrix inverseMatrix = mMatrix.invert();
     if (inverseMatrix != null) {
       if (inverse != null) {
@@ -310,7 +310,7 @@ public class ShadowMatrix {
   }
 
   @Implementation
-  public boolean mapRect(RectF destination, RectF source) {
+  protected boolean mapRect(RectF destination, RectF source) {
     final PointF leftTop = mapPoint(source.left, source.top);
     final PointF rightBottom = mapPoint(source.right, source.bottom);
     destination.set(

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaMetadataRetriever.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaMetadataRetriever.java
@@ -31,27 +31,27 @@ public class ShadowMediaMetadataRetriever {
   }
 
   @Implementation
-  public void setDataSource(String path) {
+  protected void setDataSource(String path) {
     setDataSource(toDataSource(path));
   }
 
   @Implementation
-  public void setDataSource(Context context, Uri uri) {
+  protected void setDataSource(Context context, Uri uri) {
     setDataSource(toDataSource(context, uri));
   }
 
   @Implementation
-  public void setDataSource(String uri, Map<String, String> headers) {
+  protected void setDataSource(String uri, Map<String, String> headers) {
     setDataSource(toDataSource(uri, headers));
   }
 
   @Implementation
-  public void setDataSource(FileDescriptor fd, long offset, long length) {
+  protected void setDataSource(FileDescriptor fd, long offset, long length) {
     setDataSource(toDataSource(fd, offset, length));
   }
 
   @Implementation
-  public String extractMetadata(int keyCode) {
+  protected String extractMetadata(int keyCode) {
     if (metadata.containsKey(dataSource)) {
       return metadata.get(dataSource).get(keyCode);
     }
@@ -59,7 +59,7 @@ public class ShadowMediaMetadataRetriever {
   }
 
   @Implementation
-  public Bitmap getFrameAtTime(long timeUs, int option) {
+  protected Bitmap getFrameAtTime(long timeUs, int option) {
     return (frames.containsKey(dataSource) ?
             frames.get(dataSource).get(timeUs) : null);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
@@ -89,7 +89,7 @@ import org.robolectric.shadows.util.DataSource;
 @Implements(MediaPlayer.class)
 public class ShadowMediaPlayer extends ShadowPlayerBase {
   @Implementation
-  public static void __staticInitializer__() {
+  protected static void __staticInitializer__() {
     // don't bind the JNI library
   }
 
@@ -504,7 +504,7 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
   }
 
   @Implementation
-  public static MediaPlayer create(Context context, int resId) {
+  protected static MediaPlayer create(Context context, int resId) {
     MediaPlayer mp = new MediaPlayer();
     ShadowMediaPlayer shadow = Shadow.extract(mp);
     shadow.sourceResId = resId;
@@ -520,7 +520,7 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
   }
 
   @Implementation
-  public static MediaPlayer create(Context context, Uri uri) {
+  protected static MediaPlayer create(Context context, Uri uri) {
     MediaPlayer mp = new MediaPlayer();
     try {
       mp.setDataSource(context, uri);
@@ -533,7 +533,7 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
   }
 
   @Implementation
-  public void __constructor__() {
+  protected void __constructor__() {
     // Contract of audioSessionId is that if it is 0 (which represents
     // the master mix) then that's an error. By default it generates
     // an ID that is unique system-wide. We could simulate guaranteed
@@ -623,25 +623,26 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
     }
     this.dataSource = dataSource;
   }
-  
+
   @Implementation
-  public void setDataSource(String path) throws IOException {
+  protected void setDataSource(String path) throws IOException {
     setDataSource(toDataSource(path));
   }
 
   @Implementation
-  public void setDataSource(Context context, Uri uri, Map<String, String> headers) throws IOException {
+  protected void setDataSource(Context context, Uri uri, Map<String, String> headers)
+      throws IOException {
     setDataSource(toDataSource(context, uri, headers));
     sourceUri = uri;
   }
 
   @Implementation
-  public void setDataSource(String uri, Map<String, String> headers) throws IOException {
+  protected void setDataSource(String uri, Map<String, String> headers) throws IOException {
     setDataSource(toDataSource(uri, headers));
   }
 
   @Implementation
-  public void setDataSource(FileDescriptor fd, long offset, long length) throws IOException {
+  protected void setDataSource(FileDescriptor fd, long offset, long length) throws IOException {
     setDataSource(toDataSource(fd, offset, length));
   }
 
@@ -767,33 +768,32 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
   }
 
   @Implementation
-  public void setOnCompletionListener(MediaPlayer.OnCompletionListener listener) {
+  protected void setOnCompletionListener(MediaPlayer.OnCompletionListener listener) {
     completionListener = listener;
   }
 
   @Implementation
-  public void setOnSeekCompleteListener(
-      MediaPlayer.OnSeekCompleteListener listener) {
+  protected void setOnSeekCompleteListener(MediaPlayer.OnSeekCompleteListener listener) {
     seekCompleteListener = listener;
   }
 
   @Implementation
-  public void setOnPreparedListener(MediaPlayer.OnPreparedListener listener) {
+  protected void setOnPreparedListener(MediaPlayer.OnPreparedListener listener) {
     preparedListener = listener;
   }
 
   @Implementation
-  public void setOnInfoListener(MediaPlayer.OnInfoListener listener) {
+  protected void setOnInfoListener(MediaPlayer.OnInfoListener listener) {
     infoListener = listener;
   }
 
   @Implementation
-  public void setOnErrorListener(MediaPlayer.OnErrorListener listener) {
+  protected void setOnErrorListener(MediaPlayer.OnErrorListener listener) {
     errorListener = listener;
   }
 
   @Implementation
-  public boolean isLooping() {
+  protected boolean isLooping() {
     checkStateException("isLooping()", nonEndStates);
     return looping;
   }
@@ -804,20 +804,20 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
       .complementOf(EnumSet.of(ERROR, END));
 
   @Implementation
-  public void setLooping(boolean looping) {
+  protected void setLooping(boolean looping) {
     checkStateError("setLooping()", nonErrorStates);
     this.looping = looping;
   }
 
   @Implementation
-  public void setVolume(float left, float right) {
+  protected void setVolume(float left, float right) {
     checkStateError("setVolume()", nonErrorStates);
     leftVolume = left;
     rightVolume = right;
   }
 
   @Implementation
-  public boolean isPlaying() {
+  protected boolean isPlaying() {
     checkStateError("isPlaying()", nonErrorStates);
     return state == STARTED;
   }
@@ -826,19 +826,17 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
       STOPPED);
 
   /**
-   * Simulates {@link MediaPlayer#prepareAsync()}. Sleeps for
-   * {@link MediaInfo#getPreparationDelay() preparationDelay} ms by calling
-   * {@link SystemClock#sleep(long)} before calling
-   * {@link #invokePreparedListener()}.
-   * 
-   * If {@code preparationDelay} is not positive and non-zero, there is no
-   * sleep.
-   * 
+   * Simulates {@link MediaPlayer#prepareAsync()}. Sleeps for {@link MediaInfo#getPreparationDelay()
+   * preparationDelay} ms by calling {@link SystemClock#sleep(long)} before calling {@link
+   * #invokePreparedListener()}.
+   *
+   * <p>If {@code preparationDelay} is not positive and non-zero, there is no sleep.
+   *
    * @see MediaInfo#setPreparationDelay(int)
    * @see #invokePreparedListener()
    */
   @Implementation
-  public void prepare() {
+  protected void prepare() {
     checkStateException("prepare()", preparableStates);
     MediaInfo info = getMediaInfo();
     if (info.preparationDelay > 0) {
@@ -848,17 +846,16 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
   }
 
   /**
-   * Simulates {@link MediaPlayer#prepareAsync()}. Sets state to PREPARING and
-   * posts a callback to {@link #invokePreparedListener()} if the current
-   * preparation delay for the current media (see {@link #getMediaInfo()}) is &gt;=
-   * 0, otherwise the test suite is responsible for calling
-   * {@link #invokePreparedListener()} directly if required.
-   * 
+   * Simulates {@link MediaPlayer#prepareAsync()}. Sets state to PREPARING and posts a callback to
+   * {@link #invokePreparedListener()} if the current preparation delay for the current media (see
+   * {@link #getMediaInfo()}) is &gt;= 0, otherwise the test suite is responsible for calling {@link
+   * #invokePreparedListener()} directly if required.
+   *
    * @see MediaInfo#setPreparationDelay(int)
    * @see #invokePreparedListener()
    */
   @Implementation
-  public void prepareAsync() {
+  protected void prepareAsync() {
     checkStateException("prepareAsync()", preparableStates);
     state = PREPARING;
     MediaInfo info = getMediaInfo();
@@ -873,14 +870,14 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
   /**
    * Simulates private native method {@link MediaPlayer#_start()}. Sets state to STARTED and calls
    * {@link #doStart()} to start scheduling playback callback events.
-   * 
-   * If the current state is PLAYBACK_COMPLETED, the current position is reset
-   * to zero before starting playback.
-   * 
+   *
+   * <p>If the current state is PLAYBACK_COMPLETED, the current position is reset to zero before
+   * starting playback.
+   *
    * @see #doStart()
    */
   @Implementation
-  public void start() {
+  protected void start() {
     if (checkStateError("start()", startableStates)) {
       if (state == PLAYBACK_COMPLETED) {
         startOffset = 0;
@@ -976,13 +973,13 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
       PAUSED, PLAYBACK_COMPLETED);
 
   /**
-   * Simulates {@link MediaPlayer#_pause()}. Invokes {@link #doStop()} to suspend
-   * playback event callbacks and sets the state to PAUSED.
-   * 
+   * Simulates {@link MediaPlayer#_pause()}. Invokes {@link #doStop()} to suspend playback event
+   * callbacks and sets the state to PAUSED.
+   *
    * @see #doStop()
    */
   @Implementation
-  public void _pause() {
+  protected void _pause() {
     if (checkStateError("pause()", pausableStates)) {
       doStop();
       state = PAUSED;
@@ -992,11 +989,11 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
   static final EnumSet<State> allStates = EnumSet.allOf(State.class);
 
   /**
-   * Simulates call to {@link MediaPlayer#_release()}. Calls {@link #doStop()} to
-   * suspend playback event callbacks and sets the state to END.
+   * Simulates call to {@link MediaPlayer#_release()}. Calls {@link #doStop()} to suspend playback
+   * event callbacks and sets the state to END.
    */
   @Implementation
-  public void _release() {
+  protected void _release() {
     checkStateException("release()", allStates);
     doStop();
     state = END;
@@ -1004,11 +1001,11 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
   }
 
   /**
-   * Simulates call to {@link MediaPlayer#_reset()}. Calls {@link #doStop()} to
-   * suspend playback event callbacks and sets the state to IDLE.
+   * Simulates call to {@link MediaPlayer#_reset()}. Calls {@link #doStop()} to suspend playback
+   * event callbacks and sets the state to IDLE.
    */
   @Implementation
-  public void _reset() {
+  protected void _reset() {
     checkStateException("reset()", nonEndStates);
     doStop();
     state = IDLE;
@@ -1020,11 +1017,11 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
       STARTED, PAUSED, STOPPED, PLAYBACK_COMPLETED);
 
   /**
-   * Simulates call to {@link MediaPlayer#release()}. Calls {@link #doStop()} to
-   * suspend playback event callbacks and sets the state to STOPPED.
+   * Simulates call to {@link MediaPlayer#release()}. Calls {@link #doStop()} to suspend playback
+   * event callbacks and sets the state to STOPPED.
    */
   @Implementation
-  public void _stop() {
+  protected void _stop() {
     if (checkStateError("stop()", stoppableStates)) {
       doStop();
       state = STOPPED;
@@ -1036,52 +1033,52 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
       PLAYBACK_COMPLETED);
 
   @Implementation
-  public void attachAuxEffect(int effectId) {
+  protected void attachAuxEffect(int effectId) {
     checkStateError("attachAuxEffect()", attachableStates);
     auxEffect = effectId;
   }
 
   @Implementation
-  public int getAudioSessionId() {
+  protected int getAudioSessionId() {
     checkStateException("getAudioSessionId()", allStates);
     return audioSessionId;
   }
 
   /**
-   * Simulates call to {@link MediaPlayer#getCurrentPosition()}. Simply does the
-   * state validity checks and then invokes {@link #getCurrentPositionRaw()} to
-   * calculate the simulated playback position.
-   * 
+   * Simulates call to {@link MediaPlayer#getCurrentPosition()}. Simply does the state validity
+   * checks and then invokes {@link #getCurrentPositionRaw()} to calculate the simulated playback
+   * position.
+   *
    * @return The current offset (in ms) of the simulated playback.
    * @see #getCurrentPositionRaw()
    */
   @Implementation
-  public int getCurrentPosition() {
+  protected int getCurrentPosition() {
     checkStateError("getCurrentPosition()", attachableStates);
     return getCurrentPositionRaw();
   }
 
   /**
-   * Simulates call to {@link MediaPlayer#getDuration()}. Retrieves the duration
-   * as defined by the current {@link MediaInfo} instance.
-   * 
+   * Simulates call to {@link MediaPlayer#getDuration()}. Retrieves the duration as defined by the
+   * current {@link MediaInfo} instance.
+   *
    * @return The duration (in ms) of the current simulated playback.
    * @see #addMediaInfo(DataSource, MediaInfo)
    */
   @Implementation
-  public int getDuration() {
+  protected int getDuration() {
     checkStateError("getDuration()", stoppableStates);
     return getMediaInfo().duration;
   }
 
   @Implementation
-  public int getVideoHeight() {
+  protected int getVideoHeight() {
     checkStateLog("getVideoHeight()", attachableStates);
     return videoHeight;
   }
 
   @Implementation
-  public int getVideoWidth() {
+  protected int getVideoWidth() {
     checkStateLog("getVideoWidth()", attachableStates);
     return videoWidth;
   }
@@ -1090,16 +1087,14 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
       STARTED, PAUSED, PLAYBACK_COMPLETED);
 
   /**
-   * Simulates seeking to specified position. The seek will complete after
-   * {@link #seekDelay} ms (defaults to 0), or else if seekDelay is negative
-   * then the controlling test is expected to simulate seek completion by
-   * manually invoking {@link #invokeSeekCompleteListener}.
-   * 
-   * @param seekTo
-   *          the offset (in ms) from the start of the track to seek to.
+   * Simulates seeking to specified position. The seek will complete after {@link #seekDelay} ms
+   * (defaults to 0), or else if seekDelay is negative then the controlling test is expected to
+   * simulate seek completion by manually invoking {@link #invokeSeekCompleteListener}.
+   *
+   * @param seekTo the offset (in ms) from the start of the track to seek to.
    */
   @Implementation
-  public void seekTo(int seekTo) {
+  protected void seekTo(int seekTo) {
     seekTo(seekTo, MediaPlayer.SEEK_PREVIOUS_SYNC);
   }
 
@@ -1125,7 +1120,7 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
   static private final EnumSet<State> idleState = EnumSet.of(IDLE);
 
   @Implementation
-  public void setAudioSessionId(int sessionId) {
+  protected void setAudioSessionId(int sessionId) {
     checkStateError("setAudioSessionId()", idleState);
     audioSessionId = sessionId;
   }
@@ -1134,7 +1129,7 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
       INITIALIZED, STOPPED);
 
   @Implementation
-  public void setAudioStreamType(int audioStreamType) {
+  protected void setAudioStreamType(int audioStreamType) {
     checkStateError("setAudioStreamType()", nonPlayingStates);
     this.audioStreamType = audioStreamType;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaRecorder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaRecorder.java
@@ -10,7 +10,7 @@ import org.robolectric.annotation.Implements;
 public class ShadowMediaRecorder {
   @SuppressWarnings("UnusedDeclaration")
   @Implementation
-  public static void __staticInitializer__() {
+  protected static void __staticInitializer__() {
     // don't bind the JNI library
   }
 
@@ -48,132 +48,132 @@ public class ShadowMediaRecorder {
   private MediaRecorder.OnInfoListener infoListener;
 
   @Implementation
-  public void __constructor__() {
+  protected void __constructor__() {
     state = STATE_INITIAL;
   }
 
   @Implementation
-  public void setAudioChannels(int numChannels) {
+  protected void setAudioChannels(int numChannels) {
     audioChannels = numChannels;
   }
 
   @Implementation
-  public void setAudioEncoder(int audio_encoder) {
+  protected void setAudioEncoder(int audio_encoder) {
     audioEncoder = audio_encoder;
     state = STATE_DATA_SOURCE_CONFIGURED;
   }
 
   @Implementation
-  public void setAudioEncodingBitRate(int bitRate) {
+  protected void setAudioEncodingBitRate(int bitRate) {
     audioBitRate = bitRate;
   }
 
   @Implementation
-  public void setAudioSamplingRate(int samplingRate) {
+  protected void setAudioSamplingRate(int samplingRate) {
     audioSamplingRate = samplingRate;
   }
 
   @Implementation
-  public void setAudioSource(int audio_source) {
+  protected void setAudioSource(int audio_source) {
     audioSource = audio_source;
     state = STATE_INITIALIZED;
   }
 
   @Implementation
-  public void setCamera(Camera c) {
+  protected void setCamera(Camera c) {
     camera = c;
   }
 
   @Implementation
-  public void setMaxDuration(int max_duration_ms) {
+  protected void setMaxDuration(int max_duration_ms) {
     maxDuration = max_duration_ms;
   }
 
   @Implementation
-  public void setMaxFileSize(long max_filesize_bytes) {
+  protected void setMaxFileSize(long max_filesize_bytes) {
     maxFileSize = max_filesize_bytes;
   }
 
   @Implementation
-  public void setOnErrorListener(MediaRecorder.OnErrorListener l) {
+  protected void setOnErrorListener(MediaRecorder.OnErrorListener l) {
     errorListener = l;
   }
 
   @Implementation
-  public void setOnInfoListener(MediaRecorder.OnInfoListener listener) {
+  protected void setOnInfoListener(MediaRecorder.OnInfoListener listener) {
     infoListener = listener;
   }
 
   @Implementation
-  public void setOutputFile(String path) {
+  protected void setOutputFile(String path) {
     outputPath = path;
     state = STATE_DATA_SOURCE_CONFIGURED;
   }
 
   @Implementation
-  public void setOutputFormat(int output_format) {
+  protected void setOutputFormat(int output_format) {
     outputFormat = output_format;
     state = STATE_DATA_SOURCE_CONFIGURED;
   }
 
   @Implementation
-  public void setPreviewDisplay(Surface sv) {
+  protected void setPreviewDisplay(Surface sv) {
     previewDisplay = sv;
     state = STATE_DATA_SOURCE_CONFIGURED;
   }
 
   @Implementation
-  public void setVideoEncoder(int video_encoder) {
+  protected void setVideoEncoder(int video_encoder) {
     videoEncoder = video_encoder;
     state = STATE_DATA_SOURCE_CONFIGURED;
   }
 
   @Implementation
-  public void setVideoEncodingBitRate(int bitRate) {
+  protected void setVideoEncodingBitRate(int bitRate) {
     videoBitRate = bitRate;
   }
 
   @Implementation
-  public void setVideoFrameRate(int rate) {
+  protected void setVideoFrameRate(int rate) {
     videoFrameRate = rate;
     state = STATE_DATA_SOURCE_CONFIGURED;
   }
 
   @Implementation
-  public void setVideoSize(int width, int height) {
+  protected void setVideoSize(int width, int height) {
     videoWidth = width;
     videoHeight = height;
     state = STATE_DATA_SOURCE_CONFIGURED;
   }
 
   @Implementation
-  public void setVideoSource(int video_source) {
+  protected void setVideoSource(int video_source) {
     videoSource = video_source;
     state = STATE_INITIALIZED;
   }
 
   @Implementation
-  public void prepare() {
+  protected void prepare() {
     state = STATE_PREPARED;
   }
 
   @Implementation
-  public void start() {
+  protected void start() {
     state = STATE_RECORDING;
   }
 
   @Implementation
-  public void stop() {
+  protected void stop() {
     state = STATE_INITIAL;
   }
 
   @Implementation
-  public void reset() {
+  protected void reset() {
     state = STATE_INITIAL;
   }
 
   @Implementation
-  public void release() {
+  protected void release() {
     state = STATE_RELEASED;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaStore.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaStore.java
@@ -18,7 +18,7 @@ public class ShadowMediaStore {
     public static class ShadowMedia {
 
       @Implementation
-      public static Bitmap getBitmap(ContentResolver cr, Uri url) {
+      protected static Bitmap getBitmap(ContentResolver cr, Uri url) {
         return ShadowBitmapFactory.create(url.toString());
       }
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessage.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessage.java
@@ -56,12 +56,11 @@ public class ShadowMessage {
   }
 
   /**
-   * Hook to unscheduled the callback when the message is recycled.
-   * Invokes {@link #unschedule()} and then calls through to
-   * {@link Message#recycle()} on the real object.
+   * Hook to unscheduled the callback when the message is recycled. Invokes {@link #unschedule()}
+   * and then calls through to {@link Message#recycle()} on the real object.
    */
   @Implementation(maxSdk = KITKAT_WATCH)
-  public void recycle() {
+  protected void recycle() {
     unschedule();
     directlyOn(realMessage, Message.class, "recycle");
   }
@@ -85,18 +84,18 @@ public class ShadowMessage {
   }
 
   /**
-   * Convenience method to provide access to the private {@code Message.isInUse()}
-   * method. Note that the definition of "in use" changed with API 21:
+   * Convenience method to provide access to the private {@code Message.isInUse()} method. Note that
+   * the definition of "in use" changed with API 21:
    *
-   * In API 19, a message was only considered "in use" during its dispatch. In API 21, the
-   * message is considered "in use" from the time it is enqueued until the time that
-   * it is freshly obtained via a call to {@link Message#obtain()}. This means that
-   * in API 21 messages that are in the recycled pool will still be marked as "in use". 
+   * <p>In API 19, a message was only considered "in use" during its dispatch. In API 21, the
+   * message is considered "in use" from the time it is enqueued until the time that it is freshly
+   * obtained via a call to {@link Message#obtain()}. This means that in API 21 messages that are in
+   * the recycled pool will still be marked as "in use".
    *
    * @return {@code true} if the message is currently "in use", {@code false} otherwise.
    */
   @Implementation
-  public boolean isInUse() {
+  protected boolean isInUse() {
   	return directlyOn(realMessage, Message.class, "isInUse");
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessageQueue.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessageQueue.java
@@ -55,8 +55,7 @@ public class ShadowMessageQueue {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeDestroy(long ptr) {
-  }
+  protected static void nativeDestroy(long ptr) {}
 
   @HiddenApi
   @Implementation(minSdk = KITKAT, maxSdk = KITKAT_WATCH)
@@ -65,7 +64,7 @@ public class ShadowMessageQueue {
   }
 
   @Implementation(minSdk = LOLLIPOP, maxSdk = LOLLIPOP_MR1)
-  public static boolean nativeIsIdling(long ptr) {
+  protected static boolean nativeIsIdling(long ptr) {
     return false;
   }
 
@@ -93,7 +92,7 @@ public class ShadowMessageQueue {
 
   @Implementation
   @SuppressWarnings("SynchronizeOnNonFinalField")
-  public boolean enqueueMessage(final Message msg, long when) {
+  protected boolean enqueueMessage(final Message msg, long when) {
     final boolean retval = directlyOn(realQueue, MessageQueue.class, "enqueueMessage", from(Message.class, msg), from(long.class, when));
     if (retval) {
       final Runnable callback = new Runnable() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessenger.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessenger.java
@@ -29,28 +29,28 @@ public class ShadowMessenger {
   private Handler handler;
 
   @Implementation
-  public void __constructor__(Handler handler) {
+  protected void __constructor__(Handler handler) {
     this.handler = handler;
     Object target = ReflectionHelpers.callInstanceMethod(handler, "getIMessenger");
     ReflectionHelpers.setField(messenger, "mTarget", target);
   }
 
   @Implementation
-  public void __constructor__(IBinder target) {
+  protected void __constructor__(IBinder target) {
     if (target != null && target instanceof FakeBinder) {
       handler = ((FakeBinder) target).handler;
     }
   }
 
   @Implementation
-  public void send(Message message) throws RemoteException {
+  protected void send(Message message) throws RemoteException {
     lastMessageSent = message;
     message.setTarget(handler);
     message.sendToTarget();
   }
 
   @Implementation
-  public IBinder getBinder() {
+  protected IBinder getBinder() {
     return new FakeBinder(handler);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMimeTypeMap.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMimeTypeMap.java
@@ -16,7 +16,7 @@ public class ShadowMimeTypeMap {
   private static final Object singletonLock = new Object();
 
   @Implementation
-  public static MimeTypeMap getSingleton() {
+  protected static MimeTypeMap getSingleton() {
     if (singleton == null) {
       synchronized (singletonLock) {
         if (singleton == null) {
@@ -37,7 +37,7 @@ public class ShadowMimeTypeMap {
   }
 
   @Implementation
-  public String getMimeTypeFromExtension(String extension) {
+  protected String getMimeTypeFromExtension(String extension) {
     if (extensionToMimeTypeMap.containsKey(extension))
       return extensionToMimeTypeMap.get(extension);
 
@@ -45,7 +45,7 @@ public class ShadowMimeTypeMap {
   }
 
   @Implementation
-  public String getExtensionFromMimeType(String mimeType) {
+  protected String getExtensionFromMimeType(String mimeType) {
     if (mimeTypeToExtensionMap.containsKey(mimeType))
       return mimeTypeToExtensionMap.get(mimeType);
 
@@ -63,12 +63,12 @@ public class ShadowMimeTypeMap {
   }
 
   @Implementation
-  public boolean hasExtension(String extension) {
+  protected boolean hasExtension(String extension) {
     return extensionToMimeTypeMap.containsKey(extension);
   }
 
   @Implementation
-  public boolean hasMimeType(String mimeType) {
+  protected boolean hasMimeType(String mimeType) {
     return mimeTypeToExtensionMap.containsKey(mimeType);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetwork.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetwork.java
@@ -27,7 +27,7 @@ public class ShadowNetwork {
   }
 
   @Implementation
-  public void __constructor__(int netId) {
+  protected void __constructor__(int netId) {
     this.netId = netId;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkInfo.java
@@ -12,9 +12,9 @@ public class ShadowNetworkInfo {
   private int connectionType;
   private int connectionSubType;
   private NetworkInfo.DetailedState detailedState;
-  
+
   @Implementation
-  public static void __staticInitializer__() {}
+  protected static void __staticInitializer__() {}
 
   /**
    * @deprecated use {@link #newInstance(NetworkInfo.DetailedState, int, int, boolean,
@@ -53,37 +53,37 @@ public class ShadowNetworkInfo {
   }
 
   @Implementation
-  public boolean isConnected() {
+  protected boolean isConnected() {
     return state == NetworkInfo.State.CONNECTED;
   }
 
   @Implementation
-  public boolean isConnectedOrConnecting() {
+  protected boolean isConnectedOrConnecting() {
     return isConnected() || state == NetworkInfo.State.CONNECTING;
   }
 
   @Implementation
-  public NetworkInfo.State getState() {
+  protected NetworkInfo.State getState() {
     return state;
   }
 
   @Implementation
-  public NetworkInfo.DetailedState getDetailedState() {
+  protected NetworkInfo.DetailedState getDetailedState() {
     return detailedState;
   }
 
   @Implementation
-  public int getType(){
+  protected int getType() {
     return connectionType;
   }
 
   @Implementation
-  public int getSubtype() {
+  protected int getSubtype() {
     return connectionSubType;
   }
 
   @Implementation
-  public boolean isAvailable() {
+  protected boolean isAvailable() {
     return isAvailable;
   }
 
@@ -124,7 +124,7 @@ public class ShadowNetworkInfo {
    *
    * @param connectionType the value that {@link #getType()} will return.
    */
-  public void setConnectionType(int connectionType){
+  public void setConnectionType(int connectionType) {
     this.connectionType = connectionType;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNfcAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNfcAdapter.java
@@ -28,7 +28,7 @@ public class ShadowNfcAdapter {
   private NfcAdapter.OnNdefPushCompleteCallback onNdefPushCompleteCallback;
 
   @Implementation
-  public static NfcAdapter getNfcAdapter(Context context) {
+  protected static NfcAdapter getNfcAdapter(Context context) {
     if (!hardwareExists) {
       return null;
     }
@@ -36,7 +36,8 @@ public class ShadowNfcAdapter {
   }
 
   @Implementation
-  public void enableForegroundDispatch(Activity activity, PendingIntent intent, IntentFilter[] filters, String[][] techLists) {
+  protected void enableForegroundDispatch(
+      Activity activity, PendingIntent intent, IntentFilter[] filters, String[][] techLists) {
     this.enabledActivity = activity;
     this.intent = intent;
     this.filters = filters;
@@ -44,7 +45,7 @@ public class ShadowNfcAdapter {
   }
 
   @Implementation
-  public void disableForegroundDispatch(Activity activity) {
+  protected void disableForegroundDispatch(Activity activity) {
     disabledActivity = activity;
   }
 
@@ -68,7 +69,8 @@ public class ShadowNfcAdapter {
   }
 
   @Implementation
-  public void setNdefPushMessageCallback(NfcAdapter.CreateNdefMessageCallback callback, Activity activity, Activity... activities) {
+  protected void setNdefPushMessageCallback(
+      NfcAdapter.CreateNdefMessageCallback callback, Activity activity, Activity... activities) {
     this.ndefPushMessageCallback = callback;
   }
 
@@ -79,7 +81,7 @@ public class ShadowNfcAdapter {
    * #getOnNdefPushCompleteCallback}.
    */
   @Implementation
-  public void setOnNdefPushCompleteCallback(
+  protected void setOnNdefPushCompleteCallback(
       NfcAdapter.OnNdefPushCompleteCallback callback, Activity activity, Activity... activities) {
     if (activity == null) {
       throw new NullPointerException("activity cannot be null");
@@ -93,7 +95,7 @@ public class ShadowNfcAdapter {
   }
 
   @Implementation
-  public boolean isEnabled() {
+  protected boolean isEnabled() {
     return enabled;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNinePatch.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNinePatch.java
@@ -7,7 +7,7 @@ import org.robolectric.annotation.Implements;
 @Implements(NinePatch.class)
 public class ShadowNinePatch {
   @Implementation
-  public static boolean isNinePatchChunk(byte[] chunk) {
+  protected static boolean isNinePatchChunk(byte[] chunk) {
     return chunk != null;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -38,22 +38,22 @@ public class ShadowNotificationManager {
   private Policy notificationPolicy;
 
   @Implementation
-  public void notify(int id, Notification notification) {
+  protected void notify(int id, Notification notification) {
     notify(null, id, notification);
   }
 
   @Implementation
-  public void notify(String tag, int id, Notification notification) {
+  protected void notify(String tag, int id, Notification notification) {
     notifications.put(new Key(tag, id), notification);
   }
 
   @Implementation
-  public void cancel(int id) {
+  protected void cancel(int id) {
     cancel(null, id);
   }
 
   @Implementation
-  public void cancel(String tag, int id) {
+  protected void cancel(String tag, int id) {
     Key key = new Key(tag, id);
     if (notifications.containsKey(key)) {
       notifications.remove(key);
@@ -61,12 +61,12 @@ public class ShadowNotificationManager {
   }
 
   @Implementation
-  public void cancelAll() {
+  protected void cancelAll() {
     notifications.clear();
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.N)
-  public boolean areNotificationsEnabled() {
+  protected boolean areNotificationsEnabled() {
     return mAreNotificationsEnabled;
   }
 
@@ -96,23 +96,23 @@ public class ShadowNotificationManager {
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public Object /*NotificationChannel*/ getNotificationChannel(String channelId) {
+  protected Object /*NotificationChannel*/ getNotificationChannel(String channelId) {
     return notificationChannels.get(channelId);
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public void createNotificationChannelGroup(Object /*NotificationChannelGroup*/ group) {
+  protected void createNotificationChannelGroup(Object /*NotificationChannelGroup*/ group) {
     String id = ReflectionHelpers.callInstanceMethod(group, "getId");
     notificationChannelGroups.put(id, group);
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public List<Object /*NotificationChannelGroup*/> getNotificationChannelGroups() {
+  protected List<Object /*NotificationChannelGroup*/> getNotificationChannelGroups() {
     return ImmutableList.copyOf(notificationChannelGroups.values());
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public void createNotificationChannel(Object /*NotificationChannel*/ channel) {
+  protected void createNotificationChannel(Object /*NotificationChannel*/ channel) {
     String id = ReflectionHelpers.callInstanceMethod(channel, "getId");
     // Per documentation, recreating a deleted channel should have the same settings as the old
     // deleted channel. See
@@ -126,7 +126,7 @@ public class ShadowNotificationManager {
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public void createNotificationChannels(List<Object /*NotificationChannel*/> channelList) {
+  protected void createNotificationChannels(List<Object /*NotificationChannel*/> channelList) {
     for (Object channel : channelList) {
       createNotificationChannel(channel);
     }
@@ -138,7 +138,7 @@ public class ShadowNotificationManager {
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public void deleteNotificationChannel(String channelId) {
+  protected void deleteNotificationChannel(String channelId) {
     if (getNotificationChannel(channelId) != null) {
       Object /*NotificationChannel*/ channel = notificationChannels.remove(channelId);
       deletedNotificationChannels.put(channelId, channel);
@@ -151,7 +151,7 @@ public class ShadowNotificationManager {
    * notification channel groups nor to notification channels.
    */
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public void deleteNotificationChannelGroup(String channelGroupId) {
+  protected void deleteNotificationChannelGroup(String channelGroupId) {
     if (getNotificationChannelGroup(channelGroupId) != null) {
       // Deleting a channel group also deleted all associated channels. See
       // https://developer.android.com/reference/android/app/NotificationManager.html#deleteNotificationChannelGroup%28java.lang.String%29
@@ -182,7 +182,7 @@ public class ShadowNotificationManager {
    * @see NotificationManager#getCurrentInterruptionFilter()
    */
   @Implementation(minSdk = M)
-  public final void setInterruptionFilter(int interruptionFilter) {
+  protected final void setInterruptionFilter(int interruptionFilter) {
     currentInteruptionFilter = interruptionFilter;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNumberPicker.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNumberPicker.java
@@ -18,57 +18,57 @@ public class ShadowNumberPicker extends ShadowLinearLayout {
   private NumberPicker.OnValueChangeListener onValueChangeListener;
 
   @Implementation
-  public void setValue(int value) {
+  protected void setValue(int value) {
     this.value = value;
   }
 
   @Implementation
-  public int getValue() {
+  protected int getValue() {
     return value;
   }
 
   @Implementation
-  public void setDisplayedValues(String[] displayedValues) {
+  protected void setDisplayedValues(String[] displayedValues) {
     this.displayedValues = displayedValues;
   }
 
   @Implementation
-  public String[] getDisplayedValues() {
+  protected String[] getDisplayedValues() {
     return displayedValues;
   }
 
   @Implementation
-  public void setMinValue(int minValue) {
+  protected void setMinValue(int minValue) {
     this.minValue = minValue;
   }
 
   @Implementation
-  public void setMaxValue(int maxValue) {
+  protected void setMaxValue(int maxValue) {
     this.maxValue = maxValue;
   }
 
   @Implementation
-  public int getMinValue() {
+  protected int getMinValue() {
     return this.minValue;
   }
 
   @Implementation
-  public int getMaxValue() {
+  protected int getMaxValue() {
     return this.maxValue;
   }
 
   @Implementation
-  public void setWrapSelectorWheel(boolean wrapSelectorWheel) {
+  protected void setWrapSelectorWheel(boolean wrapSelectorWheel) {
     this.wrapSelectorWheel = wrapSelectorWheel;
   }
 
   @Implementation
-  public boolean getWrapSelectorWheel() {
+  protected boolean getWrapSelectorWheel() {
     return wrapSelectorWheel;
   }
 
   @Implementation
-  public void setOnValueChangedListener(NumberPicker.OnValueChangeListener listener) {
+  protected void setOnValueChangedListener(NumberPicker.OnValueChangeListener listener) {
     directlyOn(realNumberPicker, NumberPicker.class).setOnValueChangedListener(listener);
     this.onValueChangeListener = listener;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOpenGLMatrix.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOpenGLMatrix.java
@@ -8,30 +8,26 @@ import org.robolectric.annotation.Implements;
 public class ShadowOpenGLMatrix {
 
   /**
-   * Multiplies two 4x4 matrices together and stores the result in a third 4x4
-   * matrix. In matrix notation: result = lhs x rhs. Due to the way
-   * matrix multiplication works, the result matrix will have the same
-   * effect as first multiplying by the rhs matrix, then multiplying by
-   * the lhs matrix. This is the opposite of what you might expect.
+   * Multiplies two 4x4 matrices together and stores the result in a third 4x4 matrix. In matrix
+   * notation: result = lhs x rhs. Due to the way matrix multiplication works, the result matrix
+   * will have the same effect as first multiplying by the rhs matrix, then multiplying by the lhs
+   * matrix. This is the opposite of what you might expect.
    *
-   * The same float array may be passed for result, lhs, and/or rhs. However,
-   * the result element values are undefined if the result elements overlap
-   * either the lhs or rhs elements.
+   * <p>The same float array may be passed for result, lhs, and/or rhs. However, the result element
+   * values are undefined if the result elements overlap either the lhs or rhs elements.
    *
-   * @param result       The float array that holds the result.
-   * @param resultOffset The offset into the result array where the result is
-   *                     stored.
-   * @param lhs          The float array that holds the left-hand-side matrix.
-   * @param lhsOffset    The offset into the lhs array where the lhs is stored
-   * @param rhs          The float array that holds the right-hand-side matrix.
-   * @param rhsOffset    The offset into the rhs array where the rhs is stored.
-   * @throws IllegalArgumentException if result, lhs, or rhs are null, or if
-   *                                  resultOffset + 16 > result.length or lhsOffset + 16 > lhs.length or
-   *                                  rhsOffset + 16 > rhs.length.
+   * @param result The float array that holds the result.
+   * @param resultOffset The offset into the result array where the result is stored.
+   * @param lhs The float array that holds the left-hand-side matrix.
+   * @param lhsOffset The offset into the lhs array where the lhs is stored
+   * @param rhs The float array that holds the right-hand-side matrix.
+   * @param rhsOffset The offset into the rhs array where the rhs is stored.
+   * @throws IllegalArgumentException if result, lhs, or rhs are null, or if resultOffset + 16 >
+   *     result.length or lhsOffset + 16 > lhs.length or rhsOffset + 16 > rhs.length.
    */
   @Implementation
-  public static void multiplyMM(float[] result, int resultOffset,
-                                float[] lhs, int lhsOffset, float[] rhs, int rhsOffset) {
+  protected static void multiplyMM(
+      float[] result, int resultOffset, float[] lhs, int lhsOffset, float[] rhs, int rhsOffset) {
     if (result == null) {
       throw new IllegalArgumentException("result == null");
     }
@@ -71,30 +67,31 @@ public class ShadowOpenGLMatrix {
   }
 
   /**
-   * Multiplies a 4 element vector by a 4x4 matrix and stores the result in a
-   * 4-element column vector. In matrix notation: result = lhs x rhs
+   * Multiplies a 4 element vector by a 4x4 matrix and stores the result in a 4-element column
+   * vector. In matrix notation: result = lhs x rhs
    *
-   * The same float array may be passed for resultVec, lhsMat, and/or rhsVec.
-   * However, the resultVec element values are undefined if the resultVec
-   * elements overlap either the lhsMat or rhsVec elements.
+   * <p>The same float array may be passed for resultVec, lhsMat, and/or rhsVec. However, the
+   * resultVec element values are undefined if the resultVec elements overlap either the lhsMat or
+   * rhsVec elements.
    *
-   * @param resultVec       The float array that holds the result vector.
-   * @param resultVecOffset The offset into the result array where the result
-   *                        vector is stored.
-   * @param lhsMat          The float array that holds the left-hand-side matrix.
-   * @param lhsMatOffset    The offset into the lhs array where the lhs is stored
-   * @param rhsVec          The float array that holds the right-hand-side vector.
-   * @param rhsVecOffset    The offset into the rhs vector where the rhs vector
-   *                        is stored.
-   * @throws IllegalArgumentException if resultVec, lhsMat,
-   *                                  or rhsVec are null, or if resultVecOffset + 4 > resultVec.length
-   *                                  or lhsMatOffset + 16 > lhsMat.length or
-   *                                  rhsVecOffset + 4 > rhsVec.length.
+   * @param resultVec The float array that holds the result vector.
+   * @param resultVecOffset The offset into the result array where the result vector is stored.
+   * @param lhsMat The float array that holds the left-hand-side matrix.
+   * @param lhsMatOffset The offset into the lhs array where the lhs is stored
+   * @param rhsVec The float array that holds the right-hand-side vector.
+   * @param rhsVecOffset The offset into the rhs vector where the rhs vector is stored.
+   * @throws IllegalArgumentException if resultVec, lhsMat, or rhsVec are null, or if
+   *     resultVecOffset + 4 > resultVec.length or lhsMatOffset + 16 > lhsMat.length or rhsVecOffset
+   *     + 4 > rhsVec.length.
    */
   @Implementation
-  public static void multiplyMV(float[] resultVec,
-                                int resultVecOffset, float[] lhsMat, int lhsMatOffset,
-                                float[] rhsVec, int rhsVecOffset) {
+  protected static void multiplyMV(
+      float[] resultVec,
+      int resultVecOffset,
+      float[] lhsMat,
+      int lhsMatOffset,
+      float[] rhsVec,
+      int rhsVecOffset) {
     if (resultVec == null) {
       throw new IllegalArgumentException("resultVec == null");
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOutline.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOutline.java
@@ -11,6 +11,5 @@ import org.robolectric.annotation.Implements;
 public class ShadowOutline {
 
   @Implementation
-  public void setConvexPath(Path convexPath) {
-  }
+  protected void setConvexPath(Path convexPath) {}
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOverScroller.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOverScroller.java
@@ -18,44 +18,44 @@ public class ShadowOverScroller {
   private boolean started;
 
   @Implementation
-  public int getStartX() {
+  protected int getStartX() {
     return startX;
   }
 
   @Implementation
-  public int getStartY() {
+  protected int getStartY() {
     return startY;
   }
 
   @Implementation
-  public int getCurrX() {
+  protected int getCurrX() {
     long dt = deltaTime();
     return dt >= duration ? finalX : startX + (int) ((deltaX() * dt) / duration);
   }
 
   @Implementation
-  public int getCurrY() {
+  protected int getCurrY() {
     long dt = deltaTime();
     return dt >= duration ? finalY : startY + (int) ((deltaY() * dt) / duration);
   }
 
   @Implementation
-  public int getFinalX() {
+  protected int getFinalX() {
     return finalX;
   }
 
   @Implementation
-  public int getFinalY() {
+  protected int getFinalY() {
     return finalY;
   }
 
   @Implementation
-  public int getDuration() {
+  protected int getDuration() {
     return (int) duration;
   }
 
   @Implementation
-  public void startScroll(int startX, int startY, int dx, int dy, int duration) {
+  protected void startScroll(int startX, int startY, int dx, int dy, int duration) {
     this.startX = startX;
     this.startY = startY;
     finalX = startX + dx;
@@ -73,12 +73,12 @@ public class ShadowOverScroller {
   }
 
   @Implementation
-  public void abortAnimation() {
+  protected void abortAnimation() {
     duration = deltaTime() - 1;
   }
 
   @Implementation
-  public void forceFinished(boolean finished) {
+  protected void forceFinished(boolean finished) {
     if (!finished) {
       throw new RuntimeException("Not implemented.");
     }
@@ -89,7 +89,7 @@ public class ShadowOverScroller {
   }
 
   @Implementation
-  public boolean computeScrollOffset() {
+  protected boolean computeScrollOffset() {
     if (!started) {
       return false;
     }
@@ -98,17 +98,17 @@ public class ShadowOverScroller {
   }
 
   @Implementation
-  public boolean isFinished() {
+  protected boolean isFinished() {
     return deltaTime() > duration;
   }
 
   @Implementation
-  public int timePassed() {
+  protected int timePassed() {
     return (int) deltaTime();
   }
 
   @Implementation
-  public boolean isScrollingInDirection(float xvel, float yvel) {
+  protected boolean isScrollingInDirection(float xvel, float yvel) {
     final int dx = finalX - startX;
     final int dy = finalY - startY;
     return !isFinished()

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageInstaller.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageInstaller.java
@@ -38,12 +38,13 @@ public class ShadowPackageInstaller {
   }
 
   @Implementation
-  public List<PackageInstaller.SessionInfo> getAllSessions() {
+  protected List<PackageInstaller.SessionInfo> getAllSessions() {
     return ImmutableList.copyOf(sessionInfos.values());
   }
 
   @Implementation
-  public void registerSessionCallback(@NonNull PackageInstaller.SessionCallback callback, @NonNull Handler handler) {
+  protected void registerSessionCallback(
+      @NonNull PackageInstaller.SessionCallback callback, @NonNull Handler handler) {
     CallbackInfo callbackInfo = new CallbackInfo();
     callbackInfo.callback = callback;
     callbackInfo.handler = handler;
@@ -52,12 +53,12 @@ public class ShadowPackageInstaller {
 
   @Implementation
   @Nullable
-  public PackageInstaller.SessionInfo getSessionInfo(int sessionId) {
+  protected PackageInstaller.SessionInfo getSessionInfo(int sessionId) {
     return sessionInfos.get(sessionId);
   }
 
   @Implementation
-  public int createSession(@NonNull PackageInstaller.SessionParams params) throws IOException {
+  protected int createSession(@NonNull PackageInstaller.SessionParams params) throws IOException {
     final PackageInstaller.SessionInfo sessionInfo = new PackageInstaller.SessionInfo();
     sessionInfo.sessionId = nextSessionId++;
     sessionInfo.active = true;
@@ -77,7 +78,7 @@ public class ShadowPackageInstaller {
   }
 
   @Implementation
-  public void abandonSession(int sessionId) {
+  protected void abandonSession(int sessionId) {
     sessionInfos.remove(sessionId);
     sessions.remove(sessionId);
 
@@ -93,7 +94,7 @@ public class ShadowPackageInstaller {
 
   @Implementation
   @NonNull
-  public PackageInstaller.Session openSession(int sessionId) throws IOException {
+  protected PackageInstaller.Session openSession(int sessionId) throws IOException {
     if (!sessionInfos.containsKey(sessionId)) {
       throw new SecurityException("Invalid session Id: " + sessionId);
     }
@@ -161,10 +162,12 @@ public class ShadowPackageInstaller {
     private ShadowPackageInstaller shadowPackageInstaller;
 
     @Implementation(maxSdk = KITKAT_WATCH)
-    public void __constructor__() {}
+    protected void __constructor__() {}
 
     @Implementation
-    public @NonNull OutputStream openWrite(@NonNull String name, long offsetBytes, long lengthBytes) throws IOException {
+    @NonNull
+    protected OutputStream openWrite(@NonNull String name, long offsetBytes, long lengthBytes)
+        throws IOException {
       outputStream = new OutputStream() {
         @Override
         public void write(int aByte) throws IOException {
@@ -181,12 +184,10 @@ public class ShadowPackageInstaller {
     }
 
     @Implementation
-    public void fsync(@NonNull OutputStream out) throws IOException {
-
-    }
+    protected void fsync(@NonNull OutputStream out) throws IOException {}
 
     @Implementation
-    public void commit(@NonNull IntentSender statusReceiver) {
+    protected void commit(@NonNull IntentSender statusReceiver) {
       this.statusReceiver = statusReceiver;
       if (outputStreamOpen) {
         throw new SecurityException("OutputStream still open");
@@ -196,12 +197,10 @@ public class ShadowPackageInstaller {
     }
 
     @Implementation
-    public void close() {
-
-    }
+    protected void close() {}
 
     @Implementation
-    public void abandon() {
+    protected void abandon() {
       shadowPackageInstaller.abandonSession(sessionId);
     }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPaint.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPaint.java
@@ -40,7 +40,7 @@ public class ShadowPaint {
   private Paint.Align textAlign = Paint.Align.LEFT;
 
   @Implementation
-  public void __constructor__(Paint otherPaint) {
+  protected void __constructor__(Paint otherPaint) {
     ShadowPaint otherShadowPaint = Shadow.extract(otherPaint);
     this.color = otherShadowPaint.color;
     this.style = otherShadowPaint.style;
@@ -63,94 +63,93 @@ public class ShadowPaint {
   }
 
   @Implementation(minSdk = N)
-  public static long nInit() {
+  protected static long nInit() {
     return 1;
   }
 
   @Implementation
-  public int getFlags() {
+  protected int getFlags() {
     return flags;
   }
 
   @Implementation
-  public void setFlags(int flags) {
+  protected void setFlags(int flags) {
     this.flags = flags;
   }
 
   @Implementation
-  public Shader setShader(Shader shader) {
+  protected Shader setShader(Shader shader) {
     this.shader = shader;
     return shader;
   }
 
   @Implementation
-  public int getAlpha() {
+  protected int getAlpha() {
     return alpha;
   }
 
   @Implementation
-  public void setAlpha(int alpha) {
+  protected void setAlpha(int alpha) {
     this.alpha = alpha;
   }
 
-
   @Implementation
-  public Shader getShader() {
+  protected Shader getShader() {
     return shader;
   }
 
   @Implementation
-  public void setColor(int color) {
+  protected void setColor(int color) {
     this.color = color;
   }
 
   @Implementation
-  public int getColor() {
+  protected int getColor() {
     return color;
   }
 
   @Implementation
-  public void setStyle(Paint.Style style) {
+  protected void setStyle(Paint.Style style) {
     this.style = style;
   }
 
   @Implementation
-  public Paint.Style getStyle() {
+  protected Paint.Style getStyle() {
     return style;
   }
 
   @Implementation
-  public void setStrokeCap(Paint.Cap cap) {
+  protected void setStrokeCap(Paint.Cap cap) {
     this.cap = cap;
   }
 
   @Implementation
-  public Paint.Cap getStrokeCap() {
+  protected Paint.Cap getStrokeCap() {
     return cap;
   }
 
   @Implementation
-  public void setStrokeJoin(Paint.Join join) {
+  protected void setStrokeJoin(Paint.Join join) {
     this.join = join;
   }
 
   @Implementation
-  public Paint.Join getStrokeJoin() {
+  protected Paint.Join getStrokeJoin() {
     return join;
   }
 
   @Implementation
-  public void setStrokeWidth(float width) {
+  protected void setStrokeWidth(float width) {
     this.width = width;
   }
 
   @Implementation
-  public float getStrokeWidth() {
+  protected float getStrokeWidth() {
     return width;
   }
 
   @Implementation
-  public void setShadowLayer(float radius, float dx, float dy, int color) {
+  protected void setShadowLayer(float radius, float dx, float dy, int color) {
     shadowRadius = radius;
     shadowDx = dx;
     shadowDy = dy;
@@ -158,33 +157,33 @@ public class ShadowPaint {
   }
 
   @Implementation
-  public Typeface getTypeface() {
+  protected Typeface getTypeface() {
     return typeface;
   }
 
   @Implementation
-  public Typeface setTypeface(Typeface typeface) {
+  protected Typeface setTypeface(Typeface typeface) {
     this.typeface = typeface;
     return typeface;
   }
 
   @Implementation
-  public float getTextSize() {
+  protected float getTextSize() {
     return textSize;
   }
 
   @Implementation
-  public void setTextSize(float textSize) {
+  protected void setTextSize(float textSize) {
     this.textSize = textSize;
   }
 
   @Implementation
-  public void setTextAlign(Paint.Align align) {
+  protected void setTextAlign(Paint.Align align) {
     textAlign = align;
   }
 
   @Implementation
-  public Paint.Align getTextAlign() {
+  protected Paint.Align getTextAlign() {
     return textAlign;
   }
 
@@ -229,64 +228,64 @@ public class ShadowPaint {
   }
 
   @Implementation
-  public ColorFilter getColorFilter() {
+  protected ColorFilter getColorFilter() {
     return filter;
   }
 
   @Implementation
-  public ColorFilter setColorFilter(ColorFilter filter) {
+  protected ColorFilter setColorFilter(ColorFilter filter) {
     this.filter = filter;
     return filter;
   }
 
   @Implementation
-  public void setAntiAlias(boolean antiAlias) {
+  protected void setAntiAlias(boolean antiAlias) {
     this.flags = (flags & ~Paint.ANTI_ALIAS_FLAG) | (antiAlias ? Paint.ANTI_ALIAS_FLAG : 0);
   }
 
   @Implementation
-  public void setDither(boolean dither) {
+  protected void setDither(boolean dither) {
     this.dither = dither;
   }
 
   @Implementation
-  public final boolean isDither() {
+  protected final boolean isDither() {
     return dither;
   }
 
   @Implementation
-  public final boolean isAntiAlias() {
+  protected final boolean isAntiAlias() {
     return (flags & Paint.ANTI_ALIAS_FLAG) == Paint.ANTI_ALIAS_FLAG;
   }
 
   @Implementation
-  public PathEffect getPathEffect() {
+  protected PathEffect getPathEffect() {
     return pathEffect;
   }
 
   @Implementation
-  public PathEffect setPathEffect(PathEffect effect) {
+  protected PathEffect setPathEffect(PathEffect effect) {
     this.pathEffect = effect;
     return effect;
   }
 
   @Implementation
-  public float measureText(String text) {
+  protected float measureText(String text) {
     return text.length();
   }
 
   @Implementation
-  public float measureText(CharSequence text, int start, int end) {
+  protected float measureText(CharSequence text, int start, int end) {
     return end - start;
   }
 
   @Implementation
-  public float measureText(String text, int start, int end) {
+  protected float measureText(String text, int start, int end) {
     return end - start;
   }
 
   @Implementation
-  public float measureText(char[] text, int index, int count) {
+  protected float measureText(char[] text, int index, int count) {
     return count;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcel.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcel.java
@@ -46,8 +46,9 @@ public class ShadowParcel {
   private static final Map<Long, ByteBuffer> NATIVE_PTR_TO_PARCEL = new LinkedHashMap<>();
   private static long nextNativePtr = 1; // this needs to start above 0, which is a magic number to Parcel
 
-  @Implementation(maxSdk = JELLY_BEAN_MR1) @SuppressWarnings("TypeParameterUnusedInFormals")
-  public <T extends Parcelable> T readParcelable(ClassLoader loader) {
+  @Implementation(maxSdk = JELLY_BEAN_MR1)
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  protected <T extends Parcelable> T readParcelable(ClassLoader loader) {
     // prior to JB MR2, readParcelableCreator() is inlined here.
     Parcelable.Creator<?> creator = readParcelableCreator(loader);
     if (creator == null) {
@@ -128,7 +129,7 @@ public class ShadowParcel {
   }
 
   @Implementation
-  public void writeByteArray(byte[] b, int offset, int len) {
+  protected void writeByteArray(byte[] b, int offset, int len) {
     if (b == null) {
       realObject.writeInt(-1);
       return;
@@ -144,7 +145,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static int nativeDataSize(long nativePtr) {
+  protected static int nativeDataSize(long nativePtr) {
     return NATIVE_PTR_TO_PARCEL.get(nativePtr).dataSize();
   }
 
@@ -155,7 +156,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static int nativeDataAvail(long nativePtr) {
+  protected static int nativeDataAvail(long nativePtr) {
     return NATIVE_PTR_TO_PARCEL.get(nativePtr).dataAvailable();
   }
 
@@ -166,7 +167,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static int nativeDataPosition(long nativePtr) {
+  protected static int nativeDataPosition(long nativePtr) {
     return NATIVE_PTR_TO_PARCEL.get(nativePtr).dataPosition();
   }
 
@@ -177,7 +178,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static int nativeDataCapacity(long nativePtr) {
+  protected static int nativeDataCapacity(long nativePtr) {
     return NATIVE_PTR_TO_PARCEL.get(nativePtr).dataCapacity();
   }
 
@@ -188,7 +189,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeSetDataSize(long nativePtr, int size) {
+  protected static void nativeSetDataSize(long nativePtr, int size) {
     NATIVE_PTR_TO_PARCEL.get(nativePtr).setDataSize(size);
   }
 
@@ -199,7 +200,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeSetDataPosition(long nativePtr, int pos) {
+  protected static void nativeSetDataPosition(long nativePtr, int pos) {
     NATIVE_PTR_TO_PARCEL.get(nativePtr).setDataPosition(pos);
   }
 
@@ -210,7 +211,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeSetDataCapacity(long nativePtr, int size) {
+  protected static void nativeSetDataCapacity(long nativePtr, int size) {
     NATIVE_PTR_TO_PARCEL.get(nativePtr).setDataCapacity(size);
   }
 
@@ -221,7 +222,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeWriteByteArray(long nativePtr, byte[] b, int offset, int len) {
+  protected static void nativeWriteByteArray(long nativePtr, byte[] b, int offset, int len) {
     NATIVE_PTR_TO_PARCEL.get(nativePtr).writeByteArray(b, offset, len);
   }
 
@@ -261,7 +262,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeWriteInt(long nativePtr, int val) {
+  protected static void nativeWriteInt(long nativePtr, int val) {
     NATIVE_PTR_TO_PARCEL.get(nativePtr).writeInt(val);
   }
 
@@ -272,7 +273,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeWriteLong(long nativePtr, long val) {
+  protected static void nativeWriteLong(long nativePtr, long val) {
     NATIVE_PTR_TO_PARCEL.get(nativePtr).writeLong(val);
   }
 
@@ -283,7 +284,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeWriteFloat(long nativePtr, float val) {
+  protected static void nativeWriteFloat(long nativePtr, float val) {
     NATIVE_PTR_TO_PARCEL.get(nativePtr).writeFloat(val);
   }
 
@@ -294,7 +295,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeWriteDouble(long nativePtr, double val) {
+  protected static void nativeWriteDouble(long nativePtr, double val) {
     NATIVE_PTR_TO_PARCEL.get(nativePtr).writeDouble(val);
   }
 
@@ -305,7 +306,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeWriteString(long nativePtr, String val) {
+  protected static void nativeWriteString(long nativePtr, String val) {
     NATIVE_PTR_TO_PARCEL.get(nativePtr).writeString(val);
   }
 
@@ -327,7 +328,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static byte[] nativeCreateByteArray(long nativePtr) {
+  protected static byte[] nativeCreateByteArray(long nativePtr) {
     return NATIVE_PTR_TO_PARCEL.get(nativePtr).readByteArray();
   }
 
@@ -349,7 +350,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static int nativeReadInt(long nativePtr) {
+  protected static int nativeReadInt(long nativePtr) {
     return NATIVE_PTR_TO_PARCEL.get(nativePtr).readInt();
   }
 
@@ -360,7 +361,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static long nativeReadLong(long nativePtr) {
+  protected static long nativeReadLong(long nativePtr) {
     return NATIVE_PTR_TO_PARCEL.get(nativePtr).readLong();
   }
 
@@ -371,7 +372,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static float nativeReadFloat(long nativePtr) {
+  protected static float nativeReadFloat(long nativePtr) {
     return NATIVE_PTR_TO_PARCEL.get(nativePtr).readFloat();
   }
 
@@ -382,7 +383,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static double nativeReadDouble(long nativePtr) {
+  protected static double nativeReadDouble(long nativePtr) {
     return NATIVE_PTR_TO_PARCEL.get(nativePtr).readDouble();
   }
 
@@ -393,7 +394,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static String nativeReadString(long nativePtr) {
+  protected static String nativeReadString(long nativePtr) {
     return NATIVE_PTR_TO_PARCEL.get(nativePtr).readString();
   }
 
@@ -422,7 +423,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeFreeBuffer(long nativePtr) {
+  protected static void nativeFreeBuffer(long nativePtr) {
     NATIVE_PTR_TO_PARCEL.get(nativePtr).clear();
   }
 
@@ -433,7 +434,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeDestroy(long nativePtr) {
+  protected static void nativeDestroy(long nativePtr) {
     NATIVE_PTR_TO_PARCEL.remove(nativePtr);
   }
 
@@ -444,7 +445,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static byte[] nativeMarshall(long nativePtr) {
+  protected static byte[] nativeMarshall(long nativePtr) {
     return NATIVE_PTR_TO_PARCEL.get(nativePtr).toByteArray();
   }
 
@@ -455,7 +456,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeUnmarshall(long nativePtr, byte[] data, int offset, int length) {
+  protected static void nativeUnmarshall(long nativePtr, byte[] data, int offset, int length) {
     NATIVE_PTR_TO_PARCEL.put(nativePtr, ByteBuffer.fromByteArray(data, offset, length));
   }
 
@@ -466,7 +467,8 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeAppendFrom(long thisNativePtr, long otherNativePtr, int offset, int length) {
+  protected static void nativeAppendFrom(
+      long thisNativePtr, long otherNativePtr, int offset, int length) {
     ByteBuffer thisByteBuffer = NATIVE_PTR_TO_PARCEL.get(thisNativePtr);
     ByteBuffer otherByteBuffer = NATIVE_PTR_TO_PARCEL.get(otherNativePtr);
     thisByteBuffer.appendFrom(otherByteBuffer, offset, length);
@@ -479,7 +481,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeWriteInterfaceToken(long nativePtr, String interfaceName) {
+  protected static void nativeWriteInterfaceToken(long nativePtr, String interfaceName) {
     // Write StrictMode.ThreadPolicy bits (assume 0 for test).
     nativeWriteInt(nativePtr, 0);
     nativeWriteString(nativePtr, interfaceName);
@@ -492,7 +494,7 @@ public class ShadowParcel {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public static void nativeEnforceInterface(long nativePtr, String interfaceName) {
+  protected static void nativeEnforceInterface(long nativePtr, String interfaceName) {
     // Consume StrictMode.ThreadPolicy bits (don't bother setting in test).
     nativeReadInt(nativePtr);
     String actualInterfaceName = nativeReadString(nativePtr);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcelFileDescriptor.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcelFileDescriptor.java
@@ -4,7 +4,6 @@ import static org.robolectric.shadow.api.Shadow.invokeConstructor;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 import android.annotation.SuppressLint;
-import android.os.Parcel;
 import android.os.ParcelFileDescriptor;
 import java.io.File;
 import java.io.FileDescriptor;
@@ -31,7 +30,7 @@ public class ShadowParcelFileDescriptor {
   private @RealObject ParcelFileDescriptor realObject;
 
   @Implementation
-  public void __constructor__(ParcelFileDescriptor wrapped) {
+  protected void __constructor__(ParcelFileDescriptor wrapped) {
     invokeConstructor(ParcelFileDescriptor.class, realObject,
         from(ParcelFileDescriptor.class, wrapped));
     if (wrapped != null) {
@@ -41,7 +40,7 @@ public class ShadowParcelFileDescriptor {
   }
 
   @Implementation
-  public static ParcelFileDescriptor open(File file, int mode) throws FileNotFoundException {
+  protected static ParcelFileDescriptor open(File file, int mode) throws FileNotFoundException {
     ParcelFileDescriptor pfd;
     try {
       Constructor<ParcelFileDescriptor> constructor =
@@ -82,7 +81,7 @@ public class ShadowParcelFileDescriptor {
   }
 
   @Implementation
-  public FileDescriptor getFileDescriptor() {
+  protected FileDescriptor getFileDescriptor() {
       try {
         return file.getFD();
       } catch (IOException e) {
@@ -91,7 +90,7 @@ public class ShadowParcelFileDescriptor {
   }
 
   @Implementation
-  public long getStatSize() {
+  protected long getStatSize() {
     try {
       return file.length();
     } catch (IOException e) {
@@ -105,12 +104,12 @@ public class ShadowParcelFileDescriptor {
    * @return a fixed int (`0`)
    */
   @Implementation
-  public int getFd() {
+  protected int getFd() {
     return 0;
   }
 
   @Implementation
-  public void close() throws IOException {
+  protected void close() throws IOException {
     file.close();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPath.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPath.java
@@ -51,7 +51,7 @@ public class ShadowPath {
   protected boolean isSimplePath;
 
   @Implementation
-  public void __constructor__(Path path) {
+  protected void __constructor__(Path path) {
     ShadowPath shadowPath = extract(path);
     points = new ArrayList<>(shadowPath.getPoints());
     wasMovedTo = shadowPath.wasMovedTo;
@@ -63,7 +63,7 @@ public class ShadowPath {
   }
 
   @Implementation
-  public void moveTo(float x, float y) {
+  protected void moveTo(float x, float y) {
     mPath.moveTo(mLastX = x, mLastY = y);
 
     // Legacy recording behavior
@@ -73,7 +73,7 @@ public class ShadowPath {
   }
 
   @Implementation
-  public void lineTo(float x, float y) {
+  protected void lineTo(float x, float y) {
     if (!hasPoints()) {
       mPath.moveTo(mLastX = 0, mLastY = 0);
     }
@@ -85,7 +85,7 @@ public class ShadowPath {
   }
 
   @Implementation
-  public void quadTo(float x1, float y1, float x2, float y2) {
+  protected void quadTo(float x1, float y1, float x2, float y2) {
     isSimplePath = false;
     if (!hasPoints()) {
       moveTo(0, 0);
@@ -118,7 +118,7 @@ public class ShadowPath {
   }
 
   @Implementation
-  public void reset() {
+  protected void reset() {
     mPath.reset();
     mLastX = 0;
     mLastY = 0;
@@ -445,6 +445,11 @@ public class ShadowPath {
   }
 
   @Implementation
+  protected void addRect(RectF rect, Direction dir) {
+    addRect(rect.left, rect.top, rect.right, rect.bottom, dir);
+  }
+
+  @Implementation
   protected void addRect(float left, float top, float right, float bottom, Path.Direction dir) {
     moveTo(left, top);
 
@@ -564,7 +569,7 @@ public class ShadowPath {
   }
 
   @Implementation
-  public void offset(float dx, float dy, Path dst) {
+  protected void offset(float dx, float dy, Path dst) {
     if (dst != null) {
       dst.set(realObject);
     } else {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
@@ -60,37 +60,37 @@ public class ShadowPendingIntent {
   private boolean canceled;
 
   @Implementation
-  public static PendingIntent getActivity(
+  protected static PendingIntent getActivity(
       Context context, int requestCode, @NonNull Intent intent, int flags) {
     return create(context, new Intent[] {intent}, Type.ACTIVITY, requestCode, flags);
   }
 
   @Implementation
-  public static PendingIntent getActivity(
+  protected static PendingIntent getActivity(
       Context context, int requestCode, @NonNull Intent intent, int flags, Bundle options) {
     return create(context, new Intent[] {intent}, Type.ACTIVITY, requestCode, flags);
   }
 
   @Implementation
-  public static PendingIntent getActivities(
+  protected static PendingIntent getActivities(
       Context context, int requestCode, @NonNull Intent[] intents, int flags) {
     return create(context, intents, Type.ACTIVITY, requestCode, flags);
   }
 
   @Implementation
-  public static PendingIntent getActivities(
+  protected static PendingIntent getActivities(
       Context context, int requestCode, @NonNull Intent[] intents, int flags, Bundle options) {
     return create(context, intents, Type.ACTIVITY, requestCode, flags);
   }
 
   @Implementation
-  public static PendingIntent getBroadcast(
+  protected static PendingIntent getBroadcast(
       Context context, int requestCode, @NonNull Intent intent, int flags) {
     return create(context, new Intent[] {intent}, Type.BROADCAST, requestCode, flags);
   }
 
   @Implementation
-  public static PendingIntent getService(
+  protected static PendingIntent getService(
       Context context, int requestCode, @NonNull Intent intent, int flags) {
     return create(context, new Intent[] {intent}, Type.SERVICE, requestCode, flags);
   }
@@ -103,7 +103,7 @@ public class ShadowPendingIntent {
 
   @Implementation
   @SuppressWarnings("ReferenceEquality")
-  public void cancel() {
+  protected void cancel() {
     for (Iterator<PendingIntent> i = createdIntents.iterator(); i.hasNext(); ) {
       PendingIntent pendingIntent = i.next();
       if (pendingIntent == realPendingIntent) {
@@ -115,7 +115,7 @@ public class ShadowPendingIntent {
   }
 
   @Implementation
-  public void send() throws CanceledException {
+  protected void send() throws CanceledException {
     send(savedContext, 0, null);
   }
 
@@ -125,9 +125,8 @@ public class ShadowPendingIntent {
     send(savedContext, code, null, onFinished, handler);
   }
 
-
   @Implementation
-  public void send(Context context, int code, Intent intent) throws CanceledException {
+  protected void send(Context context, int code, Intent intent) throws CanceledException {
     send(context, code, intent, null, null);
   }
 
@@ -196,7 +195,7 @@ public class ShadowPendingIntent {
   }
 
   @Implementation
-  public IntentSender getIntentSender() {
+  protected IntentSender getIntentSender() {
     return new RoboIntentSender(realPendingIntent);
   }
 
@@ -284,12 +283,12 @@ public class ShadowPendingIntent {
   }
 
   @Implementation
-  public String getTargetPackage() {
+  protected String getTargetPackage() {
     return getCreatorPackage();
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR1)
-  public String getCreatorPackage() {
+  protected String getCreatorPackage() {
     return (creatorPackage == null)
         ? RuntimeEnvironment.application.getPackageName()
         : creatorPackage;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPicture.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPicture.java
@@ -16,32 +16,32 @@ public class ShadowPicture {
   private int height;
 
   @Implementation
-  public void __constructor__() {}
+  protected void __constructor__() {}
 
   @Implementation(minSdk = LOLLIPOP)
-  public void __constructor__(long nativePicture) {}
+  protected void __constructor__(long nativePicture) {}
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public void __constructor__(int nativePicture, boolean fromStream) {}
+  protected void __constructor__(int nativePicture, boolean fromStream) {}
 
   @Implementation
-  public void __constructor__(Picture src) {
+  protected void __constructor__(Picture src) {
     width = src.getWidth();
     height = src.getHeight();
   }
 
   @Implementation
-  public int getWidth() {
+  protected int getWidth() {
     return width;
   }
 
   @Implementation
-  public int getHeight() {
+  protected int getHeight() {
     return height;
   }
 
   @Implementation
-  public Canvas beginRecording(int width, int height) {
+  protected Canvas beginRecording(int width, int height) {
     this.width = width;
     this.height = height;
     return new Canvas(Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888));

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPopupMenu.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPopupMenu.java
@@ -19,20 +19,20 @@ public class ShadowPopupMenu {
   private PopupMenu.OnMenuItemClickListener onMenuItemClickListener;
 
   @Implementation
-  public void show() {
+  protected void show() {
     this.isShowing = true;
     setLatestPopupMenu(this);
     directlyOn(realPopupMenu, PopupMenu.class).show();
   }
 
   @Implementation
-  public void dismiss() {
+  protected void dismiss() {
     this.isShowing = false;
     directlyOn(realPopupMenu, PopupMenu.class).dismiss();
   }
 
   @Implementation
-  public void setOnMenuItemClickListener(PopupMenu.OnMenuItemClickListener listener) {
+  protected void setOnMenuItemClickListener(PopupMenu.OnMenuItemClickListener listener) {
     this.onMenuItemClickListener = listener;
     directlyOn(realPopupMenu, PopupMenu.class).setOnMenuItemClickListener(listener);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPopupWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPopupWindow.java
@@ -16,7 +16,7 @@ public class ShadowPopupWindow {
   private PopupWindow realPopupWindow;
 
   @Implementation
-  public void invokePopup(WindowManager.LayoutParams p) {
+  protected void invokePopup(WindowManager.LayoutParams p) {
     ShadowApplication.getInstance().setLatestPopupWindow(realPopupWindow);
     directlyOn(realPopupWindow,
         PopupWindow.class,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPorterDuffColorFilter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPorterDuffColorFilter.java
@@ -14,18 +14,18 @@ public class ShadowPorterDuffColorFilter {
   private PorterDuff.Mode mode;
 
   @Implementation
-  public void __constructor__(int color, PorterDuff.Mode mode) {
+  protected void __constructor__(int color, PorterDuff.Mode mode) {
     this.color = color;
     this.mode = mode;
   }
 
   @Implementation(minSdk = LOLLIPOP, maxSdk = P)
-  public void setColor(int color) {
+  protected void setColor(int color) {
     this.color = color;
   }
 
   @Implementation(minSdk = LOLLIPOP, maxSdk = P)
-  public void setMode(PorterDuff.Mode mode) {
+  protected void setMode(PorterDuff.Mode mode) {
     this.mode = mode;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
@@ -27,14 +27,14 @@ public class ShadowPowerManager {
   private Map<String, Boolean> ignoringBatteryOptimizations = new HashMap<>();
 
   @Implementation
-  public PowerManager.WakeLock newWakeLock(int flags, String tag) {
+  protected PowerManager.WakeLock newWakeLock(int flags, String tag) {
     PowerManager.WakeLock wl = Shadow.newInstanceOf(PowerManager.WakeLock.class);
     getInstance().addWakeLock(wl);
     return wl;
   }
 
   @Implementation
-  public boolean isScreenOn() {
+  protected boolean isScreenOn() {
     return isScreenOn;
   }
 
@@ -43,7 +43,7 @@ public class ShadowPowerManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean isInteractive() {
+  protected boolean isInteractive() {
     return isInteractive;
   }
 
@@ -52,7 +52,7 @@ public class ShadowPowerManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean isPowerSaveMode() {
+  protected boolean isPowerSaveMode() {
     return isPowerSaveMode;
   }
 
@@ -63,7 +63,7 @@ public class ShadowPowerManager {
   private Map<Integer, Boolean> supportedWakeLockLevels = new HashMap<>();
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean isWakeLockLevelSupported(int level) {
+  protected boolean isWakeLockLevelSupported(int level) {
     return supportedWakeLockLevels.containsKey(level) ? supportedWakeLockLevels.get(level) : false;
   }
 
@@ -104,7 +104,7 @@ public class ShadowPowerManager {
   }
 
   @Implementation(minSdk = M)
-  public boolean isIgnoringBatteryOptimizations(String packageName) {
+  protected boolean isIgnoringBatteryOptimizations(String packageName) {
     Boolean result = ignoringBatteryOptimizations.get(packageName);
     return result == null ? false : result;
   }
@@ -136,12 +136,12 @@ public class ShadowPowerManager {
     private WorkSource workSource = null;
 
     @Implementation
-    public void acquire() {
+    protected void acquire() {
       acquire(0);
     }
 
     @Implementation
-    public synchronized void acquire(long timeout) {
+    protected synchronized void acquire(long timeout) {
       if (refCounted) {
         refCount++;
       } else {
@@ -150,7 +150,7 @@ public class ShadowPowerManager {
     }
 
     @Implementation
-    public synchronized void release() {
+    protected synchronized void release() {
       if (refCounted) {
         if (--refCount < 0) throw new RuntimeException("WakeLock under-locked");
       } else {
@@ -159,7 +159,7 @@ public class ShadowPowerManager {
     }
 
     @Implementation
-    public synchronized boolean isHeld() {
+    protected synchronized boolean isHeld() {
       return refCounted ? refCount > 0 : locked;
     }
 
@@ -173,12 +173,12 @@ public class ShadowPowerManager {
     }
 
     @Implementation
-    public void setReferenceCounted(boolean value) {
+    protected void setReferenceCounted(boolean value) {
       refCounted = value;
     }
 
     @Implementation
-    public synchronized void setWorkSource(WorkSource ws) {
+    protected synchronized void setWorkSource(WorkSource ws) {
       workSource = ws;
     }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowProgressDialog.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowProgressDialog.java
@@ -30,7 +30,7 @@ public class ShadowProgressDialog extends ShadowAlertDialog {
   }
 
   @Implementation
-  public void setProgressStyle(int style) {
+  protected void setProgressStyle(int style) {
     mProgressStyle = style;
     directlyOn(realProgressDialog, ProgressDialog.class).setProgressStyle(style);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRemoteCallbackList.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRemoteCallbackList.java
@@ -33,12 +33,12 @@ public class ShadowRemoteCallbackList<E extends IInterface> {
   }
 
   @Implementation
-  public boolean register(E callback) {
+  protected boolean register(E callback) {
     return register(callback, null);
   }
 
   @Implementation
-  public boolean register(E callback, Object cookie) {
+  protected boolean register(E callback, Object cookie) {
     synchronized (callbacks) {
       if (killed) {
         return false;
@@ -56,7 +56,7 @@ public class ShadowRemoteCallbackList<E extends IInterface> {
   }
 
   @Implementation
-  public boolean unregister(E callback) {
+  protected boolean unregister(E callback) {
     synchronized (callbacks) {
       Callback cb = callbacks.remove(callback.asBinder());
       if (cb != null) {
@@ -68,7 +68,7 @@ public class ShadowRemoteCallbackList<E extends IInterface> {
   }
 
   @Implementation
-  public void kill() {
+  protected void kill() {
     synchronized (callbacks) {
       for (Callback cb : callbacks.values()) {
         cb.callback.asBinder().unlinkToDeath(cb, 0);
@@ -79,15 +79,15 @@ public class ShadowRemoteCallbackList<E extends IInterface> {
   }
 
   @Implementation
-  public void onCallbackDied(E callback) {}
+  protected void onCallbackDied(E callback) {}
 
   @Implementation
-  public void onCallbackDied(E callback, Object cookie) {
+  protected void onCallbackDied(E callback, Object cookie) {
     onCallbackDied(callback);
   }
 
   @Implementation
-  public int beginBroadcast() {
+  protected int beginBroadcast() {
     synchronized (callbacks) {
       if (broadcastCount > 0) {
         throw new IllegalStateException("beginBroadcast() called while already in a broadcast");
@@ -109,17 +109,17 @@ public class ShadowRemoteCallbackList<E extends IInterface> {
   }
 
   @Implementation
-  public E getBroadcastItem(int index) {
+  protected E getBroadcastItem(int index) {
     return ((Callback) activeBroadcast[index]).callback;
   }
 
   @Implementation
-  public Object getBroadcastCookie(int index) {
+  protected Object getBroadcastCookie(int index) {
     return ((Callback) activeBroadcast[index]).cookie;
   }
 
   @Implementation
-  public void finishBroadcast() {
+  protected void finishBroadcast() {
     if (broadcastCount < 0) {
       throw new IllegalStateException("finishBroadcast() called outside of a broadcast");
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowResolveInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowResolveInfo.java
@@ -46,7 +46,7 @@ public class ShadowResolveInfo {
   }
 
   @Implementation
-  public String loadLabel(PackageManager mgr) {
+  protected String loadLabel(PackageManager mgr) {
     return label;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowResultReceiver.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowResultReceiver.java
@@ -13,7 +13,7 @@ public class ShadowResultReceiver {
   @RealObject private ResultReceiver realResultReceiver;
 
   @Implementation
-  public void send(int resultCode, android.os.Bundle resultData) {
+  protected void send(int resultCode, android.os.Bundle resultData) {
     ReflectionHelpers.callInstanceMethod(realResultReceiver, "onReceiveResult",
         ClassParameter.from(Integer.TYPE, resultCode),
         ClassParameter.from(Bundle.class, resultData));

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSQLiteOpenHelper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSQLiteOpenHelper.java
@@ -3,7 +3,6 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.O_MR1;
 
 import android.database.sqlite.SQLiteOpenHelper;
-
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
@@ -14,7 +13,7 @@ import org.robolectric.annotation.Implements;
 @Implements(SQLiteOpenHelper.class)
 public class ShadowSQLiteOpenHelper {
   @Implementation(minSdk = O_MR1)
-  public void setIdleConnectionTimeout(long idleConnectionTimeoutMs) {
+  protected void setIdleConnectionTimeout(long idleConnectionTimeoutMs) {
     // Calling the real one currently results in a Robolectric deadlock. Just ignore it.
     // See b/78464547 .
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowScaleGestureDetector.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowScaleGestureDetector.java
@@ -17,12 +17,13 @@ public class ShadowScaleGestureDetector {
   private float focusY;
 
   @Implementation
-  public void __constructor__(Context context, ScaleGestureDetector.OnScaleGestureListener listener) {
+  protected void __constructor__(
+      Context context, ScaleGestureDetector.OnScaleGestureListener listener) {
     this.listener = listener;
   }
 
   @Implementation
-  public boolean onTouchEvent(MotionEvent event) {
+  protected boolean onTouchEvent(MotionEvent event) {
     onTouchEventMotionEvent = event;
     return true;
   }
@@ -47,7 +48,7 @@ public class ShadowScaleGestureDetector {
   }
 
   @Implementation
-  public float getScaleFactor() {
+  protected float getScaleFactor() {
     return scaleFactor;
   }
 
@@ -57,12 +58,12 @@ public class ShadowScaleGestureDetector {
   }
 
   @Implementation
-  public float getFocusX(){
+  protected float getFocusX() {
     return focusX;
   }
 
   @Implementation
-  public float getFocusY(){
+  protected float getFocusY() {
     return focusY;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowScroller.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowScroller.java
@@ -15,44 +15,44 @@ public class ShadowScroller {
   private boolean started;
 
   @Implementation
-  public int getStartX() {
+  protected int getStartX() {
     return startX;
   }
 
   @Implementation
-  public int getStartY() {
+  protected int getStartY() {
     return startY;
   }
 
   @Implementation
-  public int getCurrX() {
+  protected int getCurrX() {
     long dt = deltaTime();
     return dt >= duration ? finalX : startX + (int) ((deltaX() * dt) / duration);
   }
 
   @Implementation
-  public int getCurrY() {
+  protected int getCurrY() {
     long dt = deltaTime();
     return dt >= duration ? finalY : startY + (int) ((deltaY() * dt) / duration);
   }
 
   @Implementation
-  public int getFinalX() {
+  protected int getFinalX() {
     return finalX;
   }
 
   @Implementation
-  public int getFinalY() {
+  protected int getFinalY() {
     return finalY;
   }
 
   @Implementation
-  public int getDuration() {
+  protected int getDuration() {
     return (int) duration;
   }
 
   @Implementation
-  public void startScroll(int startX, int startY, int dx, int dy, int duration) {
+  protected void startScroll(int startX, int startY, int dx, int dy, int duration) {
     this.startX = startX;
     this.startY = startY;
     finalX = startX + dx;
@@ -70,7 +70,7 @@ public class ShadowScroller {
   }
 
   @Implementation
-  public boolean computeScrollOffset() {
+  protected boolean computeScrollOffset() {
     if (!started) {
       return false;
     }
@@ -79,12 +79,12 @@ public class ShadowScroller {
   }
 
   @Implementation
-  public boolean isFinished() {
+  protected boolean isFinished() {
     return deltaTime() > duration;
   }
 
   @Implementation
-  public int timePassed() {
+  protected int timePassed() {
     return (int) deltaTime();
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSeekBar.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSeekBar.java
@@ -15,7 +15,7 @@ public class ShadowSeekBar extends ShadowAbsSeekBar {
   private SeekBar.OnSeekBarChangeListener listener;
 
   @Implementation
-  public void setOnSeekBarChangeListener(SeekBar.OnSeekBarChangeListener listener) {
+  protected void setOnSeekBarChangeListener(SeekBar.OnSeekBarChangeListener listener) {
     this.listener = listener;
     Shadow.directlyOn(realSeekBar, SeekBar.class).setOnSeekBarChangeListener(listener);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
@@ -49,7 +49,7 @@ public class ShadowSensorManager {
   }
 
   @Implementation
-  public Sensor getDefaultSensor(int type) {
+  protected Sensor getDefaultSensor(int type) {
     return sensorMap.get(type);
   }
 
@@ -61,7 +61,7 @@ public class ShadowSensorManager {
   }
 
   @Implementation
-  public boolean registerListener(SensorEventListener listener, Sensor sensor, int rate) {
+  protected boolean registerListener(SensorEventListener listener, Sensor sensor, int rate) {
     if (forceListenersToFail) {
       return false;
     }
@@ -72,12 +72,12 @@ public class ShadowSensorManager {
   }
 
   @Implementation
-  public void unregisterListener(SensorEventListener listener, Sensor sensor) {
+  protected void unregisterListener(SensorEventListener listener, Sensor sensor) {
     listeners.remove(listener);
   }
 
   @Implementation
-  public void unregisterListener(SensorEventListener listener) {
+  protected void unregisterListener(SensorEventListener listener) {
     listeners.remove(listener);
   }
 
@@ -123,10 +123,8 @@ public class ShadowSensorManager {
     return ReflectionHelpers.callConstructor(SensorEvent.class, valueArraySizeParam);
   }
 
-
-
   @Implementation(minSdk = O)
-  public Object createDirectChannel(MemoryFile mem) {
+  protected Object createDirectChannel(MemoryFile mem) {
     return ReflectionHelpers.callConstructor(SensorDirectChannel.class,
         ClassParameter.from(SensorManager.class, realObject),
         ClassParameter.from(int.class, 0),

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowService.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowService.java
@@ -21,17 +21,17 @@ public class ShadowService extends ShadowContextWrapper {
   private boolean notificationShouldRemoved;
 
   @Implementation
-  public void onDestroy() {
+  protected void onDestroy() {
     removeForegroundNotification();
   }
 
   @Implementation
-  public void stopSelf() {
+  protected void stopSelf() {
     selfStopped = true;
   }
 
   @Implementation
-  public void stopSelf(int id) {
+  protected void stopSelf(int id) {
     selfStopped = true;
   }
 
@@ -42,7 +42,7 @@ public class ShadowService extends ShadowContextWrapper {
   }
 
   @Implementation
-  public final void startForeground(int id, Notification notification) {
+  protected final void startForeground(int id, Notification notification) {
     foregroundStopped = false;
     lastForegroundNotificationId = id;
     lastForegroundNotification = notification;
@@ -52,7 +52,7 @@ public class ShadowService extends ShadowContextWrapper {
   }
 
   @Implementation
-  public void stopForeground(boolean removeNotification) {
+  protected void stopForeground(boolean removeNotification) {
     foregroundStopped = true;
     notificationShouldRemoved = removeNotification;
     if (removeNotification) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSettings.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSettings.java
@@ -192,7 +192,7 @@ public class ShadowSettings {
     }
 
     @Implementation(minSdk = LOLLIPOP)
-    public static boolean putIntForUser(
+    protected static boolean putIntForUser(
         ContentResolver cr, String name, int value, int userHandle) {
       putInt(cr, name, value);
       return true;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSmsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSmsManager.java
@@ -20,12 +20,12 @@ public class ShadowSmsManager {
   private static final SparseArray<SmsManager> subSmsManagers = new SparseArray<>(1);
 
   @Implementation
-  public static SmsManager getDefault() {
+  protected static SmsManager getDefault() {
     return realManager;
   }
 
   @Implementation(minSdk = LOLLIPOP_MR1)
-  public static SmsManager getSmsManagerForSubscriptionId(int subId) {
+  protected static SmsManager getSmsManagerForSubscriptionId(int subId) {
     SmsManager smsManager = subSmsManagers.get(subId);
     if (smsManager == null) {
       smsManager =
@@ -40,7 +40,13 @@ public class ShadowSmsManager {
   private DataMessageParams lastDataParams;
 
   @Implementation
-  public void sendDataMessage(String destinationAddress, String scAddress, short destinationPort, byte[] data, PendingIntent sentIntent, PendingIntent deliveryIntent) {
+  protected void sendDataMessage(
+      String destinationAddress,
+      String scAddress,
+      short destinationPort,
+      byte[] data,
+      PendingIntent sentIntent,
+      PendingIntent deliveryIntent) {
     if (TextUtils.isEmpty(destinationAddress)) {
       throw new IllegalArgumentException("Invalid destinationAddress");
     }
@@ -49,7 +55,12 @@ public class ShadowSmsManager {
   }
 
   @Implementation
-  public void sendTextMessage(String destinationAddress, String scAddress, String text, PendingIntent sentIntent, PendingIntent deliveryIntent) {
+  protected void sendTextMessage(
+      String destinationAddress,
+      String scAddress,
+      String text,
+      PendingIntent sentIntent,
+      PendingIntent deliveryIntent) {
     if (TextUtils.isEmpty(destinationAddress)) {
       throw new IllegalArgumentException("Invalid destinationAddress");
     }
@@ -62,7 +73,12 @@ public class ShadowSmsManager {
   }
 
   @Implementation
-  public void sendMultipartTextMessage(String destinationAddress, String scAddress, ArrayList<String> parts, ArrayList<PendingIntent> sentIntents, ArrayList<PendingIntent> deliveryIntents) {
+  protected void sendMultipartTextMessage(
+      String destinationAddress,
+      String scAddress,
+      ArrayList<String> parts,
+      ArrayList<PendingIntent> sentIntents,
+      ArrayList<PendingIntent> deliveryIntents) {
     if (TextUtils.isEmpty(destinationAddress)) {
       throw new IllegalArgumentException("Invalid destinationAddress");
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSslErrorHandler.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSslErrorHandler.java
@@ -11,7 +11,7 @@ public class ShadowSslErrorHandler extends ShadowHandler {
   private boolean proceedCalled = false;
 
   @Implementation
-  public void cancel() {
+  protected void cancel() {
     cancelCalled = true;
   }
 
@@ -20,7 +20,7 @@ public class ShadowSslErrorHandler extends ShadowHandler {
   }
 
   @Implementation
-  public void proceed() {
+  protected void proceed() {
     proceedCalled = true;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStatFs.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStatFs.java
@@ -24,51 +24,52 @@ public class ShadowStatFs {
   private Stats stat;
 
   @Implementation
-  public void __constructor__(String path) {
+  protected void __constructor__(String path) {
     restat(path);
   }
 
   @Implementation
-  public int getBlockSize() {
+  protected int getBlockSize() {
     return BLOCK_SIZE;
   }
 
   @Implementation
-  public int getBlockCount() {
+  protected int getBlockCount() {
     return stat.blockCount;
   }
 
   @Implementation
-  public int getFreeBlocks() {
+  protected int getFreeBlocks() {
     return stat.freeBlocks;
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public long getFreeBlocksLong() {
+  protected long getFreeBlocksLong() {
     return stat.freeBlocks;
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public long getFreeBytes() {
+  protected long getFreeBytes() {
     return getBlockSizeLong() * getFreeBlocksLong();
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public long getAvailableBytes() {
+  protected long getAvailableBytes() {
     return getBlockSizeLong() * getAvailableBlocksLong();
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public long getTotalBytes() {
+  protected long getTotalBytes() {
     return getBlockSizeLong() * getBlockCountLong();
   }
+
   @Implementation
-  public int getAvailableBlocks() {
+  protected int getAvailableBlocks() {
     return stat.availableBlocks;
   }
 
   @Implementation
-  public void restat(String path) {
+  protected void restat(String path) {
     Map.Entry<String, Stats> mapEntry = stats.floorEntry(path);
     for (;;) {
       // We will hit all matching paths, longest one first. We may hit non-matching paths before we
@@ -86,21 +87,19 @@ public class ShadowStatFs {
     }
   }
 
-  /**
-   * Robolectric always uses a block size of `4096`.
-   */
+  /** Robolectric always uses a block size of `4096`. */
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public long getBlockSizeLong() {
+  protected long getBlockSizeLong() {
     return BLOCK_SIZE;
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public long getBlockCountLong() {
+  protected long getBlockCountLong() {
     return stat.blockCount;
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public long getAvailableBlocksLong() {
+  protected long getAvailableBlocksLong() {
     return stat.availableBlocks;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStateListDrawable.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStateListDrawable.java
@@ -24,7 +24,7 @@ public class ShadowStateListDrawable extends ShadowDrawable {
   }
 
   @Implementation
-  public void addState(int[] stateSet, Drawable drawable) {
+  protected void addState(int[] stateSet, Drawable drawable) {
     stateToDrawable.put(createStateList(stateSet), drawable);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSubscriptionManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSubscriptionManager.java
@@ -118,6 +118,23 @@ public class ShadowSubscriptionManager {
   }
 
   /**
+   * Returns subscription that were set via {@link #setActiveSubscriptionInfoList} if it can find
+   * one with the specified slot index or null if none found.
+   */
+  @Implementation(minSdk = N)
+  protected SubscriptionInfo getActiveSubscriptionInfoForSimSlotIndex(int slotIndex) {
+    if (subscriptionList == null) {
+      return null;
+    }
+    for (SubscriptionInfo info : subscriptionList) {
+      if (info.getSimSlotIndex() == slotIndex) {
+        return info;
+      }
+    }
+    return null;
+  }
+
+  /**
    * Sets the active list of {@link SubscriptionInfo}. This call internally triggers {@link
    * OnSubscriptionsChangedListener#onSubscriptionsChanged()} to all the listeners.
    * @param list - The subscription info list, can be null.
@@ -206,7 +223,7 @@ public class ShadowSubscriptionManager {
    * Ids will be considered as non-roaming if they are not in the cache.
    */
   @Implementation(minSdk = LOLLIPOP_MR1)
-  public boolean isNetworkRoaming(int simSubscriptionId) {
+  protected boolean isNetworkRoaming(int simSubscriptionId) {
     return roamingSimSubscriptionIds.contains(simSubscriptionId);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSurface.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSurface.java
@@ -14,7 +14,7 @@ public class ShadowSurface {
   @RealObject private Surface realSurface;
 
   @Implementation
-  public void __constructor__(SurfaceTexture surfaceTexture) {
+  protected void __constructor__(SurfaceTexture surfaceTexture) {
     this.surfaceTexture = surfaceTexture;
     Shadow.invokeConstructor(
         Surface.class, realSurface, ClassParameter.from(SurfaceTexture.class, surfaceTexture));

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSurfaceView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSurfaceView.java
@@ -16,11 +16,10 @@ public class ShadowSurfaceView extends ShadowView {
   private final FakeSurfaceHolder fakeSurfaceHolder = new FakeSurfaceHolder();
 
   @Implementation
-  public void onAttachedToWindow() {
-  }
+  protected void onAttachedToWindow() {}
 
   @Implementation
-  public SurfaceHolder getHolder() {
+  protected SurfaceHolder getHolder() {
     return fakeSurfaceHolder;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
@@ -30,7 +30,7 @@ public class ShadowSystemClock {
   }
 
   @Implementation
-  public static void sleep(long millis) {
+  protected static void sleep(long millis) {
     if (ShadowApplication.getInstance() == null) {
       return;
     }
@@ -40,7 +40,7 @@ public class ShadowSystemClock {
   }
 
   @Implementation
-  public static boolean setCurrentTimeMillis(long millis) {
+  protected static boolean setCurrentTimeMillis(long millis) {
     if (ShadowApplication.getInstance() == null) {
       return false;
     }
@@ -54,12 +54,12 @@ public class ShadowSystemClock {
   }
 
   @Implementation
-  public static long uptimeMillis() {
+  protected static long uptimeMillis() {
     return now() - bootedAt;
   }
 
   @Implementation
-  public static long elapsedRealtime() {
+  protected static long elapsedRealtime() {
     return uptimeMillis();
   }
 
@@ -69,7 +69,7 @@ public class ShadowSystemClock {
   }
 
   @Implementation
-  public static long currentThreadTimeMillis() {
+  protected static long currentThreadTimeMillis() {
     return uptimeMillis();
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTabActivity.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTabActivity.java
@@ -14,7 +14,7 @@ public class ShadowTabActivity extends ShadowActivityGroup {
   private TabHost tabhost;
 
   @Implementation
-  public TabHost getTabHost() {
+  protected TabHost getTabHost() {
     if (tabhost==null) {
       tabhost = new TabHost(realTabActivity);
     }
@@ -22,7 +22,7 @@ public class ShadowTabActivity extends ShadowActivityGroup {
   }
 
   @Implementation
-  public TabWidget getTabWidget() {
+  protected TabWidget getTabWidget() {
     return getTabHost().getTabWidget();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTabHost.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTabHost.java
@@ -27,7 +27,7 @@ public class ShadowTabHost extends ShadowViewGroup {
   private TabHost realObject;
 
   @Implementation
-  public android.widget.TabHost.TabSpec newTabSpec(java.lang.String tag) {
+  protected android.widget.TabHost.TabSpec newTabSpec(java.lang.String tag) {
     TabSpec realTabSpec = Shadow.newInstanceOf(TabHost.TabSpec.class);
     ShadowTabSpec shadowTabSpec = Shadow.extract(realTabSpec);
     shadowTabSpec.setTag(tag);
@@ -35,7 +35,7 @@ public class ShadowTabHost extends ShadowViewGroup {
   }
 
   @Implementation
-  public void addTab(android.widget.TabHost.TabSpec tabSpec) {
+  protected void addTab(android.widget.TabHost.TabSpec tabSpec) {
     tabSpecs.add(tabSpec);
     ShadowTabSpec shadowTabSpec = Shadow.extract(tabSpec);
     View indicatorAsView = shadowTabSpec.getIndicatorAsView();
@@ -45,7 +45,7 @@ public class ShadowTabHost extends ShadowViewGroup {
   }
 
   @Implementation
-  public void setCurrentTab(int index) {
+  protected void setCurrentTab(int index) {
     currentTab = index;
     if (listener != null) {
       listener.onTabChanged(getCurrentTabTag());
@@ -53,7 +53,7 @@ public class ShadowTabHost extends ShadowViewGroup {
   }
 
   @Implementation
-  public void setCurrentTabByTag(String tag) {
+  protected void setCurrentTabByTag(String tag) {
     for (int x = 0; x < tabSpecs.size(); x++) {
       TabSpec tabSpec = tabSpecs.get(x);
       if (tabSpec.getTag().equals(tag)) {
@@ -66,7 +66,7 @@ public class ShadowTabHost extends ShadowViewGroup {
   }
 
   @Implementation
-  public int getCurrentTab() {
+  protected int getCurrentTab() {
     if (currentTab == -1 && tabSpecs.size() > 0) currentTab = 0;
     return currentTab;
   }
@@ -76,7 +76,7 @@ public class ShadowTabHost extends ShadowViewGroup {
   }
 
   @Implementation
-  public String getCurrentTabTag() {
+  protected String getCurrentTabTag() {
     int i = getCurrentTab();
     if (i >= 0 && i < tabSpecs.size()) {
       return tabSpecs.get(i).getTag();
@@ -85,12 +85,12 @@ public class ShadowTabHost extends ShadowViewGroup {
   }
 
   @Implementation
-  public void setOnTabChangedListener(android.widget.TabHost.OnTabChangeListener listener) {
+  protected void setOnTabChangedListener(android.widget.TabHost.OnTabChangeListener listener) {
     this.listener = listener;
   }
 
   @Implementation
-  public View getCurrentView() {
+  protected View getCurrentView() {
     ShadowTabSpec ts = Shadow.extract(getCurrentTabSpec());
     View v = ts.getContentView();
     if (v == null) {
@@ -105,7 +105,7 @@ public class ShadowTabHost extends ShadowViewGroup {
   }
 
   @Implementation
-  public TabWidget getTabWidget() {
+  protected TabWidget getTabWidget() {
     Context context = realView.getContext();
     if (context instanceof Activity) {
       return (TabWidget) ((Activity)context).findViewById(R.id.tabs);
@@ -147,7 +147,7 @@ public class ShadowTabHost extends ShadowViewGroup {
     }
 
     @Implementation
-    public String getTag() {
+    protected String getTag() {
       return tag;
     }
 
@@ -176,19 +176,19 @@ public class ShadowTabHost extends ShadowViewGroup {
     }
 
     @Implementation
-    public TabSpec setIndicator(View view) {
+    protected TabSpec setIndicator(View view) {
       this.indicatorView = view;
       return realObject;
     }
 
     @Implementation
-    public TabSpec setIndicator(CharSequence label) {
+    protected TabSpec setIndicator(CharSequence label) {
       this.label = label;
       return realObject;
     }
 
     @Implementation
-    public TabSpec setIndicator(CharSequence label, Drawable icon) {
+    protected TabSpec setIndicator(CharSequence label, Drawable icon) {
       this.label = label;
       this.icon = icon;
       return realObject;
@@ -202,19 +202,19 @@ public class ShadowTabHost extends ShadowViewGroup {
     }
 
     @Implementation
-    public TabSpec setContent(Intent intent) {
+    protected TabSpec setContent(Intent intent) {
       this.intent = intent;
       return realObject;
     }
 
     @Implementation
-    public TabSpec setContent(TabHost.TabContentFactory factory) {
+    protected TabSpec setContent(TabHost.TabContentFactory factory) {
       contentView = factory.createTabContent(this.tag);
       return realObject;
     }
 
     @Implementation
-    public TabSpec setContent(int viewId) {
+    protected TabSpec setContent(int viewId) {
       this.viewId = viewId;
       return realObject;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelecomManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelecomManager.java
@@ -36,7 +36,7 @@ public class ShadowTelecomManager {
   private String defaultDialerPackageName;
 
   @Implementation
-  public PhoneAccountHandle getDefaultOutgoingPhoneAccount(String uriScheme) {
+  protected PhoneAccountHandle getDefaultOutgoingPhoneAccount(String uriScheme) {
     return null;
   }
 
@@ -52,7 +52,7 @@ public class ShadowTelecomManager {
   }
 
   @Implementation
-  public PhoneAccountHandle getSimCallManager() {
+  protected PhoneAccountHandle getSimCallManager() {
     return simCallManager;
   }
 
@@ -83,7 +83,7 @@ public class ShadowTelecomManager {
   }
 
   @Implementation(minSdk = M)
-  public List<PhoneAccountHandle> getCallCapablePhoneAccounts() {
+  protected List<PhoneAccountHandle> getCallCapablePhoneAccounts() {
     return this.getCallCapablePhoneAccounts(false);
   }
 
@@ -117,7 +117,7 @@ public class ShadowTelecomManager {
   }
 
   @Implementation
-  public PhoneAccount getPhoneAccount(PhoneAccountHandle account) {
+  protected PhoneAccount getPhoneAccount(PhoneAccountHandle account) {
     return accounts.get(account);
   }
 
@@ -140,12 +140,12 @@ public class ShadowTelecomManager {
   }
 
   @Implementation
-  public void registerPhoneAccount(PhoneAccount account) {
+  protected void registerPhoneAccount(PhoneAccount account) {
     accounts.put(account.getAccountHandle(), account);
   }
 
   @Implementation
-  public void unregisterPhoneAccount(PhoneAccountHandle accountHandle) {
+  protected void unregisterPhoneAccount(PhoneAccountHandle accountHandle) {
     accounts.remove(accountHandle);
   }
 
@@ -183,7 +183,7 @@ public class ShadowTelecomManager {
   }
 
   @Implementation(minSdk = M)
-  public String getDefaultDialerPackage() {
+  protected String getDefaultDialerPackage() {
     return defaultDialerPackageName;
   }
 
@@ -201,22 +201,22 @@ public class ShadowTelecomManager {
   }
 
   @Implementation(minSdk = LOLLIPOP_MR1)
-  public boolean isVoiceMailNumber(PhoneAccountHandle accountHandle, String number) {
+  protected boolean isVoiceMailNumber(PhoneAccountHandle accountHandle, String number) {
     return false;
   }
 
   @Implementation(minSdk = M)
-  public String getVoiceMailNumber(PhoneAccountHandle accountHandle) {
+  protected String getVoiceMailNumber(PhoneAccountHandle accountHandle) {
     return null;
   }
 
   @Implementation(minSdk = LOLLIPOP_MR1)
-  public String getLine1Number(PhoneAccountHandle accountHandle) {
+  protected String getLine1Number(PhoneAccountHandle accountHandle) {
     return null;
   }
 
   @Implementation
-  public boolean isInCall() {
+  protected boolean isInCall() {
     return false;
   }
 
@@ -239,15 +239,13 @@ public class ShadowTelecomManager {
   }
 
   @Implementation
-  public void acceptRingingCall() {
-  }
+  protected void acceptRingingCall() {}
 
   @Implementation
-  public void silenceRinger() {
-  }
+  protected void silenceRinger() {}
 
   @Implementation
-  public boolean isTtySupported() {
+  protected boolean isTtySupported() {
     return false;
   }
 
@@ -258,7 +256,7 @@ public class ShadowTelecomManager {
   }
 
   @Implementation
-  public void addNewIncomingCall(PhoneAccountHandle phoneAccount, Bundle extras) {
+  protected void addNewIncomingCall(PhoneAccountHandle phoneAccount, Bundle extras) {
     incomingCalls.add(new CallRecord(phoneAccount, extras));
   }
 
@@ -277,31 +275,28 @@ public class ShadowTelecomManager {
   }
 
   @Implementation
-  public boolean handleMmi(String dialString) {
+  protected boolean handleMmi(String dialString) {
     return false;
   }
 
   @Implementation(minSdk = M)
-  public boolean handleMmi(String dialString, PhoneAccountHandle accountHandle) {
+  protected boolean handleMmi(String dialString, PhoneAccountHandle accountHandle) {
     return false;
   }
 
   @Implementation(minSdk = LOLLIPOP_MR1)
-  public Uri getAdnUriForPhoneAccount(PhoneAccountHandle accountHandle) {
+  protected Uri getAdnUriForPhoneAccount(PhoneAccountHandle accountHandle) {
     return Uri.parse("content://icc/adn");
   }
 
   @Implementation
-  public void cancelMissedCallsNotification() {
-  }
+  protected void cancelMissedCallsNotification() {}
 
   @Implementation
-  public void showInCallScreen(boolean showDialpad) {
-  }
+  protected void showInCallScreen(boolean showDialpad) {}
 
   @Implementation(minSdk = M)
-  public void placeCall(Uri address, Bundle extras) {
-  }
+  protected void placeCall(Uri address, Bundle extras) {}
 
   @Implementation(minSdk = M)
   @HiddenApi

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
@@ -426,7 +426,7 @@ public class ShadowTelephonyManager {
    * #setCarrierConfig(PersistableBundle)}.
    */
   @Implementation(minSdk = O)
-  public PersistableBundle getCarrierConfig() {
+  protected PersistableBundle getCarrierConfig() {
     return carrierConfig != null ? carrierConfig : new PersistableBundle();
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextToSpeech.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextToSpeech.java
@@ -19,13 +19,14 @@ public class ShadowTextToSpeech {
   private int queueMode = -1;
 
   @Implementation
-  public void __constructor__(Context context, TextToSpeech.OnInitListener listener) {
+  protected void __constructor__(Context context, TextToSpeech.OnInitListener listener) {
     this.context = context;
     this.listener = listener;
   }
 
   @Implementation
-  public int speak(final String text, final int queueMode, final HashMap<String, String> params) {
+  protected int speak(
+      final String text, final int queueMode, final HashMap<String, String> params) {
     stopped = false;
     lastSpokenText = text;
     this.queueMode = queueMode;
@@ -39,7 +40,7 @@ public class ShadowTextToSpeech {
   }
 
   @Implementation
-  public void shutdown() {
+  protected void shutdown() {
     shutdown = true;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextUtils.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextUtils.java
@@ -14,7 +14,7 @@ import org.robolectric.annotation.Implements;
 public class ShadowTextUtils {
 
   @Implementation
-  public static CharSequence ellipsize(
+  protected static CharSequence ellipsize(
       CharSequence text, TextPaint p, float avail, TruncateAt where) {
     // This shadow follows the convention of ShadowPaint#measureText where each
     // characters width is 1.0.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextView.java
@@ -62,20 +62,20 @@ public class ShadowTextView extends ShadowView {
   private int compoundDrawablesWithIntrinsicBoundsBottom;
 
   @Implementation
-  public void setTextAppearance(Context context, int resid) {
+  protected void setTextAppearance(Context context, int resid) {
     textAppearanceId = resid;
     directlyOn(realTextView, TextView.class).setTextAppearance(context, resid);
   }
 
   @Implementation
-  public boolean onKeyDown(int keyCode, KeyEvent event) {
+  protected boolean onKeyDown(int keyCode, KeyEvent event) {
     previousKeyCodes.add(keyCode);
     previousKeyEvents.add(event);
     return directlyOn(realTextView, TextView.class).onKeyDown(keyCode, event);
   }
 
   @Implementation
-  public boolean onKeyUp(int keyCode, KeyEvent event) {
+  protected boolean onKeyUp(int keyCode, KeyEvent event) {
     previousKeyCodes.add(keyCode);
     previousKeyEvents.add(event);
     return directlyOn(realTextView, TextView.class).onKeyUp(keyCode, event);
@@ -105,13 +105,13 @@ public class ShadowTextView extends ShadowView {
   }
 
   @Implementation
-  public void addTextChangedListener(TextWatcher watcher) {
+  protected void addTextChangedListener(TextWatcher watcher) {
     this.watchers.add(watcher);
     directlyOn(realTextView, TextView.class).addTextChangedListener(watcher);
   }
 
   @Implementation
-  public void removeTextChangedListener(TextWatcher watcher) {
+  protected void removeTextChangedListener(TextWatcher watcher) {
     this.watchers.remove(watcher);
     directlyOn(realTextView, TextView.class).removeTextChangedListener(watcher);
   }
@@ -138,17 +138,17 @@ public class ShadowTextView extends ShadowView {
   }
 
   @Implementation
-  public int getPaintFlags() {
+  protected int getPaintFlags() {
     return paintFlags;
   }
 
   @Implementation
-  public void setPaintFlags(int paintFlags) {
+  protected void setPaintFlags(int paintFlags) {
     this.paintFlags = paintFlags;
   }
 
   @Implementation
-  public void setOnEditorActionListener(TextView.OnEditorActionListener l) {
+  protected void setOnEditorActionListener(TextView.OnEditorActionListener l) {
     this.onEditorActionListener = l;
     directlyOn(realTextView, TextView.class).setOnEditorActionListener(l);
   }
@@ -158,7 +158,7 @@ public class ShadowTextView extends ShadowView {
   }
 
   @Implementation
-  public void setCompoundDrawablesWithIntrinsicBounds(int left, int top, int right, int bottom) {
+  protected void setCompoundDrawablesWithIntrinsicBounds(int left, int top, int right, int bottom) {
     this.compoundDrawablesWithIntrinsicBoundsLeft = left;
     this.compoundDrawablesWithIntrinsicBoundsTop = top;
     this.compoundDrawablesWithIntrinsicBoundsRight = right;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTime.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTime.java
@@ -23,7 +23,7 @@ public class ShadowTime {
   private Time time;
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public void setToNow() {
+  protected void setToNow() {
     time.set(ShadowSystemClock.currentTimeMillis());
   }
 
@@ -33,12 +33,12 @@ public class ShadowTime {
   private static final long DAY_IN_MILLIS = HOUR_IN_MILLIS * 24;
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public void __constructor__() {
+  protected void __constructor__() {
     __constructor__(getCurrentTimezone());
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public void __constructor__(String timezone) {
+  protected void __constructor__(String timezone) {
     if (timezone == null) {
       throw new NullPointerException("timezone is null!");
     }
@@ -49,12 +49,12 @@ public class ShadowTime {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public void __constructor__(Time other) {
+  protected void __constructor__(Time other) {
     set(other);
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public void set(Time other) {
+  protected void set(Time other) {
     time.timezone = other.timezone;
     time.second = other.second;
     time.minute = other.minute;
@@ -69,20 +69,20 @@ public class ShadowTime {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static boolean isEpoch(Time time) {
+  protected static boolean isEpoch(Time time) {
     long millis = time.toMillis(true);
     return getJulianDay(millis, 0) == Time.EPOCH_JULIAN_DAY;
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static int getJulianDay(long millis, long gmtoff) {
+  protected static int getJulianDay(long millis, long gmtoff) {
     long offsetMillis = gmtoff * 1000;
     long julianDay = (millis + offsetMillis) / DAY_IN_MILLIS;
     return (int) julianDay + Time.EPOCH_JULIAN_DAY;
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public long setJulianDay(int julianDay) {
+  protected long setJulianDay(int julianDay) {
     // Don't bother with the GMT offset since we don't know the correct
     // value for the given Julian day.  Just get close and then adjust
     // the day.
@@ -105,7 +105,7 @@ public class ShadowTime {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public void set(long millis) {
+  protected void set(long millis) {
     Calendar c = getCalendar();
     c.setTimeInMillis(millis);
     set(
@@ -119,13 +119,13 @@ public class ShadowTime {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public long toMillis(boolean ignoreDst) {
+  protected long toMillis(boolean ignoreDst) {
     Calendar c = getCalendar();
     return c.getTimeInMillis();
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public void set(int second, int minute, int hour, int monthDay, int month, int year) {
+  protected void set(int second, int minute, int hour, int monthDay, int month, int year) {
     time.second = second;
     time.minute = minute;
     time.hour = hour;
@@ -139,12 +139,12 @@ public class ShadowTime {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public void set(int monthDay, int month, int year) {
+  protected void set(int monthDay, int month, int year) {
     set(0, 0, 0, monthDay, month, year);
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public void clear(String timezone) {
+  protected void clear(String timezone) {
     if (timezone == null) {
       throw new NullPointerException("timezone is null!");
     }
@@ -163,12 +163,12 @@ public class ShadowTime {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static String getCurrentTimezone() {
+  protected static String getCurrentTimezone() {
     return TimeZone.getDefault().getID();
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public void switchTimezone(String timezone) {
+  protected void switchTimezone(String timezone) {
     long date = toMillis(true);
     long gmtoff = TimeZone.getTimeZone(timezone).getOffset(date);
     set(date + gmtoff);
@@ -177,7 +177,7 @@ public class ShadowTime {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public static int compare(Time a, Time b) {
+  protected static int compare(Time a, Time b) {
     long ams = a.toMillis(false);
     long bms = b.toMillis(false);
     if (ams == bms) {
@@ -190,17 +190,17 @@ public class ShadowTime {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public boolean before(Time other) {
+  protected boolean before(Time other) {
     return Time.compare(time, other) < 0;
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public boolean after(Time other) {
+  protected boolean after(Time other) {
     return Time.compare(time, other) > 0;
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public boolean parse(String timeString) {
+  protected boolean parse(String timeString) {
     TimeZone tz;
     if (timeString.endsWith("Z")) {
       timeString = timeString.substring(0, timeString.length() - 1);
@@ -226,7 +226,7 @@ public class ShadowTime {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public String format2445() {
+  protected String format2445() {
     String value = format("%Y%m%dT%H%M%S");
     if ( "UTC".equals(time.timezone)){
       value += "Z";
@@ -235,7 +235,7 @@ public class ShadowTime {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public String format3339(boolean allDay) {
+  protected String format3339(boolean allDay) {
     if (allDay) {
       return format("%Y-%m-%d");
     } else if ("UTC".equals(time.timezone)) {
@@ -251,7 +251,7 @@ public class ShadowTime {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public boolean parse3339(String rfc3339String) {
+  protected boolean parse3339(String rfc3339String) {
     SimpleDateFormat formatter =  new SimpleDateFormat();
     // Special case Date without time first
     if (rfc3339String.matches("\\d{4}-\\d{2}-\\d{2}")) {
@@ -312,7 +312,7 @@ public class ShadowTime {
   }
 
   @Implementation(maxSdk = KITKAT_WATCH)
-  public String format(String format) {
+  protected String format(String format) {
     return Strftime.format(format, new Date(toMillis(false)), Locale.getDefault(), TimeZone.getTimeZone(time.timezone));
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimePickerDialog.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimePickerDialog.java
@@ -17,7 +17,7 @@ public class ShadowTimePickerDialog extends ShadowAlertDialog {
   private int minute;
 
   @Implementation
-  public void __constructor__(
+  protected void __constructor__(
       Context context,
       int theme,
       TimePickerDialog.OnTimeSetListener callBack,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsageStatsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsageStatsManager.java
@@ -316,7 +316,8 @@ public class ShadowUsageStatsManager {
    * UsageStatsManager.STANDBY_BUCKET_ACTIVE}.
    */
   @Implementation(minSdk = Build.VERSION_CODES.P)
-  public @StandbyBuckets int getAppStandbyBucket() {
+  @StandbyBuckets
+  protected int getAppStandbyBucket() {
     return currentAppStandbyBucket;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowValueAnimator.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowValueAnimator.java
@@ -43,7 +43,7 @@ public class ShadowValueAnimator {
   }
 
   @Implementation
-  public void setRepeatCount(int count) {
+  protected void setRepeatCount(int count) {
     actualRepeatCount = count;
     if (count == ValueAnimator.INFINITE) {
       count = 1;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVectorDrawable.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVectorDrawable.java
@@ -79,20 +79,18 @@ public class ShadowVectorDrawable extends ShadowDrawable {
     return get(pathPtr, Path.class);
   }
 
-
   @Implementation
-  public static long nCreateFullPath() {
+  protected static long nCreateFullPath() {
     return put(new Path());
   }
 
   @Implementation
-  public static long nCreateFullPath(long nativeFullPathPtr) {
+  protected static long nCreateFullPath(long nativeFullPathPtr) {
     return put(getPath(nativeFullPathPtr).clone());
   }
 
   @Implementation
-  public static boolean nGetFullPathProperties(long pathPtr, byte[] properties,
-                                               int length) {
+  protected static boolean nGetFullPathProperties(long pathPtr, byte[] properties, int length) {
     if (length != TOTAL_PROPERTY_COUNT * 4) return false;
 
     Path path = getPath(pathPtr);
@@ -115,10 +113,20 @@ public class ShadowVectorDrawable extends ShadowDrawable {
   }
 
   @Implementation
-  public static void nUpdateFullPathProperties(long pathPtr, float strokeWidth,
-                                               int strokeColor, float strokeAlpha, int fillColor, float fillAlpha, float trimPathStart,
-                                               float trimPathEnd, float trimPathOffset, float strokeMiterLimit, int strokeLineCap,
-                                               int strokeLineJoin, int fillType) {
+  protected static void nUpdateFullPathProperties(
+      long pathPtr,
+      float strokeWidth,
+      int strokeColor,
+      float strokeAlpha,
+      int fillColor,
+      float fillAlpha,
+      float trimPathStart,
+      float trimPathEnd,
+      float trimPathOffset,
+      float strokeMiterLimit,
+      int strokeLineCap,
+      int strokeLineJoin,
+      int fillType) {
     Path path = getPath(pathPtr);
     path.strokeWidth = strokeWidth;
     path.strokeColor = strokeColor;
@@ -172,21 +180,20 @@ public class ShadowVectorDrawable extends ShadowDrawable {
   }
 
   @Implementation
-  public static long nCreateGroup() {
+  protected static long nCreateGroup() {
     return put(new Group());
   }
 
   @Implementation
-  public static long nCreateGroup(long groupPtr) {
+  protected static long nCreateGroup(long groupPtr) {
     return put(getGroup(groupPtr).clone());
   }
 
-//  public static void nSetName(long nodePtr, String name) {
-//  }
+  //  public static void nSetName(long nodePtr, String name) {
+  //  }
 
   @Implementation
-  public static boolean nGetGroupProperties(long groupPtr, float[] properties,
-                                            int length) {
+  protected static boolean nGetGroupProperties(long groupPtr, float[] properties, int length) {
     if (length != 7) return false;
     Group group = getGroup(groupPtr);
     properties[0] = group.rotation;
@@ -200,8 +207,15 @@ public class ShadowVectorDrawable extends ShadowDrawable {
   }
 
   @Implementation
-  public static void nUpdateGroupProperties(long groupPtr, float rotate, float pivotX,
-                                            float pivotY, float scaleX, float scaleY, float translateX, float translateY) {
+  protected static void nUpdateGroupProperties(
+      long groupPtr,
+      float rotate,
+      float pivotX,
+      float pivotY,
+      float scaleX,
+      float scaleY,
+      float translateX,
+      float translateY) {
     Group group = getGroup(groupPtr);
     group.rotation = rotate;
     group.pivotX = pivotX;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVelocityTracker.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVelocityTracker.java
@@ -33,7 +33,7 @@ public class ShadowVelocityTracker {
   }
 
   @Implementation
-  public void clear() {
+  protected void clear() {
     maybeInitialize();
     curIndex = 0;
     computedVelocityX.clear();
@@ -44,7 +44,7 @@ public class ShadowVelocityTracker {
   }
 
   @Implementation
-  public void addMovement(MotionEvent event) {
+  protected void addMovement(MotionEvent event) {
     maybeInitialize();
     if (event == null) {
       throw new IllegalArgumentException("event must not be null");
@@ -62,12 +62,12 @@ public class ShadowVelocityTracker {
   }
 
   @Implementation
-  public void computeCurrentVelocity(int units) {
+  protected void computeCurrentVelocity(int units) {
     computeCurrentVelocity(units, Float.MAX_VALUE);
   }
 
   @Implementation
-  public void computeCurrentVelocity(int units, float maxVelocity) {
+  protected void computeCurrentVelocity(int units, float maxVelocity) {
     maybeInitialize();
 
     // Estimation based on AOSP's LegacyVelocityTrackerStrategy
@@ -129,17 +129,17 @@ public class ShadowVelocityTracker {
   }
 
   @Implementation
-  public float getXVelocity() {
+  protected float getXVelocity() {
     return getXVelocity(ACTIVE_POINTER_ID);
   }
 
   @Implementation
-  public float getYVelocity() {
+  protected float getYVelocity() {
     return getYVelocity(ACTIVE_POINTER_ID);
   }
 
   @Implementation
-  public float getXVelocity(int id) {
+  protected float getXVelocity(int id) {
     if (id == ACTIVE_POINTER_ID) {
       id = activePointerId;
     }
@@ -148,7 +148,7 @@ public class ShadowVelocityTracker {
   }
 
   @Implementation
-  public float getYVelocity(int id) {
+  protected float getYVelocity(int id) {
     if (id == ACTIVE_POINTER_ID) {
       id = activePointerId;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVideoView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVideoView.java
@@ -28,84 +28,84 @@ public class ShadowVideoView extends ShadowSurfaceView {
   private int currentPosition;
 
   @Implementation
-  public void setOnPreparedListener(MediaPlayer.OnPreparedListener l) {
+  protected void setOnPreparedListener(MediaPlayer.OnPreparedListener l) {
     preparedListener = l;
   }
 
   @Implementation
-  public void setOnErrorListener(MediaPlayer.OnErrorListener l) {
+  protected void setOnErrorListener(MediaPlayer.OnErrorListener l) {
     errorListener = l;
   }
 
   @Implementation
-  public void setOnCompletionListener(MediaPlayer.OnCompletionListener l) {
+  protected void setOnCompletionListener(MediaPlayer.OnCompletionListener l) {
     completionListner = l;
   }
 
   @Implementation
-  public void setVideoPath(String path) {
+  protected void setVideoPath(String path) {
     this.path = path;
   }
 
   @Implementation
-  public void setVideoURI(Uri uri) {
+  protected void setVideoURI(Uri uri) {
     this.uri = uri;
   }
 
   @Implementation
-  public void start() {
+  protected void start() {
     savePrevState();
     currentState = ShadowVideoView.START;
   }
 
   @Implementation
-  public void stopPlayback() {
+  protected void stopPlayback() {
     savePrevState();
     currentState = ShadowVideoView.STOP;
   }
 
   @Implementation
-  public void suspend() {
+  protected void suspend() {
     savePrevState();
     currentState = ShadowVideoView.SUSPEND;
   }
 
   @Implementation
-  public void pause() {
+  protected void pause() {
     savePrevState();
     currentState = ShadowVideoView.PAUSE;
   }
 
   @Implementation
-  public void resume() {
+  protected void resume() {
     savePrevState();
     currentState = ShadowVideoView.RESUME;
   }
 
   @Implementation
-  public boolean isPlaying() {
+  protected boolean isPlaying() {
     return (currentState == ShadowVideoView.START);
   }
 
   @Implementation
-  public boolean canPause() {
+  protected boolean canPause() {
     return (currentState != ShadowVideoView.PAUSE &&
         currentState != ShadowVideoView.STOP &&
         currentState != ShadowVideoView.SUSPEND);
   }
 
   @Implementation
-  public void seekTo(int msec) {
+  protected void seekTo(int msec) {
     currentPosition = msec;
   }
 
   @Implementation
-  public int getCurrentPosition() {
+  protected int getCurrentPosition() {
     return currentPosition;
   }
 
   @Implementation
-  public int getDuration() {
+  protected int getDuration() {
     return duration;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowViewAnimator.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowViewAnimator.java
@@ -12,12 +12,12 @@ public class ShadowViewAnimator extends ShadowViewGroup {
   private int currentChild = 0;
 
   @Implementation
-  public int getDisplayedChild() {
+  protected int getDisplayedChild() {
     return currentChild;
   }
 
   @Implementation
-  public void setDisplayedChild(int whichChild) {
+  protected void setDisplayedChild(int whichChild) {
     currentChild = whichChild;
     for (int i = ((ViewGroup) realView).getChildCount() - 1; i >= 0; i--) {
       View child = ((ViewGroup) realView).getChildAt(i);
@@ -26,17 +26,17 @@ public class ShadowViewAnimator extends ShadowViewGroup {
   }
 
   @Implementation
-  public View getCurrentView() {
+  protected View getCurrentView() {
     return ((ViewGroup) realView).getChildAt(getDisplayedChild());
   }
 
   @Implementation
-  public void showNext() {
+  protected void showNext() {
     setDisplayedChild((getDisplayedChild() + 1) % ((ViewGroup) realView).getChildCount());
   }
 
   @Implementation
-  public void showPrevious() {
+  protected void showPrevious() {
     setDisplayedChild(getDisplayedChild() == 0 ? ((ViewGroup) realView).getChildCount() - 1 : getDisplayedChild() - 1);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowViewConfiguration.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowViewConfiguration.java
@@ -85,7 +85,7 @@ public class ShadowViewConfiguration {
   }
 
   @Implementation
-  public static ViewConfiguration get(Context context) {
+  protected static ViewConfiguration get(Context context) {
     ViewConfiguration viewConfiguration = Shadow.newInstanceOf(ViewConfiguration.class);
     ShadowViewConfiguration shadowViewConfiguration = Shadow.extract(viewConfiguration);
     shadowViewConfiguration.setup(context);
@@ -93,142 +93,142 @@ public class ShadowViewConfiguration {
   }
 
   @Implementation
-  public static int getScrollBarSize() {
+  protected static int getScrollBarSize() {
     return SCROLL_BAR_SIZE;
   }
 
   @Implementation
-  public int getScaledScrollBarSize() {
+  protected int getScaledScrollBarSize() {
     return scrollbarSize;
   }
 
   @Implementation
-  public static int getScrollBarFadeDuration() {
+  protected static int getScrollBarFadeDuration() {
     return SCROLL_BAR_FADE_DURATION;
   }
 
   @Implementation
-  public static int getScrollDefaultDelay() {
+  protected static int getScrollDefaultDelay() {
     return SCROLL_BAR_DEFAULT_DELAY;
   }
 
   @Implementation
-  public static int getFadingEdgeLength() {
+  protected static int getFadingEdgeLength() {
     return FADING_EDGE_LENGTH;
   }
 
   @Implementation
-  public int getScaledFadingEdgeLength() {
+  protected int getScaledFadingEdgeLength() {
     return fadingEdgeLength;
   }
 
   @Implementation
-  public static int getPressedStateDuration() {
+  protected static int getPressedStateDuration() {
     return PRESSED_STATE_DURATION;
   }
 
   @Implementation
-  public static int getLongPressTimeout() {
+  protected static int getLongPressTimeout() {
     return LONG_PRESS_TIMEOUT;
   }
 
   @Implementation
-  public static int getTapTimeout() {
+  protected static int getTapTimeout() {
     return TAP_TIMEOUT;
   }
 
   @Implementation
-  public static int getJumpTapTimeout() {
+  protected static int getJumpTapTimeout() {
     return JUMP_TAP_TIMEOUT;
   }
 
   @Implementation
-  public static int getDoubleTapTimeout() {
+  protected static int getDoubleTapTimeout() {
     return DOUBLE_TAP_TIMEOUT;
   }
 
   @Implementation
-  public static int getEdgeSlop() {
+  protected static int getEdgeSlop() {
     return EDGE_SLOP;
   }
 
   @Implementation
-  public int getScaledEdgeSlop() {
+  protected int getScaledEdgeSlop() {
     return edgeSlop;
   }
 
   @Implementation
-  public static int getTouchSlop() {
+  protected static int getTouchSlop() {
     return TOUCH_SLOP;
   }
 
   @Implementation
-  public int getScaledTouchSlop() {
+  protected int getScaledTouchSlop() {
     return touchSlop;
   }
 
   @Implementation
-  public int getScaledPagingTouchSlop() {
+  protected int getScaledPagingTouchSlop() {
     return pagingTouchSlop;
   }
 
   @Implementation
-  public int getScaledDoubleTapSlop() {
+  protected int getScaledDoubleTapSlop() {
     return doubleTapSlop;
   }
 
   @Implementation
-  public static int getWindowTouchSlop() {
+  protected static int getWindowTouchSlop() {
     return WINDOW_TOUCH_SLOP;
   }
 
   @Implementation
-  public int getScaledWindowTouchSlop() {
+  protected int getScaledWindowTouchSlop() {
     return windowTouchSlop;
   }
 
   @Implementation
-  public static int getMinimumFlingVelocity() {
+  protected static int getMinimumFlingVelocity() {
     return MINIMUM_FLING_VELOCITY;
   }
 
   @Implementation
-  public int getScaledMinimumFlingVelocity() {
+  protected int getScaledMinimumFlingVelocity() {
     return minimumFlingVelocity;
   }
 
   @Implementation
-  public static int getMaximumFlingVelocity() {
+  protected static int getMaximumFlingVelocity() {
     return MAXIMUM_FLING_VELOCITY;
   }
 
   @Implementation
-  public int getScaledMaximumFlingVelocity() {
+  protected int getScaledMaximumFlingVelocity() {
     return maximumFlingVelocity;
   }
 
   @Implementation
-  public static int getMaximumDrawingCacheSize() {
+  protected static int getMaximumDrawingCacheSize() {
     return MAXIMUM_DRAWING_CACHE_SIZE;
   }
 
   @Implementation
-  public static long getZoomControlsTimeout() {
+  protected static long getZoomControlsTimeout() {
     return ZOOM_CONTROLS_TIMEOUT;
   }
 
   @Implementation
-  public static long getGlobalActionKeyTimeout() {
+  protected static long getGlobalActionKeyTimeout() {
     return GLOBAL_ACTIONS_KEY_TIMEOUT;
   }
 
   @Implementation
-  public static float getScrollFriction() {
+  protected static float getScrollFriction() {
     return SCROLL_FRICTION;
   }
 
   @Implementation
-  public boolean hasPermanentMenuKey() {
+  protected boolean hasPermanentMenuKey() {
     return hasPermanentMenuKey;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowViewGroup.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowViewGroup.java
@@ -22,7 +22,7 @@ public class ShadowViewGroup extends ShadowView {
   private MotionEvent interceptedTouchEvent;
 
   @Implementation
-  public void addView(final View child, final int index, final ViewGroup.LayoutParams params) {
+  protected void addView(final View child, final int index, final ViewGroup.LayoutParams params) {
     ShadowLooper shadowLooper = Shadow.extract(Looper.getMainLooper());
     shadowLooper.runPaused(() ->
         directlyOn(realViewGroup, ViewGroup.class, "addView",
@@ -76,7 +76,7 @@ public class ShadowViewGroup extends ShadowView {
   }
 
   @Implementation
-  public void requestDisallowInterceptTouchEvent(boolean disallowIntercept) {
+  protected void requestDisallowInterceptTouchEvent(boolean disallowIntercept) {
     disallowInterceptTouchEvent = disallowIntercept;
   }
 
@@ -96,7 +96,7 @@ public class ShadowViewGroup extends ShadowView {
   }
 
   @Implementation
-  public boolean onInterceptTouchEvent(MotionEvent ev) {
+  protected boolean onInterceptTouchEvent(MotionEvent ev) {
     interceptedTouchEvent = ev;
     return false;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVisualVoicemailSms.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVisualVoicemailSms.java
@@ -29,7 +29,7 @@ public class ShadowVisualVoicemailSms {
   }
 
   @Implementation
-  public PhoneAccountHandle getPhoneAccountHandle() {
+  protected PhoneAccountHandle getPhoneAccountHandle() {
     return phoneAccountHandle;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWallpaperManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWallpaperManager.java
@@ -12,11 +12,11 @@ import org.robolectric.shadow.api.Shadow;
 public class ShadowWallpaperManager {
 
   @Implementation
-  public static WallpaperManager getInstance(Context context) {
+  protected static WallpaperManager getInstance(Context context) {
     return Shadow.newInstanceOf(WallpaperManager.class);
   }
 
   @Implementation
-  public void sendWallpaperCommand(IBinder windowToken, String action, int x, int y, int z, Bundle extras) {
-  }
+  protected void sendWallpaperCommand(
+      IBinder windowToken, String action, int x, int y, int z, Bundle extras) {}
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWebSyncManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWebSyncManager.java
@@ -8,7 +8,7 @@ public class ShadowWebSyncManager {
   protected boolean synced = false;
 
   @Implementation
-  public void sync() {
+  protected void sync() {
     synced = true;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWebView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWebView.java
@@ -107,7 +107,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public void setLayoutParams(LayoutParams params) {
+  protected void setLayoutParams(LayoutParams params) {
     ReflectionHelpers.setField(realWebView, "mLayoutParams", params);
   }
 
@@ -133,12 +133,12 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public void loadUrl(String url) {
+  protected void loadUrl(String url) {
     loadUrl(url, null);
   }
 
   @Implementation
-  public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
+  protected void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
     history.add(0, url);
     originalUrl = url;
     lastUrl = url;
@@ -151,7 +151,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public void loadDataWithBaseURL(
+  protected void loadDataWithBaseURL(
       String baseUrl, String data, String mimeType, String encoding, String historyUrl) {
     if (historyUrl != null) {
       originalUrl = historyUrl;
@@ -162,7 +162,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public void loadData(String data, String mimeType, String encoding) {
+  protected void loadData(String data, String mimeType, String encoding) {
     lastLoadData = new LoadData(data, mimeType, encoding);
   }
 
@@ -172,12 +172,12 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public String getOriginalUrl() {
+  protected String getOriginalUrl() {
     return originalUrl;
   }
 
   @Implementation
-  public String getUrl() {
+  protected String getUrl() {
     return originalUrl;
   }
 
@@ -187,17 +187,17 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public WebSettings getSettings() {
+  protected WebSettings getSettings() {
     return webSettings;
   }
 
   @Implementation
-  public void setWebViewClient(WebViewClient client) {
+  protected void setWebViewClient(WebViewClient client) {
     webViewClient = client;
   }
 
   @Implementation
-  public void setWebChromeClient(WebChromeClient client) {
+  protected void setWebChromeClient(WebChromeClient client) {
     webChromeClient = client;
   }
 
@@ -206,7 +206,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public void addJavascriptInterface(Object obj, String interfaceName) {
+  protected void addJavascriptInterface(Object obj, String interfaceName) {
     javascriptInterfaces.put(interfaceName, obj);
   }
 
@@ -215,7 +215,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public void clearCache(boolean includeDiskFiles) {
+  protected void clearCache(boolean includeDiskFiles) {
     clearCacheCalled = true;
     clearCacheIncludeDiskFiles = includeDiskFiles;
   }
@@ -229,7 +229,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public void clearFormData() {
+  protected void clearFormData() {
     clearFormDataCalled = true;
   }
 
@@ -238,7 +238,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public void clearHistory() {
+  protected void clearHistory() {
     clearHistoryCalled = true;
     history.clear();
   }
@@ -248,7 +248,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public void clearView() {
+  protected void clearView() {
     clearViewCalled = true;
   }
 
@@ -257,7 +257,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public void onPause() {
+  protected void onPause() {
     onPauseCalled = true;
   }
 
@@ -266,7 +266,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public void onResume() {
+  protected void onResume() {
     onResumeCalled = true;
   }
 
@@ -275,7 +275,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public void destroy() {
+  protected void destroy() {
     destroyCalled = true;
   }
 
@@ -289,7 +289,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public boolean canGoBack() {
+  protected boolean canGoBack() {
     // TODO: Remove the canGoBack check when setCanGoBack is deleted.
     if (canGoBackIsSet) {
       return canGoBack;
@@ -298,7 +298,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public void goBack() {
+  protected void goBack() {
     if (canGoBack()) {
       goBackInvocations++;
       // TODO: Delete this when setCanGoBack is deleted, since this creates two different behavior
@@ -314,7 +314,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation
-  public static String findAddress(String addr) {
+  protected static String findAddress(String addr) {
     return null;
   }
 
@@ -325,7 +325,7 @@ public class ShadowWebView extends ShadowViewGroup {
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.KITKAT)
-  public void evaluateJavascript(String script, ValueCallback<String> callback) {
+  protected void evaluateJavascript(String script, ValueCallback<String> callback) {
     this.lastEvaluatedJavascript = script;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWebViewDatabase.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWebViewDatabase.java
@@ -10,7 +10,7 @@ import org.robolectric.shadow.api.Shadow;
 public class ShadowWebViewDatabase {
 
   @Implementation
-  public static WebViewDatabase getInstance(Context ignored) {
+  protected static WebViewDatabase getInstance(Context ignored) {
     return Shadow.newInstanceOf(WebViewDatabase.class);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
@@ -46,20 +46,20 @@ public class ShadowWifiManager {
   private boolean is5GHzBandSupported = false;
 
   @Implementation
-  public boolean setWifiEnabled(boolean wifiEnabled) {
+  protected boolean setWifiEnabled(boolean wifiEnabled) {
     checkAccessWifiStatePermission();
     this.wifiEnabled = wifiEnabled;
     return true;
   }
 
   @Implementation
-  public boolean isWifiEnabled() {
+  protected boolean isWifiEnabled() {
     checkAccessWifiStatePermission();
     return wifiEnabled;
   }
 
   @Implementation
-  public int getWifiState() {
+  protected int getWifiState() {
     if (isWifiEnabled()) {
       return WifiManager.WIFI_STATE_ENABLED;
     } else {
@@ -68,7 +68,7 @@ public class ShadowWifiManager {
   }
 
   @Implementation
-  public WifiInfo getConnectionInfo() {
+  protected WifiInfo getConnectionInfo() {
     checkAccessWifiStatePermission();
     if (wifiInfo == null) {
       wifiInfo = ReflectionHelpers.callConstructor(WifiInfo.class);
@@ -77,7 +77,7 @@ public class ShadowWifiManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public boolean is5GHzBandSupported() {
+  protected boolean is5GHzBandSupported() {
     return is5GHzBandSupported;
   }
 
@@ -99,12 +99,12 @@ public class ShadowWifiManager {
   }
 
   @Implementation
-  public List<ScanResult> getScanResults() {
+  protected List<ScanResult> getScanResults() {
     return scanResults;
   }
 
   @Implementation
-  public List<WifiConfiguration> getConfiguredNetworks() {
+  protected List<WifiConfiguration> getConfiguredNetworks() {
     final ArrayList<WifiConfiguration> wifiConfigurations = new ArrayList<>();
     for (WifiConfiguration wifiConfiguration : networkIdToConfiguredNetworks.values()) {
       wifiConfigurations.add(wifiConfiguration);
@@ -113,12 +113,12 @@ public class ShadowWifiManager {
   }
 
   @Implementation(minSdk = LOLLIPOP)
-  public List<WifiConfiguration> getPrivilegedConfiguredNetworks() {
+  protected List<WifiConfiguration> getPrivilegedConfiguredNetworks() {
     return getConfiguredNetworks();
   }
 
   @Implementation
-  public int addNetwork(WifiConfiguration config) {
+  protected int addNetwork(WifiConfiguration config) {
     int networkId = networkIdToConfiguredNetworks.size();
     config.networkId = -1;
     networkIdToConfiguredNetworks.put(networkId, makeCopy(config, networkId));
@@ -126,13 +126,13 @@ public class ShadowWifiManager {
   }
 
   @Implementation
-  public boolean removeNetwork(int netId) {
+  protected boolean removeNetwork(int netId) {
     networkIdToConfiguredNetworks.remove(netId);
     return true;
   }
 
   @Implementation
-  public int updateNetwork(WifiConfiguration config) {
+  protected int updateNetwork(WifiConfiguration config) {
     if (config == null || config.networkId < 0) {
       return -1;
     }
@@ -141,29 +141,29 @@ public class ShadowWifiManager {
   }
 
   @Implementation
-  public boolean saveConfiguration() {
+  protected boolean saveConfiguration() {
     wasSaved = true;
     return true;
   }
 
   @Implementation
-  public boolean enableNetwork(int netId, boolean disableOthers) {
+  protected boolean enableNetwork(int netId, boolean disableOthers) {
     lastEnabledNetwork = new Pair<>(netId, disableOthers);
     return true;
   }
 
   @Implementation
-  public WifiManager.WifiLock createWifiLock(int lockType, java.lang.String tag) {
+  protected WifiManager.WifiLock createWifiLock(int lockType, java.lang.String tag) {
     return ReflectionHelpers.callConstructor(WifiManager.WifiLock.class);
   }
 
   @Implementation
-  public WifiManager.WifiLock createWifiLock(java.lang.String tag) {
+  protected WifiManager.WifiLock createWifiLock(java.lang.String tag) {
     return createWifiLock(WifiManager.WIFI_MODE_FULL, tag);
   }
 
   @Implementation
-  public static int calculateSignalLevel(int rssi, int numLevels) {
+  protected static int calculateSignalLevel(int rssi, int numLevels) {
     return (int) (sSignalLevelInPercent * (numLevels - 1));
   }
 
@@ -177,17 +177,17 @@ public class ShadowWifiManager {
    *     was never called.
    */
   @Implementation
-  public boolean startScan() {
+  protected boolean startScan() {
     return startScanSucceeds;
   }
 
   @Implementation
-  public DhcpInfo getDhcpInfo() {
+  protected DhcpInfo getDhcpInfo() {
     return dhcpInfo;
   }
 
   @Implementation(minSdk = JELLY_BEAN_MR2)
-  public boolean isScanAlwaysAvailable() {
+  protected boolean isScanAlwaysAvailable() {
     return isScanAlwaysAvailable;
   }
 
@@ -327,7 +327,7 @@ public class ShadowWifiManager {
     public static final int MAX_ACTIVE_LOCKS = 50;
 
     @Implementation
-    public synchronized void acquire() {
+    protected synchronized void acquire() {
       if (refCounted) {
         if (++refCount >= MAX_ACTIVE_LOCKS) throw new UnsupportedOperationException("Exceeded maximum number of wifi locks");
       } else {
@@ -336,7 +336,7 @@ public class ShadowWifiManager {
     }
 
     @Implementation
-    public synchronized void release() {
+    protected synchronized void release() {
       if (refCounted) {
         if (--refCount < 0) throw new RuntimeException("WifiLock under-locked");
       } else {
@@ -345,12 +345,12 @@ public class ShadowWifiManager {
     }
 
     @Implementation
-    public synchronized boolean isHeld() {
+    protected synchronized boolean isHeld() {
       return refCounted ? refCount > 0 : locked;
     }
 
     @Implementation
-    public void setReferenceCounted(boolean refCounted) {
+    protected void setReferenceCounted(boolean refCounted) {
       this.refCounted = refCounted;
     }
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiP2pManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiP2pManager.java
@@ -41,7 +41,7 @@ public class ShadowWifiP2pManager {
   }
 
   @Implementation(minSdk = KITKAT)
-  public void setWifiP2pChannels(
+  protected void setWifiP2pChannels(
       Channel c, int listeningChannel, int operatingChannel, ActionListener al) {
     Preconditions.checkNotNull(c);
     Preconditions.checkNotNull(al);
@@ -50,13 +50,14 @@ public class ShadowWifiP2pManager {
   }
 
   @Implementation
-  public Channel initialize(Context context, Looper looper, WifiP2pManager.ChannelListener listener) {
+  protected Channel initialize(
+      Context context, Looper looper, WifiP2pManager.ChannelListener listener) {
     handler = new Handler(looper);
     return ReflectionHelpers.newInstance(Channel.class);
   }
 
   @Implementation
-  public void createGroup(Channel c, ActionListener al) {
+  protected void createGroup(Channel c, ActionListener al) {
     postActionListener(al);
   }
 
@@ -79,7 +80,7 @@ public class ShadowWifiP2pManager {
   }
 
   @Implementation
-  public void requestGroupInfo(final Channel c, final WifiP2pManager.GroupInfoListener gl) {
+  protected void requestGroupInfo(final Channel c, final WifiP2pManager.GroupInfoListener gl) {
     if (gl == null) {
       return;
     }
@@ -93,7 +94,7 @@ public class ShadowWifiP2pManager {
   }
 
   @Implementation
-  public void removeGroup(Channel c, ActionListener al) {
+  protected void removeGroup(Channel c, ActionListener al) {
     postActionListener(al);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindow.java
@@ -34,13 +34,13 @@ public class ShadowWindow {
   }
 
   @Implementation
-  public void setFlags(int flags, int mask) {
+  protected void setFlags(int flags, int mask) {
     this.flags = (this.flags & ~mask) | (flags & mask);
     directlyOn(realWindow, Window.class, "setFlags", ClassParameter.from(int.class, flags), ClassParameter.from(int.class, mask));
   }
 
   @Implementation
-  public void setSoftInputMode(int softInputMode) {
+  protected void setSoftInputMode(int softInputMode) {
     this.softInputMode = softInputMode;
     directlyOn(realWindow, Window.class, "setSoftInputMode", ClassParameter.from(int.class, softInputMode));
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindowManagerImpl.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindowManagerImpl.java
@@ -81,7 +81,7 @@ public class ShadowWindowManagerImpl extends ShadowWindowManager {
   @Implements(className = "android.view.WindowManagerImpl$CompatModeWrapper", maxSdk = JELLY_BEAN)
   public static class ShadowCompatModeWrapper {
     @Implementation(maxSdk = JELLY_BEAN)
-    public Display getDefaultDisplay() {
+    protected Display getDefaultDisplay() {
       return defaultDisplayJB;
     }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowZoomButtonsController.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowZoomButtonsController.java
@@ -11,10 +11,10 @@ public class ShadowZoomButtonsController {
   private ZoomButtonsController.OnZoomListener listener;
 
   @Implementation
-  public void __constructor__(View ownerView) {}
+  protected void __constructor__(View ownerView) {}
 
   @Implementation
-  public void setOnZoomListener(ZoomButtonsController.OnZoomListener listener) {
+  protected void setOnZoomListener(ZoomButtonsController.OnZoomListener listener) {
     this.listener = listener;
   }
 

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/ShadowAndroidHttpClient.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/ShadowAndroidHttpClient.java
@@ -26,62 +26,80 @@ public class ShadowAndroidHttpClient {
   private HttpClient httpClient = new DefaultHttpClient();
 
   @Implementation
-  public static AndroidHttpClient newInstance(String userAgent) {
+  protected static AndroidHttpClient newInstance(String userAgent) {
     return ReflectionHelpers.callConstructor(AndroidHttpClient.class);
   }
 
   @Implementation
-  public static AndroidHttpClient newInstance(String userAgent, Context context) {
+  protected static AndroidHttpClient newInstance(String userAgent, Context context) {
     return ReflectionHelpers.callConstructor(AndroidHttpClient.class);
   }
 
   @Implementation
-  public HttpParams getParams() {
+  protected HttpParams getParams() {
     return httpClient.getParams();
   }
 
   @Implementation
-  public ClientConnectionManager getConnectionManager() {
+  protected ClientConnectionManager getConnectionManager() {
     return httpClient.getConnectionManager();
   }
 
   @Implementation
-  public HttpResponse execute(HttpUriRequest httpUriRequest) throws IOException, ClientProtocolException {
+  protected HttpResponse execute(HttpUriRequest httpUriRequest)
+      throws IOException, ClientProtocolException {
     return httpClient.execute(httpUriRequest);
   }
 
   @Implementation
-  public HttpResponse execute(HttpUriRequest httpUriRequest, HttpContext httpContext) throws IOException, ClientProtocolException {
+  protected HttpResponse execute(HttpUriRequest httpUriRequest, HttpContext httpContext)
+      throws IOException, ClientProtocolException {
     return httpClient.execute(httpUriRequest, httpContext);
   }
 
   @Implementation
-  public HttpResponse execute(HttpHost httpHost, HttpRequest httpRequest) throws IOException, ClientProtocolException {
+  protected HttpResponse execute(HttpHost httpHost, HttpRequest httpRequest)
+      throws IOException, ClientProtocolException {
     return httpClient.execute(httpHost, httpRequest);
   }
 
   @Implementation
-  public HttpResponse execute(HttpHost httpHost, HttpRequest httpRequest, HttpContext httpContext) throws IOException, ClientProtocolException {
+  protected HttpResponse execute(
+      HttpHost httpHost, HttpRequest httpRequest, HttpContext httpContext)
+      throws IOException, ClientProtocolException {
     return httpClient.execute(httpHost, httpRequest, httpContext);
   }
 
   @Implementation
-  public <T> T execute(HttpUriRequest httpUriRequest, ResponseHandler<? extends T> responseHandler) throws IOException, ClientProtocolException {
+  protected <T> T execute(
+      HttpUriRequest httpUriRequest, ResponseHandler<? extends T> responseHandler)
+      throws IOException, ClientProtocolException {
     return httpClient.execute(httpUriRequest, responseHandler);
   }
 
   @Implementation
-  public <T> T execute(HttpUriRequest httpUriRequest, ResponseHandler<? extends T> responseHandler, HttpContext httpContext) throws IOException, ClientProtocolException {
+  protected <T> T execute(
+      HttpUriRequest httpUriRequest,
+      ResponseHandler<? extends T> responseHandler,
+      HttpContext httpContext)
+      throws IOException, ClientProtocolException {
     return httpClient.execute(httpUriRequest, responseHandler, httpContext);
   }
 
   @Implementation
-  public <T> T execute(HttpHost httpHost, HttpRequest httpRequest, ResponseHandler<? extends T> responseHandler) throws IOException, ClientProtocolException {
+  protected <T> T execute(
+      HttpHost httpHost, HttpRequest httpRequest, ResponseHandler<? extends T> responseHandler)
+      throws IOException, ClientProtocolException {
     return httpClient.execute(httpHost, httpRequest, responseHandler);
   }
 
   @Implementation
-  public <T> T execute(HttpHost httpHost, HttpRequest httpRequest, ResponseHandler<? extends T> responseHandler, HttpContext httpContext) throws IOException, ClientProtocolException {
+  protected <T> T execute(
+      HttpHost httpHost,
+      HttpRequest httpRequest,
+      ResponseHandler<? extends T> responseHandler,
+      HttpContext httpContext)
+      throws IOException, ClientProtocolException {
     return httpClient.execute(httpHost, httpRequest, responseHandler, httpContext);
   }
 }

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
@@ -54,7 +54,7 @@ public class ShadowDefaultRequestDirector {
   org.robolectric.shadows.httpclient.DefaultRequestDirector redirector;
 
   @Implementation
-  public void __constructor__(
+  protected void __constructor__(
       Log log,
       HttpRequestExecutor requestExec,
       ClientConnectionManager conman,
@@ -104,7 +104,7 @@ public class ShadowDefaultRequestDirector {
   }
 
   @Implementation
-  public void __constructor__(
+  protected void __constructor__(
       HttpRequestExecutor requestExec,
       ClientConnectionManager conman,
       ConnectionReuseStrategy reustrat,
@@ -163,7 +163,9 @@ public class ShadowDefaultRequestDirector {
   }
 
   @Implementation
-  public HttpResponse execute(HttpHost httpHost, HttpRequest httpRequest, HttpContext httpContext) throws HttpException, IOException {
+  protected HttpResponse execute(
+      HttpHost httpHost, HttpRequest httpRequest, HttpContext httpContext)
+      throws HttpException, IOException {
     if (FakeHttp.getFakeHttpLayer().isInterceptingHttpRequests()) {
       return FakeHttp.getFakeHttpLayer().emulateRequest(httpHost, httpRequest, httpContext, realObject);
     } else {

--- a/shadows/multidex/src/main/java/org/robolectric/shadows/multidex/ShadowMultiDex.java
+++ b/shadows/multidex/src/main/java/org/robolectric/shadows/multidex/ShadowMultiDex.java
@@ -9,7 +9,7 @@ import org.robolectric.annotation.Implements;
 public class ShadowMultiDex {
 
   @Implementation
-  public static void install(Context context) {
+  protected static void install(Context context) {
     // Do nothing since with Robolectric nothing is dexed.
   }
 }

--- a/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowAsyncTaskLoader.java
+++ b/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowAsyncTaskLoader.java
@@ -16,12 +16,12 @@ public class ShadowAsyncTaskLoader<D> {
   private BackgroundWorker worker;
 
   @Implementation
-  public void __constructor__(Context context) {
+  protected void __constructor__(Context context) {
     worker = new BackgroundWorker();
   }
 
   @Implementation
-  public void onForceLoad() {
+  protected void onForceLoad() {
     FutureTask<D> future = new FutureTask<D>(worker) {
       @Override protected void done() {
         try {

--- a/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowDrawerLayout.java
+++ b/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowDrawerLayout.java
@@ -15,7 +15,7 @@ public class ShadowDrawerLayout extends ShadowViewGroup {
   private DrawerLayout.DrawerListener drawerListener;
 
   @Implementation
-  public void setDrawerListener(DrawerLayout.DrawerListener drawerListener) {
+  protected void setDrawerListener(DrawerLayout.DrawerListener drawerListener) {
     this.drawerListener = drawerListener;
     directlyOn(realDrawerLayout, DrawerLayout.class).setDrawerListener(drawerListener);
   }
@@ -24,19 +24,15 @@ public class ShadowDrawerLayout extends ShadowViewGroup {
     return drawerListener;
   }
 
-  /**
-   * Drawer animations are disabled in unit tests.
-   */
+  /** Drawer animations are disabled in unit tests. */
   @Implementation
-  public void openDrawer(View drawerView, boolean animate) {
+  protected void openDrawer(View drawerView, boolean animate) {
     directlyOn(realDrawerLayout, DrawerLayout.class).openDrawer(drawerView, false);
   }
 
-  /**
-   * Drawer animations are disabled in unit tests.
-   */
+  /** Drawer animations are disabled in unit tests. */
   @Implementation
-  public void closeDrawer(View drawerView, boolean animate) {
+  protected void closeDrawer(View drawerView, boolean animate) {
     directlyOn(realDrawerLayout, DrawerLayout.class).closeDrawer(drawerView, false);
   }
 }

--- a/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManager.java
+++ b/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManager.java
@@ -23,7 +23,7 @@ public class ShadowLocalBroadcastManager {
   private final List<Wrapper> registeredReceivers = new ArrayList<>();
 
   @Implementation
-  public static LocalBroadcastManager getInstance(final Context context) {
+  protected static LocalBroadcastManager getInstance(final Context context) {
     return ShadowApplication.getInstance().getSingleton(LocalBroadcastManager.class, new Provider<LocalBroadcastManager>() {
       @Override
       public LocalBroadcastManager get() {
@@ -33,12 +33,12 @@ public class ShadowLocalBroadcastManager {
   }
 
   @Implementation
-  public void registerReceiver(BroadcastReceiver receiver, IntentFilter filter) {
+  protected void registerReceiver(BroadcastReceiver receiver, IntentFilter filter) {
     registeredReceivers.add(new Wrapper(receiver, filter));
   }
 
   @Implementation
-  public void unregisterReceiver(BroadcastReceiver receiver) {
+  protected void unregisterReceiver(BroadcastReceiver receiver) {
     Iterator<Wrapper> iterator = registeredReceivers.iterator();
     while (iterator.hasNext()) {
       Wrapper wrapper = iterator.next();
@@ -49,7 +49,7 @@ public class ShadowLocalBroadcastManager {
   }
 
   @Implementation
-  public boolean sendBroadcast(Intent intent) {
+  protected boolean sendBroadcast(Intent intent) {
     boolean sent = false;
     sentBroadcastIntents.add(intent);
     List<Wrapper> copy = new ArrayList<>();

--- a/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowSwipeRefreshLayout.java
+++ b/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowSwipeRefreshLayout.java
@@ -14,7 +14,7 @@ public class ShadowSwipeRefreshLayout extends ShadowViewGroup {
   private OnRefreshListener listener;
 
   @Implementation
-  public void setOnRefreshListener(OnRefreshListener listener) {
+  protected void setOnRefreshListener(OnRefreshListener listener) {
     this.listener = listener;
     Shadow.directlyOn(realObject, SwipeRefreshLayout.class).setOnRefreshListener(listener);
   }


### PR DESCRIPTION
Tests should always prefer to call Android API methods on the real framework class rather than calling the corresponding shadow implementation method. Calling the shadow method can cause unexpected behavior, e.g. calling `shadowOf(activity).onCreateOptionsMenu()` would prevent a subclass of Activity's overridden `onCreateOptionsMenu()` from being called.