### PR TITLE
Issue 4491: Fix generation of getProvidedPackageNames() for androidx. (Make shadows-supportv4 work with agp 3.3.0)

### DIFF
--- a/integration_tests/androidx_shadows/build.gradle
+++ b/integration_tests/androidx_shadows/build.gradle
@@ -1,0 +1,36 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 28
+
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 28
+    }
+
+    compileOptions {
+        sourceCompatibility = '1.8'
+        targetCompatibility = '1.8'
+    }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+
+}
+
+dependencies {
+    implementation project(":robolectric")
+    implementation project(":shadows:supportv4")
+    implementation "androidx.loader:loader:1.0.0"
+    implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.0.0"
+    implementation "androidx.media2:media2:1.0.0-alpha03"
+    implementation "androidx.drawerlayout:drawerlayout:1.0.0"
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    implementation "junit:junit:4.12"
+
+    // Testing dependencies
+    testImplementation("com.google.truth:truth:0.42")
+}

--- a/integration_tests/androidx_shadows/gradle.properties
+++ b/integration_tests/androidx_shadows/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true

--- a/integration_tests/androidx_shadows/src/main/AndroidManifest.xml
+++ b/integration_tests/androidx_shadows/src/main/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Manifest for instrumentation tests
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.robolectric.integration_tests.androidx_shadows">
+  <uses-sdk
+      android:minSdkVersion="16"
+      android:targetSdkVersion="27" />
+
+  <application />
+</manifest>

--- a/integration_tests/androidx_shadows/src/test/java/org/robolectric/shadows/ShadowsTest.java
+++ b/integration_tests/androidx_shadows/src/test/java/org/robolectric/shadows/ShadowsTest.java
@@ -1,0 +1,26 @@
+package org.robolectric.shadows;
+
+import static com.google.common.truth.Truth.assertThat;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.shadows.support.v4.Shadows;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class ShadowsTest {
+
+  @Test
+  public void testGetProvidedPackageNames() throws Exception {
+    String[] actualProvidedPackageNames = new Shadows().getProvidedPackageNames();
+    assertThat(Arrays.asList(actualProvidedPackageNames)).containsExactly(
+        "android.support.v4.media",
+        "androidx.drawerlayout.widget",
+        "androidx.loader.content",
+        "androidx.localbroadcastmanager.content",
+        "androidx.swiperefreshlayout.widget"
+    );
+  }
+
+}

--- a/processor/src/main/java/org/robolectric/annotation/processing/RobolectricModel.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/RobolectricModel.java
@@ -214,8 +214,10 @@ public class RobolectricModel {
       }
 
       // Other imports that the generated class needs
+      imports.add("java.util.Arrays");
       imports.add("java.util.Map");
       imports.add("java.util.HashMap");
+      imports.add("java.util.LinkedHashSet");
       imports.add("javax.annotation.Generated");
       imports.add("org.robolectric.internal.ShadowProvider");
       imports.add("org.robolectric.shadow.api.Shadow");
@@ -308,7 +310,16 @@ public class RobolectricModel {
         continue;
       }
 
-      packages.add("\"" + packageName + "\"");
+      // Issue 4491: For support lib classes, we don't know if they will be used as support lib or
+      // androidx. Jetifier can't migrate string constants, but it can migrate class references.
+      // Resolve these package names as android.support.v4.somepackage.SomeClass.class.getPackage().getName(),
+      // instead of "android.support.v4.somepackage"
+      if (packageName.startsWith("android.support.v4")) {
+        String className = shadowInfo.getActualName();
+        packages.add(className + ".class.getPackage().getName()");
+      } else {
+        packages.add("\"" + packageName + "\"");
+      }
     }
     return packages;
   }

--- a/processor/src/main/java/org/robolectric/annotation/processing/generator/ShadowProviderGenerator.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/generator/ShadowProviderGenerator.java
@@ -163,11 +163,11 @@ public class ShadowProviderGenerator extends Generator {
 
     writer.println("  @Override");
     writer.println("  public String[] getProvidedPackageNames() {");
-    writer.println("    return new String[] {");
+    writer.println("    return new LinkedHashSet<>(Arrays.asList(");
     if (shouldInstrumentPackages) {
       writer.println("      " + Joiner.on(",\n      ").join(model.getShadowedPackages()));
     }
-    writer.println("    };");
+    writer.println("    )).toArray(new String[0]);");
     writer.println("  }");
     writer.println();
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,6 +23,7 @@ include ":integration_tests:mockito"
 include ":integration_tests:mockito-experimental"
 include ":integration_tests:powermock"
 include ':integration_tests:androidx'
+include ':integration_tests:androidx_shadows'
 include ':integration_tests:androidx_test'
 include ':integration_tests:ctesque'
 include ':testapp'

--- a/shadows/supportv4/src/test/java/org/robolectric/shadows/ShadowsTest.java
+++ b/shadows/supportv4/src/test/java/org/robolectric/shadows/ShadowsTest.java
@@ -1,0 +1,24 @@
+package org.robolectric.shadows;
+
+import static com.google.common.truth.Truth.assertThat;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.shadows.support.v4.Shadows;
+import org.robolectric.util.TestRunnerWithManifest;
+
+@RunWith(TestRunnerWithManifest.class)
+public class ShadowsTest {
+
+  @Test
+  public void testGetProvidedPackageNames() throws Exception {
+    String[] actualProvidedPackageNames = new Shadows().getProvidedPackageNames();
+    assertThat(Arrays.asList(actualProvidedPackageNames)).containsExactly(
+        "android.support.v4.content",
+        "android.support.v4.media",
+        "android.support.v4.widget"
+    );
+  }
+
+}


### PR DESCRIPTION
### Overview
This is one possible fix for issue #4491. A project using agp 3.3.0 and androidx with jetifier cannot use robolectric shadows-supportv4. The robolectric shadows-supportv4 jar file contains string literals referring to `android.support.*` packages. These string literals are in the generated `Shadows.getProvidedPackageNames()` method.

### Proposed Changes
For support lib classes, don't include string literals for the package names in `getProvidedPackageNames()`. Instead, provide package references via `android.support.v4.somepackage.SomeClass.class.getPackage().getName()`. The jetifier tool is able to migrate these references to androidx.

This PR adds unit tests for the return value of `Shadows.getProvidedPackageNames()`  for both the support library and androidx.

### Alternatives
Alternative fixes could be:
* provide a separate `shadows-androidx` artifact that could be used instead of a jetified `shadows-supportv4`
* remove the `getProvidedPackageNames()` api entirely. I didn't see where it's used...
* just exclude `android.support` classes from `getProvidedPackageNames()`