### PR TITLE
Add failing test for clicking on menu items with androidx toolbar

### DIFF
--- a/integration_tests/androidx_test/src/main/AndroidManifest.xml
+++ b/integration_tests/androidx_test/src/main/AndroidManifest.xml
@@ -18,6 +18,9 @@
         <activity android:name="org.robolectric.integration_tests.axt.ActivityWithAppCompatMenu"
             android:exported="true"
             android:theme="@style/Theme.AppCompat" />
+        <activity android:name="org.robolectric.integration_tests.axt.AppCompatActivityWithToolbarMenu"
+            android:exported="true"
+            android:theme="@style/Theme.AppCompat.NoActionBar" />
         <activity android:name="org.robolectric.integration_tests.axt.ActivityTestRuleTest$TranscriptActivity"/>
         <activity android:name="org.robolectric.integration_tests.axt.IntentsTest$ResultCapturingActivity"/>
         <activity android:name="org.robolectric.integration_tests.axt.IntentsTest$DummyActivity"/>

--- a/integration_tests/androidx_test/src/main/java/org/robolectric/integration_tests/axt/AppCompatActivityWithToolbarMenu.java
+++ b/integration_tests/androidx_test/src/main/java/org/robolectric/integration_tests/axt/AppCompatActivityWithToolbarMenu.java
@@ -1,0 +1,28 @@
+package org.robolectric.integration_tests.axt;
+
+import android.os.Bundle;
+
+import org.robolectric.integration.axt.R;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
+/** {@link EspressoWithMenuTest} fixture activity that uses appcompat menu's */
+public class AppCompatActivityWithToolbarMenu extends AppCompatActivity {
+
+  boolean menuClicked;
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    setContentView(R.layout.appcompat_activity_with_toolbar_menu);
+
+    final Toolbar toolbar = findViewById(R.id.toolbar);
+    toolbar.inflateMenu(R.menu.menu);
+    toolbar.setOnMenuItemClickListener(item -> {
+      menuClicked = true;
+      return true;
+    });
+  }
+}

--- a/integration_tests/androidx_test/src/main/res/layout/appcompat_activity_with_toolbar_menu.xml
+++ b/integration_tests/androidx_test/src/main/res/layout/appcompat_activity_with_toolbar_menu.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/layout"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal"
+    >
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"/>
+
+</LinearLayout>

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integration_tests/axt/EspressoWithMenuTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integration_tests/axt/EspressoWithMenuTest.java
@@ -45,4 +45,15 @@ public class EspressoWithMenuTest {
       scenario.onActivity(activity -> assertThat(activity.menuClicked).isTrue());
     }
   }
+
+  @Test
+  public void appCompatToolbarMenuClick() throws InterruptedException {
+    try (ActivityScenario<AppCompatActivityWithToolbarMenu> scenario =
+             ActivityScenario.launch(AppCompatActivityWithToolbarMenu.class)) {
+      openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext());
+      onView(withText("menu_title")).perform(click());
+
+      scenario.onActivity(activity -> assertThat(activity.menuClicked).isTrue());
+    }
+  }
 }


### PR DESCRIPTION
### Overview

When we use a standalone toolbar and create menu with `toolbar.inflateMenu`.  
Opening the menu with `openActionBarOverflowOrOptionsMenu` seems to be ok.

But, when we try to click on an item through `onView(withText("menu_title")).perform(click());` the view is not found.
 

### Proposed Changes

I do not know, but it should work on either native and androidx toolbar