### PR TITLE
Remove minSdkVersion from AndroidManifest.xml's.

### DIFF
--- a/integration_tests/ctesque/src/main/AndroidManifest.xml
+++ b/integration_tests/ctesque/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.robolectric.ctesque">
 
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="27"/>
+  <uses-sdk android:targetSdkVersion="27"/>
 
   <application android:theme="@style/Theme.Robolectric">
     <activity

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     package="org.robolectric.testapp"
     android:versionCode="123"
     android:versionName="aVersionName">
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="23"/>
+    <uses-sdk android:targetSdkVersion="23"/>
 
     <application
         android:theme="@style/Theme.Robolectric" android:enabled="true">


### PR DESCRIPTION
In current AGP, Gradle import fails if minSdkVersion is specified.