### PR TITLE
Avoid reading invalid buffer offsets to fix crash when applying themes

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
@@ -1066,7 +1066,8 @@ public class CppAssetManager2 {
     final int parentEntryCount = parent_bag.entry_count;
 
     // The keys are expected to be in sorted order. Merge the two bags.
-    while (map_entry != null && map_entry.myOffset() != map_entry_end && parentEntryIndex != parentEntryCount) {
+    while (map_entry != null && curOffset != map_entry_end && parentEntryIndex != parentEntryCount) {
+      map_entry = new ResTable_map(map_entry.myBuf(), curOffset);
       final Ref<Integer> child_keyRef = new Ref<>(dtohl(map_entry.name.ident));
       if (!is_internal_resid(child_keyRef.get())) {
         if (entry.dynamic_ref_table.lookupResourceId(child_keyRef) != NO_ERROR) {
@@ -1103,7 +1104,7 @@ public class CppAssetManager2 {
         }
 
         // ++map_entry;
-        map_entry = new ResTable_map(map_entry.myBuf(), map_entry.myOffset() + map_entry.value.size + ResTable_map.SIZEOF - Res_value.SIZEOF);
+        curOffset += map_entry.value.size + ResTable_map.SIZEOF - Res_value.SIZEOF;
       } else {
         // Take the parent entry as-is.
         // memcpy(new_entry, parent_entry, sizeof(*new_entry));
@@ -1122,7 +1123,8 @@ public class CppAssetManager2 {
     }
 
     // Finish the child entries if they exist.
-    while (map_entry != null && map_entry.myOffset() != map_entry_end) {
+    while (map_entry != null && curOffset != map_entry_end) {
+      map_entry = new ResTable_map(map_entry.myBuf(), curOffset);
       final Ref<Integer> new_key = new Ref<>(map_entry.name.ident);
       if (!is_internal_resid(new_key.get())) {
         if (entry.dynamic_ref_table.lookupResourceId(new_key) != NO_ERROR) {
@@ -1149,7 +1151,7 @@ public class CppAssetManager2 {
         return null;
       }
       // ++map_entry;
-      map_entry = new ResTable_map(map_entry.myBuf(), map_entry.myOffset() + map_entry.value.size + ResTable_map.SIZEOF - Res_value.SIZEOF);
+      curOffset += map_entry.value.size + ResTable_map.SIZEOF - Res_value.SIZEOF;
       // ++new_entry;
       ++newEntryIndex;
     }


### PR DESCRIPTION
### Overview

When running a test with sdk 28, applying a theme can crash due to reading invalid buffer offsets.

Before this change, I observe this crash when a test constructs a view with a themed context (with quite a complex theme):
```
Caused by: java.lang.IllegalStateException: res0 != 0 (1)
	at org.robolectric.res.android.ResourceTypes$Res_value.<init>(ResourceTypes.java:332)
	at org.robolectric.res.android.ResourceTypes$ResTable_map.<init>(ResourceTypes.java:1446)
	at org.robolectric.res.android.CppAssetManager2.GetBag(CppAssetManager2.java:1106)
	at org.robolectric.res.android.CppAssetManager2.GetBag(CppAssetManager2.java:932)
	at org.robolectric.res.android.CppAssetManager2$Theme.ApplyStyle(CppAssetManager2.java:1409)
	at org.robolectric.shadows.ShadowArscAssetManager9.nativeThemeApplyStyle(ShadowArscAssetManager9.java:1507)
	at android.content.res.AssetManager.nativeThemeApplyStyle(AssetManager.java)
	at android.content.res.AssetManager.applyStyleToTheme(AssetManager.java:1038)
	at android.content.res.ResourcesImpl$ThemeImpl.applyStyle(ResourcesImpl.java:1305)
	at android.content.res.Resources$Theme.applyStyle(Resources.java:1420)
	at android.view.ContextThemeWrapper.onApplyThemeResource(ContextThemeWrapper.java:186)
	at android.view.ContextThemeWrapper.initializeTheme(ContextThemeWrapper.java:198)
	at android.view.ContextThemeWrapper.getTheme(ContextThemeWrapper.java:158)
	at android.content.Context.obtainStyledAttributes(Context.java:712)
	at android.view.View.__constructor__(View.java:4950)
	at android.view.View.<init>(View.java)
	at android.widget.ProgressBar.<init>(ProgressBar.java)
... (truncated for privacy)
```

I believe there is a bug in the translated Java code in CppAssetManager2:

In the cpp source, `map_entry` is a pointer and incremented with the for loop condition breaking when `map_entry == map_entry_end`: https://android.googlesource.com/platform/frameworks/base/+/android-9.0.0_r12/libs/androidfw/AssetManager2.cpp#617

In the robolectric's Java translation, the `++map_entry` part of the for loop constructs a `ResTable_map()` with an offset at the end of the buffer on the last iteration - this causes invalid data to be read and the "res0 != 0" assertion to possibly fail.

### Proposed Changes

Fix by only constructing `ResTable_map()` *after* we have checked that the current offset is less than `map_entry_end`.

I noticed that one loop is already fixed in https://github.com/robolectric/robolectric/commit/d077799a2c36f3628ce1c2134a986f64b90f9489#diff-5f5dbc57e078308b17d64f2bd2a0e7b1033b308008bf1a24ad768cbfd297a94c

This change fixes the other two loops.