### PR TITLE
Fix 'Duplicate key' error when running ./gradlew upload

### DIFF
--- a/buildSrc/src/main/groovy/org/robolectric/gradle/DeployedRoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/DeployedRoboJavaModulePlugin.groovy
@@ -38,7 +38,6 @@ class DeployedRoboJavaModulePlugin implements Plugin<Project> {
 
         def skipJavadoc = System.getenv('SKIP_JAVADOC') == "true"
         artifacts {
-            archives jar
             archives sourcesJar
             if (!skipJavadoc) {
                 archives javadocJar


### PR DESCRIPTION
When performing a release and running './gradlew upload', the following
error occurred:

Execution failed for task ':annotations:signArchives'.
> Duplicate key annotations:jar.asc:asc:
  (attempted merging values Signature annotations:jar.asc:asc:
  and Signature annotations:jar.asc:asc:)

The fix was removing 'archives jar' from the 'artifacts' block in
DeployedRoboJavaModulePlugin.groovy.

More details here:
https://discuss.gradle.org/t/apply-plugin-signing-broke-in-gradle-5-1-1-and-prints-out-non-existent-task/31418
