### PR TITLE
Fix confusing error message when application.onCreate fails.

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -391,13 +391,7 @@ public class RobolectricTestRunner extends SandboxTestRunner {
     try {
       roboMethod.parallelUniverseInterface.tearDownApplication();
     } finally {
-      try {
-        internalAfterTest(method, bootstrappedMethod);
-      } finally {
-        // reset static state afterward too, so statics don't defeat GC?
-        PerfStatsCollector.getInstance().measure("reset Android state (after test)",
-            () -> resetStaticState());
-      }
+      internalAfterTest(method, bootstrappedMethod);
     }
   }
 
@@ -409,10 +403,15 @@ public class RobolectricTestRunner extends SandboxTestRunner {
 
   @Override
   protected void finallyAfterTest(FrameworkMethod method) {
-    RobolectricFrameworkMethod roboMethod = (RobolectricFrameworkMethod) method;
-
-    roboMethod.testLifecycle = null;
-    roboMethod.parallelUniverseInterface = null;
+    try {
+      // reset static state afterward too, so statics don't defeat GC?
+      PerfStatsCollector.getInstance().measure("reset Android state (after test)",
+          this::resetStaticState);
+    } finally {
+      RobolectricFrameworkMethod roboMethod = (RobolectricFrameworkMethod) method;
+      roboMethod.testLifecycle = null;
+      roboMethod.parallelUniverseInterface = null;
+    }
   }
 
   @Override protected SandboxTestRunner.HelperTestRunner getHelperTestRunner(Class bootstrappedTestClass) {


### PR DESCRIPTION
Future tests shouldn't fail with "IllegalStateException: this method should only be called by Robolectric".

Fixes #4235.