### PR TITLE
Attempt to make ShadowLogTest more robust.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
@@ -244,7 +244,7 @@ public class ShadowLogTest {
   }
 
   private void assertLogged(int type, String tag, String msg, Throwable throwable) {
-    LogItem lastLog = Iterables.getLast(ShadowLog.getLogs());
+    LogItem lastLog = Iterables.getLast(ShadowLog.getLogsForTag(tag));
     assertEquals(type, lastLog.type);
     assertEquals(msg, lastLog.msg);
     assertEquals(tag, lastLog.tag);


### PR DESCRIPTION
It previously just verified the last log entry, which can be flaky if
there are background threads running and logging stuff.

