### PR TITLE
Don't measure very frequently executed operations

### DIFF
--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/SandboxClassLoader.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/SandboxClassLoader.java
@@ -114,9 +114,7 @@ public class SandboxClassLoader extends URLClassLoader {
       }
 
       if (config.shouldAcquire(name)) {
-        loadedClass =
-            PerfStatsCollector.getInstance()
-                .measure("load sandboxed class", () -> maybeInstrumentClass(name));
+        loadedClass = maybeInstrumentClass(name);
       } else {
         loadedClass = getParent().loadClass(name);
       }
@@ -132,16 +130,13 @@ public class SandboxClassLoader extends URLClassLoader {
   protected Class<?> maybeInstrumentClass(String className) throws ClassNotFoundException {
     final byte[] origClassBytes = getByteCode(className);
 
-    MutableClass mutableClass = PerfStatsCollector.getInstance().measure("analyze class",
-        () -> classInstrumentor.analyzeClass(origClassBytes, config, classNodeProvider)
-    );
+    MutableClass mutableClass =
+        classInstrumentor.analyzeClass(origClassBytes, config, classNodeProvider);
 
     try {
       final byte[] bytes;
       if (config.shouldInstrument(mutableClass)) {
-        bytes = PerfStatsCollector.getInstance().measure("instrument class",
-            () -> classInstrumentor.instrumentToBytes(mutableClass)
-        );
+        bytes = classInstrumentor.instrumentToBytes(mutableClass);
       } else {
         bytes = postProcessUninstrumentedClass(mutableClass, origClassBytes);
       }

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
@@ -174,7 +174,6 @@ public class ShadowWrangler implements ClassHandler {
 
   @SuppressWarnings("ReferenceEquality")
   private Plan calculatePlan(String signature, boolean isStatic, Class<?> definingClass) {
-    return PerfStatsCollector.getInstance().measure("find shadow method", () -> {
       final ClassLoader classLoader = definingClass.getClassLoader();
       final InvocationProfile invocationProfile =
           new InvocationProfile(signature, isStatic, classLoader);
@@ -191,13 +190,11 @@ public class ShadowWrangler implements ClassHandler {
       } catch (ClassNotFoundException e) {
         throw new RuntimeException(e);
       }
-    });
   }
 
   @SuppressWarnings("ReferenceEquality")
   @Override public MethodHandle findShadowMethodHandle(Class<?> definingClass, String name,
       MethodType methodType, boolean isStatic) throws IllegalAccessException {
-    return PerfStatsCollector.getInstance().measure("find shadow method handle", () -> {
       MethodType actualType = isStatic ? methodType : methodType.dropParameterTypes(0, 1);
       Class<?>[] paramTypes = actualType.parameterArray();
 
@@ -219,7 +216,6 @@ public class ShadowWrangler implements ClassHandler {
       } else {
         return mh;
       }
-    });
   }
 
   protected Method pickShadowMethod(Class<?> definingClass, String name, Class<?>[] paramTypes) {

--- a/utils/src/main/java/org/robolectric/util/SimplePerfStatsReporter.java
+++ b/utils/src/main/java/org/robolectric/util/SimplePerfStatsReporter.java
@@ -10,13 +10,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 import org.robolectric.AndroidMetadata;
 import org.robolectric.pluginapi.perf.Metadata;
 import org.robolectric.pluginapi.perf.Metric;
 import org.robolectric.pluginapi.perf.PerfStatsReporter;
 
 /**
- * Simple implementation of PerfStatsReporter that writes stats to `stdout`.
+ * Simple implementation of PerfStatsReporter that writes stats to a PrintStream.
  */
 public class SimplePerfStatsReporter implements PerfStatsReporter {
 
@@ -73,10 +74,10 @@ public class SimplePerfStatsReporter implements PerfStatsReporter {
           key.resourcesMode,
           Boolean.toString(key.success),
           Integer.toString(value.count),
-          Integer.toString((int) (value.minNs / 1000000)),
-          Integer.toString((int) (value.maxNs / 1000000)),
-          Integer.toString((int) (value.elapsedNs / 1000000 / value.count)),
-          Integer.toString((int) (value.elapsedNs / 1000000)));
+          Long.toString(TimeUnit.NANOSECONDS.toMillis(value.minNs)),
+          Long.toString(TimeUnit.NANOSECONDS.toMillis(value.maxNs)),
+          Long.toString(TimeUnit.NANOSECONDS.toMillis(value.elapsedNs) / value.count),
+          Long.toString(TimeUnit.NANOSECONDS.toMillis(value.elapsedNs)));
     }
     table.print(printWriter);
     printWriter.close();
@@ -89,6 +90,8 @@ public class SimplePerfStatsReporter implements PerfStatsReporter {
 
     private final int[] columnsWidths;
     private final List<String[]> tableData = new ArrayList<>();
+    // number of spaces between columns
+    private final static int COLUMN_SPACING = 1;
 
     TableText(int numColumns) {
       columnsWidths = new int[numColumns];
@@ -98,8 +101,8 @@ public class SimplePerfStatsReporter implements PerfStatsReporter {
       Preconditions.checkArgument(rowValues.length == columnsWidths.length);
       // adjust columnwidths
       for (int i = 0; i < rowValues.length; i++) {
-        if ((rowValues[i].length() + 1) > columnsWidths[i]) {
-          columnsWidths[i] = rowValues[i].length() + 1;
+        if ((rowValues[i].length() + COLUMN_SPACING) > columnsWidths[i]) {
+          columnsWidths[i] = rowValues[i].length() + COLUMN_SPACING;
         }
       }
       tableData.add(rowValues);


### PR DESCRIPTION
PerfCollector was used to capture individual events like loading
classes, finding shadow methods, etc that were executed thousands
of times during a test run. This measurement was not free - those
measurements added 180ms on average to test startup time on a fast
machine.

Arguably it doesn't provide much value to have this data collected
continuously, so remove the measurements to get some performance
back.