### PR TITLE
Fix SQLiteLibraryLoader for OSX

### DIFF
--- a/robolectric/src/test/java/org/robolectric/util/SQLiteLibraryLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/SQLiteLibraryLoaderTest.java
@@ -90,15 +90,9 @@ public class SQLiteLibraryLoaderTest {
   }
 
   @Test
-  public void shouldFindLibraryForMacWithAnyArch() throws IOException {
-    assertThat(loadLibrary(new SQLiteLibraryLoader(MAC), "Mac OS X", "any architecture"))
-        .isEqualTo("sqlite4java/osx/libsqlite4java.jnilib");
-  }
-
-  @Test
   public void shouldFindLibraryForMacWithAnyArchAndDyLibMapping() throws IOException {
-    assertThat(loadLibrary(new SQLiteLibraryLoader(MAC_DYLIB), "Mac OS X", "any architecture"))
-        .isEqualTo("sqlite4java/osx/libsqlite4java.jnilib");
+    assertThat(loadLibrary(new SQLiteLibraryLoader(MAC), "Mac OS X", "any architecture"))
+        .isEqualTo("sqlite4java/osx/libsqlite4java.dylib");
   }
 
   @Test(expected = UnsupportedOperationException.class)
@@ -137,7 +131,5 @@ public class SQLiteLibraryLoaderTest {
   private static final SQLiteLibraryLoader.LibraryNameMapper WINDOWS =
       new LibraryMapperTest("", "dll");
   private static final SQLiteLibraryLoader.LibraryNameMapper MAC =
-      new LibraryMapperTest("lib", "jnilib");
-  private static final SQLiteLibraryLoader.LibraryNameMapper MAC_DYLIB =
       new LibraryMapperTest("lib", "dylib");
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/util/SQLiteLibraryLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/util/SQLiteLibraryLoader.java
@@ -57,7 +57,7 @@ public class SQLiteLibraryLoader {
   }
 
   public String getLibClasspathResourceName() {
-    return "sqlite4java/" + getNativesResourcesPathPart() + "/" + getNativesResourcesFilePart();
+    return "sqlite4java/" + getNativesResourcesPathPart() + "/" + getLibName();
   }
 
   private ByteSource getLibraryByteSource() {
@@ -106,10 +106,6 @@ public class SQLiteLibraryLoader {
     } else {
       return prefix;
     }
-  }
-
-  private String getNativesResourcesFilePart() {
-    return getLibName().replace(".dylib", ".jnilib");
   }
 
   private String getOsPrefix() {


### PR DESCRIPTION
There were references to libsqlite4java.jnilib, which only exists
in the previous version of the mac sqlite4java native library.

Fixes #5961
