### PR TITLE
Update android support libraries to v28.0.0

### DIFF
--- a/shadows/playservices/build.gradle
+++ b/shadows/playservices/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     api project(":annotations")
     api "com.google.guava:guava:27.0.1-jre"
 
-    compileOnly "com.android.support:support-fragment:26.0.1"
+    compileOnly "com.android.support:support-fragment:28.0.0"
     compileOnly "com.google.android.gms:play-services-base:8.4.0"
     compileOnly "com.google.android.gms:play-services-basement:8.4.0"
 
@@ -27,7 +27,7 @@ dependencies {
     testImplementation "junit:junit:4.13.1"
     testImplementation "com.google.truth:truth:1.0.1"
     testImplementation "org.mockito:mockito-core:2.5.4"
-    testRuntime "com.android.support:support-fragment:26.0.1"
+    testRuntime "com.android.support:support-fragment:28.0.0"
     testRuntime "com.google.android.gms:play-services-base:8.4.0"
     testRuntime "com.google.android.gms:play-services-basement:8.4.0"
 

--- a/shadows/supportv4/build.gradle
+++ b/shadows/supportv4/build.gradle
@@ -16,27 +16,29 @@ test {
     systemProperty "robolectric.resourcesMode", "binary"
 }
 
+def supportLibraryVersions = "28.0.0"
+
 dependencies {
     compileOnly project(":robolectric")
     compileOnly project(":shadows:framework")
 
     compileOnly AndroidSdk.MAX_SDK.coordinates
-    compileOnly "com.android.support:support-annotations:26.0.1"
-    compileOnly "com.android.support:support-v4:26.0.1"
-    compileOnly "com.android.support:support-compat:26.0.1"
-    compileOnly "com.android.support:support-core-ui:26.0.1"
-    compileOnly "com.android.support:support-core-utils:26.0.1"
-    compileOnly "com.android.support:support-fragment:26.0.1"
-    compileOnly "com.android.support:support-media-compat:26.0.1"
+    compileOnly "com.android.support:support-annotations:${supportLibraryVersions}"
+    compileOnly "com.android.support:support-v4:${supportLibraryVersions}"
+    compileOnly "com.android.support:support-compat:${supportLibraryVersions}"
+    compileOnly "com.android.support:support-core-ui:${supportLibraryVersions}"
+    compileOnly "com.android.support:support-core-utils:${supportLibraryVersions}"
+    compileOnly "com.android.support:support-fragment:${supportLibraryVersions}"
+    compileOnly "com.android.support:support-media-compat:${supportLibraryVersions}"
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
-    testCompileOnly "com.android.support:support-annotations:26.0.1"
-    testCompileOnly "com.android.support:support-v4:26.0.1"
-    testCompileOnly "com.android.support:support-compat:26.0.1"
-    testCompileOnly "com.android.support:support-core-ui:26.0.1"
-    testCompileOnly "com.android.support:support-core-utils:26.0.1"
-    testCompileOnly "com.android.support:support-fragment:26.0.1"
-    testCompileOnly "com.android.support:support-media-compat:26.0.1"
+    testCompileOnly "com.android.support:support-annotations:${supportLibraryVersions}"
+    testCompileOnly "com.android.support:support-v4:${supportLibraryVersions}"
+    testCompileOnly "com.android.support:support-compat:${supportLibraryVersions}"
+    testCompileOnly "com.android.support:support-core-ui:${supportLibraryVersions}"
+    testCompileOnly "com.android.support:support-core-utils:${supportLibraryVersions}"
+    testCompileOnly "com.android.support:support-fragment:${supportLibraryVersions}"
+    testCompileOnly "com.android.support:support-media-compat:${supportLibraryVersions}"
 
     testImplementation project(":robolectric")
     testImplementation "androidx.test.ext:junit:1.1.2-rc03"
@@ -47,12 +49,12 @@ dependencies {
 
     earlyTestRuntime "org.hamcrest:hamcrest-junit:2.0.0.0"
     testRuntime AndroidSdk.MAX_SDK.coordinates
-    testRuntime "com.android.support:support-v4:26.0.1"
-    testRuntime "com.android.support:support-compat:26.0.1"
-    testRuntime "com.android.support:support-core-ui:26.0.1"
-    testRuntime "com.android.support:support-core-utils:26.0.1"
-    testRuntime "com.android.support:support-fragment:26.0.1"
-    testRuntime "com.android.support:support-media-compat:26.0.1"
+    testRuntime "com.android.support:support-v4:${supportLibraryVersions}"
+    testRuntime "com.android.support:support-compat:${supportLibraryVersions}"
+    testRuntime "com.android.support:support-core-ui:${supportLibraryVersions}"
+    testRuntime "com.android.support:support-core-utils:${supportLibraryVersions}"
+    testRuntime "com.android.support:support-fragment:${supportLibraryVersions}"
+    testRuntime "com.android.support:support-media-compat:${supportLibraryVersions}"
 }
 
 // hamcrest needs to come before junit on runtime classpath; the gradle IntelliJ plugin


### PR DESCRIPTION
### Overview

Update the Android support libraries to the latest version (v28.0.0)

### Proposed Changes

28.0.0 is the last release under the `android.support` package name (last, not just the latest, according to https://developer.android.com/topic/libraries/support-library/revisions), so a bump will give us all the benefits of the bug-fixes in the 27 series and move us to the last supported version which will be a simple bump upgrade (the recommended future path is to use androidx).