### PR TITLE
Change compileTest to compileTestJava in doc

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Copy all required Android dependencies into your local Maven repository:
 
 Perform a full build of all shadows:
 
-    ./gradlew clean assemble install compileTest
+    ./gradlew clean assemble install compileTestJava
 
 ## Building and Testing
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Robolectric is built using Gradle. Both IntelliJ and Android Studio can import t
 
 Robolectric supports running tests against multiple Android API levels. The work it must do to support each API level is slightly different, so its shadows are built separately for each. To build shadows for every API version, run:
 
-    ./gradlew clean assemble install compileTest
+    ./gradlew clean assemble install compileTestJava
 
 ### Using Snapshots
 


### PR DESCRIPTION
The gradle can't find task `compileTest` now.

I run gradle with `openjdk-11`.