### PR TITLE
Drop maven-ant-tasks dependency and fetch from Maven manually

### DIFF
--- a/pluginapi/build.gradle
+++ b/pluginapi/build.gradle
@@ -4,10 +4,6 @@ apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     api project(":annotations")
-    api "org.apache.ant:ant:1.8.0"
-    api("org.apache.maven:maven-ant-tasks:2.1.3") {
-        exclude group: "junit", module: "junit"
-    }
 
     testImplementation "junit:junit:4.12"
     testImplementation "com.google.truth:truth:1.0.1"

--- a/plugins/maven-dependency-resolver/build.gradle
+++ b/plugins/maven-dependency-resolver/build.gradle
@@ -4,12 +4,9 @@ apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
 dependencies {
     api project(":pluginapi")
     api project(":utils")
-
-    api "org.apache.ant:ant:1.8.0"
-    api("org.apache.maven:maven-ant-tasks:2.1.3") {
-        exclude group: "junit", module: "junit"
-    }
+    api "com.google.guava:guava:27.0.1-jre"
 
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-core:2.5.4"
+    testImplementation "com.google.truth:truth:1.0.1"
 }

--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/MavenRoboSettings.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/MavenRoboSettings.java
@@ -14,8 +14,10 @@ public class MavenRoboSettings {
   private static String mavenRepositoryPassword;
 
   static {
-    mavenRepositoryId = System.getProperty("robolectric.dependency.repo.id", "sonatype");
-    mavenRepositoryUrl = System.getProperty("robolectric.dependency.repo.url", "https://oss.sonatype.org/content/groups/public/");
+    mavenRepositoryId = System.getProperty("robolectric.dependency.repo.id", "mavenCentral");
+    mavenRepositoryUrl =
+        System.getProperty(
+            "robolectric.dependency.repo.url", "https://repo.maven.apache.org/maven2/");
     mavenRepositoryUserName = System.getProperty("robolectric.dependency.repo.username");
     mavenRepositoryPassword = System.getProperty("robolectric.dependency.repo.password");
   }

--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenArtifactFetcher.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenArtifactFetcher.java
@@ -1,6 +1,5 @@
 package org.robolectric.internal.dependency;
 
-
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Strings;

--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenArtifactFetcher.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenArtifactFetcher.java
@@ -65,6 +65,11 @@ public class MavenArtifactFetcher {
               fetchToStagingRepository(artifact.jarPath()))
           .callAsync(
               () -> {
+                // double check that the artifact has not been installed
+                if (new File(localRepositoryDir, artifact.jarPath()).exists()) {
+                  removeArtifactFiles(stagingRepositoryDir, artifact);
+                  return Futures.immediateFuture(null);
+                }
                 createArtifactSubdirectory(artifact, localRepositoryDir);
                 boolean pomValid = validateStagedFiles(artifact.pomPath(), artifact.pomSha1Path());
                 if (!pomValid) {

--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenArtifactFetcher.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenArtifactFetcher.java
@@ -1,0 +1,184 @@
+package org.robolectric.internal.dependency;
+
+import com.google.common.base.Strings;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Files;
+import com.google.common.util.concurrent.AsyncCallable;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Class responsible for fetching artifacts from Maven. This uses a thread pool of size two in order
+ * to parallelize downloads.
+ */
+@SuppressWarnings("UnstableApiUsage")
+public class MavenArtifactFetcher {
+
+  private final String repositoryUrl;
+  private final String repositoryUserName;
+  private final String repositoryPassword;
+  private final File localRepositoryDir;
+  private final ExecutorService executorService;
+  private File stagingRepositoryDir;
+
+  public MavenArtifactFetcher(
+      String repositoryUrl,
+      String repositoryUserName,
+      String repositoryPassword,
+      File localRepositoryDir,
+      ExecutorService executorService) {
+    this.repositoryUrl = repositoryUrl;
+    this.repositoryUserName = repositoryUserName;
+    this.repositoryPassword = repositoryPassword;
+    this.localRepositoryDir = localRepositoryDir;
+    this.executorService = executorService;
+  }
+
+  public void fetchArtifact(MavenJarArtifact artifact) {
+    // Assume that if the file exists in the local repository, it has been fetched successfully.
+    if (new File(localRepositoryDir, artifact.jarPath()).exists()) {
+      return;
+    }
+    this.stagingRepositoryDir = Files.createTempDir();
+    this.stagingRepositoryDir.deleteOnExit();
+    createArtifactSubdirectory(artifact, stagingRepositoryDir);
+    try {
+      Futures.whenAllSucceed(
+              fetchToStagingRepository(artifact.pomSha1Path()),
+              fetchToStagingRepository(artifact.pomPath()),
+              fetchToStagingRepository(artifact.jarSha1Path()),
+              fetchToStagingRepository(artifact.jarPath()))
+          .callAsync(
+              () -> {
+                createArtifactSubdirectory(artifact, localRepositoryDir);
+                boolean pomValid = validateStagedFiles(artifact.pomPath(), artifact.pomSha1Path());
+                if (!pomValid) {
+                  throw new AssertionError("Unable to validate POM file");
+                }
+                boolean jarValid = validateStagedFiles(artifact.jarPath(), artifact.jarSha1Path());
+                if (!jarValid) {
+                  throw new AssertionError("Unable to validate JAR file");
+                }
+                commitFromStaging(artifact.pomPath());
+                commitFromStaging(artifact.jarPath());
+                commitFromStaging(artifact.jarSha1Path());
+                commitFromStaging(artifact.pomSha1Path());
+                removeArtifactFiles(stagingRepositoryDir, artifact);
+                return Futures.immediateFuture(null);
+              },
+              executorService)
+          .get();
+    } catch (InterruptedException | ExecutionException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt(); // Restore the interrupted status
+      }
+      removeArtifactFiles(stagingRepositoryDir, artifact);
+      removeArtifactFiles(localRepositoryDir, artifact);
+      throw new AssertionError("Failed to fetch maven artifacts", e);
+    }
+  }
+
+  private void removeArtifactFiles(File repositoryDir, MavenJarArtifact artifact) {
+    new File(repositoryDir, artifact.jarPath()).delete();
+    new File(repositoryDir, artifact.jarSha1Path()).delete();
+    new File(repositoryDir, artifact.pomPath()).delete();
+    new File(repositoryDir, artifact.pomSha1Path()).delete();
+  }
+
+  private boolean validateStagedFiles(String filePath, String sha1Path) throws IOException {
+    File tempFile = new File(this.stagingRepositoryDir, filePath);
+    File sha1File = new File(this.stagingRepositoryDir, sha1Path);
+
+    HashCode expected = HashCode.fromString(new String(Files.asByteSource(sha1File).read()));
+    HashCode actual = Files.asByteSource(tempFile).hash(Hashing.sha1());
+    return expected.equals(actual);
+  }
+
+  private void createArtifactSubdirectory(MavenJarArtifact artifact, File repositoryDir) {
+    File artifactDirectory = new File(repositoryDir, artifact.jarPath()).getParentFile();
+    artifactDirectory.mkdirs();
+  }
+
+  private URL getRemoteUrl(String path) {
+    String url = this.repositoryUrl;
+    if (!url.endsWith("/")) {
+      url = url + "/";
+    }
+    try {
+      return new URI(url + path).toURL();
+    } catch (URISyntaxException | MalformedURLException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private ListenableFuture<Void> fetchToStagingRepository(String path) {
+    URL remoteUrl = getRemoteUrl(path);
+    File destination = new File(this.stagingRepositoryDir, path);
+    return createFetchToFileTask(remoteUrl, destination);
+  }
+
+  protected ListenableFuture<Void> createFetchToFileTask(URL remoteUrl, File tempFile) {
+    return Futures.submitAsync(
+        new FetchToFileTask(remoteUrl, tempFile, repositoryUserName, repositoryPassword),
+        this.executorService);
+  }
+
+  private void commitFromStaging(String path) throws IOException {
+    File source = new File(this.stagingRepositoryDir, path);
+    File destination = new File(this.localRepositoryDir, path);
+    if (!source.renameTo(destination)) {
+      throw new IOException("Unable to rename to " + destination);
+    }
+  }
+
+  private static class FetchToFileTask implements AsyncCallable<Void> {
+    private final URL remoteURL;
+    private final File localFile;
+    private String repositoryUserName;
+    private String repositoryPassword;
+
+    public FetchToFileTask(
+        URL remoteURL, File localFile, String repositoryUserName, String repositoryPassword) {
+      this.remoteURL = remoteURL;
+      this.localFile = localFile;
+      this.repositoryUserName = repositoryUserName;
+      this.repositoryPassword = repositoryPassword;
+    }
+
+    @Override
+    public ListenableFuture<Void> call() throws Exception {
+      HttpURLConnection connection = (HttpURLConnection) remoteURL.openConnection();
+
+      // Add authoriztion header if applicable.
+      if (!Strings.isNullOrEmpty(this.repositoryUserName)) {
+        String encoded =
+            Base64.getEncoder()
+                .encodeToString(
+                    (this.repositoryUserName + ":" + this.repositoryPassword)
+                        .getBytes(StandardCharsets.UTF_8));
+        connection.setRequestProperty("Authorization", "Basic " + encoded);
+      }
+
+      try (InputStream inputStream = remoteURL.openConnection().getInputStream();
+          FileOutputStream outputStream = new FileOutputStream(localFile)) {
+        ByteStreams.copy(inputStream, outputStream);
+      }
+      return Futures.immediateFuture(null);
+    }
+  }
+}

--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
@@ -22,6 +22,21 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+/**
+ * This class is mainly responsible for fetching Android framework JAR dependencies from
+ * MavenCentral. Initially the fetching was being done with maven-ant-tasks, but that dependency
+ * become outdated and unmaintained and had security vulnerabilities.
+ *
+ * <p>There was an initial attempt to use maven-resolver for this, but that depends on a newer
+ * version of Apache Http Client that is not compatible with the one expected to be on the classpath
+ * for Android 16-18.
+ *
+ * <p>This uses only basic {@link java.net.HttpURLConnection} for fetching. In general using an HTTP
+ * client library here could create conflicts with the ones in the Android system.
+ *
+ * @see <a href="https://maven.apache.org/ant-tasks/">maven-ant-tasks</a>
+ * @see <a href="https://maven.apache.org/resolver/index.html">Maven Resolver</a></a>
+ */
 public class MavenDependencyResolver implements DependencyResolver {
 
   private final ExecutorService executorService;

--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
@@ -57,7 +57,6 @@ public class MavenDependencyResolver implements DependencyResolver {
   @SuppressWarnings("NewApi")
   public URL[] getLocalArtifactUrls(DependencyJar... dependencies) {
     List<MavenJarArtifact> artifacts = new ArrayList<>(dependencies.length);
-
     whileLocked(
         () -> {
           for (DependencyJar dependencyJar : dependencies) {

--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenJarArtifact.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenJarArtifact.java
@@ -1,0 +1,50 @@
+package org.robolectric.internal.dependency;
+
+/**
+ * Encapsulates some parts of a Maven artifact. This assumes all artifacts are of type jar and do
+ * not have a classifier.
+ */
+public class MavenJarArtifact {
+  private final String groupId;
+  private final String artifactId;
+  private final String version;
+  private final String jarPath;
+  private final String jarSha1Path;
+  private final String pomPath;
+  private final String pomSha1Path;
+
+  public MavenJarArtifact(DependencyJar dependencyJar) {
+    this.groupId = dependencyJar.getGroupId();
+    this.artifactId = dependencyJar.getArtifactId();
+    this.version = dependencyJar.getVersion();
+    String basePath =
+        String.format("%s/%s/%s", this.groupId.replace(".", "/"), this.artifactId, this.version);
+    String baseName = String.format("%s-%s", this.artifactId, this.version);
+    this.jarPath = String.format("%s/%s.jar", basePath, baseName);
+    this.jarSha1Path = String.format("%s/%s.jar.sha1", basePath, baseName);
+    this.pomPath = String.format("%s/%s.pom", basePath, baseName);
+    this.pomSha1Path = String.format("%s/%s.pom.sha1", basePath, baseName);
+  }
+
+  public String jarPath() {
+    return jarPath;
+  }
+
+  public String jarSha1Path() {
+    return jarSha1Path;
+  }
+
+  public String pomPath() {
+    return pomPath;
+  }
+
+  public String pomSha1Path() {
+    return pomSha1Path;
+  }
+
+  @Override
+  public String toString() {
+    // return coordinates
+    return String.format("%s:%s:%s", groupId, artifactId, version);
+  }
+}

--- a/plugins/maven-dependency-resolver/src/test/java/org/robolectric/MavenRoboSettingsTest.java
+++ b/plugins/maven-dependency-resolver/src/test/java/org/robolectric/MavenRoboSettingsTest.java
@@ -34,7 +34,7 @@ public class MavenRoboSettingsTest {
 
   @Test
   public void getMavenRepositoryId_defaultSonatype() {
-    assertEquals("sonatype", MavenRoboSettings.getMavenRepositoryId());
+    assertEquals("mavenCentral", MavenRoboSettings.getMavenRepositoryId());
   }
 
   @Test
@@ -45,7 +45,8 @@ public class MavenRoboSettingsTest {
 
   @Test
   public void getMavenRepositoryUrl_defaultSonatype() {
-    assertEquals("https://oss.sonatype.org/content/groups/public/", MavenRoboSettings.getMavenRepositoryUrl());
+    assertEquals(
+        "https://repo.maven.apache.org/maven2/", MavenRoboSettings.getMavenRepositoryUrl());
   }
 
   @Test

--- a/plugins/maven-dependency-resolver/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
+++ b/plugins/maven-dependency-resolver/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
@@ -1,133 +1,225 @@
 package org.robolectric.internal.dependency;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
+import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import com.google.common.io.Files;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.Paths;
-import java.util.List;
-import org.apache.maven.artifact.ant.DependenciesTask;
-import org.apache.maven.artifact.ant.RemoteRepository;
-import org.apache.maven.model.Dependency;
-import org.apache.tools.ant.Project;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 @RunWith(JUnit4.class)
+@SuppressWarnings("UnstableApiUsage")
 public class MavenDependencyResolverTest {
-
-  private static final String REPOSITORY_URL = "https://default-repo";
-
-  private static final String REPOSITORY_ID = "remote";
-
+  private static final String REPOSITORY_URL = "https://default-repo/";
   private static final String REPOSITORY_USERNAME = "username";
-
   private static final String REPOSITORY_PASSWORD = "password";
+  private static final HashFunction SHA1 = Hashing.sha1();
 
-  private DependenciesTask dependenciesTask;
+  private static DependencyJar[] successCases =
+      new DependencyJar[] {
+        new DependencyJar("group", "artifact", "1"),
+        new DependencyJar("org.group2", "artifact2-name", "2.4.5"),
+        new DependencyJar("org.robolectric", "android-all", "10-robolectric-5803371"),
+      };
 
-  private Project project;
+  private static Map<URL, String> urlContents = new HashMap<>();
+
+  static {
+    for (DependencyJar dependencyJar : successCases) {
+      addTestArtifact(dependencyJar);
+    }
+  }
+
+  private File localRepositoryDir;
+  private ExecutorService executorService;
+  private MavenDependencyResolver mavenDependencyResolver;
+  private TestMavenArtifactFetcher mavenArtifactFetcher;
 
   @Before
-  public void setUp() {
-    dependenciesTask = spy(new DependenciesTask());
-    doNothing().when(dependenciesTask).execute();
-    doAnswer(new Answer() {
-      @Override
-      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
-        invocationOnMock.callRealMethod();
-        Object[] args = invocationOnMock.getArguments();
-        project = (Project) args[0];
-        project.setProperty("group1:artifact1:jar", "path1");
-        project.setProperty("group2:artifact2:jar", "path2");
-        project.setProperty("group3:artifact3:jar:classifier3", "path3");
-        return null;
-      }
-    }).when(dependenciesTask).setProject(any(Project.class));
+  public void setUp() throws Exception {
+    executorService = MoreExecutors.newDirectExecutorService();
+    localRepositoryDir = Files.createTempDir();
+    localRepositoryDir.deleteOnExit();
+    mavenArtifactFetcher =
+        new TestMavenArtifactFetcher(
+            REPOSITORY_URL,
+            REPOSITORY_USERNAME,
+            REPOSITORY_PASSWORD,
+            localRepositoryDir,
+            executorService);
+    mavenDependencyResolver = new TestMavenDependencyResolver();
   }
 
   @Test
-  public void getLocalArtifactUrl_shouldAddConfiguredRemoteRepository() {
-    DependencyResolver dependencyResolver = createResolver();
-    DependencyJar dependencyJar = new DependencyJar("group1", "artifact1", "", null);
-
-    dependencyResolver.getLocalArtifactUrl(dependencyJar);
-
-    List<RemoteRepository> repositories = dependenciesTask.getRemoteRepositories();
-
-    assertEquals(1, repositories.size());
-    RemoteRepository remoteRepository = repositories.get(0);
-    assertEquals(REPOSITORY_URL, remoteRepository.getUrl());
-    assertEquals(REPOSITORY_ID, remoteRepository.getId());
+  public void getLocalArtifactUrl_placesFilesCorrectlyForSingleURL() throws Exception {
+    DependencyJar dependencyJar = successCases[0];
+    mavenDependencyResolver.getLocalArtifactUrl(dependencyJar);
+    assertThat(mavenArtifactFetcher.getNumRequests()).isEqualTo(4);
+    MavenJarArtifact artifact = new MavenJarArtifact(dependencyJar);
+    checkJarArtifact(artifact);
   }
 
   @Test
-  public void getLocalArtifactUrl_shouldAddDependencyToDependenciesTask() {
-    DependencyResolver dependencyResolver = createResolver();
-    DependencyJar dependencyJar = new DependencyJar("group1", "artifact1", "3", null);
+  public void getLocalArtifactUrl_placesFilesCorrectlyForMultipleURL() throws Exception {
+    mavenDependencyResolver.getLocalArtifactUrls(successCases);
+    assertThat(mavenArtifactFetcher.getNumRequests()).isEqualTo(4 * successCases.length);
+    for (DependencyJar dependencyJar : successCases) {
+      MavenJarArtifact artifact = new MavenJarArtifact(dependencyJar);
+      checkJarArtifact(artifact);
+    }
+  }
 
-    dependencyResolver.getLocalArtifactUrl(dependencyJar);
-
-    List<Dependency> dependencies = dependenciesTask.getDependencies();
-
-    assertEquals(1, dependencies.size());
-    Dependency dependency = dependencies.get(0);
-    assertEquals("group1", dependency.getGroupId());
-    assertEquals("artifact1", dependency.getArtifactId());
-    assertEquals("3", dependency.getVersion());
-    assertEquals("jar", dependency.getType());
-    assertNull(dependency.getClassifier());
+  private void checkJarArtifact(MavenJarArtifact artifact) throws Exception {
+    File jar = new File(localRepositoryDir, artifact.jarPath());
+    File pom = new File(localRepositoryDir, artifact.pomPath());
+    File jarSha1 = new File(localRepositoryDir, artifact.jarSha1Path());
+    File pomSha1 = new File(localRepositoryDir, artifact.pomSha1Path());
+    assertThat(jar.exists()).isTrue();
+    assertThat(readFile(jar)).isEqualTo(artifact.toString() + " jar contents");
+    assertThat(pom.exists()).isTrue();
+    assertThat(readFile(pom)).isEqualTo(artifact.toString() + " pom contents");
+    assertThat(jarSha1.exists()).isTrue();
+    assertThat(readFile(jarSha1)).isEqualTo(sha1(artifact.toString() + " jar contents"));
+    assertThat(pom.exists()).isTrue();
+    assertThat(readFile(pomSha1)).isEqualTo(sha1(artifact.toString() + " pom contents"));
   }
 
   @Test
-  public void getLocalArtifactUrl_shouldExecuteDependenciesTask() {
-    DependencyResolver dependencyResolver = createResolver();
-    DependencyJar dependencyJar = new DependencyJar("group1", "artifact1", "", null);
-
-    dependencyResolver.getLocalArtifactUrl(dependencyJar);
-
-    verify(dependenciesTask).execute();
+  public void getLocalArtifactUrl_doesNotFetchWhenArtifactsExist() throws Exception {
+    DependencyJar dependencyJar = new DependencyJar("group", "artifact", "1");
+    MavenJarArtifact mavenJarArtifact = new MavenJarArtifact(dependencyJar);
+    File artifactFile = new File(localRepositoryDir, mavenJarArtifact.jarPath());
+    artifactFile.getParentFile().mkdirs();
+    Files.write(new byte[0], artifactFile);
+    assertThat(artifactFile.exists()).isTrue();
+    mavenDependencyResolver.getLocalArtifactUrl(dependencyJar);
+    assertThat(mavenArtifactFetcher.getNumRequests()).isEqualTo(0);
   }
 
-  @Test
-  public void getLocalArtifactUrl_shouldReturnCorrectUrlForArtifactKey() throws Exception {
-    DependencyResolver dependencyResolver = createResolver();
-    DependencyJar dependencyJar = new DependencyJar("group1", "artifact1", "", null);
-
-    URL url = dependencyResolver.getLocalArtifactUrl(dependencyJar);
-
-    assertEquals(Paths.get("path1").toUri().toURL().toExternalForm(),
-        url.toExternalForm());
+  @Test(expected = AssertionError.class)
+  public void getLocalArtifactUrl_handlesFileNotFound() throws Exception {
+    DependencyJar dependencyJar = new DependencyJar("group", "missing-artifact", "1");
+    mavenDependencyResolver.getLocalArtifactUrl(dependencyJar);
   }
 
-  @Test
-  public void getLocalArtifactUrl_shouldReturnCorrectUrlForArtifactKeyWithClassifier()
-      throws Exception {
-    DependencyResolver dependencyResolver = createResolver();
-    DependencyJar dependencyJar = new DependencyJar("group3", "artifact3", "", "classifier3");
-
-    URL url = dependencyResolver.getLocalArtifactUrl(dependencyJar);
-
-    assertEquals(Paths.get("path3").toUri().toURL().toExternalForm(),
-        url.toExternalForm());
+  @Test(expected = AssertionError.class)
+  public void getLocalArtifactUrl_handlesInvalidSha1() throws Exception {
+    DependencyJar dependencyJar = new DependencyJar("group", "artifact-invalid-sha1", "1");
+    addTestArtifactInvalidSha1(dependencyJar);
+    mavenDependencyResolver.getLocalArtifactUrl(dependencyJar);
   }
 
-  private DependencyResolver createResolver() {
-    return new MavenDependencyResolver(REPOSITORY_URL, REPOSITORY_ID, REPOSITORY_USERNAME,
-        REPOSITORY_PASSWORD) {
-      @Override
-      protected DependenciesTask createDependenciesTask() {
-        return dependenciesTask;
-      }
-    };
+  class TestMavenDependencyResolver extends MavenDependencyResolver {
+
+    @Override
+    protected MavenArtifactFetcher createMavenFetcher(
+        String repositoryUrl,
+        String repositoryUserName,
+        String repositoryPassword,
+        File localRepositoryDir,
+        ExecutorService executorService) {
+      return mavenArtifactFetcher;
+    }
+
+    @Override
+    protected ExecutorService createExecutorService() {
+      return executorService;
+    }
+
+    @Override
+    protected File getLocalRepositoryDir() {
+      return localRepositoryDir;
+    }
+  }
+
+  static class TestMavenArtifactFetcher extends MavenArtifactFetcher {
+    private ExecutorService executorService;
+    private int numRequests;
+
+    public TestMavenArtifactFetcher(
+        String repositoryUrl,
+        String repositoryUserName,
+        String repositoryPassword,
+        File localRepositoryDir,
+        ExecutorService executorService) {
+      super(
+          repositoryUrl,
+          repositoryUserName,
+          repositoryPassword,
+          localRepositoryDir,
+          executorService);
+      this.executorService = executorService;
+    }
+
+    @Override
+    protected ListenableFuture<Void> createFetchToFileTask(URL remoteUrl, File tempFile) {
+      return Futures.submitAsync(
+          () -> {
+            numRequests += 1;
+            if (!urlContents.containsKey(remoteUrl)) {
+              throw new IOException("Resource not found " + remoteUrl);
+            }
+            Files.write(urlContents.get(remoteUrl).getBytes(), tempFile);
+            return Futures.immediateFuture(null);
+          },
+          executorService);
+    }
+
+    public int getNumRequests() {
+      return numRequests;
+    }
+  }
+
+  static void addTestArtifact(DependencyJar dependencyJar) {
+    MavenJarArtifact mavenJarArtifact = new MavenJarArtifact(dependencyJar);
+    try {
+      String jarContents = mavenJarArtifact.toString() + " jar contents";
+      urlContents.put(new URL(REPOSITORY_URL + mavenJarArtifact.jarPath()), jarContents);
+      urlContents.put(new URL(REPOSITORY_URL + mavenJarArtifact.jarSha1Path()), sha1(jarContents));
+      String pomContents = mavenJarArtifact.toString() + " pom contents";
+      urlContents.put(new URL(REPOSITORY_URL + mavenJarArtifact.pomPath()), pomContents);
+      urlContents.put(new URL(REPOSITORY_URL + mavenJarArtifact.pomSha1Path()), sha1(pomContents));
+    } catch (MalformedURLException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  static void addTestArtifactInvalidSha1(DependencyJar dependencyJar) {
+    MavenJarArtifact mavenJarArtifact = new MavenJarArtifact(dependencyJar);
+    try {
+      String jarContents = mavenJarArtifact.toString() + " jar contents";
+      urlContents.put(new URL(REPOSITORY_URL + mavenJarArtifact.jarPath()), jarContents);
+      urlContents.put(
+          new URL(REPOSITORY_URL + mavenJarArtifact.jarSha1Path()), sha1("No the same content"));
+      String pomContents = mavenJarArtifact.toString() + " pom contents";
+      urlContents.put(new URL(REPOSITORY_URL + mavenJarArtifact.pomPath()), pomContents);
+      urlContents.put(
+          new URL(REPOSITORY_URL + mavenJarArtifact.pomSha1Path()),
+          sha1("Really not the same content"));
+    } catch (MalformedURLException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  static String sha1(String contents) {
+    return SHA1.hashString(contents, StandardCharsets.UTF_8).toString();
+  }
+
+  static String readFile(File file) throws IOException {
+    return new String(Files.asByteSource(file).read());
   }
 }


### PR DESCRIPTION
The dependency maven-ant-tasks is outdated and has security issues. Replace the
maven dependency fetching logic with simple fetching through HTTPUrlConnection.
There was an initial attempt to use maven-resolver, but the version of Apache
HttpClient that uses conflicts with the HttpClient that must be bundled for
Android 16-18. Because the use cases for Robolectric is very narrow (only
fetching single artifacts with no dependencies), it is feasible to use this
approach.
