### PR TITLE
Replace testCompile with testImplementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ If you'd like to start a new project with Robolectric tests you can refer to `de
 #### build.gradle:
 
 ```groovy
-testCompile "org.robolectric:robolectric:4.0"
+testImplementation "org.robolectric:robolectric:4.0"
+
 ```
 
 ## Building And Contributing
@@ -66,6 +67,6 @@ repositories {
 }
 
 dependencies {
-    testCompile "org.robolectric:robolectric:4.1-SNAPSHOT"
+    testImplementation "org.robolectric:robolectric:4.1-SNAPSHOT"
 }
 ```


### PR DESCRIPTION
`testCompile` was deprecated in Android Gradle Plugin 3.0.0.

Using `testCompile` in `build.gradle` now yields the following warning:
> Configuration 'testCompile' is obsolete and has been replaced with 'testImplementation' and 'testApi'.
> It will be removed at the end of 2018. For more information see:
> http://d.android.com/r/tools/update-dependency-configurations.html