### PR TITLE
Use Logger in test runner for logging test lifecycle

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -69,12 +69,12 @@ public class RobolectricTestRunner extends SandboxTestRunner {
   private static final Map<ManifestIdentifier, AndroidManifest> appManifestsCache = new HashMap<>();
 
   static {
-    new SecureRandom(); // this starts up the Poller SunPKCS11-Darwin thread early, outside of any Robolectric classloader
+    new SecureRandom(); // this starts up the Poller SunPKCS11-Darwin thread early, outside of any
+                        // Robolectric classloader
   }
 
   protected static Injector.Builder defaultInjector() {
-    return SandboxTestRunner.defaultInjector()
-        .bind(Properties.class, System.getProperties());
+    return SandboxTestRunner.defaultInjector().bind(Properties.class, System.getProperties());
   }
 
   private final SandboxManager sandboxManager;
@@ -140,18 +140,19 @@ public class RobolectricTestRunner extends SandboxTestRunner {
   }
 
   /**
-   * Create an {@link InstrumentationConfiguration} suitable for the provided
-   * {@link FrameworkMethod}.
+   * Create an {@link InstrumentationConfiguration} suitable for the provided {@link
+   * FrameworkMethod}.
    *
-   * Adds configuration for Android using {@link AndroidConfigurer}.
+   * <p>Adds configuration for Android using {@link AndroidConfigurer}.
    *
-   * Custom TestRunner subclasses may wish to override this method to provide additional
+   * <p>Custom TestRunner subclasses may wish to override this method to provide additional
    * configuration.
    *
    * @param method the test method that's about to run
    * @return an {@link InstrumentationConfiguration}
    */
-  @Override @Nonnull
+  @Override
+  @Nonnull
   protected InstrumentationConfiguration createClassLoaderConfig(final FrameworkMethod method) {
     Configuration configuration = ((RobolectricFrameworkMethod) method).getConfiguration();
     Config config = configuration.get(Config.class);
@@ -165,9 +166,11 @@ public class RobolectricTestRunner extends SandboxTestRunner {
   /**
    * An instance of the returned class will be created for each test invocation.
    *
-   * Custom TestRunner subclasses may wish to override this method to provide alternate configuration.
+   * <p>Custom TestRunner subclasses may wish to override this method to provide alternate
+   * configuration.
    *
-   * @return a class which implements {@link TestLifecycle}. This implementation returns a {@link DefaultTestLifecycle}.
+   * @return a class which implements {@link TestLifecycle}. This implementation returns a {@link
+   *     DefaultTestLifecycle}.
    */
   @Nonnull
   protected Class<? extends TestLifecycle> getTestLifecycleClass() {
@@ -189,8 +192,7 @@ public class RobolectricTestRunner extends SandboxTestRunner {
 
     boolean includeLegacy(AndroidManifest appManifest) {
       return appManifest.supportsLegacyResourcesMode()
-          &&
-          (this == legacy
+          && (this == legacy
               || (this == best && !appManifest.supportsBinaryResourcesMode())
               || this == both);
     }
@@ -242,9 +244,14 @@ public class RobolectricTestRunner extends SandboxTestRunner {
           last.dontIncludeVariantMarkersInTestName();
         }
       } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException("failed to configure " +
-            getTestClass().getName() + "." + frameworkMethod.getMethod().getName() +
-            ": " + e.getMessage(), e);
+        throw new IllegalArgumentException(
+            "failed to configure "
+                + getTestClass().getName()
+                + "."
+                + frameworkMethod.getMethod().getName()
+                + ": "
+                + e.getMessage(),
+            e);
       }
     }
     return children;
@@ -262,15 +269,18 @@ public class RobolectricTestRunner extends SandboxTestRunner {
     if (resourcesMode == ResourcesMode.LEGACY && sdk.getApiLevel() > Build.VERSION_CODES.P) {
       throw new AssumptionViolatedException("Robolectric doesn't support legacy mode after P");
     }
-    LooperMode.Mode looperMode = roboMethod.configuration == null ? Mode.LEGACY
-        : roboMethod.configuration.get(LooperMode.Mode.class);
+    LooperMode.Mode looperMode =
+        roboMethod.configuration == null
+            ? Mode.LEGACY
+            : roboMethod.configuration.get(LooperMode.Mode.class);
 
     sdk.verifySupportedSdk(method.getDeclaringClass().getName());
     return sandboxManager.getAndroidSandbox(classLoaderConfig, sdk, resourcesMode, looperMode);
   }
 
   @Override
-  protected void beforeTest(Sandbox sandbox, FrameworkMethod method, Method bootstrappedMethod) throws Throwable {
+  protected void beforeTest(Sandbox sandbox, FrameworkMethod method, Method bootstrappedMethod)
+      throws Throwable {
     AndroidSandbox androidSandbox = (AndroidSandbox) sandbox;
     RobolectricFrameworkMethod roboMethod = (RobolectricFrameworkMethod) method;
 
@@ -283,9 +293,13 @@ public class RobolectricTestRunner extends SandboxTestRunner {
             roboMethod.resourcesMode.name()));
 
     Logger.lifecycle(
-        roboMethod.getDeclaringClass().getName() + "."
-            + roboMethod.getMethod().getName() + ": sdk=" + sdk.getApiLevel()
-            + "; resources=" + roboMethod.resourcesMode);
+        roboMethod.getDeclaringClass().getName()
+            + "."
+            + roboMethod.getMethod().getName()
+            + ": sdk="
+            + sdk.getApiLevel()
+            + "; resources="
+            + roboMethod.resourcesMode);
 
     if (roboMethod.resourcesMode == ResourcesMode.LEGACY) {
       Logger.warn(
@@ -299,10 +313,9 @@ public class RobolectricTestRunner extends SandboxTestRunner {
 
     AndroidManifest appManifest = roboMethod.getAppManifest();
 
-    roboMethod.getTestEnvironment().setUpApplicationState(
-        bootstrappedMethod,
-        roboMethod.getConfiguration(), appManifest
-    );
+    roboMethod
+        .getTestEnvironment()
+        .setUpApplicationState(bootstrappedMethod, roboMethod.getConfiguration(), appManifest);
 
     roboMethod.testLifecycle.beforeTest(bootstrappedMethod);
   }
@@ -339,7 +352,8 @@ public class RobolectricTestRunner extends SandboxTestRunner {
     }
   }
 
-  @Override protected SandboxTestRunner.HelperTestRunner getHelperTestRunner(Class bootstrappedTestClass) {
+  @Override
+  protected SandboxTestRunner.HelperTestRunner getHelperTestRunner(Class bootstrappedTestClass) {
     try {
       return new HelperTestRunner(bootstrappedTestClass);
     } catch (InitializationError initializationError) {
@@ -348,9 +362,11 @@ public class RobolectricTestRunner extends SandboxTestRunner {
   }
 
   /**
-   * Detects which build system is in use and returns the appropriate ManifestFactory implementation.
+   * Detects which build system is in use and returns the appropriate ManifestFactory
+   * implementation.
    *
-   * Custom TestRunner subclasses may wish to override this method to provide alternate configuration.
+   * <p>Custom TestRunner subclasses may wish to override this method to provide alternate
+   * configuration.
    *
    * @param config Specification of the SDK version, manifest file, package name, etc.
    */
@@ -410,6 +426,7 @@ public class RobolectricTestRunner extends SandboxTestRunner {
 
   /**
    * Internal use only.
+   *
    * @deprecated Do not use.
    */
   @Deprecated
@@ -422,8 +439,12 @@ public class RobolectricTestRunner extends SandboxTestRunner {
       libraryManifests.add(createAndroidManifest(library));
     }
 
-    return new AndroidManifest(manifestIdentifier.getManifestFile(), manifestIdentifier.getResDir(),
-        manifestIdentifier.getAssetDir(), libraryManifests, manifestIdentifier.getPackageName(),
+    return new AndroidManifest(
+        manifestIdentifier.getManifestFile(),
+        manifestIdentifier.getResDir(),
+        manifestIdentifier.getAssetDir(),
+        libraryManifests,
+        manifestIdentifier.getPackageName(),
         manifestIdentifier.getApkFile());
   }
 
@@ -452,7 +473,8 @@ public class RobolectricTestRunner extends SandboxTestRunner {
   /**
    * Calculate the configuration for a given test method.
    *
-   * Temporarily visible for migration.
+   * <p>Temporarily visible for migration.
+   *
    * @deprecated Going away before 4.2. DO NOT SHIP.
    */
   @Deprecated
@@ -506,15 +528,16 @@ public class RobolectricTestRunner extends SandboxTestRunner {
     }
   }
 
-  @Override @Nonnull
+  @Override
+  @Nonnull
   protected Class<?>[] getExtraShadows(FrameworkMethod frameworkMethod) {
-    Config config = ((RobolectricFrameworkMethod) frameworkMethod).getConfiguration().get(Config.class);
+    Config config =
+        ((RobolectricFrameworkMethod) frameworkMethod).getConfiguration().get(Config.class);
     return config.shadows();
   }
 
   @Override
-  protected void afterClass() {
-  }
+  protected void afterClass() {}
 
   @Override
   public Object createTest() throws Exception {
@@ -532,7 +555,8 @@ public class RobolectricTestRunner extends SandboxTestRunner {
       super(bootstrappedTestClass);
     }
 
-    @Override protected Object createTest() throws Exception {
+    @Override
+    protected Object createTest() throws Exception {
       Object test = super.createTest();
       RobolectricFrameworkMethod roboMethod = (RobolectricFrameworkMethod) this.frameworkMethod;
       roboMethod.testLifecycle.prepareTest(test);
@@ -569,7 +593,7 @@ public class RobolectricTestRunner extends SandboxTestRunner {
 
     private static final AtomicInteger NEXT_ID = new AtomicInteger();
     private static final Map<Integer, TestExecutionContext> CONTEXT = new HashMap<>();
-    
+
     private final int id;
 
     @Nonnull private final AndroidManifest appManifest;
@@ -582,7 +606,8 @@ public class RobolectricTestRunner extends SandboxTestRunner {
     TestLifecycle testLifecycle;
 
     protected RobolectricFrameworkMethod(RobolectricFrameworkMethod other) {
-      this(other.getMethod(),
+      this(
+          other.getMethod(),
           other.appManifest,
           other.getSdk(),
           other.configuration,

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -1,6 +1,5 @@
 package org.robolectric;
 
-
 import android.os.Build;
 import com.google.auto.service.AutoService;
 import com.google.common.annotations.VisibleForTesting;
@@ -53,6 +52,7 @@ import org.robolectric.pluginapi.config.ConfigurationStrategy;
 import org.robolectric.pluginapi.config.ConfigurationStrategy.Configuration;
 import org.robolectric.pluginapi.config.GlobalConfigProvider;
 import org.robolectric.plugins.HierarchicalConfigurationStrategy.ConfigurationImpl;
+import org.robolectric.util.Logger;
 import org.robolectric.util.PerfStatsCollector;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.inject.Injector;
@@ -282,14 +282,14 @@ public class RobolectricTestRunner extends SandboxTestRunner {
             ImmutableMap.of("ro.build.version.sdk", "" + sdk.getApiLevel()),
             roboMethod.resourcesMode.name()));
 
-    System.out.println(
-        "[Robolectric] " + roboMethod.getDeclaringClass().getName() + "."
+    Logger.lifecycle(
+        roboMethod.getDeclaringClass().getName() + "."
             + roboMethod.getMethod().getName() + ": sdk=" + sdk.getApiLevel()
             + "; resources=" + roboMethod.resourcesMode);
 
     if (roboMethod.resourcesMode == ResourcesMode.LEGACY) {
-      System.out.println(
-          "[Robolectric] NOTICE: legacy resources mode is deprecated; see"
+      Logger.warn(
+          "Legacy resources mode is deprecated; see"
               + " http://robolectric.org/migrating/#migrating-to-40");
     }
 
@@ -324,7 +324,7 @@ public class RobolectricTestRunner extends SandboxTestRunner {
     // If the test was interrupted, it will interfere with new AbstractInterruptibleChannels in
     // subsequent tests, e.g. created by Files.newInputStream(), so clear it and warn.
     if (Thread.interrupted()) {
-      System.out.println("WARNING: Test thread was interrupted! " + method.toString());
+      Logger.warn("Test thread was interrupted! " + method.toString());
     }
 
     try {

--- a/utils/src/main/java/org/robolectric/util/Logger.java
+++ b/utils/src/main/java/org/robolectric/util/Logger.java
@@ -19,7 +19,7 @@ public class Logger {
   public static void strict(String message, Object... args) {
     if (loggingEnabled()) {
       System.out.print("WARNING: ");
-      System.out.println(String.format(message, args));
+      System.out.printf(message + "%n", args);
     }
   }
 
@@ -32,7 +32,7 @@ public class Logger {
   public static void info(String message, Object... args) {
     if (loggingEnabled()) {
       System.out.print("INFO: ");
-      System.out.println(String.format(message, args));
+      System.out.printf(message + "%n", args);
     }
   }
 
@@ -45,7 +45,7 @@ public class Logger {
   public static void warn(String message, Object... args) {
     if (loggingEnabled()) {
       System.out.print("WARN: ");
-      System.out.println(String.format(message, args));
+      System.out.printf(message + "%n", args);
     }
   }
 
@@ -69,7 +69,7 @@ public class Logger {
    */
   public static void error(String message, Object... args) {
     System.err.print("ERROR: ");
-    System.err.println(String.format(message, args));
+    System.err.printf(message + "%n", args);
   }
 
   /**
@@ -81,7 +81,19 @@ public class Logger {
   public static void debug(String message, Object... args) {
     if (loggingEnabled()) {
       System.out.print("DEBUG: ");
-      System.out.println(String.format(message, args));
+      System.out.printf(message + "%n", args);
+    }
+  }
+
+  /**
+   * Log a lifecycle message.
+   *
+   * @param message Message text.
+   * @param args    Message arguments.
+   */
+  public static void lifecycle(String message, Object... args) {
+    if (loggingEnabled()) {
+      System.out.printf(message + "%n", args);
     }
   }
 

--- a/utils/src/main/java/org/robolectric/util/Logger.java
+++ b/utils/src/main/java/org/robolectric/util/Logger.java
@@ -3,7 +3,7 @@ package org.robolectric.util;
 /**
  * Logger for Robolectric. For now, it simply prints messages to stdout.
  *
- * Logging can be enabled by setting the property: {@code robolectric.logging.enabled = true}.
+ * <p>Logging can be enabled by setting the property: {@code robolectric.logging.enabled = true}.
  */
 public class Logger {
   private static final String LOGGING_ENABLED = "robolectric.logging.enabled";
@@ -27,7 +27,7 @@ public class Logger {
    * Log an info message.
    *
    * @param message Message text.
-   * @param args    Message arguments.
+   * @param args Message arguments.
    */
   public static void info(String message, Object... args) {
     if (loggingEnabled()) {
@@ -40,7 +40,7 @@ public class Logger {
    * Log a warning message.
    *
    * @param message Message text.
-   * @param args    Message arguments.
+   * @param args Message arguments.
    */
   public static void warn(String message, Object... args) {
     if (loggingEnabled()) {
@@ -53,7 +53,7 @@ public class Logger {
    * Log an error message.
    *
    * @param message Message text.
-   * @param e       The exception.
+   * @param e The exception.
    */
   public static void error(String message, Throwable e) {
     System.err.print("ERROR: ");
@@ -65,7 +65,7 @@ public class Logger {
    * Log an error message.
    *
    * @param message Message text.
-   * @param args    Message arguments.
+   * @param args Message arguments.
    */
   public static void error(String message, Object... args) {
     System.err.print("ERROR: ");
@@ -76,7 +76,7 @@ public class Logger {
    * Log a debug message.
    *
    * @param message Message text.
-   * @param args    Message arguments.
+   * @param args Message arguments.
    */
   public static void debug(String message, Object... args) {
     if (loggingEnabled()) {
@@ -89,7 +89,7 @@ public class Logger {
    * Log a lifecycle message.
    *
    * @param message Message text.
-   * @param args    Message arguments.
+   * @param args Message arguments.
    */
   public static void lifecycle(String message, Object... args) {
     if (loggingEnabled()) {


### PR DESCRIPTION
### Overview

It's noisy to print every test method in the runner when we already have UIs for this in whatever tool is running them, especially when there's a configurable logging API in robolectric available. This adds a new `lifecycle()` method to the `Logger` class for reporting such events (common in logging APIs). 

Also opportunistically uses a more idiomatic printf for the logging

CC @hoisie @brettchabot 
