### PR TITLE
Keep ubuntu to ubuntu-18.04 on CI

### DIFF
--- a/.github/workflows/check_java_formatting.yml
+++ b/.github/workflows/check_java_formatting.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check_java_formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
         run: SKIP_JAVADOC=true ./gradlew clean assemble testClasses --parallel --stacktrace
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: build
     strategy:
       fail-fast: false


### PR DESCRIPTION
The ubuntu-latest will change to ubuntu-20.04 soon, and maybe other
version someday. Keep ubuntu to ubuntu-18.04 will ensure the CI scripts
have the same result every run.

See https://github.com/actions/virtual-environments/issues/1816.
