### PR TITLE
Clean up AutoService usage and dependencies

### DIFF
--- a/errorprone/build.gradle
+++ b/errorprone/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile "com.google.errorprone:error_prone_annotation:2.3.2"
     compile "com.google.errorprone:error_prone_refaster:2.3.2"
     compile "com.google.errorprone:error_prone_check_api:2.3.2"
-    compile "com.google.auto.service:auto-service:1.0-rc6"
+    compileOnly "com.google.auto.service:auto-service-annotations:1.0-rc6"
     compileOnly(AndroidSdk.MAX_SDK.coordinates) { force = true }
 
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc6"

--- a/errorprone/build.gradle
+++ b/errorprone/build.gradle
@@ -20,10 +20,10 @@ dependencies {
     compile "com.google.errorprone:error_prone_annotation:2.3.2"
     compile "com.google.errorprone:error_prone_refaster:2.3.2"
     compile "com.google.errorprone:error_prone_check_api:2.3.2"
-    compile "com.google.auto.service:auto-service:1.0-rc4"
+    compile "com.google.auto.service:auto-service:1.0-rc6"
     compileOnly(AndroidSdk.MAX_SDK.coordinates) { force = true }
 
-    annotationProcessor "com.google.auto.service:auto-service:1.0-rc4"
+    annotationProcessor "com.google.auto.service:auto-service:1.0-rc6"
 
     // in jdk 9, tools.jar disappears!
     def toolsJar = org.gradle.internal.jvm.Jvm.current().getToolsJar()

--- a/pluginapi/build.gradle
+++ b/pluginapi/build.gradle
@@ -4,7 +4,7 @@ new RoboJavaModulePlugin(
 
 dependencies {
     api project(":annotations")
-    compileOnly "com.google.auto.service:auto-service:1.0-rc4"
+    compileOnly "com.google.auto.service:auto-service:1.0-rc6"
     api "org.apache.ant:ant:1.8.0"
     api("org.apache.maven:maven-ant-tasks:2.1.3") {
         exclude group: "junit", module: "junit"

--- a/pluginapi/build.gradle
+++ b/pluginapi/build.gradle
@@ -4,7 +4,6 @@ new RoboJavaModulePlugin(
 
 dependencies {
     api project(":annotations")
-    compileOnly "com.google.auto.service:auto-service:1.0-rc6"
     api "org.apache.ant:ant:1.8.0"
     api("org.apache.maven:maven-ant-tasks:2.1.3") {
         exclude group: "junit", module: "junit"

--- a/pluginapi/build.gradle
+++ b/pluginapi/build.gradle
@@ -3,6 +3,7 @@ new RoboJavaModulePlugin(
 ).apply(project)
 
 dependencies {
+    compileOnly "com.google.code.findbugs:jsr302:3.0.2"
     api project(":annotations")
     api "org.apache.ant:ant:1.8.0"
     api("org.apache.maven:maven-ant-tasks:2.1.3") {

--- a/pluginapi/build.gradle
+++ b/pluginapi/build.gradle
@@ -3,7 +3,7 @@ new RoboJavaModulePlugin(
 ).apply(project)
 
 dependencies {
-    compileOnly "com.google.code.findbugs:jsr302:3.0.2"
+    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     api project(":annotations")
     api "org.apache.ant:ant:1.8.0"
     api("org.apache.maven:maven-ant-tasks:2.1.3") {

--- a/plugins/maven-dependency-resolver/build.gradle
+++ b/plugins/maven-dependency-resolver/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     api project(":pluginapi")
     api project(":utils")
 
-    compileOnly "com.google.auto.service:auto-service:1.0-rc6"
     api "org.apache.ant:ant:1.8.0"
     api("org.apache.maven:maven-ant-tasks:2.1.3") {
         exclude group: "junit", module: "junit"

--- a/plugins/maven-dependency-resolver/build.gradle
+++ b/plugins/maven-dependency-resolver/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     api project(":pluginapi")
     api project(":utils")
 
-    compileOnly "com.google.auto.service:auto-service:1.0-rc4"
+    compileOnly "com.google.auto.service:auto-service:1.0-rc6"
     api "org.apache.ant:ant:1.8.0"
     api("org.apache.maven:maven-ant-tasks:2.1.3") {
         exclude group: "junit", module: "junit"

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -17,7 +17,7 @@ configurations {
 project.sourceSets.test.compileClasspath += configurations.shadow
 
 dependencies {
-    annotationProcessor "com.google.auto.service:auto-service:1.0-rc4"
+    annotationProcessor "com.google.auto.service:auto-service:1.0-rc6"
 
     api project(":annotations")
     api project(":junit")
@@ -28,7 +28,7 @@ dependencies {
     api project(":utils:reflector")
     api project(":plugins:maven-dependency-resolver")
     api "javax.inject:javax.inject:1"
-    compileOnly "com.google.auto.service:auto-service:1.0-rc4"
+    compileOnly "com.google.auto.service:auto-service:1.0-rc6"
     api "javax.annotation:javax.annotation-api:1.3.2"
 
     // We need to have shadows-framework.jar on the runtime system classpath so ServiceLoader

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     api project(":utils:reflector")
     api project(":plugins:maven-dependency-resolver")
     api "javax.inject:javax.inject:1"
-    compileOnly "com.google.auto.service:auto-service:1.0-rc6"
+    compileOnly "com.google.auto.service:auto-service-annotations:1.0-rc6"
     api "javax.annotation:javax.annotation-api:1.3.2"
 
     // We need to have shadows-framework.jar on the runtime system classpath so ServiceLoader

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     api project(":utils")
     api project(":shadowapi")
     api project(":utils:reflector")
-    compileOnly "com.google.auto.service:auto-service:1.0-rc6"
+    compileOnly "com.google.auto.service:auto-service-annotations:1.0-rc6"
     api "javax.annotation:javax.annotation-api:1.3.2"
     api "javax.inject:javax.inject:1"
 

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -3,13 +3,13 @@ new RoboJavaModulePlugin(
 ).apply(project)
 
 dependencies {
-    annotationProcessor "com.google.auto.service:auto-service:1.0-rc4"
+    annotationProcessor "com.google.auto.service:auto-service:1.0-rc6"
 
     api project(":annotations")
     api project(":utils")
     api project(":shadowapi")
     api project(":utils:reflector")
-    compileOnly "com.google.auto.service:auto-service:1.0-rc4"
+    compileOnly "com.google.auto.service:auto-service:1.0-rc6"
     api "javax.annotation:javax.annotation-api:1.3.2"
     api "javax.inject:javax.inject:1"
 

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -6,11 +6,11 @@ dependencies {
     api project(":annotations")
     api project(":pluginapi")
     api project(":utils:reflector")
-    api "com.google.auto.service:auto-service:1.0-rc6"
     api "javax.inject:javax.inject:1"
     api "javax.annotation:javax.annotation-api:1.3.2"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
+    testCompileOnly "com.google.auto.service:auto-service-annotations:1.0-rc6"
     testAnnotationProcessor "com.google.auto.service:auto-service:1.0-rc6"
 
     testImplementation "junit:junit:4.12"

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -8,6 +8,9 @@ dependencies {
     api project(":utils:reflector")
     api "javax.inject:javax.inject:1"
     api "javax.annotation:javax.annotation-api:1.3.2"
+
+    // For @VisibleForTesting
+    api "com.android.support:support-annotations:28.0.0"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
     testCompileOnly "com.google.auto.service:auto-service-annotations:1.0-rc6"

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -6,12 +6,12 @@ dependencies {
     api project(":annotations")
     api project(":pluginapi")
     api project(":utils:reflector")
-    api "com.google.auto.service:auto-service:1.0-rc4"
+    api "com.google.auto.service:auto-service:1.0-rc6"
     api "javax.inject:javax.inject:1"
     api "javax.annotation:javax.annotation-api:1.3.2"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
-    testAnnotationProcessor "com.google.auto.service:auto-service:1.0-rc4"
+    testAnnotationProcessor "com.google.auto.service:auto-service:1.0-rc6"
 
     testImplementation "junit:junit:4.12"
     testImplementation "com.google.truth:truth:0.44"

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     api "javax.annotation:javax.annotation-api:1.3.2"
 
     // For @VisibleForTesting
-    api "com.android.support:support-annotations:28.0.0"
+    implementation "com.google.guava:guava:27.0.1-jre"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
     testCompileOnly "com.google.auto.service:auto-service-annotations:1.0-rc6"

--- a/utils/src/main/java/org/robolectric/util/inject/Injector.java
+++ b/utils/src/main/java/org/robolectric/util/inject/Injector.java
@@ -1,6 +1,6 @@
 package org.robolectric.util.inject;
 
-import com.google.common.annotations.VisibleForTesting;
+import android.support.annotation.VisibleForTesting;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Array;

--- a/utils/src/main/java/org/robolectric/util/inject/Injector.java
+++ b/utils/src/main/java/org/robolectric/util/inject/Injector.java
@@ -1,6 +1,6 @@
 package org.robolectric.util.inject;
 
-import android.support.annotation.VisibleForTesting;
+import com.google.common.annotations.VisibleForTesting;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Array;


### PR DESCRIPTION
### Overview

Resolves #5354
Resolves #5245 

AutoService was being misused in some places and unnecessarily declared as a full dependency in others. This updates it the latest version and uses its `-annotations` artifact as a `compileOnly` dependency where appropriate. This should remove autoservice from robolectric's shipped artifact dependencies entirely.
