### PR TITLE
Fix enum value parsing to allow negative values

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/Converter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/Converter.java
@@ -270,7 +270,7 @@ public class Converter<T> {
         try {
           typedValue.data = findValueFor(data);
         } catch (Resources.NotFoundException e) {
-          typedValue.data = Integer.decode(data);
+          typedValue.data = convertInt(data);
         }
         typedValue.assetCookie = 0;
         typedValue.string = null;


### PR DESCRIPTION
Enumerated values that use a negative value are represented as an unsigned hex number. `Integer.decode()` fails to parse negative hex numbers, but the existing `convertInt()` method works.
