### PR TITLE
Support Android Q/API 29 final.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
                 SKIP_JAVADOC=true \
                 ./gradlew test --info --stacktrace --continue \
                 --parallel \
-                -Drobolectric.enabledSdks=28,10000 \
+                -Drobolectric.enabledSdks=28,29 \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
       - run:

--- a/buildSrc/src/main/groovy/AndroidSdk.groovy
+++ b/buildSrc/src/main/groovy/AndroidSdk.groovy
@@ -11,7 +11,7 @@ class AndroidSdk implements Comparable<AndroidSdk> {
     static final O = new AndroidSdk(26, "8.0.0_r4", "r1")
     static final O_MR1 = new AndroidSdk(27, "8.1.0", "4611349")
     static final P = new AndroidSdk(28, "9", "4913185-2");
-    static final Q = new AndroidSdk(29, "9plus", "5616371");
+    static final Q = new AndroidSdk(29, "10", "5803371");
 
     static final List<AndroidSdk> ALL_SDKS = [
             JELLY_BEAN, JELLY_BEAN_MR1, JELLY_BEAN_MR2, KITKAT,

--- a/integration_tests/agp/build.gradle
+++ b/integration_tests/agp/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: org.robolectric.gradle.AndroidProjectConfigPlugin
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
     }
 
     compileOptions {

--- a/integration_tests/agp/testsupport/build.gradle
+++ b/integration_tests/agp/testsupport/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
     }
 
     compileOptions {

--- a/integration_tests/androidx/build.gradle
+++ b/integration_tests/androidx/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
     }
 
     compileOptions {

--- a/integration_tests/androidx_test/build.gradle
+++ b/integration_tests/androidx_test/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: org.robolectric.gradle.AndroidProjectConfigPlugin
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
     }
 
     compileOptions {

--- a/integration_tests/ctesque/build.gradle
+++ b/integration_tests/ctesque/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: org.robolectric.gradle.AndroidProjectConfigPlugin
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
     }
 
     lintOptions {

--- a/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
@@ -71,7 +71,7 @@ public class DefaultSdkProvider implements SdkProvider {
     knownSdks.put(O, new DefaultSdk(O, "8.0.0_r4", "r1", "REL", 8));
     knownSdks.put(O_MR1, new DefaultSdk(O_MR1, "8.1.0", "4611349", "REL", 8));
     knownSdks.put(P, new DefaultSdk(P, "9", "4913185-2", "REL", 8));
-    knownSdks.put(Q, new DefaultSdk(Q, "9plus", "5616371", "Q", 9));
+    knownSdks.put(Q, new DefaultSdk(Q, "10", "5803371", "REL", 9));
   }
 
   @Override
@@ -153,7 +153,7 @@ public class DefaultSdkProvider implements SdkProvider {
     @Override
     public void verifySupportedSdk(String testClassName) {
       if (isKnown() && !isSupported()) {
-        throw new AssumptionViolatedException(
+        throw new UnsupportedOperationException(
             "Failed to create a Robolectric sandbox: " + getUnsupportedMessage());
       }
     }

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
And make it an error to run on Q with an unsupported java version,
instead of just silently skipping tests.

