### PR TITLE
Use Sun JSSE provider for Maven TLS artifact fetching

### DIFF
--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/MavenRoboSettings.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/MavenRoboSettings.java
@@ -16,8 +16,7 @@ public class MavenRoboSettings {
   static {
     mavenRepositoryId = System.getProperty("robolectric.dependency.repo.id", "mavenCentral");
     mavenRepositoryUrl =
-        System.getProperty(
-            "robolectric.dependency.repo.url", "https://repo.maven.apache.org/maven2/");
+        System.getProperty("robolectric.dependency.repo.url", "https://repo1.maven.org/maven2");
     mavenRepositoryUserName = System.getProperty("robolectric.dependency.repo.username");
     mavenRepositoryPassword = System.getProperty("robolectric.dependency.repo.password");
   }

--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/KeyStoreUtil.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/KeyStoreUtil.java
@@ -1,0 +1,90 @@
+package org.robolectric.internal.dependency;
+
+import com.google.common.base.Strings;
+import com.google.common.io.Closeables;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.AccessController;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchProviderException;
+import java.security.PrivilegedAction;
+import org.robolectric.util.Logger;
+
+/**
+ * Used to get KeyStore that can be used to establish TLS connections. Adapted from BouncyCastle.
+ */
+class KeyStoreUtil {
+  static KeyStore getKeyStore() throws GeneralSecurityException, IOException {
+    String defaultType = KeyStore.getDefaultType();
+
+    String tsPath = null;
+    char[] tsPassword = null;
+
+    String trustStoreProp = getSystemProperty("javax.net.ssl.trustStore");
+    if ("NONE".equals(trustStoreProp)) {
+      // Do not try to load any file
+    } else if (!Strings.isNullOrEmpty(trustStoreProp)) {
+      if (new File(trustStoreProp).exists()) {
+        tsPath = trustStoreProp;
+      }
+    } else {
+      String javaHome = getSystemProperty("java.home");
+      if (!Strings.isNullOrEmpty(javaHome)) {
+        String jsseCacertsPath = javaHome + "/lib/security/jssecacerts";
+        if (new File(jsseCacertsPath).exists()) {
+          defaultType = "jks";
+          tsPath = jsseCacertsPath;
+        } else {
+          String cacertsPath = javaHome + "/lib/security/cacerts";
+          if (new File(cacertsPath).exists()) {
+            defaultType = "jks";
+            tsPath = cacertsPath;
+          }
+        }
+      }
+    }
+
+    KeyStore ks = createTrustStore(defaultType);
+
+    String tsPasswordProp = getSystemProperty("javax.net.ssl.trustStorePassword");
+    if (!Strings.isNullOrEmpty(tsPasswordProp)) {
+      tsPassword = tsPasswordProp.toCharArray();
+    }
+
+    InputStream tsInput = null;
+    try {
+      if (Strings.isNullOrEmpty(tsPath)) {
+        Logger.info("Initializing empty trust store");
+      } else {
+        Logger.info("Initializing with trust store at path: " + tsPath);
+        tsInput = new BufferedInputStream(new FileInputStream(tsPath));
+      }
+      ks.load(tsInput, tsPassword);
+    } finally {
+      Closeables.closeQuietly(tsInput);
+    }
+
+    return ks;
+  }
+
+  private static KeyStore createTrustStore(String defaultType)
+      throws NoSuchProviderException, KeyStoreException {
+    String tsType = getSystemProperty("javax.net.ssl.trustStoreType");
+    tsType = Strings.isNullOrEmpty(tsType) ? defaultType : tsType;
+
+    String tsProv = getSystemProperty("javax.net.ssl.trustStoreProvider");
+    return Strings.isNullOrEmpty(tsProv)
+        ? KeyStore.getInstance(tsType)
+        : KeyStore.getInstance(tsType, tsProv);
+  }
+
+  private static String getSystemProperty(final String propertyName) {
+    return AccessController.doPrivileged(
+        (PrivilegedAction<String>) () -> System.getProperty(propertyName));
+  }
+}

--- a/plugins/maven-dependency-resolver/src/test/java/org/robolectric/MavenRoboSettingsTest.java
+++ b/plugins/maven-dependency-resolver/src/test/java/org/robolectric/MavenRoboSettingsTest.java
@@ -45,8 +45,7 @@ public class MavenRoboSettingsTest {
 
   @Test
   public void getMavenRepositoryUrl_defaultSonatype() {
-    assertEquals(
-        "https://repo.maven.apache.org/maven2/", MavenRoboSettings.getMavenRepositoryUrl());
+    assertEquals("https://repo1.maven.org/maven2", MavenRoboSettings.getMavenRepositoryUrl());
   }
 
   @Test

--- a/plugins/maven-dependency-resolver/src/test/java/org/robolectric/internal/dependency/KeyStoreUtilTest.java
+++ b/plugins/maven-dependency-resolver/src/test/java/org/robolectric/internal/dependency/KeyStoreUtilTest.java
@@ -1,0 +1,15 @@
+package org.robolectric.internal.dependency;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class KeyStoreUtilTest {
+  @Test
+  public void defaultType_isJKS() throws Exception {
+    assertThat(KeyStoreUtil.getKeyStore().getType()).isEqualTo("jks");
+  }
+}


### PR DESCRIPTION
If a Maven artifact fetch was performed after the BouncyCastle JCE security
provider was installed, a cryptic error message could occur:

    java.io.IOException: stream does not represent a PKCS12 key store

The problem was that BouncyCastle JCE changes the default KeyStore format from
JKS to PKCS12. If the default SunJSSE was used to establish a TLS connection,
it expected the KeyStore to be in JKS format, which caused the exception.

Instead, switch to using the built-in Sun JSSE provider.

Longer term we should re-evaluate which providers should be installed and
perhaps install BCJSSE or Conscrypt.