### PR TITLE
Remove ShadowIntrumentation#execStartActivityAsCaller

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
@@ -241,21 +241,7 @@ public class ShadowInstrumentation {
       throw new ActivityNotFoundException(intent.getAction());
     }
   }
-
-  @Implementation(minSdk = M, maxSdk = P)
-  protected ActivityResult execStartActivityAsCaller(
-      Context who,
-      IBinder contextThread,
-      IBinder token,
-      Activity target,
-      Intent intent,
-      int requestCode,
-      Bundle options,
-      boolean ignoreTargetSecurity,
-      int userId) {
-    throw new UnsupportedOperationException("Implement me!!");
-  }
-
+  
   void sendOrderedBroadcastAsUser(
       Intent intent,
       UserHandle userHandle,


### PR DESCRIPTION
It is not implemented, and there are no users to report the problem
related to this method. So it can be removed for cleaning.
