### PR TITLE
Attempt to populate width and height data in BitmapFactory.decodeFile

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapFactoryTest.java
@@ -17,6 +17,8 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import org.junit.Before;
 import org.junit.Test;
@@ -321,5 +323,42 @@ public class ShadowBitmapFactoryTest {
 
     assertThat(bitmap.getWidth()).isEqualTo(100);
     assertThat(bitmap.getHeight()).isEqualTo(100);
+  }
+
+  @Test
+  public void decodeFile_shouldHaveCorrectWidthAndHeight() throws IOException {
+    Bitmap bitmap = Bitmap.createBitmap(500, 600, Bitmap.Config.ARGB_8888);
+    assertThat(bitmap.getWidth()).isEqualTo(500);
+    assertThat(bitmap.getHeight()).isEqualTo(600);
+    File tmpFile = File.createTempFile("ShadowBitmapFactoryTest", ".jpg");
+    tmpFile.deleteOnExit();
+    try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile)) {
+      bitmap.compress(Bitmap.CompressFormat.JPEG, 80, fileOutputStream);
+    }
+    bitmap.recycle();
+    Bitmap loadedBitmap = BitmapFactory.decodeFile(tmpFile.getAbsolutePath());
+    assertThat(loadedBitmap.getWidth()).isEqualTo(500);
+    assertThat(loadedBitmap.getHeight()).isEqualTo(600);
+    loadedBitmap.recycle();
+  }
+
+  @Test
+  public void decodeFileDescriptor_shouldHaveCorrectWidthAndHeight() throws IOException {
+    Bitmap bitmap = Bitmap.createBitmap(500, 600, Bitmap.Config.ARGB_8888);
+    assertEquals(500, bitmap.getWidth());
+    assertEquals(600, bitmap.getHeight());
+
+    File tmpFile = File.createTempFile("ShadowBitmapFactoryTest", ".jpg");
+    tmpFile.deleteOnExit();
+    try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile)) {
+      bitmap.compress(Bitmap.CompressFormat.JPEG, 80, fileOutputStream);
+    }
+    bitmap.recycle();
+    try (FileInputStream fileInputStream = new FileInputStream(tmpFile)) {
+      Bitmap loadedBitmap = BitmapFactory.decodeFileDescriptor(fileInputStream.getFD());
+      assertEquals(500, loadedBitmap.getWidth());
+      assertEquals(600, loadedBitmap.getHeight());
+      loadedBitmap.recycle();
+    }
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -12,8 +12,11 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.net.Uri;
 import android.util.TypedValue;
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.FileDescriptor;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLConnection;
@@ -27,6 +30,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.Join;
+import org.robolectric.util.Logger;
 import org.robolectric.util.NamedStream;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
@@ -48,7 +52,8 @@ public class ShadowBitmapFactory {
 
     if (value != null && value.string != null && value.string.toString().contains(".9.")) {
       // todo: better support for nine-patches
-      ReflectionHelpers.callInstanceMethod(bitmap, "setNinePatchChunk", ClassParameter.from(byte[].class, new byte[0]));
+      ReflectionHelpers.callInstanceMethod(
+          bitmap, "setNinePatchChunk", ClassParameter.from(byte[].class, new byte[0]));
     }
     return bitmap;
   }
@@ -77,7 +82,17 @@ public class ShadowBitmapFactory {
 
   @Implementation
   protected static Bitmap decodeFile(String pathName, BitmapFactory.Options options) {
-    Bitmap bitmap = create("file:" + pathName, options);
+    // If a real file is used, attempt to get the image size from that file.
+    Point imageSizeFromStream = null;
+    if (pathName != null && new File(pathName).exists()) {
+      try (FileInputStream fileInputStream = new FileInputStream(pathName);
+          BufferedInputStream bufferedInputStream = new BufferedInputStream(fileInputStream); ) {
+        imageSizeFromStream = getImageSizeFromStream(bufferedInputStream);
+      } catch (IOException e) {
+        Logger.warn("Error getting size of bitmap file", e);
+      }
+    }
+    Bitmap bitmap = create("file:" + pathName, options, imageSizeFromStream);
     ShadowBitmap shadowBitmap = Shadow.extract(bitmap);
     shadowBitmap.createdFromPath = pathName;
     return bitmap;
@@ -87,7 +102,17 @@ public class ShadowBitmapFactory {
   @Implementation
   protected static Bitmap decodeFileDescriptor(
       FileDescriptor fd, Rect outPadding, BitmapFactory.Options opts) {
-    Bitmap bitmap = create("fd:" + fd, opts);
+    Point imageSizeFromStream = null;
+    // If a real FileDescriptor is used, attempt to get the image size.
+    if (fd != null && fd.valid()) {
+      try (FileInputStream fileInputStream = new FileInputStream(fd);
+          BufferedInputStream bufferedInputStream = new BufferedInputStream(fileInputStream); ) {
+        imageSizeFromStream = getImageSizeFromStream(bufferedInputStream);
+      } catch (IOException e) {
+        Logger.warn("Error getting size of bitmap file", e);
+      }
+    }
+    Bitmap bitmap = create("fd:" + fd, opts, imageSizeFromStream);
     ShadowBitmap shadowBitmap = Shadow.extract(bitmap);
     shadowBitmap.createdFromFileDescriptor = fd;
     return bitmap;
@@ -214,7 +239,9 @@ public class ShadowBitmapFactory {
   }
 
   public static void provideWidthAndHeightHints(int resourceId, int width, int height) {
-    widthAndHeightMap.put("resource:" + RuntimeEnvironment.application.getResources().getResourceName(resourceId), new Point(width, height));
+    widthAndHeightMap.put(
+        "resource:" + RuntimeEnvironment.application.getResources().getResourceName(resourceId),
+        new Point(width, height));
   }
 
   public static void provideWidthAndHeightHints(String file, int width, int height) {


### PR DESCRIPTION
Attempt to populate width and height data in BitmapFactory.decodeFile

If the file is valid and exists, use the width and height information from the
image file instead of just using 100x100. Also do the same thing for
BitmapFactory.decodeFileDescriptor.

Fixes #5774
