### PR TITLE
Synchronize Truth version being used to be v1.1.2

### DIFF
--- a/errorprone/build.gradle
+++ b/errorprone/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
     // Testing dependencies
     testCompile "junit:junit:4.13.1"
-    testCompile "com.google.truth:truth:1.0.1"
+    testCompile "com.google.truth:truth:${truthVersion}"
     testCompile("com.google.errorprone:error_prone_test_helpers:2.3.4") {
         exclude group: 'junit', module: 'junit' // because it depends on a snapshot!?
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ errorproneJavacVersion=9+181-r4173-1
 
 android.enableUnitTestBinaryResources=true
 
-truthVersion=1.1.1
+truthVersion=1.1.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,5 @@ errorproneVersion=2.3.4
 errorproneJavacVersion=9+181-r4173-1
 
 android.enableUnitTestBinaryResources=true
+
+truthVersion=1.1.1

--- a/integration_tests/androidx/build.gradle
+++ b/integration_tests/androidx/build.gradle
@@ -45,5 +45,5 @@ dependencies {
     // TODO: this should be a transitive dependency of core...
     testImplementation("androidx.lifecycle:lifecycle-common:2.0.0")
     testImplementation("androidx.test.ext:junit:1.1.2-rc03")
-    testImplementation("com.google.truth:truth:1.0.1")
+    testImplementation("com.google.truth:truth:${truthVersion}")
 }

--- a/integration_tests/androidx_test/build.gradle
+++ b/integration_tests/androidx_test/build.gradle
@@ -43,5 +43,5 @@ dependencies {
     // TODO: this should be a transitive dependency of core...
     testImplementation("androidx.lifecycle:lifecycle-common:2.0.0")
     testImplementation("androidx.test.ext:junit:1.1.2-rc03")
-    testImplementation("com.google.truth:truth:1.0.1")
+    testImplementation("com.google.truth:truth:${truthVersion}")
 }

--- a/integration_tests/ctesque/build.gradle
+++ b/integration_tests/ctesque/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     testImplementation("androidx.test.ext:junit:1.1.2-rc03")
     testImplementation("androidx.test.ext:truth:1.3.0-rc03")
     testImplementation("androidx.test:core:1.3.0-rc03")
-    testImplementation("com.google.truth:truth:0.45")
+    testImplementation("com.google.truth:truth:${truthVersion}")
     testImplementation("com.google.guava:guava:27.0.1-jre")
 
     // Testing dependencies
@@ -49,6 +49,6 @@ dependencies {
     androidTestImplementation("androidx.test:runner:1.3.0-rc03")
     androidTestImplementation("androidx.test:rules:1.3.0-rc03")
     androidTestImplementation("androidx.test.ext:junit:1.1.2-rc03")
-    androidTestImplementation("com.google.truth:truth:0.45")
+    androidTestImplementation("com.google.truth:truth:${truthVersion}")
     androidTestImplementation("com.google.guava:guava:27.0.1-jre")
 }

--- a/integration_tests/dependency-on-stubs/build.gradle
+++ b/integration_tests/dependency-on-stubs/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates // compile against latest Android SDK
     testRuntime AndroidSdk.MAX_SDK.coordinates
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:2.5.4"
     testImplementation "org.hamcrest:hamcrest-junit:2.0.0.0"
 }

--- a/integration_tests/libphonenumber/build.gradle
+++ b/integration_tests/libphonenumber/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
     testRuntime AndroidSdk.MAX_SDK.coordinates
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation 'com.googlecode.libphonenumber:libphonenumber:8.0.0'
 }

--- a/integration_tests/mockito-experimental/build.gradle
+++ b/integration_tests/mockito-experimental/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntime AndroidSdk.MAX_SDK.coordinates
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-inline:3.5.11"
 }

--- a/integration_tests/mockito/build.gradle
+++ b/integration_tests/mockito/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntime AndroidSdk.MAX_SDK.coordinates
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:2.5.4"
 }

--- a/integration_tests/mockk/build.gradle
+++ b/integration_tests/mockk/build.gradle
@@ -8,6 +8,6 @@ dependencies {
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntime AndroidSdk.MAX_SDK.coordinates
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.google.truth:truth:0.44"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation 'io.mockk:mockk:1.9.3'
 }

--- a/integration_tests/powermock/build.gradle
+++ b/integration_tests/powermock/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     testRuntime AndroidSdk.MAX_SDK.coordinates
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
 
     testImplementation "org.powermock:powermock-module-junit4:2.0.0"
     testImplementation "org.powermock:powermock-module-junit4-rule:2.0.0"

--- a/integration_tests/security-providers/build.gradle
+++ b/integration_tests/security-providers/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
     testRuntime AndroidSdk.MAX_SDK.coordinates
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.conscrypt:conscrypt-openjdk-uber:2.4.0"
     testImplementation "com.squareup.okhttp3:okhttp"
     testImplementation platform("com.squareup.okhttp3:okhttp-bom:4.8.0")

--- a/pluginapi/build.gradle
+++ b/pluginapi/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     api project(":annotations")
 
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:2.5.4"
 }

--- a/plugins/maven-dependency-resolver/build.gradle
+++ b/plugins/maven-dependency-resolver/build.gradle
@@ -8,5 +8,5 @@ dependencies {
 
     testImplementation "junit:junit:4.13.1"
     testImplementation "org.mockito:mockito-core:2.5.4"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
 }

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -46,5 +46,5 @@ dependencies {
     testImplementation "junit:junit:4.13.1"
     testImplementation "org.mockito:mockito-core:2.5.4"
     testImplementation "com.google.testing.compile:compile-testing:0.18"
-    testImplementation "com.google.truth:truth:0.45"
+    testImplementation "com.google.truth:truth:${truthVersion}"
 }

--- a/resources/build.gradle
+++ b/resources/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "com.google.testing.compile:compile-testing:0.18"
     testImplementation "org.mockito:mockito-core:2.5.4"
 }

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -43,8 +43,8 @@ dependencies {
     compile "androidx.test:monitor:1.3.0-rc03"
 
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.google.truth:truth:0.45"
-    testImplementation "com.google.truth.extensions:truth-java8-extension:0.45"
+    testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation "com.google.truth.extensions:truth-java8-extension:${truthVersion}"
     testImplementation "org.mockito:mockito-core:2.5.4"
     testImplementation "org.hamcrest:hamcrest-junit:2.0.0.0"
     testImplementation "androidx.test:core:1.3.0-rc03"

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:2.5.4"
     testImplementation project(":junit")
 }

--- a/shadowapi/build.gradle
+++ b/shadowapi/build.gradle
@@ -6,6 +6,6 @@ dependencies {
 
     api project(":annotations")
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:2.5.4"
 }

--- a/shadows/httpclient/build.gradle
+++ b/shadows/httpclient/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
     testImplementation project(":robolectric")
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:2.5.4"
     testImplementation "androidx.test.ext:junit:1.1.2-rc03"
 

--- a/shadows/playservices/build.gradle
+++ b/shadows/playservices/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
     testImplementation project(":robolectric")
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:2.5.4"
     testRuntime "com.android.support:support-fragment:26.0.1"
     testRuntime "com.google.android.gms:play-services-base:8.4.0"

--- a/shadows/supportv4/build.gradle
+++ b/shadows/supportv4/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testImplementation "androidx.test.ext:junit:1.1.2-rc03"
     testImplementation "junit:junit:4.13.1"
     testImplementation "org.hamcrest:hamcrest-junit:2.0.0.0"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:2.5.4"
 
     earlyTestRuntime "org.hamcrest:hamcrest-junit:2.0.0.0"

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -16,6 +16,6 @@ dependencies {
     testAnnotationProcessor "com.google.errorprone:error_prone_core:2.3.4"
 
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:2.5.4"
 }

--- a/utils/reflector/build.gradle
+++ b/utils/reflector/build.gradle
@@ -9,5 +9,5 @@ dependencies {
 
     testImplementation project(":shadowapi")
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
 }


### PR DESCRIPTION
### Overview

Synchronize the version of Truth being used

### Proposed Changes

We had a number of different versions of Truth being used in different test targets, so I've extracted the truth version out to a single place and switched the dependency references to use that variable. This gives us two advantages;

- The same version of Truth is being used in tests meaning less dependency downloads and more consistent behaviour
- Future upgrades to Truth can be performed by updating the variable which will be a one line change and maintain Truth version synchronization across the build.