### PR TITLE
Support jdk11

### DIFF
--- a/errorprone/build.gradle
+++ b/errorprone/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
     // Testing dependencies
     testCompile "junit:junit:4.12"
-    testCompile "com.google.truth:truth:0.44"
+    testCompile "com.google.truth:truth:1.0.1"
     testCompile("com.google.errorprone:error_prone_test_helpers:2.3.4") {
         exclude group: 'junit', module: 'junit' // because it depends on a snapshot!?
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ thisVersion=4.4-SNAPSHOT
 
 apiCompatVersion=4.2
 
-errorproneVersion=2.3.1
+errorproneVersion=2.3.4
 errorproneJavacVersion=9+181-r4173-1
 
 android.enableUnitTestBinaryResources=true

--- a/integration_tests/androidx/build.gradle
+++ b/integration_tests/androidx/build.gradle
@@ -39,5 +39,5 @@ dependencies {
     // TODO: this should be a transitive dependency of core...
     testImplementation("androidx.lifecycle:lifecycle-common:2.0.0")
     testImplementation("androidx.test.ext:junit:1.1.2-alpha04")
-    testImplementation("com.google.truth:truth:0.44")
+    testImplementation("com.google.truth:truth:1.0.1")
 }

--- a/integration_tests/androidx_test/build.gradle
+++ b/integration_tests/androidx_test/build.gradle
@@ -41,5 +41,5 @@ dependencies {
     // TODO: this should be a transitive dependency of core...
     testImplementation("androidx.lifecycle:lifecycle-common:2.0.0")
     testImplementation("androidx.test.ext:junit:1.1.2-alpha04")
-    testImplementation("com.google.truth:truth:0.44")
+    testImplementation("com.google.truth:truth:1.0.1")
 }

--- a/integration_tests/dependency-on-stubs/build.gradle
+++ b/integration_tests/dependency-on-stubs/build.gradle
@@ -8,6 +8,6 @@ dependencies {
 
     testImplementation files("${System.getenv("ANDROID_HOME")}/platforms/android-29/android.jar")
 
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
     testImplementation "org.mockito:mockito-core:2.5.4"
 }

--- a/integration_tests/libphonenumber/build.gradle
+++ b/integration_tests/libphonenumber/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
     testRuntime AndroidSdk.MAX_SDK.coordinates
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
     testImplementation 'com.googlecode.libphonenumber:libphonenumber:8.0.0'
 }

--- a/integration_tests/mockito-experimental/build.gradle
+++ b/integration_tests/mockito-experimental/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntime AndroidSdk.MAX_SDK.coordinates
     testImplementation "junit:junit:4.12"
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
     testImplementation "org.mockito:mockito-core:2.25.0"
 }

--- a/integration_tests/mockito-experimental/src/test/java/org/robolectric/integration_tests/mockito_experimental/MockitoMockFinalsTest.java
+++ b/integration_tests/mockito-experimental/src/test/java/org/robolectric/integration_tests/mockito_experimental/MockitoMockFinalsTest.java
@@ -26,7 +26,7 @@ public class MockitoMockFinalsTest {
   public void testInjection() {
     Layout layout = mock(Layout.class);
     when(textView.getLayout()).thenReturn(layout);
-    assertThat(textView.getLayout()).isSameAs(layout);
+    assertThat(textView.getLayout()).isSameInstanceAs(layout);
   }
 
   @Test

--- a/integration_tests/mockito/build.gradle
+++ b/integration_tests/mockito/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntime AndroidSdk.MAX_SDK.coordinates
     testImplementation "junit:junit:4.12"
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
     testImplementation "org.mockito:mockito-core:2.5.4"
 }

--- a/integration_tests/powermock/build.gradle
+++ b/integration_tests/powermock/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     testRuntime AndroidSdk.MAX_SDK.coordinates
     testImplementation "junit:junit:4.12"
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
 
     testImplementation "org.powermock:powermock-module-junit4:2.0.0"
     testImplementation "org.powermock:powermock-module-junit4-rule:2.0.0"

--- a/pluginapi/build.gradle
+++ b/pluginapi/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     }
 
     testImplementation "junit:junit:4.12"
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
     testImplementation "org.mockito:mockito-core:2.5.4"
 }

--- a/resources/build.gradle
+++ b/resources/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
     testImplementation "junit:junit:4.12"
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
     testImplementation "com.google.testing.compile:compile-testing:0.18"
     testImplementation "org.mockito:mockito-core:2.5.4"
 }

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -18,6 +18,7 @@ project.sourceSets.test.compileClasspath += configurations.shadow
 
 dependencies {
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc6"
+    annotationProcessor "com.google.errorprone:error_prone_core:2.3.4"
 
     api project(":annotations")
     api project(":junit")

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -4,6 +4,7 @@ new RoboJavaModulePlugin(
 
 dependencies {
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc6"
+    annotationProcessor "com.google.errorprone:error_prone_core:2.3.4"
 
     api project(":annotations")
     api project(":utils")
@@ -19,7 +20,7 @@ dependencies {
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
     testImplementation "junit:junit:4.12"
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
     testImplementation "org.mockito:mockito-core:2.5.4"
     testImplementation project(":junit")
 }

--- a/shadowapi/build.gradle
+++ b/shadowapi/build.gradle
@@ -7,6 +7,6 @@ dependencies {
 
     api project(":annotations")
     testImplementation "junit:junit:4.12"
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
     testImplementation "org.mockito:mockito-core:2.5.4"
 }

--- a/shadows/httpclient/build.gradle
+++ b/shadows/httpclient/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     testImplementation project(":robolectric")
     testImplementation "junit:junit:4.12"
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
     testImplementation "org.mockito:mockito-core:2.5.4"
     testCompileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates) { force = true }
     testRuntime AndroidSdk.LOLLIPOP_MR1.coordinates

--- a/shadows/playservices/build.gradle
+++ b/shadows/playservices/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
     testImplementation project(":robolectric")
     testImplementation "junit:junit:4.12"
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
     testImplementation "org.mockito:mockito-core:2.5.4"
     testRuntime "com.android.support:support-fragment:26.0.1"
     testRuntime "com.google.android.gms:play-services-base:8.4.0"

--- a/shadows/supportv4/build.gradle
+++ b/shadows/supportv4/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     testImplementation "androidx.test.ext:junit:1.1.2-alpha04"
     testImplementation "junit:junit:4.12"
     testImplementation "org.hamcrest:hamcrest-junit:2.0.0.0"
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
     testImplementation "org.mockito:mockito-core:2.5.4"
 
     earlyTestRuntime "org.hamcrest:hamcrest-junit:2.0.0.0"

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -15,8 +15,9 @@ dependencies {
 
     testCompileOnly "com.google.auto.service:auto-service-annotations:1.0-rc6"
     testAnnotationProcessor "com.google.auto.service:auto-service:1.0-rc6"
+    testAnnotationProcessor "com.google.errorprone:error_prone_core:2.3.4"
 
     testImplementation "junit:junit:4.12"
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
     testImplementation "org.mockito:mockito-core:2.5.4"
 }

--- a/utils/reflector/build.gradle
+++ b/utils/reflector/build.gradle
@@ -9,5 +9,5 @@ dependencies {
 
     testImplementation project(":shadowapi")
     testImplementation "junit:junit:4.12"
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:1.0.1"
 }

--- a/utils/reflector/src/main/java/org/robolectric/util/reflector/UnsafeAccess.java
+++ b/utils/reflector/src/main/java/org/robolectric/util/reflector/UnsafeAccess.java
@@ -1,11 +1,15 @@
 package org.robolectric.util.reflector;
 
+import org.robolectric.util.ReflectionHelpers;
+
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import sun.misc.Unsafe;
+
+import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 /** Access to sun.misc.Unsafe and the various scary things within. */
 @SuppressWarnings("NewApi")
@@ -40,8 +44,15 @@ public class UnsafeAccess {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Class<?> defineClass(Class<T> iClass, String reflectorClassName, byte[] bytecode) {
-      // TODO: call via reflection
-      return null;
+      // use reflection to call since this method does not exist on JDK11
+      return ReflectionHelpers.callInstanceMethod(unsafe,
+              "defineClass",
+              from(byte[].class, bytecode),
+              from(int.class, 0),
+              from(long.class, bytecode.length),
+              from(ClassLoader.class, iClass.getClassLoader()),
+              from(Object.class, null)
+              );
       //return unsafe.defineClass(
       //    reflectorClassName, bytecode, 0, bytecode.length, iClass.getClassLoader(), null);
     }


### PR DESCRIPTION
- Force use of errorprone 2.3.4 to avoid https://github.com/google/error-prone/pull/1083, including upgrading to truth 1.0.1
- Use reflection to access preJDK11 defineClass method

