### PR TITLE
Add a new system property allowing users to specify the LocalRepository to use for downloading Maven artifacts.

### DIFF
--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 import java.util.Hashtable;
 import org.apache.maven.artifact.ant.Authentication;
 import org.apache.maven.artifact.ant.DependenciesTask;
+import org.apache.maven.artifact.ant.LocalRepository;
 import org.apache.maven.artifact.ant.RemoteRepository;
 import org.apache.maven.model.Dependency;
 import org.apache.tools.ant.Project;
@@ -21,17 +22,20 @@ public class MavenDependencyResolver implements DependencyResolver {
   private final String repositoryId;
   private final String repositoryUserName;
   private final String repositoryPassword;
+  private final String repositoryLocalPath;
 
   public MavenDependencyResolver() {
     this(MavenRoboSettings.getMavenRepositoryUrl(), MavenRoboSettings.getMavenRepositoryId(), MavenRoboSettings
-        .getMavenRepositoryUserName(), MavenRoboSettings.getMavenRepositoryPassword());
+        .getMavenRepositoryUserName(), MavenRoboSettings.getMavenRepositoryPassword(),
+        System.getProperty("robolectric.dependency.repo.localpath"));
   }
 
-  public MavenDependencyResolver(String repositoryUrl, String repositoryId, String repositoryUserName, String repositoryPassword) {
+  public MavenDependencyResolver(String repositoryUrl, String repositoryId, String repositoryUserName, String repositoryPassword, String repositoryLocalPath) {
     this.repositoryUrl = repositoryUrl;
     this.repositoryId = repositoryId;
     this.repositoryUserName = repositoryUserName;
     this.repositoryPassword = repositoryPassword;
+    this.repositoryLocalPath = repositoryLocalPath;
   }
 
   @Override
@@ -50,6 +54,11 @@ public class MavenDependencyResolver implements DependencyResolver {
     RemoteRepository remoteRepository = new RemoteRepository();
     remoteRepository.setUrl(repositoryUrl);
     remoteRepository.setId(repositoryId);
+    if (repositoryLocalPath != null) {
+      LocalRepository localRepository = new LocalRepository();
+      localRepository.setPath(new File(repositoryLocalPath));
+      dependenciesTask.addLocalRepository(localRepository);
+    }
     if (repositoryUserName != null || repositoryPassword != null) {
       Authentication authentication = new Authentication();
       authentication.setUserName(repositoryUserName);


### PR DESCRIPTION
### Overview

This adds a new system property for configuring the use of Maven for downloading artifacts. The new property is robolectric.dependency.repo.localpath, and when it's set, overrides the default local repo location (typically $HOME/.m2/repo) that the artifacts will be downloaded to.

### Proposed Changes

Since MavenRoboSettings is marked deprecated with a comment saying not to add any new properties to it, I've added the property directly inside MavenDependencyResolver, which is a little ugly and inconsistent with the other four properties used there.

When the new property is set, a LocalRepository object is created with the specified path and added to the DependenciesTask being built, similar to how the Authentication object is handled for the username and password properties.

I didn't see any way to update the documentation in this project. Ideally this new property should be documented in the "System Properties" section of <http://robolectric.org/configuring/>, although I notice that's currently missing documentation for the username and password properties already.