### PR TITLE
Restore test resources shortcuts.xml

### DIFF
--- a/robolectric/src/test/resources/res/xml-v25/shortcuts.xml
+++ b/robolectric/src/test/resources/res/xml-v25/shortcuts.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android" >
+
+</shortcuts>


### PR DESCRIPTION
It is needed for ShadowResourcesTest which does not have a dependency on
the testapp.

