### PR TITLE
Remove unused import in BuildCompatTest

### DIFF
--- a/integration_tests/androidx/src/test/java/androidx/core/os/BuildCompatTest.java
+++ b/integration_tests/androidx/src/test/java/androidx/core/os/BuildCompatTest.java
@@ -3,7 +3,6 @@ package androidx.core.os;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.os.Build;
-import androidx.core.os.BuildCompat;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Ignore;
 import org.junit.Test;


### PR DESCRIPTION
The package name of the test matches the BuildCompat package name, so this
import is not necessary.
