### PR TITLE
Use BufferedImage to scale bitmap

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
@@ -42,6 +42,14 @@ public class ShadowBitmapTest {
   }
 
   @Test
+  public void createScaledBitmap_modifiesPixels() {
+    Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
+    bitmap.eraseColor(Color.BLUE);
+    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 50, 50, /* filter= */ false);
+    assertThat(scaledBitmap.getPixel(0, 0)).isEqualTo(Color.BLUE);
+  }
+
+  @Test
   public void shouldCreateActiveBitmap() {
     Bitmap bitmap = Bitmap.createBitmap(100, 200, Bitmap.Config.ARGB_8888);
     assertThat(bitmap.isRecycled()).isFalse();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
@@ -44,82 +44,52 @@ public class ShadowBitmapTest {
 
   @Test
   public void createScaledBitmap_succeedForLargeBitmapWithFilter() {
-    Bitmap bitmap = Bitmap.createBitmap(100000, 10, Bitmap.Config.ARGB_8888);
-    Bitmap.createScaledBitmap(bitmap, 480000, 48, true);
+    createScaledBitmap_succeedForLargeBitmap(true);
   }
 
   @Test
   public void createScaledBitmap_succeedForLargeBitmapWithoutFilter() {
-    Bitmap bitmap = Bitmap.createBitmap(100000, 10, Bitmap.Config.ARGB_8888);
-    Bitmap.createScaledBitmap(bitmap, 480000, 48, false);
+    createScaledBitmap_succeedForLargeBitmap(false);
   }
 
   @Test
   public void createScaledBitmap_modifiesPixelsWithFilter() {
-    Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
-    bitmap.eraseColor(Color.BLUE);
-    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 50, 50, true);
-    assertThat(scaledBitmap.getPixel(0, 0)).isEqualTo(Color.BLUE);
+    createScaledBitmap_modifiesPixels(true);
   }
 
   @Test
   public void createScaledBitmap_modifiesPixelsWithoutFilter() {
-    Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
-    bitmap.eraseColor(Color.BLUE);
-    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 50, 50, false);
-    assertThat(scaledBitmap.getPixel(0, 0)).isEqualTo(Color.BLUE);
+    createScaledBitmap_modifiesPixels(false);
   }
 
   @Test
   public void createScaledBitmap_expectedUpSizeWithFilter() {
-    Bitmap bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
-    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 32, 32, true);
-    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getWidth()).isEqualTo(32);
-    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getHeight()).isEqualTo(32);
+    createScaledBitmap_expectedUpSize(true);
   }
 
   @Test
   public void createScaledBitmap_expectedUpSizeWithoutFilter() {
-    Bitmap bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
-    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 32, 32, false);
-    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getWidth()).isEqualTo(32);
-    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getHeight()).isEqualTo(32);
+    createScaledBitmap_expectedUpSize(false);
   }
 
   @Test
   public void createScaledBitmap_expectedDownSizeWithFilter() {
-    Bitmap bitmap = Bitmap.createBitmap(32, 32, Bitmap.Config.ARGB_8888);
-    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 10, 10, true);
-    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getWidth()).isEqualTo(10);
-    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getHeight()).isEqualTo(10);
+    createScaledBitmap_expectedDownSize(true);
   }
 
   @Test
   public void createScaledBitmap_expectedDownSizeWithoutFilter() {
-    Bitmap bitmap = Bitmap.createBitmap(32, 32, Bitmap.Config.ARGB_8888);
-    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 10, 10, false);
-    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getWidth()).isEqualTo(10);
-    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getHeight()).isEqualTo(10);
+    createScaledBitmap_expectedDownSize(false);
   }
 
   @Test
   public void createScaledBitmap_drawOnScaledWithFilter() {
-    Bitmap original = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
-    Bitmap scaled = Bitmap.createScaledBitmap(original, 32, 32, false);
-    Canvas canvas = new Canvas(scaled);
-    Paint p = new Paint(Paint.ANTI_ALIAS_FLAG);
-    p.setColor(Color.BLACK);
-    canvas.drawRect(new Rect(0, 0, 32, 32), p);
+    createScaledBitmap_drawOnScaled(true);
   }
 
   @Test
   public void createScaledBitmap_drawOnScaledWithoutFilter() {
-    Bitmap original = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
-    Bitmap scaled = Bitmap.createScaledBitmap(original, 32, 32, false);
-    Canvas canvas = new Canvas(scaled);
-    Paint p = new Paint(Paint.ANTI_ALIAS_FLAG);
-    p.setColor(Color.BLACK);
-    canvas.drawRect(new Rect(0, 0, 32, 32), p);
+    createScaledBitmap_drawOnScaled(false);
   }
 
   @Test
@@ -797,5 +767,40 @@ public class ShadowBitmapTest {
 
   private static int packRGB(int r, int g, int b) {
     return 0xff000000 | r << 16 | g << 8 | b;
+  }
+
+  private void createScaledBitmap_succeedForLargeBitmap(boolean filter) {
+    Bitmap bitmap = Bitmap.createBitmap(100000, 10, Bitmap.Config.ARGB_8888);
+    Bitmap.createScaledBitmap(bitmap, 480000, 48, filter);
+  }
+
+  private void createScaledBitmap_modifiesPixels(boolean filter) {
+    Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
+    bitmap.eraseColor(Color.BLUE);
+    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 50, 50, filter);
+    assertThat(scaledBitmap.getPixel(0, 0)).isEqualTo(Color.BLUE);
+  }
+
+  private void createScaledBitmap_expectedUpSize(boolean filter) {
+    Bitmap bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
+    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 32, 32, filter);
+    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getWidth()).isEqualTo(32);
+    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getHeight()).isEqualTo(32);
+  }
+
+  private void createScaledBitmap_expectedDownSize(boolean filter) {
+    Bitmap bitmap = Bitmap.createBitmap(32, 32, Bitmap.Config.ARGB_8888);
+    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 10, 10, filter);
+    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getWidth()).isEqualTo(10);
+    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getHeight()).isEqualTo(10);
+  }
+
+  private void createScaledBitmap_drawOnScaled(boolean filter) {
+    Bitmap original = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
+    Bitmap scaled = Bitmap.createScaledBitmap(original, 32, 32, filter);
+    Canvas canvas = new Canvas(scaled);
+    Paint p = new Paint(Paint.ANTI_ALIAS_FLAG);
+    p.setColor(Color.BLACK);
+    canvas.drawRect(new Rect(0, 0, 32, 32), p);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
@@ -43,6 +43,18 @@ public class ShadowBitmapTest {
   }
 
   @Test
+  public void createScaledBitmap_succeedForLargeBitmapWithFilter() {
+    Bitmap bitmap = Bitmap.createBitmap(100000, 10, Bitmap.Config.ARGB_8888);
+    Bitmap.createScaledBitmap(bitmap, 480000, 48, true);
+  }
+
+  @Test
+  public void createScaledBitmap_succeedForLargeBitmapWithoutFilter() {
+    Bitmap bitmap = Bitmap.createBitmap(100000, 10, Bitmap.Config.ARGB_8888);
+    Bitmap.createScaledBitmap(bitmap, 480000, 48, false);
+  }
+
+  @Test
   public void createScaledBitmap_modifiesPixelsWithFilter() {
     Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
     bitmap.eraseColor(Color.BLUE);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
@@ -12,6 +12,7 @@ import android.graphics.ColorMatrix;
 import android.graphics.ColorMatrixColorFilter;
 import android.graphics.Matrix;
 import android.graphics.Paint;
+import android.graphics.Rect;
 import android.os.Build;
 import android.os.Parcel;
 import android.util.DisplayMetrics;
@@ -42,11 +43,71 @@ public class ShadowBitmapTest {
   }
 
   @Test
-  public void createScaledBitmap_modifiesPixels() {
+  public void createScaledBitmap_modifiesPixelsWithFilter() {
     Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
     bitmap.eraseColor(Color.BLUE);
-    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 50, 50, /* filter= */ false);
+    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 50, 50, true);
     assertThat(scaledBitmap.getPixel(0, 0)).isEqualTo(Color.BLUE);
+  }
+
+  @Test
+  public void createScaledBitmap_modifiesPixelsWithoutFilter() {
+    Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
+    bitmap.eraseColor(Color.BLUE);
+    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 50, 50, false);
+    assertThat(scaledBitmap.getPixel(0, 0)).isEqualTo(Color.BLUE);
+  }
+
+  @Test
+  public void createScaledBitmap_expectedUpSizeWithFilter() {
+    Bitmap bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
+    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 32, 32, true);
+    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getWidth()).isEqualTo(32);
+    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getHeight()).isEqualTo(32);
+  }
+
+  @Test
+  public void createScaledBitmap_expectedUpSizeWithoutFilter() {
+    Bitmap bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
+    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 32, 32, false);
+    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getWidth()).isEqualTo(32);
+    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getHeight()).isEqualTo(32);
+  }
+
+  @Test
+  public void createScaledBitmap_expectedDownSizeWithFilter() {
+    Bitmap bitmap = Bitmap.createBitmap(32, 32, Bitmap.Config.ARGB_8888);
+    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 10, 10, true);
+    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getWidth()).isEqualTo(10);
+    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getHeight()).isEqualTo(10);
+  }
+
+  @Test
+  public void createScaledBitmap_expectedDownSizeWithoutFilter() {
+    Bitmap bitmap = Bitmap.createBitmap(32, 32, Bitmap.Config.ARGB_8888);
+    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, 10, 10, false);
+    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getWidth()).isEqualTo(10);
+    assertThat(Shadows.shadowOf(scaledBitmap).getBufferedImage().getHeight()).isEqualTo(10);
+  }
+
+  @Test
+  public void createScaledBitmap_drawOnScaledWithFilter() {
+    Bitmap original = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
+    Bitmap scaled = Bitmap.createScaledBitmap(original, 32, 32, false);
+    Canvas canvas = new Canvas(scaled);
+    Paint p = new Paint(Paint.ANTI_ALIAS_FLAG);
+    p.setColor(Color.BLACK);
+    canvas.drawRect(new Rect(0, 0, 32, 32), p);
+  }
+
+  @Test
+  public void createScaledBitmap_drawOnScaledWithoutFilter() {
+    Bitmap original = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
+    Bitmap scaled = Bitmap.createScaledBitmap(original, 32, 32, false);
+    Canvas canvas = new Canvas(scaled);
+    Paint p = new Paint(Paint.ANTI_ALIAS_FLAG);
+    p.setColor(Color.BLACK);
+    canvas.drawRect(new Rect(0, 0, 32, 32), p);
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ImageUtil.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ImageUtil.java
@@ -34,7 +34,7 @@ public class ImageUtil {
   private static final String FORMAT_NAME_PNG = "png";
   private static boolean initialized;
 
-  public static Point getImageSizeFromStream(InputStream is) {
+  static Point getImageSizeFromStream(InputStream is) {
     if (!initialized) {
       // Stops ImageIO from creating temp files when reading images
       // from input stream.
@@ -59,7 +59,7 @@ public class ImageUtil {
     }
   }
 
-  public static RobolectricBufferedImage getImageFromStream(InputStream is) {
+  static RobolectricBufferedImage getImageFromStream(InputStream is) {
     if (!initialized) {
       // Stops ImageIO from creating temp files when reading images
       // from input stream.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ImageUtil.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ImageUtil.java
@@ -100,11 +100,13 @@ public class ImageUtil {
     if (before == null || before.getColorModel() == null) {
       return false;
     }
+    int dstWidth = dst.getWidth();
+    int dstHeight = dst.getHeight();
     int imageType = getBufferedImageType(src.getConfig(), before.getColorModel().hasAlpha());
-    BufferedImage after = new BufferedImage(srcWidth, srcHeight, imageType);
+    BufferedImage after = new BufferedImage(dstWidth, dstHeight, imageType);
     AffineTransform at = new AffineTransform();
-    at.scale(dst.getWidth() * 1.0f / srcWidth, dst.getHeight() * 1.0f / srcHeight);
-    // See Andriod's Bitmap#createScaledBitmap SDK doc
+    at.scale(dstWidth * 1.0f / srcWidth, dstHeight * 1.0f / srcHeight);
+    // See Android's Bitmap#createScaledBitmap SDK doc
     int interpolationType = filter ? TYPE_BILINEAR : TYPE_NEAREST_NEIGHBOR;
     AffineTransformOp scaleOp = new AffineTransformOp(at, interpolationType);
     ShadowBitmap shadowBitmap = Shadow.extract(dst);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmap.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmap.java
@@ -377,16 +377,18 @@ public class ShadowBitmap {
     if (shadowBitmap.config == null) {
       shadowBitmap.config = Config.ARGB_8888;
     }
-    shadowBitmap.bufferedImage =
-        new BufferedImage(dstWidth, dstHeight, BufferedImage.TYPE_INT_ARGB);
-    shadowBitmap.setPixelsInternal(
-        new int[shadowBitmap.getHeight() * shadowBitmap.getWidth()],
-        0,
-        0,
-        0,
-        0,
-        shadowBitmap.getWidth(),
-        shadowBitmap.getHeight());
+    if (!ImageUtil.scaledBitmap(src, scaledBitmap, filter)) {
+      shadowBitmap.bufferedImage =
+          new BufferedImage(dstWidth, dstHeight, BufferedImage.TYPE_INT_ARGB);
+      shadowBitmap.setPixelsInternal(
+          new int[shadowBitmap.getHeight() * shadowBitmap.getWidth()],
+          0,
+          0,
+          0,
+          0,
+          shadowBitmap.getWidth(),
+          shadowBitmap.getHeight());
+    }
     return scaledBitmap;
   }
 


### PR DESCRIPTION
Use `BufferedImage` to scale `Bitmap`. It also remove unused throws from `ShadowBitmapTest`'s test methods to clean up test code.

Close https://github.com/robolectric/robolectric/issues/6273