### PR TITLE
Fix typo and run tests on SDK 30

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-versions: ['16,17,18', '19,21,22', '23,24,25', '26,27,28', '29,20']
+        api-versions: ['16,17,18', '19,21,22', '23,24,25', '26,27,28', '29,30']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
In the api-versions matrix, SDK version '20' was specified instead of '30'.

### Overview

### Proposed Changes
