### PR TITLE
Deprecate the supportv4 shadows as mentioned in #6185

### DIFF
--- a/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowAsyncTaskLoader.java
+++ b/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowAsyncTaskLoader.java
@@ -8,10 +8,12 @@ import org.robolectric.shadows.LooperShadowPicker;
 /**
  * The shadow API for {@link AsyncTaskLoader}.
  *
- * Different shadow implementations will be used based on the current {@link LooperMode.Mode}.
+ * <p>Different shadow implementations will be used based on the current {@link LooperMode.Mode}.
+ *
  * @see ShadowLegacyAsyncTaskLoader, ShadowPausedAsyncTaskLoader
  */
 @Implements(value = AsyncTaskLoader.class, shadowPicker = ShadowAsyncTaskLoader.Picker.class)
+@Deprecated
 public abstract class ShadowAsyncTaskLoader<D> {
 
   public static class Picker extends LooperShadowPicker<ShadowAsyncTaskLoader> {

--- a/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowDrawerLayout.java
+++ b/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowDrawerLayout.java
@@ -2,14 +2,15 @@ package org.robolectric.shadows.support.v4;
 
 import static org.robolectric.shadow.api.Shadow.directlyOn;
 
-import android.view.View;
 import android.support.v4.widget.DrawerLayout;
+import android.view.View;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.shadows.ShadowViewGroup;
 
 @Implements(DrawerLayout.class)
+@Deprecated
 public class ShadowDrawerLayout extends ShadowViewGroup {
   @RealObject private DrawerLayout realDrawerLayout;
   private DrawerLayout.DrawerListener drawerListener;

--- a/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowLegacyAsyncTaskLoader.java
+++ b/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowLegacyAsyncTaskLoader.java
@@ -21,6 +21,7 @@ import org.robolectric.annotation.RealObject;
     shadowPicker = ShadowAsyncTaskLoader.Picker.class,
     // TODO: turn off shadowOf generation. Figure out why this is needed
     isInAndroidSdk = false)
+@Deprecated
 public class ShadowLegacyAsyncTaskLoader<D> extends ShadowAsyncTaskLoader {
   @RealObject private AsyncTaskLoader<D> realLoader;
   private BackgroundWorker worker;

--- a/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManager.java
+++ b/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowLocalBroadcastManager.java
@@ -19,6 +19,7 @@ import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 @Implements(LocalBroadcastManager.class)
+@Deprecated
 public class ShadowLocalBroadcastManager {
   private final List<Intent> sentBroadcastIntents = new ArrayList<>();
   private final List<Wrapper> registeredReceivers = new ArrayList<>();

--- a/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowMediaBrowserCompat.java
+++ b/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowMediaBrowserCompat.java
@@ -14,11 +14,11 @@ import android.support.v4.media.MediaBrowserCompat.ItemCallback;
 import android.support.v4.media.MediaBrowserCompat.MediaItem;
 import android.support.v4.media.MediaBrowserCompat.SearchCallback;
 import android.support.v4.media.MediaBrowserCompat.SubscriptionCallback;
+import android.support.v4.media.MediaBrowserServiceCompat;
 import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import android.support.v4.media.MediaBrowserServiceCompat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -35,6 +35,7 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
  * its own account of {@link MediaItem}s.
  */
 @Implements(MediaBrowserCompat.class)
+@Deprecated
 public class ShadowMediaBrowserCompat {
 
   private final Handler handler = new Handler();

--- a/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowSwipeRefreshLayout.java
+++ b/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowSwipeRefreshLayout.java
@@ -9,6 +9,7 @@ import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowViewGroup;
 
 @Implements(SwipeRefreshLayout.class)
+@Deprecated
 public class ShadowSwipeRefreshLayout extends ShadowViewGroup {
   @RealObject SwipeRefreshLayout realObject;
   private OnRefreshListener listener;


### PR DESCRIPTION
### Overview

Deprecating the supportv4 shadows. It seems not a lot of folk are going to be using them going forward.

### Proposed Changes

Marked the supportv4 shadows with @Deprecated