### PR TITLE
Make RobolectricTestRunner#getConfiguration private

### DIFF
--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -478,8 +478,7 @@ public class RobolectricTestRunner extends SandboxTestRunner {
    *
    * @deprecated Going away before 4.2. DO NOT SHIP.
    */
-  @Deprecated
-  protected Configuration getConfiguration(Method method) {
+  private Configuration getConfiguration(Method method) {
     Configuration configuration =
         configurationStrategy.getConfig(getTestClass().getJavaClass(), method);
 


### PR DESCRIPTION
This method is deprecated about two years ago, and it doesn't want to
be shipped with 4.2, and later version. So this CL make it private.

Close https://github.com/robolectric/robolectric/issues/4547.
