### PR TITLE
Attempt to run tests without sharding on Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,11 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2
@@ -31,36 +34,10 @@ jobs:
       - name: Build
         run: SKIP_JAVADOC=true ./gradlew clean assemble testClasses --parallel --stacktrace
 
-  tests:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        api-versions: ['16,17,18', '19,21,22', '23,24,25', '26,27,28', '29,20']
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle
-            ~/.m2
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Set up JDK 11.0.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11.0.8
-
       - name: Run tests
         run: |
           ./gradlew test --info --stacktrace --continue \
           --parallel \
-          -Drobolectric.enabledSdks=${{ matrix.api-versions }} \
           -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
           -Dorg.gradle.workers.max=2
 
@@ -68,7 +45,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: test_results_${{ matrix.api-versions }}
+          name: test_results
           path: '**/build/test-results/**/TEST-*.xml'
 
   publish_test_results:


### PR DESCRIPTION
Sharding may be an artifact of underpowered CircleCI machines and some
memory leaks that have since been fixed.
