### PR TITLE
CircleCi optimizations.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
           name: Build
-          command: SKIP_JAVADOC=true ./gradlew clean assemble --parallel --stacktrace
+          command: SKIP_JAVADOC=true ./gradlew clean assemble testClasses --parallel --stacktrace
       - persist_to_workspace:
           root: ~/code
           paths:
@@ -58,8 +58,10 @@ jobs:
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=16,17,18,19 \
-                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true
+                -Drobolectric.enabledSdks=16,17,18 \
+                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+                -Dorg.gradle.workers.max=2
+
       - run:
           name: Collect Test Results
           command: |
@@ -86,8 +88,9 @@ jobs:
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=21,22,23 \
-                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true
+                -Drobolectric.enabledSdks=19,21,22 \
+                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+                -Dorg.gradle.workers.max=2
       - run:
           name: Collect Test Results
           command: |
@@ -114,8 +117,10 @@ jobs:
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=24,25,26 \
-                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true
+                -Drobolectric.enabledSdks=23,24,25 \
+                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+                -Dorg.gradle.workers.max=2
+
       - run:
           name: Collect Test Results
           command: |
@@ -142,8 +147,10 @@ jobs:
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=27,28,10000 \
-                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true
+                -Drobolectric.enabledSdks=26,27,28,10000 \
+                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+                -Dorg.gradle.workers.max=2
+
       - run:
           name: Collect Test Results
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ jobs:
                 -Drobolectric.enabledSdks=16,17,18 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
-
       - run:
           name: Collect Test Results
           command: |
@@ -120,7 +119,6 @@ jobs:
                 -Drobolectric.enabledSdks=23,24,25 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
-
       - run:
           name: Collect Test Results
           command: |
@@ -150,7 +148,6 @@ jobs:
                 -Drobolectric.enabledSdks=26,27,28,10000 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
-
       - run:
           name: Collect Test Results
           command: |


### PR DESCRIPTION
- assemble tests too in build phase
- Limit to 2 gradle workers for test jobs
- Redistribute SDKs to effectively 3 SDKs per test job

