### PR TITLE
Fixes an error when mocking a generic method with Mockk

### DIFF
--- a/integration_tests/mockk/build.gradle
+++ b/integration_tests/mockk/build.gradle
@@ -3,6 +3,10 @@ import org.robolectric.gradle.RoboJavaModulePlugin
 apply plugin: RoboJavaModulePlugin
 apply plugin: 'kotlin'
 
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
 dependencies {
     api project(":robolectric")
     compileOnly AndroidSdk.MAX_SDK.coordinates

--- a/integration_tests/mockk/src/test/java/org/robolectric/integrationtests/mockk/MockkGenericMethodTestCase.kt
+++ b/integration_tests/mockk/src/test/java/org/robolectric/integrationtests/mockk/MockkGenericMethodTestCase.kt
@@ -1,0 +1,27 @@
+package org.robolectric.integrationtests.mockk
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+class Entity
+
+interface Repository {
+    fun <T> get(key: String, type: Class<T>): T
+}
+
+@RunWith(RobolectricTestRunner::class)
+class MockkGenericMethodTestCase {
+    @Test
+    fun `stubbing a generic method works`() {
+        val entity = Entity()
+        val repo: Repository = mockk {
+            every { get(any(), Entity::class.java) } returns entity
+        }
+
+        assertThat(repo.get("a", Entity::class.java)).isEqualTo(entity)
+    }
+}

--- a/sandbox/src/main/java/org/robolectric/config/AndroidConfigurer.java
+++ b/sandbox/src/main/java/org/robolectric/config/AndroidConfigurer.java
@@ -76,7 +76,7 @@ public class AndroidConfigurer {
         .doNotAcquirePackage(
             "scala.") //  run with Maven Surefire (see the RoboSpecs project on github)
         .doNotAcquirePackage("kotlin.")
-        .doNotAcquirePackage("io.mockk.")
+        .doNotAcquirePackage("io.mockk.proxy.")
         .doNotAcquirePackage("org.bouncycastle.")
         .doNotAcquirePackage("org.conscrypt.")
         // Fix #958: SQLite native library must be loaded once.


### PR DESCRIPTION
### Overview

When stubbing a method with a generic parameter with Mockk under the Robolectric classloader, the following exception is thrown:

```
io.mockk.MockKException: Class cast exception happened.
    Probably type information was erased.
...
Caused by:
        java.lang.ClassCastException: class Foo cannot be cast to class Foo (Foo is in unnamed module of loader 'app'; Foo is in unnamed module of loader org.robolectric.internal.AndroidSandbox$SdkSandboxClassLoader @)
```

Related issues/discussion: https://github.com/mockk/mockk/issues/606, https://github.com/robolectric/robolectric/issues/5994.

A self-contained demo project https://github.com/ogolberg/robolectric-mockk-compat ([github actions](https://github.com/ogolberg/robolectric-mockk-compat/actions)): note how overriding the runner to exclude `io.mockk.proxy.` instead of the blanket `io.mockk.` fixes the test.

### Proposed Changes

Exclude `io.mockk.proxy.` instead of `io.mockk.`.