### PR TITLE
Bump buildSrc AGP to 4.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,8 +175,9 @@ task prefetchDependencies() {
                     try {
                         config.files
                     } catch (ResolveException e) {
-                        // ignore resolution issues for integration tests, sigh
-                        if (!p.path.startsWith(":integration_tests:")) {
+                        // ignore resolution issues for integration tests and test app, sigh
+                        if (!p.path.startsWith(":integration_tests:")
+                                && !p.path.startsWith(":testapp")) {
                             throw e
                         }
                     }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,5 +12,5 @@ dependencies {
     implementation localGroovy()
 
     implementation "org.ow2.asm:asm-tree:9.0"
-    implementation 'com.android.tools.build:gradle:3.5.4'
+    implementation 'com.android.tools.build:gradle:4.1.3'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ apiCompatVersion=4.2
 errorproneVersion=2.5.1
 errorproneJavacVersion=9+181-r4173-1
 
-android.enableUnitTestBinaryResources=true
+android.useAndroidX=true
 
 truthVersion=1.1.2
 


### PR DESCRIPTION
The `android.enableUnitTestBinaryResources` in new AGP is false default now, and it will be removed in later AGP. So this CL removes it directly.