### PR TITLE
Switch to reflection to call setNinePatchChunk

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -126,7 +126,8 @@ public class ShadowBitmapFactory {
         : null;
     Point imageSize = (is instanceof NamedStream) ? null : getImageSizeFromStream(is);
     Bitmap bitmap = create(name, opts, imageSize);
-    bitmap.setNinePatchChunk(ninePatchChunk);
+    ReflectionHelpers.callInstanceMethod(bitmap, "setNinePatchChunk",
+            ClassParameter.from(byte[].class, ninePatchChunk));
     ShadowBitmap shadowBitmap = Shadow.extract(bitmap);
     shadowBitmap.createdFromStream = is;
 


### PR DESCRIPTION
Bug: 150395371

This method was never meant to be exposed publicly. Stopping calling it directly allows it to be made private.