### PR TITLE
Return true if movePosition is -1

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/fakes/RoboCursor.java
+++ b/shadows/framework/src/main/java/org/robolectric/fakes/RoboCursor.java
@@ -121,7 +121,7 @@ public class RoboCursor extends BaseCursor {
 
   private boolean doMoveToPosition(int position) {
     resultsIndex = position;
-    return resultsIndex >= 0 && resultsIndex < results.length;
+    return resultsIndex >= -1 && resultsIndex < results.length;
   }
 
   @Override


### PR DESCRIPTION
Fix incorrectly returning false when move position is -1.

["The valid range of values is -1 <= position <= count."](https://developer.android.com/reference/android/database/Cursor#moveToPosition(int))
