### PR TITLE
Migrate tests from ShadowResourcesTest to ResourcesTest

### DIFF
--- a/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
+++ b/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
@@ -805,27 +805,31 @@ public class ResourcesTest {
     typedArray.recycle();
   }
 
-  // @Test
-  // public void obtainStyledAttributesShouldCheckXmlFirst_andFollowReferences() throws Exception {
-  //
-  //   // This simulates a ResourceProvider built from a 21+ SDK as viewportHeight / viewportWidth were introduced in API 21
-  //   // but the public ID values they are assigned clash with private com.android.internal.R values on older SDKs. This
-  //   // test ensures that even on older SDKs, on calls to obtainStyledAttributes() Robolectric will first check for matching
-  //   // resource ID values in the AttributeSet before checking the theme.
-  //
-  //   AttributeSet attributes = Robolectric.buildAttributeSet()
-  //       .addAttribute(android.R.attr.viewportWidth, "@integer/test_integer1")
-  //       .addAttribute(android.R.attr.viewportHeight, "@integer/test_integer2")
-  //       .build();
-  //
-  //   TypedArray typedArray = context.getTheme().obtainStyledAttributes(attributes, new int[] {
-  //       android.R.attr.viewportWidth,
-  //       android.R.attr.viewportHeight
-  //   }, 0, 0);
-  //   assertThat(typedArray.getFloat(0, 0)).isEqualTo(2000);
-  //   assertThat(typedArray.getFloat(1, 0)).isEqualTo(9);
-  //   typedArray.recycle();
-  // }
+  @Test
+  public void obtainStyledAttributesShouldCheckXmlFirst_andFollowReferences() {
+    // This simulates a ResourceProvider built from a 21+ SDK as viewportHeight / viewportWidth were
+    // introduced in API 21 but the public ID values they are assigned clash with private
+    // com.android.internal.R values on older SDKs. This test ensures that even on older SDKs,
+    // on calls to obtainStyledAttributes() Robolectric will first check for matching
+    // resource ID values in the AttributeSet before checking the theme.
+    AttributeSet attributes =
+        Robolectric.buildAttributeSet()
+            .addAttribute(android.R.attr.viewportWidth, "@integer/test_integer1")
+            .addAttribute(android.R.attr.viewportHeight, "@integer/test_integer2")
+            .build();
+
+    TypedArray typedArray =
+        context
+            .getTheme()
+            .obtainStyledAttributes(
+                attributes,
+                new int[] {android.R.attr.viewportWidth, android.R.attr.viewportHeight},
+                0,
+                0);
+    assertThat(typedArray.getFloat(0, 0)).isEqualTo(2000);
+    assertThat(typedArray.getFloat(1, 0)).isEqualTo(9);
+    typedArray.recycle();
+  }
 
   @Test
   @SdkSuppress(minSdkVersion = LOLLIPOP)

--- a/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
+++ b/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
@@ -693,6 +693,17 @@ public class ResourcesTest {
   }
 
   @Test
+  public void obtainAttributes_shouldUseReferencedIdFromAttributeSet() {
+    // android:id/mask was introduced in API 21, but it's still possible for apps built against API
+    // 21 to refer to it in older runtimes because referenced resource ids are compiled (by aapt)
+    // into the binary XML format.
+    AttributeSet attributeSet =
+        Robolectric.buildAttributeSet().addAttribute(android.R.attr.id, "@android:id/mask").build();
+    TypedArray typedArray = resources.obtainAttributes(attributeSet, new int[] {android.R.attr.id});
+    assertThat(typedArray.getResourceId(0, -9)).isEqualTo(android.R.id.mask);
+  }
+
+  @Test
   public void obtainAttributes_shouldReturnValuesFromAttributeSet() {
     AttributeSet attributes =
         Robolectric.buildAttributeSet()

--- a/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
+++ b/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
@@ -677,6 +677,22 @@ public class ResourcesTest {
     assertThat(out.data).isEqualTo(android.R.color.black);
   }
 
+  @Test
+  public void obtainAttributes_shouldReturnValuesFromResources() throws Exception {
+    XmlPullParser parser = resources.getXml(R.xml.xml_attrs);
+    parser.next();
+    parser.next();
+    AttributeSet attributes = Xml.asAttributeSet(parser);
+
+    TypedArray typedArray =
+        resources.obtainAttributes(
+            attributes, new int[] {android.R.attr.title, android.R.attr.scrollbarFadeDuration});
+
+    assertThat(typedArray.getString(0)).isEqualTo("Android Title");
+    assertThat(typedArray.getInt(1, 0)).isEqualTo(1111);
+    typedArray.recycle();
+  }
+
   // @Test
   // public void obtainAttributes_shouldUseReferencedIdFromAttributeSet() throws Exception {
   //   // android:id/mask was introduced in API 21, but it's still possible for apps built against API 21 to refer to it

--- a/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
+++ b/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
@@ -3,6 +3,7 @@ package android.content.res;
 import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.KITKAT_WATCH;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.N_MR1;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.Q;
 import static android.util.TypedValue.COMPLEX_UNIT_DIP;
@@ -52,6 +53,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.testapp.R;
@@ -678,6 +680,19 @@ public class ResourcesTest {
   }
 
   @Test
+  @Config(minSdk = N_MR1)
+  public void obtainAttributes() {
+    TypedArray typedArray =
+        resources.obtainAttributes(
+            Robolectric.buildAttributeSet()
+                .addAttribute(R.attr.styleReference, "@xml/shortcuts")
+                .build(),
+            new int[] {R.attr.styleReference});
+    assertThat(typedArray).isNotNull();
+    assertThat(typedArray.peekValue(0).resourceId).isEqualTo(R.xml.shortcuts);
+  }
+
+  @Test
   public void obtainAttributes_shouldReturnValuesFromResources() throws Exception {
     XmlPullParser parser = resources.getXml(R.xml.xml_attrs);
     parser.next();
@@ -701,15 +716,6 @@ public class ResourcesTest {
   //       .addAttribute(android.R.attr.id, "@android:id/mask").build();
   //   TypedArray typedArray = resources.obtainAttributes(attributeSet, new int[]{android.R.attr.id});
   //   assertThat(typedArray.getResourceId(0, -9)).isEqualTo(android.R.id.mask);
-  // }
-  //
-  // @Test
-  // public void obtainAttributes() {
-  //   TypedArray typedArray = resources.obtainAttributes(Robolectric.buildAttributeSet()
-  //       .addAttribute(R.attr.styleReference, "@xml/shortcuts")
-  //       .build(), new int[]{R.attr.styleReference});
-  //   assertThat(typedArray).isNotNull();
-  //   assertThat(typedArray.peekValue(0).resourceId).isEqualTo(R.xml.shortcuts);
   // }
 
   @Test

--- a/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
+++ b/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
@@ -693,6 +693,25 @@ public class ResourcesTest {
   }
 
   @Test
+  public void obtainAttributes_shouldReturnValuesFromAttributeSet() {
+    AttributeSet attributes =
+        Robolectric.buildAttributeSet()
+            .addAttribute(android.R.attr.title, "A title!")
+            .addAttribute(android.R.attr.width, "12px")
+            .addAttribute(android.R.attr.height, "1in")
+            .build();
+    TypedArray typedArray =
+        resources.obtainAttributes(
+            attributes,
+            new int[] {android.R.attr.height, android.R.attr.width, android.R.attr.title});
+
+    assertThat(typedArray.getDimension(0, 0)).isEqualTo(160f);
+    assertThat(typedArray.getDimension(1, 0)).isEqualTo(12f);
+    assertThat(typedArray.getString(2)).isEqualTo("A title!");
+    typedArray.recycle();
+  }
+
+  @Test
   public void obtainAttributes_shouldReturnValuesFromResources() throws Exception {
     XmlPullParser parser = resources.getXml(R.xml.xml_attrs);
     parser.next();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -126,16 +126,6 @@ public class ShadowResourcesTest {
 
   // todo: port to ResourcesTest
   @Test
-  public void obtainAttributes() {
-    TypedArray typedArray = resources.obtainAttributes(Robolectric.buildAttributeSet()
-        .addAttribute(R.attr.styleReference, "@xml/shortcuts")
-        .build(), new int[]{R.attr.styleReference});
-    assertThat(typedArray).isNotNull();
-    assertThat(typedArray.peekValue(0).resourceId).isEqualTo(R.xml.shortcuts);
-  }
-
-  // todo: port to ResourcesTest
-  @Test
   public void obtainAttributes_shouldReturnValuesFromAttributeSet() {
     AttributeSet attributes = Robolectric.buildAttributeSet()
         .addAttribute(android.R.attr.title, "A title!")

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -139,35 +139,6 @@ public class ShadowResourcesTest {
     typedArray.recycle();
   }
 
-  // todo: port to ResourcesTest
-  @Test
-  public void obtainStyledAttributesShouldCheckXmlFirst_andFollowReferences() {
-    // TODO: investigate failure with binary resources
-    assumeTrue(useLegacy());
-
-    // This simulates a ResourceProvider built from a 21+ SDK as viewportHeight / viewportWidth were introduced in API 21
-    // but the public ID values they are assigned clash with private com.android.internal.R values on older SDKs. This
-    // test ensures that even on older SDKs, on calls to obtainStyledAttributes() Robolectric will first check for matching
-    // resource ID values in the AttributeSet before checking the theme.
-
-    AttributeSet attributes = Robolectric.buildAttributeSet()
-        .addAttribute(android.R.attr.viewportWidth, "@dimen/dimen20px")
-        .addAttribute(android.R.attr.viewportHeight, "@dimen/dimen30px")
-        .build();
-
-    TypedArray typedArray =
-        ApplicationProvider.getApplicationContext()
-            .getTheme()
-            .obtainStyledAttributes(
-                attributes,
-                new int[] {android.R.attr.viewportWidth, android.R.attr.viewportHeight},
-                0,
-                0);
-    assertThat(typedArray.getDimension(0, 0)).isEqualTo(20f);
-    assertThat(typedArray.getDimension(1, 0)).isEqualTo(30f);
-    typedArray.recycle();
-  }
-
   @Test
   public void getXml_shouldHavePackageContextForReferenceResolution() {
     if (!useLegacy()) {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -152,22 +152,6 @@ public class ShadowResourcesTest {
     typedArray.recycle();
   }
 
-  // todo: port to ResourcesTest
-  @Test
-  public void obtainAttributes_shouldReturnValuesFromResources() throws Exception {
-    XmlPullParser parser = resources.getXml(R.xml.xml_attrs);
-    parser.next();
-    parser.next();
-    AttributeSet attributes = Xml.asAttributeSet(parser);
-
-    TypedArray typedArray = resources
-        .obtainAttributes(attributes, new int[]{android.R.attr.title, android.R.attr.scrollbarFadeDuration});
-
-    assertThat(typedArray.getString(0)).isEqualTo("Android Title");
-    assertThat(typedArray.getInt(1, 0)).isEqualTo(1111);
-    typedArray.recycle();
-  }
-
   @Test
   public void obtainStyledAttributes_shouldCheckXmlFirst_fromAttributeSetBuilder() {
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -113,17 +113,6 @@ public class ShadowResourcesTest {
     assertThat(out.data).isEqualTo(android.R.color.black);
   }
 
-  // todo: port to ResourcesTest
-  @Test
-  public void obtainAttributes_shouldUseReferencedIdFromAttributeSet() {
-    // android:id/mask was introduced in API 21, but it's still possible for apps built against API 21 to refer to it
-    // in older runtimes because referenced resource ids are compiled (by aapt) into the binary XML format.
-    AttributeSet attributeSet = Robolectric.buildAttributeSet()
-        .addAttribute(android.R.attr.id, "@android:id/mask").build();
-    TypedArray typedArray = resources.obtainAttributes(attributeSet, new int[]{android.R.attr.id});
-    assertThat(typedArray.getResourceId(0, -9)).isEqualTo(android.R.id.mask);
-  }
-
   @Test
   public void obtainStyledAttributes_shouldCheckXmlFirst_fromAttributeSetBuilder() {
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -124,24 +124,6 @@ public class ShadowResourcesTest {
     assertThat(typedArray.getResourceId(0, -9)).isEqualTo(android.R.id.mask);
   }
 
-  // todo: port to ResourcesTest
-  @Test
-  public void obtainAttributes_shouldReturnValuesFromAttributeSet() {
-    AttributeSet attributes = Robolectric.buildAttributeSet()
-        .addAttribute(android.R.attr.title, "A title!")
-        .addAttribute(android.R.attr.width, "12px")
-        .addAttribute(android.R.attr.height, "1in")
-        .build();
-    TypedArray typedArray = resources
-        .obtainAttributes(attributes, new int[]{android.R.attr.height,
-            android.R.attr.width, android.R.attr.title});
-
-    assertThat(typedArray.getDimension(0, 0)).isEqualTo(160f);
-    assertThat(typedArray.getDimension(1, 0)).isEqualTo(12f);
-    assertThat(typedArray.getString(2)).isEqualTo("A title!");
-    typedArray.recycle();
-  }
-
   @Test
   public void obtainStyledAttributes_shouldCheckXmlFirst_fromAttributeSetBuilder() {
 

--- a/robolectric/src/test/resources/res/values/dimens.xml
+++ b/robolectric/src/test/resources/res/values/dimens.xml
@@ -9,7 +9,4 @@
   <dimen name="test_in_dimen">99in</dimen>
 
   <dimen name="ref_to_px_dimen">@dimen/test_px_dimen</dimen>
-
-  <dimen name="dimen20px">20px</dimen>
-  <dimen name="dimen30px">30px</dimen>
 </resources>

--- a/robolectric/src/test/resources/res/xml-v25/shortcuts.xml
+++ b/robolectric/src/test/resources/res/xml-v25/shortcuts.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shortcuts xmlns:android="http://schemas.android.com/apk/res/android" >
-
-</shortcuts>

--- a/testapp/src/main/res/values/attrs.xml
+++ b/testapp/src/main/res/values/attrs.xml
@@ -57,6 +57,7 @@
   <attr name="string3" format="string"/>
   <attr name="parentStyleReference" format="reference"/>
   <attr name="styleNotSpecifiedInAnyTheme" format="reference"/>
+  <attr name="title" format="string"/>
 
   <declare-styleable name="CustomStateView">
     <attr name="stateFoo" format="boolean" />

--- a/testapp/src/main/res/xml/xml_attrs.xml
+++ b/testapp/src/main/res/xml/xml_attrs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<whatever xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:width="1234px"
+    android:height="@android:dimen/app_icon_size"
+    android:scrollbarFadeDuration="1111"
+    android:title="Android Title"
+    app:title="App Title"
+    android:id="@android:id/text1"
+    style="@android:style/TextAppearance.Small"
+    class="none"
+    id="@android:id/text2"
+    />


### PR DESCRIPTION
Only migrating tests have `to-do` flag. It also removes unused resources after migration.