### PR TITLE
CircleCI: Distribute tests into 5 jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
             - ".cache-hash"
             - "[a-zA-Z]*" # not .git
 
-  test_1:
+  test_16:
     << : *job_config
     steps:
       - attach_workspace:
@@ -52,13 +52,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 1/6
+          name: Test 16
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=16,17 \
+                -Drobolectric.enabledSdks=16 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -73,7 +73,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_2:
+  test_17:
     << : *job_config
     steps:
       - attach_workspace:
@@ -81,13 +81,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 2/6
+          name: Test 17
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=18,19 \
+                -Drobolectric.enabledSdks=17 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -102,7 +102,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_3:
+  test_18:
     << : *job_config
     steps:
       - attach_workspace:
@@ -110,13 +110,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 3/6
+          name: Test 18
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=21,22 \
+                -Drobolectric.enabledSdks=18 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -131,7 +131,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_4:
+  test_19:
     << : *job_config
     steps:
       - attach_workspace:
@@ -139,13 +139,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 4/6
+          name: Test 19
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=23,24 \
+                -Drobolectric.enabledSdks=19 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -160,7 +160,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_5:
+  test_21:
     << : *job_config
     steps:
       - attach_workspace:
@@ -168,13 +168,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 5/6
+          name: Test 21
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=25,26 \
+                -Drobolectric.enabledSdks=21 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -189,7 +189,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_6:
+  test_22:
     << : *job_config
     steps:
       - attach_workspace:
@@ -197,13 +197,187 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 6/6
+          name: Test 22
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=27,28,10000 \
+                -Drobolectric.enabledSdks=22 \
+                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+                -Dorg.gradle.workers.max=2
+      - run:
+          name: Collect Test Results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: build/reports
+          destination: reports
+
+  test_23:
+    << : *job_config
+    steps:
+      - attach_workspace:
+          at: ~/code
+      - restore_cache:
+          key: cache-{{ checksum ".cache-hash" }}
+      - run:
+          name: Test 23
+          command: |
+            GRADLE_MAX_PARALLEL_FORKS=2 \
+                SKIP_JAVADOC=true \
+                ./gradlew test --info --stacktrace --continue \
+                --parallel \
+                -Drobolectric.enabledSdks=23 \
+                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+                -Dorg.gradle.workers.max=2
+      - run:
+          name: Collect Test Results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: build/reports
+          destination: reports
+
+  test_24:
+    << : *job_config
+    steps:
+      - attach_workspace:
+          at: ~/code
+      - restore_cache:
+          key: cache-{{ checksum ".cache-hash" }}
+      - run:
+          name: Test 24
+          command: |
+            GRADLE_MAX_PARALLEL_FORKS=2 \
+                SKIP_JAVADOC=true \
+                ./gradlew test --info --stacktrace --continue \
+                --parallel \
+                -Drobolectric.enabledSdks=24 \
+                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+                -Dorg.gradle.workers.max=2
+      - run:
+          name: Collect Test Results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: build/reports
+          destination: reports
+
+  test_25:
+    << : *job_config
+    steps:
+      - attach_workspace:
+          at: ~/code
+      - restore_cache:
+          key: cache-{{ checksum ".cache-hash" }}
+      - run:
+          name: Test 25
+          command: |
+            GRADLE_MAX_PARALLEL_FORKS=2 \
+                SKIP_JAVADOC=true \
+                ./gradlew test --info --stacktrace --continue \
+                --parallel \
+                -Drobolectric.enabledSdks=25 \
+                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+                -Dorg.gradle.workers.max=2
+      - run:
+          name: Collect Test Results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: build/reports
+          destination: reports
+
+  test_26:
+    << : *job_config
+    steps:
+      - attach_workspace:
+          at: ~/code
+      - restore_cache:
+          key: cache-{{ checksum ".cache-hash" }}
+      - run:
+          name: Test 26
+          command: |
+            GRADLE_MAX_PARALLEL_FORKS=2 \
+                SKIP_JAVADOC=true \
+                ./gradlew test --info --stacktrace --continue \
+                --parallel \
+                -Drobolectric.enabledSdks=26 \
+                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+                -Dorg.gradle.workers.max=2
+      - run:
+          name: Collect Test Results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: build/reports
+          destination: reports
+
+  test_27:
+    << : *job_config
+    steps:
+      - attach_workspace:
+          at: ~/code
+      - restore_cache:
+          key: cache-{{ checksum ".cache-hash" }}
+      - run:
+          name: Test 27
+          command: |
+            GRADLE_MAX_PARALLEL_FORKS=2 \
+                SKIP_JAVADOC=true \
+                ./gradlew test --info --stacktrace --continue \
+                --parallel \
+                -Drobolectric.enabledSdks=27 \
+                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+                -Dorg.gradle.workers.max=2
+      - run:
+          name: Collect Test Results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: build/reports
+          destination: reports
+
+  test_28:
+    << : *job_config
+    steps:
+      - attach_workspace:
+          at: ~/code
+      - restore_cache:
+          key: cache-{{ checksum ".cache-hash" }}
+      - run:
+          name: Test 28
+          command: |
+            GRADLE_MAX_PARALLEL_FORKS=2 \
+                SKIP_JAVADOC=true \
+                ./gradlew test --info --stacktrace --continue \
+                --parallel \
+                -Drobolectric.enabledSdks=28 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -237,29 +411,53 @@ workflows:
   build-and-test:
     jobs:
       - build
-      - test_1:
+      - test_16:
           requires:
             - build
-      - test_2:
+      - test_17:
           requires:
             - build
-      - test_3:
+      - test_18:
           requires:
             - build
-      - test_4:
+      - test_19:
           requires:
             - build
-      - test_5:
+      - test_21:
           requires:
             - build
-      - test_6:
+      - test_22:
+          requires:
+            - build
+      - test_23:
+          requires:
+            - build
+      - test_24:
+          requires:
+            - build
+      - test_25:
+          requires:
+            - build
+      - test_26:
+          requires:
+            - build
+      - test_27:
+          requires:
+            - build
+      - test_28:
           requires:
             - build
       - finish:
           requires:
-            - test_1
-            - test_2
-            - test_3
-            - test_4
-            - test_5
-            - test_6
+            - test_16
+            - test_17
+            - test_18
+            - test_19
+            - test_21
+            - test_22
+            - test_23
+            - test_24
+            - test_25
+            - test_26
+            - test_27
+            - test_28

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
             - ".cache-hash"
             - "[a-zA-Z]*" # not .git
 
-  test_16:
+  test_16_28:
     << : *job_config
     steps:
       - attach_workspace:
@@ -52,13 +52,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 16
+          name: Test 16 28
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=16 \
+                -Drobolectric.enabledSdks=16,28 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -73,7 +73,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_17:
+  test_17_27:
     << : *job_config
     steps:
       - attach_workspace:
@@ -81,13 +81,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 17
+          name: Test 17 27
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=17 \
+                -Drobolectric.enabledSdks=17,27 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -102,7 +102,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_18:
+  test_18_26:
     << : *job_config
     steps:
       - attach_workspace:
@@ -110,13 +110,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 18
+          name: Test 18 26
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=18 \
+                -Drobolectric.enabledSdks=18,26 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -131,7 +131,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_19:
+  test_19_25:
     << : *job_config
     steps:
       - attach_workspace:
@@ -139,13 +139,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 19
+          name: Test 19 25
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=19 \
+                -Drobolectric.enabledSdks=19,25 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -160,7 +160,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_21:
+  test_21_24:
     << : *job_config
     steps:
       - attach_workspace:
@@ -168,13 +168,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 21
+          name: Test 21 24
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=21 \
+                -Drobolectric.enabledSdks=21,24 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -189,36 +189,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_22:
-    << : *job_config
-    steps:
-      - attach_workspace:
-          at: ~/code
-      - restore_cache:
-          key: cache-{{ checksum ".cache-hash" }}
-      - run:
-          name: Test 22
-          command: |
-            GRADLE_MAX_PARALLEL_FORKS=2 \
-                SKIP_JAVADOC=true \
-                ./gradlew test --info --stacktrace --continue \
-                --parallel \
-                -Drobolectric.enabledSdks=22 \
-                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
-                -Dorg.gradle.workers.max=2
-      - run:
-          name: Collect Test Results
-          command: |
-            mkdir -p ~/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
-          when: always
-      - store_test_results:
-          path: ~/junit
-      - store_artifacts:
-          path: build/reports
-          destination: reports
-
-  test_23:
+  test_22_23:
     << : *job_config
     steps:
       - attach_workspace:
@@ -247,150 +218,6 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_24:
-    << : *job_config
-    steps:
-      - attach_workspace:
-          at: ~/code
-      - restore_cache:
-          key: cache-{{ checksum ".cache-hash" }}
-      - run:
-          name: Test 24
-          command: |
-            GRADLE_MAX_PARALLEL_FORKS=2 \
-                SKIP_JAVADOC=true \
-                ./gradlew test --info --stacktrace --continue \
-                --parallel \
-                -Drobolectric.enabledSdks=24 \
-                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
-                -Dorg.gradle.workers.max=2
-      - run:
-          name: Collect Test Results
-          command: |
-            mkdir -p ~/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
-          when: always
-      - store_test_results:
-          path: ~/junit
-      - store_artifacts:
-          path: build/reports
-          destination: reports
-
-  test_25:
-    << : *job_config
-    steps:
-      - attach_workspace:
-          at: ~/code
-      - restore_cache:
-          key: cache-{{ checksum ".cache-hash" }}
-      - run:
-          name: Test 25
-          command: |
-            GRADLE_MAX_PARALLEL_FORKS=2 \
-                SKIP_JAVADOC=true \
-                ./gradlew test --info --stacktrace --continue \
-                --parallel \
-                -Drobolectric.enabledSdks=25 \
-                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
-                -Dorg.gradle.workers.max=2
-      - run:
-          name: Collect Test Results
-          command: |
-            mkdir -p ~/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
-          when: always
-      - store_test_results:
-          path: ~/junit
-      - store_artifacts:
-          path: build/reports
-          destination: reports
-
-  test_26:
-    << : *job_config
-    steps:
-      - attach_workspace:
-          at: ~/code
-      - restore_cache:
-          key: cache-{{ checksum ".cache-hash" }}
-      - run:
-          name: Test 26
-          command: |
-            GRADLE_MAX_PARALLEL_FORKS=2 \
-                SKIP_JAVADOC=true \
-                ./gradlew test --info --stacktrace --continue \
-                --parallel \
-                -Drobolectric.enabledSdks=26 \
-                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
-                -Dorg.gradle.workers.max=2
-      - run:
-          name: Collect Test Results
-          command: |
-            mkdir -p ~/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
-          when: always
-      - store_test_results:
-          path: ~/junit
-      - store_artifacts:
-          path: build/reports
-          destination: reports
-
-  test_27:
-    << : *job_config
-    steps:
-      - attach_workspace:
-          at: ~/code
-      - restore_cache:
-          key: cache-{{ checksum ".cache-hash" }}
-      - run:
-          name: Test 27
-          command: |
-            GRADLE_MAX_PARALLEL_FORKS=2 \
-                SKIP_JAVADOC=true \
-                ./gradlew test --info --stacktrace --continue \
-                --parallel \
-                -Drobolectric.enabledSdks=27 \
-                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
-                -Dorg.gradle.workers.max=2
-      - run:
-          name: Collect Test Results
-          command: |
-            mkdir -p ~/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
-          when: always
-      - store_test_results:
-          path: ~/junit
-      - store_artifacts:
-          path: build/reports
-          destination: reports
-
-  test_28:
-    << : *job_config
-    steps:
-      - attach_workspace:
-          at: ~/code
-      - restore_cache:
-          key: cache-{{ checksum ".cache-hash" }}
-      - run:
-          name: Test 28
-          command: |
-            GRADLE_MAX_PARALLEL_FORKS=2 \
-                SKIP_JAVADOC=true \
-                ./gradlew test --info --stacktrace --continue \
-                --parallel \
-                -Drobolectric.enabledSdks=28 \
-                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
-                -Dorg.gradle.workers.max=2
-      - run:
-          name: Collect Test Results
-          command: |
-            mkdir -p ~/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
-          when: always
-      - store_test_results:
-          path: ~/junit
-      - store_artifacts:
-          path: build/reports
-          destination: reports
 
   finish:
     << : *job_config
@@ -411,53 +238,29 @@ workflows:
   build-and-test:
     jobs:
       - build
-      - test_16:
+      - test_16_28:
           requires:
             - build
-      - test_17:
+      - test_17_27:
           requires:
             - build
-      - test_18:
+      - test_18_26:
           requires:
             - build
-      - test_19:
+      - test_19_25:
           requires:
             - build
-      - test_21:
+      - test_21_24:
           requires:
             - build
-      - test_22:
-          requires:
-            - build
-      - test_23:
-          requires:
-            - build
-      - test_24:
-          requires:
-            - build
-      - test_25:
-          requires:
-            - build
-      - test_26:
-          requires:
-            - build
-      - test_27:
-          requires:
-            - build
-      - test_28:
+      - test_22_23:
           requires:
             - build
       - finish:
           requires:
-            - test_16
-            - test_17
-            - test_18
-            - test_19
-            - test_21
-            - test_22
-            - test_23
-            - test_24
-            - test_25
-            - test_26
-            - test_27
-            - test_28
+            - test_16_28
+            - test_17_27
+            - test_18_26
+            - test_19_25
+            - test_21_24
+            - test_22_23

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
             - ".cache-hash"
             - "[a-zA-Z]*" # not .git
 
-  test_16_28:
+  test_16_17_28:
     << : *job_config
     steps:
       - attach_workspace:
@@ -52,13 +52,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 16 28
+          name: Test 16 17 28
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=16,28 \
+                -Drobolectric.enabledSdks=16,17,28 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -73,7 +73,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_17_27:
+  test_18_19_27:
     << : *job_config
     steps:
       - attach_workspace:
@@ -81,13 +81,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 17 27
+          name: Test 18 19 27
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=17,27 \
+                -Drobolectric.enabledSdks=18,19,27 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -102,7 +102,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_18_26:
+  test_21_22_26:
     << : *job_config
     steps:
       - attach_workspace:
@@ -110,13 +110,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 18 26
+          name: Test 21 22 26
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=18,26 \
+                -Drobolectric.enabledSdks=21,22,26 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -131,7 +131,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_19_25:
+  test_23_24_25:
     << : *job_config
     steps:
       - attach_workspace:
@@ -139,71 +139,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 19 25
+          name: Test 23 24 25
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=19,25 \
-                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
-                -Dorg.gradle.workers.max=2
-      - run:
-          name: Collect Test Results
-          command: |
-            mkdir -p ~/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
-          when: always
-      - store_test_results:
-          path: ~/junit
-      - store_artifacts:
-          path: build/reports
-          destination: reports
-
-  test_21_24:
-    << : *job_config
-    steps:
-      - attach_workspace:
-          at: ~/code
-      - restore_cache:
-          key: cache-{{ checksum ".cache-hash" }}
-      - run:
-          name: Test 21 24
-          command: |
-            GRADLE_MAX_PARALLEL_FORKS=2 \
-                SKIP_JAVADOC=true \
-                ./gradlew test --info --stacktrace --continue \
-                --parallel \
-                -Drobolectric.enabledSdks=21,24 \
-                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
-                -Dorg.gradle.workers.max=2
-      - run:
-          name: Collect Test Results
-          command: |
-            mkdir -p ~/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
-          when: always
-      - store_test_results:
-          path: ~/junit
-      - store_artifacts:
-          path: build/reports
-          destination: reports
-
-  test_22_23:
-    << : *job_config
-    steps:
-      - attach_workspace:
-          at: ~/code
-      - restore_cache:
-          key: cache-{{ checksum ".cache-hash" }}
-      - run:
-          name: Test 23
-          command: |
-            GRADLE_MAX_PARALLEL_FORKS=2 \
-                SKIP_JAVADOC=true \
-                ./gradlew test --info --stacktrace --continue \
-                --parallel \
-                -Drobolectric.enabledSdks=23 \
+                -Drobolectric.enabledSdks=23,24,25 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -238,29 +180,21 @@ workflows:
   build-and-test:
     jobs:
       - build
-      - test_16_28:
+      - test_16_17_28:
           requires:
             - build
-      - test_17_27:
+      - test_18_19_27:
           requires:
             - build
-      - test_18_26:
+      - test_21_22_26:
           requires:
             - build
-      - test_19_25:
-          requires:
-            - build
-      - test_21_24:
-          requires:
-            - build
-      - test_22_23:
+      - test_23_24_25:
           requires:
             - build
       - finish:
           requires:
-            - test_16_28
-            - test_17_27
-            - test_18_26
-            - test_19_25
-            - test_21_24
-            - test_22_23
+            - test_16_17_28
+            - test_18_19_27
+            - test_21_22_26
+            - test_23_24_25

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
             - ".cache-hash"
             - "[a-zA-Z]*" # not .git
 
-  test_16_17_28:
+  test_16_17_18:
     << : *job_config
     steps:
       - attach_workspace:
@@ -52,13 +52,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 16 17 28
+          name: Test 16 17 18
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=16,17,28 \
+                -Drobolectric.enabledSdks=16,17,18 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -73,7 +73,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_18_19_27:
+  test_19_21_22:
     << : *job_config
     steps:
       - attach_workspace:
@@ -81,13 +81,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 18 19 27
+          name: Test 19 21 22
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=18,19,27 \
+                -Drobolectric.enabledSdks=19,21,22 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -102,7 +102,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_21_22_26:
+  test_23_24:
     << : *job_config
     steps:
       - attach_workspace:
@@ -110,13 +110,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 21 22 26
+          name: Test 23 24
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=21,22,26 \
+                -Drobolectric.enabledSdks=23,24 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -131,7 +131,7 @@ jobs:
           path: build/reports
           destination: reports
 
-  test_23_24_25:
+  test_25_26:
     << : *job_config
     steps:
       - attach_workspace:
@@ -139,13 +139,42 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 23 24 25
+          name: Test 25 26
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=23,24,25 \
+                -Drobolectric.enabledSdks=25,26 \
+                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+                -Dorg.gradle.workers.max=2
+      - run:
+          name: Collect Test Results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: build/reports
+          destination: reports
+
+  test_27_28:
+    << : *job_config
+    steps:
+      - attach_workspace:
+          at: ~/code
+      - restore_cache:
+          key: cache-{{ checksum ".cache-hash" }}
+      - run:
+          name: Test 27 28
+          command: |
+            GRADLE_MAX_PARALLEL_FORKS=2 \
+                SKIP_JAVADOC=true \
+                ./gradlew test --info --stacktrace --continue \
+                --parallel \
+                -Drobolectric.enabledSdks=27,28 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -180,21 +209,25 @@ workflows:
   build-and-test:
     jobs:
       - build
-      - test_16_17_28:
+      - test_16_17_18:
           requires:
             - build
-      - test_18_19_27:
+      - test_19_21_22:
           requires:
             - build
-      - test_21_22_26:
+      - test_23_24:
           requires:
             - build
-      - test_23_24_25:
+      - test_25_26:
+          requires:
+            - build
+      - test_27_28:
           requires:
             - build
       - finish:
           requires:
-            - test_16_17_28
-            - test_18_19_27
-            - test_21_22_26
-            - test_23_24_25
+            - test_16_17_18
+            - test_19_21_22
+            - test_23_24
+            - test_25_26
+            - test_27_28

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,13 +52,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 1/4
+          name: Test 1/6
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=16,17,18 \
+                -Drobolectric.enabledSdks=16,17 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -81,13 +81,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 2/4
+          name: Test 2/6
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=19,21,22 \
+                -Drobolectric.enabledSdks=18,19 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -110,13 +110,13 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 3/4
+          name: Test 3/6
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=23,24,25 \
+                -Drobolectric.enabledSdks=21,22 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -139,13 +139,71 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum ".cache-hash" }}
       - run:
-          name: Test 4/4
+          name: Test 4/6
           command: |
             GRADLE_MAX_PARALLEL_FORKS=2 \
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=26,27,28,10000 \
+                -Drobolectric.enabledSdks=23,24 \
+                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+                -Dorg.gradle.workers.max=2
+      - run:
+          name: Collect Test Results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: build/reports
+          destination: reports
+
+  test_5:
+    << : *job_config
+    steps:
+      - attach_workspace:
+          at: ~/code
+      - restore_cache:
+          key: cache-{{ checksum ".cache-hash" }}
+      - run:
+          name: Test 5/6
+          command: |
+            GRADLE_MAX_PARALLEL_FORKS=2 \
+                SKIP_JAVADOC=true \
+                ./gradlew test --info --stacktrace --continue \
+                --parallel \
+                -Drobolectric.enabledSdks=25,26 \
+                -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+                -Dorg.gradle.workers.max=2
+      - run:
+          name: Collect Test Results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: build/reports
+          destination: reports
+
+  test_6:
+    << : *job_config
+    steps:
+      - attach_workspace:
+          at: ~/code
+      - restore_cache:
+          key: cache-{{ checksum ".cache-hash" }}
+      - run:
+          name: Test 6/6
+          command: |
+            GRADLE_MAX_PARALLEL_FORKS=2 \
+                SKIP_JAVADOC=true \
+                ./gradlew test --info --stacktrace --continue \
+                --parallel \
+                -Drobolectric.enabledSdks=27,28,10000 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:
@@ -191,9 +249,17 @@ workflows:
       - test_4:
           requires:
             - build
+      - test_5:
+          requires:
+            - build
+      - test_6:
+          requires:
+            - build
       - finish:
           requires:
             - test_1
             - test_2
             - test_3
             - test_4
+            - test_5
+            - test_6

--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.2-SNAPSHOT"
 }
 ```
+


### PR DESCRIPTION
Currently circleci is configured to execute tests on 4 parallel jobs, with tests running on 3 SDKs per job, sequentially.

However, tests on more recent SDKs take longer to execute, so the execution time is not evenly distributed, with test_1 and 2 taking ~12 min but test_4 taking ~20min.

This commit increase the # of test jobs from 4 to 5, and rename the jobs to correspond with the SDKs being tested.

The distribution now looks like
test_16_17_18
test_19_21_22
test_23_24
test_25_26
test_27_28

Each job should now take between 11-13 min


