### PR TITLE
Roll forward to AGP 3.4 and Gradle 5.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
           name: Upload Snapshot
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              ./gradlew upload --no-rebuild
+              ./gradlew publish --no-rebuild
             fi
 
 workflows:

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.4.0-beta03'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.6'
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:2.2.1'
         classpath 'ch.raffael.pegdown-doclet:pegdown-doclet:1.3'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     implementation localGroovy()
 
     implementation "org.ow2.asm:asm-tree:7.0"
-    implementation 'com.android.tools.build:gradle:3.3.1'
+    implementation 'com.android.tools.build:gradle:3.4.0-beta03'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,5 @@ errorproneVersion=2.3.1
 errorproneJavacVersion=9+181-r4173-1
 
 android.enableUnitTestBinaryResources=true
+
+org.gradle.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Blocked until this IDEA/Studio stop giving this error message on project sync:

```
Unsupported method: IdeaModuleDependency.getDependencyModule().
The version of Gradle you connect to does not support that method.
To resolve the problem you can change/upgrade the target version of Gradle you connect to.
Alternatively, you can ignore this exception and read other information from the model.
```