### PR TITLE
Rebase PR 4064 - Fix NPE during saving state of WebView

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWebViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWebViewTest.java
@@ -700,4 +700,10 @@ public class ShadowWebViewTest {
 
     assertThat(shadowOf(webView).getDownloadListener()).isEqualTo(lastListener);
   }
+
+  @Test
+  public void restoreAndSaveState() {
+    webView.restoreState(new Bundle());
+    webView.saveState(new Bundle());
+  }
 }


### PR DESCRIPTION
### Overview

It is a rebased PR for https://github.com/robolectric/robolectric/pull/4064. The origin PR fixed NPE for `ShadowWebView#saveState` caused by null generated by `ShadowWebView#restoreState`, and added related test for it. But the code to avoid null for `ShadowWebView#restoreState` is merged by commit https://github.com/robolectric/robolectric/commit/6717479947e6efb1479e352d9cfba0f53449f350#diff-f077a3ddfa6b468120c2a0e47b3cffb0de9cd4aef1abd1c822d36234681f7187R544-R551. So this rebased PR only keeps the test for `restoreAndSaveState` occasion.

The author information of origin commits is important, so this rebased PR also keeps the author information of origin commits and don't squash commits to one.