### PR TITLE
Migrate jcenter to mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.gradle.plugins.ide.idea.model.IdeaModel
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         gradlePluginPortal()
     }
 
@@ -20,8 +20,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
+        gradlePluginPortal()
     }
 
     group = "org.robolectric"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,7 +3,8 @@ apply plugin: "groovy"
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
+    gradlePluginPortal()
 }
 
 dependencies {


### PR DESCRIPTION
See https://developer.android.com/studio/build/jcenter-migration
and https://stackoverflow.com/questions/49573157/android-studio-3-1-could-not-find-org-jetbrains-trove4jtrove4j20160824.