### PR TITLE
Read_android_app_from_package

### DIFF
--- a/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
@@ -208,7 +208,7 @@ public class AndroidTestEnvironment implements TestEnvironment {
     Context systemContextImpl = reflector(_ContextImpl_.class).createSystemContext(activityThread);
     RuntimeEnvironment.systemContext = systemContextImpl;
 
-    Application application = createApplication(appManifest, config);
+    Application application = createApplication(appManifest, config, applicationInfo);
     RuntimeEnvironment.application = application;
 
     Instrumentation instrumentation =
@@ -378,7 +378,7 @@ public class AndroidTestEnvironment implements TestEnvironment {
   }
 
   @VisibleForTesting
-  static Application createApplication(AndroidManifest appManifest, Config config) {
+  static Application createApplication(AndroidManifest appManifest, Config config, ApplicationInfo applicationInfo) {
     Application application = null;
     if (config != null && !Config.Builder.isDefaultApplication(config.application())) {
       if (config.application().getCanonicalName() != null) {
@@ -403,6 +403,23 @@ public class AndroidTestEnvironment implements TestEnvironment {
         try {
           applicationClass = ClassNameResolver.resolve(appManifest.getPackageName(),
               appManifest.getApplicationName());
+        } catch (ClassNotFoundException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      application = ReflectionHelpers.callConstructor(applicationClass);
+    } else if (applicationInfo.className != null) {
+      Class<? extends Application> applicationClass = null;
+      try {
+        applicationClass = (Class<? extends Application>) Class.forName(getTestApplicationName(applicationInfo.className));
+      } catch (ClassNotFoundException e) {
+        // no problem
+      }
+
+      if (applicationClass == null) {
+        try {
+          applicationClass = (Class<? extends Application>) Class.forName(applicationInfo.className);
         } catch (ClassNotFoundException e) {
           throw new RuntimeException(e);
         }


### PR DESCRIPTION
### Overview
Currently the application is not read from the binary package. The application defined in the binary should be used unless it is overridden.

### Proposed Changes
This change will supply the application info that was read from the binary package while creating the Application. If no other override is found it should be used before falling back to the base Application class.