### PR TITLE
Fix lint errors related to androidx annotations

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioTrack.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioTrack.java
@@ -6,11 +6,11 @@ import static android.media.AudioTrack.WRITE_NON_BLOCKING;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.M;
 
+import android.annotation.NonNull;
 import android.media.AudioFormat;
 import android.media.AudioTrack;
 import android.media.AudioTrack.WriteMode;
 import android.util.Log;
-import androidx.annotation.NonNull;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindow.java
@@ -12,7 +12,6 @@ import android.view.FrameMetrics;
 import android.view.Window;
 import android.view.Window.OnFrameMetricsAvailableListener;
 import android.widget.ProgressBar;
-import androidx.annotation.RequiresApi;
 import java.util.HashSet;
 import java.util.Set;
 import org.robolectric.annotation.Implementation;
@@ -118,7 +117,6 @@ public class ShadowWindow {
    * Calls {@link Window.OnFrameMetrisAvailableListener#onFrameMetricsAvailable()} on each current
    * listener with 0 as the dropCountSinceLastInvocation.
    */
-  @RequiresApi(api = N)
   public void reportOnFrameMetricsAvailable(FrameMetrics frameMetrics) {
     reportOnFrameMetricsAvailable(frameMetrics, /* dropCountSinceLastInvocation= */ 0);
   }
@@ -130,7 +128,6 @@ public class ShadowWindow {
    * @param frameMetrics the {@link FrameMetrics} instance passed to the listeners.
    * @param dropCountSinceLastInvocation the dropCountSinceLastInvocation passed to the listeners.
    */
-  @RequiresApi(api = N)
   public void reportOnFrameMetricsAvailable(
       FrameMetrics frameMetrics, int dropCountSinceLastInvocation) {
     for (OnFrameMetricsAvailableListener listener : onFrameMetricsAvailableListeners) {


### PR DESCRIPTION
* Switch to using the Android platform NonNull.
* Drop the AndroidX RequiresApi annotation.