### PR TITLE
Fix NativeInput.MAX_SAMPLES

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/NativeInput.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/NativeInput.java
@@ -49,7 +49,7 @@ public class NativeInput {
   /*
    * Maximum number of samples supported per motion event.
    */
-  private static final int MAX_SAMPLES = 2 ^ 16; /* UINT16_MAX */
+  private static final int MAX_SAMPLES = 0xffff; /* UINT16_MAX */
   /*
    * Maximum pointer id value supported in a motion event.
    * Smallest pointer id is 0.


### PR DESCRIPTION
In `2 ^ 16` the `^` is bitwise exclusive or, not a power operator

Fixes #5276