### PR TITLE
Run integration tests only for the set of robolectric.enabledSdks.

### DIFF
--- a/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/RoboJavaModulePlugin.groovy
@@ -54,6 +54,8 @@ class RoboJavaModulePlugin implements Plugin<Project> {
 
         test {
             exclude "**/*\$*" // otherwise gradle runs static inner classes like TestRunnerSequenceTest$SimpleTest
+
+            // TODO: DRY up code with AndroidProjectConfigPlugin...
             testLogging {
                 exceptionFormat "full"
                 showCauses true

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/AndroidProjectConfigPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/AndroidProjectConfigPlugin.groovy
@@ -1,0 +1,39 @@
+package org.robolectric.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+public class AndroidProjectConfigPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.android.testOptions.unitTests.all {
+            // TODO: DRY up code with RoboJavaModulePlugin...
+            testLogging {
+                exceptionFormat "full"
+                showCauses true
+                showExceptions true
+                showStackTraces true
+                showStandardStreams true
+                events = ["failed", "skipped"]
+            }
+
+            minHeapSize = "1024m"
+            maxHeapSize = "4096m"
+
+            if (System.env['GRADLE_MAX_PARALLEL_FORKS'] != null) {
+                maxParallelForks = Integer.parseInt(System.env['GRADLE_MAX_PARALLEL_FORKS'])
+            }
+
+            def forwardedSystemProperties = System.properties
+                    .findAll { k,v -> k.startsWith("robolectric.") }
+                    .collect { k,v -> "-D$k=$v" }
+            jvmArgs = ["-XX:MaxPermSize=1024m"] + forwardedSystemProperties
+
+            doFirst {
+                if (!forwardedSystemProperties.isEmpty()) {
+                    println "Running tests with ${forwardedSystemProperties}"
+                }
+            }
+        }
+    }
+}

--- a/integration_tests/agp/build.gradle
+++ b/integration_tests/agp/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: org.robolectric.gradle.AndroidProjectConfigPlugin
 
 android {
     compileSdkVersion 28

--- a/integration_tests/androidx/build.gradle
+++ b/integration_tests/androidx/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: org.robolectric.gradle.AndroidProjectConfigPlugin
 
 android {
     compileSdkVersion 28

--- a/integration_tests/androidx_test/build.gradle
+++ b/integration_tests/androidx_test/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: org.robolectric.gradle.AndroidProjectConfigPlugin
 
 android {
     compileSdkVersion 28

--- a/integration_tests/ctesque/build.gradle
+++ b/integration_tests/ctesque/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: org.robolectric.gradle.AndroidProjectConfigPlugin
 
 android {
     compileSdkVersion 28


### PR DESCRIPTION
Add this to any AGP projects:

```groovy
apply plugin: org.robolectric.gradle.AndroidProjectConfigPlugin
```