### PR TITLE
Update to the latest available sqlite4java artifacts

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/SQLiteStatementTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SQLiteStatementTest.java
@@ -129,6 +129,17 @@ public class SQLiteStatementTest {
     assertThat(stmt.simpleQueryForString()).isEqualTo("2");
   }
 
+  @Test
+  public void simpleQueryTestWithCommonTableExpression() {
+    try(SQLiteStatement statement = database.compileStatement("WITH RECURSIVE\n" +
+            "  cnt(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM cnt WHERE x<100)\n" +
+            "SELECT COUNT(*) FROM cnt;")) {
+      assertThat(statement).isNotNull();
+      assertThat(statement.simpleQueryForLong()).isEqualTo(100);
+    }
+  }
+
+
   @Test(expected = SQLiteDoneException.class)
   public void simpleQueryForStringThrowsSQLiteDoneExceptionTest() throws Exception {
     //throw SQLiteDOneException if no rows returned.

--- a/robolectric/src/test/java/org/robolectric/util/SQLiteLibraryLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/SQLiteLibraryLoaderTest.java
@@ -43,55 +43,61 @@ public class SQLiteLibraryLoaderTest {
   @Test
   public void shouldFindLibraryForWindowsXPX86() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(WINDOWS), "Windows XP", "x86"))
-        .isEqualTo("windows-x86/sqlite4java.dll");
+        .isEqualTo("sqlite4java/win32-x86/sqlite4java.dll");
   }
 
   @Test
   public void shouldFindLibraryForWindows7X86() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(WINDOWS), "Windows 7", "x86"))
-        .isEqualTo("windows-x86/sqlite4java.dll");
+        .isEqualTo("sqlite4java/win32-x86/sqlite4java.dll");
   }
 
   @Test
   public void shouldFindLibraryForWindowsXPAmd64() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(WINDOWS), "Windows XP", "amd64"))
-        .isEqualTo("windows-x86_64/sqlite4java.dll");
+        .isEqualTo("sqlite4java/win32-x64/sqlite4java.dll");
   }
 
   @Test
   public void shouldFindLibraryForWindows7Amd64() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(WINDOWS), "Windows 7", "amd64"))
-        .isEqualTo("windows-x86_64/sqlite4java.dll");
+        .isEqualTo("sqlite4java/win32-x64/sqlite4java.dll");
+  }
+
+  @Test
+  public void shouldFindLibraryForWindows10Amd64() throws IOException {
+    assertThat(loadLibrary(new SQLiteLibraryLoader(WINDOWS), "Windows 10", "amd64"))
+            .isEqualTo("sqlite4java/win32-x64/sqlite4java.dll");
   }
 
   @Test
   public void shouldFindLibraryForLinuxi386() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(LINUX), "Some linux version", "i386"))
-        .isEqualTo("linux-x86/libsqlite4java.so");
+        .isEqualTo("sqlite4java/linux-i386/libsqlite4java.so");
   }
 
   @Test
   public void shouldFindLibraryForLinuxx86() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(LINUX), "Some linux version", "x86"))
-        .isEqualTo("linux-x86/libsqlite4java.so");
+        .isEqualTo("sqlite4java/linux-i386/libsqlite4java.so");
   }
 
   @Test
   public void shouldFindLibraryForLinuxAmd64() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(LINUX), "Some linux version", "amd64"))
-        .isEqualTo("linux-x86_64/libsqlite4java.so");
+        .isEqualTo("sqlite4java/linux-amd64/libsqlite4java.so");
   }
 
   @Test
   public void shouldFindLibraryForMacWithAnyArch() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(MAC), "Mac OS X", "any architecture"))
-        .isEqualTo("mac-x86_64/libsqlite4java.jnilib");
+        .isEqualTo("sqlite4java/osx/libsqlite4java.jnilib");
   }
 
   @Test
   public void shouldFindLibraryForMacWithAnyArchAndDyLibMapping() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(MAC_DYLIB), "Mac OS X", "any architecture"))
-        .isEqualTo("mac-x86_64/libsqlite4java.jnilib");
+        .isEqualTo("sqlite4java/osx/libsqlite4java.jnilib");
   }
 
   @Test(expected = UnsupportedOperationException.class)

--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -10,30 +10,32 @@ shadows {
 }
 
 configurations {
-    jni
+    sqlite4java
 }
 
-task copyNatives(type: Copy) {
-    outputs.dir file("${buildDir}/resources/main")
+def sqlite4javaVersion = '1.0.392'
 
-    project.afterEvaluate {
-        configurations.jni.files.each { File file ->
-            def nativeJarMatch = file.name =~ /lib.*-natives-(.*)\.jar/
-            if (nativeJarMatch) {
-                inputs.file file
+task copySqliteNatives(type: Copy) {
+    from project.configurations.sqlite4java {
+        include '**/*.dll'
+        include '**/*.so'
+        include '**/*.dylib'
+        rename { String filename ->
+            def filenameMatch = filename =~ /^([^\-]+)-(.+)-${sqlite4javaVersion}\.(.+)/
+            if (filenameMatch) {
+                def platformFilename = filenameMatch[0][1]
+                def platformFolder = filenameMatch[0][2]
+                def platformExtension = filenameMatch[0][3]
 
-                def platformName = nativeJarMatch[0][1]
-                from(zipTree(file)) { rename { f -> "$platformName/$f" } }
+                "${platformFolder}/${platformFilename}.${platformExtension}"
             }
-
         }
     }
-
-    into project.file("$buildDir/resources/main")
+    into project.file("$buildDir/resources/main/sqlite4java")
 }
 
 jar {
-    dependsOn copyNatives
+    dependsOn copySqliteNatives
 }
 
 dependencies {
@@ -46,7 +48,7 @@ dependencies {
     api "androidx.test:monitor:1.3.0-alpha01"
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
-    api "com.almworks.sqlite4java:sqlite4java:0.282"
+    api "com.almworks.sqlite4java:sqlite4java:$sqlite4javaVersion"
     compileOnly(AndroidSdk.MAX_SDK.coordinates) { force = true }
     api "com.ibm.icu:icu4j:53.1"
     api "com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework:2.1"
@@ -54,9 +56,9 @@ dependencies {
     api "com.google.auto.value:auto-value-annotations:1.6.2"
     annotationProcessor "com.google.auto.value:auto-value:1.6.2"
 
-    jni "com.github.axet.litedb:libsqlite:0.282-3:natives-mac-x86_64"
-    jni "com.github.axet.litedb:libsqlite:0.282-3:natives-linux-x86"
-    jni "com.github.axet.litedb:libsqlite:0.282-3:natives-linux-x86_64"
-    jni "com.github.axet.litedb:libsqlite:0.282-3:natives-windows-x86"
-    jni "com.github.axet.litedb:libsqlite:0.282-3:natives-windows-x86_64"
+    sqlite4java "com.almworks.sqlite4java:libsqlite4java-osx:$sqlite4javaVersion"
+    sqlite4java "com.almworks.sqlite4java:libsqlite4java-linux-amd64:$sqlite4javaVersion"
+    sqlite4java "com.almworks.sqlite4java:sqlite4java-win32-x64:$sqlite4javaVersion"
+    sqlite4java "com.almworks.sqlite4java:libsqlite4java-linux-i386:$sqlite4javaVersion"
+    sqlite4java "com.almworks.sqlite4java:sqlite4java-win32-x86:$sqlite4javaVersion"
 }


### PR DESCRIPTION
### Overview
Update to the latest available sqlite4java artifacts to enable common table expression support in tests using the framework's SQlite Shadow implementation.

### Proposed Changes
- Update sqlite4java to version 1.0.392 bundled
with SQLite 3.8.7 which comes with support for CTEs
- Use the first-hand natives Maven  artifacts published by almworks.
- The original repo of the project is at
https://bitbucket.org/almworks/sqlite4java
