### PR TITLE
SQLiteDatabase insertWithOnConflict() with CONFLICT_IGNORE should return -1 if no changes where made

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
@@ -259,6 +259,23 @@ public class SQLiteDatabaseTest {
   }
 
   @Test
+  public void testInsertDuplicatedKeyGeneration() throws Exception {
+    ContentValues values = new ContentValues();
+    values.put("id", 123);
+    values.put("name", "Chuck");
+
+    long firstKey =
+            database.insertWithOnConflict("table_name", null, values, SQLiteDatabase.CONFLICT_IGNORE);
+
+    assertThat(firstKey).isEqualTo(123L);
+
+    long duplicateKey =
+            database.insertWithOnConflict("table_name", null, values, SQLiteDatabase.CONFLICT_IGNORE);
+
+    assertThat(duplicateKey).isEqualTo(-1L);
+  }
+
+  @Test
   public void testInsertEmptyBlobArgument() throws Exception {
     ContentValues emptyBlobValues = new ContentValues();
     emptyBlobValues.put("id", 1);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSQLiteConnection.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSQLiteConnection.java
@@ -745,7 +745,7 @@ static class Connections {
         @Override
         public Long call() throws Exception {
           statement.stepThrough();
-          return connection.getLastInsertId();
+          return connection.getChanges() > 0 ? connection.getLastInsertId() : -1L;
         }
       });
     }


### PR DESCRIPTION
Fixing #5320 by returning -1 if no changes where made

Implementing the same logic as in: https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/jni/android_database_SQLiteConnection.cpp;l=549-557;drc=master?q=frameworks%2Fbase%2Fcore%2Fjni%2Fandroid_database_SQLiteConnection.cpp&ss=android