### PR TITLE
Fix syntax warning of build.gradle

### DIFF
--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"

--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,7 @@ task prefetchDependencies() {
                 if (config.isCanBeResolved()) {
                     try {
                         config.files
-                    } catch (org.gradle.api.artifacts.ResolveException e) {
+                    } catch (ResolveException e) {
                         // ignore resolution issues for integration tests, sigh
                         if (!p.path.startsWith(":integration_tests:")) {
                             throw e

--- a/errorprone/build.gradle
+++ b/errorprone/build.gradle
@@ -1,5 +1,9 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.gradle.internal.jvm.Jvm
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 // Disable annotation processor for tests
 compileTestJava {
@@ -12,13 +16,13 @@ test {
 
 dependencies {
     // Project dependencies
-    compile project(":annotations")
-    compile project(":shadowapi")
+    implementation project(":annotations")
+    implementation project(":shadowapi")
 
     // Compile dependencies
-    compile "com.google.errorprone:error_prone_annotation:2.3.4"
-    compile "com.google.errorprone:error_prone_refaster:2.3.4"
-    compile "com.google.errorprone:error_prone_check_api:2.3.4"
+    implementation "com.google.errorprone:error_prone_annotation:2.3.4"
+    implementation "com.google.errorprone:error_prone_refaster:2.3.4"
+    implementation "com.google.errorprone:error_prone_check_api:2.3.4"
     compileOnly "com.google.auto.service:auto-service-annotations:1.0-rc6"
     compileOnly(AndroidSdk.MAX_SDK.coordinates) { force = true }
 
@@ -26,15 +30,15 @@ dependencies {
     annotationProcessor "com.google.errorprone:error_prone_core:2.3.4"
 
     // in jdk 9, tools.jar disappears!
-    def toolsJar = org.gradle.internal.jvm.Jvm.current().getToolsJar()
+    def toolsJar = Jvm.current().getToolsJar()
     if (toolsJar != null) {
         compile files(toolsJar)
     }
 
     // Testing dependencies
-    testCompile "junit:junit:4.13.1"
-    testCompile "com.google.truth:truth:${truthVersion}"
-    testCompile("com.google.errorprone:error_prone_test_helpers:2.3.4") {
+    testImplementation "junit:junit:4.13.1"
+    testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation("com.google.errorprone:error_prone_test_helpers:2.3.4") {
         exclude group: 'junit', module: 'junit' // because it depends on a snapshot!?
     }
     testCompileOnly(AndroidSdk.MAX_SDK.coordinates) { force = true }

--- a/integration_tests/agp/build.gradle
+++ b/integration_tests/agp/build.gradle
@@ -1,5 +1,7 @@
+import org.robolectric.gradle.AndroidProjectConfigPlugin
+
 apply plugin: 'com.android.library'
-apply plugin: org.robolectric.gradle.AndroidProjectConfigPlugin
+apply plugin: AndroidProjectConfigPlugin
 
 android {
     compileSdkVersion 30

--- a/integration_tests/androidx/build.gradle
+++ b/integration_tests/androidx/build.gradle
@@ -1,5 +1,7 @@
+import org.robolectric.gradle.AndroidProjectConfigPlugin
+
 apply plugin: 'com.android.library'
-apply plugin: org.robolectric.gradle.AndroidProjectConfigPlugin
+apply plugin: AndroidProjectConfigPlugin
 
 android {
     compileSdkVersion 30

--- a/integration_tests/androidx_test/build.gradle
+++ b/integration_tests/androidx_test/build.gradle
@@ -1,5 +1,7 @@
+import org.robolectric.gradle.AndroidProjectConfigPlugin
+
 apply plugin: 'com.android.library'
-apply plugin: org.robolectric.gradle.AndroidProjectConfigPlugin
+apply plugin: AndroidProjectConfigPlugin
 
 android {
     compileSdkVersion 30

--- a/integration_tests/ctesque/build.gradle
+++ b/integration_tests/ctesque/build.gradle
@@ -1,5 +1,7 @@
+import org.robolectric.gradle.AndroidProjectConfigPlugin
+
 apply plugin: 'com.android.library'
-apply plugin: org.robolectric.gradle.AndroidProjectConfigPlugin
+apply plugin: AndroidProjectConfigPlugin
 
 android {
     compileSdkVersion 30

--- a/integration_tests/dependency-on-stubs/build.gradle
+++ b/integration_tests/dependency-on-stubs/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
 
 // test with a project that depends on the stubs jar, not org.robolectric:android-all
 

--- a/integration_tests/libphonenumber/build.gradle
+++ b/integration_tests/libphonenumber/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
 
 dependencies {
     api project(":robolectric")

--- a/integration_tests/mockito-experimental/build.gradle
+++ b/integration_tests/mockito-experimental/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
 
 test {
     systemProperty "robolectric.resourcesMode", "binary"

--- a/integration_tests/mockito/build.gradle
+++ b/integration_tests/mockito/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
 
 test {
     systemProperty "robolectric.resourcesMode", "binary"

--- a/integration_tests/mockk/build.gradle
+++ b/integration_tests/mockk/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
 apply plugin: 'kotlin'
 
 dependencies {

--- a/integration_tests/powermock/build.gradle
+++ b/integration_tests/powermock/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
 
 dependencies {
     api project(":robolectric")

--- a/integration_tests/security-providers/build.gradle
+++ b/integration_tests/security-providers/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
 
 dependencies {
     api project(":robolectric")

--- a/junit/build.gradle
+++ b/junit/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
     api project(":annotations")

--- a/pluginapi/build.gradle
+++ b/pluginapi/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'

--- a/plugins/maven-dependency-resolver/build.gradle
+++ b/plugins/maven-dependency-resolver/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
     api project(":pluginapi")

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -1,5 +1,9 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.gradle.internal.jvm.Jvm
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 class GenerateSdksFileTask extends DefaultTask {
     @OutputFile File outFile
@@ -37,7 +41,7 @@ dependencies {
     api "com.google.guava:guava:27.0.1-jre"
     api "com.google.code.gson:gson:2.8.2"
 
-    def toolsJar = org.gradle.internal.jvm.Jvm.current().getToolsJar()
+    def toolsJar = Jvm.current().getToolsJar()
     if (toolsJar != null) {
         implementation files(toolsJar)
     }

--- a/resources/build.gradle
+++ b/resources/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
     api project(":utils")

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 processResources {
     filesMatching("**/robolectric-version.properties") {

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc6"

--- a/shadowapi/build.gradle
+++ b/shadowapi/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"

--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 apply plugin: ShadowsPlugin
 

--- a/shadows/httpclient/build.gradle
+++ b/shadows/httpclient/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 apply plugin: ShadowsPlugin
 

--- a/shadows/multidex/build.gradle
+++ b/shadows/multidex/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 apply plugin: ShadowsPlugin
 

--- a/shadows/playservices/build.gradle
+++ b/shadows/playservices/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 apply plugin: ShadowsPlugin
 

--- a/shadows/supportv4/build.gradle
+++ b/shadows/supportv4/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 apply plugin: ShadowsPlugin
 

--- a/shadows/supportv4/src/test/java/org/robolectric/shadows/support/v4/ShadowViewPagerTest.java
+++ b/shadows/supportv4/src/test/java/org/robolectric/shadows/support/v4/ShadowViewPagerTest.java
@@ -6,10 +6,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import android.view.View;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
+import android.view.View;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
     api project(":annotations")

--- a/utils/reflector/build.gradle
+++ b/utils/reflector/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: org.robolectric.gradle.RoboJavaModulePlugin
-apply plugin: org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.DeployedRoboJavaModulePlugin
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
     api "org.ow2.asm:asm:9.0"


### PR DESCRIPTION
1. Use import for plugin.
2. Use implementation to replace compile.
