### PR TITLE
Add legacy mode warning.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -359,6 +359,11 @@ public class RobolectricTestRunner extends SandboxTestRunner {
             + roboMethod.getMethod().getName() + ": sdk=" + sdkConfig.getApiLevel()
             + "; resources=" + roboMethod.resourcesMode);
 
+    if (roboMethod.resourcesMode == ResourcesMode.legacy) {
+      System.out.println(
+          "[Robolectric] NOTICE: legacy resources mode is deprecated; see http://robolectric.org/migrating/#migrating-to-40");
+    }
+
     roboMethod.parallelUniverseInterface = getHooksInterface(sdkEnvironment);
     Class<TestLifecycle> cl = sdkEnvironment.bootstrappedClass(getTestLifecycleClass());
     roboMethod.testLifecycle = ReflectionHelpers.newInstance(cl);


### PR DESCRIPTION
`[Robolectric] NOTICE: legacy resources mode is deprecated; see http://robolectric.org/migrating/#migrating-to-40`