### PR TITLE
Keep up build command with circle ci config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Robolectric is built using Gradle. Both IntelliJ and Android Studio can import t
 
 Robolectric supports running tests against multiple Android API levels. The work it must do to support each API level is slightly different, so its shadows are built separately for each. To build shadows for every API version, run:
 
-    ./gradlew clean assemble install compileTestJava
+    SKIP_JAVADOC=true ./gradlew clean assemble testClasses --parallel --stacktrace
 
 ### Using Snapshots
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Robolectric is built using Gradle. Both IntelliJ and Android Studio can import t
 
 Robolectric supports running tests against multiple Android API levels. The work it must do to support each API level is slightly different, so its shadows are built separately for each. To build shadows for every API version, run:
 
-    SKIP_JAVADOC=true ./gradlew clean assemble testClasses --parallel --stacktrace
+    ./gradlew clean assemble testClasses --parallel
 
 ### Using Snapshots
 


### PR DESCRIPTION
The old build command will fail at task `:testapp:installDebugAndroidTest`.
