### PR TITLE
Use ASM 7.0 to support class bytecode version 12 and Java 10+.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
 
-    implementation "org.ow2.asm:asm-tree:5.0.1"
+    implementation "org.ow2.asm:asm-tree:7.0"
 }

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -7,8 +7,8 @@ dependencies {
     api project(":utils")
     api project(":shadowapi")
 
-    api "org.ow2.asm:asm:6.0"
-    api "org.ow2.asm:asm-commons:6.0"
+    api "org.ow2.asm:asm:7.0"
+    api "org.ow2.asm:asm-commons:7.0"
     api "com.google.guava:guava:20.0"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 


### PR DESCRIPTION
Fixes #4085.