### PR TITLE
Exclude `io.mockk` from AndroidConfigurer and JarInstrumentor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.6'
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:2.2.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.41"
     }
 }
 

--- a/integration_tests/mockk/build.gradle
+++ b/integration_tests/mockk/build.gradle
@@ -1,0 +1,13 @@
+apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
+apply plugin: 'kotlin'
+
+dependencies {
+    api project(":robolectric")
+    compileOnly AndroidSdk.MAX_SDK.coordinates
+
+    testCompileOnly AndroidSdk.MAX_SDK.coordinates
+    testRuntime AndroidSdk.MAX_SDK.coordinates
+    testImplementation "junit:junit:4.12"
+    testImplementation "com.google.truth:truth:0.44"
+    testImplementation 'io.mockk:mockk:1.9.3'
+}

--- a/integration_tests/mockk/src/test/java/org/robolectric/integration_tests/mockk/MockkInitTestCase.kt
+++ b/integration_tests/mockk/src/test/java/org/robolectric/integration_tests/mockk/MockkInitTestCase.kt
@@ -1,0 +1,30 @@
+package org.robolectric.integration_tests.mockk;
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+class NumberReturner {
+  fun returnNumber() = 0
+}
+
+@RunWith(RobolectricTestRunner::class)
+class MockkInitTestCase {
+
+  @MockK
+  lateinit var returner: NumberReturner
+
+  @Before
+  fun setUp() = MockKAnnotations.init(this)
+
+  @Test
+  fun `Mockk1`() {
+    every { returner.returnNumber() } returns 1
+    assert(returner.returnNumber() == 1)
+  }
+}
+

--- a/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
+++ b/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
@@ -85,6 +85,7 @@ public class AndroidConfigurer {
         .doNotAcquirePackage(
             "scala.") //  run with Maven Surefire (see the RoboSpecs project on github)
         .doNotAcquirePackage("kotlin.")
+        .doNotAcquirePackage("io.mockk.")
         // Fix #958: SQLite native library must be loaded once.
         .doNotAcquirePackage("com.almworks.sqlite4java")
         .doNotAcquirePackage("org.jacoco.");

--- a/sandbox/src/main/java/org/robolectric/JarInstrumentor.java
+++ b/sandbox/src/main/java/org/robolectric/JarInstrumentor.java
@@ -185,6 +185,7 @@ public class JarInstrumentor {
         .doNotAcquirePackage(
             "scala.") //  run with Maven Surefire (see the RoboSpecs project on github)
         .doNotAcquirePackage("kotlin.")
+        .doNotAcquirePackage("io.mockk.")
         // Fix #958: SQLite native library must be loaded once.
         .doNotAcquirePackage("com.almworks.sqlite4java")
         .doNotAcquirePackage("org.jacoco.");

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,3 +29,4 @@ include ':integration_tests:androidx'
 include ':integration_tests:androidx_test'
 include ':integration_tests:ctesque'
 include ':testapp'
+include ":integration_tests:mockk"


### PR DESCRIPTION
This prevents Robolectric from instrumenting the io.mockk packages,
which caused MockK to throw the following error:

java.lang.NoClassDefFoundError: io/mockk/proxy/jvm/dispatcher/JvmMockKWeakMap

Thanks to @Szauren for the report and the test case.

Fixes #5169