### PR TITLE
Ignore ctesque tests failing in legacy mode.

### DIFF
--- a/integration_tests/androidx/build.gradle
+++ b/integration_tests/androidx/build.gradle
@@ -13,11 +13,9 @@ android {
         targetCompatibility = '1.8'
     }
 
-    android {
-        testOptions {
-            unitTests {
-                includeAndroidResources = true
-            }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
         }
     }
 
@@ -43,5 +41,4 @@ dependencies {
     testImplementation("androidx.lifecycle:lifecycle-common:2.0.0")
     testImplementation("androidx.test.ext:junit:1.1.0")
     testImplementation("com.google.truth:truth:0.42")
-
 }

--- a/integration_tests/ctesque/build.gradle
+++ b/integration_tests/ctesque/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
+    
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 28
@@ -10,6 +11,7 @@ android {
     lintOptions {
         abortOnError false
     }
+    
     testOptions {
         unitTests {
             includeAndroidResources = true
@@ -21,7 +23,7 @@ android {
         targetCompatibility 1.8
     }
 
-    defaultConfig  {
+    defaultConfig {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 }


### PR DESCRIPTION
Not sure why `integration_tests:ctesque:test` runs in legacy mode. The tests pass in binary mode. Disabling for now.