### PR TITLE
Shadow BluetoothAdapter#setScanMode with duration in SDK 30

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothAdapterTest.java
@@ -5,6 +5,7 @@ import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.Q;
+import static android.os.Build.VERSION_CODES.R;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -201,6 +202,23 @@ public class ShadowBluetoothAdapterTest {
                     ClassParameter.from(
                         int.class, BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE),
                     ClassParameter.from(int.class, 42)))
+        .isTrue();
+    assertThat(bluetoothAdapter.getScanMode())
+        .isEqualTo(BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE);
+    assertThat(bluetoothAdapter.getDiscoverableTimeout()).isEqualTo(42);
+  }
+
+  @Config(minSdk = R)
+  @Test
+  public void scanMode_withDiscoverableTimeout_R() {
+    assertThat(
+            (boolean)
+                ReflectionHelpers.callInstanceMethod(
+                    bluetoothAdapter,
+                    "setScanMode",
+                    ClassParameter.from(
+                        int.class, BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE),
+                    ClassParameter.from(long.class, 42_000L)))
         .isTrue();
     assertThat(bluetoothAdapter.getScanMode())
         .isEqualTo(BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
@@ -5,6 +5,7 @@ import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.Q;
+import static android.os.Build.VERSION_CODES.R;
 import static org.robolectric.shadow.api.Shadow.directlyOn;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
@@ -265,6 +266,13 @@ public class ShadowBluetoothAdapter {
   @Implementation(maxSdk = Q)
   protected boolean setScanMode(int scanMode, int discoverableTimeout) {
     setDiscoverableTimeout(discoverableTimeout);
+    return setScanMode(scanMode);
+  }
+
+  @Implementation(minSdk = R)
+  protected boolean setScanMode(int scanMode, long durationMillis) {
+    int durationSeconds = Math.toIntExact(durationMillis / 1000);
+    setDiscoverableTimeout(durationSeconds);
     return setScanMode(scanMode);
   }
 


### PR DESCRIPTION
### Overview

In SDK 30 (R) the signature of `BluetoothAdapter#setScanMode` that takes duration changed `int duration` param to `long durationMillis`.

See https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/bluetooth/BluetoothAdapter.java;l=1525?q=BluetoothAdapter

### Proposed Changes

Add a shadow for the new signature, mimicking the ms -> second conversion logic in the real impl.