### PR TITLE
Use 'sneaky throw' technique instead of Unsafe

### DIFF
--- a/junit/src/main/java/org/robolectric/internal/SandboxTestRunner.java
+++ b/junit/src/main/java/org/robolectric/internal/SandboxTestRunner.java
@@ -40,8 +40,8 @@ import org.robolectric.pluginapi.perf.Metric;
 import org.robolectric.pluginapi.perf.PerfStatsReporter;
 import org.robolectric.util.PerfStatsCollector;
 import org.robolectric.util.PerfStatsCollector.Event;
+import org.robolectric.util.Util;
 import org.robolectric.util.inject.Injector;
-import org.robolectric.util.reflector.UnsafeAccess;
 
 @SuppressWarnings("NewApi")
 public class SandboxTestRunner extends BlockJUnit4ClassRunner {
@@ -258,7 +258,7 @@ public class SandboxTestRunner extends BlockJUnit4ClassRunner {
               afterTest(method, bootstrappedMethod);
             }
           } catch (Throwable throwable) {
-            UnsafeAccess.throwException(throwable);
+            Util.sneakyThrow(throwable);
           } finally {
             Thread.currentThread().setContextClassLoader(priorContextClassLoader);
             try {

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/Sandbox.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/Sandbox.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import javax.inject.Inject;
 import org.robolectric.shadow.api.Shadow;
-import org.robolectric.util.reflector.UnsafeAccess;
+import org.robolectric.util.Util;
 
 public class Sandbox {
   private final SandboxClassLoader sandboxClassLoader;
@@ -99,8 +99,7 @@ public class Sandbox {
       future.cancel(true);
       throw new RuntimeException(e);
     } catch (ExecutionException e) {
-      UnsafeAccess.throwException(e.getCause());
-      throw new IllegalStateException("we won't get here");
+      throw Util.sneakyThrow(e.getCause());
     }
   }
 }

--- a/utils/reflector/src/main/java/org/robolectric/util/reflector/UnsafeAccess.java
+++ b/utils/reflector/src/main/java/org/robolectric/util/reflector/UnsafeAccess.java
@@ -18,16 +18,10 @@ public class UnsafeAccess {
 
   interface Danger {
     <T> Class<?> defineClass(Class<T> iClass, String reflectorClassName, byte[] bytecode);
-
-    void throwException(Throwable t);
   }
 
   static <T> Class<?> defineClass(Class<T> iClass, String reflectorClassName, byte[] bytecode) {
     return DANGER.defineClass(iClass, reflectorClassName, bytecode);
-  }
-
-  public static void throwException(Throwable t) {
-    DANGER.throwException(t);
   }
 
   private static class DangerPre11 implements Danger {
@@ -47,11 +41,6 @@ public class UnsafeAccess {
     public <T> Class<?> defineClass(Class<T> iClass, String reflectorClassName, byte[] bytecode) {
       return unsafe.defineClass(
           reflectorClassName, bytecode, 0, bytecode.length, iClass.getClassLoader(), null);
-    }
-
-    @Override
-    public void throwException(Throwable t) {
-      unsafe.throwException(t);
     }
   }
 
@@ -85,11 +74,6 @@ public class UnsafeAccess {
       } catch (IllegalAccessException | InvocationTargetException e) {
         throw new AssertionError(e);
       }
-    }
-
-    @Override
-    public void throwException(Throwable t) {
-      throw new RuntimeException("huh? java 11, need help!", t);
     }
   }
 

--- a/utils/src/main/java/org/robolectric/util/Util.java
+++ b/utils/src/main/java/org/robolectric/util/Util.java
@@ -116,4 +116,22 @@ public class Util {
       return Integer.parseInt(valueFor, 10);
     }
   }
+
+  /**
+   * Re-throw {@code t} (even if it's a checked exception) without requiring a {@code throws}
+   * declaration.
+   * <p>
+   * This function declares a return type of {@link RuntimeException} but will never actually return
+   * a value. This allows you to use it with a {@code throw} statement to convince the compiler that
+   * the current branch will not complete.
+   * <pre>{@code
+   * throw Util.sneakyThrow(new IOException());
+   * }</pre>
+   * <p>
+   * Adapted from https://www.mail-archive.com/javaposse@googlegroups.com/msg05984.html
+   */
+  @SuppressWarnings("unchecked")
+  public static <T extends Throwable> RuntimeException sneakyThrow(Throwable t) throws T {
+    throw (T) t;
+  }
 }

--- a/utils/src/main/java/org/robolectric/util/inject/Injector.java
+++ b/utils/src/main/java/org/robolectric/util/inject/Injector.java
@@ -25,7 +25,7 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
-import org.robolectric.util.reflector.UnsafeAccess;
+import org.robolectric.util.Util;
 
 /**
  * A tiny dependency injection and plugin helper for Robolectric.
@@ -238,8 +238,7 @@ public class Injector {
     try {
       return ctor.newInstance(params);
     } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-      UnsafeAccess.throwException(e.getCause());
-      throw new IllegalStateException(); // unreachable
+      throw Util.sneakyThrow(e.getCause());
     }
   }
 


### PR DESCRIPTION
This works on all JDK versions including 11+ where no re-throw implementation existed previously.