### PR TITLE
Use an ExecutorService to throttle the amount of TempDirectory threads.

### DIFF
--- a/utils/src/main/java/org/robolectric/util/TempDirectory.java
+++ b/utils/src/main/java/org/robolectric/util/TempDirectory.java
@@ -47,9 +47,9 @@ public class TempDirectory {
         // This is necessary because File.deleteOnExit won't delete non empty directories
         Runtime.getRuntime().addShutdownHook(new Thread(TempDirectory::clearAllDirectories));
       }
-    }
 
-    tempDirectoriesToDelete.add(this);
+      tempDirectoriesToDelete.add(this);
+    }
   }
 
   private static void clearAllDirectories() {

--- a/utils/src/main/java/org/robolectric/util/TempDirectory.java
+++ b/utils/src/main/java/org/robolectric/util/TempDirectory.java
@@ -24,7 +24,7 @@ public class TempDirectory {
   private static final int DELETE_THREAD_POOL_SIZE = 5;
 
   /** Set to track the undeleted TempDirectory instances which we need to erase. */
-  private static Set<TempDirectory> tempDiretoriesToDelete;
+  private static Set<TempDirectory> tempDirectoriesToDelete;
 
   private final Path basePath;
 
@@ -41,8 +41,8 @@ public class TempDirectory {
 
     synchronized (TempDirectory.class) {
       // If we haven't initialised the shutdown hook we should set everything up.
-      if (tempDiretoriesToDelete == null) {
-        tempDiretoriesToDelete = Collections.synchronizedSet(new HashSet<>());
+      if (tempDirectoriesToDelete == null) {
+        tempDirectoriesToDelete = Collections.synchronizedSet(new HashSet<>());
 
         // Use a manual hook that actually clears the directory
         // This is necessary because File.deleteOnExit won't delete non empty directories
@@ -50,12 +50,12 @@ public class TempDirectory {
       }
     }
 
-    tempDiretoriesToDelete.add(this);
+    tempDirectoriesToDelete.add(this);
   }
 
   private static void clearAllDirectories() {
     ExecutorService deletionExecutorService = Executors.newFixedThreadPool(DELETE_THREAD_POOL_SIZE);
-    for (TempDirectory undeletedDirectory : tempDiretoriesToDelete) {
+    for (TempDirectory undeletedDirectory : tempDirectoriesToDelete) {
       deletionExecutorService.execute(undeletedDirectory::destroy);
     }
     deletionExecutorService.shutdown();

--- a/utils/src/main/java/org/robolectric/util/TempDirectory.java
+++ b/utils/src/main/java/org/robolectric/util/TempDirectory.java
@@ -17,14 +17,13 @@ import java.util.concurrent.Executors;
 @SuppressWarnings({"NewApi", "AndroidJdkLibsChecker"})
 public class TempDirectory {
   /**
-   * The number of concurrent deletions which should take place, too high and it'll become I/O bound, to low
-   * and it'll take a long time to complete. 5 is an estimate of a decent balance, feel free to experiment.
+   * The number of concurrent deletions which should take place, too high and it'll become I/O
+   * bound, to low and it'll take a long time to complete. 5 is an estimate of a decent balance,
+   * feel free to experiment.
    */
   private static final int DELETE_THREAD_POOL_SIZE = 5;
 
-  /**
-   * Set to track the undeleted TempDirectory instances which we need to erase.
-   */
+  /** Set to track the undeleted TempDirectory instances which we need to erase. */
   private static Set<TempDirectory> tempDiretoriesToDelete;
 
   private final Path basePath;
@@ -40,7 +39,7 @@ public class TempDirectory {
       throw new RuntimeException(e);
     }
 
-    synchronized(TempDirectory.class) {
+    synchronized (TempDirectory.class) {
       // If we haven't initialised the shutdown hook we should set everything up.
       if (tempDiretoriesToDelete == null) {
         tempDiretoriesToDelete = Collections.synchronizedSet(new HashSet<>());
@@ -56,7 +55,7 @@ public class TempDirectory {
 
   private static void clearAllDirectories() {
     ExecutorService deletionExecutorService = Executors.newFixedThreadPool(DELETE_THREAD_POOL_SIZE);
-    for(TempDirectory undeletedDirectory : tempDiretoriesToDelete) {
+    for (TempDirectory undeletedDirectory : tempDiretoriesToDelete) {
       deletionExecutorService.execute(undeletedDirectory::destroy);
     }
     deletionExecutorService.shutdown();


### PR DESCRIPTION
### Overview

Resolve the issues associated with a thread-per-TempDirectory deletion when a large number of TempDirectory objects are used in a set of tests being run.

This should address/ease the following issues;

#3801 - Replaces the "Thread per `TempDirectory`" pattern with a limited thread pool Executor Service.
#4941 - A single shutdown hook is registered on the first `TempDirectory` creation as opposed to the current approach of a registration on each `TempDirectory` creation.
#5472 - Which seems to have reached a similar point to #4941 

### Proposed Changes

The current implementation has two issues when running against tests which create a large number of `TempDirectory`s;

1) The number of threads started at shutdown scales linearly, meaning the machine becomes overloaded at some, host specific, point.
2) Due to 1 the amount of concurrent I/O will cause I/O contention on the host and, where the test execution is wrapped in a wrapper with a timeout, the host will kill the test runs with multiple semi-deleted temporary directories left.

Moving to a limited size thread pool `ExecutorService` solves the problem in two ways;

1) The limit on the thread pool size ensures that there is an upper bound on the number of threads created, and so it can not overload the machine.
2) The limit on the thread pool size ensures that only a limited number of directories will be deleted at any one time (limiting the contention chances), and that one directory will be completely erased before another is deleted, meaning in the timeout scenario the maximum number of semi-deleted temporary directories will be equal the thread pool size.

