### PR TITLE
Add the ability to set Layout for ShadowTextView

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextView.java
@@ -5,6 +5,7 @@ import static org.robolectric.shadow.api.Shadow.directlyOn;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.text.InputFilter;
+import android.text.Layout;
 import android.text.TextPaint;
 import android.text.TextWatcher;
 import android.text.method.MovementMethod;
@@ -60,6 +61,8 @@ public class ShadowTextView extends ShadowView {
   private int compoundDrawablesWithIntrinsicBoundsTop;
   private int compoundDrawablesWithIntrinsicBoundsRight;
   private int compoundDrawablesWithIntrinsicBoundsBottom;
+
+  private Layout layout;
 
   @Implementation
   protected void setTextAppearance(Context context, int resid) {
@@ -180,5 +183,14 @@ public class ShadowTextView extends ShadowView {
 
   public int getCompoundDrawablesWithIntrinsicBoundsBottom() {
     return compoundDrawablesWithIntrinsicBoundsBottom;
+  }
+
+  @Implementation
+  public Layout getLayout() {
+    return layout;
+  }
+
+  public void setLayout(Layout layout) {
+    this.layout = layout;
   }
 }


### PR DESCRIPTION
Our team has been working on a custom implementation of EditText which
includes a custom MovementMethod. In some cases, we default to the
default implementation of movement, which ends up calling up to
Selection.moveLeft, Selection.moveRight, etc. Similarly some
calculations require the Layout. We'd like to be able to set a mocked
Layout instance for this.

This change includes the needed changes to ShadowTextView and a test to
verify functionality.

### Overview

### Proposed Changes
