### PR TITLE
Move Robolectric-only resource tests back to ShadowResourcesTest

### DIFF
--- a/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
+++ b/integration_tests/ctesque/src/test/java/android/content/res/ResourcesTest.java
@@ -53,7 +53,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.testapp.R;
@@ -680,49 +679,6 @@ public class ResourcesTest {
   }
 
   @Test
-  @Config(minSdk = N_MR1)
-  public void obtainAttributes() {
-    TypedArray typedArray =
-        resources.obtainAttributes(
-            Robolectric.buildAttributeSet()
-                .addAttribute(R.attr.styleReference, "@xml/shortcuts")
-                .build(),
-            new int[] {R.attr.styleReference});
-    assertThat(typedArray).isNotNull();
-    assertThat(typedArray.peekValue(0).resourceId).isEqualTo(R.xml.shortcuts);
-  }
-
-  @Test
-  public void obtainAttributes_shouldUseReferencedIdFromAttributeSet() {
-    // android:id/mask was introduced in API 21, but it's still possible for apps built against API
-    // 21 to refer to it in older runtimes because referenced resource ids are compiled (by aapt)
-    // into the binary XML format.
-    AttributeSet attributeSet =
-        Robolectric.buildAttributeSet().addAttribute(android.R.attr.id, "@android:id/mask").build();
-    TypedArray typedArray = resources.obtainAttributes(attributeSet, new int[] {android.R.attr.id});
-    assertThat(typedArray.getResourceId(0, -9)).isEqualTo(android.R.id.mask);
-  }
-
-  @Test
-  public void obtainAttributes_shouldReturnValuesFromAttributeSet() {
-    AttributeSet attributes =
-        Robolectric.buildAttributeSet()
-            .addAttribute(android.R.attr.title, "A title!")
-            .addAttribute(android.R.attr.width, "12px")
-            .addAttribute(android.R.attr.height, "1in")
-            .build();
-    TypedArray typedArray =
-        resources.obtainAttributes(
-            attributes,
-            new int[] {android.R.attr.height, android.R.attr.width, android.R.attr.title});
-
-    assertThat(typedArray.getDimension(0, 0)).isEqualTo(160f);
-    assertThat(typedArray.getDimension(1, 0)).isEqualTo(12f);
-    assertThat(typedArray.getString(2)).isEqualTo("A title!");
-    typedArray.recycle();
-  }
-
-  @Test
   public void obtainAttributes_shouldReturnValuesFromResources() throws Exception {
     XmlPullParser parser = resources.getXml(R.xml.xml_attrs);
     parser.next();
@@ -802,32 +758,6 @@ public class ResourcesTest {
     }, 0, 0);
     assertThat(typedArray.getFloat(0, 0)).isEqualTo(12.0f);
     assertThat(typedArray.getFloat(1, 0)).isEqualTo(24.0f);
-    typedArray.recycle();
-  }
-
-  @Test
-  public void obtainStyledAttributesShouldCheckXmlFirst_andFollowReferences() {
-    // This simulates a ResourceProvider built from a 21+ SDK as viewportHeight / viewportWidth were
-    // introduced in API 21 but the public ID values they are assigned clash with private
-    // com.android.internal.R values on older SDKs. This test ensures that even on older SDKs,
-    // on calls to obtainStyledAttributes() Robolectric will first check for matching
-    // resource ID values in the AttributeSet before checking the theme.
-    AttributeSet attributes =
-        Robolectric.buildAttributeSet()
-            .addAttribute(android.R.attr.viewportWidth, "@integer/test_integer1")
-            .addAttribute(android.R.attr.viewportHeight, "@integer/test_integer2")
-            .build();
-
-    TypedArray typedArray =
-        context
-            .getTheme()
-            .obtainStyledAttributes(
-                attributes,
-                new int[] {android.R.attr.viewportWidth, android.R.attr.viewportHeight},
-                0,
-                0);
-    assertThat(typedArray.getFloat(0, 0)).isEqualTo(2000);
-    assertThat(typedArray.getFloat(1, 0)).isEqualTo(9);
     typedArray.recycle();
   }
 


### PR DESCRIPTION
ctesque ResourcesTest cannot depend on Robolectric.buildAttributeSet,
which is only available in a Robolectric environent. ctesque
ResourcesTest is designed to work across all execution environments
(e.g. emulators).

