### PR TITLE
Update to Gradle 6 8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,5 @@ errorproneVersion=2.3.4
 errorproneJavacVersion=9+181-r4173-1
 
 android.enableUnitTestBinaryResources=true
+
+org.gradle.vfs.watch=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,3 @@ errorproneVersion=2.3.4
 errorproneJavacVersion=9+181-r4173-1
 
 android.enableUnitTestBinaryResources=true
-
-org.gradle.vfs.watch=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Overview

Update to Gradle 6.8 to allow us to use the VFS watcher

### Proposed Changes

VFS Watcher has some benefits during development (see https://blog.gradle.org/introducing-file-system-watching), but to get a production ready version of it we need to be using Gradle 6.7 or later. 6.8 is the most recently released version so I've picked that as the version to go with.