### PR TITLE
Fix many error prone warnings

### DIFF
--- a/buildSrc/src/main/groovy/AndroidSdk.groovy
+++ b/buildSrc/src/main/groovy/AndroidSdk.groovy
@@ -10,7 +10,7 @@ class AndroidSdk implements Comparable<AndroidSdk> {
     static final N_MR1 = new AndroidSdk(25, "7.1.0_r7", "r1")
     static final O = new AndroidSdk(26, "8.0.0_r4", "r1")
     static final O_MR1 = new AndroidSdk(27, "8.1.0", "4611349")
-    static final P = new AndroidSdk(28, "9", "4913185-2");
+    static final P = new AndroidSdk(28, "9", "4913185-2")
 
     static final List<AndroidSdk> ALL_SDKS = [
             JELLY_BEAN, JELLY_BEAN_MR1, JELLY_BEAN_MR2, KITKAT,

--- a/buildSrc/src/main/groovy/CheckApiChangesPlugin.groovy
+++ b/buildSrc/src/main/groovy/CheckApiChangesPlugin.groovy
@@ -89,9 +89,9 @@ class CheckApiChangesPlugin implements Plugin<Project> {
                         }
                     } else {
                         if (prevClassMethod.deprecated) {
-                            deprecatedNotRemoved << prevClassMethod;
+                            deprecatedNotRemoved << prevClassMethod
                         } else if (curClassMethod.deprecated) {
-                            newlyDeprecated << prevClassMethod;
+                            newlyDeprecated << prevClassMethod
                         }
 //                        println "changed: $classMethodName"
                     }
@@ -281,19 +281,19 @@ class CheckApiChangesPlugin implements Plugin<Project> {
             for (; i < chars.length;) {
                 def c = chars[i++]
                 switch (c) {
-                    case '(': break;
-                    case ')': buf = returnType; break;
-                    case '[': arrayDepth++; break;
-                    case 'Z': write('boolean'); break;
-                    case 'B': write('byte'); break;
-                    case 'S': write('short'); break;
-                    case 'I': write('int'); break;
-                    case 'J': write('long'); break;
-                    case 'F': write('float'); break;
-                    case 'D': write('double'); break;
-                    case 'C': write('char'); break;
-                    case 'L': readObj(); break;
-                    case 'V': write('void'); break;
+                    case '(': break
+                    case ')': buf = returnType; break
+                    case '[': arrayDepth++; break
+                    case 'Z': write('boolean'); break
+                    case 'B': write('byte'); break
+                    case 'S': write('short'); break
+                    case 'I': write('int'); break
+                    case 'J': write('long'); break
+                    case 'F': write('float'); break
+                    case 'D': write('double'); break
+                    case 'C': write('char'); break
+                    case 'L': readObj(); break
+                    case 'V': write('void'); break
                 }
             }
             "$methodAccessString ${isHiddenApi() ? "@HiddenApi " : ""}${isImplementation() ? "@Implementation " : ""}$methodNode.name(${args.toString()}): ${returnType.toString()}"

--- a/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
@@ -6,7 +6,7 @@ import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.JavaCompile
 
 class RoboJavaModulePlugin implements Plugin<Project> {
-    Boolean deploy = false;
+    Boolean deploy = false
 
     Closure doApply = {
         apply plugin: "java-library"
@@ -31,6 +31,13 @@ class RoboJavaModulePlugin implements Plugin<Project> {
                 }
                 compilerArgs << "-Xlint:-options"       // Turn off "missing" bootclasspath warning
                 encoding = "utf-8"                      // Make sure source encoding is UTF-8
+
+                errorprone {
+                    disableWarningsInGeneratedCode = true
+                    errorproneArgs << "-XepExcludedPaths:.*\\/org\\/robolectric\\/(res\\/android\\/.*|.*shadows\\/.*)"
+                    errorproneArgs << "-Xep:ThreadLocalUsage:OFF"
+                    errorproneArgs << "-Xep:CatchAndPrintStackTrace:OFF"
+                }
             }
 
             def noRebuild = System.getenv('NO_REBUILD') == "true"

--- a/errorprone/build.gradle
+++ b/errorprone/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.internal.jvm.Jvm
+
 new RoboJavaModulePlugin(
         deploy: true,
 ).apply(project)
@@ -16,16 +18,16 @@ dependencies {
     compile project(":annotations")
 
     // Compile dependencies
-    compile "com.google.errorprone:error_prone_annotation:2.3.2"
-    compile "com.google.errorprone:error_prone_refaster:2.3.2"
-    compile "com.google.errorprone:error_prone_check_api:2.3.2"
+    compile "com.google.errorprone:error_prone_annotation:$errorproneVersion"
+    compile "com.google.errorprone:error_prone_refaster:$errorproneVersion"
+    compile "com.google.errorprone:error_prone_check_api:$errorproneVersion"
     compile "com.google.auto.service:auto-service:1.0-rc4"
     compileOnly(AndroidSdk.MAX_SDK.coordinates) { force = true }
 
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc4"
 
     // in jdk 9, tools.jar disappears!
-    def toolsJar = org.gradle.internal.jvm.Jvm.current().getToolsJar()
+    def toolsJar = Jvm.current().getToolsJar()
     if (toolsJar != null) {
         compile files(toolsJar)
     }
@@ -33,7 +35,7 @@ dependencies {
     // Testing dependencies
     testCompile "junit:junit:4.12"
     testCompile "com.google.truth:truth:0.42"
-    testCompile("com.google.errorprone:error_prone_test_helpers:2.3.1") {
+    testCompile("com.google.errorprone:error_prone_test_helpers:$errorproneVersion") {
         exclude group: 'junit', module: 'junit' // because it depends on a snapshot!?
     }
 }

--- a/errorprone/src/main/java/org/robolectric/errorprone/bugpatterns/DeprecatedMethodsCheck.java
+++ b/errorprone/src/main/java/org/robolectric/errorprone/bugpatterns/DeprecatedMethodsCheck.java
@@ -110,7 +110,7 @@ public class DeprecatedMethodsCheck extends BugChecker implements ClassTreeMatch
           new AppGetLastMatcher(
               "org.robolectric.shadows.ShadowPopupMenu", "ShadowPopupMenu", "getLatestPopupMenu"));
 
-  abstract class MethodInvocationMatcher {
+  abstract static class MethodInvocationMatcher {
     abstract MethodNameMatcher matcher();
 
     abstract void replace(

--- a/errorprone/src/main/java/org/robolectric/errorprone/bugpatterns/ShadowUsageCheck.java
+++ b/errorprone/src/main/java/org/robolectric/errorprone/bugpatterns/ShadowUsageCheck.java
@@ -17,10 +17,8 @@ import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
-import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.SuggestedFix;
-import com.google.errorprone.fixes.SuggestedFix.Builder;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
@@ -92,7 +90,7 @@ import org.robolectric.errorprone.bugpatterns.Helpers.AnnotatedMethodMatcher;
     link = "http://robolectric.org/migrating/#improper-use-of-shadows",
     linkType = LinkType.CUSTOM,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
-public final class ShadowUsageCheck extends BugChecker implements ClassTreeMatcher {
+public final class ShadowUsageCheck extends BugChecker implements BugChecker.ClassTreeMatcher {
 
   /** Matches when the shadowOf method is used to obtain a shadow from an instrumented instance. */
   private static final Matcher<MethodInvocationTree> shadowStaticMatcher =
@@ -776,12 +774,12 @@ public final class ShadowUsageCheck extends BugChecker implements ClassTreeMatch
 
   static class PossibleFixes {
 
-    private final Builder fixBuilder;
+    private final SuggestedFix.Builder fixBuilder;
     private final JCCompilationUnit compilationUnit;
     private final Map<Tree, PossibleFix> map = new HashMap<>();
     private final List<PossibleFix> list = new ArrayList<>();
 
-    public PossibleFixes(Builder builder, JCCompilationUnit compilationUnit) {
+    public PossibleFixes(SuggestedFix.Builder builder, JCCompilationUnit compilationUnit) {
       fixBuilder = builder;
       this.compilationUnit = compilationUnit;
     }
@@ -847,7 +845,7 @@ public final class ShadowUsageCheck extends BugChecker implements ClassTreeMatch
         this.trace = new RuntimeException();
       }
 
-      abstract void applyFix(Builder fixBuilder);
+      abstract void applyFix(SuggestedFix.Builder fixBuilder);
 
       @Override
       public String toString() {
@@ -872,7 +870,7 @@ public final class ShadowUsageCheck extends BugChecker implements ClassTreeMatch
       }
 
       @Override
-      void applyFix(Builder fixBuilder) {
+      void applyFix(SuggestedFix.Builder fixBuilder) {
         fixBuilder.replace(tree, replaceWith);
       }
 
@@ -892,7 +890,7 @@ public final class ShadowUsageCheck extends BugChecker implements ClassTreeMatch
       }
 
       @Override
-      void applyFix(Builder fixBuilder) {
+      void applyFix(SuggestedFix.Builder fixBuilder) {
         fixBuilder.replace(startPosition, endPosition, replaceWith);
       }
 
@@ -909,7 +907,7 @@ public final class ShadowUsageCheck extends BugChecker implements ClassTreeMatch
       }
 
       @Override
-      void applyFix(Builder fixBuilder) {
+      void applyFix(SuggestedFix.Builder fixBuilder) {
         fixBuilder.delete(tree);
       }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ thisVersion=4.1-SNAPSHOT
 
 apiCompatVersion=3.8
 
-errorproneVersion=2.3.1
+errorproneVersion=2.3.2
 errorproneJavacVersion=9+181-r4173-1
 
 android.enableUnitTestBinaryResources=true

--- a/junit/src/main/java/org/robolectric/internal/SandboxTestRunner.java
+++ b/junit/src/main/java/org/robolectric/internal/SandboxTestRunner.java
@@ -164,9 +164,12 @@ public class SandboxTestRunner extends BlockJUnit4ClassRunner {
         .doNotAcquirePackage("org.junit.");
 
     String customPackages = System.getProperty("org.robolectric.packagesToNotAcquire", "");
-    for (String pkg : customPackages.split(",")) {
-      if (!pkg.isEmpty()) {
-        builder.doNotAcquirePackage(pkg);
+    String[] packages = customPackages.split(",", -1);
+    if (packages.length > 0) {
+      for (String pkg : packages) {
+        if (!pkg.isEmpty()) {
+          builder.doNotAcquirePackage(pkg);
+        }
       }
     }
 

--- a/processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
@@ -15,7 +15,6 @@ import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
-import org.robolectric.annotation.processing.RobolectricModel.Builder;
 import org.robolectric.annotation.processing.generator.Generator;
 import org.robolectric.annotation.processing.generator.JavadocJsonGenerator;
 import org.robolectric.annotation.processing.generator.ServiceLoaderGenerator;
@@ -31,18 +30,18 @@ import org.robolectric.annotation.processing.validator.Validator;
  * Annotation processor entry point for Robolectric annotations.
  */
 @SupportedOptions({
-  RobolectricProcessor.PACKAGE_OPT, 
+  RobolectricProcessor.PACKAGE_OPT,
   RobolectricProcessor.SHOULD_INSTRUMENT_PKG_OPT})
 @SupportedAnnotationTypes("org.robolectric.annotation.*")
 public class RobolectricProcessor extends AbstractProcessor {
   static final String PACKAGE_OPT = "org.robolectric.annotation.processing.shadowPackage";
-  static final String SHOULD_INSTRUMENT_PKG_OPT = 
+  static final String SHOULD_INSTRUMENT_PKG_OPT =
       "org.robolectric.annotation.processing.shouldInstrumentPackage";
   static final String JSON_DOCS_DIR = "org.robolectric.annotation.processing.jsonDocsDir";
   static final String SDK_CHECK_MODE =
       "org.robolectric.annotation.processing.sdkCheckMode";
 
-  private Builder modelBuilder;
+  private RobolectricModel.Builder modelBuilder;
   private String shadowPackage;
   private boolean shouldInstrumentPackages;
   private ImplementsValidator.SdkCheckMode sdkCheckMode;
@@ -75,7 +74,7 @@ public class RobolectricProcessor extends AbstractProcessor {
   public synchronized void init(ProcessingEnvironment environment) {
     super.init(environment);
     processOptions(environment.getOptions());
-    modelBuilder = new Builder(environment);
+    modelBuilder = new RobolectricModel.Builder(environment);
 
     addValidator(new ImplementationValidator(modelBuilder, environment));
     addValidator(new ImplementsValidator(modelBuilder, environment, sdkCheckMode));

--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementationValidator.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/ImplementationValidator.java
@@ -7,7 +7,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic.Kind;
-import org.robolectric.annotation.processing.RobolectricModel.Builder;
+import org.robolectric.annotation.processing.RobolectricModel;
 
 /**
  * Validator that checks usages of {@link org.robolectric.annotation.Implementation}.
@@ -20,7 +20,7 @@ public class ImplementationValidator extends FoundOnImplementsValidator {
           "equals"
       );
 
-  public ImplementationValidator(Builder modelBuilder, ProcessingEnvironment env) {
+  public ImplementationValidator(RobolectricModel.Builder modelBuilder, ProcessingEnvironment env) {
     super(modelBuilder, env, "org.robolectric.annotation.Implementation");
   }
 

--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/RealObjectValidator.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/RealObjectValidator.java
@@ -10,14 +10,14 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVisitor;
 import javax.lang.model.util.SimpleTypeVisitor6;
 import javax.tools.Diagnostic.Kind;
-import org.robolectric.annotation.processing.RobolectricModel.Builder;
+import org.robolectric.annotation.processing.RobolectricModel;
 
 /**
  * Validator that checks usages of {@link org.robolectric.annotation.RealObject}.
  */
 public class RealObjectValidator extends FoundOnImplementsValidator {
 
-  public RealObjectValidator(Builder modelBuilder, ProcessingEnvironment env) {
+  public RealObjectValidator(RobolectricModel.Builder modelBuilder, ProcessingEnvironment env) {
     super(modelBuilder, env, "org.robolectric.annotation.RealObject");
   }
 
@@ -33,7 +33,7 @@ public class RealObjectValidator extends FoundOnImplementsValidator {
     }
     return retval.toString();
   }
-  
+
   TypeVisitor<Void,VariableElement> typeVisitor = new SimpleTypeVisitor6<Void,VariableElement>() {
     @Override
     public Void visitDeclared(DeclaredType t, VariableElement v) {
@@ -51,12 +51,12 @@ public class RealObjectValidator extends FoundOnImplementsValidator {
       }
       return null;
     }
-    
-    
+
+
   };
-  
+
   TypeElement parent;
-  
+
   @Override
   public Void visitVariable(VariableElement elem, TypeElement parent) {
     this.parent = parent;

--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/SdkStore.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/SdkStore.java
@@ -385,25 +385,23 @@ class SdkStore {
       return new MethodInfo(name, paramTypes.size());
     }
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
+    @Override public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof MethodInfo)) return false;
+
       MethodInfo that = (MethodInfo) o;
-      return Objects.equals(name, that.name)
-          && Objects.equals(paramTypes, that.paramTypes);
+
+      if (name != null ? !name.equals(that.name) : that.name != null) return false;
+      return paramTypes != null ? paramTypes.equals(that.paramTypes) : that.paramTypes == null;
     }
 
-    @Override
-    public int hashCode() {
-      return Objects.hash(name, paramTypes);
+    @Override public int hashCode() {
+      int result = name != null ? name.hashCode() : 0;
+      result = 31 * result + (paramTypes != null ? paramTypes.hashCode() : 0);
+      return result;
     }
-    @Override
-    public String toString() {
+
+    @Override public String toString() {
       return "MethodInfo{"
           + "name='" + name + '\''
           + ", paramTypes=" + paramTypes
@@ -429,22 +427,20 @@ class SdkStore {
       this.returnType = typeWithoutGenerics(canonicalize(methodElement.getReturnType()));
     }
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
+    @Override public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof MethodExtraInfo)) return false;
+
       MethodExtraInfo that = (MethodExtraInfo) o;
-      return isStatic == that.isStatic &&
-          Objects.equals(returnType, that.returnType);
+
+      if (isStatic != that.isStatic) return false;
+      return returnType != null ? returnType.equals(that.returnType) : that.returnType == null;
     }
 
-    @Override
-    public int hashCode() {
-      return Objects.hash(isStatic, returnType);
+    @Override public int hashCode() {
+      int result = (isStatic ? 1 : 0);
+      result = 31 * result + (returnType != null ? returnType.hashCode() : 0);
+      return result;
     }
   }
 }

--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -17,6 +17,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.robolectric.UsesSdk;
 import org.robolectric.res.FsFile;
+import org.robolectric.res.ResName;
 import org.robolectric.res.ResourcePath;
 import org.robolectric.res.ResourceTable;
 import org.w3c.dom.Document;
@@ -518,7 +519,7 @@ public class AndroidManifest implements UsesSdk {
   }
 
   private String resolveClassRef(String maybePartialClassName) {
-    return (maybePartialClassName.startsWith(".")) ? packageName + maybePartialClassName : maybePartialClassName;
+    return maybePartialClassName.startsWith(".") ? packageName + maybePartialClassName : maybePartialClassName;
   }
 
   private List<Node> getChildrenTags(final Node node, final String tagName) {
@@ -713,9 +714,7 @@ public class AndroidManifest implements UsesSdk {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
+    if (!(o instanceof AndroidManifest)) return false;
 
     AndroidManifest that = (AndroidManifest) o;
 

--- a/resources/src/main/java/org/robolectric/res/FileFsFile.java
+++ b/resources/src/main/java/org/robolectric/res/FileFsFile.java
@@ -107,7 +107,7 @@ public class FileFsFile implements FsFile {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof FileFsFile)) return false;
 
     FileFsFile fsFile = (FileFsFile) o;
 

--- a/resources/src/main/java/org/robolectric/res/Fs.java
+++ b/resources/src/main/java/org/robolectric/res/Fs.java
@@ -26,7 +26,7 @@ abstract public class Fs {
   public static Fs fromJar(URL url) {
     return new JarFs(new File(fixFileURL(url).getPath()));
   }
-  
+
   private static URI fixFileURL(URL u) {
     if (!"file".equals(u.getProtocol())) {
       throw new IllegalArgumentException();
@@ -232,7 +232,7 @@ abstract public class Fs {
       @Override
       public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof JarFsFile)) return false;
 
         JarFsFile jarFsFile = (JarFsFile) o;
 

--- a/resources/src/main/java/org/robolectric/res/ResName.java
+++ b/resources/src/main/java/org/robolectric/res/ResName.java
@@ -110,7 +110,7 @@ public class ResName {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof ResName)) return false;
 
     ResName resName = (ResName) o;
 

--- a/resources/src/main/java/org/robolectric/res/ResourcePath.java
+++ b/resources/src/main/java/org/robolectric/res/ResourcePath.java
@@ -45,7 +45,7 @@ public class ResourcePath {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof ResourcePath)) return false;
 
     ResourcePath that = (ResourcePath) o;
 

--- a/resources/src/main/java/org/robolectric/res/ResourceRemapper.java
+++ b/resources/src/main/java/org/robolectric/res/ResourceRemapper.java
@@ -110,7 +110,7 @@ class ResourceRemapper {
         for (Field field : innerClass.getFields()) {
           if (field.getType().equals(int[].class)) {
             try {
-              int[] styleableArray = (int[]) (field.get(null));
+              int[] styleableArray = (int[]) field.get(null);
               for (int k = 0; k < styleableArray.length; k++) {
                 Integer value = resIds.get("attr/" + localAttributeIds.get(styleableArray[k]));
                 if (value != null) {

--- a/resources/src/main/java/org/robolectric/res/ResourceTableFactory.java
+++ b/resources/src/main/java/org/robolectric/res/ResourceTableFactory.java
@@ -88,7 +88,7 @@ public class ResourceTableFactory {
           if (field.getType().equals(int[].class) && Modifier.isStatic(field.getModifiers())) {
             styleableName = field.getName();
             try {
-              styleableArray = (int[]) (field.get(null));
+              styleableArray = (int[]) field.get(null);
             } catch (IllegalAccessException e) {
               throw new RuntimeException(e);
             }

--- a/resources/src/main/java/org/robolectric/res/StyleData.java
+++ b/resources/src/main/java/org/robolectric/res/StyleData.java
@@ -1,10 +1,8 @@
 package org.robolectric.res;
 
-import com.google.common.base.Strings;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.regex.Pattern;
 
 public class StyleData implements Style {
@@ -45,7 +43,7 @@ public class StyleData implements Style {
     // scheme.
     if (attributeResource == null && !"android".equals(resName.packageName) && !"android".equals(packageName)) {
       attributeResource = items.get(resName.withPackageName(packageName));
-      if (attributeResource != null && (!"android".equals(attributeResource.contextPackageName))) {
+      if (attributeResource != null && !"android".equals(attributeResource.contextPackageName)) {
         attributeResource = new AttributeResource(resName, attributeResource.value, resName.packageName);
       }
     }
@@ -72,27 +70,27 @@ public class StyleData implements Style {
     void visit(AttributeResource attributeResource);
   }
 
-  @Override
-  public boolean equals(Object obj) {
-    if (!(obj instanceof StyleData)) {
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof StyleData)) return false;
+
+    StyleData styleData = (StyleData) o;
+
+    if (packageName != null ? !packageName.equals(styleData.packageName)
+        : styleData.packageName != null) {
       return false;
     }
-    StyleData other = (StyleData) obj;
-
-    return Objects.equals(packageName, other.packageName)
-        && Objects.equals(name, other.name)
-        && Objects.equals(parent, other.parent)
-        && items.size() == other.items.size();
+    if (name != null ? !name.equals(styleData.name) : styleData.name != null) return false;
+    if (parent != null ? !parent.equals(styleData.parent) : styleData.parent != null) return false;
+    return items != null ? items.equals(styleData.items) : styleData.items == null;
   }
 
-  @Override
-  public int hashCode() {
-    int hashCode = 0;
-    hashCode = 31 * hashCode + Strings.nullToEmpty(packageName).hashCode();
-    hashCode = 31 * hashCode + Strings.nullToEmpty(name).hashCode();
-    hashCode = 31 * hashCode + Strings.nullToEmpty(parent).hashCode();
-    hashCode = 31 * hashCode + items.size();
-    return hashCode;
+  @Override public int hashCode() {
+    int result = packageName != null ? packageName.hashCode() : 0;
+    result = 31 * result + (name != null ? name.hashCode() : 0);
+    result = 31 * result + (parent != null ? parent.hashCode() : 0);
+    result = 31 * result + (items != null ? items.hashCode() : 0);
+    return result;
   }
 
   @Override public String toString() {

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -41,7 +41,6 @@ import org.robolectric.internal.SdkEnvironment;
 import org.robolectric.internal.ShadowProvider;
 import org.robolectric.internal.bytecode.ClassHandler;
 import org.robolectric.internal.bytecode.InstrumentationConfiguration;
-import org.robolectric.internal.bytecode.InstrumentationConfiguration.Builder;
 import org.robolectric.internal.bytecode.Interceptor;
 import org.robolectric.internal.bytecode.Sandbox;
 import org.robolectric.internal.bytecode.SandboxClassLoader;
@@ -218,8 +217,8 @@ public class RobolectricTestRunner extends SandboxTestRunner {
    * @return an {@link InstrumentationConfiguration}
    */
   @Override @Nonnull
-  protected InstrumentationConfiguration createClassLoaderConfig(final FrameworkMethod method) {
-    Builder builder = new Builder(super.createClassLoaderConfig(method));
+  protected InstrumentationConfiguration createClassLoaderConfig(FrameworkMethod method) {
+    InstrumentationConfiguration.Builder builder = new InstrumentationConfiguration.Builder(super.createClassLoaderConfig(method));
     AndroidConfigurer.configure(builder, getInterceptors());
     AndroidConfigurer.withConfig(builder, ((RobolectricFrameworkMethod) method).config);
     return builder.build();
@@ -668,7 +667,7 @@ public class RobolectricTestRunner extends SandboxTestRunner {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
+      if (!(o instanceof RobolectricFrameworkMethod)) return false;
       if (!super.equals(o)) return false;
 
       RobolectricFrameworkMethod that = (RobolectricFrameworkMethod) o;

--- a/robolectric/src/main/java/org/robolectric/android/AttributeSetBuilderImpl.java
+++ b/robolectric/src/main/java/org/robolectric/android/AttributeSetBuilderImpl.java
@@ -289,7 +289,7 @@ public class AttributeSetBuilderImpl implements AttributeSetBuilder {
           } else {
             String attrNameStr = resourceResolver.getResourceName(attrId);
             attrResName = ResName.qualifyResName(attrNameStr, packageName, "attr");
-            attrNs = (attrResName.packageName.equals("android")) ? ANDROID_NS : AUTO_NS;
+            attrNs = attrResName.packageName.equals("android") ? ANDROID_NS : AUTO_NS;
             attrName = attrResName.name;
           }
 

--- a/robolectric/src/main/java/org/robolectric/android/internal/ParallelUniverse.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/ParallelUniverse.java
@@ -3,7 +3,6 @@ package org.robolectric.android.internal;
 import static android.location.LocationManager.GPS_PROVIDER;
 import static android.os.Build.VERSION_CODES.P;
 import static org.robolectric.shadow.api.Shadow.newInstanceOf;
-import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 import android.annotation.SuppressLint;
 import android.app.ActivityThread;
@@ -61,6 +60,7 @@ import org.robolectric.shadows.ShadowPackageManager;
 import org.robolectric.shadows.ShadowPackageParser;
 import org.robolectric.util.PerfStatsCollector;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
 import org.robolectric.util.Scheduler;
 import org.robolectric.util.TempDirectory;
 
@@ -198,7 +198,7 @@ public class ParallelUniverse implements ParallelUniverseInterface {
     systemResources.updateConfiguration(configuration, displayMetrics);
 
     Context systemContextImpl = ReflectionHelpers.callStaticMethod(contextImplClass,
-        "createSystemContext", from(ActivityThread.class, activityThread));
+        "createSystemContext", ClassParameter.from(ActivityThread.class, activityThread));
     RuntimeEnvironment.systemContext = systemContextImpl;
 
     Application application = createApplication(appManifest, config);
@@ -351,20 +351,20 @@ public class ParallelUniverse implements ParallelUniverseInterface {
             applicationInfo.packageName, androidInstrumentation.getClass().getSimpleName());
     if (RuntimeEnvironment.getApiLevel() <= VERSION_CODES.JELLY_BEAN_MR1) {
       ReflectionHelpers.callInstanceMethod(androidInstrumentation, "init",
-          from(ActivityThread.class, activityThread),
-          from(Context.class, application),
-          from(Context.class, application),
-          from(ComponentName.class, component),
-          from(IInstrumentationWatcher.class, null));
+          ClassParameter.from(ActivityThread.class, activityThread),
+          ClassParameter.from(Context.class, application),
+          ClassParameter.from(Context.class, application),
+          ClassParameter.from(ComponentName.class, component),
+          ClassParameter.from(IInstrumentationWatcher.class, null));
     } else {
       ReflectionHelpers.callInstanceMethod(androidInstrumentation,
           "init",
-          from(ActivityThread.class, activityThread),
-          from(Context.class, application),
-          from(Context.class, application),
-          from(ComponentName.class, component),
-          from(IInstrumentationWatcher.class, null),
-          from(IUiAutomationConnection.class, null));
+          ClassParameter.from(ActivityThread.class, activityThread),
+          ClassParameter.from(Context.class, application),
+          ClassParameter.from(Context.class, application),
+          ClassParameter.from(ComponentName.class, component),
+          ClassParameter.from(IInstrumentationWatcher.class, null),
+          ClassParameter.from(IUiAutomationConnection.class, null));
     }
 
     return androidInstrumentation;

--- a/robolectric/src/main/java/org/robolectric/internal/ManifestIdentifier.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ManifestIdentifier.java
@@ -88,7 +88,7 @@ public class ManifestIdentifier {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof ManifestIdentifier)) {
       return false;
     }
 

--- a/robolectric/src/main/java/org/robolectric/internal/SandboxFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SandboxFactory.java
@@ -72,7 +72,7 @@ public class SandboxFactory {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SandboxKey)) {
         return false;
       }
       SandboxKey that = (SandboxKey) o;

--- a/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
@@ -79,7 +79,7 @@ public class SdkConfig implements Comparable<SdkConfig> {
 
   @Override
   public boolean equals(Object that) {
-    return that == this || (that instanceof SdkConfig && ((SdkConfig) that).apiLevel == (apiLevel));
+    return that == this || (that instanceof SdkConfig && ((SdkConfig) that).apiLevel == apiLevel);
   }
 
   @Override

--- a/sandbox/src/main/java/org/robolectric/JarInstrumentor.java
+++ b/sandbox/src/main/java/org/robolectric/JarInstrumentor.java
@@ -146,7 +146,7 @@ public class JarInstrumentor {
   }
 
   private static InstrumentationConfiguration createInstrumentationConfiguration() {
-    Builder builder =
+    InstrumentationConfiguration.Builder builder =
         InstrumentationConfiguration.newBuilder()
             .doNotAcquirePackage("java.")
             .doNotAcquirePackage("sun.")

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassInstrumentor.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassInstrumentor.java
@@ -185,7 +185,7 @@ public abstract class ClassInstrumentor {
   private void doSpecialHandling(MutableClass mutableClass) {
     if (mutableClass.getName().equals("android.os.Build$VERSION")) {
       for (FieldNode fieldNode : mutableClass.getFields()) {
-        fieldNode.access &= ~(Modifier.FINAL);
+        fieldNode.access &= ~Modifier.FINAL;
       }
     }
   }

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
@@ -86,8 +86,8 @@ public class InstrumentationConfiguration {
         && (isInInstrumentedPackage(mutableClass.getName())
             || instrumentedClasses.contains(mutableClass.getName())
             || mutableClass.hasAnnotation(Instrument.class))
-        && !(classesToNotInstrument.contains(mutableClass.getName()))
-        && !(isInPackagesToNotInstrument(mutableClass.getName()));
+        && !classesToNotInstrument.contains(mutableClass.getName())
+        && !isInPackagesToNotInstrument(mutableClass.getName());
   }
 
   /**
@@ -173,7 +173,7 @@ public class InstrumentationConfiguration {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof InstrumentationConfiguration)) return false;
 
     InstrumentationConfiguration that = (InstrumentationConfiguration) o;
 

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/MethodRef.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/MethodRef.java
@@ -19,7 +19,7 @@ public class MethodRef {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof MethodRef)) return false;
 
     MethodRef methodRef = (MethodRef) o;
 

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/RobolectricGeneratorAdapter.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/RobolectricGeneratorAdapter.java
@@ -39,6 +39,7 @@ class RobolectricGeneratorAdapter extends GeneratorAdapter {
     visitInsn(Opcodes.ACONST_NULL);
   }
 
+  @Override
   public Type getReturnType() {
     return Type.getReturnType(desc);
   }

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/SandboxClassLoader.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/SandboxClassLoader.java
@@ -2,7 +2,6 @@ package org.robolectric.internal.bytecode;
 
 import static com.google.common.base.StandardSystemProperty.JAVA_CLASS_PATH;
 import static com.google.common.base.StandardSystemProperty.PATH_SEPARATOR;
-import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -15,6 +14,7 @@ import java.net.URLClassLoader;
 import org.robolectric.util.Logger;
 import org.robolectric.util.PerfStatsCollector;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
 import org.robolectric.util.Util;
 
 /**
@@ -153,7 +153,7 @@ public class SandboxClassLoader extends URLClassLoader {
     }
 
     return ReflectionHelpers.callInstanceMethod(systemClassLoader, "getPackage",
-        from(String.class, name));
+        ClassParameter.from(String.class, name));
   }
 
   protected byte[] getByteCode(String className) throws ClassNotFoundException {
@@ -169,7 +169,7 @@ public class SandboxClassLoader extends URLClassLoader {
     }
   }
 
-  private void ensurePackage(final String className) {
+  private void ensurePackage(String className) {
     int lastDotIndex = className.lastIndexOf('.');
     if (lastDotIndex != -1) {
       String pckgName = className.substring(0, lastDotIndex);

--- a/shadows/framework/src/main/java/org/robolectric/android/controller/ActivityController.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/controller/ActivityController.java
@@ -3,7 +3,6 @@ package org.robolectric.android.controller;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.O_MR1;
 import static org.robolectric.shadow.api.Shadow.extract;
-import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 import android.app.Activity;
 import android.app.ActivityThread;
@@ -22,6 +21,7 @@ import org.robolectric.shadows.ShadowActivity;
 import org.robolectric.shadows.ShadowContextThemeWrapper;
 import org.robolectric.shadows.ShadowViewRootImpl;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 public class ActivityController<T extends Activity> extends ComponentController<ActivityController<T>, T> {
 
@@ -70,8 +70,8 @@ public class ActivityController<T extends Activity> extends ComponentController<
       invokeWhilePaused("performRestart");
     } else {
       invokeWhilePaused("performRestart",
-          from(boolean.class, true),
-          from(String.class, "restart()"));
+          ClassParameter.from(boolean.class, true),
+          ClassParameter.from(String.class, "restart()"));
     }
     return this;
   }
@@ -83,7 +83,7 @@ public class ActivityController<T extends Activity> extends ComponentController<
     if (RuntimeEnvironment.getApiLevel() <= O_MR1) {
       invokeWhilePaused("performStart");
     } else {
-      invokeWhilePaused("performStart", from(String.class, "start()"));
+      invokeWhilePaused("performStart", ClassParameter.from(String.class, "start()"));
     }
     return this;
   }
@@ -95,7 +95,7 @@ public class ActivityController<T extends Activity> extends ComponentController<
   }
 
   public ActivityController<T> postCreate(Bundle bundle) {
-    invokeWhilePaused("onPostCreate", from(Bundle.class, bundle));
+    invokeWhilePaused("onPostCreate", ClassParameter.from(Bundle.class, bundle));
     return this;
   }
 
@@ -104,8 +104,8 @@ public class ActivityController<T extends Activity> extends ComponentController<
       invokeWhilePaused("performResume");
     } else {
       invokeWhilePaused("performResume",
-          from(boolean.class, true),
-          from(String.class, "resume()"));
+          ClassParameter.from(boolean.class, true),
+          ClassParameter.from(String.class, "resume()"));
     }
     return this;
   }
@@ -138,8 +138,8 @@ public class ActivityController<T extends Activity> extends ComponentController<
     ViewRootImpl root = component.getWindow().getDecorView().getViewRootImpl();
 
     ReflectionHelpers.callInstanceMethod(root, "windowFocusChanged",
-        from(boolean.class, hasFocus), /* hasFocus */
-        from(boolean.class, false) /* inTouchMode */);
+        ClassParameter.from(boolean.class, hasFocus), /* hasFocus */
+        ClassParameter.from(boolean.class, false) /* inTouchMode */);
     return this;
   }
 
@@ -166,9 +166,9 @@ public class ActivityController<T extends Activity> extends ComponentController<
     if (RuntimeEnvironment.getApiLevel() <= M) {
       invokeWhilePaused("performStop");
     } else if (RuntimeEnvironment.getApiLevel() <= O_MR1) {
-      invokeWhilePaused("performStop", from(boolean.class, true));
+      invokeWhilePaused("performStop", ClassParameter.from(boolean.class, true));
     } else {
-      invokeWhilePaused("performStop", from(boolean.class, true), from(String.class, "stop()"));
+      invokeWhilePaused("performStop", ClassParameter.from(boolean.class, true), ClassParameter.from(String.class, "stop()"));
     }
     return this;
   }
@@ -203,7 +203,7 @@ public class ActivityController<T extends Activity> extends ComponentController<
   }
 
   public ActivityController<T> newIntent(Intent intent) {
-    invokeWhilePaused("onNewIntent", from(Intent.class, intent));
+    invokeWhilePaused("onNewIntent", ClassParameter.from(Intent.class, intent));
     return this;
   }
 
@@ -246,7 +246,7 @@ public class ActivityController<T extends Activity> extends ComponentController<
         @Override
         public void run() {
           ReflectionHelpers.callInstanceMethod(Activity.class, component, "onConfigurationChanged",
-            from(Configuration.class, newConfiguration));
+              ClassParameter.from(Configuration.class, newConfiguration));
         }
       });
 
@@ -275,19 +275,19 @@ public class ActivityController<T extends Activity> extends ComponentController<
                   Activity.class,
                   component,
                   "performSaveInstanceState",
-                  from(Bundle.class, outState));
+                  ClassParameter.from(Bundle.class, outState));
               if (RuntimeEnvironment.getApiLevel() <= M) {
                 ReflectionHelpers.callInstanceMethod(Activity.class, component, "performStop");
               } else if (RuntimeEnvironment.getApiLevel() <= O_MR1) {
                 ReflectionHelpers.callInstanceMethod(
-                    Activity.class, component, "performStop", from(boolean.class, true));
+                    Activity.class, component, "performStop", ClassParameter.from(boolean.class, true));
               } else {
                 ReflectionHelpers.callInstanceMethod(
                     Activity.class,
                     component,
                     "performStop",
-                    from(boolean.class, true),
-                    from(String.class, "configurationChange"));
+                    ClassParameter.from(boolean.class, true),
+                    ClassParameter.from(String.class, "configurationChange"));
               }
 
               // This is the true and complete retained state, including loaders and retained
@@ -326,7 +326,7 @@ public class ActivityController<T extends Activity> extends ComponentController<
 
               // Create lifecycle
               ReflectionHelpers.callInstanceMethod(
-                  Activity.class, recreatedActivity, "performCreate", from(Bundle.class, outState));
+                  Activity.class, recreatedActivity, "performCreate", ClassParameter.from(Bundle.class, outState));
 
               if (RuntimeEnvironment.getApiLevel() <= O_MR1) {
 
@@ -338,16 +338,16 @@ public class ActivityController<T extends Activity> extends ComponentController<
                     Activity.class,
                     recreatedActivity,
                     "performStart",
-                    from(String.class, "configurationChange"));
+                    ClassParameter.from(String.class, "configurationChange"));
               }
 
               ReflectionHelpers.callInstanceMethod(
                   Activity.class,
                   recreatedActivity,
                   "performRestoreInstanceState",
-                  from(Bundle.class, outState));
+                  ClassParameter.from(Bundle.class, outState));
               ReflectionHelpers.callInstanceMethod(
-                  Activity.class, recreatedActivity, "onPostCreate", from(Bundle.class, outState));
+                  Activity.class, recreatedActivity, "onPostCreate", ClassParameter.from(Bundle.class, outState));
               if (RuntimeEnvironment.getApiLevel() <= O_MR1) {
                 ReflectionHelpers.callInstanceMethod(
                     Activity.class, recreatedActivity, "performResume");
@@ -356,8 +356,8 @@ public class ActivityController<T extends Activity> extends ComponentController<
                     Activity.class,
                     recreatedActivity,
                     "performResume",
-                    from(boolean.class, true),
-                    from(String.class, "configurationChange"));
+                    ClassParameter.from(boolean.class, true),
+                    ClassParameter.from(String.class, "configurationChange"));
               }
               ReflectionHelpers.callInstanceMethod(
                   Activity.class, recreatedActivity, "onPostResume");

--- a/shadows/framework/src/main/java/org/robolectric/android/controller/IntentServiceController.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/controller/IntentServiceController.java
@@ -1,7 +1,5 @@
 package org.robolectric.android.controller;
 
-import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
-
 import android.app.ActivityThread;
 import android.app.Application;
 import android.app.IntentService;
@@ -11,6 +9,7 @@ import android.content.Intent;
 import android.os.IBinder;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 public class IntentServiceController<T extends IntentService> extends ComponentController<IntentServiceController<T>, T> {
 
@@ -30,19 +29,19 @@ public class IntentServiceController<T extends IntentService> extends ComponentC
     }
 
     ReflectionHelpers.callInstanceMethod(Service.class, component, "attach",
-       from(Context.class, RuntimeEnvironment.application.getBaseContext()),
-       from(ActivityThread.class, null),
-       from(String.class, component.getClass().getSimpleName()),
-       from(IBinder.class, null),
-       from(Application.class, RuntimeEnvironment.application),
-       from(Object.class, null));
+       ClassParameter.from(Context.class, RuntimeEnvironment.application.getBaseContext()),
+       ClassParameter.from(ActivityThread.class, null),
+       ClassParameter.from(String.class, component.getClass().getSimpleName()),
+       ClassParameter.from(IBinder.class, null),
+       ClassParameter.from(Application.class, RuntimeEnvironment.application),
+       ClassParameter.from(Object.class, null));
 
     attached = true;
     return this;
   }
 
   public IntentServiceController<T> bind() {
-    invokeWhilePaused("onBind", from(Intent.class, getIntent()));
+    invokeWhilePaused("onBind", ClassParameter.from(Intent.class, getIntent()));
     return this;
   }
 
@@ -57,7 +56,7 @@ public class IntentServiceController<T extends IntentService> extends ComponentC
   }
 
   public IntentServiceController<T> rebind() {
-    invokeWhilePaused("onRebind", from(Intent.class, getIntent()));
+    invokeWhilePaused("onRebind", ClassParameter.from(Intent.class, getIntent()));
     return this;
   }
 
@@ -68,12 +67,12 @@ public class IntentServiceController<T extends IntentService> extends ComponentC
   }
 
   public IntentServiceController<T> unbind() {
-    invokeWhilePaused("onUnbind", from(Intent.class, getIntent()));
+    invokeWhilePaused("onUnbind", ClassParameter.from(Intent.class, getIntent()));
     return this;
   }
 
   public IntentServiceController<T> handleIntent() {
-    invokeWhilePaused("onHandleIntent", from(Intent.class, getIntent()));
+    invokeWhilePaused("onHandleIntent", ClassParameter.from(Intent.class, getIntent()));
     return this;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/android/controller/ServiceController.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/controller/ServiceController.java
@@ -1,7 +1,5 @@
 package org.robolectric.android.controller;
 
-import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
-
 import android.app.ActivityThread;
 import android.app.Application;
 import android.app.Service;
@@ -10,6 +8,7 @@ import android.content.Intent;
 import android.os.IBinder;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 public class ServiceController<T extends Service> extends ComponentController<ServiceController<T>, T> {
 
@@ -29,19 +28,19 @@ public class ServiceController<T extends Service> extends ComponentController<Se
     }
 
     ReflectionHelpers.callInstanceMethod(Service.class, component, "attach",
-        from(Context.class, RuntimeEnvironment.application.getBaseContext()),
-        from(ActivityThread.class, null),
-        from(String.class, component.getClass().getSimpleName()),
-        from(IBinder.class, null),
-        from(Application.class, RuntimeEnvironment.application),
-        from(Object.class, null));
+        ClassParameter.from(Context.class, RuntimeEnvironment.application.getBaseContext()),
+        ClassParameter.from(ActivityThread.class, null),
+        ClassParameter.from(String.class, component.getClass().getSimpleName()),
+        ClassParameter.from(IBinder.class, null),
+        ClassParameter.from(Application.class, RuntimeEnvironment.application),
+        ClassParameter.from(Object.class, null));
 
     attached = true;
     return this;
   }
 
   public ServiceController<T> bind() {
-    invokeWhilePaused("onBind", from(Intent.class, getIntent()));
+    invokeWhilePaused("onBind", ClassParameter.from(Intent.class, getIntent()));
     return this;
   }
 
@@ -56,17 +55,17 @@ public class ServiceController<T extends Service> extends ComponentController<Se
   }
 
   public ServiceController<T> rebind() {
-    invokeWhilePaused("onRebind", from(Intent.class, getIntent()));
+    invokeWhilePaused("onRebind", ClassParameter.from(Intent.class, getIntent()));
     return this;
   }
 
   public ServiceController<T> startCommand(int flags, int startId) {
-    invokeWhilePaused("onStartCommand", from(Intent.class, getIntent()), from(int.class, flags), from(int.class, startId));
+    invokeWhilePaused("onStartCommand", ClassParameter.from(Intent.class, getIntent()), ClassParameter.from(int.class, flags), ClassParameter.from(int.class, startId));
     return this;
   }
 
   public ServiceController<T> unbind() {
-    invokeWhilePaused("onUnbind", from(Intent.class, getIntent()));
+    invokeWhilePaused("onUnbind", ClassParameter.from(Intent.class, getIntent()));
     return this;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/android/internal/DisplayConfig.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/internal/DisplayConfig.java
@@ -454,6 +454,7 @@ public final class DisplayConfig {
   }
 
   // For debugging purposes
+  @SuppressWarnings("ObjectToString")
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/shadows/framework/src/main/java/org/robolectric/fakes/RoboMenu.java
+++ b/shadows/framework/src/main/java/org/robolectric/fakes/RoboMenu.java
@@ -183,7 +183,7 @@ public class RoboMenu implements Menu {
   public RoboMenuItem findMenuItem(CharSequence title) {
     for (int i = 0; i < size(); i++) {
       RoboMenuItem menuItem = (RoboMenuItem) getItem(i);
-      if (menuItem.getTitle().equals(title)) {
+      if (menuItem.getTitle().toString().equals(title.toString())) {
         return menuItem;
       }
     }
@@ -193,7 +193,7 @@ public class RoboMenu implements Menu {
   public RoboMenuItem findMenuItemContaining(CharSequence desiredText) {
     for (int i = 0; i < size(); i++) {
       RoboMenuItem menuItem = (RoboMenuItem) getItem(i);
-      if (menuItem.getTitle().toString().contains(desiredText)) {
+      if (menuItem.getTitle().toString().contains(desiredText.toString())) {
         return menuItem;
       }
     }
@@ -204,13 +204,7 @@ public class RoboMenu implements Menu {
 
     @Override
     public int compare(MenuItem a, MenuItem b) {
-      if (a.getOrder() == b.getOrder()) {
-        return 0;
-      } else if (a.getOrder() > b.getOrder()) {
-        return 1;
-      } else {
-        return -1;
-      }
+      return Integer.compare(a.getOrder(), b.getOrder());
     }
   }
 }

--- a/utils/src/main/java/org/robolectric/util/PerfStatsCollector.java
+++ b/utils/src/main/java/org/robolectric/util/PerfStatsCollector.java
@@ -181,7 +181,7 @@ public class PerfStatsCollector {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Metric)) {
         return false;
       }
 
@@ -236,7 +236,7 @@ public class PerfStatsCollector {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof MetricKey)) {
         return false;
       }
 


### PR DESCRIPTION
## Warnings fixed:
- EqualsGetClass
- UnnecessaryParentheses
- StringSplitter
- CatchAndPrintStackTrace
- BadImport
- MissingOverride
- ThreadLocalUsage

@xian @jongerrish 