### PR TITLE
Remove publish_test_results job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,25 +70,3 @@ jobs:
         with:
           name: test_results_${{ matrix.api-versions }}
           path: '**/build/test-results/**/TEST-*.xml'
-
-  publish_test_results:
-    needs: tests
-    if: always()
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download All Test Results
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
-
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: artifacts
-
-      - name: Publish All Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.7
-        if: always()
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: 'artifacts/**/TEST-*.xml'


### PR DESCRIPTION
This job is redundant, the results already get posted to the PR itself,
and the final aggregate job was only needed before individual checks
could be reported. Also the email notification is noisy. We may need an
aggregate job in the future, however, to upload snapshots for tests on
the master branch.