### PR TITLE
Switch to using mockito-inline in mockito-experimental project

### DIFF
--- a/integration_tests/mockito-experimental/build.gradle
+++ b/integration_tests/mockito-experimental/build.gradle
@@ -8,5 +8,5 @@ dependencies {
     testRuntime AndroidSdk.MAX_SDK.coordinates
     testImplementation "junit:junit:4.12"
     testImplementation "com.google.truth:truth:1.0.1"
-    testImplementation "org.mockito:mockito-core:2.25.0"
+    testImplementation "org.mockito:mockito-inline:3.5.2"
 }

--- a/integration_tests/mockito-experimental/src/test/java/org/robolectric/integration_tests/mockito_experimental/MockitoMockFinalsTest.java
+++ b/integration_tests/mockito-experimental/src/test/java/org/robolectric/integration_tests/mockito_experimental/MockitoMockFinalsTest.java
@@ -1,11 +1,14 @@
 package org.robolectric.integration_tests.mockito_experimental;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import android.text.Layout;
 import android.widget.TextView;
+import java.io.File;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,5 +44,18 @@ public class MockitoMockFinalsTest {
     final int getId() {
       return -1;
     }
+  }
+
+  /**
+   * Mocking Java classes with mockito-inline is currently broken.
+   *
+   * @see <a href="https://github.com/robolectric/robolectric/issues/5522">Issue 5522</a>
+   */
+  @Test
+  @Ignore
+  public void file_getAbsolutePath_isMockable() throws Exception {
+    File file = mock(File.class);
+    doReturn("absolute/path").when(file).getAbsolutePath();
+    assertThat(file.getAbsolutePath()).isEqualTo("absolute/path");
   }
 }

--- a/integration_tests/mockito-experimental/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/integration_tests/mockito-experimental/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline


### PR DESCRIPTION
Switch to using mockito-inline in mockito-experimental project

This lets us remove the MockMaker resource file. Also, add an ignored test
for the issue mocking Java classes.
