### PR TITLE
Update to the latest available sqlite4java artifacts

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
@@ -25,936 +25,988 @@ import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class SQLiteDatabaseTest {
-    private SQLiteDatabase database;
-    private List<SQLiteDatabase> openDatabases = new ArrayList<>();
-    private static final String ANY_VALID_SQL = "SELECT 1";
-    private File databasePath;
+  private SQLiteDatabase database;
+  private List<SQLiteDatabase> openDatabases = new ArrayList<>();
+  private static final String ANY_VALID_SQL = "SELECT 1";
+  private File databasePath;
 
-    @Before
-    public void setUp() throws Exception {
+  @Before
+  public void setUp() throws Exception {
     databasePath = ApplicationProvider.getApplicationContext().getDatabasePath("database.db");
-        databasePath.getParentFile().mkdirs();
+    databasePath.getParentFile().mkdirs();
 
-        database = openOrCreateDatabase(databasePath);
-        database.execSQL("CREATE TABLE table_name (\n" +
-                "  id INTEGER PRIMARY KEY AUTOINCREMENT,\n" +
-                "  first_column VARCHAR(255),\n" +
-                "  second_column BINARY,\n" +
-                "  name VARCHAR(255),\n" +
-                "  big_int INTEGER\n" +
-                ");");
+    database = openOrCreateDatabase(databasePath);
+    database.execSQL(
+        "CREATE TABLE table_name (\n"
+            + "  id INTEGER PRIMARY KEY AUTOINCREMENT,\n"
+            + "  first_column VARCHAR(255),\n"
+            + "  second_column BINARY,\n"
+            + "  name VARCHAR(255),\n"
+            + "  big_int INTEGER\n"
+            + ");");
 
-        database.execSQL("CREATE TABLE rawtable (\n" +
-                "  id INTEGER PRIMARY KEY AUTOINCREMENT,\n" +
-                "  first_column VARCHAR(255),\n" +
-                "  second_column BINARY,\n" +
-                "  name VARCHAR(255),\n" +
-                "  big_int INTEGER\n" +
-                ");");
+    database.execSQL(
+        "CREATE TABLE rawtable (\n"
+            + "  id INTEGER PRIMARY KEY AUTOINCREMENT,\n"
+            + "  first_column VARCHAR(255),\n"
+            + "  second_column BINARY,\n"
+            + "  name VARCHAR(255),\n"
+            + "  big_int INTEGER\n"
+            + ");");
 
-        database.execSQL("CREATE TABLE exectable (\n" +
-                "  id INTEGER PRIMARY KEY AUTOINCREMENT,\n" +
-                "  first_column VARCHAR(255),\n" +
-                "  second_column BINARY,\n" +
-                "  name VARCHAR(255),\n" +
-                "  big_int INTEGER\n" +
-                ");");
+    database.execSQL(
+        "CREATE TABLE exectable (\n"
+            + "  id INTEGER PRIMARY KEY AUTOINCREMENT,\n"
+            + "  first_column VARCHAR(255),\n"
+            + "  second_column BINARY,\n"
+            + "  name VARCHAR(255),\n"
+            + "  big_int INTEGER\n"
+            + ");");
 
-        database.execSQL("CREATE TABLE blob_table (\n" +
-                "  id INTEGER PRIMARY KEY,\n" +
-                "  blob_col BLOB\n" +
-                ");");
+    database.execSQL(
+        "CREATE TABLE blob_table (\n" + "  id INTEGER PRIMARY KEY,\n" + "  blob_col BLOB\n" + ");");
 
-        String stringColumnValue = "column_value";
-        byte[] byteColumnValue = new byte[]{1, 2, 3};
+    String stringColumnValue = "column_value";
+    byte[] byteColumnValue = new byte[] {1, 2, 3};
 
-        ContentValues values = new ContentValues();
+    ContentValues values = new ContentValues();
 
-        values.put("first_column", stringColumnValue);
-        values.put("second_column", byteColumnValue);
+    values.put("first_column", stringColumnValue);
+    values.put("second_column", byteColumnValue);
 
-        database.insert("rawtable", null, values);
-        ////////////////////////////////////////////////
-        String stringColumnValue2 = "column_value2";
-        byte[] byteColumnValue2 = new byte[]{4, 5, 6};
-        ContentValues values2 = new ContentValues();
+    database.insert("rawtable", null, values);
+    ////////////////////////////////////////////////
+    String stringColumnValue2 = "column_value2";
+    byte[] byteColumnValue2 = new byte[] {4, 5, 6};
+    ContentValues values2 = new ContentValues();
 
-        values2.put("first_column", stringColumnValue2);
-        values2.put("second_column", byteColumnValue2);
+    values2.put("first_column", stringColumnValue2);
+    values2.put("second_column", byteColumnValue2);
 
-        database.insert("rawtable", null, values2);
+    database.insert("rawtable", null, values2);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    for (SQLiteDatabase openDatabase : openDatabases) {
+      openDatabase.close();
+    }
+  }
+
+  @Test
+  public void testInsertAndQuery() throws Exception {
+    String stringColumnValue = "column_value";
+    byte[] byteColumnValue = new byte[] {1, 2, 3};
+
+    ContentValues values = new ContentValues();
+
+    values.put("first_column", stringColumnValue);
+    values.put("second_column", byteColumnValue);
+
+    database.insert("table_name", null, values);
+
+    Cursor cursor =
+        database.query(
+            "table_name",
+            new String[] {"second_column", "first_column"},
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    assertThat(cursor.moveToFirst()).isTrue();
+
+    byte[] byteValueFromDatabase = cursor.getBlob(0);
+    String stringValueFromDatabase = cursor.getString(1);
+
+    assertThat(stringValueFromDatabase).isEqualTo(stringColumnValue);
+    assertThat(byteValueFromDatabase).isEqualTo(byteColumnValue);
+  }
+
+  @Test
+  public void testInsertAndRawQuery() throws Exception {
+    String stringColumnValue = "column_value";
+    byte[] byteColumnValue = new byte[] {1, 2, 3};
+
+    ContentValues values = new ContentValues();
+
+    values.put("first_column", stringColumnValue);
+    values.put("second_column", byteColumnValue);
+
+    database.insert("table_name", null, values);
+
+    Cursor cursor =
+        database.rawQuery("select second_column, first_column from" + " table_name", null);
+
+    assertThat(cursor.moveToFirst()).isTrue();
+
+    byte[] byteValueFromDatabase = cursor.getBlob(0);
+    String stringValueFromDatabase = cursor.getString(1);
+
+    assertThat(stringValueFromDatabase).isEqualTo(stringColumnValue);
+    assertThat(byteValueFromDatabase).isEqualTo(byteColumnValue);
+  }
+
+  @Test(expected = android.database.SQLException.class)
+  public void testInsertOrThrowWithSQLException() {
+    ContentValues values = new ContentValues();
+    values.put("id", 1);
+
+    database.insertOrThrow("table_name", null, values);
+    database.insertOrThrow("table_name", null, values);
+  }
+
+  @Test
+  public void testInsertOrThrow() {
+    String stringColumnValue = "column_value";
+    byte[] byteColumnValue = new byte[] {1, 2, 3};
+    ContentValues values = new ContentValues();
+    values.put("first_column", stringColumnValue);
+    values.put("second_column", byteColumnValue);
+    database.insertOrThrow("table_name", null, values);
+
+    Cursor cursor =
+        database.rawQuery("select second_column, first_column from" + " table_name", null);
+    assertThat(cursor.moveToFirst()).isTrue();
+    byte[] byteValueFromDatabase = cursor.getBlob(0);
+    String stringValueFromDatabase = cursor.getString(1);
+    assertThat(stringValueFromDatabase).isEqualTo(stringColumnValue);
+    assertThat(byteValueFromDatabase).isEqualTo(byteColumnValue);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRawQueryThrowsIndex0NullException() throws Exception {
+    database.rawQuery(
+        "select second_column, first_column from rawtable" + " WHERE `id` = ?",
+        new String[] {null});
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRawQueryThrowsIndex0NullException2() throws Exception {
+    database.rawQuery("select second_column, first_column from rawtable", new String[] {null});
+  }
+
+  @Test
+  public void testRawQueryCountWithOneArgument() throws Exception {
+    Cursor cursor =
+        database.rawQuery(
+            "select second_column, first_column from rawtable WHERE" + " `id` = ?",
+            new String[] {"1"});
+    assertThat(cursor.getCount()).isEqualTo(1);
+  }
+
+  @Test
+  public void testRawQueryCountWithNullArgs() throws Exception {
+    Cursor cursor = database.rawQuery("select second_column, first_column from rawtable", null);
+    assertThat(cursor.getCount()).isEqualTo(2);
+  }
+
+  @Test
+  public void testRawQueryCountWithEmptyArguments() throws Exception {
+    Cursor cursor =
+        database.rawQuery(
+            "select second_column, first_column" + " from" + " rawtable", new String[] {});
+    assertThat(cursor.getCount()).isEqualTo(2);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowWhenArgumentsDoNotMatchQuery() throws Exception {
+    database.rawQuery("select second_column, first_column from rawtable", new String[] {"1"});
+  }
+
+  @Test
+  public void testInsertWithException() {
+    ContentValues values = new ContentValues();
+
+    assertEquals(-1, database.insert("table_that_doesnt_exist", null, values));
+  }
+
+  @Test
+  public void testEmptyTable() throws Exception {
+    Cursor cursor =
+        database.query(
+            "table_name",
+            new String[] {"second_column", "first_column"},
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    assertThat(cursor.moveToFirst()).isFalse();
+  }
+
+  @Test
+  public void testInsertRowIdGeneration() throws Exception {
+    ContentValues values = new ContentValues();
+    values.put("name", "Chuck");
+
+    long id = database.insert("table_name", null, values);
+
+    assertThat(id).isNotEqualTo(0L);
+  }
+
+  @Test
+  public void testInsertKeyGeneration() throws Exception {
+    ContentValues values = new ContentValues();
+    values.put("name", "Chuck");
+
+    long key =
+        database.insertWithOnConflict("table_name", null, values, SQLiteDatabase.CONFLICT_IGNORE);
+
+    assertThat(key).isNotEqualTo(0L);
+  }
+
+  @Test
+  public void testInsertEmptyBlobArgument() throws Exception {
+    ContentValues emptyBlobValues = new ContentValues();
+    emptyBlobValues.put("id", 1);
+    emptyBlobValues.put("blob_col", new byte[] {});
+
+    ContentValues nullBlobValues = new ContentValues();
+    nullBlobValues.put("id", 2);
+    nullBlobValues.put("blob_col", (byte[]) null);
+
+    long key =
+        database.insertWithOnConflict(
+            "blob_table", null, emptyBlobValues, SQLiteDatabase.CONFLICT_FAIL);
+    assertThat(key).isNotEqualTo(0L);
+    key =
+        database.insertWithOnConflict(
+            "blob_table", null, nullBlobValues, SQLiteDatabase.CONFLICT_FAIL);
+    assertThat(key).isNotEqualTo(0L);
+
+    Cursor cursor =
+        database.query("blob_table", new String[] {"blob_col"}, "id=1", null, null, null, null);
+    try {
+      assertThat(cursor.moveToFirst()).isTrue();
+      assertThat(cursor.getBlob(cursor.getColumnIndexOrThrow("blob_col"))).isNotNull();
+    } finally {
+      cursor.close();
     }
 
-    @After
-    public void tearDown() throws Exception {
-        for (SQLiteDatabase openDatabase : openDatabases) {
-            openDatabase.close();
-        }
+    cursor =
+        database.query("blob_table", new String[] {"blob_col"}, "id=2", null, null, null, null);
+    try {
+      assertThat(cursor.moveToFirst()).isTrue();
+      assertThat(cursor.getBlob(cursor.getColumnIndexOrThrow("blob_col"))).isNull();
+    } finally {
+      cursor.close();
     }
+  }
 
-    @Test
-    public void testInsertAndQuery() throws Exception {
-        String stringColumnValue = "column_value";
-        byte[] byteColumnValue = new byte[]{1, 2, 3};
+  @Test
+  public void testUpdate() throws Exception {
+    addChuck();
 
-        ContentValues values = new ContentValues();
+    assertThat(updateName(1234L, "Buster")).isEqualTo(1);
 
-        values.put("first_column", stringColumnValue);
-        values.put("second_column", byteColumnValue);
+    Cursor cursor =
+        database.query("table_name", new String[] {"id", "name"}, null, null, null, null, null);
+    assertThat(cursor.moveToFirst()).isTrue();
+    assertThat(cursor.getCount()).isEqualTo(1);
 
-        database.insert("table_name", null, values);
+    assertIdAndName(cursor, 1234L, "Buster");
+  }
 
-        Cursor cursor = database.query("table_name", new String[]{"second_column", "first_column"}, null, null, null, null, null);
+  @Test
+  public void testUpdateNoMatch() throws Exception {
+    addChuck();
 
-        assertThat(cursor.moveToFirst()).isTrue();
+    assertThat(updateName(5678L, "Buster")).isEqualTo(0);
 
-        byte[] byteValueFromDatabase = cursor.getBlob(0);
-        String stringValueFromDatabase = cursor.getString(1);
+    Cursor cursor =
+        database.query("table_name", new String[] {"id", "name"}, null, null, null, null, null);
+    assertThat(cursor.moveToFirst()).isTrue();
+    assertThat(cursor.getCount()).isEqualTo(1);
 
-        assertThat(stringValueFromDatabase).isEqualTo(stringColumnValue);
-        assertThat(byteValueFromDatabase).isEqualTo(byteColumnValue);
+    assertIdAndName(cursor, 1234L, "Chuck");
+  }
+
+  @Test
+  public void testUpdateAll() throws Exception {
+    addChuck();
+    addJulie();
+
+    assertThat(updateName("Belvedere")).isEqualTo(2);
+
+    Cursor cursor =
+        database.query("table_name", new String[] {"id", "name"}, null, null, null, null, null);
+    assertThat(cursor.moveToFirst()).isTrue();
+    assertThat(cursor.getCount()).isEqualTo(2);
+
+    assertIdAndName(cursor, 1234L, "Belvedere");
+    assertThat(cursor.moveToNext()).isTrue();
+
+    assertIdAndName(cursor, 1235L, "Belvedere");
+    assertThat(cursor.isLast()).isTrue();
+    assertThat(cursor.moveToNext()).isFalse();
+    assertThat(cursor.isAfterLast()).isTrue();
+    assertThat(cursor.moveToNext()).isFalse();
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    addChuck();
+
+    int deleted = database.delete("table_name", "id=1234", null);
+    assertThat(deleted).isEqualTo(1);
+
+    assertEmptyDatabase();
+  }
+
+  @Test
+  public void testDeleteNoMatch() throws Exception {
+    addChuck();
+
+    int deleted = database.delete("table_name", "id=5678", null);
+    assertThat(deleted).isEqualTo(0);
+
+    assertNonEmptyDatabase();
+  }
+
+  @Test
+  public void testDeleteAll() throws Exception {
+    addChuck();
+    addJulie();
+
+    int deleted = database.delete("table_name", "1", null);
+    assertThat(deleted).isEqualTo(2);
+
+    assertEmptyDatabase();
+  }
+
+  @Test
+  public void testExecSQL() throws Exception {
+    database.execSQL("INSERT INTO table_name (id, name) VALUES(1234, 'Chuck');");
+
+    Cursor cursor = database.rawQuery("SELECT COUNT(*) FROM table_name", null);
+    assertThat(cursor).isNotNull();
+    assertThat(cursor.moveToNext()).isTrue();
+    assertThat(cursor.getInt(0)).isEqualTo(1);
+
+    cursor = database.rawQuery("SELECT * FROM table_name", null);
+    assertThat(cursor).isNotNull();
+    assertThat(cursor.moveToNext()).isTrue();
+
+    assertThat(cursor.getInt(cursor.getColumnIndex("id"))).isEqualTo(1234);
+    assertThat(cursor.getString(cursor.getColumnIndex("name"))).isEqualTo("Chuck");
+  }
+
+  @Test
+  public void testExecSQLParams() throws Exception {
+    database.execSQL(
+        "CREATE TABLE `routine` (`id` INTEGER PRIMARY KEY AUTOINCREMENT , `name`"
+            + " VARCHAR , `lastUsed` INTEGER DEFAULT 0 , "
+            + " UNIQUE (`name`)) ",
+        new Object[] {});
+    database.execSQL(
+        "INSERT INTO `routine` (`name`" + " ,`lastUsed`" + " ) VALUES" + " (?,?)",
+        new Object[] {"Leg Press", 0});
+    database.execSQL(
+        "INSERT INTO `routine` (`name`" + " ,`lastUsed`" + " ) VALUES" + " (?,?)",
+        new Object[] {"Bench" + " Press", 1});
+
+    Cursor cursor = database.rawQuery("SELECT COUNT(*) FROM `routine`", null);
+    assertThat(cursor).isNotNull();
+    assertThat(cursor.moveToNext()).isTrue();
+    assertThat(cursor.getInt(0)).isEqualTo(2);
+
+    cursor = database.rawQuery("SELECT `id`, `name` ,`lastUsed` FROM `routine`", null);
+    assertThat(cursor).isNotNull();
+    assertThat(cursor.moveToNext()).isTrue();
+
+    assertThat(cursor.getInt(cursor.getColumnIndex("id"))).isEqualTo(1);
+    assertThat(cursor.getInt(cursor.getColumnIndex("lastUsed"))).isEqualTo(0);
+    assertThat(cursor.getString(cursor.getColumnIndex("name"))).isEqualTo("Leg Press");
+
+    assertThat(cursor.moveToNext()).isTrue();
+
+    assertThat(cursor.getInt(cursor.getColumnIndex("id"))).isEqualTo(2);
+    assertThat(cursor.getInt(cursor.getColumnIndex("lastUsed"))).isEqualTo(1);
+    assertThat(cursor.getString(cursor.getColumnIndex("name"))).isEqualTo("Bench Press");
+  }
+
+  @Test(expected = SQLiteException.class)
+  public void execSqlShouldThrowOnBadQuery() throws Exception {
+    database.execSQL("INSERT INTO table_name;"); // invalid SQL
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testExecSQLExceptionParametersWithoutArguments() throws Exception {
+    database.execSQL("insert into exectable (first_column) values (?);", null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testExecSQLWithNullBindArgs() throws Exception {
+    database.execSQL("insert into exectable (first_column) values ('sdfsfs');", null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testExecSQLTooManyBindArguments() throws Exception {
+    database.execSQL(
+        "insert into exectable (first_column) values" + " ('kjhk');", new String[] {"xxxx"});
+  }
+
+  @Test
+  public void testExecSQLWithEmptyBindArgs() throws Exception {
+    database.execSQL("insert into exectable (first_column) values ('eff');", new String[] {});
+  }
+
+  @Test
+  public void testExecSQLInsertNull() throws Exception {
+    String name = "nullone";
+
+    database.execSQL(
+        "insert into exectable (first_column, name)" + " values" + " (?,?);",
+        new String[] {null, name});
+
+    Cursor cursor =
+        database.rawQuery(
+            "select * from exectable WHERE" + " `name`" + " = ?", new String[] {name});
+    cursor.moveToFirst();
+    int firstIndex = cursor.getColumnIndex("first_column");
+    int nameIndex = cursor.getColumnIndex("name");
+    assertThat(cursor.getString(nameIndex)).isEqualTo(name);
+    assertThat(cursor.getString(firstIndex)).isEqualTo(null);
+  }
+
+  @Test
+  public void testExecSQLAutoIncrementSQLite() throws Exception {
+    database.execSQL(
+        "CREATE TABLE auto_table (id INTEGER PRIMARY KEY AUTOINCREMENT, name" + " VARCHAR(255));");
+
+    ContentValues values = new ContentValues();
+    values.put("name", "Chuck");
+
+    long key = database.insert("auto_table", null, values);
+    assertThat(key).isNotEqualTo(0L);
+
+    long key2 = database.insert("auto_table", null, values);
+    assertThat(key2).isNotEqualTo(key);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testClose() throws Exception {
+    database.close();
+
+    database.execSQL("INSERT INTO table_name (id, name) VALUES(1234, 'Chuck');");
+  }
+
+  @Test
+  public void testIsOpen() throws Exception {
+    assertThat(database.isOpen()).isTrue();
+    database.close();
+    assertThat(database.isOpen()).isFalse();
+  }
+
+  @Test
+  public void shouldStoreGreatBigHonkingIntegersCorrectly() throws Exception {
+    database.execSQL("INSERT INTO table_name(big_int) VALUES(1234567890123456789);");
+    Cursor cursor =
+        database.query("table_name", new String[] {"big_int"}, null, null, null, null, null);
+    assertThat(cursor.moveToFirst()).isTrue();
+    assertEquals(1234567890123456789L, cursor.getLong(0));
+  }
+
+  @Test
+  public void testSuccessTransaction() throws Exception {
+    database.beginTransaction();
+    database.execSQL("INSERT INTO table_name (id, name) VALUES(1234, 'Chuck');");
+    database.setTransactionSuccessful();
+    database.endTransaction();
+
+    Cursor cursor = database.rawQuery("SELECT COUNT(*) FROM table_name", null);
+    assertThat(cursor.moveToNext()).isTrue();
+    assertThat(cursor.getInt(0)).isEqualTo(1);
+  }
+
+  @Test
+  public void testFailureTransaction() throws Exception {
+    database.beginTransaction();
+
+    database.execSQL("INSERT INTO table_name (id, name) VALUES(1234, 'Chuck');");
+
+    final String select = "SELECT COUNT(*) FROM table_name";
+
+    Cursor cursor = database.rawQuery(select, null);
+    assertThat(cursor.moveToNext()).isTrue();
+    assertThat(cursor.getInt(0)).isEqualTo(1);
+    cursor.close();
+
+    database.endTransaction();
+
+    cursor = database.rawQuery(select, null);
+    assertThat(cursor.moveToNext()).isTrue();
+    assertThat(cursor.getInt(0)).isEqualTo(0);
+  }
+
+  @Test
+  public void testSuccessNestedTransaction() throws Exception {
+    database.beginTransaction();
+    database.execSQL("INSERT INTO table_name (id, name) VALUES(1234, 'Chuck');");
+    database.beginTransaction();
+    database.execSQL("INSERT INTO table_name (id, name) VALUES(12345, 'Julie');");
+    database.setTransactionSuccessful();
+    database.endTransaction();
+    database.setTransactionSuccessful();
+    database.endTransaction();
+
+    Cursor cursor = database.rawQuery("SELECT COUNT(*) FROM table_name", null);
+    assertThat(cursor.moveToNext()).isTrue();
+    assertThat(cursor.getInt(0)).isEqualTo(2);
+  }
+
+  @Test
+  public void testFailureNestedTransaction() throws Exception {
+    database.beginTransaction();
+    database.execSQL("INSERT INTO table_name (id, name) VALUES(1234, 'Chuck');");
+    database.beginTransaction();
+    database.execSQL("INSERT INTO table_name (id, name) VALUES(12345, 'Julie');");
+    database.endTransaction();
+    database.setTransactionSuccessful();
+    database.endTransaction();
+
+    Cursor cursor = database.rawQuery("SELECT COUNT(*) FROM table_name", null);
+    assertThat(cursor.moveToNext()).isTrue();
+    assertThat(cursor.getInt(0)).isEqualTo(0);
+  }
+
+  @Test
+  public void testTransactionAlreadySuccessful() {
+    database.beginTransaction();
+    database.setTransactionSuccessful();
+    try {
+      database.setTransactionSuccessful();
+      fail("didn't receive the expected IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage()).contains("transaction");
+      assertThat(e.getMessage()).contains("successful");
     }
-
-    @Test
-    public void testInsertAndRawQuery() throws Exception {
-        String stringColumnValue = "column_value";
-        byte[] byteColumnValue = new byte[]{1, 2, 3};
-
-        ContentValues values = new ContentValues();
-
-        values.put("first_column", stringColumnValue);
-        values.put("second_column", byteColumnValue);
-
-        database.insert("table_name", null, values);
-
-        Cursor cursor = database.rawQuery("select second_column, first_column from"
-                                              + " table_name", null);
-
-        assertThat(cursor.moveToFirst()).isTrue();
-
-        byte[] byteValueFromDatabase = cursor.getBlob(0);
-        String stringValueFromDatabase = cursor.getString(1);
-
-        assertThat(stringValueFromDatabase).isEqualTo(stringColumnValue);
-        assertThat(byteValueFromDatabase).isEqualTo(byteColumnValue);
-    }
-
-    @Test(expected = android.database.SQLException.class)
-    public void testInsertOrThrowWithSQLException() {
-        ContentValues values = new ContentValues();
-        values.put("id", 1);
-
-        database.insertOrThrow("table_name", null, values);
-        database.insertOrThrow("table_name", null, values);
-    }
-
-    @Test
-    public void testInsertOrThrow() {
-        String stringColumnValue = "column_value";
-        byte[] byteColumnValue = new byte[]{1, 2, 3};
-        ContentValues values = new ContentValues();
-        values.put("first_column", stringColumnValue);
-        values.put("second_column", byteColumnValue);
-        database.insertOrThrow("table_name", null, values);
-
-        Cursor cursor = database.rawQuery("select second_column, first_column from"
-                                              + " table_name", null);
-        assertThat(cursor.moveToFirst()).isTrue();
-        byte[] byteValueFromDatabase = cursor.getBlob(0);
-        String stringValueFromDatabase = cursor.getString(1);
-        assertThat(stringValueFromDatabase).isEqualTo(stringColumnValue);
-        assertThat(byteValueFromDatabase).isEqualTo(byteColumnValue);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testRawQueryThrowsIndex0NullException() throws Exception {
-        database.rawQuery("select second_column, first_column from rawtable"
-                              + " WHERE `id` = ?", new String[]{null});
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testRawQueryThrowsIndex0NullException2() throws Exception {
-        database.rawQuery("select second_column, first_column from rawtable", new String[]{null});
-    }
-
-    @Test
-    public void testRawQueryCountWithOneArgument() throws Exception {
-        Cursor cursor = database.rawQuery("select second_column, first_column from rawtable WHERE"
-                                              + " `id` = ?", new String[]{"1"});
-        assertThat(cursor.getCount()).isEqualTo(1);
-    }
-
-    @Test
-    public void testRawQueryCountWithNullArgs() throws Exception {
-        Cursor cursor = database.rawQuery("select second_column, first_column from rawtable", null);
-        assertThat(cursor.getCount()).isEqualTo(2);
-    }
-
-    @Test
-    public void testRawQueryCountWithEmptyArguments() throws Exception {
-        Cursor cursor = database.rawQuery("select second_column, first_column"
-                                              + " from"
-                                              + " rawtable", new String[]{});
-        assertThat(cursor.getCount()).isEqualTo(2);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowWhenArgumentsDoNotMatchQuery() throws Exception {
-        database.rawQuery("select second_column, first_column from rawtable", new String[]{"1"});
-    }
-
-    @Test
-    public void testInsertWithException() {
-        ContentValues values = new ContentValues();
-
-        assertEquals(-1, database.insert("table_that_doesnt_exist", null, values));
-    }
-
-
-    @Test
-    public void testEmptyTable() throws Exception {
-        Cursor cursor = database.query("table_name", new String[]{"second_column", "first_column"}, null, null, null, null, null);
-
-        assertThat(cursor.moveToFirst()).isFalse();
-    }
-
-    @Test
-    public void testInsertRowIdGeneration() throws Exception {
-        ContentValues values = new ContentValues();
-        values.put("name", "Chuck");
-
-        long id = database.insert("table_name", null, values);
-
-        assertThat(id).isNotEqualTo(0L);
-    }
-
-    @Test
-    public void testInsertKeyGeneration() throws Exception {
-        ContentValues values = new ContentValues();
-        values.put("name", "Chuck");
-
-        long key = database.insertWithOnConflict("table_name", null, values, SQLiteDatabase.CONFLICT_IGNORE);
-
-        assertThat(key).isNotEqualTo(0L);
-    }
-
-    @Test
-    public void testInsertEmptyBlobArgument() throws Exception {
-        ContentValues emptyBlobValues = new ContentValues();
-        emptyBlobValues.put("id", 1);
-        emptyBlobValues.put("blob_col", new byte[]{});
-
-        ContentValues nullBlobValues = new ContentValues();
-        nullBlobValues.put("id", 2);
-        nullBlobValues.put("blob_col", (byte[])null);
-
-        long key = database.insertWithOnConflict("blob_table", null, emptyBlobValues, SQLiteDatabase.CONFLICT_FAIL);
-        assertThat(key).isNotEqualTo(0L);
-        key = database.insertWithOnConflict("blob_table", null, nullBlobValues, SQLiteDatabase.CONFLICT_FAIL);
-        assertThat(key).isNotEqualTo(0L);
-
-        Cursor cursor = database.query("blob_table", new String[]{"blob_col"}, "id=1", null, null, null, null);
-        try {
-          assertThat(cursor.moveToFirst()).isTrue();
-          assertThat(cursor.getBlob(cursor.getColumnIndexOrThrow("blob_col"))).isNotNull();
-        } finally {
-          cursor.close();
-        }
-
-        cursor = database.query("blob_table", new String[]{"blob_col"}, "id=2", null, null, null, null);
-        try {
-          assertThat(cursor.moveToFirst()).isTrue();
-          assertThat(cursor.getBlob(cursor.getColumnIndexOrThrow("blob_col"))).isNull();
-        } finally {
-          cursor.close();
-        }
-
-    }
-
-    @Test
-    public void testUpdate() throws Exception {
-        addChuck();
-
-        assertThat(updateName(1234L, "Buster")).isEqualTo(1);
-
-        Cursor cursor = database.query("table_name", new String[]{"id", "name"}, null, null, null, null, null);
-        assertThat(cursor.moveToFirst()).isTrue();
-        assertThat(cursor.getCount()).isEqualTo(1);
-
-        assertIdAndName(cursor, 1234L, "Buster");
-    }
-
-    @Test
-    public void testUpdateNoMatch() throws Exception {
-        addChuck();
-
-        assertThat(updateName(5678L, "Buster")).isEqualTo(0);
-
-        Cursor cursor = database.query("table_name", new String[]{"id", "name"}, null, null, null, null, null);
-        assertThat(cursor.moveToFirst()).isTrue();
-        assertThat(cursor.getCount()).isEqualTo(1);
-
-        assertIdAndName(cursor, 1234L, "Chuck");
-    }
-
-    @Test
-    public void testUpdateAll() throws Exception {
-        addChuck();
-        addJulie();
-
-        assertThat(updateName("Belvedere")).isEqualTo(2);
-
-        Cursor cursor = database.query("table_name", new String[]{"id", "name"}, null, null, null, null, null);
-        assertThat(cursor.moveToFirst()).isTrue();
-        assertThat(cursor.getCount()).isEqualTo(2);
-
-        assertIdAndName(cursor, 1234L, "Belvedere");
-        assertThat(cursor.moveToNext()).isTrue();
-
-        assertIdAndName(cursor, 1235L, "Belvedere");
-        assertThat(cursor.isLast()).isTrue();
-        assertThat(cursor.moveToNext()).isFalse();
-        assertThat(cursor.isAfterLast()).isTrue();
-        assertThat(cursor.moveToNext()).isFalse();
-    }
-
-    @Test
-    public void testDelete() throws Exception {
-        addChuck();
-
-        int deleted = database.delete("table_name", "id=1234", null);
-        assertThat(deleted).isEqualTo(1);
-
-        assertEmptyDatabase();
-    }
-
-    @Test
-    public void testDeleteNoMatch() throws Exception {
-        addChuck();
-
-        int deleted = database.delete("table_name", "id=5678", null);
-        assertThat(deleted).isEqualTo(0);
-
-        assertNonEmptyDatabase();
-    }
-
-    @Test
-    public void testDeleteAll() throws Exception {
-        addChuck();
-        addJulie();
-
-        int deleted = database.delete("table_name", "1", null);
-        assertThat(deleted).isEqualTo(2);
-
-        assertEmptyDatabase();
-    }
-
-    @Test
-    public void testExecSQL() throws Exception {
-        database.execSQL("INSERT INTO table_name (id, name) VALUES(1234, 'Chuck');");
-
-        Cursor cursor = database.rawQuery("SELECT COUNT(*) FROM table_name", null);
-        assertThat(cursor).isNotNull();
-        assertThat(cursor.moveToNext()).isTrue();
-        assertThat(cursor.getInt(0)).isEqualTo(1);
-
-        cursor = database.rawQuery("SELECT * FROM table_name", null);
-        assertThat(cursor).isNotNull();
-        assertThat(cursor.moveToNext()).isTrue();
-
-        assertThat(cursor.getInt(cursor.getColumnIndex("id"))).isEqualTo(1234);
-        assertThat(cursor.getString(cursor.getColumnIndex("name"))).isEqualTo("Chuck");
-    }
-
-    @Test
-    public void testExecSQLParams() throws Exception {
-        database.execSQL("CREATE TABLE `routine` (`id` INTEGER PRIMARY KEY AUTOINCREMENT , `name`"
-                             + " VARCHAR , `lastUsed` INTEGER DEFAULT 0 , "
-                             + " UNIQUE (`name`)) ", new Object[]{});
-        database.execSQL("INSERT INTO `routine` (`name`"
-                             + " ,`lastUsed`"
-                             + " ) VALUES"
-                             + " (?,?)", new Object[]{"Leg Press", 0});
-        database.execSQL("INSERT INTO `routine` (`name`"
-                             + " ,`lastUsed`"
-                             + " ) VALUES"
-                             + " (?,?)", new Object[]{"Bench"
-                                                                                                      + " Press", 1});
-
-        Cursor cursor = database.rawQuery("SELECT COUNT(*) FROM `routine`", null);
-        assertThat(cursor).isNotNull();
-        assertThat(cursor.moveToNext()).isTrue();
-        assertThat(cursor.getInt(0)).isEqualTo(2);
-
-        cursor = database.rawQuery("SELECT `id`, `name` ,`lastUsed` FROM `routine`", null);
-        assertThat(cursor).isNotNull();
-        assertThat(cursor.moveToNext()).isTrue();
-
-        assertThat(cursor.getInt(cursor.getColumnIndex("id"))).isEqualTo(1);
-        assertThat(cursor.getInt(cursor.getColumnIndex("lastUsed"))).isEqualTo(0);
-        assertThat(cursor.getString(cursor.getColumnIndex("name"))).isEqualTo("Leg Press");
-
-        assertThat(cursor.moveToNext()).isTrue();
-
-        assertThat(cursor.getInt(cursor.getColumnIndex("id"))).isEqualTo(2);
-        assertThat(cursor.getInt(cursor.getColumnIndex("lastUsed"))).isEqualTo(1);
-        assertThat(cursor.getString(cursor.getColumnIndex("name"))).isEqualTo("Bench Press");
-    }
-
-    @Test(expected = SQLiteException.class)
-    public void execSqlShouldThrowOnBadQuery() throws Exception {
-        database.execSQL("INSERT INTO table_name;");    // invalid SQL
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testExecSQLExceptionParametersWithoutArguments() throws Exception {
-        database.execSQL("insert into exectable (first_column) values (?);", null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testExecSQLWithNullBindArgs() throws Exception {
-        database.execSQL("insert into exectable (first_column) values ('sdfsfs');", null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testExecSQLTooManyBindArguments() throws Exception {
-        database.execSQL("insert into exectable (first_column) values"
-                             + " ('kjhk');", new String[]{"xxxx"});
-    }
-
-    @Test
-    public void testExecSQLWithEmptyBindArgs() throws Exception {
-        database.execSQL("insert into exectable (first_column) values ('eff');", new String[]{});
-    }
-
-    @Test
-    public void testExecSQLInsertNull() throws Exception {
-        String name = "nullone";
-
-        database.execSQL("insert into exectable (first_column, name)"
-                             + " values"
-                             + " (?,?);", new String[]{null, name});
-
-        Cursor cursor = database.rawQuery("select * from exectable WHERE"
-                                              + " `name`"
-                                              + " = ?", new String[]{name});
-        cursor.moveToFirst();
-        int firstIndex = cursor.getColumnIndex("first_column");
-        int nameIndex = cursor.getColumnIndex("name");
-        assertThat(cursor.getString(nameIndex)).isEqualTo(name);
-        assertThat(cursor.getString(firstIndex)).isEqualTo(null);
-
-    }
-
-    @Test
-    public void testExecSQLAutoIncrementSQLite() throws Exception {
-        database.execSQL("CREATE TABLE auto_table (id INTEGER PRIMARY KEY AUTOINCREMENT, name"
-                             + " VARCHAR(255));");
-
-        ContentValues values = new ContentValues();
-        values.put("name", "Chuck");
-
-        long key = database.insert("auto_table", null, values);
-        assertThat(key).isNotEqualTo(0L);
-
-        long key2 = database.insert("auto_table", null, values);
-        assertThat(key2).isNotEqualTo(key);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testClose() throws Exception {
-        database.close();
-
-        database.execSQL("INSERT INTO table_name (id, name) VALUES(1234, 'Chuck');");
-    }
-
-    @Test
-    public void testIsOpen() throws Exception {
-        assertThat(database.isOpen()).isTrue();
-        database.close();
-        assertThat(database.isOpen()).isFalse();
-    }
-
-    @Test
-    public void shouldStoreGreatBigHonkingIntegersCorrectly() throws Exception {
-        database.execSQL("INSERT INTO table_name(big_int) VALUES(1234567890123456789);");
-        Cursor cursor = database.query("table_name", new String[]{"big_int"}, null, null, null, null, null);
-        assertThat(cursor.moveToFirst()).isTrue();
-        assertEquals(1234567890123456789L, cursor.getLong(0));
-    }
-
-    @Test
-    public void testSuccessTransaction() throws Exception {
-        database.beginTransaction();
-        database.execSQL("INSERT INTO table_name (id, name) VALUES(1234, 'Chuck');");
-        database.setTransactionSuccessful();
-        database.endTransaction();
-
-        Cursor cursor = database.rawQuery("SELECT COUNT(*) FROM table_name", null);
-        assertThat(cursor.moveToNext()).isTrue();
-        assertThat(cursor.getInt(0)).isEqualTo(1);
-    }
-
-    @Test
-    public void testFailureTransaction() throws Exception {
-        database.beginTransaction();
-
-        database.execSQL("INSERT INTO table_name (id, name) VALUES(1234, 'Chuck');");
-
-        final String select = "SELECT COUNT(*) FROM table_name";
-
-        Cursor cursor = database.rawQuery(select, null);
-        assertThat(cursor.moveToNext()).isTrue();
-        assertThat(cursor.getInt(0)).isEqualTo(1);
-        cursor.close();
-
-        database.endTransaction();
-
-        cursor = database.rawQuery(select, null);
-        assertThat(cursor.moveToNext()).isTrue();
-        assertThat(cursor.getInt(0)).isEqualTo(0);
-    }
-
-    @Test
-    public void testSuccessNestedTransaction() throws Exception {
-        database.beginTransaction();
-        database.execSQL("INSERT INTO table_name (id, name) VALUES(1234, 'Chuck');");
-        database.beginTransaction();
-        database.execSQL("INSERT INTO table_name (id, name) VALUES(12345, 'Julie');");
-        database.setTransactionSuccessful();
-        database.endTransaction();
-        database.setTransactionSuccessful();
-        database.endTransaction();
-
-        Cursor cursor = database.rawQuery("SELECT COUNT(*) FROM table_name", null);
-        assertThat(cursor.moveToNext()).isTrue();
-        assertThat(cursor.getInt(0)).isEqualTo(2);
-    }
-
-    @Test
-    public void testFailureNestedTransaction() throws Exception {
-        database.beginTransaction();
-        database.execSQL("INSERT INTO table_name (id, name) VALUES(1234, 'Chuck');");
-        database.beginTransaction();
-        database.execSQL("INSERT INTO table_name (id, name) VALUES(12345, 'Julie');");
-        database.endTransaction();
-        database.setTransactionSuccessful();
-        database.endTransaction();
-
-        Cursor cursor = database.rawQuery("SELECT COUNT(*) FROM table_name", null);
-        assertThat(cursor.moveToNext()).isTrue();
-        assertThat(cursor.getInt(0)).isEqualTo(0);
-    }
-
-    @Test
-    public void testTransactionAlreadySuccessful() {
-        database.beginTransaction();
-        database.setTransactionSuccessful();
-        try {
-            database.setTransactionSuccessful();
-            fail("didn't receive the expected IllegalStateException");
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage()).contains("transaction");
-            assertThat(e.getMessage()).contains("successful");
-        }
-    }
-
-    @Test
-    public void testInTransaction() throws Exception {
-        assertThat(database.inTransaction()).isFalse();
-        database.beginTransaction();
-        assertThat(database.inTransaction()).isTrue();
-        database.endTransaction();
-        assertThat(database.inTransaction()).isFalse();
-    }
-
-    @Test
-    public void testReplace() throws Exception {
-        long id = addChuck();
-        assertThat(id).isNotEqualTo(-1L);
-
-        ContentValues values = new ContentValues();
-        values.put("id", id);
-        values.put("name", "Norris");
-
-        long replaceId = database.replace("table_name", null, values);
-        assertThat(replaceId).isEqualTo(id);
-
-        String query = "SELECT name FROM table_name where id = " + id;
-        Cursor cursor = executeQuery(query);
-
-        assertThat(cursor.moveToNext()).isTrue();
-        assertThat(cursor.getString(cursor.getColumnIndex("name"))).isEqualTo("Norris");
-    }
-
-    @Test
-    public void testReplaceIsReplacing() throws Exception {
-        final String query = "SELECT first_column FROM table_name WHERE id = ";
-        String stringValueA = "column_valueA";
-        String stringValueB = "column_valueB";
-        long id = 1;
-
-        ContentValues valuesA = new ContentValues();
-        valuesA.put("id", id);
-        valuesA.put("first_column", stringValueA);
-
-        ContentValues valuesB = new ContentValues();
-        valuesB.put("id", id);
-        valuesB.put("first_column", stringValueB);
-
-        long firstId = database.replaceOrThrow("table_name", null, valuesA);
-        Cursor firstCursor = executeQuery(query + firstId);
-        assertThat(firstCursor.moveToNext()).isTrue();
-        long secondId = database.replaceOrThrow("table_name", null, valuesB);
-        Cursor secondCursor = executeQuery(query + secondId);
-        assertThat(secondCursor.moveToNext()).isTrue();
-
-        assertThat(firstId).isEqualTo(id);
-        assertThat(secondId).isEqualTo(id);
-        assertThat(firstCursor.getString(0)).isEqualTo(stringValueA);
-        assertThat(secondCursor.getString(0)).isEqualTo(stringValueB);
-    }
-
-    @Test
-    public void shouldCreateDefaultCursorFactoryWhenNullFactoryPassedToRawQuery() throws Exception {
-        database.rawQueryWithFactory(null, ANY_VALID_SQL, null, null);
-    }
-
-    @Test
-    public void shouldCreateDefaultCursorFactoryWhenNullFactoryPassedToQuery() throws Exception {
-        database.queryWithFactory(null, false, "table_name", null, null, null, null, null, null, null);
-    }
-
-    @Test
-    public void shouldOpenExistingDatabaseFromFileSystemIfFileExists() throws Exception {
-
-        database.close();
-
-        SQLiteDatabase db = SQLiteDatabase.openDatabase(databasePath.getAbsolutePath(), null, OPEN_READWRITE);
-        Cursor c = db.rawQuery("select * from rawtable", null);
-        assertThat(c).isNotNull();
-        assertThat(c.getCount()).isEqualTo(2);
-        assertThat(db.isOpen()).isTrue();
-        db.close();
-        assertThat(db.isOpen()).isFalse();
-
-        SQLiteDatabase reopened = SQLiteDatabase.openDatabase(databasePath.getAbsolutePath(), null, OPEN_READWRITE);
+  }
+
+  @Test
+  public void testInTransaction() throws Exception {
+    assertThat(database.inTransaction()).isFalse();
+    database.beginTransaction();
+    assertThat(database.inTransaction()).isTrue();
+    database.endTransaction();
+    assertThat(database.inTransaction()).isFalse();
+  }
+
+  @Test
+  public void testReplace() throws Exception {
+    long id = addChuck();
+    assertThat(id).isNotEqualTo(-1L);
+
+    ContentValues values = new ContentValues();
+    values.put("id", id);
+    values.put("name", "Norris");
+
+    long replaceId = database.replace("table_name", null, values);
+    assertThat(replaceId).isEqualTo(id);
+
+    String query = "SELECT name FROM table_name where id = " + id;
+    Cursor cursor = executeQuery(query);
+
+    assertThat(cursor.moveToNext()).isTrue();
+    assertThat(cursor.getString(cursor.getColumnIndex("name"))).isEqualTo("Norris");
+  }
+
+  @Test
+  public void testReplaceIsReplacing() throws Exception {
+    final String query = "SELECT first_column FROM table_name WHERE id = ";
+    String stringValueA = "column_valueA";
+    String stringValueB = "column_valueB";
+    long id = 1;
+
+    ContentValues valuesA = new ContentValues();
+    valuesA.put("id", id);
+    valuesA.put("first_column", stringValueA);
+
+    ContentValues valuesB = new ContentValues();
+    valuesB.put("id", id);
+    valuesB.put("first_column", stringValueB);
+
+    long firstId = database.replaceOrThrow("table_name", null, valuesA);
+    Cursor firstCursor = executeQuery(query + firstId);
+    assertThat(firstCursor.moveToNext()).isTrue();
+    long secondId = database.replaceOrThrow("table_name", null, valuesB);
+    Cursor secondCursor = executeQuery(query + secondId);
+    assertThat(secondCursor.moveToNext()).isTrue();
+
+    assertThat(firstId).isEqualTo(id);
+    assertThat(secondId).isEqualTo(id);
+    assertThat(firstCursor.getString(0)).isEqualTo(stringValueA);
+    assertThat(secondCursor.getString(0)).isEqualTo(stringValueB);
+  }
+
+  @Test
+  public void shouldCreateDefaultCursorFactoryWhenNullFactoryPassedToRawQuery() throws Exception {
+    database.rawQueryWithFactory(null, ANY_VALID_SQL, null, null);
+  }
+
+  @Test
+  public void shouldCreateDefaultCursorFactoryWhenNullFactoryPassedToQuery() throws Exception {
+    database.queryWithFactory(null, false, "table_name", null, null, null, null, null, null, null);
+  }
+
+  @Test
+  public void shouldOpenExistingDatabaseFromFileSystemIfFileExists() throws Exception {
+
+    database.close();
+
+    SQLiteDatabase db =
+        SQLiteDatabase.openDatabase(databasePath.getAbsolutePath(), null, OPEN_READWRITE);
+    Cursor c = db.rawQuery("select * from rawtable", null);
+    assertThat(c).isNotNull();
+    assertThat(c.getCount()).isEqualTo(2);
+    assertThat(db.isOpen()).isTrue();
+    db.close();
+    assertThat(db.isOpen()).isFalse();
+
+    SQLiteDatabase reopened =
+        SQLiteDatabase.openDatabase(databasePath.getAbsolutePath(), null, OPEN_READWRITE);
     assertThat(reopened).isNotSameInstanceAs(db);
-        assertThat(reopened.isOpen()).isTrue();
+    assertThat(reopened.isOpen()).isTrue();
+  }
+
+  @Test(expected = SQLiteException.class)
+  public void shouldThrowIfFileDoesNotExist() throws Exception {
+    File testDb = new File("/i/do/not/exist");
+    assertThat(testDb.exists()).isFalse();
+    SQLiteDatabase.openOrCreateDatabase(testDb.getAbsolutePath(), null);
+  }
+
+  @Test
+  public void shouldUseInMemoryDatabaseWhenCallingCreate() throws Exception {
+    SQLiteDatabase db = SQLiteDatabase.create(null);
+    assertThat(db.isOpen()).isTrue();
+    assertThat(db.getPath()).isEqualTo(":memory:");
+  }
+
+  @Test
+  public void shouldSetAndGetVersion() throws Exception {
+    assertThat(database.getVersion()).isEqualTo(0);
+    database.setVersion(20);
+    assertThat(database.getVersion()).isEqualTo(20);
+  }
+
+  @Test
+  public void testTwoConcurrentDbConnections() throws Exception {
+    SQLiteDatabase db1 = openOrCreateDatabase("db1");
+    SQLiteDatabase db2 = openOrCreateDatabase("db2");
+
+    db1.execSQL("CREATE TABLE foo(id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT);");
+    db2.execSQL("CREATE TABLE bar(id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT);");
+
+    ContentValues d1 = new ContentValues();
+    d1.put("data", "d1");
+
+    ContentValues d2 = new ContentValues();
+    d2.put("data", "d2");
+
+    db1.insert("foo", null, d1);
+    db2.insert("bar", null, d2);
+
+    Cursor c = db1.rawQuery("select * from foo", null);
+    assertThat(c).isNotNull();
+    assertThat(c.getCount()).isEqualTo(1);
+    assertThat(c.moveToNext()).isTrue();
+    assertThat(c.getString(c.getColumnIndex("data"))).isEqualTo("d1");
+
+    c = db2.rawQuery("select * from bar", null);
+    assertThat(c).isNotNull();
+    assertThat(c.getCount()).isEqualTo(1);
+    assertThat(c.moveToNext()).isTrue();
+    assertThat(c.getString(c.getColumnIndex("data"))).isEqualTo("d2");
+  }
+
+  @Test(expected = SQLiteException.class)
+  public void testQueryThrowsSQLiteException() throws Exception {
+    SQLiteDatabase db1 = openOrCreateDatabase("db1");
+    db1.query("FOO", null, null, null, null, null, null);
+  }
+
+  @Test(expected = SQLiteException.class)
+  public void testShouldThrowSQLiteExceptionIfOpeningNonexistentDatabase() {
+    SQLiteDatabase.openDatabase("/does/not/exist", null, OPEN_READWRITE);
+  }
+
+  @Test
+  public void testCreateAndDropTable() throws Exception {
+    SQLiteDatabase db = openOrCreateDatabase("db1");
+    db.execSQL("CREATE TABLE foo(id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT);");
+    Cursor c = db.query("FOO", null, null, null, null, null, null);
+    assertThat(c).isNotNull();
+    c.close();
+    db.close();
+    db = openOrCreateDatabase("db1");
+    db.execSQL("DROP TABLE IF EXISTS foo;");
+    try {
+      c = db.query("FOO", null, null, null, null, null, null);
+      fail("expected no such table exception");
+    } catch (SQLiteException e) {
+      // TODO
     }
+    db.close();
+  }
 
-    @Test(expected = SQLiteException.class)
-    public void shouldThrowIfFileDoesNotExist() throws Exception {
-        File testDb = new File("/i/do/not/exist");
-        assertThat(testDb.exists()).isFalse();
-        SQLiteDatabase.openOrCreateDatabase(testDb.getAbsolutePath(), null);
+  @Test
+  public void testCreateAndAlterTable() throws Exception {
+    SQLiteDatabase db = openOrCreateDatabase("db1");
+    db.execSQL("CREATE TABLE foo(id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT);");
+    Cursor c = db.query("FOO", null, null, null, null, null, null);
+    assertThat(c).isNotNull();
+    c.close();
+    db.close();
+    db = openOrCreateDatabase("db1");
+    db.execSQL("ALTER TABLE foo ADD COLUMN more TEXT NULL;");
+    c = db.query("FOO", null, null, null, null, null, null);
+    assertThat(c).isNotNull();
+    int moreIndex = c.getColumnIndex("more");
+    assertThat(moreIndex).isAtLeast(0);
+    c.close();
+  }
+
+  @Test
+  public void testDataInMemoryDatabaseIsPersistentAfterClose() throws Exception {
+    SQLiteDatabase db1 = openOrCreateDatabase("db1");
+    db1.execSQL("CREATE TABLE foo(id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT);");
+    ContentValues d1 = new ContentValues();
+    d1.put("data", "d1");
+    db1.insert("foo", null, d1);
+    db1.close();
+
+    SQLiteDatabase db2 = openOrCreateDatabase("db1");
+    Cursor c = db2.rawQuery("select * from foo", null);
+    assertThat(c).isNotNull();
+    assertThat(c.getCount()).isEqualTo(1);
+    assertThat(c.moveToNext()).isTrue();
+    assertThat(c.getString(c.getColumnIndex("data"))).isEqualTo("d1");
+  }
+
+  @Test
+  public void testRawQueryWithFactoryAndCancellationSignal() throws Exception {
+    CancellationSignal signal = new CancellationSignal();
+
+    Cursor cursor =
+        database.rawQueryWithFactory(null, "select * from" + " table_name", null, null, signal);
+    assertThat(cursor).isNotNull();
+    assertThat(cursor.getColumnCount()).isEqualTo(5);
+    assertThat(cursor.isClosed()).isFalse();
+
+    signal.cancel();
+
+    try {
+      cursor.moveToNext();
+      fail("did not get cancellation signal");
+    } catch (OperationCanceledException e) {
+      // expected
     }
+  }
 
-    @Test
-    public void shouldUseInMemoryDatabaseWhenCallingCreate() throws Exception {
-        SQLiteDatabase db = SQLiteDatabase.create(null);
-        assertThat(db.isOpen()).isTrue();
-        assertThat(db.getPath()).isEqualTo(":memory:");
+  @Test
+  public void testRawQueryWithCommonTableExpression() {
+    try (Cursor cursor =
+        database.rawQuery(
+            "WITH RECURSIVE\n"
+                + "  cnt(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM cnt WHERE x<100)\n"
+                + "SELECT COUNT(*) FROM cnt;",
+            null)) {
+      assertThat(cursor).isNotNull();
+      assertThat(cursor.moveToNext()).isTrue();
+      assertThat(cursor.getCount()).isEqualTo(1);
+      assertThat(cursor.isNull(0)).isFalse();
+      assertThat(cursor.getLong(0)).isEqualTo(100);
     }
+  }
 
-    @Test
-    public void shouldSetAndGetVersion() throws Exception {
-        assertThat(database.getVersion()).isEqualTo(0);
-        database.setVersion(20);
-        assertThat(database.getVersion()).isEqualTo(20);
+  @Test
+  public void shouldThrowWhenForeignKeysConstraintIsViolated() {
+    database.execSQL("CREATE TABLE master (master_value INTEGER)");
+    database.execSQL(
+        "CREATE TABLE slave (master_value INTEGER REFERENCES" + " master(master_value))");
+    database.execSQL("PRAGMA foreign_keys=ON");
+    try {
+      database.execSQL("INSERT INTO slave(master_value) VALUES (1)");
+      fail("Foreign key constraint is violated but exception is not thrown");
+    } catch (SQLiteException e) {
+      assertThat(e.getCause()).hasMessageThat().contains("foreign");
     }
+  }
 
-    @Test
-    public void testTwoConcurrentDbConnections() throws Exception {
-        SQLiteDatabase db1 = openOrCreateDatabase("db1");
-        SQLiteDatabase db2 = openOrCreateDatabase("db2");
+  @Test
+  public void shouldBeAbleToBeUsedFromDifferentThread() {
+    final CountDownLatch sync = new CountDownLatch(1);
+    final Throwable[] error = {null};
 
-        db1.execSQL("CREATE TABLE foo(id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT);");
-        db2.execSQL("CREATE TABLE bar(id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT);");
-
-        ContentValues d1 = new ContentValues();
-        d1.put("data", "d1");
-
-        ContentValues d2 = new ContentValues();
-        d2.put("data", "d2");
-
-        db1.insert("foo", null, d1);
-        db2.insert("bar", null, d2);
-
-        Cursor c = db1.rawQuery("select * from foo", null);
-        assertThat(c).isNotNull();
-        assertThat(c.getCount()).isEqualTo(1);
-        assertThat(c.moveToNext()).isTrue();
-        assertThat(c.getString(c.getColumnIndex("data"))).isEqualTo("d1");
-
-        c = db2.rawQuery("select * from bar", null);
-        assertThat(c).isNotNull();
-        assertThat(c.getCount()).isEqualTo(1);
-        assertThat(c.moveToNext()).isTrue();
-        assertThat(c.getString(c.getColumnIndex("data"))).isEqualTo("d2");
-    }
-
-    @Test(expected = SQLiteException.class)
-    public void testQueryThrowsSQLiteException() throws Exception {
-        SQLiteDatabase db1 = openOrCreateDatabase("db1");
-        db1.query("FOO", null, null, null, null, null, null);
-    }
-
-    @Test(expected = SQLiteException.class)
-    public void testShouldThrowSQLiteExceptionIfOpeningNonexistentDatabase() {
-        SQLiteDatabase.openDatabase("/does/not/exist", null, OPEN_READWRITE);
-    }
-
-    @Test
-    public void testCreateAndDropTable() throws Exception {
-        SQLiteDatabase db = openOrCreateDatabase("db1");
-        db.execSQL("CREATE TABLE foo(id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT);");
-        Cursor c = db.query("FOO", null, null, null, null, null, null);
-        assertThat(c).isNotNull();
-        c.close();
-        db.close();
-        db = openOrCreateDatabase("db1");
-        db.execSQL("DROP TABLE IF EXISTS foo;");
+    new Thread() {
+      @Override
+      public void run() {
         try {
-            c = db.query("FOO", null, null, null, null, null, null);
-            fail("expected no such table exception");
-        } catch (SQLiteException e) {
-            // TODO
+          executeQuery("select * from table_name");
+        } catch (Throwable e) {
+          e.printStackTrace();
+          error[0] = e;
+        } finally {
+          sync.countDown();
         }
-        db.close();
+      }
+    }.start();
+
+    try {
+      sync.await();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
     }
 
-    @Test
-    public void testCreateAndAlterTable() throws Exception {
-        SQLiteDatabase db = openOrCreateDatabase("db1");
-        db.execSQL("CREATE TABLE foo(id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT);");
-        Cursor c = db.query("FOO", null, null, null, null, null, null);
-        assertThat(c).isNotNull();
-        c.close();
-        db.close();
-        db = openOrCreateDatabase("db1");
-        db.execSQL("ALTER TABLE foo ADD COLUMN more TEXT NULL;");
-        c = db.query("FOO", null, null, null, null, null, null);
-        assertThat(c).isNotNull();
-        int moreIndex = c.getColumnIndex("more");
-        assertThat(moreIndex).isAtLeast(0);
-        c.close();
-    }
+    assertThat(error[0]).isNull();
+  }
 
-    @Test
-    public void testDataInMemoryDatabaseIsPersistentAfterClose() throws Exception {
-        SQLiteDatabase db1 = openOrCreateDatabase("db1");
-        db1.execSQL("CREATE TABLE foo(id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT);");
-        ContentValues d1 = new ContentValues();
-        d1.put("data", "d1");
-        db1.insert("foo", null, d1);
-        db1.close();
+  private Cursor executeQuery(String query) {
+    return database.rawQuery(query, null);
+  }
 
-        SQLiteDatabase db2 = openOrCreateDatabase("db1");
-        Cursor c = db2.rawQuery("select * from foo", null);
-        assertThat(c).isNotNull();
-        assertThat(c.getCount()).isEqualTo(1);
-        assertThat(c.moveToNext()).isTrue();
-        assertThat(c.getString(c.getColumnIndex("data"))).isEqualTo("d1");
-    }
+  private long addChuck() {
+    return addPerson(1234L, "Chuck");
+  }
 
-    @Test
-    public void testRawQueryWithFactoryAndCancellationSignal() throws Exception {
-        CancellationSignal signal = new CancellationSignal();
+  private long addJulie() {
+    return addPerson(1235L, "Julie");
+  }
 
-        Cursor cursor = database.rawQueryWithFactory(null, "select * from"
-                                                               + " table_name", null, null, signal);
-        assertThat(cursor).isNotNull();
-        assertThat(cursor.getColumnCount()).isEqualTo(5);
-        assertThat(cursor.isClosed()).isFalse();
+  private long addPerson(long id, String name) {
+    ContentValues values = new ContentValues();
+    values.put("id", id);
+    values.put("name", name);
+    return database.insert("table_name", null, values);
+  }
 
-        signal.cancel();
+  private int updateName(long id, String name) {
+    ContentValues values = new ContentValues();
+    values.put("name", name);
+    return database.update("table_name", values, "id=" + id, null);
+  }
 
-        try {
-            cursor.moveToNext();
-            fail("did not get cancellation signal");
-        } catch (OperationCanceledException e) {
-            // expected
-        }
-    }
+  private int updateName(String name) {
+    ContentValues values = new ContentValues();
+    values.put("name", name);
+    return database.update("table_name", values, null, null);
+  }
 
-    @Test
-    public void shouldThrowWhenForeignKeysConstraintIsViolated() {
-        database.execSQL("CREATE TABLE master (master_value INTEGER)");
-        database.execSQL("CREATE TABLE slave (master_value INTEGER REFERENCES"
-                             + " master(master_value))");
-        database.execSQL("PRAGMA foreign_keys=ON");
-        try {
-            database.execSQL("INSERT INTO slave(master_value) VALUES (1)");
-            fail("Foreign key constraint is violated but exception is not thrown");
-        } catch (SQLiteException e) {
-            assertThat(e.getCause()).hasMessageThat().contains("foreign");
-        }
-    }
+  private void assertIdAndName(Cursor cursor, long id, String name) {
+    long idValueFromDatabase;
+    String stringValueFromDatabase;
 
+    idValueFromDatabase = cursor.getLong(0);
+    stringValueFromDatabase = cursor.getString(1);
+    assertThat(idValueFromDatabase).isEqualTo(id);
+    assertThat(stringValueFromDatabase).isEqualTo(name);
+  }
 
-    @Test
-    public void shouldBeAbleToBeUsedFromDifferentThread() {
-        final CountDownLatch sync = new CountDownLatch(1);
-        final Throwable[] error = {null};
+  private void assertEmptyDatabase() {
+    Cursor cursor =
+        database.query("table_name", new String[] {"id", "name"}, null, null, null, null, null);
+    assertThat(cursor.moveToFirst()).isFalse();
+    assertThat(cursor.isClosed()).isFalse();
+    assertThat(cursor.getCount()).isEqualTo(0);
+  }
 
-        new Thread() {
-            @Override
-            public void run() {
-                try {
-                    executeQuery("select * from table_name");
-                } catch (Throwable e) {
-                    e.printStackTrace();
-                    error[0] = e;
-                } finally {
-                    sync.countDown();
-                }
-            }
-        }
-                .start();
+  private void assertNonEmptyDatabase() {
+    Cursor cursor =
+        database.query("table_name", new String[] {"id", "name"}, null, null, null, null, null);
+    assertThat(cursor.moveToFirst()).isTrue();
+    assertThat(cursor.getCount()).isNotEqualTo(0);
+  }
 
-        try {
-            sync.await();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+  @Test
+  public void shouldAlwaysReturnCorrectIdFromInsert() throws Exception {
+    database.execSQL(
+        "CREATE TABLE table_A (\n"
+            + "  _id INTEGER PRIMARY KEY AUTOINCREMENT,\n"
+            + "  id INTEGER DEFAULT 0\n"
+            + ");");
 
-        assertThat(error[0]).isNull();
-    }
+    database.execSQL("CREATE VIRTUAL TABLE new_search USING fts3 (id);");
 
+    database.execSQL(
+        "CREATE TRIGGER t1 AFTER INSERT ON table_A WHEN new.id=0 BEGIN UPDATE"
+            + " table_A SET id=-new._id WHERE _id=new._id AND id=0; END;");
+    database.execSQL(
+        "CREATE TRIGGER t2 AFTER INSERT ON table_A BEGIN INSERT INTO new_search"
+            + " (id) VALUES (new._id); END;");
+    database.execSQL(
+        "CREATE TRIGGER t3 BEFORE UPDATE ON table_A BEGIN DELETE FROM new_search"
+            + " WHERE id MATCH old._id; END;");
+    database.execSQL(
+        "CREATE TRIGGER t4 AFTER UPDATE ON table_A BEGIN INSERT INTO new_search"
+            + " (id) VALUES (new._id); END;");
 
-    private Cursor executeQuery(String query) {
-        return database.rawQuery(query, null);
-    }
-
-    private long addChuck() {
-        return addPerson(1234L, "Chuck");
-    }
-
-    private long addJulie() {
-        return addPerson(1235L, "Julie");
-    }
-
-    private long addPerson(long id, String name) {
-        ContentValues values = new ContentValues();
-        values.put("id", id);
-        values.put("name", name);
-        return database.insert("table_name", null, values);
-    }
-
-    private int updateName(long id, String name) {
-        ContentValues values = new ContentValues();
-        values.put("name", name);
-        return database.update("table_name", values, "id=" + id, null);
-    }
-
-    private int updateName(String name) {
-        ContentValues values = new ContentValues();
-        values.put("name", name);
-        return database.update("table_name", values, null, null);
-    }
-
-    private void assertIdAndName(Cursor cursor, long id, String name) {
-        long idValueFromDatabase;
-        String stringValueFromDatabase;
-
-        idValueFromDatabase = cursor.getLong(0);
-        stringValueFromDatabase = cursor.getString(1);
-        assertThat(idValueFromDatabase).isEqualTo(id);
-        assertThat(stringValueFromDatabase).isEqualTo(name);
-    }
-
-    private void assertEmptyDatabase() {
-        Cursor cursor = database.query("table_name", new String[]{"id", "name"}, null, null, null, null, null);
-        assertThat(cursor.moveToFirst()).isFalse();
-        assertThat(cursor.isClosed()).isFalse();
-        assertThat(cursor.getCount()).isEqualTo(0);
-    }
-
-    private void assertNonEmptyDatabase() {
-        Cursor cursor = database.query("table_name", new String[]{"id", "name"}, null, null, null, null, null);
-        assertThat(cursor.moveToFirst()).isTrue();
-        assertThat(cursor.getCount()).isNotEqualTo(0);
-    }
-
-    @Test
-    public void shouldAlwaysReturnCorrectIdFromInsert() throws Exception {
-        database.execSQL("CREATE TABLE table_A (\n" +
-                "  _id INTEGER PRIMARY KEY AUTOINCREMENT,\n" +
-                "  id INTEGER DEFAULT 0\n" +
-                ");");
-
-        database.execSQL("CREATE VIRTUAL TABLE new_search USING fts3 (id);");
-
-        database.execSQL("CREATE TRIGGER t1 AFTER INSERT ON table_A WHEN new.id=0 BEGIN UPDATE"
-                             + " table_A SET id=-new._id WHERE _id=new._id AND id=0; END;");
-        database.execSQL("CREATE TRIGGER t2 AFTER INSERT ON table_A BEGIN INSERT INTO new_search"
-                             + " (id) VALUES (new._id); END;");
-        database.execSQL("CREATE TRIGGER t3 BEFORE UPDATE ON table_A BEGIN DELETE FROM new_search"
-                             + " WHERE id MATCH old._id; END;");
-        database.execSQL("CREATE TRIGGER t4 AFTER UPDATE ON table_A BEGIN INSERT INTO new_search"
-                             + " (id) VALUES (new._id); END;");
-
-        long[] returnedIds = new long[]{
-                database.insert("table_A", "id", new ContentValues()),
-                database.insert("table_A", "id", new ContentValues())
+    long[] returnedIds =
+        new long[] {
+          database.insert("table_A", "id", new ContentValues()),
+          database.insert("table_A", "id", new ContentValues())
         };
 
-        Cursor c = database.query("table_A", new String[]{"_id"}, null, null, null, null, null);
-        assertThat(c).isNotNull();
+    Cursor c = database.query("table_A", new String[] {"_id"}, null, null, null, null, null);
+    assertThat(c).isNotNull();
 
-        long[] actualIds = new long[c.getCount()];
-        for (c.moveToFirst(); !c.isAfterLast(); c.moveToNext()) {
-            actualIds[c.getPosition()] = c.getLong(c.getColumnIndexOrThrow("_id"));
-        }
-        c.close();
-
-        assertThat(returnedIds).isEqualTo(actualIds);
+    long[] actualIds = new long[c.getCount()];
+    for (c.moveToFirst(); !c.isAfterLast(); c.moveToNext()) {
+      actualIds[c.getPosition()] = c.getLong(c.getColumnIndexOrThrow("_id"));
     }
+    c.close();
 
-    @Test
-    public void shouldCorrectlyReturnNullValues() {
-        database.execSQL("CREATE TABLE null_test (col_int INTEGER, col_text TEXT, col_real REAL,"
-                             + " col_blob BLOB)");
+    assertThat(returnedIds).isEqualTo(actualIds);
+  }
 
-        ContentValues data = new ContentValues();
-        data.putNull("col_int");
-        data.putNull("col_text");
-        data.putNull("col_real");
-        data.putNull("col_blob");
-        assertThat(database.insert("null_test", null, data)).isAtLeast(0L);
+  @Test
+  public void shouldCorrectlyReturnNullValues() {
+    database.execSQL(
+        "CREATE TABLE null_test (col_int INTEGER, col_text TEXT, col_real REAL,"
+            + " col_blob BLOB)");
 
-        Cursor nullValuesCursor = database.query("null_test", null, null, null, null, null, null);
-        nullValuesCursor.moveToFirst();
-        final int colsCount = 4;
-        for (int i = 0; i < colsCount; i++) {
-            assertThat(nullValuesCursor.getType(i)).isEqualTo(Cursor.FIELD_TYPE_NULL);
-            assertThat(nullValuesCursor.getString(i)).isNull();
-        }
-        assertThat(nullValuesCursor.getBlob(3)).isNull();
+    ContentValues data = new ContentValues();
+    data.putNull("col_int");
+    data.putNull("col_text");
+    data.putNull("col_real");
+    data.putNull("col_blob");
+    assertThat(database.insert("null_test", null, data)).isAtLeast(0L);
+
+    Cursor nullValuesCursor = database.query("null_test", null, null, null, null, null, null);
+    nullValuesCursor.moveToFirst();
+    final int colsCount = 4;
+    for (int i = 0; i < colsCount; i++) {
+      assertThat(nullValuesCursor.getType(i)).isEqualTo(Cursor.FIELD_TYPE_NULL);
+      assertThat(nullValuesCursor.getString(i)).isNull();
     }
+    assertThat(nullValuesCursor.getBlob(3)).isNull();
+  }
 
-    @Test
-    public void shouldGetBlobFromString() {
-        ContentValues values = new ContentValues();
-        values.put("first_column", "this is a string");
-        database.insert("table_name", null, values);
+  @Test
+  public void shouldGetBlobFromString() {
+    ContentValues values = new ContentValues();
+    values.put("first_column", "this is a string");
+    database.insert("table_name", null, values);
 
-        Cursor data = database.query("table_name", new String[]{"first_column"}, null, null, null, null, null);
-        assertThat(data.getCount()).isEqualTo(1);
-        data.moveToFirst();
-        assertThat(data.getBlob(0)).isEqualTo(values.getAsString("first_column").getBytes(UTF_8));
-    }
+    Cursor data =
+        database.query("table_name", new String[] {"first_column"}, null, null, null, null, null);
+    assertThat(data.getCount()).isEqualTo(1);
+    data.moveToFirst();
+    assertThat(data.getBlob(0)).isEqualTo(values.getAsString("first_column").getBytes(UTF_8));
+  }
 
-    /////////////////////
+  /////////////////////
 
-    private SQLiteDatabase openOrCreateDatabase(String name) {
+  private SQLiteDatabase openOrCreateDatabase(String name) {
     return openOrCreateDatabase(ApplicationProvider.getApplicationContext().getDatabasePath(name));
-    }
+  }
 
-    private SQLiteDatabase openOrCreateDatabase(File databasePath) {
-        SQLiteDatabase database = SQLiteDatabase.openOrCreateDatabase(databasePath, null);
-        openDatabases.add(database);
-        return database;
-    }
+  private SQLiteDatabase openOrCreateDatabase(File databasePath) {
+    SQLiteDatabase database = SQLiteDatabase.openOrCreateDatabase(databasePath, null);
+    openDatabases.add(database);
+    return database;
+  }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/SQLiteStatementTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SQLiteStatementTest.java
@@ -25,10 +25,16 @@ public class SQLiteStatementTest {
     databasePath.getParentFile().mkdirs();
 
     database = SQLiteDatabase.openOrCreateDatabase(databasePath.getPath(), null);
-    SQLiteStatement createStatement = database.compileStatement("CREATE TABLE `routine` (`id` INTEGER PRIMARY KEY AUTOINCREMENT , `name` VARCHAR , `lastUsed` INTEGER DEFAULT 0 ,  UNIQUE (`name`)) ;");
+    SQLiteStatement createStatement =
+        database.compileStatement(
+            "CREATE TABLE `routine` (`id` INTEGER PRIMARY KEY AUTOINCREMENT , `name` VARCHAR ,"
+                + " `lastUsed` INTEGER DEFAULT 0 ,  UNIQUE (`name`)) ;");
     createStatement.execute();
 
-    SQLiteStatement createStatement2 = database.compileStatement("CREATE TABLE `countme` (`id` INTEGER PRIMARY KEY AUTOINCREMENT , `name` VARCHAR , `lastUsed` INTEGER DEFAULT 0 ,  UNIQUE (`name`)) ;");
+    SQLiteStatement createStatement2 =
+        database.compileStatement(
+            "CREATE TABLE `countme` (`id` INTEGER PRIMARY KEY AUTOINCREMENT , `name` VARCHAR ,"
+                + " `lastUsed` INTEGER DEFAULT 0 ,  UNIQUE (`name`)) ;");
     createStatement2.execute();
   }
 
@@ -39,7 +45,8 @@ public class SQLiteStatementTest {
 
   @Test
   public void testExecuteInsert() throws Exception {
-    SQLiteStatement insertStatement = database.compileStatement("INSERT INTO `routine` (`name` ,`lastUsed` ) VALUES (?,?)");
+    SQLiteStatement insertStatement =
+        database.compileStatement("INSERT INTO `routine` (`name` ,`lastUsed` ) VALUES (?,?)");
     insertStatement.bindString(1, "Leg Press");
     insertStatement.bindLong(2, 0);
     long pkeyOne = insertStatement.executeInsert();
@@ -79,8 +86,9 @@ public class SQLiteStatementTest {
     // if actualDBStatement will be mocked
     database.beginTransaction();
     try {
-      SQLiteStatement insertStatement = database.compileStatement("INSERT INTO `routine` " +
-          "(`name` ,`lastUsed`) VALUES ('test',0)");
+      SQLiteStatement insertStatement =
+          database.compileStatement(
+              "INSERT INTO `routine` " + "(`name` ,`lastUsed`) VALUES ('test',0)");
       try {
         insertStatement.executeInsert();
       } finally {
@@ -94,12 +102,14 @@ public class SQLiteStatementTest {
   @Test
   public void testExecuteUpdateDelete() throws Exception {
 
-    SQLiteStatement insertStatement = database.compileStatement("INSERT INTO `routine` (`name`) VALUES (?)");
+    SQLiteStatement insertStatement =
+        database.compileStatement("INSERT INTO `routine` (`name`) VALUES (?)");
     insertStatement.bindString(1, "Hand Press");
     long pkeyOne = insertStatement.executeInsert();
     assertThat(pkeyOne).isEqualTo(1);
 
-    SQLiteStatement updateStatement = database.compileStatement("UPDATE `routine` SET `name`=? WHERE `id`=?");
+    SQLiteStatement updateStatement =
+        database.compileStatement("UPDATE `routine` SET `name`=? WHERE `id`=?");
     updateStatement.bindString(1, "Head Press");
     updateStatement.bindLong(2, pkeyOne);
     assertThat(updateStatement.executeUpdateDelete()).isEqualTo(1);
@@ -116,7 +126,8 @@ public class SQLiteStatementTest {
     assertThat(stmt.simpleQueryForLong()).isEqualTo(0L);
     assertThat(stmt.simpleQueryForString()).isEqualTo("0");
 
-    SQLiteStatement insertStatement = database.compileStatement("INSERT INTO `countme` (`name` ,`lastUsed` ) VALUES (?,?)");
+    SQLiteStatement insertStatement =
+        database.compileStatement("INSERT INTO `countme` (`name` ,`lastUsed` ) VALUES (?,?)");
     insertStatement.bindString(1, "Leg Press");
     insertStatement.bindLong(2, 0);
     insertStatement.executeInsert();
@@ -129,24 +140,39 @@ public class SQLiteStatementTest {
     assertThat(stmt.simpleQueryForString()).isEqualTo("2");
   }
 
+  @Test
+  public void simpleQueryTestWithCommonTableExpression() {
+    try (SQLiteStatement statement =
+        database.compileStatement(
+            "WITH RECURSIVE\n"
+                + "  cnt(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM cnt WHERE x<100)\n"
+                + "SELECT COUNT(*) FROM cnt;")) {
+      assertThat(statement).isNotNull();
+      assertThat(statement.simpleQueryForLong()).isEqualTo(100);
+    }
+  }
+
   @Test(expected = SQLiteDoneException.class)
   public void simpleQueryForStringThrowsSQLiteDoneExceptionTest() throws Exception {
-    //throw SQLiteDOneException if no rows returned.
-    SQLiteStatement stmt = database.compileStatement("SELECT * FROM `countme` where `name`= 'cessationoftime'");
+    // throw SQLiteDOneException if no rows returned.
+    SQLiteStatement stmt =
+        database.compileStatement("SELECT * FROM `countme` where `name`= 'cessationoftime'");
 
     assertThat(stmt.simpleQueryForString()).isEqualTo("0");
   }
 
   @Test(expected = SQLiteDoneException.class)
   public void simpleQueryForLongThrowsSQLiteDoneExceptionTest() throws Exception {
-    //throw SQLiteDOneException if no rows returned.
-    SQLiteStatement stmt = database.compileStatement("SELECT * FROM `countme` where `name`= 'cessationoftime'");
+    // throw SQLiteDOneException if no rows returned.
+    SQLiteStatement stmt =
+        database.compileStatement("SELECT * FROM `countme` where `name`= 'cessationoftime'");
     stmt.simpleQueryForLong();
   }
 
   @Test
   public void testCloseShouldCloseUnderlyingPreparedStatement() throws Exception {
-    SQLiteStatement insertStatement = database.compileStatement("INSERT INTO `routine` (`name`) VALUES (?)");
+    SQLiteStatement insertStatement =
+        database.compileStatement("INSERT INTO `routine` (`name`) VALUES (?)");
     insertStatement.bindString(1, "Hand Press");
     insertStatement.close();
     try {

--- a/robolectric/src/test/java/org/robolectric/util/SQLiteLibraryLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/SQLiteLibraryLoaderTest.java
@@ -14,6 +14,7 @@ import org.robolectric.shadows.util.SQLiteLibraryLoader;
 public class SQLiteLibraryLoaderTest {
   /** Saved system properties. */
   private String savedOs, savedArch;
+
   private SQLiteLibraryLoader loader;
 
   @Before
@@ -43,55 +44,61 @@ public class SQLiteLibraryLoaderTest {
   @Test
   public void shouldFindLibraryForWindowsXPX86() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(WINDOWS), "Windows XP", "x86"))
-        .isEqualTo("windows-x86/sqlite4java.dll");
+        .isEqualTo("sqlite4java/win32-x86/sqlite4java.dll");
   }
 
   @Test
   public void shouldFindLibraryForWindows7X86() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(WINDOWS), "Windows 7", "x86"))
-        .isEqualTo("windows-x86/sqlite4java.dll");
+        .isEqualTo("sqlite4java/win32-x86/sqlite4java.dll");
   }
 
   @Test
   public void shouldFindLibraryForWindowsXPAmd64() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(WINDOWS), "Windows XP", "amd64"))
-        .isEqualTo("windows-x86_64/sqlite4java.dll");
+        .isEqualTo("sqlite4java/win32-x64/sqlite4java.dll");
   }
 
   @Test
   public void shouldFindLibraryForWindows7Amd64() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(WINDOWS), "Windows 7", "amd64"))
-        .isEqualTo("windows-x86_64/sqlite4java.dll");
+        .isEqualTo("sqlite4java/win32-x64/sqlite4java.dll");
+  }
+
+  @Test
+  public void shouldFindLibraryForWindows10Amd64() throws IOException {
+    assertThat(loadLibrary(new SQLiteLibraryLoader(WINDOWS), "Windows 10", "amd64"))
+        .isEqualTo("sqlite4java/win32-x64/sqlite4java.dll");
   }
 
   @Test
   public void shouldFindLibraryForLinuxi386() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(LINUX), "Some linux version", "i386"))
-        .isEqualTo("linux-x86/libsqlite4java.so");
+        .isEqualTo("sqlite4java/linux-i386/libsqlite4java.so");
   }
 
   @Test
   public void shouldFindLibraryForLinuxx86() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(LINUX), "Some linux version", "x86"))
-        .isEqualTo("linux-x86/libsqlite4java.so");
+        .isEqualTo("sqlite4java/linux-i386/libsqlite4java.so");
   }
 
   @Test
   public void shouldFindLibraryForLinuxAmd64() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(LINUX), "Some linux version", "amd64"))
-        .isEqualTo("linux-x86_64/libsqlite4java.so");
+        .isEqualTo("sqlite4java/linux-amd64/libsqlite4java.so");
   }
 
   @Test
   public void shouldFindLibraryForMacWithAnyArch() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(MAC), "Mac OS X", "any architecture"))
-        .isEqualTo("mac-x86_64/libsqlite4java.jnilib");
+        .isEqualTo("sqlite4java/osx/libsqlite4java.jnilib");
   }
 
   @Test
   public void shouldFindLibraryForMacWithAnyArchAndDyLibMapping() throws IOException {
     assertThat(loadLibrary(new SQLiteLibraryLoader(MAC_DYLIB), "Mac OS X", "any architecture"))
-        .isEqualTo("mac-x86_64/libsqlite4java.jnilib");
+        .isEqualTo("sqlite4java/osx/libsqlite4java.jnilib");
   }
 
   @Test(expected = UnsupportedOperationException.class)
@@ -99,7 +106,8 @@ public class SQLiteLibraryLoaderTest {
     loadLibrary(new SQLiteLibraryLoader(LINUX), "ACME Electronic", "FooBar2000");
   }
 
-  private String loadLibrary(SQLiteLibraryLoader loader, String name, String arch) throws IOException {
+  private String loadLibrary(SQLiteLibraryLoader loader, String name, String arch)
+      throws IOException {
     setNameAndArch(name, arch);
     return loader.getLibClasspathResourceName();
   }
@@ -124,8 +132,12 @@ public class SQLiteLibraryLoaderTest {
     System.setProperty("os.arch", arch);
   }
 
-  private static final SQLiteLibraryLoader.LibraryNameMapper LINUX = new LibraryMapperTest("lib", "so");
-  private static final SQLiteLibraryLoader.LibraryNameMapper WINDOWS = new LibraryMapperTest("", "dll");
-  private static final SQLiteLibraryLoader.LibraryNameMapper MAC = new LibraryMapperTest("lib", "jnilib");
-  private static final SQLiteLibraryLoader.LibraryNameMapper MAC_DYLIB = new LibraryMapperTest("lib", "dylib");
+  private static final SQLiteLibraryLoader.LibraryNameMapper LINUX =
+      new LibraryMapperTest("lib", "so");
+  private static final SQLiteLibraryLoader.LibraryNameMapper WINDOWS =
+      new LibraryMapperTest("", "dll");
+  private static final SQLiteLibraryLoader.LibraryNameMapper MAC =
+      new LibraryMapperTest("lib", "jnilib");
+  private static final SQLiteLibraryLoader.LibraryNameMapper MAC_DYLIB =
+      new LibraryMapperTest("lib", "dylib");
 }

--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -9,30 +9,32 @@ shadows {
 }
 
 configurations {
-    jni
+    sqlite4java
 }
 
-task copyNatives(type: Copy) {
-    outputs.dir file("${buildDir}/resources/main")
+def sqlite4javaVersion = '1.0.392'
 
-    project.afterEvaluate {
-        configurations.jni.files.each { File file ->
-            def nativeJarMatch = file.name =~ /lib.*-natives-(.*)\.jar/
-            if (nativeJarMatch) {
-                inputs.file file
+task copySqliteNatives(type: Copy) {
+    from project.configurations.sqlite4java {
+        include '**/*.dll'
+        include '**/*.so'
+        include '**/*.dylib'
+        rename { String filename ->
+            def filenameMatch = filename =~ /^([^\-]+)-(.+)-${sqlite4javaVersion}\.(.+)/
+            if (filenameMatch) {
+                def platformFilename = filenameMatch[0][1]
+                def platformFolder = filenameMatch[0][2]
+                def platformExtension = filenameMatch[0][3]
 
-                def platformName = nativeJarMatch[0][1]
-                from(zipTree(file)) { rename { f -> "$platformName/$f" } }
+                "${platformFolder}/${platformFilename}.${platformExtension}"
             }
-
         }
     }
-
-    into project.file("$buildDir/resources/main")
+    into project.file("$buildDir/resources/main/sqlite4java")
 }
 
 jar {
-    dependsOn copyNatives
+    dependsOn copySqliteNatives
 }
 
 dependencies {
@@ -45,16 +47,16 @@ dependencies {
     api "androidx.test:monitor:1.3.0-rc03@aar"
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
-    api "com.almworks.sqlite4java:sqlite4java:0.282"
+    api "com.almworks.sqlite4java:sqlite4java:$sqlite4javaVersion"
     compileOnly(AndroidSdk.MAX_SDK.coordinates) { force = true }
     api "com.ibm.icu:icu4j:53.1"
     api "androidx.annotation:annotation:1.1.0"
     api "com.google.auto.value:auto-value-annotations:1.6.2"
     annotationProcessor "com.google.auto.value:auto-value:1.6.2"
 
-    jni "com.github.axet.litedb:libsqlite:0.282-3:natives-mac-x86_64"
-    jni "com.github.axet.litedb:libsqlite:0.282-3:natives-linux-x86"
-    jni "com.github.axet.litedb:libsqlite:0.282-3:natives-linux-x86_64"
-    jni "com.github.axet.litedb:libsqlite:0.282-3:natives-windows-x86"
-    jni "com.github.axet.litedb:libsqlite:0.282-3:natives-windows-x86_64"
+    sqlite4java "com.almworks.sqlite4java:libsqlite4java-osx:$sqlite4javaVersion"
+    sqlite4java "com.almworks.sqlite4java:libsqlite4java-linux-amd64:$sqlite4javaVersion"
+    sqlite4java "com.almworks.sqlite4java:sqlite4java-win32-x64:$sqlite4javaVersion"
+    sqlite4java "com.almworks.sqlite4java:libsqlite4java-linux-i386:$sqlite4javaVersion"
+    sqlite4java "com.almworks.sqlite4java:sqlite4java-win32-x86:$sqlite4javaVersion"
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/util/SQLiteLibraryLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/util/SQLiteLibraryLoader.java
@@ -13,13 +13,11 @@ import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Initializes sqlite native libraries.
- */
+/** Initializes sqlite native libraries. */
 public class SQLiteLibraryLoader {
   private static SQLiteLibraryLoader instance;
   private static final String SQLITE4JAVA = "sqlite4java";
-  private static final String OS_WIN = "windows", OS_LINUX = "linux", OS_MAC = "mac";
+  private static final String OS_WIN = "win32", OS_LINUX = "linux", OS_MAC = "osx";
 
   private final LibraryNameMapper libraryNameMapper;
   private boolean loaded;
@@ -59,7 +57,7 @@ public class SQLiteLibraryLoader {
   }
 
   public String getLibClasspathResourceName() {
-    return getNativesResourcesPathPart() + "/" + getNativesResourcesFilePart();
+    return "sqlite4java/" + getNativesResourcesPathPart() + "/" + getNativesResourcesFilePart();
   }
 
   private ByteSource getLibraryByteSource() {
@@ -85,7 +83,11 @@ public class SQLiteLibraryLoader {
 
     SQLite.setLibraryPath(libPath.getAbsolutePath());
     try {
-      log("SQLite version: library " + SQLite.getLibraryVersion() + " / core " + SQLite.getSQLiteVersion());
+      log(
+          "SQLite version: library "
+              + SQLite.getLibraryVersion()
+              + " / core "
+              + SQLite.getSQLiteVersion());
     } catch (SQLiteException e) {
       throw new RuntimeException(e);
     }
@@ -97,7 +99,13 @@ public class SQLiteLibraryLoader {
   }
 
   private String getNativesResourcesPathPart() {
-    return getOsPrefix() + "-" + getArchitectureSuffix();
+    String prefix = getOsPrefix();
+    String suffix = getArchitectureSuffix(prefix);
+    if (suffix != null) {
+      return prefix + "-" + suffix;
+    } else {
+      return prefix;
+    }
   }
 
   private String getNativesResourcesFilePart() {
@@ -113,17 +121,38 @@ public class SQLiteLibraryLoader {
     } else if (name.contains("mac")) {
       return OS_MAC;
     } else {
-      throw new UnsupportedOperationException("Architecture '" + name + "' is not supported by SQLite library");
+      throw new UnsupportedOperationException(
+          "Platform \'" + name + "\' is not supported by SQLite library");
     }
   }
 
-  private String getArchitectureSuffix() {
+  private String getArchitectureSuffix(String prefix) {
     String arch = System.getProperty("os.arch").toLowerCase(Locale.US).replaceAll("\\W", "");
-    if ("i386".equals(arch) || "x86".equals(arch)) {
-      return "x86";
-    } else {
-      return "x86_64";
+    switch (prefix) {
+      case OS_MAC:
+        return null;
+      case OS_LINUX:
+        switch (arch) {
+          case "i386":
+          case "x86":
+            return "i386";
+          case "x86_64":
+          case "amd64":
+            return "amd64";
+        }
+        break;
+      case OS_WIN:
+        switch (arch) {
+          case "x86":
+            return "x86";
+          case "x86_64":
+          case "amd64":
+            return "x64";
+        }
+        break;
     }
+    throw new UnsupportedOperationException(
+        "Architecture \'" + arch + "\' is not supported by SQLite library");
   }
 
   public interface LibraryNameMapper {


### PR DESCRIPTION


### Overview
Add support for CTEs in `SQLiteDatabase`  by updating the underlying sqlite4java library

### Proposed Changes
- Update sqlite4java to version 1.0.392 bundled
with SQLite 3.8.7 which comes with support for CTEs
- Use the first-hand natives Maven  artifacts published by almworks.
- Update `SQLiteLibraryLoader` and related `SQLiteLibraryLoaderTest` for
the updated library paths and names
- Add unit test functions to assert CTE support
- The original repo of the project is at
https://bitbucket.org/almworks/sqlite4java