### PR TITLE
Fix for ShadowMediaPlayer.create(Context context, Uri uri);

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
@@ -4,6 +4,7 @@ import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.O;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.shadows.ShadowLooper.shadowMainLooper;
@@ -111,6 +112,18 @@ public class ShadowMediaPlayerTest {
     assertThat(shadow.getDataSource())
         .isEqualTo(
             DataSource.toDataSource("android.resource://" + context.getPackageName() + "/123"));
+  }
+
+  @Test
+  public void create_withUri_notNull() {
+    final String dummyPath = "dummy";
+    Application context = ApplicationProvider.getApplicationContext();
+    Uri dummyUri = new Uri.Builder().appendPath(dummyPath).build();
+
+    MediaPlayer mp = MediaPlayer.create(context, dummyUri);
+    assertNotNull(mp);
+    ShadowMediaPlayer shadow = shadowOf(mp);
+    assertThat(shadow.getDataSource()).isEqualTo(DataSource.toDataSource(context, dummyUri));
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
@@ -523,9 +523,13 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
 
   @Implementation
   protected static MediaPlayer create(Context context, Uri uri) {
+    DataSource ds = DataSource.toDataSource(String.valueOf(uri.getPath()));
+    addMediaInfo(ds, new ShadowMediaPlayer.MediaInfo());
     MediaPlayer mp = new MediaPlayer();
+    ShadowMediaPlayer shadow = Shadow.extract(mp);
     try {
-      mp.setDataSource(context, uri);
+      shadow.setDataSource(ds);
+      shadow.setState(ShadowMediaPlayer.State.INITIALIZED);
       mp.prepare();
     } catch (Exception e) {
       return null;


### PR DESCRIPTION
Stopped ShadowMediaPlayer create(Context context, Uri uri) from returning null due to an IOException

### Overview
The original code were causing my unit test to fail because MediaPlayer would always return null when calling this create method. It seems the there was no support to convert the Uri to a datasource object so that it could be retrieved from the ShadowMediaPlayer.mediaInfo map and it was therefore always throwing an IOException
### Proposed Changes
Changed the implementation of the class and added unit tests, to prove that it now doesn't return null and contains the datasource of the Uri parameter.
