### PR TITLE
Clean up SdkProvider interface.

### DIFF
--- a/pluginapi/src/main/java/org/robolectric/pluginapi/Sdk.java
+++ b/pluginapi/src/main/java/org/robolectric/pluginapi/Sdk.java
@@ -1,62 +1,111 @@
 package org.robolectric.pluginapi;
 
 import java.nio.file.Path;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 
 /**
  * Represents a unique build of the Android SDK.
  */
-public interface Sdk extends Comparable<Sdk> {
+@SuppressWarnings("NewApi")
+public abstract class Sdk implements Comparable<Sdk> {
+
+  private final int apiLevel;
+
+  protected Sdk(int apiLevel) {
+    this.apiLevel = apiLevel;
+  }
 
   /**
    * Returns the [Android API level](https://source.android.com/setup/start/build-numbers) for this
-   * sdk.
+   * SDK.
    *
    * It must match the version reported by `android.os.Build.VERSION.SDK_INT` provided within.
    */
-  int getApiLevel();
+  public final int getApiLevel() {
+    return apiLevel;
+  }
 
   /**
    * Returns the [Android Version](https://source.android.com/setup/start/build-numbers) for this
-   * sdk.
+   * SDK.
    *
    * It should match the version reported by `android.os.Build.VERSION.RELEASE` provided within.
+   *
+   * If this is an expensive operation, the implementation should cache the return value.
    */
-  String getAndroidVersion();
+  public abstract String getAndroidVersion();
 
   /**
    * Returns the Android codename for this SDK.
    *
    * It should match the version reported by `android.os.Build.VERSION.CODENAME` provided within.
+   *
+   * If this is an expensive operation, the implementation should cache the return value.
    */
-  String getAndroidCodeName();
+  public abstract String getAndroidCodeName();
 
   /**
    * Returns the path to jar for this SDK.
    */
-  Path getJarPath();
+  public abstract Path getJarPath();
 
   /**
-   * Determines if this `Sdk` is known by its provider.
+   * Determines if this SDK is supported in the running Robolectric environment.
    *
-   * Unknown sdks can serve as placeholder objects; they should throw some explanatory exception
-   * when {@link #getJarPath()} is invoked.
-   */
-  boolean isKnown();
-
-  /**
-   * Determines if this `Sdk` is supported in the running Robolectric environment.
-   *
-   * An sdk might be unsupported if e.g. it requires a newer version of the JVM than is currently
+   * An SDK might be unsupported if e.g. it requires a newer version of the JVM than is currently
    * running.
    *
-   * Unsupported sdks should throw some explanatory exception when {@link #getJarPath()} is invoked.
+   * Unsupported SDKs should throw some explanatory exception when {@link #getJarPath()} is invoked.
+   *
+   * If this is an expensive operation, the implementation should cache the return value.
    */
-  boolean isSupported();
+  public abstract boolean isSupported();
+
+  /**
+   * Returns a human-readable message explaining why this SDK isn't supported.
+   *
+   * If this is an expensive operation, the implementation should cache the return value.
+   */
+  public abstract String getUnsupportedMessage();
+
+  /**
+   * Determines if this SDK is known by its provider.
+   *
+   * Unknown SDKs can serve as placeholder objects; they should throw some explanatory exception
+   * when {@link #getJarPath()} is invoked.
+   */
+  public boolean isKnown() {
+    return true;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Sdk)) {
+      return false;
+    }
+    Sdk sdk = (Sdk) o;
+    return apiLevel == sdk.apiLevel;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(apiLevel);
+  }
+
+  @Override
+  public String toString() {
+    return "API Level " + apiLevel;
+  }
 
   /**
    * Instances of `Sdk` are ordered by the API level they implement.
    */
   @Override
-  int compareTo(@Nonnull Sdk o);
+  public int compareTo(@Nonnull Sdk o) {
+    return apiLevel - o.apiLevel;
+  }
 }

--- a/pluginapi/src/main/java/org/robolectric/pluginapi/Sdk.java
+++ b/pluginapi/src/main/java/org/robolectric/pluginapi/Sdk.java
@@ -98,7 +98,7 @@ public abstract class Sdk implements Comparable<Sdk> {
 
   @Override
   public String toString() {
-    return "API Level " + apiLevel;
+    return "SDK " + apiLevel;
   }
 
   /**

--- a/pluginapi/src/main/java/org/robolectric/pluginapi/SdkProvider.java
+++ b/pluginapi/src/main/java/org/robolectric/pluginapi/SdkProvider.java
@@ -7,13 +7,11 @@ import java.util.Collection;
  */
 public interface SdkProvider {
 
-  Sdk getMaxKnownSdk();
-
-  Sdk getMaxSupportedSdk();
-
-  Sdk getSdk(int apiLevel);
-
-  Collection<Sdk> getSupportedSdks();
-
-  Collection<Sdk> getKnownSdks();
+  /**
+   * Returns the set of SDKs available to run tests against.
+   *
+   * It's okay for the implementation to block briefly while building the list; the results will be
+   * cached.
+   */
+  Collection<Sdk> getSdks();
 }

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -49,6 +49,7 @@ import org.robolectric.internal.bytecode.ShadowWrangler;
 import org.robolectric.manifest.AndroidManifest;
 import org.robolectric.pluginapi.Sdk;
 import org.robolectric.pluginapi.SdkPicker;
+import org.robolectric.plugins.SdkCollection;
 import org.robolectric.util.PerfStatsCollector;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.inject.Injector;
@@ -85,6 +86,7 @@ public class RobolectricTestRunner extends SandboxTestRunner {
         .register(Properties.class, System.getProperties())
         .registerDefault(ApkLoader.class, ApkLoader.class)
         .registerDefault(SandboxFactory.class, SandboxFactory.class)
+        .registerDefault(SdkCollection.class, SdkCollection.class)
         .registerDefault(Ctx.class, Ctx.class);
   }
 

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -285,12 +285,8 @@ public class RobolectricTestRunner extends SandboxTestRunner {
     }
 
     if (sdk.isKnown() && !sdk.isSupported()) {
-      try {
-        return ctx.sandboxFactory.getSdkEnvironment(
-            classLoaderConfig, sdk, useLegacyResources);
-      } catch (Throwable e) {
-        throw new AssumptionViolatedException("Failed to create a Robolectric sandbox", e);
-      }
+      throw new AssumptionViolatedException(
+          "Failed to create a Robolectric sandbox: " + sdk.getUnsupportedMessage());
     } else {
       return ctx.sandboxFactory.getSdkEnvironment(
           classLoaderConfig, sdk, useLegacyResources);

--- a/robolectric/src/main/java/org/robolectric/SdkPicker.java
+++ b/robolectric/src/main/java/org/robolectric/SdkPicker.java
@@ -1,17 +1,18 @@
 package org.robolectric;
 
 import java.util.Properties;
+import javax.annotation.Nonnull;
 import javax.inject.Inject;
-import org.robolectric.pluginapi.SdkProvider;
 import org.robolectric.plugins.DefaultSdkPicker;
+import org.robolectric.plugins.SdkCollection;
 
 /** @deprecated use {@link org.robolectric.plugins.DefaultSdkPicker} instead. */
 @Deprecated
 public class SdkPicker extends DefaultSdkPicker {
 
   @Inject
-  public SdkPicker(SdkProvider sdkProvider, Properties systemProperties) {
-    super(sdkProvider, systemProperties);
+  public SdkPicker(@Nonnull SdkCollection sdkCollection, Properties systemProperties) {
+    super(sdkCollection, systemProperties);
   }
 
 }

--- a/robolectric/src/main/java/org/robolectric/internal/SandboxFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/SandboxFactory.java
@@ -12,7 +12,7 @@ import javax.inject.Inject;
 import org.robolectric.internal.bytecode.InstrumentationConfiguration;
 import org.robolectric.internal.bytecode.SandboxClassLoader;
 import org.robolectric.pluginapi.Sdk;
-import org.robolectric.pluginapi.SdkProvider;
+import org.robolectric.plugins.SdkCollection;
 
 @SuppressLint("NewApi")
 public class SandboxFactory {
@@ -20,18 +20,18 @@ public class SandboxFactory {
   /** The factor for cache size. See {@link #sdkToEnvironment} for details. */
   private static final int CACHE_SIZE_FACTOR = 3;
 
-  private final SdkProvider sdkProvider;
+  private final SdkCollection sdkCollection;
 
   // Simple LRU Cache. SdkEnvironments are unique across InstrumentationConfiguration and Sdk
   private final LinkedHashMap<SandboxKey, SdkEnvironment> sdkToEnvironment;
 
   @Inject
-  public SandboxFactory(SdkProvider sdkProvider) {
-    this.sdkProvider = sdkProvider;
+  public SandboxFactory(SdkCollection sdkCollection) {
+    this.sdkCollection = sdkCollection;
 
     // We need to set the cache size of class loaders more than the number of supported APIs as
     // different tests may have different configurations.
-    final int cacheSize = sdkProvider.getSupportedSdks().size() * CACHE_SIZE_FACTOR;
+    final int cacheSize = sdkCollection.getSupportedSdks().size() * CACHE_SIZE_FACTOR;
     sdkToEnvironment = new LinkedHashMap<SandboxKey, SdkEnvironment>() {
       @Override
       protected boolean removeEldestEntry(Map.Entry<SandboxKey, SdkEnvironment> eldest) {
@@ -71,7 +71,7 @@ public class SandboxFactory {
   protected SdkEnvironment createSdkEnvironment(
       Sdk sdk, ClassLoader robolectricClassLoader) {
     return new SdkEnvironment(
-        sdk, robolectricClassLoader, sdkProvider.getMaxSupportedSdk());
+        sdk, robolectricClassLoader, sdkCollection.getMaxSupportedSdk());
   }
 
   @Nonnull
@@ -110,7 +110,6 @@ public class SandboxFactory {
 
     @Override
     public int hashCode() {
-
       return Objects.hash(sdk, instrumentationConfiguration, useLegacyResources);
     }
   }

--- a/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkPicker.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkPicker.java
@@ -1,7 +1,7 @@
 package org.robolectric.plugins;
 
-import androidx.annotation.VisibleForTesting;
 import com.google.auto.service.AutoService;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.Collections;

--- a/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import javax.annotation.Nonnull;
 import javax.annotation.Priority;
 import javax.inject.Inject;
 import org.robolectric.internal.dependency.DependencyJar;
@@ -18,7 +17,11 @@ import org.robolectric.pluginapi.Sdk;
 import org.robolectric.pluginapi.SdkProvider;
 import org.robolectric.util.Util;
 
-/** Robolectric's default {@link SdkProvider}. */
+/**
+ * Robolectric's default {@link SdkProvider}.
+ *
+ * The list of SDKs is hard-coded. SDKs are obtained from the provided {@link DependencyResolver}.
+ */
 @SuppressWarnings("NewApi")
 @AutoService(SdkProvider.class)
 @Priority(Integer.MIN_VALUE)
@@ -29,7 +32,6 @@ public class DefaultSdkProvider implements SdkProvider {
   private final DependencyResolver dependencyResolver;
 
   private final SortedMap<Integer, Sdk> knownApis;
-  private final SortedMap<Integer, Sdk> supportedApis;
 
   {
     addSdk(Build.VERSION_CODES.JELLY_BEAN, "4.1.2_r1", "r1", "REL", 8);
@@ -46,11 +48,7 @@ public class DefaultSdkProvider implements SdkProvider {
     addSdk(Build.VERSION_CODES.P, "9", "4913185-2", "REL", 8);
 
     knownApis = Collections.unmodifiableSortedMap(Setup.knownApis);
-    supportedApis = Collections.unmodifiableSortedMap(Setup.supportedApis);
   }
-
-  private final Sdk maxKnownSdk = Collections.max(knownApis.values());
-  private final Sdk maxSupportedSdk = Collections.max(supportedApis.values());
 
   @Inject
   public DefaultSdkProvider(DependencyResolver dependencyResolver) {
@@ -58,33 +56,7 @@ public class DefaultSdkProvider implements SdkProvider {
   }
 
   @Override
-  public Sdk getMaxKnownSdk() {
-    return maxKnownSdk;
-  }
-
-  @Override
-  public Sdk getMaxSupportedSdk() {
-    return maxSupportedSdk;
-  }
-
-  @Override
-  public Sdk getSdk(int apiLevel) {
-    final Sdk sdk = knownApis.get(apiLevel);
-
-    if (sdk == null) {
-      return new UnknownSdk(apiLevel);
-    }
-
-    return sdk;
-  }
-
-  @Override
-  public Collection<Sdk> getSupportedSdks() {
-    return Collections.unmodifiableCollection(supportedApis.values());
-  }
-
-  @Override
-  public Collection<Sdk> getKnownSdks() {
+  public Collection<Sdk> getSdks() {
     return Collections.unmodifiableCollection(knownApis.values());
   }
 
@@ -95,24 +67,14 @@ public class DefaultSdkProvider implements SdkProvider {
             requiredJavaVersion);
 
     Setup.knownApis.put(apiLevel, sdk);
-    if (sdk.isSupported()) {
-      Setup.supportedApis.put(apiLevel, sdk);
-    } else {
-      System.err.printf(
-          "[Robolectric] WARN: %s. Tests won't be run on this SDK unless explicitly requested\n",
-          sdk.getUnsupportedMessage());
-    }
   }
 
   private static class Setup {
 
     static final TreeMap<Integer, Sdk> knownApis = new TreeMap<>();
-    static final TreeMap<Integer, Sdk> supportedApis = new TreeMap<>();
   }
 
-  public class DefaultSdk implements Sdk {
-
-    private final int apiLevel;
+  public class DefaultSdk extends Sdk {
 
     private final String androidVersion;
     private final String robolectricVersion;
@@ -123,16 +85,11 @@ public class DefaultSdkProvider implements SdkProvider {
     DefaultSdk(
         int apiLevel, String androidVersion, String robolectricVersion, String codeName,
         int requiredJavaVersion) {
-      this.apiLevel = apiLevel;
+      super(apiLevel);
       this.androidVersion = androidVersion;
       this.robolectricVersion = robolectricVersion;
       this.codeName = codeName;
       this.requiredJavaVersion = requiredJavaVersion;
-    }
-
-    @Override
-    public int getApiLevel() {
-      return apiLevel;
     }
 
     @Override
@@ -165,43 +122,18 @@ public class DefaultSdkProvider implements SdkProvider {
     }
 
     @Override
-    public boolean isKnown() {
-      return true;
-    }
-
-    @Override
     public boolean isSupported() {
       return requiredJavaVersion <= RUNNING_JAVA_VERSION;
     }
 
-    String getUnsupportedMessage() {
+    @Override
+    public String getUnsupportedMessage() {
       return String.format(
           Locale.getDefault(),
           "Android SDK %d requires Java %d (have Java %d)",
-          apiLevel,
+          getApiLevel(),
           requiredJavaVersion,
           RUNNING_JAVA_VERSION);
-    }
-
-    @Override
-    public boolean equals(Object that) {
-      return that == this || (that instanceof DefaultSdk
-          && ((DefaultSdk) that).apiLevel == (apiLevel));
-    }
-
-    @Override
-    public int hashCode() {
-      return apiLevel;
-    }
-
-    @Override
-    public String toString() {
-      return "API Level " + apiLevel;
-    }
-
-    @Override
-    public int compareTo(@Nonnull Sdk o) {
-      return apiLevel - o.getApiLevel();
     }
   }
 }

--- a/robolectric/src/main/java/org/robolectric/plugins/SdkCollection.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/SdkCollection.java
@@ -6,6 +6,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import javax.inject.Inject;
 import org.robolectric.pluginapi.Sdk;
 import org.robolectric.pluginapi.SdkProvider;
 
@@ -15,6 +16,7 @@ public class SdkCollection {
   private final SortedMap<Integer, Sdk> knownSdks = new TreeMap<>();
   private final SortedSet<Sdk> supportedSdks;
 
+  @Inject
   public SdkCollection(SdkProvider sdkProvider) {
     Collection<Sdk> knownSdks = sdkProvider.getSdks();
     SortedSet<Sdk> supportedSdks = new TreeSet<>();

--- a/robolectric/src/main/java/org/robolectric/plugins/SdkCollection.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/SdkCollection.java
@@ -30,8 +30,8 @@ public class SdkCollection {
         supportedSdks.add(sdk);
       } else {
         System.err.printf(
-            "[Robolectric] WARN: %s. Tests won't be run on this SDK unless explicitly requested\n",
-            sdk.getUnsupportedMessage());
+            "[Robolectric] WARN: %s. Tests won't be run on SDK %d unless explicitly requested.\n",
+            sdk.getUnsupportedMessage(), sdk.getApiLevel());
       }
     });
     this.supportedSdks = Collections.unmodifiableSortedSet(supportedSdks);
@@ -44,6 +44,10 @@ public class SdkCollection {
 
   public Sdk getMaxSupportedSdk() {
     return supportedSdks.last();
+  }
+
+  public SortedSet<Sdk> getKnownSdks() {
+    return new TreeSet<>(knownSdks.values());
   }
 
   public SortedSet<Sdk> getSupportedSdks() {

--- a/robolectric/src/main/java/org/robolectric/plugins/SdkCollection.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/SdkCollection.java
@@ -1,0 +1,50 @@
+package org.robolectric.plugins;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import org.robolectric.pluginapi.Sdk;
+import org.robolectric.pluginapi.SdkProvider;
+
+@SuppressWarnings("NewApi")
+public class SdkCollection {
+
+  private final SortedMap<Integer, Sdk> knownSdks = new TreeMap<>();
+  private final SortedSet<Sdk> supportedSdks;
+
+  public SdkCollection(SdkProvider sdkProvider) {
+    Collection<Sdk> knownSdks = sdkProvider.getSdks();
+    SortedSet<Sdk> supportedSdks = new TreeSet<>();
+    knownSdks.forEach((sdk) -> {
+      if (this.knownSdks.put(sdk.getApiLevel(), sdk) != null) {
+        throw new IllegalArgumentException(
+            String.format("duplicate SDKs for API level %d", sdk.getApiLevel()));
+      }
+
+      if (sdk.isSupported()) {
+        supportedSdks.add(sdk);
+      } else {
+        System.err.printf(
+            "[Robolectric] WARN: %s. Tests won't be run on this SDK unless explicitly requested\n",
+            sdk.getUnsupportedMessage());
+      }
+    });
+    this.supportedSdks = Collections.unmodifiableSortedSet(supportedSdks);
+  }
+
+  public Sdk getSdk(int apiLevel) {
+    Sdk sdk = knownSdks.get(apiLevel);
+    return sdk == null ? new UnknownSdk(apiLevel) : sdk;
+  }
+
+  public Sdk getMaxSupportedSdk() {
+    return supportedSdks.last();
+  }
+
+  public SortedSet<Sdk> getSupportedSdks() {
+    return supportedSdks;
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/plugins/UnknownSdk.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/UnknownSdk.java
@@ -1,41 +1,28 @@
 package org.robolectric.plugins;
 
 import java.nio.file.Path;
-import javax.annotation.Nonnull;
+import java.util.Locale;
 import org.robolectric.pluginapi.Sdk;
 
-class UnknownSdk implements Sdk {
-
-  private final int apiLevel;
+class UnknownSdk extends Sdk {
 
   UnknownSdk(int apiLevel) {
-    this.apiLevel = apiLevel;
-  }
-
-  @Override
-  public int getApiLevel() {
-    return apiLevel;
+    super(apiLevel);
   }
 
   @Override
   public String getAndroidVersion() {
-    return null;
+    throw new IllegalArgumentException(getUnsupportedMessage());
   }
 
   @Override
   public String getAndroidCodeName() {
-    return null;
+    throw new IllegalArgumentException(getUnsupportedMessage());
   }
 
   @Override
   public Path getJarPath() {
-    throw new IllegalArgumentException(
-        String.format("Robolectric does not support API level %d.", getApiLevel()));
-  }
-
-  @Override
-  public boolean isKnown() {
-    return false;
+    throw new IllegalArgumentException(getUnsupportedMessage());
   }
 
   @Override
@@ -44,7 +31,12 @@ class UnknownSdk implements Sdk {
   }
 
   @Override
-  public int compareTo(@Nonnull Sdk o) {
-    return 0;
+  public String getUnsupportedMessage() {
+    return String.format(Locale.getDefault(), "API level %d is not available", getApiLevel());
+  }
+
+  @Override
+  public boolean isKnown() {
+    return false;
   }
 }

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerMultiApiTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerMultiApiTest.java
@@ -31,9 +31,8 @@ import org.junit.runners.model.InitializationError;
 import org.robolectric.annotation.Config;
 import org.robolectric.pluginapi.Sdk;
 import org.robolectric.pluginapi.SdkPicker;
-import org.robolectric.pluginapi.SdkProvider;
 import org.robolectric.plugins.DefaultSdkPicker;
-import org.robolectric.plugins.DefaultSdkProvider;
+import org.robolectric.plugins.SdkCollection;
 import org.robolectric.util.TestUtil;
 import org.robolectric.util.inject.Injector;
 
@@ -57,7 +56,7 @@ public class RobolectricTestRunnerMultiApiTest {
   private String priorResourcesMode;
   private String priorAlwaysInclude;
 
-  private SdkProvider sdkProvider;
+  private SdkCollection sdkCollection;
 
   @Before
   public void setUp() {
@@ -66,9 +65,8 @@ public class RobolectricTestRunnerMultiApiTest {
     runListener = new MyRunListener();
     runNotifier = new RunNotifier();
     runNotifier.addListener(runListener);
-    sdkProvider = new DefaultSdkProvider(null);
-    delegateSdkPicker =
-        new DefaultSdkPicker(map(APIS_FOR_TEST), null);
+    sdkCollection = new SdkCollection(() -> map(APIS_FOR_TEST));
+    delegateSdkPicker = new DefaultSdkPicker(sdkCollection, null);
 
     priorResourcesMode = System.getProperty("robolectric.resourcesMode");
     System.setProperty("robolectric.resourcesMode", "legacy");
@@ -111,7 +109,7 @@ public class RobolectricTestRunnerMultiApiTest {
 
   @Test
   public void withEnabledSdks_createChildrenForEachSupportedSdk() throws Throwable {
-    delegateSdkPicker = new DefaultSdkPicker(map(16, 17), null);
+    delegateSdkPicker = new DefaultSdkPicker(new SdkCollection(() -> map(16, 17)), null);
 
     runner = runnerOf(TestWithNoConfig.class);
     assertThat(runner.getChildren()).hasSize(2);
@@ -354,6 +352,6 @@ public class RobolectricTestRunnerMultiApiTest {
   }
 
   private List<Sdk> map(int... sdkInts) {
-    return Arrays.stream(sdkInts).mapToObj(sdkProvider::getSdk).collect(Collectors.toList());
+    return Arrays.stream(sdkInts).mapToObj(sdkCollection::getSdk).collect(Collectors.toList());
   }
 }

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerMultiApiTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerMultiApiTest.java
@@ -32,6 +32,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.pluginapi.Sdk;
 import org.robolectric.pluginapi.SdkPicker;
 import org.robolectric.plugins.DefaultSdkPicker;
+import org.robolectric.plugins.DefaultSdkProvider;
 import org.robolectric.plugins.SdkCollection;
 import org.robolectric.util.TestUtil;
 import org.robolectric.util.inject.Injector;
@@ -352,6 +353,7 @@ public class RobolectricTestRunnerMultiApiTest {
   }
 
   private List<Sdk> map(int... sdkInts) {
-    return Arrays.stream(sdkInts).mapToObj(sdkCollection::getSdk).collect(Collectors.toList());
+    SdkCollection allSdks = new SdkCollection(new DefaultSdkProvider(null));
+    return Arrays.stream(sdkInts).mapToObj(allSdks::getSdk).collect(Collectors.toList());
   }
 }

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -94,7 +94,7 @@ public class RobolectricTestRunnerTest {
     RobolectricTestRunner runner = new RobolectricTestRunner(TestWithOldSdk.class);
     runner.run(notifier);
     assertThat(events).containsExactly(
-        "failure: Robolectric does not support API level 11.",
+        "failure: API level 11 is not available",
         "ignored: ignoredOldSdkMethod(org.robolectric.RobolectricTestRunnerTest$TestWithOldSdk)"
     );
   }

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -41,8 +41,8 @@ import org.robolectric.annotation.Config;
 import org.robolectric.internal.ParallelUniverseInterface;
 import org.robolectric.internal.SdkEnvironment;
 import org.robolectric.manifest.AndroidManifest;
-import org.robolectric.pluginapi.SdkProvider;
 import org.robolectric.plugins.DefaultSdkProvider;
+import org.robolectric.plugins.SdkCollection;
 import org.robolectric.util.PerfStatsCollector.Metric;
 import org.robolectric.util.PerfStatsReporter;
 import org.robolectric.util.TempDirectory;
@@ -55,7 +55,7 @@ public class RobolectricTestRunnerTest {
   private List<String> events;
   private String priorEnabledSdks;
   private String priorAlwaysInclude;
-  private SdkProvider sdkProvider;
+  private SdkCollection sdkCollection;
 
   @Before
   public void setUp() throws Exception {
@@ -79,7 +79,7 @@ public class RobolectricTestRunnerTest {
     priorAlwaysInclude = System.getProperty("robolectric.alwaysIncludeVariantMarkersInTestName");
     System.clearProperty("robolectric.alwaysIncludeVariantMarkersInTestName");
 
-    sdkProvider = new DefaultSdkProvider(null);
+    sdkCollection = new SdkCollection(new DefaultSdkProvider(null));
   }
 
   @After
@@ -144,7 +144,7 @@ public class RobolectricTestRunnerTest {
         new RobolectricFrameworkMethod(
             method,
             mock(AndroidManifest.class),
-            sdkProvider.getSdk(16),
+            sdkCollection.getSdk(16),
             mock(Config.class),
             ResourcesMode.legacy,
             ResourcesMode.legacy,
@@ -153,7 +153,7 @@ public class RobolectricTestRunnerTest {
         new RobolectricFrameworkMethod(
             method,
             mock(AndroidManifest.class),
-            sdkProvider.getSdk(17),
+            sdkCollection.getSdk(17),
             mock(Config.class),
             ResourcesMode.legacy,
             ResourcesMode.legacy,
@@ -162,7 +162,7 @@ public class RobolectricTestRunnerTest {
         new RobolectricFrameworkMethod(
             method,
             mock(AndroidManifest.class),
-            sdkProvider.getSdk(16),
+            sdkCollection.getSdk(16),
             mock(Config.class),
             ResourcesMode.legacy,
             ResourcesMode.legacy,
@@ -171,7 +171,7 @@ public class RobolectricTestRunnerTest {
         new RobolectricFrameworkMethod(
             method,
             mock(AndroidManifest.class),
-            sdkProvider.getSdk(16),
+            sdkCollection.getSdk(16),
             mock(Config.class),
             ResourcesMode.binary,
             ResourcesMode.legacy,

--- a/robolectric/src/test/java/org/robolectric/SingleSdkRobolectricTestRunner.java
+++ b/robolectric/src/test/java/org/robolectric/SingleSdkRobolectricTestRunner.java
@@ -35,7 +35,7 @@ class SingleSdkRobolectricTestRunner extends RobolectricTestRunner {
     }
 
     SingleSdkPicker(int apiLevel) {
-      this.sdk = TestUtil.getSdkProvider().getSdk(apiLevel);
+      this.sdk = TestUtil.getSdkCollection().getSdk(apiLevel);
     }
 
     @Nonnull

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/AndroidSandboxClassLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/AndroidSandboxClassLoaderTest.java
@@ -13,6 +13,7 @@ import org.robolectric.android.AndroidInterceptors;
 import org.robolectric.internal.AndroidConfigurer;
 import org.robolectric.internal.SandboxFactory;
 import org.robolectric.plugins.DefaultSdkProvider;
+import org.robolectric.plugins.SdkCollection;
 
 @RunWith(JUnit4.class)
 public class AndroidSandboxClassLoaderTest {
@@ -22,8 +23,8 @@ public class AndroidSandboxClassLoaderTest {
   @Before
   public void setUp() throws Exception {
     classLoader =
-        new SandboxFactory(new DefaultSdkProvider(null))
-        .createClassLoader(configureBuilder().build());
+        new SandboxFactory(new SdkCollection(new DefaultSdkProvider(null)))
+            .createClassLoader(configureBuilder().build());
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/plugins/DefaultSdkPickerTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/DefaultSdkPickerTest.java
@@ -17,28 +17,27 @@ import org.robolectric.annotation.Config;
 import org.robolectric.annotation.internal.ConfigUtils;
 import org.robolectric.pluginapi.Sdk;
 import org.robolectric.pluginapi.SdkPicker;
-import org.robolectric.pluginapi.SdkProvider;
 import org.robolectric.pluginapi.UsesSdk;
 
 @RunWith(JUnit4.class)
 public class DefaultSdkPickerTest {
   private static final int[] sdkInts = { 16, 17, 18, 19, 21, 22, 23 };
+  private SdkCollection sdkCollection;
   private UsesSdk usesSdk;
   private SdkPicker sdkPicker;
-  private SdkProvider sdkProvider;
 
   @Before
   public void setUp() throws Exception {
     usesSdk = mock(UsesSdk.class);
-    sdkProvider = new DefaultSdkProvider(null);
-    sdkPicker = new DefaultSdkPicker(map(sdkInts), null);
+    sdkCollection = new SdkCollection(() -> map(sdkInts));
+    sdkPicker = new DefaultSdkPicker(sdkCollection, "");
   }
 
   @Test
   public void withDefaultSdk_shouldUseTargetSdkFromAndroidManifest() throws Exception {
     when(usesSdk.getTargetSdkVersion()).thenReturn(22);
     assertThat(sdkPicker.selectSdks(new Config.Builder().build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(22));
+        .containsExactly(sdkCollection.getSdk(22));
   }
 
   @Test
@@ -47,8 +46,8 @@ public class DefaultSdkPickerTest {
     when(usesSdk.getMinSdkVersion()).thenReturn(19);
     when(usesSdk.getMaxSdkVersion()).thenReturn(23);
     assertThat(sdkPicker.selectSdks(new Config.Builder().setSdk(Config.ALL_SDKS).build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(19), sdkProvider.getSdk(21),
-            sdkProvider.getSdk(22), sdkProvider.getSdk(23));
+        .containsExactly(sdkCollection.getSdk(19), sdkCollection.getSdk(21),
+            sdkCollection.getSdk(22), sdkCollection.getSdk(23));
   }
 
   @Test
@@ -57,9 +56,9 @@ public class DefaultSdkPickerTest {
     when(usesSdk.getMinSdkVersion()).thenReturn(1);
     when(usesSdk.getMaxSdkVersion()).thenReturn(22);
     assertThat(sdkPicker.selectSdks(new Config.Builder().setSdk(Config.ALL_SDKS).build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(16), sdkProvider.getSdk(17),
-            sdkProvider.getSdk(18), sdkProvider.getSdk(19),
-            sdkProvider.getSdk(21), sdkProvider.getSdk(22));
+        .containsExactly(sdkCollection.getSdk(16), sdkCollection.getSdk(17),
+            sdkCollection.getSdk(18), sdkCollection.getSdk(19),
+            sdkCollection.getSdk(21), sdkCollection.getSdk(22));
   }
 
   @Test
@@ -68,8 +67,8 @@ public class DefaultSdkPickerTest {
     when(usesSdk.getMinSdkVersion()).thenReturn(19);
     when(usesSdk.getMaxSdkVersion()).thenReturn(null);
     assertThat(sdkPicker.selectSdks(new Config.Builder().setSdk(Config.ALL_SDKS).build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(19), sdkProvider.getSdk(21),
-            sdkProvider.getSdk(22), sdkProvider.getSdk(23));
+        .containsExactly(sdkCollection.getSdk(19), sdkCollection.getSdk(21),
+            sdkCollection.getSdk(22), sdkCollection.getSdk(23));
   }
 
   @Test
@@ -127,7 +126,7 @@ public class DefaultSdkPickerTest {
     when(usesSdk.getMinSdkVersion()).thenReturn(1);
     when(usesSdk.getMaxSdkVersion()).thenReturn(null);
     assertThat(sdkPicker.selectSdks(new Config.Builder().build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(16));
+        .containsExactly(sdkCollection.getSdk(16));
   }
 
   @Test
@@ -136,8 +135,8 @@ public class DefaultSdkPickerTest {
     when(usesSdk.getMinSdkVersion()).thenReturn(19);
     when(usesSdk.getMaxSdkVersion()).thenReturn(23);
     assertThat(sdkPicker.selectSdks(new Config.Builder().setMinSdk(21).build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(21), sdkProvider.getSdk(22),
-            sdkProvider.getSdk(23));
+        .containsExactly(sdkCollection.getSdk(21), sdkCollection.getSdk(22),
+            sdkCollection.getSdk(23));
   }
 
   @Test
@@ -146,7 +145,7 @@ public class DefaultSdkPickerTest {
     when(usesSdk.getMinSdkVersion()).thenReturn(19);
     when(usesSdk.getMaxSdkVersion()).thenReturn(23);
     assertThat(sdkPicker.selectSdks(new Config.Builder().setMaxSdk(21).build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(19), sdkProvider.getSdk(21));
+        .containsExactly(sdkCollection.getSdk(19), sdkCollection.getSdk(21));
   }
 
   @Test
@@ -156,27 +155,27 @@ public class DefaultSdkPickerTest {
     when(usesSdk.getMaxSdkVersion()).thenReturn(22);
 
     assertThat(sdkPicker.selectSdks(new Config.Builder().setSdk(21).build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(21));
+        .containsExactly(sdkCollection.getSdk(21));
     assertThat(sdkPicker.selectSdks(new Config.Builder().setSdk(Config.OLDEST_SDK).build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(19));
+        .containsExactly(sdkCollection.getSdk(19));
     assertThat(sdkPicker.selectSdks(new Config.Builder().setSdk(Config.TARGET_SDK).build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(21));
+        .containsExactly(sdkCollection.getSdk(21));
     assertThat(sdkPicker.selectSdks(new Config.Builder().setSdk(Config.NEWEST_SDK).build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(22));
+        .containsExactly(sdkCollection.getSdk(22));
 
     assertThat(sdkPicker.selectSdks(new Config.Builder().setSdk(16).build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(16));
+        .containsExactly(sdkCollection.getSdk(16));
     assertThat(sdkPicker.selectSdks(new Config.Builder().setSdk(23).build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(23));
+        .containsExactly(sdkCollection.getSdk(23));
   }
 
   @Test
   public void withEnabledSdks_shouldRestrictAsSpecified() throws Exception {
     when(usesSdk.getMinSdkVersion()).thenReturn(16);
     when(usesSdk.getMaxSdkVersion()).thenReturn(23);
-    sdkPicker = new DefaultSdkPicker(map(sdkInts), map(17, 18));
+    sdkPicker = new DefaultSdkPicker(sdkCollection, "17,18");
     assertThat(sdkPicker.selectSdks(new Config.Builder().setSdk(Config.ALL_SDKS).build(), usesSdk))
-        .containsExactly(sdkProvider.getSdk(17), sdkProvider.getSdk(18));
+        .containsExactly(sdkCollection.getSdk(17), sdkCollection.getSdk(18));
   }
 
   @Test
@@ -190,6 +189,7 @@ public class DefaultSdkPickerTest {
   }
 
   private List<Sdk> map(int... sdkInts) {
-    return Arrays.stream(sdkInts).mapToObj(sdkProvider::getSdk).collect(Collectors.toList());
+    SdkCollection allSdks = new SdkCollection(new DefaultSdkProvider(null));
+    return Arrays.stream(sdkInts).mapToObj(allSdks::getSdk).collect(Collectors.toList());
   }
 }

--- a/robolectric/src/test/java/org/robolectric/plugins/SdkCollectionTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/SdkCollectionTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.nio.file.Path;
 import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
@@ -66,48 +65,15 @@ public class SdkCollectionTest {
   }
 
   @Test
+  public void getKnownSdks_shouldReturnAll() throws Exception {
+    assertThat(sdkCollection.getKnownSdks())
+        .containsExactly(fakeSdk1234, fakeSdk1235, fakeSdk1236, fakeUnsupportedSdk1237).inOrder();
+  }
+
+  @Test
   public void getSupportedSdks_shouldReturnOnlySupported() throws Exception {
     assertThat(sdkCollection.getSupportedSdks())
         .containsExactly(fakeSdk1234, fakeSdk1235, fakeSdk1236).inOrder();
   }
 
-  private static class StubSdk extends Sdk {
-
-    private final boolean isSupported;
-
-    public StubSdk(int apiLevel, boolean isSupported) {
-      super(apiLevel);
-      this.isSupported = isSupported;
-    }
-
-    @Override
-    public String getAndroidVersion() {
-      return null;
-    }
-
-    @Override
-    public String getAndroidCodeName() {
-      return null;
-    }
-
-    @Override
-    public Path getJarPath() {
-      return null;
-    }
-
-    @Override
-    public boolean isSupported() {
-      return isSupported;
-    }
-
-    @Override
-    public String getUnsupportedMessage() {
-      return null;
-    }
-
-    @Override
-    public boolean isKnown() {
-      return false;
-    }
-  }
 }

--- a/robolectric/src/test/java/org/robolectric/plugins/SdkCollectionTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/SdkCollectionTest.java
@@ -1,0 +1,113 @@
+package org.robolectric.plugins;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.pluginapi.Sdk;
+import org.robolectric.pluginapi.SdkProvider;
+
+public class SdkCollectionTest {
+
+  private SdkProvider mockSdkProvider;
+  private SdkCollection sdkCollection;
+  private Sdk fakeSdk1234;
+  private Sdk fakeSdk1235;
+  private Sdk fakeSdk1236;
+  private Sdk fakeUnsupportedSdk1237;
+
+  @Before
+  public void setUp() throws Exception {
+    mockSdkProvider = mock(SdkProvider.class);
+    fakeSdk1234 = new StubSdk(1234, true);
+    fakeSdk1235 = new StubSdk(1235, true);
+    fakeSdk1236 = new StubSdk(1236, true);
+    fakeUnsupportedSdk1237 = new StubSdk(1237, false);
+    when(mockSdkProvider.getSdks())
+        .thenReturn(Arrays.asList(fakeSdk1235, fakeSdk1234, fakeSdk1236, fakeUnsupportedSdk1237));
+
+    sdkCollection = new SdkCollection(mockSdkProvider);
+  }
+
+  @Test
+  public void shouldComplainAboutDupes() throws Exception {
+    try {
+      new SdkCollection(() -> Arrays.asList(fakeSdk1234, fakeSdk1234));
+      fail();
+    } catch (Exception e) {
+      assertThat(e.getMessage()).contains("duplicate SDKs for API level 1234");
+    }
+  }
+
+  @Test
+  public void shouldCacheSdks() throws Exception {
+    assertThat(sdkCollection.getSdk(1234)).isSameAs(fakeSdk1234);
+    assertThat(sdkCollection.getSdk(1234)).isSameAs(fakeSdk1234);
+
+    verify(mockSdkProvider, times(1)).getSdks();
+  }
+
+  @Test
+  public void getMaxSupportedSdk() throws Exception {
+    assertThat(sdkCollection.getMaxSupportedSdk()).isSameAs(fakeSdk1236);
+  }
+
+  @Test
+  public void getSdk_shouldReturnNullObjectForUnknownSdks() throws Exception {
+    assertThat(sdkCollection.getSdk(4321)).isNotNull();
+    assertThat(sdkCollection.getSdk(4321).isKnown()).isFalse();
+  }
+
+  @Test
+  public void getSupportedSdks_shouldReturnOnlySupported() throws Exception {
+    assertThat(sdkCollection.getSupportedSdks())
+        .containsExactly(fakeSdk1234, fakeSdk1235, fakeSdk1236).inOrder();
+  }
+
+  private static class StubSdk extends Sdk {
+
+    private final boolean isSupported;
+
+    public StubSdk(int apiLevel, boolean isSupported) {
+      super(apiLevel);
+      this.isSupported = isSupported;
+    }
+
+    @Override
+    public String getAndroidVersion() {
+      return null;
+    }
+
+    @Override
+    public String getAndroidCodeName() {
+      return null;
+    }
+
+    @Override
+    public Path getJarPath() {
+      return null;
+    }
+
+    @Override
+    public boolean isSupported() {
+      return isSupported;
+    }
+
+    @Override
+    public String getUnsupportedMessage() {
+      return null;
+    }
+
+    @Override
+    public boolean isKnown() {
+      return false;
+    }
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/plugins/StubSdk.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/StubSdk.java
@@ -1,0 +1,45 @@
+package org.robolectric.plugins;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.robolectric.pluginapi.Sdk;
+
+public class StubSdk extends Sdk {
+
+  private final boolean isSupported;
+
+  public StubSdk(int apiLevel, boolean isSupported) {
+    super(apiLevel);
+    this.isSupported = isSupported;
+  }
+
+  @Override
+  public String getAndroidVersion() {
+    return null;
+  }
+
+  @Override
+  public String getAndroidCodeName() {
+    return null;
+  }
+
+  @Override
+  public Path getJarPath() {
+    return Paths.get("fake/path-" + getApiLevel() + ".jar");
+  }
+
+  @Override
+  public boolean isSupported() {
+    return isSupported;
+  }
+
+  @Override
+  public String getUnsupportedMessage() {
+    return "unsupported";
+  }
+
+  @Override
+  public boolean isKnown() {
+    return true;
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/util/TestUtil.java
+++ b/robolectric/src/test/java/org/robolectric/util/TestUtil.java
@@ -10,8 +10,8 @@ import org.robolectric.LegacyDependencyResolver;
 import org.robolectric.R;
 import org.robolectric.internal.dependency.DependencyResolver;
 import org.robolectric.pluginapi.Sdk;
-import org.robolectric.pluginapi.SdkProvider;
 import org.robolectric.plugins.DefaultSdkProvider;
+import org.robolectric.plugins.SdkCollection;
 import org.robolectric.res.Fs;
 import org.robolectric.res.ResourcePath;
 
@@ -20,7 +20,7 @@ public abstract class TestUtil {
   private static ResourcePath TEST_RESOURCE_PATH;
   private static File testDirLocation;
   private static LegacyDependencyResolver dependencyResolver;
-  private static SdkProvider sdkProvider;
+  private static SdkCollection sdkCollection;
 
   public static Path resourcesBaseDir() {
     return resourcesBaseDirFile().toPath();
@@ -48,7 +48,7 @@ public abstract class TestUtil {
 
   public static ResourcePath systemResources() {
     if (SYSTEM_RESOURCE_PATH == null) {
-      Sdk sdk = getSdkProvider().getMaxSupportedSdk();
+      Sdk sdk = getSdkCollection().getMaxSupportedSdk();
       Path path = sdk.getJarPath();
       SYSTEM_RESOURCE_PATH =
           new ResourcePath(
@@ -58,7 +58,7 @@ public abstract class TestUtil {
   }
 
   public static ResourcePath sdkResources(int apiLevel) {
-    Path path = getSdkProvider().getSdk(apiLevel).getJarPath();
+    Path path = getSdkCollection().getSdk(apiLevel).getJarPath();
     return new ResourcePath(null, path.resolve("raw-res/res"), null, null);
   }
 
@@ -74,11 +74,11 @@ public abstract class TestUtil {
     return dependencyResolver;
   }
 
-  public static SdkProvider getSdkProvider() {
-    if (sdkProvider == null) {
-      sdkProvider = new DefaultSdkProvider(getDependencyResolver());
+  public static SdkCollection getSdkCollection() {
+    if (sdkCollection == null) {
+      sdkCollection = new SdkCollection(new DefaultSdkProvider(getDependencyResolver()));
     }
-    return sdkProvider;
+    return sdkCollection;
   }
 
   public static void resetSystemProperty(String name, String value) {

--- a/utils/reflector/src/test/java/org/robolectric/util/reflector/ReflectorTest.java
+++ b/utils/reflector/src/test/java/org/robolectric/util/reflector/ReflectorTest.java
@@ -88,7 +88,7 @@ public class ReflectorTest {
     try {
       reflector.throwException(expected);
       fail("should have failed");
-    } catch (Throwable thrown) {
+    } catch (Exception thrown) {
       actual = thrown;
     }
     assertThat(actual).isSameAs(expected);


### PR DESCRIPTION
`SdkProvider` now has a single method, `getSdks()`. Better javadoc.