### PR TITLE
Separate espresso menu toolbar test into a new test class

### DIFF
--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integration_tests/axt/EspressoWithToolbarMenuTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integration_tests/axt/EspressoWithToolbarMenuTest.java
@@ -1,6 +1,5 @@
 package org.robolectric.integration_tests.axt;
 
-
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -16,30 +15,18 @@ import org.junit.runner.RunWith;
 import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.TextLayoutMode;
 import org.robolectric.annotation.TextLayoutMode.Mode;
+import org.robolectric.shadows.ShadowViewConfiguration;
 
-/**
- * Test Espresso on Robolectric interoperability for menus.
- */
+/** Test Espresso on Robolectric interoperability for toolbar menus. */
 @RunWith(AndroidJUnit4.class)
 @TextLayoutMode(Mode.REALISTIC)
 @LooperMode(PAUSED)
-public class EspressoWithMenuTest {
-
+public class EspressoWithToolbarMenuTest {
   @Test
-  public void platformMenuClick() throws InterruptedException {
-    try (ActivityScenario<ActivityWithPlatformMenu> scenario =
-        ActivityScenario.launch(ActivityWithPlatformMenu.class)) {
-      openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext());
-      onView(withText("menu_title")).perform(click());
-
-      scenario.onActivity(activity -> assertThat(activity.menuClicked).isTrue());
-    }
-  }
-
-  @Test
-  public void appCompatMenuClick() throws InterruptedException {
-    try (ActivityScenario<ActivityWithAppCompatMenu> scenario =
-        ActivityScenario.launch(ActivityWithAppCompatMenu.class)) {
+  public void appCompatToolbarMenuClick() {
+    ShadowViewConfiguration.setHasPermanentMenuKey(false);
+    try (ActivityScenario<AppCompatActivityWithToolbarMenu> scenario =
+        ActivityScenario.launch(AppCompatActivityWithToolbarMenu.class)) {
       openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext());
       onView(withText("menu_title")).perform(click());
 


### PR DESCRIPTION
EspressoWithMenuTest is designed to work in both Robolectric and
emulator environments, and the ShadowViewConfiguration import breaks
that. Instead, move the test to a new class file, which can be run in a
Robolectric environment.
