### PR TITLE
Do not instrument AndroidX DataStore

### DIFF
--- a/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
+++ b/robolectric/src/main/java/org/robolectric/internal/AndroidConfigurer.java
@@ -126,6 +126,7 @@ public class AndroidConfigurer {
     builder.doNotInstrumentPackage("androidx.lifecycle");
     builder.doNotInstrumentPackage("androidx.paging");
     builder.doNotInstrumentPackage("androidx.work");
+    builder.doNotInstrumentPackage("androidx.datastore");
 
     // exclude Compose libraries from instrumentation. These are written in Kotlin and
     // fail on any usage due to DefaultConstructorMarker being inaccessible.


### PR DESCRIPTION
### Overview

Due to #4340, AndroidX DataStore breaks Robolectric tests when the `DataMigrationInitializer` is initialized.

### Proposed Changes

Excludes `androidx.datastore` from instrumentation.

### Notes

Based on other similar commits, I haven't included any tests. If it's easy enough, I'm happy to try, but I have limited time.