### PR TITLE
Add mutable checking for ShadowBitmap.setPixels

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapTest.java
@@ -282,6 +282,12 @@ public class ShadowBitmapTest {
     bitmap.setPixel(0, 0, 2);
   }
 
+  @Test(expected = IllegalStateException.class)
+  public void shouldThrowExceptionForSetPixelsOnImmutableBitmap() {
+    Bitmap bitmap = Bitmap.createBitmap(new int[] {1}, 1, 1, Bitmap.Config.ARGB_8888);
+    bitmap.setPixels(new int[] {1}, 0, 0, 0, 0, 1, 1);
+  }
+
   @Test
   public void bitmapsAreReused() {
     Bitmap b = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmap.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmap.java
@@ -267,17 +267,14 @@ public class ShadowBitmap {
     if (shadowBitmap.config == null) {
       shadowBitmap.config = Config.ARGB_8888;
     }
-    boolean isMutable = shadowBitmap.isMutable();
-    shadowBitmap.setMutable(true);
-    shadowBitmap.setPixels(
-            new int[shadowBitmap.getHeight() * shadowBitmap.getWidth()],
-            0,
-            0,
-            0,
-            0,
-            shadowBitmap.getWidth(),
-            shadowBitmap.getHeight());
-    shadowBitmap.setMutable(isMutable);
+    shadowBitmap.setPixelsInternal(
+        new int[shadowBitmap.getHeight() * shadowBitmap.getWidth()],
+        0,
+        0,
+        0,
+        0,
+        shadowBitmap.getWidth(),
+        shadowBitmap.getHeight());
     return scaledBitmap;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmap.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmap.java
@@ -267,14 +267,17 @@ public class ShadowBitmap {
     if (shadowBitmap.config == null) {
       shadowBitmap.config = Config.ARGB_8888;
     }
+    boolean isMutable = shadowBitmap.isMutable();
+    shadowBitmap.setMutable(true);
     shadowBitmap.setPixels(
-        new int[shadowBitmap.getHeight() * shadowBitmap.getWidth()],
-        0,
-        0,
-        0,
-        0,
-        shadowBitmap.getWidth(),
-        shadowBitmap.getHeight());
+            new int[shadowBitmap.getHeight() * shadowBitmap.getWidth()],
+            0,
+            0,
+            0,
+            0,
+            shadowBitmap.getWidth(),
+            shadowBitmap.getHeight());
+    shadowBitmap.setMutable(isMutable);
     return scaledBitmap;
   }
 
@@ -305,6 +308,7 @@ public class ShadowBitmap {
   @Implementation
   protected void setPixels(
       int[] pixels, int offset, int stride, int x, int y, int width, int height) {
+    checkBitmapMutable();
     this.colors = pixels;
   }
 
@@ -400,11 +404,7 @@ public class ShadowBitmap {
 
   @Implementation
   protected void setPixel(int x, int y, int color) {
-    if (isRecycled()) {
-      throw new IllegalStateException("Can't call setPixel() on a recycled bitmap");
-    } else if (!isMutable()) {
-      throw new IllegalStateException("Bitmap is immutable");
-    }
+    checkBitmapMutable();
     internalCheckPixelAccess(x, y);
     if (colors == null) {
       colors = new int[getWidth() * getHeight()];
@@ -730,6 +730,22 @@ public class ShadowBitmap {
   public void setCreatedFromResId(int resId, String description) {
     this.createdFromResId = resId;
     appendDescription(" for resource:" + description);
+  }
+
+  void setPixelsForcibly(
+      int[] pixels, int offset, int stride, int x, int y, int width, int height) {
+    boolean isMutable = isMutable();
+    setMutable(true);
+    setPixels(pixels, offset, stride, x, y, width, height);
+    setMutable(isMutable);
+  }
+
+  private void checkBitmapMutable() {
+    if (isRecycled()) {
+      throw new IllegalStateException("Can't call setPixel() on a recycled bitmap");
+    } else if (!isMutable()) {
+      throw new IllegalStateException("Bitmap is immutable");
+    }
   }
 
   private void internalCheckPixelAccess(int x, int y) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmap.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmap.java
@@ -309,7 +309,7 @@ public class ShadowBitmap {
   protected void setPixels(
       int[] pixels, int offset, int stride, int x, int y, int width, int height) {
     checkBitmapMutable();
-    this.colors = pixels;
+    setPixelsInternal(pixels, offset, stride, x, y, width, height);
   }
 
   @Implementation
@@ -732,12 +732,9 @@ public class ShadowBitmap {
     appendDescription(" for resource:" + description);
   }
 
-  void setPixelsForcibly(
+  void setPixelsInternal(
       int[] pixels, int offset, int stride, int x, int y, int width, int height) {
-    boolean isMutable = isMutable();
-    setMutable(true);
-    setPixels(pixels, offset, stride, x, y, width, height);
-    setMutable(isMutable);
+    this.colors = pixels;
   }
 
   private void checkBitmapMutable() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -297,13 +297,7 @@ public class ShadowBitmapFactory {
               int[] pixels = shadowBitmap.getPixelsInternal();
               if (pixels.length == image.getWidth() * image.getHeight()) {
                 image.getRGB(
-                    0,
-                    0,
-                    image.getWidth(),
-                    image.getHeight(),
-                    pixels,
-                    0,
-                    image.getWidth());
+                    0, 0, image.getWidth(), image.getHeight(), pixels, 0, image.getWidth());
               }
             });
     shadowBitmap.setMutable(mutable);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -343,7 +343,7 @@ public class ShadowBitmapFactory {
 
     shadowBitmap.setWidth(p.x);
     shadowBitmap.setHeight(p.y);
-    shadowBitmap.setPixels(new int[p.x * p.y], 0, 0, 0, 0, p.x, p.y);
+    shadowBitmap.setPixelsForcibly(new int[p.x * p.y], 0, 0, 0, 0, p.x, p.y);
     if (options != null) {
       options.outWidth = p.x;
       options.outHeight = p.y;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -343,7 +343,7 @@ public class ShadowBitmapFactory {
 
     shadowBitmap.setWidth(p.x);
     shadowBitmap.setHeight(p.y);
-    shadowBitmap.setPixelsForcibly(new int[p.x * p.y], 0, 0, 0, 0, p.x, p.y);
+    shadowBitmap.setPixelsInternal(new int[p.x * p.y], 0, 0, 0, 0, p.x, p.y);
     if (options != null) {
       options.outWidth = p.x;
       options.outHeight = p.y;


### PR DESCRIPTION
This CL also create a package level method called `setPixelsInternal` for
internal usage to set pixels more concise. If the user wants to set
pixels to `ShadowBitmap`, it should use the following example:

```java
boolean isMutable = shadowBitmap.isMutable();
setMutable(true);
shadowBitmap.setPixels(...);
setMutable(isMutable);
```

Close https://github.com/robolectric/robolectric/issues/6281