### PR TITLE
Only using ApplicationExitInfo for compile sdk 30 and above

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/PackageRollbackInfoBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/PackageRollbackInfoBuilder.java
@@ -133,17 +133,17 @@ public final class PackageRollbackInfoBuilder {
           ReflectionHelpers.ClassParameter.from(IntArray.class, installedUsers),
           ReflectionHelpers.ClassParameter.from(SparseLongArray.class, ceSnapshotInodes));
     } else if (apiLevel == VERSION_CODES.R) {
-        // We only have access to constructor on R. For all other SDKs, we will need
-        // ReflectionHelper.
-        return new PackageRollbackInfo(
-            packageRolledBackFrom,
-            packageRolledBackTo,
-            pendingBackups,
-            pendingRestores,
-            isApex,
-            isApkInApex,
-            snapshottedUsers,
-            ceSnapshotInodes);
+      // We only have access to constructor on R. For all other SDKs, we will need
+      // ReflectionHelper.
+      return new PackageRollbackInfo(
+          packageRolledBackFrom,
+          packageRolledBackTo,
+          pendingBackups,
+          pendingRestores,
+          isApex,
+          isApkInApex,
+          snapshottedUsers,
+          ceSnapshotInodes);
     } else if (apiLevel > VERSION_CODES.R) {
       return ReflectionHelpers.callConstructor(
           PackageRollbackInfo.class,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
@@ -21,6 +21,7 @@ import android.os.Build.VERSION_CODES;
 import android.os.Handler;
 import android.os.Process;
 import android.os.UserHandle;
+import androidx.annotation.RequiresApi;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -305,6 +306,7 @@ public class ShadowActivityManager {
    * @deprecated Prefer using overload with {@link ApplicationExitInfoBuilder}
    */
   @Deprecated
+  @RequiresApi(api = R)
   public void addApplicationExitInfo(String processName, int pid, int reason, int status) {
     ApplicationExitInfo info =
         ApplicationExitInfoBuilder.newBuilder()
@@ -317,8 +319,11 @@ public class ShadowActivityManager {
   }
 
   /** Adds given {@link ApplicationExitInfo}, see {@link ApplicationExitInfoBuilder} */
-  public void addApplicationExitInfo(ApplicationExitInfo info) {
-    appExitInfoList.addFirst(info);
+  @RequiresApi(api = R)
+  public void addApplicationExitInfo(Object info) {
+    if (info instanceof ApplicationExitInfo) {
+      appExitInfoList.addFirst(info);
+    }
   }
 
   @Implementation
@@ -340,7 +345,8 @@ public class ShadowActivityManager {
         .contains(RuntimeEnvironment.getApplication().getPackageName());
   }
 
-  /** Builder class for {@link android.app.ApplicationExitInfo} */
+  /** Builder class for {@link ApplicationExitInfo} */
+  @RequiresApi(api = R)
   public static class ApplicationExitInfoBuilder {
 
     private final ApplicationExitInfo instance;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
@@ -22,6 +22,7 @@ import android.os.Handler;
 import android.os.Process;
 import android.os.UserHandle;
 import androidx.annotation.RequiresApi;
+import com.google.common.base.Preconditions;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -321,9 +322,8 @@ public class ShadowActivityManager {
   /** Adds given {@link ApplicationExitInfo}, see {@link ApplicationExitInfoBuilder} */
   @RequiresApi(api = R)
   public void addApplicationExitInfo(Object info) {
-    if (info instanceof ApplicationExitInfo) {
-      appExitInfoList.addFirst(info);
-    }
+    Preconditions.checkArgument(info instanceof ApplicationExitInfo);
+    appExitInfoList.addFirst(info);
   }
 
   @Implementation


### PR DESCRIPTION
`ApplicationExitInfo` is added from SDK 30, but our `ShadowActivityManager` uses it directly on public method, and it will cause `NoClassDefFoundException` problem if user app's `compileSDK` is less than 30. This PR adds `RequiresApi(api = R)` to methods related to `ApplicationExitInfo` to restrict test usage, and uses `Object` to replace `ApplicationExitInfo` on those methods' signature to avoid JVM to link `ApplicationExitInfo` when initializing `ShadowActivityManager`. The `import` for `ApplicationExitInfo` is fine, maybe it will be ignored if there are no code to use it.

Close https://github.com/robolectric/robolectric/issues/6589