### PR TITLE
Support ConnectivityManager.registerDefaultNetworkCallback for P+ in

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowConnectivityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowConnectivityManager.java
@@ -115,6 +115,12 @@ public class ShadowConnectivityManager {
     networkCallbacks.add(networkCallback);
   }
 
+  @Implementation(minSdk = P)
+  protected void registerDefaultNetworkCallback(
+      ConnectivityManager.NetworkCallback networkCallback, Handler handler) {
+    networkCallbacks.add(networkCallback);
+  }
+
   @Implementation(minSdk = LOLLIPOP)
   protected void unregisterNetworkCallback(ConnectivityManager.NetworkCallback networkCallback) {
     if (networkCallback == null) {


### PR DESCRIPTION
### Overview
New implementation of registerDefaultNetworkCallback was added to ConnectivityManager in Android P sources. See https://android.googlesource.com/platform/frameworks/base.git/+/refs/tags/android-q-preview-5/core/java/android/net/ConnectivityManager.java#3942.