### PR TITLE
Support running on Java 13

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,6 +10,6 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
 
-    implementation "org.ow2.asm:asm-tree:7.0"
+    implementation "org.ow2.asm:asm-tree:7.2"
     implementation 'com.android.tools.build:gradle:3.5.3'
 }

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -35,8 +35,8 @@ dependencies {
     api project(":shadowapi")
 
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
-    api "org.ow2.asm:asm:7.0"
-    api "org.ow2.asm:asm-commons:7.0"
+    api "org.ow2.asm:asm:7.2"
+    api "org.ow2.asm:asm-commons:7.2"
     api "com.google.guava:guava:27.0.1-jre"
     api "com.google.code.gson:gson:2.8.2"
     api 'ch.raffael.pegdown-doclet:pegdown-doclet:1.3'

--- a/resources/src/main/java/org/robolectric/res/Fs.java
+++ b/resources/src/main/java/org/robolectric/res/Fs.java
@@ -167,7 +167,7 @@ abstract public class Fs {
     synchronized (ZIP_FILESYSTEMS) {
       FsWrapper fs = ZIP_FILESYSTEMS.get(key);
       if (fs == null) {
-        fs = new FsWrapper(FileSystems.newFileSystem(key, null), key);
+        fs = new FsWrapper(FileSystems.newFileSystem(key, (ClassLoader) null), key);
         fs.incrRefCount();
 
         ZIP_FILESYSTEMS.put(key, fs);

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     api "javax.annotation:javax.annotation-api:1.3.2"
     api "javax.inject:javax.inject:1"
 
-    api "org.ow2.asm:asm:7.0"
-    api "org.ow2.asm:asm-commons:7.0"
+    api "org.ow2.asm:asm:7.2"
+    api "org.ow2.asm:asm-commons:7.2"
     api "com.google.guava:guava:27.0.1-jre"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 

--- a/shadowapi/src/main/java/org/robolectric/shadow/api/Shadow.java
+++ b/shadowapi/src/main/java/org/robolectric/shadow/api/Shadow.java
@@ -5,7 +5,7 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 public class Shadow {
   @SuppressWarnings("unused")
-  private final static IShadow SHADOW_IMPL;
+  private static IShadow SHADOW_IMPL;
 
   static {
     try {

--- a/utils/reflector/build.gradle
+++ b/utils/reflector/build.gradle
@@ -2,9 +2,9 @@ apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
 apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
 
 dependencies {
-    api "org.ow2.asm:asm:7.0"
-    api "org.ow2.asm:asm-commons:7.0"
-    api "org.ow2.asm:asm-util:7.0"
+    api "org.ow2.asm:asm:7.2"
+    api "org.ow2.asm:asm-commons:7.2"
+    api "org.ow2.asm:asm-util:7.2"
 
     testImplementation project(":shadowapi")
     testImplementation "junit:junit:4.12"


### PR DESCRIPTION
Setting final fields in Java 13 throws:
```
Caused by: java.lang.IllegalAccessException: Can not set static final org.robolectric.internal.IShadow field org.robolectric.shadow.api.Shadow.SHADOW_IMPL to org.robolectric.internal.bytecode.ShadowImpl
```
(see https://github.com/robolectric/robolectric/issues/4776#issuecomment-594450650)

Bump to ASM 7.2 to support class file format 57.

Building Robolectric with JDK 13 requires [Gradle 6.x](https://github.com/gradle/gradle/issues/8681), and commenting out errorprone, which [doesn't support Java 11+ yet](https://github.com/google/error-prone/issues/1106).

Fixes #5303.