### PR TITLE
Bouncy castle crypto provider vs critical vulnerability.

### DIFF
--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     //   can find its META-INF/services/org.robolectric.shadows.ShadowAdapter.
     api project(":shadows:framework")
 
-    api "org.bouncycastle:bcprov-jdk15on:1.52"
+    api "org.bouncycastle:bcprov-jdk15on:1.65"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
     compileOnly AndroidSdk.MAX_SDK.coordinates


### PR DESCRIPTION
### Overview
The Bouncy castle provider as its flagged by security scanners because of https://nvd.nist.gov/vuln/detail/CVE-2018-1000613. It is showing up in security scanners, failing builds.

### Proposed Changes
Bump to unaffected version.