### PR TITLE
Support to handle emoji in xml

### DIFF
--- a/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
+++ b/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
@@ -914,8 +914,12 @@ public class ResourcesTest {
     assertThat(xmlResourceParser.getName()).isEqualTo("EmojiRoot");
     AttributeSet attributeSet = Xml.asAttributeSet(xmlResourceParser);
     assertThat(attributeSet.getAttributeValue(null, "label1")).isEqualTo("no emoji");
-    assertThat(attributeSet.getAttributeValue(null, "label2")).isEqualTo("\uD83D\uDE00");
-    assertThat(attributeSet.getAttributeValue(null, "label3")).isEqualTo("\uD83D\uDE00");
+    String pureEmoji = "\uD83D\uDE00";
+    assertThat(attributeSet.getAttributeValue(null, "label2")).isEqualTo(pureEmoji);
+    assertThat(attributeSet.getAttributeValue(null, "label3")).isEqualTo(pureEmoji);
+    String mixEmojiAndText = "\uD83D\uDE00internal1\uD83D\uDE00internal2\uD83D\uDE00";
+    assertThat(attributeSet.getAttributeValue(null, "label4")).isEqualTo(mixEmojiAndText);
+    assertThat(attributeSet.getAttributeValue(null, "label5")).isEqualTo(mixEmojiAndText);
   }
 
   @Test

--- a/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
+++ b/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
@@ -920,6 +920,8 @@ public class ResourcesTest {
     String mixEmojiAndText = "\uD83D\uDE00internal1\uD83D\uDE00internal2\uD83D\uDE00";
     assertThat(attributeSet.getAttributeValue(null, "label4")).isEqualTo(mixEmojiAndText);
     assertThat(attributeSet.getAttributeValue(null, "label5")).isEqualTo(mixEmojiAndText);
+    assertThat(attributeSet.getAttributeValue(null, "label6"))
+        .isEqualTo("don't worry be \uD83D\uDE00");
   }
 
   @Test

--- a/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
+++ b/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
@@ -45,6 +45,7 @@ import androidx.test.InstrumentationRegistry;
 import androidx.test.filters.SdkSuppress;
 import androidx.test.runner.AndroidJUnit4;
 import com.google.common.collect.Range;
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import org.junit.Before;
@@ -55,6 +56,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.testapp.R;
 import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
 
 /**
  * Compatibility test for {@link Resources}
@@ -902,6 +904,18 @@ public class ResourcesTest {
     assertThat(xmlResourceParser.next()).isEqualTo(XmlResourceParser.START_DOCUMENT);
     assertThat(xmlResourceParser.next()).isEqualTo(XmlResourceParser.START_TAG);
     assertThat(xmlResourceParser.getName()).isEqualTo("PreferenceScreen");
+  }
+
+  @Test
+  public void getXml_shouldParseEmojiCorrectly() throws IOException, XmlPullParserException {
+    XmlResourceParser xmlResourceParser = resources.getXml(R.xml.has_emoji);
+    xmlResourceParser.next();
+    xmlResourceParser.next();
+    assertThat(xmlResourceParser.getName()).isEqualTo("EmojiRoot");
+    AttributeSet attributeSet = Xml.asAttributeSet(xmlResourceParser);
+    assertThat(attributeSet.getAttributeValue(null, "label1")).isEqualTo("no emoji");
+    assertThat(attributeSet.getAttributeValue(null, "label2")).isEqualTo("\uD83D\uDE00");
+    assertThat(attributeSet.getAttributeValue(null, "label3")).isEqualTo("\uD83D\uDE00");
   }
 
   @Test

--- a/resources/src/main/java/org/robolectric/res/android/ResourceString.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResourceString.java
@@ -82,7 +82,7 @@ public final class ResourceString {
     } else {
       length = characterCount * 2;
     }
-    final ByteBuffer stringBuffer = ByteBuffer.wrap(buffer.array(), offset, length);
+    ByteBuffer stringBuffer = ByteBuffer.wrap(buffer.array(), offset, length);
     // Use normal UTF-8 and UTF-16 decoder to decode string
     try {
       return type.decoder().decode(stringBuffer).toString();
@@ -91,6 +91,7 @@ public final class ResourceString {
         return null;
       }
     }
+    stringBuffer = ByteBuffer.wrap(buffer.array(), offset, length);
     // Use CESU8 decoder to try decode failed UTF-8 string, especially modified UTF-8.
     // See
     // https://source.android.com/devices/tech/dalvik/dex-format?hl=hr-HR&skip_cache=true#mutf-8.

--- a/resources/src/main/java/org/robolectric/res/android/ResourceString.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResourceString.java
@@ -92,7 +92,8 @@ public final class ResourceString {
       }
     }
     // Use CESU8 decoder to try decode failed UTF-8 string, especially modified UTF-8.
-    // See https://en.wikipedia.org/wiki/CESU-8.
+    // See
+    // https://source.android.com/devices/tech/dalvik/dex-format?hl=hr-HR&skip_cache=true#mutf-8.
     try {
       return Type.CESU8.decoder().decode(stringBuffer).toString();
     } catch (CharacterCodingException e) {

--- a/testapp/src/main/res/xml/has_emoji.xml
+++ b/testapp/src/main/res/xml/has_emoji.xml
@@ -3,5 +3,7 @@
 <EmojiRoot
     label1="no emoji"
     label2="&#128512;"
-    label3="😀" >
+    label3="😀"
+    label4="😀internal1😀internal2😀"
+    label5="&#128512;internal1&#128512;internal2&#128512;">
 </EmojiRoot>

--- a/testapp/src/main/res/xml/has_emoji.xml
+++ b/testapp/src/main/res/xml/has_emoji.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- The emoji unicode is \uD83D\uDE00 -->
+<EmojiRoot
+    label1="no emoji"
+    label2="&#128512;"
+    label3="😀" >
+</EmojiRoot>

--- a/testapp/src/main/res/xml/has_emoji.xml
+++ b/testapp/src/main/res/xml/has_emoji.xml
@@ -5,5 +5,6 @@
     label2="&#128512;"
     label3="😀"
     label4="😀internal1😀internal2😀"
-    label5="&#128512;internal1&#128512;internal2&#128512;">
+    label5="&#128512;internal1&#128512;internal2&#128512;"
+    label6="don't worry be 😀">
 </EmojiRoot>


### PR DESCRIPTION
We found emoji/unicode is compressed with modified `UTF-8`, and normal
`String` decoding can't process it correctly, so we should use
`DataInputStream` to read `UTF-8` firstly to fix this problem. If it
encounters any problem, it will fallback to normal `String` decoding.

Close https://github.com/robolectric/robolectric/issues/6433

