### PR TITLE
Added gradle dependency version checker to the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:1.3.0'
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.36.0"
     }
 }
 
@@ -28,6 +29,7 @@ allprojects {
 }
 
 apply plugin: 'idea'
+apply plugin: 'com.github.ben-manes.versions'
 
 project.ext.configAnnotationProcessing = []
 project.afterEvaluate {


### PR DESCRIPTION
### Overview

We currently have some out of date dependencies. Adding this plugin allows us to easily identify where an upgrade is available using the command `gradle dependencyUpdates -Drevision=release`

### Proposed Changes

Adding a plugin which comes from https://github.com/ben-manes/gradle-versions-plugin

Current dependencies identified as out of date;

```
------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest release version:
 - com.almworks.sqlite4java:libsqlite4java-linux-amd64:1.0.392
 - com.almworks.sqlite4java:libsqlite4java-linux-i386:1.0.392
 - com.almworks.sqlite4java:libsqlite4java-osx:1.0.392
 - com.almworks.sqlite4java:sqlite4java:1.0.392
 - com.almworks.sqlite4java:sqlite4java-win32-x64:1.0.392
 - com.almworks.sqlite4java:sqlite4java-win32-x86:1.0.392
 - com.github.ben-manes:gradle-versions-plugin:0.36.0
 - com.google.code.findbugs:jsr305:3.0.2
 - com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1
 - javax.annotation:javax.annotation-api:1.3.2
 - javax.inject:javax.inject:1
 - junit:junit:4.13.1
 - net.ltgt.gradle:gradle-errorprone-plugin:1.3.0
 - org.hamcrest:hamcrest-junit:2.0.0.0
 - org.ow2.asm:asm:9.0
 - org.ow2.asm:asm-commons:9.0
 - org.ow2.asm:asm-util:9.0
 - org.robolectric:android-all:11-robolectric-6757853

The following dependencies have later release versions:
 - androidx.annotation:annotation [1.1.0 -> 1.2.0-beta01]
     https://developer.android.com/jetpack/androidx/releases/annotation#1.2.0-beta01
 - androidx.appcompat:appcompat [1.0.0 -> 1.3.0-beta01]
     https://developer.android.com/jetpack/androidx/releases/appcompat#1.3.0-beta01
 - androidx.constraintlayout:constraintlayout [1.1.0 -> 2.1.0-alpha2]
     http://tools.android.com
 - androidx.core:core [1.1.0-alpha05 -> 1.5.0-beta01]
     https://developer.android.com/jetpack/androidx/releases/core#1.5.0-beta01
 - androidx.fragment:fragment [1.0.0 -> 1.3.0-rc01]
     https://developer.android.com/jetpack/androidx/releases/fragment#1.3.0-rc01
 - androidx.fragment:fragment-testing [1.3.0-beta02 -> 1.3.0-rc01]
     https://developer.android.com/jetpack/androidx/releases/fragment#1.3.0-rc01
 - androidx.lifecycle:lifecycle-common [2.0.0 -> 2.3.0-rc01]
     https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.0-rc01
 - androidx.test:core [1.3.0-rc03 -> 1.3.1-alpha03]
     https://developer.android.com/testing
 - androidx.test:monitor [1.3.0-rc03 -> 1.3.1-alpha03]
     https://developer.android.com/testing
 - androidx.test:rules [1.3.0-rc03 -> 1.3.1-alpha03]
     https://developer.android.com/testing
 - androidx.test:runner [1.3.0-rc03 -> 1.3.1-alpha03]
     https://developer.android.com/testing
 - androidx.test.espresso:espresso-core [3.3.0-rc03 -> 3.4.0-alpha03]
     https://developer.android.com/testing
 - androidx.test.espresso:espresso-intents [3.3.0-rc03 -> 3.4.0-alpha03]
     https://developer.android.com/testing
 - androidx.test.ext:junit [1.1.2-rc03 -> 1.1.3-alpha03]
     https://developer.android.com/testing
 - androidx.test.ext:truth [1.3.0-rc03 -> 1.3.1-alpha03]
     https://developer.android.com/testing
 - com.android.support:multidex [1.0.1 -> 1.0.3]
 - com.android.support:support-annotations [26.0.1 -> 28.0.0]
     http://developer.android.com/tools/extras/support-library.html
 - com.android.support:support-compat [26.0.1 -> 28.0.0]
     http://developer.android.com/tools/extras/support-library.html
 - com.android.support:support-core-ui [26.0.1 -> 28.0.0]
     http://developer.android.com/tools/extras/support-library.html
 - com.android.support:support-core-utils [26.0.1 -> 28.0.0]
     http://developer.android.com/tools/extras/support-library.html
 - com.android.support:support-fragment [26.0.1 -> 28.0.0]
     http://developer.android.com/tools/extras/support-library.html
 - com.android.support:support-media-compat [26.0.1 -> 28.0.0]
     http://developer.android.com/tools/extras/support-library.html
 - com.android.support:support-v4 [26.0.1 -> 28.0.0]
     http://developer.android.com/tools/extras/support-library.html
 - com.android.tools.build:gradle [4.1.1 -> 7.0.0-alpha04]
     http://tools.android.com/
 - com.google.android.gms:play-services-base [8.4.0 -> 17.5.0]
 - com.google.android.gms:play-services-basement [8.4.0 -> 17.5.0]
 - com.google.auto.service:auto-service [1.0-rc6 -> 1.0-rc7]
     https://github.com/google/auto/tree/master/service
 - com.google.auto.service:auto-service-annotations [1.0-rc6 -> 1.0-rc7]
     https://github.com/google/auto/tree/master/service
 - com.google.auto.value:auto-value [1.6.2 -> 1.7.4]
     https://github.com/google/auto/tree/master/value
 - com.google.auto.value:auto-value-annotations [1.6.2 -> 1.7.4]
     https://github.com/google/auto/tree/master/value
 - com.google.code.gson:gson [2.8.2 -> 2.8.6]
     https://github.com/google/gson
 - com.google.errorprone:error_prone_annotation [2.3.4 -> 2.5.1]
 - com.google.errorprone:error_prone_check_api [2.3.4 -> 2.5.1]
 - com.google.errorprone:error_prone_core [2.3.4 -> 2.5.1]
 - com.google.errorprone:error_prone_refaster [2.3.4 -> 2.5.1]
 - com.google.errorprone:error_prone_test_helpers [2.3.4 -> 2.5.1]
 - com.google.guava:guava [27.0.1-jre -> 30.1-jre]
     https://github.com/google/guava
 - com.google.testing.compile:compile-testing [0.18 -> 0.19]
     http://github.com/google/compile-testing
 - com.google.truth:truth [0.44 -> 1.1.1]
     http://github.com/google/truth
 - com.google.truth:truth [0.45 -> 1.1.1]
     http://github.com/google/truth
 - com.google.truth:truth [1.0.1 -> 1.1.1]
     http://github.com/google/truth
 - com.google.truth.extensions:truth-java8-extension [0.45 -> 1.1.1]
     http://github.com/google/truth
 - com.googlecode.libphonenumber:libphonenumber [8.0.0 -> 8.12.16]
     https://github.com/google/libphonenumber/
 - com.ibm.icu:icu4j [53.1 -> 68.2]
     http://icu-project.org/
 - com.squareup.okhttp3:okhttp [4.8.0 -> 4.10.0-RC1]
     https://square.github.io/okhttp/
 - com.squareup.okhttp3:okhttp-bom [4.8.0 -> 4.10.0-RC1]
     https://square.github.io/okhttp/
 - io.mockk:mockk [1.9.3 -> 1.10.5]
     http://mockk.io
 - javax.annotation:jsr250-api [1.0 -> 1.0-20050927.133100]
     https://jax-ws.dev.java.net/
 - org.apache.httpcomponents:httpclient [4.0.3 -> 4.5.13]
     http://hc.apache.org/httpcomponents-client
 - org.apache.httpcomponents:httpcore [4.0.1 -> 4.4.14]
     http://hc.apache.org/httpcomponents-core-ga
 - org.bouncycastle:bcprov-jdk15on [1.65 -> 1.68]
     http://www.bouncycastle.org/java.html
 - org.conscrypt:conscrypt-openjdk-uber [2.4.0 -> 2.5.1]
     https://conscrypt.org/
 - org.jetbrains.kotlin:kotlin-gradle-plugin [1.3.72 -> 1.4.30-RC]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable [1.3.72 -> 1.4.30-RC]
     https://kotlinlang.org/
 - org.mockito:mockito-core [2.5.4 -> 3.7.7]
     https://github.com/mockito/mockito
 - org.mockito:mockito-inline [3.5.11 -> 3.7.7]
     https://github.com/mockito/mockito
 - org.powermock:powermock-api-mockito2 [2.0.0 -> 2.0.9]
     http://www.powermock.org
 - org.powermock:powermock-classloading-xstream [2.0.0 -> 2.0.9]
     http://www.powermock.org
 - org.powermock:powermock-module-junit4 [2.0.0 -> 2.0.9]
     http://www.powermock.org
 - org.powermock:powermock-module-junit4-rule [2.0.0 -> 2.0.9]
     http://www.powermock.org
 - org.robolectric:android-all [5.1.1_r9-robolectric-r2 -> 11-robolectric-6757853]
     http://source.android.com/
```
