### PR TITLE
Temporarily disabling prefetching Android SDKs in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ commands:
                 -Drobolectric.enabledSdks=<< parameters.versions >> \
                 -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
                 -Dorg.gradle.workers.max=2
+                -Drobolectric.logging.enabled=true
       - run:
           name: Collect Test Results
           command: |
@@ -71,7 +72,6 @@ jobs:
             mkdir -p ~/Android/cmdline-tools && (cd ~/Android/cmdline-tools && unzip -o ~/commandlinetools.zip)
             yes | $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager --licenses || true
             $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager --install 'platforms;android-29' > /dev/null
-            ./gradlew --parallel prefetchDependencies
       - save_cache:
           paths:
             - ~/.gradle


### PR DESCRIPTION
This is for more test cycles on Robolectric's new Maven dependency fetcher.
