### PR TITLE
Revert "Change max sdk to R for ShadowIntrumentation#execStartActivityAsCaller"

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
@@ -10,7 +10,6 @@ import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.N_MR1;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.P;
-import static android.os.Build.VERSION_CODES.R;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -243,7 +242,7 @@ public class ShadowInstrumentation {
     }
   }
 
-  @Implementation(minSdk = M, maxSdk = R)
+  @Implementation(minSdk = M, maxSdk = P)
   protected ActivityResult execStartActivityAsCaller(
       Context who,
       IBinder contextThread,


### PR DESCRIPTION
Reverts robolectric/robolectric#6320

Looks like the parameters are different in R (and possibly Q):

https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/app/Instrumentation.java;l=1948-1951?q=execStartActivityAsCaller

