### PR TITLE
Fix ActivityController to invoke Instrumentation#callActivityOn* meth…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,5 @@ apiCompatVersion=3.8
 
 errorproneVersion=2.3.1
 errorproneJavacVersion=9+181-r4173-1
+
+android.enableUnitTestBinaryResources=true

--- a/integration_tests/androidx_test/build.gradle
+++ b/integration_tests/androidx_test/build.gradle
@@ -1,7 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
+    compileOptions {
+        sourceCompatibility = '1.8'
+        targetCompatibility = '1.8'
+    }
 
     android {
         testOptions {
@@ -17,6 +21,7 @@ dependencies {
     implementation project(":robolectric")
     implementation "junit:junit:4.12"
     implementation("androidx.test:runner:1.1.0")
+    implementation("androidx.appcompat:appcompat:1.0.0")
 
     // Testing dependencies
     testImplementation("androidx.test:runner:1.1.0")
@@ -29,4 +34,5 @@ dependencies {
     testImplementation("androidx.lifecycle:lifecycle-common:2.0.0")
     testImplementation("androidx.test.ext:junit:1.0.0")
     testImplementation("com.google.truth:truth:0.42")
+
 }

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integration_tests/axt/ActivityScenarioTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integration_tests/axt/ActivityScenarioTest.java
@@ -3,7 +3,11 @@ package org.robolectric.integration_tests.axt;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.app.Activity;
+import android.arch.lifecycle.Lifecycle.State;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.appcompat.R;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.ArrayList;
@@ -72,6 +76,14 @@ public class ActivityScenarioTest {
     }
   }
 
+  public static class LifecycleOwnerActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(@Nullable Bundle bundle) {
+      super.onCreate(bundle);
+      setTheme(R.style.Theme_AppCompat);
+    }
+  }
+
   @Before
   public void setUp() {
     callbacks.clear();
@@ -86,4 +98,24 @@ public class ActivityScenarioTest {
         .containsExactly("onCreate", "onStart", "onResume", "onWindowFocusChanged true");
   }
 
+  @Test
+  public void launch_lifecycleOwnerActivity() {
+    ActivityScenario<LifecycleOwnerActivity> activityScenario =
+        ActivityScenario.launch(LifecycleOwnerActivity.class);
+    assertThat(activityScenario).isNotNull();
+    activityScenario.onActivity(
+        activity -> {
+          assertThat(activity.getLifecycle().getCurrentState()).isEqualTo(State.RESUMED);
+        });
+    activityScenario.moveToState(State.STARTED);
+    activityScenario.onActivity(
+        activity -> {
+          assertThat(activity.getLifecycle().getCurrentState()).isEqualTo(State.STARTED);
+        });
+    activityScenario.moveToState(State.CREATED);
+    activityScenario.onActivity(
+        activity -> {
+          assertThat(activity.getLifecycle().getCurrentState()).isEqualTo(State.CREATED);
+        });
+  }
 }

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integration_tests/axt/ActivityScenarioTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integration_tests/axt/ActivityScenarioTest.java
@@ -3,11 +3,10 @@ package org.robolectric.integration_tests.axt;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.app.Activity;
-import android.arch.lifecycle.Lifecycle.State;
+import androidx.lifecycle.Lifecycle.State;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.appcompat.R;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.R;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.ArrayList;
@@ -78,7 +77,7 @@ public class ActivityScenarioTest {
 
   public static class LifecycleOwnerActivity extends AppCompatActivity {
     @Override
-    protected void onCreate(@Nullable Bundle bundle) {
+    protected void onCreate(Bundle bundle) {
       super.onCreate(bundle);
       setTheme(R.style.Theme_AppCompat);
     }

--- a/robolectric/src/main/java/org/robolectric/android/fakes/RoboMonitoringInstrumentation.java
+++ b/robolectric/src/main/java/org/robolectric/android/fakes/RoboMonitoringInstrumentation.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import androidx.test.runner.MonitoringInstrumentation;
 import org.robolectric.Robolectric;
-import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowLooper;
 
 public class RoboMonitoringInstrumentation extends MonitoringInstrumentation {
@@ -35,14 +34,15 @@ public class RoboMonitoringInstrumentation extends MonitoringInstrumentation {
     ActivityInfo ai = intent.resolveActivityInfo(getTargetContext().getPackageManager(), 0);
     try {
       Class<? extends Activity> activityClass = Class.forName(ai.name).asSubclass(Activity.class);
-      ActivityController<? extends Activity> controller = Robolectric.buildActivity(activityClass, intent);
-      Activity activity = controller.get();
-      callActivityOnCreate(activity, null);
-      controller.postCreate(null);
-      callActivityOnStart(activity);
-      callActivityOnResume(activity);
-      controller.visible().windowFocusChanged(true);
-      return activity;
+      return Robolectric.buildActivity(activityClass, intent)
+          .create()
+          .postCreate(null)
+          .start()
+          .resume()
+          .postResume()
+          .visible()
+          .windowFocusChanged(true)
+          .get();
     } catch (ClassNotFoundException e) {
       throw new RuntimeException("Could not load activity " + ai.name, e);
     }


### PR DESCRIPTION
Fix ActivityController to invoke Instrumentation#callActivityOn* method properly on their lifecycle control methods such as #create, #pause, etc, instead of calling Activity#perform* directly. Those method should have invoked via Instrumentation. Note #start and #stop are the special case. Activity#performStart calls Instrumentation#callActivityOnStart internally so the dependency direction is the opposite.

Fix RoboMonitoringInstrumentation#startActivitySync to use ActivityController instead of calling callActivityOn* directly. Similarly, apply the same fix to LocalActivityInvoker.

Those changes indirectly fix an issue where AppCompatActivity#getLifecycle().getCurrentState() returns wrong value. This happens because the fragment transitions posted in Activity#onCreate weren't executed due to the above bug if you start Activity by Instrumentation#startActivitySync or indirectly from ActivityTestRule and ActivityScenario. This CL adds test case to ActivityScenarioTest to ensure it.

From Piper CL: 218766014

### Overview

### Proposed Changes
