### PR TITLE
Don't instrument androidx.room.CoroutinesRoom$Companion

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
+++ b/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
@@ -117,6 +117,7 @@ public class AndroidConfigurer {
     builder.doNotInstrumentPackage("androidx.test");
     builder.doNotInstrumentPackage("android.arch.persistence.room.migration");
     builder.doNotInstrumentPackage("android.support.test");
+    builder.doNotInstrumentClass("androidx.room.CoroutinesRoom$Companion");
 
     for (String packagePrefix : shadowProviders.getInstrumentedPackages()) {
       builder.addInstrumentedPackage(packagePrefix);


### PR DESCRIPTION
### Overview
This adds an instrumentation exception for androidx.room.CoroutinesRoom$Companion.

Without this exception, Robolectric is incompatible with the Kotlin coroutines
support added in AndroidX Room 2.1.

### Proposed Changes
Update AndroidConfigurer to add an exception for androidx.room.CoroutinesRoom$Companion.
There are already exceptions for Room migrations, so this doesn't seem terribly out of scope.

### Addresses bugs
Issue: https://github.com/robolectric/robolectric/issues/4340
From Room's issuetracker: https://issuetracker.google.com/issues/124781244
