### PR TITLE
Disable jsonDocs generation by default

### DIFF
--- a/buildSrc/src/main/groovy/ShadowsPlugin.groovy
+++ b/buildSrc/src/main/groovy/ShadowsPlugin.groovy
@@ -28,6 +28,7 @@ class ShadowsPlugin implements Plugin<Project> {
         compileJavaTask.outputs.dir(generatedSrcDir)
 
         compileJavaTask.doFirst {
+            options.compilerArgs.add("-Aorg.robolectric.annotation.processing.jsonDocsEnabled=true")
             options.compilerArgs.add("-Aorg.robolectric.annotation.processing.jsonDocsDir=${project.buildDir}/docs/json")
             options.compilerArgs.add("-Aorg.robolectric.annotation.processing.shadowPackage=${project.shadows.packageName}")
             options.compilerArgs.add("-Aorg.robolectric.annotation.processing.sdkCheckMode=${project.shadows.sdkCheckMode}")

--- a/processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
@@ -40,6 +40,7 @@ public class RobolectricProcessor extends AbstractProcessor {
   static final String SHOULD_INSTRUMENT_PKG_OPT = 
       "org.robolectric.annotation.processing.shouldInstrumentPackage";
   static final String JSON_DOCS_DIR = "org.robolectric.annotation.processing.jsonDocsDir";
+  static final String JSON_DOCS_ENABLED = "org.robolectric.annotation.processing.jsonDocsEnabled";
   static final String SDK_CHECK_MODE = "org.robolectric.annotation.processing.sdkCheckMode";
   private static final String SDKS_FILE = "org.robolectric.annotation.processing.sdks";
   private static final String PRIORITY = "org.robolectric.annotation.processing.priority";
@@ -55,6 +56,7 @@ public class RobolectricProcessor extends AbstractProcessor {
   private final List<Generator> generators = new ArrayList<>();
   private final Map<TypeElement, Validator> elementValidators = new HashMap<>(13);
   private File jsonDocsDir;
+  private boolean jsonDocsEnabled;
 
   /**
    * Default constructor.
@@ -107,8 +109,9 @@ public class RobolectricProcessor extends AbstractProcessor {
           new ShadowProviderGenerator(
               model, processingEnv, shadowPackage, shouldInstrumentPackages, priority));
       generators.add(new ServiceLoaderGenerator(processingEnv, shadowPackage));
-      generators.add(new JavadocJsonGenerator(model, processingEnv, jsonDocsDir));
-
+      if (jsonDocsEnabled) {
+        generators.add(new JavadocJsonGenerator(model, processingEnv, jsonDocsDir));
+      }
       for (Generator generator : generators) {
         generator.generate();
       }
@@ -127,7 +130,8 @@ public class RobolectricProcessor extends AbstractProcessor {
       this.shadowPackage = options.get(PACKAGE_OPT);
       this.shouldInstrumentPackages =
           !"false".equalsIgnoreCase(options.get(SHOULD_INSTRUMENT_PKG_OPT));
-      jsonDocsDir = new File(options.getOrDefault(JSON_DOCS_DIR, "build/docs/json"));
+      this.jsonDocsDir = new File(options.getOrDefault(JSON_DOCS_DIR, "build/docs/json"));
+      this.jsonDocsEnabled = "true".equalsIgnoreCase(options.get(JSON_DOCS_ENABLED));
       this.sdkCheckMode =
           SdkCheckMode.valueOf(options.getOrDefault(SDK_CHECK_MODE, "WARN").toUpperCase());
       this.sdksFile = options.getOrDefault(SDKS_FILE, "/sdks.txt");

--- a/processor/src/main/java/org/robolectric/annotation/processing/generator/JavadocJsonGenerator.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/generator/JavadocJsonGenerator.java
@@ -17,6 +17,10 @@ import org.robolectric.annotation.processing.DocumentedType;
 import org.robolectric.annotation.processing.RobolectricModel;
 import org.robolectric.annotation.processing.RobolectricModel.ShadowInfo;
 
+/**
+ * Primarily used by the Robolectric Chrome extension for Robolectric docs alongside of Android SDK
+ * docs.
+ */
 public class JavadocJsonGenerator extends Generator {
   private final RobolectricModel model;
   private final Messager messager;

--- a/processor/src/test/java/org/robolectric/annotation/processing/JavadocJsonGeneratorTest.java
+++ b/processor/src/test/java/org/robolectric/annotation/processing/JavadocJsonGeneratorTest.java
@@ -6,6 +6,7 @@ import static com.google.testing.compile.JavaFileObjects.forResource;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.robolectric.annotation.processing.RobolectricProcessor.JSON_DOCS_DIR;
+import static org.robolectric.annotation.processing.RobolectricProcessor.JSON_DOCS_ENABLED;
 import static org.robolectric.annotation.processing.Utils.DEFAULT_OPTS;
 
 import com.google.common.collect.ImmutableList;
@@ -13,8 +14,11 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -22,18 +26,38 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link org.robolectric.annotation.processing.generator.JavadocJsonGenerator} */
 @RunWith(JUnit4.class)
 public class JavadocJsonGeneratorTest {
+
   @Test
-  public void shouldGenerateJavadocJson() throws Exception {
+  public void jsonDocs_disabledByDefault() throws Exception {
+    File tmpDir = Files.createTempDirectory("JavadocJsonGeneratorTest").toFile();
+    tmpDir.deleteOnExit();
+    Map<String, String> options = new HashMap<>(DEFAULT_OPTS);
+    options.put(JSON_DOCS_DIR, tmpDir.getAbsolutePath());
     assertAbout(javaSources())
         .that(
             ImmutableList.of(
                 forResource("org/robolectric/DocumentedObjectOuter.java"),
                 forResource(
                     "org/robolectric/annotation/processing/shadows/DocumentedObjectShadow.java")))
-        .processedWith(new RobolectricProcessor(DEFAULT_OPTS))
+        .processedWith(new RobolectricProcessor(options))
+        .compilesWithoutError();
+    assertThat(tmpDir.list()).isEmpty();
+  }
+
+  @Test
+  public void shouldGenerateJavadocJson() throws Exception {
+    Map<String, String> options = new HashMap<>(DEFAULT_OPTS);
+    options.put(JSON_DOCS_ENABLED, "true");
+    assertAbout(javaSources())
+        .that(
+            ImmutableList.of(
+                forResource("org/robolectric/DocumentedObjectOuter.java"),
+                forResource(
+                    "org/robolectric/annotation/processing/shadows/DocumentedObjectShadow.java")))
+        .processedWith(new RobolectricProcessor(options))
         .compilesWithoutError();
     JsonParser jsonParser = new JsonParser();
-    String jsonDocsDir = DEFAULT_OPTS.get(JSON_DOCS_DIR);
+    String jsonDocsDir = options.get(JSON_DOCS_DIR);
     String jsonFile = jsonDocsDir + "/org.robolectric.DocumentedObjectOuter.DocumentedObject.json";
     JsonElement json = jsonParser.parse(Files.newBufferedReader(Paths.get(jsonFile), UTF_8));
     assertThat(((JsonObject) json).get("documentation").getAsString())

--- a/processor/src/test/java/org/robolectric/annotation/processing/Utils.java
+++ b/processor/src/test/java/org/robolectric/annotation/processing/Utils.java
@@ -18,8 +18,10 @@ public class Utils {
           .put(SDK_CHECK_MODE, "OFF")
           .build();
 
-  public static final JavaFileObject SHADOW_PROVIDER_SOURCE = forResource("mock-source/org/robolectric/internal/ShadowProvider.java");
-  public static final JavaFileObject SHADOW_EXTRACTOR_SOURCE = forResource("mock-source/org/robolectric/shadow/api/Shadow.java");
+  public static final JavaFileObject SHADOW_PROVIDER_SOURCE =
+      forResource("mock-source/org/robolectric/internal/ShadowProvider.java");
+  public static final JavaFileObject SHADOW_EXTRACTOR_SOURCE =
+      forResource("mock-source/org/robolectric/shadow/api/Shadow.java");
 
   public static String toResourcePath(String clazzName) {
     return clazzName.replace('.', '/') + ".java";


### PR DESCRIPTION
The jsonDocs processor currently runs for all shadow packages, including
custom shadow packages.  Change it to off by default and enable it for
the Robolectric project.
