### PR TITLE
Remove redundant Gradle dsl from androidx_test

### DIFF
--- a/integration_tests/androidx_test/build.gradle
+++ b/integration_tests/androidx_test/build.gradle
@@ -13,14 +13,11 @@ android {
         targetCompatibility = '1.8'
     }
 
-    android {
-        testOptions {
-            unitTests {
-                includeAndroidResources = true
-            }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
         }
     }
-
 }
 
 dependencies {


### PR DESCRIPTION
### Overview

This `android` DSL duplicates. there is no need.

