### PR TITLE
CTEsque ResourcesTest:

### DIFF
--- a/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
+++ b/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
@@ -287,7 +287,7 @@ public class ResourcesTest {
   }
 
   @Test
-  public void getDimensionPixelOffset() throws Exception {
+  public void getDimensionPixelOffset() {
     assertThat(resources.getDimensionPixelOffset(R.dimen.test_dip_dimen))
         .isEqualTo(convertDimension(COMPLEX_UNIT_DIP, 20));
     assertThat(resources.getDimensionPixelOffset(R.dimen.test_dp_dimen))
@@ -309,31 +309,40 @@ public class ResourcesTest {
   }
 
   @Test
-  public void getDimension_withReference() throws Exception {
+  public void getDimension_withReference() {
     assertThat(resources.getBoolean(R.bool.reference_to_true)).isEqualTo(true);
   }
 
   @Test(expected = Resources.NotFoundException.class)
-  public void getStringArray_shouldThrowExceptionIfNotFound() throws Exception {
+  public void getStringArray_shouldThrowExceptionIfNotFound() {
     resources.getStringArray(-1);
   }
 
   @Test(expected = Resources.NotFoundException.class)
-  public void getIntegerArray_shouldThrowExceptionIfNotFound() throws Exception {
+  public void getIntegerArray_shouldThrowExceptionIfNotFound() {
     resources.getIntArray(-1);
   }
 
   @Test
-  @Ignore("todo: incorrect behavior on robolectric vs framework?")
-  public void getQuantityString() throws Exception {
-    assertThat(resources.getQuantityString(R.plurals.beer, 0)).isEqualTo("Howdy");
-    assertThat(resources.getQuantityString(R.plurals.beer, 1)).isEqualTo("One beer");
-    assertThat(resources.getQuantityString(R.plurals.beer, 2)).isEqualTo("Two beers");
-    assertThat(resources.getQuantityString(R.plurals.beer, 3)).isEqualTo("%d beers, yay!");
+  public void getQuantityString() {
+    assertThat(resources.getQuantityString(R.plurals.beer, 1)).isEqualTo("a beer");
+    assertThat(resources.getQuantityString(R.plurals.beer, 2)).isEqualTo("some beers");
+    assertThat(resources.getQuantityString(R.plurals.beer, 3)).isEqualTo("some beers");
   }
 
   @Test
-  public void getFraction() throws Exception {
+  public void getQuantityText() {
+    // Feature not supported in legacy (raw) resource mode.
+    if (isRobolectricLegacyMode()) {
+      return;
+    }
+    assertThat(resources.getQuantityText(R.plurals.beer, 1)).isEqualTo("a beer");
+    assertThat(resources.getQuantityText(R.plurals.beer, 2)).isEqualTo("some beers");
+    assertThat(resources.getQuantityText(R.plurals.beer, 3)).isEqualTo("some beers");
+  }
+
+  @Test
+  public void getFraction() {
     final int myself = 300;
     final int myParent = 600;
     assertThat(resources.getFraction(R.fraction.half, myself, myParent)).isEqualTo(150f);
@@ -364,7 +373,7 @@ public class ResourcesTest {
   }
 
   @Test(expected = Resources.NotFoundException.class)
-  public void testGetDrawableNullRClass() throws Exception {
+  public void testGetDrawableNullRClass() {
     assertThat(resources.getDrawable(-12345)).isInstanceOf(BitmapDrawable.class);
   }
 
@@ -1044,6 +1053,7 @@ public class ResourcesTest {
   @SdkSuppress(minSdkVersion = O)
   @Config(minSdk = O)
   public void getFont() {
+    // Feature not supported in legacy (raw) resource mode.
     if (isRobolectricLegacyMode()) {
       return;
     }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -36,14 +36,6 @@ public class ShadowResourcesTest {
   }
 
   @Test
-  public void getQuantityString() throws Exception {
-    assertThat(resources.getQuantityString(R.plurals.beer, 0)).isEqualTo("beers");
-    assertThat(resources.getQuantityString(R.plurals.beer, 1)).isEqualTo("beer");
-    assertThat(resources.getQuantityString(R.plurals.beer, 2)).isEqualTo("beers");
-    assertThat(resources.getQuantityString(R.plurals.beer, 3)).isEqualTo("beers");
-  }
-
-  @Test
   @Config(qualifiers = "fr")
   public void testGetValuesResFromSpecificQualifiers() {
     assertThat(resources.getString(R.string.hello)).isEqualTo("Bonjour");

--- a/robolectric/src/test/resources/res/values/plurals.xml
+++ b/robolectric/src/test/resources/res/values/plurals.xml
@@ -5,10 +5,8 @@
     In us-en locale, only one and other plurals are used because there are only two possible
     variants: singular vs plural tense.
     -->
-    <item quantity="zero">unused</item>
-    <item quantity="one">beer</item>
-    <item quantity="two">unused</item>
-    <item quantity="other">beers</item>
+    <item quantity="one">a beer</item>
+    <item quantity="other">some beers</item>
   </plurals>
   <plurals name="minute">
     <item quantity="one">@string/minute_singular</item>

--- a/testapp/src/main/res/values/plurals.xml
+++ b/testapp/src/main/res/values/plurals.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <plurals name="beer">
-    <item quantity="zero">@string/howdy</item>
-    <item quantity="one">One beer</item>
-    <item quantity="two">Two beers</item>
-    <item quantity="other">%d beers, yay!</item>
+    <!--
+    In us-en locale, only one and other plurals are used because there are only two possible
+    variants: singular vs plural tense.
+    -->
+    <item quantity="one">a beer</item>
+    <item quantity="other">some beers</item>
   </plurals>
   <plurals name="minute">
     <item quantity="one">@string/minute_singular</item>


### PR DESCRIPTION
Enable commented out getQuantityString() and fix expectations.
Add getQuantityText() test - disabled for legacy mode, verifies https://github.com/robolectric/robolectric/issues/2288 on binary resource mode.
Create dedicated build target for ResourcesTest in legacy mode (Gradle still runs tests in both modes so this prevents breakages submitted internally

PiperOrigin-RevId: 219998098

### Overview

### Proposed Changes
