### PR TITLE
Fix Kotlin lint warnings in the mockk integration test

### DIFF
--- a/integration_tests/mockk/src/test/java/org/robolectric/integrationtests/mockk/MockkInitTestCase.kt
+++ b/integration_tests/mockk/src/test/java/org/robolectric/integrationtests/mockk/MockkInitTestCase.kt
@@ -1,4 +1,4 @@
-package org.robolectric.integration_tests.mockk;
+package org.robolectric.integrationtests.mockk
 
 import io.mockk.MockKAnnotations
 import io.mockk.every
@@ -27,4 +27,3 @@ class MockkInitTestCase {
     assert(returner.returnNumber() == 1)
   }
 }
-


### PR DESCRIPTION
No logic in the test was changed. The package name of
MockkInitTestCase.kt was changed and an unnecessary semicolon removed.
