### PR TITLE
Remove pegdown-doclet markdown javadoc doclet plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.6'
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:2.2.1'
-        classpath 'ch.raffael.pegdown-doclet:pegdown-doclet:1.3'
     }
 }
 
@@ -69,7 +68,6 @@ project.afterEvaluate {
 }
 
 apply plugin: 'nebula-aggregate-javadocs'
-apply plugin: 'ch.raffael.pegdown-doclet'
 
 rootProject.gradle.projectsEvaluated {
     rootProject.tasks['aggregateJavadocs'].failOnError = false

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/DeployedRoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/DeployedRoboJavaModulePlugin.groovy
@@ -10,7 +10,6 @@ class DeployedRoboJavaModulePlugin implements Plugin<Project> {
     Closure doApply = {
         project.apply plugin: "signing"
         project.apply plugin: "maven"
-        project.apply plugin: 'ch.raffael.pegdown-doclet'
 
         task('sourcesJar', type: Jar, dependsOn: classes) {
             classifier "sources"

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     api "org.ow2.asm:asm-commons:7.2"
     api "com.google.guava:guava:27.0.1-jre"
     api "com.google.code.gson:gson:2.8.2"
-    api 'ch.raffael.pegdown-doclet:pegdown-doclet:1.3'
 
     def toolsJar = org.gradle.internal.jvm.Jvm.current().getToolsJar()
     if (toolsJar != null) {


### PR DESCRIPTION
Robolectric was using the pegdown-doclet gradle plugin to support Markdown in
Javadoc. This plugin is not compatible with JDK 10+, which introduces a new
doclet API and javadoc command-line arguments. I tried to find alternatives to
pegdown-doclet, but couldn't find any that support JDK 10+. Instead, remove the
plugin and switch to using vanilla Javadoc. This may require some follow-up
commits to reformat markdown javadoc into HTML.

Fixes #5743
