### PR TITLE
Revert to Gradle 4.10.3 and AGP 3.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0-beta03'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.6'
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:2.2.1'
         classpath 'ch.raffael.pegdown-doclet:pegdown-doclet:1.3'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     implementation localGroovy()
 
     implementation "org.ow2.asm:asm-tree:7.0"
-    implementation 'com.android.tools.build:gradle:3.4.0-beta03'
+    implementation 'com.android.tools.build:gradle:3.3.1'
 }

--- a/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
@@ -1,19 +1,18 @@
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.artifacts.maven.MavenDeployment
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.JavaCompile
-import org.robolectric.gradle.AarDepsPlugin
 
 class RoboJavaModulePlugin implements Plugin<Project> {
     Boolean deploy = false;
 
     Closure doApply = {
-        project.apply plugin: "java-library"
-        project.apply plugin: "net.ltgt.errorprone"
+        apply plugin: "java-library"
+        apply plugin: "net.ltgt.errorprone"
 
-        project.apply plugin: AarDepsPlugin
+        apply plugin: org.robolectric.gradle.AarDepsPlugin
 
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
@@ -68,7 +67,7 @@ class RoboJavaModulePlugin implements Plugin<Project> {
             maxHeapSize = "4096m"
 
             if (System.env['GRADLE_MAX_PARALLEL_FORKS'] != null) {
-                maxParallelForks = Integer.parseInt(System.env['GRADLE_MAX_PARALLEL_FORKS'] as String)
+                maxParallelForks = Integer.parseInt(System.env['GRADLE_MAX_PARALLEL_FORKS'])
             }
 
             def forwardedSystemProperties = System.properties
@@ -88,12 +87,12 @@ class RoboJavaModulePlugin implements Plugin<Project> {
 
         if (owner.deploy) {
             project.apply plugin: "signing"
-            project.apply plugin: "maven-publish"
+            project.apply plugin: "maven"
             project.apply plugin: 'ch.raffael.pegdown-doclet'
 
-            task('sourcesJar', type: Jar) {
+            task('sourcesJar', type: Jar, dependsOn: classes) {
+                classifier "sources"
                 from sourceSets.main.allJava
-                archiveClassifier = "sources"
             }
 
             javadoc {
@@ -104,97 +103,84 @@ class RoboJavaModulePlugin implements Plugin<Project> {
                 options.footer = "<ul class=\"navList\"><li>Robolectric $thisVersion | <a href=\"/\">Home</a></li></ul>"
                 options.bottom = "<link rel=\"stylesheet\" href=\"https://robolectric.org/assets/css/main.css\">"
                 options.version = thisVersion
-
-                if(JavaVersion.current().isJava9Compatible()) {
-                    options.addBooleanOption('html5', true)
-                }
             }
 
             task('javadocJar', type: Jar, dependsOn: javadoc) {
+                classifier "javadoc"
                 from javadoc.destinationDir
-                archiveClassifier = "javadoc"
+            }
+
+            signing {
+                required { !version.endsWith("SNAPSHOT") && gradle.taskGraph.hasTask("uploadArchives") }
+                sign configurations.archives
+            }
+
+            def skipJavadoc = System.getenv('SKIP_JAVADOC') == "true"
+            artifacts {
+                archives jar
+                archives sourcesJar
+                if (!skipJavadoc) {
+                    archives javadocJar
+                }
             }
 
             // for maven local install:
             archivesBaseName = mavenArtifactName
 
-            publishing {
-                publications {
-                    mavenJava(MavenPublication) {
-                        from components.java
-
-                        def skipJavadoc = System.getenv('SKIP_JAVADOC') == "true"
-                        artifact sourcesJar
-                        if (!skipJavadoc) {
-                            artifact javadocJar
-                        }
-
-                        artifactId = mavenArtifactName
-                        pom {
-                            name = project.name
+            uploadArchives {
+                repositories {
+                    mavenDeployer {
+                        pom.artifactId = mavenArtifactName
+                        pom.project {
+                            name project.name
                             description = "An alternative Android testing framework."
                             url = "http://robolectric.org"
 
                             licenses {
                                 license {
-                                    name = "The MIT License"
-                                    url = "https://opensource.org/licenses/MIT"
+                                    name "The MIT License"
+                                    url "https://opensource.org/licenses/MIT"
                                 }
                             }
 
                             scm {
-                                url = "git@github.com:robolectric/robolectric.git"
-                                connection = "scm:git:git://github.com/robolectric/robolectric.git"
-                                developerConnection = "scm:git:https://github.com/robolectric/robolectric.git"
+                                url "git@github.com:robolectric/robolectric.git"
+                                connection "scm:git:git://github.com/robolectric/robolectric.git"
+                                developerConnection "scm:git:https://github.com/robolectric/robolectric.git"
                             }
 
                             developers {
                                 developer {
-                                    name = "Brett Chabot"
-                                    email = "brettchabot@google.com"
+                                    name "Christian Williams"
+                                    email "christianw@google.com"
                                     organization = "Google Inc."
-                                    organizationUrl = "http://google.com"
+                                    organizationUrl "http://google.com"
                                 }
 
                                 developer {
-                                    name = "Jonathan Gerrish"
-                                    email = "jongerrish@google.com"
+                                    name "Jonathan Gerrish"
+                                    email "jongerrish@google.com"
                                     organization = "Google Inc."
-                                    organizationUrl = "http://google.com"
-                                }
-
-                                developer {
-                                    name = "Christian Williams"
-                                    email = "christianw@google.com"
-                                    organization = "Google Inc."
-                                    organizationUrl = "http://google.com"
+                                    organizationUrl "http://google.com"
                                 }
                             }
                         }
-                    }
-                }
 
-                repositories {
-                    maven {
-                        def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-                        def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
-                        url = project.version.endsWith("-SNAPSHOT") ? snapshotsRepoUrl : releasesRepoUrl
-
-                        credentials {
-                            username = System.properties["sonatype-login"] ?: System.env['sonatypeLogin']
-                            password = System.properties["sonatype-password"] ?: System.env['sonatypePassword']
+                        def url = project.version.endsWith("-SNAPSHOT") ?
+                                "https://oss.sonatype.org/content/repositories/snapshots" :
+                                "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                        repository(url: url) {
+                            authentication(
+                                    userName: System.properties["sonatype-login"] ?: System.env['sonatypeLogin'],
+                                    password: System.properties["sonatype-password"] ?: System.env['sonatypePassword']
+                            )
                         }
 
-//                        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+                        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
                     }
                 }
             }
-
-            signing {
-                required { !version.endsWith("SNAPSHOT") && gradle.taskGraph.hasTask("uploadArchives") }
-                sign publishing.publications.mavenJava
-            }
-         }
+        }
     }
 
     @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,3 @@ errorproneVersion=2.3.1
 errorproneJavacVersion=9+181-r4173-1
 
 android.enableUnitTestBinaryResources=true
-
-org.gradle.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
IntelliJ fails to configure project with Gradle 5.x, which is required by AGP 3.4:

    Unsupported method: IdeaModuleDependency.getDependencyModule().
    The version of Gradle you connect to does not support that method.
    To resolve the problem you can change/upgrade the target version of Gradle you connect to.
    Alternatively, you can ignore this exception and read other information from the model.