### PR TITLE
Do not acquire MockMethodDispatcher

### DIFF
--- a/integration_tests/mockito-experimental/src/test/java/org/robolectric/integration_tests/mockito_experimental/MockitoMockJavaFrameworkTest.java
+++ b/integration_tests/mockito-experimental/src/test/java/org/robolectric/integration_tests/mockito_experimental/MockitoMockJavaFrameworkTest.java
@@ -1,0 +1,27 @@
+package org.robolectric.integration_tests.mockito_experimental;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class MockitoMockJavaFrameworkTest {
+  /**
+   * Mocking Java classes with mockito-inline is currently broken.
+   *
+   * @see <a href="https://github.com/robolectric/robolectric/issues/5522">Issue 5522</a>
+   */
+  @Test
+  @Ignore("Enable when Mockito 3.5.4 is released")
+  public void file_getAbsolutePath_isMockable() throws Exception {
+    File file = mock(File.class);
+    doReturn("absolute/path").when(file).getAbsolutePath();
+    assertThat(file.getAbsolutePath()).isEqualTo("absolute/path");
+  }
+}

--- a/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
+++ b/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
@@ -134,6 +134,9 @@ public class AndroidConfigurer {
     builder.doNotInstrumentPackage("androidx.test");
     builder.doNotInstrumentPackage("android.support.test");
 
+    builder.doNotAcquireClass(
+        "org.mockito.internal.creation.bytebuddy.inject.MockMethodDispatcher");
+
     for (String packagePrefix : shadowProviders.getInstrumentedPackages()) {
       builder.addInstrumentedPackage(packagePrefix);
     }

--- a/sandbox/src/main/java/org/robolectric/JarInstrumentor.java
+++ b/sandbox/src/main/java/org/robolectric/JarInstrumentor.java
@@ -205,6 +205,9 @@ public class JarInstrumentor {
         .addInstrumentedPackage("org.kxml2.");
 
     builder.doNotInstrumentPackage("androidx.test");
+
+    builder.doNotAcquireClass(
+        "org.mockito.internal.creation.bytebuddy.inject.MockMethodDispatcher");
     return builder.build();
   }
 }

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/SandboxClassLoader.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/SandboxClassLoader.java
@@ -157,18 +157,7 @@ public class SandboxClassLoader extends URLClassLoader {
   }
 
   protected byte[] getByteCode(String className) throws ClassNotFoundException {
-    // Mockito shipped a workaround to work with the (previously broken) SandboxClassLoader:
-    // https://github.com/mockito/mockito/issues/845
-    // We need to special-case this one file to make sure the integration with the inline-mockmaker
-    // does not break. At some point we have to revert this workaround, which would constitute a
-    // breaking change if Robolectric is used in combination with an old version of Mockito. At the
-    // same time, Mockito needs to remove their workaround and make sure it works with both the old
-    // (broken) and new ClassLoader.
-    String extension =
-        className.equals("org.mockito.internal.creation.bytebuddy.inject.MockMethodDispatcher")
-            ? "raw"
-            : "class";
-    String classFilename = className.replace('.', '/') + "." + extension;
+    String classFilename = className.replace('.', '/') + ".class";
     try (InputStream classBytesStream = getClassBytesAsStreamPreferringLocalUrls(classFilename)) {
       if (classBytesStream == null) {
         throw new ClassNotFoundException(className);


### PR DESCRIPTION
For Mockito to work, it is critical that MockMethodDispatcher only exists in
the base ClassLoader and is not defined in multiple class loaders.
