### PR TITLE
Support dealing with v53 (Java 9) .class files.

### DIFF
--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/SandboxClassLoader.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/SandboxClassLoader.java
@@ -143,7 +143,7 @@ public class SandboxClassLoader extends URLClassLoader implements Opcodes {
       @Override
       public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
         desc = remapParamType(desc);
-        return super.visitField(access, name, desc, signature, value);
+        return super.visitField(access & ~ACC_FINAL, name, desc, signature, value);
       }
 
       @Override
@@ -381,7 +381,7 @@ public class SandboxClassLoader extends URLClassLoader implements Opcodes {
       // Need Java version >=7 to allow invokedynamic
       classNode.version = Math.max(classNode.version, V1_7);
 
-      classNode.fields.add(0, new FieldNode(ACC_PUBLIC | ACC_FINAL,
+      classNode.fields.add(0, new FieldNode(ACC_PUBLIC,
           ShadowConstants.CLASS_HANDLER_DATA_FIELD_NAME, OBJECT_DESC, OBJECT_DESC, null));
 
       Set<String> foundMethods = instrumentMethods();

--- a/sandbox/src/test/java/org/robolectric/SandboxClassLoaderTest.java
+++ b/sandbox/src/test/java/org/robolectric/SandboxClassLoaderTest.java
@@ -158,9 +158,14 @@ public class SandboxClassLoaderTest {
     assertNotNull(roboDataField);
     assertThat(Modifier.isPublic(roboDataField.getModifiers())).isTrue();
 
-    // field should be marked final so Mockito doesn't try to @InjectMocks on it;
-    //   see https://github.com/robolectric/robolectric/issues/2442
-    assertThat(Modifier.isFinal(roboDataField.getModifiers())).isTrue();
+    // Java 9 doesn't allow updates to final fields from outside <init> or <clinit>:
+    // https://bugs.openjdk.java.net/browse/JDK-8157181
+    // Therefore, these fields need to be nonfinal / be made nonfinal.
+    assertThat(Modifier.isFinal(roboDataField.getModifiers())).isFalse();
+    assertThat(
+        Modifier.isFinal(exampleClass.getField("STATIC_FINAL_FIELD").getModifiers())).isFalse();
+    assertThat(
+        Modifier.isFinal(exampleClass.getField("nonstaticFinalField").getModifiers())).isFalse();
   }
 
   @Test

--- a/sandbox/src/test/java/org/robolectric/testing/AnExampleClass.java
+++ b/sandbox/src/test/java/org/robolectric/testing/AnExampleClass.java
@@ -7,6 +7,9 @@ import org.robolectric.annotation.internal.Instrument;
 public class AnExampleClass {
   static int foo = 123;
 
+  public static final String STATIC_FINAL_FIELD = "STATIC_FINAL_FIELD";
+  public final String nonstaticFinalField = "nonstaticFinalField";
+
   public String normalMethod(String stringArg, int intArg) {
     return "normalMethod(" + stringArg + ", " + intArg + ")";
   }


### PR DESCRIPTION
This is a backport of commit 8334ae81805ce7d13898f6438ce0fee98fef1c0f from the master branch.
This commit fixes https://github.com/robolectric/robolectric/issues/3999 but regresses https://github.com/robolectric/robolectric/issues/2442

Original commit message follows:

The Java VM Specification says that updating final fields from the putstatic bytecode is only allowed in <init> or <clinit> of the current class [1]. OpenJDK 9 enforces this for code from v53 (OpenJDK 9) .class files [2].

Since Robolectric updates various fields from $$robo$init or from __staticInitializer__, those fields must be nonfinal in order for Robolectric to work on v53 fields.

Before this CL, Robolectric supported running under OpenJDK 9 java, but not on v53 .class files (written by default by OpenJDK 9 javac). This CL fixes one breakage on v53 .class files, although other breakages might remain in areas that I have not exercised; for example, there are still a couple of occurrences of Opcodes.ASM4 in sources and of org.ow2.asm:asm-tree:5.0.1 in buildSrc/build.gradle, which might need to be updated to ASM6, but I don't know if / where they are used.

Note that this CL regresses on the bugfix for https://github.com/robolectric/robolectric/issues/2442 because that fix relied on __robo_data__ being final (which is no longer supported). The original bug report involved @InjectMocks on an Activity, which is probably an edge case that we may not want to support. If we do want to support it, then we'll have to find a different fix for the original issue; for example, if there was a setter for __robo_data__ whose implementation does nothing then mockito would probably call that instead.

[1] https://bugs.openjdk.java.net/browse/JDK-8157181
[2] http://hg.openjdk.java.net/jdk9/jdk9/hotspot/annotate/c558d46c1af2/src/share/vm/interpreter/linkResolver.cpp#l960
[3] https://github.com/15characterlimi/robolectric/commit/72e4373f4922d72efbf08fc43d2b4c22509e35d5
[4] https://android-review.googlesource.com/c/platform/libcore/+/754694

PiperOrigin-RevId: 215005271

### Overview

### Proposed Changes
