### PR TITLE
Update ShadowDisplayTest to fail if expected exception isn't thrown.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayTest.java
@@ -194,13 +194,13 @@ public class ShadowDisplayTest {
   public void setDisplayHdrCapabilities_shouldntThrowUnSupportedOperationExceptionNPlus() {
     Display display = ShadowDisplay.getDefaultDisplay();
     int[] hdrCapabilities =
-            new int[] {HdrCapabilities.HDR_TYPE_HDR10, HdrCapabilities.HDR_TYPE_DOLBY_VISION};
+        new int[] {HdrCapabilities.HDR_TYPE_HDR10, HdrCapabilities.HDR_TYPE_DOLBY_VISION};
 
     shadow.setDisplayHdrCapabilities(
-            display.getDisplayId(),
-            /* maxLuminance= */ 100f,
-            /* maxAverageLuminance= */ 100f,
-            /* minLuminance= */ 100f,
-            hdrCapabilities);
+        display.getDisplayId(),
+        /* maxLuminance= */ 100f,
+        /* maxAverageLuminance= */ 100f,
+        /* minLuminance= */ 100f,
+        hdrCapabilities);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayTest.java
@@ -6,6 +6,7 @@ import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.N;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import android.graphics.Point;
 import android.graphics.Rect;
@@ -170,8 +171,8 @@ public class ShadowDisplayTest {
   }
 
   @Test
-  @Config(minSdk = M)
-  public void setDisplayHdrCapabilities_shouldThrowUnSupportedOperationException() {
+  @Config(maxSdk = M)
+  public void setDisplayHdrCapabilities_shouldThrowUnSupportedOperationExceptionPreN() {
     Display display = ShadowDisplay.getDefaultDisplay();
     int[] hdrCapabilities =
         new int[] {HdrCapabilities.HDR_TYPE_HDR10, HdrCapabilities.HDR_TYPE_DOLBY_VISION};
@@ -182,8 +183,24 @@ public class ShadowDisplayTest {
           /* maxAverageLuminance= */ 100f,
           /* minLuminance= */ 100f,
           hdrCapabilities);
+      fail();
     } catch (UnsupportedOperationException e) {
       assertThat(e).hasMessageThat().contains("HDR capabilities are not supported below Android N");
     }
+  }
+
+  @Test
+  @Config(minSdk = N)
+  public void setDisplayHdrCapabilities_shouldntThrowUnSupportedOperationExceptionNPlus() {
+    Display display = ShadowDisplay.getDefaultDisplay();
+    int[] hdrCapabilities =
+            new int[] {HdrCapabilities.HDR_TYPE_HDR10, HdrCapabilities.HDR_TYPE_DOLBY_VISION};
+
+    shadow.setDisplayHdrCapabilities(
+            display.getDisplayId(),
+            /* maxLuminance= */ 100f,
+            /* maxAverageLuminance= */ 100f,
+            /* minLuminance= */ 100f,
+            hdrCapabilities);
   }
 }


### PR DESCRIPTION
### Overview

In Pre-N environments an UnsupportedOperationException should be thrown some specific text, but, if the exception wasn't thrown the test would still complete successfully. 

### Proposed Changes

I've split the test into two;

 - One for M- which check the exception is thrown and fails if it isn't.
 - One for N+ which checks the exception isn't thrown.