### PR TITLE
Converting the proxy version of directlyOn(...) to @Direct with reflector(...).

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityWindowInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityWindowInfo.java
@@ -2,7 +2,7 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.N;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.graphics.Rect;
 import android.view.accessibility.AccessibilityNodeInfo;
@@ -16,6 +16,8 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 /**
  * Shadow of {@link android.view.accessibility.AccessibilityWindowInfo} that allows a test to set
@@ -47,8 +49,7 @@ public class ShadowAccessibilityWindowInfo {
 
   private boolean isFocused = false;
 
-  @RealObject
-  private AccessibilityWindowInfo mRealAccessibilityWindowInfo;
+  @RealObject private AccessibilityWindowInfo mRealAccessibilityWindowInfo;
 
   @Implementation
   protected void __constructor__() {}
@@ -204,7 +205,7 @@ public class ShadowAccessibilityWindowInfo {
 
   @Implementation
   protected int getId() {
-    return directlyOn(mRealAccessibilityWindowInfo, AccessibilityWindowInfo.class).getId();
+    return reflector(AccessibilityWindowInfoReflector.class, mRealAccessibilityWindowInfo).getId();
   }
 
   @Implementation
@@ -263,7 +264,7 @@ public class ShadowAccessibilityWindowInfo {
   }
 
   public void setId(int value) {
-    directlyOn(mRealAccessibilityWindowInfo, AccessibilityWindowInfo.class).setId(value);
+    reflector(AccessibilityWindowInfoReflector.class, mRealAccessibilityWindowInfo).setId(value);
   }
 
   public void setLayer(int value) {
@@ -334,5 +335,15 @@ public class ShadowAccessibilityWindowInfo {
         + ", title:"
         + title
         + "}";
+  }
+
+  @ForType(AccessibilityWindowInfo.class)
+  interface AccessibilityWindowInfoReflector {
+
+    @Direct
+    int getId();
+
+    @Direct
+    void setId(int value);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -6,7 +6,6 @@ import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.N;
 import static android.os.Build.VERSION_CODES.O;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.app.Activity;
@@ -55,6 +54,7 @@ import org.robolectric.fakes.RoboMenuItem;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowInstrumentation.TargetAndRequestCode;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 import org.robolectric.util.reflector.WithType;
 
@@ -281,7 +281,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
    */
   @Deprecated
   public boolean isFinishing() {
-    return directlyOn(realActivity, Activity.class).isFinishing();
+    return reflector(DirectActivityReflector.class, realActivity).isFinishing();
   }
 
   /**
@@ -292,7 +292,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
    */
   @Implementation
   protected Window getWindow() {
-    Window window = directlyOn(realActivity, Activity.class).getWindow();
+    Window window = reflector(DirectActivityReflector.class, realActivity).getWindow();
 
     if (window == null) {
       try {
@@ -417,7 +417,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
     if (lastNonConfigurationInstance != null) {
       return lastNonConfigurationInstance;
     }
-    return directlyOn(realActivity, Activity.class).getLastNonConfigurationInstance();
+    return reflector(DirectActivityReflector.class, realActivity).getLastNonConfigurationInstance();
   }
 
   /** @deprecated use {@link ActivityController#recreate()}. */
@@ -447,7 +447,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   @Implementation
   protected boolean onCreateOptionsMenu(Menu menu) {
     optionsMenu = menu;
-    return directlyOn(realActivity, Activity.class).onCreateOptionsMenu(menu);
+    return reflector(DirectActivityReflector.class, realActivity).onCreateOptionsMenu(menu);
   }
 
   /**
@@ -677,7 +677,8 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   @Implementation(minSdk = M)
   protected final void requestPermissions(String[] permissions, int requestCode) {
     lastRequestedPermission = new PermissionsRequest(permissions, requestCode);
-    directlyOn(realActivity, Activity.class).requestPermissions(permissions, requestCode);
+    reflector(DirectActivityReflector.class, realActivity)
+        .requestPermissions(permissions, requestCode);
   }
 
   /**
@@ -856,5 +857,20 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
     void runOnUiThread(Runnable action);
 
     void onDestroy();
+
+    @Direct
+    boolean isFinishing();
+
+    @Direct
+    Window getWindow();
+
+    @Direct
+    Object getLastNonConfigurationInstance();
+
+    @Direct
+    boolean onCreateOptionsMenu(Menu menu);
+
+    @Direct
+    void requestPermissions(String[] permissions, int requestCode);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAlertController.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAlertController.java
@@ -1,7 +1,7 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.view.LayoutInflater;
 import android.view.View;
@@ -14,6 +14,8 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @Implements(value = AlertController.class, isInAndroidSdk = false)
 public class ShadowAlertController {
@@ -29,7 +31,7 @@ public class ShadowAlertController {
   @Implementation
   public void setTitle(CharSequence title) throws InvocationTargetException, IllegalAccessException {
     this.title = title;
-    directlyOn(realAlertController, AlertController.class).setTitle(title);
+    reflector(AlertControllerReflector.class, realAlertController).setTitle(title);
   }
 
   public CharSequence getTitle() {
@@ -39,7 +41,7 @@ public class ShadowAlertController {
   @Implementation
   public void setCustomTitle(View customTitleView) {
     this.customTitleView = customTitleView;
-    directlyOn(realAlertController, AlertController.class).setCustomTitle(customTitleView);
+    reflector(AlertControllerReflector.class, realAlertController).setCustomTitle(customTitleView);
   }
 
   public View getCustomTitleView() {
@@ -49,7 +51,7 @@ public class ShadowAlertController {
   @Implementation
   public void setMessage(CharSequence message) {
     this.message = message;
-    directlyOn(realAlertController, AlertController.class).setMessage(message);
+    reflector(AlertControllerReflector.class, realAlertController).setMessage(message);
   }
 
   public CharSequence getMessage() {
@@ -59,7 +61,7 @@ public class ShadowAlertController {
   @Implementation
   public void setView(View view) {
     this.view = view;
-    directlyOn(realAlertController, AlertController.class).setView(view);
+    reflector(AlertControllerReflector.class, realAlertController).setView(view);
   }
 
   @Implementation(minSdk = LOLLIPOP)
@@ -70,7 +72,7 @@ public class ShadowAlertController {
   @Implementation
   public void setIcon(int iconId) {
     this.iconId = iconId;
-    directlyOn(realAlertController, AlertController.class).setIcon(iconId);
+    reflector(AlertControllerReflector.class, realAlertController).setIcon(iconId);
   }
 
   public int getIconId() {
@@ -84,5 +86,24 @@ public class ShadowAlertController {
   public Adapter getAdapter() {
     return ReflectionHelpers.<ListView>callInstanceMethod(realAlertController, "getListView")
         .getAdapter();
+  }
+
+  @ForType(AlertController.class)
+  interface AlertControllerReflector {
+
+    @Direct
+    void setTitle(CharSequence title);
+
+    @Direct
+    void setCustomTitle(View customTitleView);
+
+    @Direct
+    void setMessage(CharSequence message);
+
+    @Direct
+    void setView(View view);
+
+    @Direct
+    void setIcon(int iconId);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -108,8 +108,8 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.config.ConfigurationRegistry;
-import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.reflector.Accessor;
+import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 
 @Implements(value = ApplicationPackageManager.class, isInAndroidSdk = false, looseSignatures = true)
@@ -891,7 +891,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
 
       try {
         resources =
-            Shadow.directlyOn(realObject, ApplicationPackageManager.class)
+            reflector(ReflectorApplicationPackageManager.class, realObject)
                 .getResourcesForApplication(applicationInfo);
       } catch (Exception ex) {
         // handled below
@@ -1508,7 +1508,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
     if (result != null) {
       return result;
     }
-    return Shadow.directlyOn(realObject, ApplicationPackageManager.class)
+    return reflector(ReflectorApplicationPackageManager.class, realObject)
         .getDrawable(packageName, resId, appInfo);
   }
 
@@ -1518,7 +1518,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
     if (result != null) {
       return result;
     }
-    return Shadow.directlyOn(realObject, ApplicationPackageManager.class)
+    return reflector(ReflectorApplicationPackageManager.class, realObject)
         .getActivityIcon(activityName);
   }
 
@@ -1809,7 +1809,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
     if (result != null) {
       return result;
     }
-    return Shadow.directlyOn(realObject, ApplicationPackageManager.class)
+    return reflector(ReflectorApplicationPackageManager.class, realObject)
         .loadUnbadgedItemIcon(itemInfo, appInfo);
   }
 
@@ -2055,9 +2055,23 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
     return reflector(ReflectorApplicationPackageManager.class, realObject).getContext();
   }
 
-  /** Accessor interface for {@link ApplicationPackageManager}'s internals. */
+  /** Reflector interface for {@link ApplicationPackageManager}'s internals. */
   @ForType(ApplicationPackageManager.class)
   private interface ReflectorApplicationPackageManager {
+
+    @Direct
+    Resources getResourcesForApplication(@NonNull ApplicationInfo applicationInfo);
+
+    @Direct
+    Drawable getDrawable(
+        String packageName, @DrawableRes int resId, @Nullable ApplicationInfo appInfo);
+
+    @Direct
+    Drawable getActivityIcon(ComponentName activityName);
+
+    @Direct
+    Drawable loadUnbadgedItemIcon(PackageItemInfo itemInfo, ApplicationInfo appInfo);
+
     @Accessor("mContext")
     Context getContext();
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapDrawable.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapDrawable.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -14,6 +14,8 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(BitmapDrawable.class)
@@ -53,7 +55,7 @@ public class ShadowBitmapDrawable extends ShadowDrawable {
   @Implementation
   protected void setColorFilter(ColorFilter colorFilter) {
     this.colorFilter = colorFilter;
-    directlyOn(realBitmapDrawable, BitmapDrawable.class).setColorFilter(colorFilter);
+    reflector(BitmapDrawableReflector.class, realBitmapDrawable).setColorFilter(colorFilter);
   }
 
   /**
@@ -76,5 +78,12 @@ public class ShadowBitmapDrawable extends ShadowDrawable {
 
   public String getPath() {
     return drawableCreateFromPath;
+  }
+
+  @ForType(BitmapDrawable.class)
+  interface BitmapDrawableReflector {
+
+    @Direct
+    void setColorFilter(ColorFilter colorFilter);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
@@ -6,7 +6,6 @@ import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.Q;
 import static android.os.Build.VERSION_CODES.R;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.bluetooth.BluetoothAdapter;
@@ -422,7 +421,7 @@ public class ShadowBluetoothAdapter {
   protected boolean getProfileProxy(
       Context context, BluetoothProfile.ServiceListener listener, int profile) {
     if (!isOverridingProxyBehavior) {
-      return directlyOn(realAdapter, BluetoothAdapter.class)
+      return reflector(BluetoothAdapterReflector.class, realAdapter)
           .getProfileProxy(context, listener, profile);
     }
 
@@ -445,7 +444,7 @@ public class ShadowBluetoothAdapter {
   @Implementation
   protected void closeProfileProxy(int profile, BluetoothProfile proxy) {
     if (!isOverridingProxyBehavior) {
-      directlyOn(realAdapter, BluetoothAdapter.class).closeProfileProxy(profile, proxy);
+      reflector(BluetoothAdapterReflector.class, realAdapter).closeProfileProxy(profile, proxy);
       return;
     }
 
@@ -480,6 +479,13 @@ public class ShadowBluetoothAdapter {
     @Static
     @Direct
     BluetoothAdapter getDefaultAdapter();
+
+    @Direct
+    boolean getProfileProxy(
+        Context context, BluetoothProfile.ServiceListener listener, int profile);
+
+    @Direct
+    void closeProfileProxy(int profile, BluetoothProfile proxy);
 
     @Accessor("sAdapter")
     @Static

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBroadcastReceiver.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBroadcastReceiver.java
@@ -1,5 +1,7 @@
 package org.robolectric.shadows;
 
+import static org.robolectric.util.reflector.Reflector.reflector;
+
 import android.content.BroadcastReceiver;
 import android.content.BroadcastReceiver.PendingResult;
 import android.content.Context;
@@ -8,7 +10,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.shadow.api.Shadow;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @Implements(BroadcastReceiver.class)
 public class ShadowBroadcastReceiver {
@@ -47,7 +50,7 @@ public class ShadowBroadcastReceiver {
     // Save the PendingResult before goAsync() clears it.
     originalPendingResult = receiver.getPendingResult();
     wentAsync = true;
-    return Shadow.directlyOn(receiver, BroadcastReceiver.class).goAsync();
+    return reflector(BroadcastReceiverReflector.class, receiver).goAsync();
   }
 
   public boolean wentAsync() {
@@ -60,5 +63,12 @@ public class ShadowBroadcastReceiver {
     } else {
       return receiver.getPendingResult();
     }
+  }
+
+  @ForType(BroadcastReceiver.class)
+  interface BroadcastReceiverReflector {
+
+    @Direct
+    PendingResult goAsync();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowClipboardManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowClipboardManager.java
@@ -3,7 +3,7 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
 import static android.os.Build.VERSION_CODES.N;
 import static org.robolectric.RuntimeEnvironment.getApiLevel;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.content.ClipData;
 import android.content.ClipDescription;
@@ -15,6 +15,8 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @SuppressWarnings("UnusedDeclaration")
 @Implements(ClipboardManager.class)
@@ -74,7 +76,14 @@ public class ShadowClipboardManager {
 
   @Implementation
   protected boolean hasText() {
-    CharSequence text = directlyOn(realClipboardManager, ClipboardManager.class).getText();
+    CharSequence text = reflector(ClipboardManagerReflector.class, realClipboardManager).getText();
     return text != null && text.length() > 0;
+  }
+
+  @ForType(ClipboardManager.class)
+  interface ClipboardManagerReflector {
+
+    @Direct
+    CharSequence getText();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDialog.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDialog.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.app.Activity;
 import android.app.Dialog;
@@ -20,6 +20,8 @@ import org.robolectric.annotation.Resetter;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Dialog.class)
@@ -61,12 +63,12 @@ public class ShadowDialog {
   protected void show() {
     setLatestDialog(this);
     shownDialogs.add(realDialog);
-    directlyOn(realDialog, Dialog.class).show();
+    reflector(DialogReflector.class, realDialog).show();
   }
 
   @Implementation
   protected void dismiss() {
-    directlyOn(realDialog, Dialog.class).dismiss();
+    reflector(DialogReflector.class, realDialog).dismiss();
     hasBeenDismissed = true;
   }
 
@@ -77,7 +79,7 @@ public class ShadowDialog {
   @Implementation
   protected void setCanceledOnTouchOutside(boolean flag) {
     isCancelableOnTouchOutside = flag;
-    directlyOn(realDialog, Dialog.class).setCanceledOnTouchOutside(flag);
+    reflector(DialogReflector.class, realDialog).setCanceledOnTouchOutside(flag);
   }
 
   public boolean isCancelable() {
@@ -95,7 +97,7 @@ public class ShadowDialog {
   @Implementation
   protected void setOnCancelListener(DialogInterface.OnCancelListener listener) {
     this.onCancelListener = listener;
-    directlyOn(realDialog, Dialog.class).setOnCancelListener(listener);
+    reflector(DialogReflector.class, realDialog).setOnCancelListener(listener);
   }
 
   public boolean hasBeenDismissed() {
@@ -148,5 +150,21 @@ public class ShadowDialog {
   public void callOnCreate(Bundle bundle) {
     ReflectionHelpers.callInstanceMethod(
         realDialog, "onCreate", ClassParameter.from(Bundle.class, bundle));
+  }
+
+  @ForType(Dialog.class)
+  interface DialogReflector {
+
+    @Direct
+    void show();
+
+    @Direct
+    void dismiss();
+
+    @Direct
+    void setCanceledOnTouchOutside(boolean flag);
+
+    @Direct
+    void setOnCancelListener(DialogInterface.OnCancelListener listener);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplay.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplay.java
@@ -1,7 +1,6 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.content.Context;
@@ -19,6 +18,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.reflector.Accessor;
+import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 
 /**
@@ -78,7 +78,7 @@ public class ShadowDisplay {
       outMetrics.xdpi = xdpi;
       outMetrics.ydpi = ydpi;
     } else {
-      directlyOn(realObject, Display.class).getMetrics(outMetrics);
+      reflector(_Display_.class, realObject).getMetrics(outMetrics);
       if (scaledDensity != null) {
         outMetrics.scaledDensity = scaledDensity;
       }
@@ -99,7 +99,7 @@ public class ShadowDisplay {
       outMetrics.widthPixels = realWidth;
       outMetrics.heightPixels = realHeight;
     } else {
-      directlyOn(realObject, Display.class).getRealMetrics(outMetrics);
+      reflector(_Display_.class, realObject).getRealMetrics(outMetrics);
       if (scaledDensity != null) {
         outMetrics.scaledDensity = scaledDensity;
       }
@@ -114,7 +114,7 @@ public class ShadowDisplay {
   @Deprecated
   @Implementation
   protected int getDisplayId() {
-    return displayId == null ? directlyOn(realObject, Display.class).getDisplayId() : displayId;
+    return displayId == null ? reflector(_Display_.class, realObject).getDisplayId() : displayId;
   }
 
   /**
@@ -128,7 +128,7 @@ public class ShadowDisplay {
     if (refreshRate != null) {
       return refreshRate;
     }
-    float realRefreshRate = directlyOn(realObject, Display.class).getRefreshRate();
+    float realRefreshRate = reflector(_Display_.class, realObject).getRefreshRate();
     // refresh rate may be set by native code. if its 0, set to 60fps
     if (realRefreshRate < 0.1) {
       realRefreshRate = 60;
@@ -145,7 +145,7 @@ public class ShadowDisplay {
   @Implementation
   protected int getPixelFormat() {
     return pixelFormat == null
-        ? directlyOn(realObject, Display.class).getPixelFormat()
+        ? reflector(_Display_.class, realObject).getPixelFormat()
         : pixelFormat;
   }
 
@@ -452,9 +452,24 @@ public class ShadowDisplay {
             : Surface.ROTATION_90;
   }
 
-  /** Accessor interface for {@link Display}'s internals. */
+  /** Reflector interface for {@link Display}'s internals. */
   @ForType(Display.class)
   interface _Display_ {
+
+    @Direct
+    void getMetrics(DisplayMetrics outMetrics);
+
+    @Direct
+    void getRealMetrics(DisplayMetrics outMetrics);
+
+    @Direct
+    int getDisplayId();
+
+    @Direct
+    float getRefreshRate();
+
+    @Direct
+    int getPixelFormat();
 
     @Accessor("mFlags")
     void setFlags(int flags);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManager.java
@@ -2,10 +2,10 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
 import static android.os.Build.VERSION_CODES.P;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
 import static org.robolectric.shadow.api.Shadow.extract;
 import static org.robolectric.shadow.api.Shadow.invokeConstructor;
 import static org.robolectric.shadows.ShadowLooper.shadowMainLooper;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.content.Context;
 import android.content.res.Configuration;
@@ -28,6 +28,8 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.res.Qualifiers;
 import org.robolectric.util.Consumer;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 /**
  * For tests, display properties may be changed and devices may be added or removed
@@ -44,8 +46,8 @@ public class ShadowDisplayManager {
   protected void __constructor__(Context context) {
     this.context = context;
 
-    invokeConstructor(DisplayManager.class, realDisplayManager,
-        ClassParameter.from(Context.class, context));
+    invokeConstructor(
+        DisplayManager.class, realDisplayManager, ClassParameter.from(Context.class, context));
   }
 
   /**
@@ -140,8 +142,8 @@ public class ShadowDisplayManager {
           baseDisplayInfo.logicalDensityDpi * DisplayMetrics.DENSITY_DEFAULT_SCALE;
     }
 
-    Bootstrap.applyQualifiers(qualifiersStr, RuntimeEnvironment.getApiLevel(), configuration,
-        displayMetrics);
+    Bootstrap.applyQualifiers(
+        qualifiersStr, RuntimeEnvironment.getApiLevel(), configuration, displayMetrics);
 
     return createDisplayInfo(configuration, displayMetrics);
   }
@@ -216,7 +218,7 @@ public class ShadowDisplayManager {
    * {@link android.hardware.display.DisplayManager#setSaturationLevel(float)}.
    */
   public void setSaturationLevel(float level) {
-    directlyOn(realDisplayManager, DisplayManager.class).setSaturationLevel(level);
+    reflector(DisplayManagerReflector.class, realDisplayManager).setSaturationLevel(level);
   }
 
   @Implementation(minSdk = P)
@@ -247,5 +249,12 @@ public class ShadowDisplayManager {
     }
 
     return extract(DisplayManagerGlobal.getInstance());
+  }
+
+  @ForType(DisplayManager.class)
+  interface DisplayManagerReflector {
+
+    @Direct
+    void setSaturationLevel(float level);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDrawable.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDrawable.java
@@ -151,7 +151,7 @@ public class ShadowDrawable {
   @Implementation
   protected void setAlpha(int alpha) {
     this.alpha = alpha;
-    Shadow.directlyOn(realDrawable, Drawable.class).setAlpha(alpha);
+    reflector(DrawableReflector.class, realDrawable).setAlpha(alpha);
   }
 
   @Implementation
@@ -182,5 +182,8 @@ public class ShadowDrawable {
 
     @Direct
     void invalidateSelf();
+
+    @Direct
+    void setAlpha(int alpha);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGestureDetector.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGestureDetector.java
@@ -1,8 +1,8 @@
 package org.robolectric.shadows;
 
 import static android.view.GestureDetector.OnDoubleTapListener;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.content.Context;
 import android.os.Handler;
@@ -12,12 +12,13 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.shadow.api.Shadow;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(GestureDetector.class)
 public class ShadowGestureDetector {
-  @RealObject
-  private GestureDetector realObject;
+  @RealObject private GestureDetector realObject;
 
   private static GestureDetector lastActiveGestureDetector;
 
@@ -28,7 +29,9 @@ public class ShadowGestureDetector {
   @Implementation
   protected void __constructor__(
       Context context, GestureDetector.OnGestureListener listener, Handler handler) {
-    Shadow.invokeConstructor(GestureDetector.class, realObject,
+    Shadow.invokeConstructor(
+        GestureDetector.class,
+        realObject,
         from(Context.class, context),
         from(GestureDetector.OnGestureListener.class, listener),
         from(Handler.class, handler));
@@ -40,12 +43,13 @@ public class ShadowGestureDetector {
     lastActiveGestureDetector = realObject;
     onTouchEventMotionEvent = ev;
 
-    return directlyOn(realObject, GestureDetector.class).onTouchEvent(ev);
+    return reflector(GestureDetectorReflector.class, realObject).onTouchEvent(ev);
   }
 
   @Implementation
   protected void setOnDoubleTapListener(OnDoubleTapListener onDoubleTapListener) {
-    directlyOn(realObject, GestureDetector.class).setOnDoubleTapListener(onDoubleTapListener);
+    reflector(GestureDetectorReflector.class, realObject)
+        .setOnDoubleTapListener(onDoubleTapListener);
     this.onDoubleTapListener = onDoubleTapListener;
   }
 
@@ -67,5 +71,15 @@ public class ShadowGestureDetector {
 
   public OnDoubleTapListener getOnDoubleTapListener() {
     return onDoubleTapListener;
+  }
+
+  @ForType(GestureDetector.class)
+  interface GestureDetectorReflector {
+
+    @Direct
+    boolean onTouchEvent(MotionEvent ev);
+
+    @Direct
+    void setOnDoubleTapListener(OnDoubleTapListener onDoubleTapListener);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGradientDrawable.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGradientDrawable.java
@@ -1,17 +1,18 @@
 package org.robolectric.shadows;
 
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.graphics.drawable.GradientDrawable;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @Implements(GradientDrawable.class)
 public class ShadowGradientDrawable extends ShadowDrawable {
 
-  @RealObject
-  private GradientDrawable realGradientDrawable;
+  @RealObject private GradientDrawable realGradientDrawable;
 
   private int color;
   private int strokeColor;
@@ -20,14 +21,14 @@ public class ShadowGradientDrawable extends ShadowDrawable {
   @Implementation
   protected void setColor(int color) {
     this.color = color;
-    directlyOn(realGradientDrawable, GradientDrawable.class).setColor(color);
+    reflector(GradientDrawableReflector.class, realGradientDrawable).setColor(color);
   }
 
   @Implementation
   protected void setStroke(int width, int color) {
     this.strokeWidth = width;
     this.strokeColor = color;
-    directlyOn(realGradientDrawable, GradientDrawable.class).setStroke(width, color);
+    reflector(GradientDrawableReflector.class, realGradientDrawable).setStroke(width, color);
   }
 
 
@@ -47,5 +48,15 @@ public class ShadowGradientDrawable extends ShadowDrawable {
 
   public int getStrokeColor() {
     return strokeColor;
+  }
+
+  @ForType(GradientDrawable.class)
+  interface GradientDrawableReflector {
+
+    @Direct
+    void setColor(int color);
+
+    @Direct
+    void setStroke(int width, int color);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowIcon.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowIcon.java
@@ -1,7 +1,7 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.M;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.graphics.Bitmap;
 import android.graphics.drawable.Icon;
@@ -10,53 +10,79 @@ import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(value = Icon.class, minSdk = M)
 public class ShadowIcon {
 
-  @RealObject
-  private Icon realIcon;
+  @RealObject private Icon realIcon;
 
   @HiddenApi
   @Implementation
   public int getType() {
-    return directlyOn(realIcon, Icon.class).getType();
+    return reflector(IconReflector.class, realIcon).getType();
   }
 
   @HiddenApi
   @Implementation
   public int getResId() {
-    return directlyOn(realIcon, Icon.class).getResId();
+    return reflector(IconReflector.class, realIcon).getResId();
   }
 
   @HiddenApi
   @Implementation
   public Bitmap getBitmap() {
-    return directlyOn(realIcon, Icon.class).getBitmap();
+    return reflector(IconReflector.class, realIcon).getBitmap();
   }
 
   @HiddenApi
   @Implementation
   public Uri getUri() {
-    return directlyOn(realIcon, Icon.class).getUri();
+    return reflector(IconReflector.class, realIcon).getUri();
   }
 
   @HiddenApi
   @Implementation
   public int getDataLength() {
-    return directlyOn(realIcon, Icon.class).getDataLength();
+    return reflector(IconReflector.class, realIcon).getDataLength();
   }
 
   @HiddenApi
   @Implementation
   public int getDataOffset() {
-    return directlyOn(realIcon, Icon.class).getDataOffset();
+    return reflector(IconReflector.class, realIcon).getDataOffset();
   }
 
   @HiddenApi
   @Implementation
   public byte[] getDataBytes() {
-    return directlyOn(realIcon, Icon.class).getDataBytes();
+    return reflector(IconReflector.class, realIcon).getDataBytes();
+  }
+
+  @ForType(Icon.class)
+  interface IconReflector {
+
+    @Direct
+    int getType();
+
+    @Direct
+    int getResId();
+
+    @Direct
+    Bitmap getBitmap();
+
+    @Direct
+    Uri getUri();
+
+    @Direct
+    int getDataLength();
+
+    @Direct
+    int getDataOffset();
+
+    @Direct
+    byte[] getDataBytes();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
@@ -13,7 +13,7 @@ import static android.os.Build.VERSION_CODES.P;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.annotation.Nullable;
 import android.app.Activity;
@@ -63,6 +63,7 @@ import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowActivity.IntentForResult;
 import org.robolectric.shadows.ShadowApplication.Wrapper;
 import org.robolectric.util.Logger;
+import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 import org.robolectric.util.reflector.WithType;
 
@@ -155,7 +156,7 @@ public class ShadowInstrumentation {
     if (who == null) {
       return null;
     }
-    return directlyOn(realObject, Instrumentation.class)
+    return reflector(_Instrumentation_.class, realObject)
         .execStartActivity(who, contextThread, token, target, intent, requestCode, options);
   }
 
@@ -185,7 +186,7 @@ public class ShadowInstrumentation {
     verifyActivityInManifest(intent);
     logStartedActivity(intent, target, requestCode, options);
 
-    return directlyOn(realObject, Instrumentation.class)
+    return reflector(_Instrumentation_.class, realObject)
         .execStartActivity(who, contextThread, token, target, intent, requestCode, options);
   }
 
@@ -241,7 +242,7 @@ public class ShadowInstrumentation {
       throw new ActivityNotFoundException(intent.getAction());
     }
   }
-  
+
   void sendOrderedBroadcastAsUser(
       Intent intent,
       UserHandle userHandle,
@@ -986,7 +987,7 @@ public class ShadowInstrumentation {
     return mainHandler;
   }
 
-  /** Accessor interface for {@link Instrumentation}'s internals. */
+  /** Reflector interface for {@link Instrumentation}'s internals. */
   @ForType(Instrumentation.class)
   public interface _Instrumentation_ {
     // <= JELLY_BEAN_MR1:
@@ -1005,6 +1006,26 @@ public class ShadowInstrumentation {
         ComponentName component,
         @WithType("android.app.IInstrumentationWatcher") Object watcher,
         @WithType("android.app.IUiAutomationConnection") Object uiAutomationConnection);
+
+    @Direct
+    ActivityResult execStartActivity(
+        Context who,
+        IBinder contextThread,
+        IBinder token,
+        Activity target,
+        Intent intent,
+        int requestCode,
+        Bundle options);
+
+    @Direct
+    ActivityResult execStartActivity(
+        Context who,
+        IBinder contextThread,
+        IBinder token,
+        String target,
+        Intent intent,
+        int requestCode,
+        Bundle options);
   }
 
   private static final class BroadcastResultHolder {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAssetInputStream.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAssetInputStream.java
@@ -1,20 +1,22 @@
 package org.robolectric.shadows;
 
+import static org.robolectric.util.reflector.Reflector.reflector;
+
 import android.content.res.AssetManager.AssetInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowAssetInputStream.Picker;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @SuppressWarnings("UnusedDeclaration")
 @Implements(value = AssetInputStream.class, shadowPicker = Picker.class)
 public class ShadowLegacyAssetInputStream extends ShadowAssetInputStream {
 
-  @RealObject
-  private AssetInputStream realObject;
+  @RealObject private AssetInputStream realObject;
 
   private InputStream delegate;
   private boolean ninePatch;
@@ -39,50 +41,101 @@ public class ShadowLegacyAssetInputStream extends ShadowAssetInputStream {
 
   @Implementation
   protected int read() throws IOException {
-    return stream().read();
+    return delegate == null
+        ? reflector(AssetInputStreamReflector.class, realObject).read()
+        : delegate.read();
   }
 
   @Implementation
   protected int read(byte[] b) throws IOException {
-    return stream().read(b);
+    return delegate == null
+        ? reflector(AssetInputStreamReflector.class, realObject).read(b)
+        : delegate.read(b);
   }
 
   @Implementation
   protected int read(byte[] b, int off, int len) throws IOException {
-    return stream().read(b, off, len);
+    return delegate == null
+        ? reflector(AssetInputStreamReflector.class, realObject).read(b, off, len)
+        : delegate.read(b, off, len);
   }
 
   @Implementation
   protected long skip(long n) throws IOException {
-    return stream().skip(n);
+    return delegate == null
+        ? reflector(AssetInputStreamReflector.class, realObject).skip(n)
+        : delegate.skip(n);
   }
 
   @Implementation
   protected int available() throws IOException {
-    return stream().available();
+    return delegate == null
+        ? reflector(AssetInputStreamReflector.class, realObject).available()
+        : delegate.available();
   }
 
   @Implementation
   protected void close() throws IOException {
-    stream().close();
+    if (delegate == null) {
+      reflector(AssetInputStreamReflector.class, realObject).close();
+    } else {
+      delegate.close();
+    }
   }
 
   @Implementation
   protected void mark(int readlimit) {
-    stream().mark(readlimit);
+    if (delegate == null) {
+      reflector(AssetInputStreamReflector.class, realObject).mark(readlimit);
+    } else {
+      delegate.mark(readlimit);
+    }
   }
 
   @Implementation
   protected void reset() throws IOException {
-    stream().reset();
+    if (delegate == null) {
+      reflector(AssetInputStreamReflector.class, realObject).reset();
+    } else {
+      delegate.reset();
+    }
   }
 
   @Implementation
   protected boolean markSupported() {
-    return stream().markSupported();
+    return delegate == null
+        ? reflector(AssetInputStreamReflector.class, realObject).markSupported()
+        : delegate.markSupported();
   }
 
-  private InputStream stream() {
-    return delegate == null ? Shadow.directlyOn(realObject, AssetInputStream.class) : delegate;
+  @ForType(AssetInputStream.class)
+  interface AssetInputStreamReflector {
+
+    @Direct
+    int read();
+
+    @Direct
+    int read(byte[] b);
+
+    @Direct
+    int read(byte[] b, int off, int len);
+
+    @Direct
+    long skip(long n);
+
+    @Direct
+    int available();
+
+    @Direct
+    void close();
+
+    @Direct
+    void mark(int readlimit);
+
+    @Direct
+    void reset();
+
+    @Direct
+    boolean markSupported();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowListPopupWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowListPopupWindow.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.widget.ListPopupWindow;
 import org.robolectric.RuntimeEnvironment;
@@ -8,22 +8,30 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.shadow.api.Shadow;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @Implements(ListPopupWindow.class)
 public class ShadowListPopupWindow {
-  
-  @RealObject
-  private ListPopupWindow realListPopupWindow;
+
+  @RealObject private ListPopupWindow realListPopupWindow;
 
   @Implementation
   protected void show() {
     ShadowApplication shadowApplication = Shadow.extract(RuntimeEnvironment.getApplication());
     shadowApplication.setLatestListPopupWindow(realListPopupWindow);
-    directlyOn(realListPopupWindow, ListPopupWindow.class).show();
+    reflector(ListPopupWindowReflector.class, realListPopupWindow).show();
   }
 
   public static ListPopupWindow getLatestListPopupWindow() {
     ShadowApplication shadowApplication = Shadow.extract(RuntimeEnvironment.getApplication());
     return shadowApplication.getLatestListPopupWindow();
+  }
+
+  @ForType(ListPopupWindow.class)
+  interface ListPopupWindowReflector {
+
+    @Direct
+    void show();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaActionSound.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaActionSound.java
@@ -1,5 +1,7 @@
 package org.robolectric.shadows;
 
+import static org.robolectric.util.reflector.Reflector.reflector;
+
 import android.media.MediaActionSound;
 import android.os.Build;
 import java.util.HashMap;
@@ -9,7 +11,8 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
-import org.robolectric.shadow.api.Shadow;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 /** A shadow implementation of {@link android.media.MediaActionSound}. */
 @Implements(value = MediaActionSound.class, minSdk = Build.VERSION_CODES.JELLY_BEAN)
@@ -54,8 +57,15 @@ public class ShadowMediaActionSound {
   /** Instrumented call to {@link android.media.MediaActionSound#play} */
   @Implementation
   protected void play(int soundName) {
-    Shadow.directlyOn(realObject, MediaActionSound.class).play(soundName);
+    reflector(MediaActionSoundReflector.class, realObject).play(soundName);
 
     playCount.get(soundName).incrementAndGet();
+  }
+
+  @ForType(MediaActionSound.class)
+  interface MediaActionSoundReflector {
+
+    @Direct
+    void play(int soundName);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessenger.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessenger.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.os.Message;
 import android.os.Messenger;
@@ -9,6 +9,8 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @Implements(Messenger.class)
 public class ShadowMessenger {
@@ -24,11 +26,18 @@ public class ShadowMessenger {
   @Implementation
   protected void send(Message message) throws RemoteException {
     lastMessageSent = Message.obtain(message);
-    directlyOn(messenger, Messenger.class).send(message);
+    reflector(MessengerReflector.class, messenger).send(message);
   }
 
   @Resetter
   public static void reset() {
     lastMessageSent = null;
+  }
+
+  @ForType(Messenger.class)
+  interface MessengerReflector {
+
+    @Direct
+    void send(Message message);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNumberPicker.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNumberPicker.java
@@ -1,11 +1,13 @@
 package org.robolectric.shadows;
 
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.widget.NumberPicker;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @Implements(value = NumberPicker.class)
 public class ShadowNumberPicker extends ShadowLinearLayout {
@@ -69,11 +71,18 @@ public class ShadowNumberPicker extends ShadowLinearLayout {
 
   @Implementation
   protected void setOnValueChangedListener(NumberPicker.OnValueChangeListener listener) {
-    directlyOn(realNumberPicker, NumberPicker.class).setOnValueChangedListener(listener);
+    reflector(NumberPickerReflector.class, realNumberPicker).setOnValueChangedListener(listener);
     this.onValueChangeListener = listener;
   }
 
   public NumberPicker.OnValueChangeListener getOnValueChangeListener() {
     return onValueChangeListener;
+  }
+
+  @ForType(NumberPicker.class)
+  interface NumberPickerReflector {
+
+    @Direct
+    void setOnValueChangedListener(NumberPicker.OnValueChangeListener listener);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
@@ -99,8 +99,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
-import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowPackageParser._PackageParser_;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @SuppressWarnings("NewApi")
 @Implements(PackageManager.class)
@@ -1056,7 +1057,7 @@ public class ShadowPackageManager {
     if (shadowPackageInfo != null) {
       return shadowPackageInfo;
     } else {
-      return Shadow.directlyOn(realPackageManager, PackageManager.class)
+      return reflector(PackageManagerReflector.class, realPackageManager)
           .getPackageArchiveInfo(archiveFilePath, flags);
     }
   }
@@ -1510,7 +1511,7 @@ public class ShadowPackageManager {
    * Method to retrieve persistent preferred activities as set by {@link
    * android.app.admin.DevicePolicyManager#addPersistentPreferredActivity}.
    *
-   * Works the same way as analogous {@link PackageManager#getPreferredActivities} for regular
+   * <p>Works the same way as analogous {@link PackageManager#getPreferredActivities} for regular
    * preferred activities.
    */
   public int getPersistentPreferredActivities(
@@ -1673,5 +1674,12 @@ public class ShadowPackageManager {
       packageSettings.clear();
       safeMode = false;
     }
+  }
+
+  @ForType(PackageManager.class)
+  interface PackageManagerReflector {
+
+    @Direct
+    PackageInfo getPackageArchiveInfo(String archiveFilePath, int flags);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcelFileDescriptor.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcelFileDescriptor.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.KITKAT;
 import static org.robolectric.shadow.api.Shadow.invokeConstructor;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.annotation.SuppressLint;
 import android.os.ParcelFileDescriptor;
@@ -19,6 +20,8 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @Implements(ParcelFileDescriptor.class)
 @SuppressLint("NewApi")
@@ -140,6 +143,13 @@ public class ShadowParcelFileDescriptor {
   @Implementation
   protected void close() throws IOException {
     file.close();
-    Shadow.directlyOn(realObject, ParcelFileDescriptor.class).close();
+    reflector(ParcelFileDescriptorReflector.class, realParcelFd).close();
+  }
+
+  @ForType(ParcelFileDescriptor.class)
+  interface ParcelFileDescriptorReflector {
+
+    @Direct
+    void close();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedMessage.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedMessage.java
@@ -1,7 +1,6 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.os.Build;
@@ -40,7 +39,7 @@ public class ShadowPausedMessage extends ShadowMessage {
     if (Build.VERSION.SDK_INT >= LOLLIPOP) {
       reflector(ReflectorMessage.class, realObject).recycleUnchecked();
     } else {
-      directlyOn(realObject, Message.class).recycle();
+      reflector(ReflectorMessage.class, realObject).recycle();
     }
   }
 
@@ -72,6 +71,9 @@ public class ShadowPausedMessage extends ShadowMessage {
 
     @Direct
     void recycleUnchecked();
+
+    @Direct
+    void recycle();
 
     @Accessor("when")
     long getWhen();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPopupMenu.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPopupMenu.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.widget.PopupMenu;
 import org.robolectric.RuntimeEnvironment;
@@ -8,12 +8,13 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.shadow.api.Shadow;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @Implements(PopupMenu.class)
 public class ShadowPopupMenu {
 
-  @RealObject
-  private PopupMenu realPopupMenu;
+  @RealObject private PopupMenu realPopupMenu;
 
   private boolean isShowing;
   private PopupMenu.OnMenuItemClickListener onMenuItemClickListener;
@@ -22,19 +23,19 @@ public class ShadowPopupMenu {
   protected void show() {
     this.isShowing = true;
     setLatestPopupMenu(this);
-    directlyOn(realPopupMenu, PopupMenu.class).show();
+    reflector(PopupMenuReflector.class, realPopupMenu).show();
   }
 
   @Implementation
   protected void dismiss() {
     this.isShowing = false;
-    directlyOn(realPopupMenu, PopupMenu.class).dismiss();
+    reflector(PopupMenuReflector.class, realPopupMenu).dismiss();
   }
 
   @Implementation
   protected void setOnMenuItemClickListener(PopupMenu.OnMenuItemClickListener listener) {
     this.onMenuItemClickListener = listener;
-    directlyOn(realPopupMenu, PopupMenu.class).setOnMenuItemClickListener(listener);
+    reflector(PopupMenuReflector.class, realPopupMenu).setOnMenuItemClickListener(listener);
   }
 
   public boolean isShowing() {
@@ -54,5 +55,18 @@ public class ShadowPopupMenu {
 
   public PopupMenu.OnMenuItemClickListener getOnMenuItemClickListener() {
     return onMenuItemClickListener;
+  }
+
+  @ForType(PopupMenu.class)
+  interface PopupMenuReflector {
+
+    @Direct
+    void show();
+
+    @Direct
+    void dismiss();
+
+    @Direct
+    void setOnMenuItemClickListener(PopupMenu.OnMenuItemClickListener listener);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowProgressDialog.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowProgressDialog.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.app.ProgressDialog;
 import android.widget.TextView;
@@ -8,6 +8,8 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(ProgressDialog.class)
@@ -32,7 +34,7 @@ public class ShadowProgressDialog extends ShadowAlertDialog {
   @Implementation
   protected void setProgressStyle(int style) {
     mProgressStyle = style;
-    directlyOn(realProgressDialog, ProgressDialog.class).setProgressStyle(style);
+    reflector(ProgressDialogReflector.class, realProgressDialog).setProgressStyle(style);
   }
 
   /**
@@ -40,5 +42,12 @@ public class ShadowProgressDialog extends ShadowAlertDialog {
    */
   public int getProgressStyle() {
     return mProgressStyle;
+  }
+
+  @ForType(ProgressDialog.class)
+  interface ProgressDialogReflector {
+
+    @Direct
+    void setProgressStyle(int style);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowResources.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowResources.java
@@ -5,7 +5,6 @@ import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.N;
 import static android.os.Build.VERSION_CODES.N_MR1;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
 import static org.robolectric.shadows.ShadowAssetManager.legacyShadowOf;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
@@ -91,7 +90,7 @@ public class ShadowResources {
       return legacyShadowOf(realResources.getAssets())
           .attrsToTypedArray(realResources, set, attrs, 0, 0, 0);
     } else {
-      return directlyOn(realResources, Resources.class).obtainAttributes(set, attrs);
+      return reflector(ResourcesReflector.class, realResources).obtainAttributes(set, attrs);
     }
   }
 
@@ -102,7 +101,8 @@ public class ShadowResources {
       String raw = getQuantityString(id, quantity);
       return String.format(Locale.ENGLISH, raw, formatArgs);
     } else {
-      return directlyOn(realResources, Resources.class).getQuantityString(id, quantity, formatArgs);
+      return reflector(ResourcesReflector.class, realResources)
+          .getQuantityString(id, quantity, formatArgs);
     }
   }
 
@@ -132,7 +132,7 @@ public class ShadowResources {
         return null;
       }
     } else {
-      return directlyOn(realResources, Resources.class).getQuantityString(resId, quantity);
+      return reflector(ResourcesReflector.class, realResources).getQuantityString(resId, quantity);
     }
   }
 
@@ -148,7 +148,7 @@ public class ShadowResources {
         return inputStream;
       }
     } else {
-      return directlyOn(realResources, Resources.class).openRawResource(id);
+      return reflector(ResourcesReflector.class, realResources).openRawResource(id);
     }
   }
 
@@ -174,7 +174,7 @@ public class ShadowResources {
         throw newNotFoundException(id);
       }
     } else {
-      return directlyOn(realResources, Resources.class).openRawResourceFd(id);
+      return reflector(ResourcesReflector.class, realResources).openRawResourceFd(id);
     }
   }
 
@@ -199,7 +199,7 @@ public class ShadowResources {
         throw newNotFoundException(id);
       }
     } else {
-      return directlyOn(realResources, Resources.class).obtainTypedArray(id);
+      return reflector(ResourcesReflector.class, realResources).obtainTypedArray(id);
     }
   }
 
@@ -374,5 +374,23 @@ public class ShadowResources {
 
     @Direct
     Drawable loadDrawable(TypedValue value, int id, Resources.Theme theme);
+
+    @Direct
+    TypedArray obtainAttributes(AttributeSet set, int[] attrs);
+
+    @Direct
+    String getQuantityString(int id, int quantity, Object... formatArgs);
+
+    @Direct
+    String getQuantityString(int resId, int quantity);
+
+    @Direct
+    InputStream openRawResource(int id);
+
+    @Direct
+    AssetFileDescriptor openRawResourceFd(int id);
+
+    @Direct
+    TypedArray obtainTypedArray(int id);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSeekBar.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSeekBar.java
@@ -1,26 +1,35 @@
 package org.robolectric.shadows;
 
+import static org.robolectric.util.reflector.Reflector.reflector;
+
 import android.widget.SeekBar;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.shadow.api.Shadow;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @Implements(SeekBar.class)
 public class ShadowSeekBar extends ShadowAbsSeekBar {
 
-  @RealObject
-  private SeekBar realSeekBar;
+  @RealObject private SeekBar realSeekBar;
 
   private SeekBar.OnSeekBarChangeListener listener;
 
   @Implementation
   protected void setOnSeekBarChangeListener(SeekBar.OnSeekBarChangeListener listener) {
     this.listener = listener;
-    Shadow.directlyOn(realSeekBar, SeekBar.class).setOnSeekBarChangeListener(listener);
+    reflector(SeekBarReflector.class, realSeekBar).setOnSeekBarChangeListener(listener);
   }
 
   public SeekBar.OnSeekBarChangeListener getOnSeekBarChangeListener() {
     return this.listener;
+  }
+
+  @ForType(SeekBar.class)
+  interface SeekBarReflector {
+
+    @Direct
+    void setOnSeekBarChangeListener(SeekBar.OnSeekBarChangeListener listener);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSuspendDialogInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSuspendDialogInfo.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.annotation.DrawableRes;
 import android.annotation.StringRes;
@@ -11,6 +11,8 @@ import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 /** Shadow of {@link SuspendDialogInfo} to expose hidden methods. */
 @Implements(value = SuspendDialogInfo.class, isInAndroidSdk = false, minSdk = Build.VERSION_CODES.Q)
@@ -23,7 +25,7 @@ public class ShadowSuspendDialogInfo {
   @HiddenApi
   @DrawableRes
   public int getIconResId() {
-    return directly().getIconResId();
+    return reflector(SuspendDialogInfoReflector.class, realInfo).getIconResId();
   }
 
   /** Returns the resource id of the title to be used with the dialog. */
@@ -31,7 +33,7 @@ public class ShadowSuspendDialogInfo {
   @HiddenApi
   @StringRes
   public int getTitleResId() {
-    return directly().getTitleResId();
+    return reflector(SuspendDialogInfoReflector.class, realInfo).getTitleResId();
   }
 
   /** Returns the resource id of the text to be shown in the dialog's body. */
@@ -39,7 +41,7 @@ public class ShadowSuspendDialogInfo {
   @HiddenApi
   @StringRes
   public int getDialogMessageResId() {
-    return directly().getDialogMessageResId();
+    return reflector(SuspendDialogInfoReflector.class, realInfo).getDialogMessageResId();
   }
 
   /**
@@ -50,7 +52,7 @@ public class ShadowSuspendDialogInfo {
   @HiddenApi
   @Nullable
   public String getDialogMessage() {
-    return directly().getDialogMessage();
+    return reflector(SuspendDialogInfoReflector.class, realInfo).getDialogMessage();
   }
 
   /** Returns the text to be shown. */
@@ -58,11 +60,7 @@ public class ShadowSuspendDialogInfo {
   @HiddenApi
   @StringRes
   public int getNeutralButtonTextResId() {
-    return directly().getNeutralButtonTextResId();
-  }
-
-  private SuspendDialogInfo directly() {
-    return directlyOn(realInfo, SuspendDialogInfo.class);
+    return reflector(SuspendDialogInfoReflector.class, realInfo).getNeutralButtonTextResId();
   }
 
   /**
@@ -72,6 +70,28 @@ public class ShadowSuspendDialogInfo {
    *     SuspendDialogInfo.BUTTON_ACTION_UNSUSPEND}
    */
   public int getNeutralButtonAction() {
-    return directlyOn(realInfo, SuspendDialogInfo.class).getNeutralButtonAction();
+    return reflector(SuspendDialogInfoReflector.class, realInfo).getNeutralButtonAction();
+  }
+
+  @ForType(SuspendDialogInfo.class)
+  interface SuspendDialogInfoReflector {
+
+    @Direct
+    int getIconResId();
+
+    @Direct
+    int getTitleResId();
+
+    @Direct
+    int getDialogMessageResId();
+
+    @Direct
+    String getDialogMessage();
+
+    @Direct
+    int getNeutralButtonTextResId();
+
+    @Direct
+    int getNeutralButtonAction();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextToSpeech.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextToSpeech.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.content.Context;
 import android.os.Bundle;
@@ -27,6 +28,8 @@ import org.robolectric.annotation.Resetter;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @Implements(TextToSpeech.class)
 public class ShadowTextToSpeech {
@@ -86,7 +89,7 @@ public class ShadowTextToSpeech {
   protected int speak(
       final String text, final int queueMode, final HashMap<String, String> params) {
     if (RuntimeEnvironment.getApiLevel() >= LOLLIPOP) {
-      return Shadow.directlyOn(tts, TextToSpeech.class).speak(text, queueMode, params);
+      return reflector(TextToSpeechReflector.class, tts).speak(text, queueMode, params);
     }
     return speak(
         text, queueMode, null, params == null ? null : params.get(Engine.KEY_PARAM_UTTERANCE_ID));
@@ -266,5 +269,12 @@ public class ShadowTextToSpeech {
     languageAvailabilities.clear();
     voices.clear();
     lastTextToSpeechInstance = null;
+  }
+
+  @ForType(TextToSpeech.class)
+  interface TextToSpeechReflector {
+
+    @Direct
+    int speak(final String text, final int queueMode, final HashMap params);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextView.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.content.Context;
 import android.graphics.Typeface;
@@ -21,6 +21,8 @@ import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(TextView.class)
@@ -64,21 +66,21 @@ public class ShadowTextView extends ShadowView {
   @Implementation
   protected void setTextAppearance(Context context, int resid) {
     textAppearanceId = resid;
-    directlyOn(realTextView, TextView.class).setTextAppearance(context, resid);
+    reflector(TextViewReflector.class, realTextView).setTextAppearance(context, resid);
   }
 
   @Implementation
   protected boolean onKeyDown(int keyCode, KeyEvent event) {
     previousKeyCodes.add(keyCode);
     previousKeyEvents.add(event);
-    return directlyOn(realTextView, TextView.class).onKeyDown(keyCode, event);
+    return reflector(TextViewReflector.class, realTextView).onKeyDown(keyCode, event);
   }
 
   @Implementation
   protected boolean onKeyUp(int keyCode, KeyEvent event) {
     previousKeyCodes.add(keyCode);
     previousKeyEvents.add(event);
-    return directlyOn(realTextView, TextView.class).onKeyUp(keyCode, event);
+    return reflector(TextViewReflector.class, realTextView).onKeyUp(keyCode, event);
   }
 
   public int getPreviousKeyCode(int index) {
@@ -107,13 +109,13 @@ public class ShadowTextView extends ShadowView {
   @Implementation
   protected void addTextChangedListener(TextWatcher watcher) {
     this.watchers.add(watcher);
-    directlyOn(realTextView, TextView.class).addTextChangedListener(watcher);
+    reflector(TextViewReflector.class, realTextView).addTextChangedListener(watcher);
   }
 
   @Implementation
   protected void removeTextChangedListener(TextWatcher watcher) {
     this.watchers.remove(watcher);
-    directlyOn(realTextView, TextView.class).removeTextChangedListener(watcher);
+    reflector(TextViewReflector.class, realTextView).removeTextChangedListener(watcher);
   }
 
   /**
@@ -150,7 +152,7 @@ public class ShadowTextView extends ShadowView {
   @Implementation
   protected void setOnEditorActionListener(TextView.OnEditorActionListener l) {
     this.onEditorActionListener = l;
-    directlyOn(realTextView, TextView.class).setOnEditorActionListener(l);
+    reflector(TextViewReflector.class, realTextView).setOnEditorActionListener(l);
   }
 
   public TextView.OnEditorActionListener getOnEditorActionListener() {
@@ -163,7 +165,8 @@ public class ShadowTextView extends ShadowView {
     this.compoundDrawablesWithIntrinsicBoundsTop = top;
     this.compoundDrawablesWithIntrinsicBoundsRight = right;
     this.compoundDrawablesWithIntrinsicBoundsBottom = bottom;
-    directlyOn(realTextView, TextView.class).setCompoundDrawablesWithIntrinsicBounds(left, top, right, bottom);
+    reflector(TextViewReflector.class, realTextView)
+        .setCompoundDrawablesWithIntrinsicBounds(left, top, right, bottom);
   }
 
   public int getCompoundDrawablesWithIntrinsicBoundsLeft() {
@@ -180,5 +183,30 @@ public class ShadowTextView extends ShadowView {
 
   public int getCompoundDrawablesWithIntrinsicBoundsBottom() {
     return compoundDrawablesWithIntrinsicBoundsBottom;
+  }
+
+  @ForType(TextView.class)
+  interface TextViewReflector {
+
+    @Direct
+    void setTextAppearance(Context context, int resid);
+
+    @Direct
+    boolean onKeyDown(int keyCode, KeyEvent event);
+
+    @Direct
+    boolean onKeyUp(int keyCode, KeyEvent event);
+
+    @Direct
+    void addTextChangedListener(TextWatcher watcher);
+
+    @Direct
+    void removeTextChangedListener(TextWatcher watcher);
+
+    @Direct
+    void setOnEditorActionListener(TextView.OnEditorActionListener l);
+
+    @Direct
+    void setCompoundDrawablesWithIntrinsicBounds(int left, int top, int right, int bottom);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowValueAnimator.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowValueAnimator.java
@@ -1,7 +1,6 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.N;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.animation.AnimationHandler;
@@ -13,14 +12,14 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.reflector.Accessor;
+import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 import org.robolectric.util.reflector.Static;
 
 @Implements(ValueAnimator.class)
 public class ShadowValueAnimator {
 
-  @RealObject
-  private ValueAnimator realObject;
+  @RealObject private ValueAnimator realObject;
 
   private int actualRepeatCount;
 
@@ -54,7 +53,7 @@ public class ShadowValueAnimator {
     if (count == ValueAnimator.INFINITE) {
       count = 1;
     }
-    directlyOn(realObject, ValueAnimator.class).setRepeatCount(count);
+    reflector(ValueAnimatorReflector.class, realObject).setRepeatCount(count);
   }
 
   /**
@@ -77,6 +76,10 @@ public class ShadowValueAnimator {
 
   @ForType(ValueAnimator.class)
   interface ValueAnimatorReflector {
+
+    @Direct
+    void setRepeatCount(int count);
+
     @Static
     @Accessor("sDurationScale")
     void setDurationScale(float duration);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowView.java
@@ -3,7 +3,6 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
 import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.N;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
 import static org.robolectric.shadow.api.Shadow.invokeConstructor;
 import static org.robolectric.shadows.ShadowLooper.shadowMainLooper;
 import static org.robolectric.util.ReflectionHelpers.getField;
@@ -151,47 +150,49 @@ public class ShadowView {
   @Implementation
   protected void setOnFocusChangeListener(View.OnFocusChangeListener l) {
     onFocusChangeListener = l;
-    directly().setOnFocusChangeListener(l);
+    reflector(_View_.class, realView).setOnFocusChangeListener(l);
   }
 
   @Implementation
   protected void setOnClickListener(View.OnClickListener onClickListener) {
     this.onClickListener = onClickListener;
-    directly().setOnClickListener(onClickListener);
+    reflector(_View_.class, realView).setOnClickListener(onClickListener);
   }
 
   @Implementation
   protected void setOnLongClickListener(View.OnLongClickListener onLongClickListener) {
     this.onLongClickListener = onLongClickListener;
-    directly().setOnLongClickListener(onLongClickListener);
+    reflector(_View_.class, realView).setOnLongClickListener(onLongClickListener);
   }
 
   @Implementation
   protected void setOnSystemUiVisibilityChangeListener(
       View.OnSystemUiVisibilityChangeListener onSystemUiVisibilityChangeListener) {
     this.onSystemUiVisibilityChangeListener = onSystemUiVisibilityChangeListener;
-    directly().setOnSystemUiVisibilityChangeListener(onSystemUiVisibilityChangeListener);
+    reflector(_View_.class, realView)
+        .setOnSystemUiVisibilityChangeListener(onSystemUiVisibilityChangeListener);
   }
 
   @Implementation
   protected void setOnCreateContextMenuListener(
       View.OnCreateContextMenuListener onCreateContextMenuListener) {
     this.onCreateContextMenuListener = onCreateContextMenuListener;
-    directly().setOnCreateContextMenuListener(onCreateContextMenuListener);
+    reflector(_View_.class, realView).setOnCreateContextMenuListener(onCreateContextMenuListener);
   }
 
   @Implementation
   protected void addOnAttachStateChangeListener(
       View.OnAttachStateChangeListener onAttachStateChangeListener) {
     onAttachStateChangeListeners.add(onAttachStateChangeListener);
-    directly().addOnAttachStateChangeListener(onAttachStateChangeListener);
+    reflector(_View_.class, realView).addOnAttachStateChangeListener(onAttachStateChangeListener);
   }
 
   @Implementation
   protected void removeOnAttachStateChangeListener(
       View.OnAttachStateChangeListener onAttachStateChangeListener) {
     onAttachStateChangeListeners.remove(onAttachStateChangeListener);
-    directly().removeOnAttachStateChangeListener(onAttachStateChangeListener);
+    reflector(_View_.class, realView)
+        .removeOnAttachStateChangeListener(onAttachStateChangeListener);
   }
 
   @Implementation
@@ -226,7 +227,7 @@ public class ShadowView {
   @Implementation
   protected void requestLayout() {
     didRequestLayout = true;
-    directly().requestLayout();
+    reflector(_View_.class, realView).requestLayout();
   }
 
   @Implementation
@@ -234,7 +235,7 @@ public class ShadowView {
     for (View.OnClickListener listener : globalClickListeners) {
       listener.onClick(realView);
     }
-    return directlyOn(realView, View.class).performClick();
+    return reflector(_View_.class, realView).performClick();
   }
 
   /**
@@ -260,7 +261,7 @@ public class ShadowView {
     for (View.OnLongClickListener listener : globalLongClickListeners) {
       listener.onLongClick(realView);
     }
-    return directlyOn(realView, View.class).performLongClick();
+    return reflector(_View_.class, realView).performLongClick();
   }
 
   /**
@@ -304,19 +305,19 @@ public class ShadowView {
   @Implementation
   protected void invalidate() {
     wasInvalidated = true;
-    directly().invalidate();
+    reflector(_View_.class, realView).invalidate();
   }
 
   @Implementation
   protected boolean onTouchEvent(MotionEvent event) {
     lastTouchEvent = event;
-    return directly().onTouchEvent(event);
+    return reflector(_View_.class, realView).onTouchEvent(event);
   }
 
   @Implementation
   protected void setOnTouchListener(View.OnTouchListener onTouchListener) {
     this.onTouchListener = onTouchListener;
-    directly().setOnTouchListener(onTouchListener);
+    reflector(_View_.class, realView).setOnTouchListener(onTouchListener);
   }
 
   public MotionEvent getLastTouchEvent() {
@@ -475,7 +476,7 @@ public class ShadowView {
   @Implementation
   protected boolean post(Runnable action) {
     if (ShadowLooper.looperMode() == LooperMode.Mode.PAUSED) {
-      return directly().post(action);
+      return reflector(_View_.class, realView).post(action);
     } else {
       ShadowApplication.getInstance().getForegroundThreadScheduler().post(action);
       return true;
@@ -485,7 +486,7 @@ public class ShadowView {
   @Implementation
   protected boolean postDelayed(Runnable action, long delayMills) {
     if (ShadowLooper.looperMode() == LooperMode.Mode.PAUSED) {
-      return directly().postDelayed(action, delayMills);
+      return reflector(_View_.class, realView).postDelayed(action, delayMills);
     } else {
       ShadowApplication.getInstance()
           .getForegroundThreadScheduler()
@@ -497,7 +498,7 @@ public class ShadowView {
   @Implementation
   protected void postInvalidateDelayed(long delayMilliseconds) {
     if (ShadowLooper.looperMode() == LooperMode.Mode.PAUSED) {
-      directly().postInvalidateDelayed(delayMilliseconds);
+      reflector(_View_.class, realView).postInvalidateDelayed(delayMilliseconds);
     } else {
       ShadowApplication.getInstance()
           .getForegroundThreadScheduler()
@@ -515,7 +516,7 @@ public class ShadowView {
   @Implementation
   protected boolean removeCallbacks(Runnable callback) {
     if (ShadowLooper.looperMode() == LooperMode.Mode.PAUSED) {
-      return directlyOn(realView, View.class).removeCallbacks(callback);
+      return reflector(_View_.class, realView).removeCallbacks(callback);
     } else {
       ShadowLegacyLooper shadowLooper = Shadow.extract(Looper.getMainLooper());
       shadowLooper.getScheduler().remove(callback);
@@ -571,7 +572,7 @@ public class ShadowView {
 
   @Implementation
   protected void setAnimation(final Animation animation) {
-    directly().setAnimation(animation);
+    reflector(_View_.class, realView).setAnimation(animation);
 
     if (animation != null) {
       new AnimationRunner(animation);
@@ -580,7 +581,7 @@ public class ShadowView {
 
   @Implementation
   protected void clearAnimation() {
-    directly().clearAnimation();
+    reflector(_View_.class, realView).clearAnimation();
 
     if (animationRunner != null) {
       animationRunner.cancel();
@@ -665,6 +666,73 @@ public class ShadowView {
     @Direct
     void assignParent(ViewParent viewParent);
 
+    @Direct
+    void setOnFocusChangeListener(View.OnFocusChangeListener l);
+
+    @Direct
+    void setOnClickListener(View.OnClickListener onClickListener);
+
+    @Direct
+    void setOnLongClickListener(View.OnLongClickListener onLongClickListener);
+
+    @Direct
+    void setOnSystemUiVisibilityChangeListener(
+        View.OnSystemUiVisibilityChangeListener onSystemUiVisibilityChangeListener);
+
+    @Direct
+    void setOnCreateContextMenuListener(
+        View.OnCreateContextMenuListener onCreateContextMenuListener);
+
+    @Direct
+    void addOnAttachStateChangeListener(
+        View.OnAttachStateChangeListener onAttachStateChangeListener);
+
+    @Direct
+    void removeOnAttachStateChangeListener(
+        View.OnAttachStateChangeListener onAttachStateChangeListener);
+
+    @Direct
+    void requestLayout();
+
+    @Direct
+    boolean performClick();
+
+    @Direct
+    boolean performLongClick();
+
+    @Direct
+    void invalidate();
+
+    @Direct
+    boolean onTouchEvent(MotionEvent event);
+
+    @Direct
+    void setOnTouchListener(View.OnTouchListener onTouchListener);
+
+    @Direct
+    boolean post(Runnable action);
+
+    @Direct
+    boolean postDelayed(Runnable action, long delayMills);
+
+    @Direct
+    void postInvalidateDelayed(long delayMilliseconds);
+
+    @Direct
+    boolean removeCallbacks(Runnable callback);
+
+    @Direct
+    void setAnimation(final Animation animation);
+
+    @Direct
+    void clearAnimation();
+
+    @Direct
+    boolean getGlobalVisibleRect(Rect rect, Point globalOffset);
+
+    @Direct
+    WindowId getWindowId();
+
     @Accessor("mAttachInfo")
     Object getAttachInfo();
 
@@ -695,7 +763,7 @@ public class ShadowView {
   @Implementation
   protected boolean getGlobalVisibleRect(Rect rect, Point globalOffset) {
     if (globalVisibleRect == null) {
-      return directly().getGlobalVisibleRect(rect, globalOffset);
+      return reflector(_View_.class, realView).getGlobalVisibleRect(rect, globalOffset);
     }
 
     if (!globalVisibleRect.isEmpty()) {
@@ -744,10 +812,6 @@ public class ShadowView {
     ShadowDisplay.getDefaultDisplay().getRectSize(outRect);
   }
 
-  private View directly() {
-    return directlyOn(realView, View.class);
-  }
-
   public static class WindowIdHelper {
     public static WindowId getWindowId(ShadowView shadowView) {
       if (shadowView.isAttachedToWindow()) {
@@ -759,7 +823,7 @@ public class ShadowView {
         }
       }
 
-      return shadowView.directly().getWindowId();
+      return reflector(_View_.class, shadowView.realView).getWindowId();
     }
 
     private static class MyIWindowIdStub extends IWindowId.Stub {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiInfo.java
@@ -1,9 +1,6 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.JELLY_BEAN;
-import static android.os.Build.VERSION_CODES.KITKAT;
-import static android.os.Build.VERSION_CODES.LOLLIPOP;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.net.wifi.SupplicantState;
@@ -28,29 +25,18 @@ public class ShadowWifiInfo {
   @RealObject WifiInfo realObject;
 
   public void setInetAddress(InetAddress address) {
-    if (RuntimeEnvironment.getApiLevel() >= LOLLIPOP) {
-      directlyOn(realObject, WifiInfo.class).setInetAddress(address);
-    } else {
-      reflector(WifiInfoReflector.class, realObject).setInetAddress(address);
-    }
+    reflector(WifiInfoReflector.class, realObject).setInetAddress(address);
   }
 
   public void setMacAddress(String newMacAddress) {
-    if (RuntimeEnvironment.getApiLevel() >= LOLLIPOP) {
-      directlyOn(realObject, WifiInfo.class).setMacAddress(newMacAddress);
-    } else {
-      reflector(WifiInfoReflector.class, realObject).setMacAddress(newMacAddress);
-    }
+    reflector(WifiInfoReflector.class, realObject).setMacAddress(newMacAddress);
   }
 
   public void setSSID(String ssid) {
     if (RuntimeEnvironment.getApiLevel() <= JELLY_BEAN) {
       reflector(WifiInfoReflector.class, realObject).setSSID(ssid);
-    } else if (RuntimeEnvironment.getApiLevel() <= KITKAT) {
-
-      reflector(WifiInfoReflector.class, realObject).setSSID(getWifiSsid(ssid));
     } else {
-      directlyOn(realObject, WifiInfo.class).setSSID((WifiSsid) getWifiSsid(ssid));
+      reflector(WifiInfoReflector.class, realObject).setSSID(getWifiSsid(ssid));
     }
   }
 
@@ -65,47 +51,27 @@ public class ShadowWifiInfo {
   }
 
   public void setBSSID(String bssid) {
-    if (RuntimeEnvironment.getApiLevel() >= LOLLIPOP) {
-      directlyOn(realObject, WifiInfo.class).setBSSID(bssid);
-    } else {
-      reflector(WifiInfoReflector.class, realObject).setBSSID(bssid);
-    }
+    reflector(WifiInfoReflector.class, realObject).setBSSID(bssid);
   }
 
   public void setSupplicantState(SupplicantState state) {
-    if (RuntimeEnvironment.getApiLevel() >= LOLLIPOP) {
-      directlyOn(realObject, WifiInfo.class).setSupplicantState(state);
-    } else {
-      reflector(WifiInfoReflector.class, realObject).setSupplicantState(state);
-    }
+    reflector(WifiInfoReflector.class, realObject).setSupplicantState(state);
   }
 
   public void setRssi(int rssi) {
-    if (RuntimeEnvironment.getApiLevel() >= LOLLIPOP) {
-      directlyOn(realObject, WifiInfo.class).setRssi(rssi);
-    } else {
-      reflector(WifiInfoReflector.class, realObject).setRssi(rssi);
-    }
+    reflector(WifiInfoReflector.class, realObject).setRssi(rssi);
   }
 
   public void setLinkSpeed(int linkSpeed) {
-    if (RuntimeEnvironment.getApiLevel() >= LOLLIPOP) {
-      directlyOn(realObject, WifiInfo.class).setLinkSpeed(linkSpeed);
-    } else {
-      reflector(WifiInfoReflector.class, realObject).setLinkSpeed(linkSpeed);
-    }
+    reflector(WifiInfoReflector.class, realObject).setLinkSpeed(linkSpeed);
   }
 
   public void setFrequency(int frequency) {
-    directlyOn(realObject, WifiInfo.class).setFrequency(frequency);
+    reflector(WifiInfoReflector.class, realObject).setFrequency(frequency);
   }
 
   public void setNetworkId(int id) {
-    if (RuntimeEnvironment.getApiLevel() >= LOLLIPOP) {
-      directlyOn(realObject, WifiInfo.class).setNetworkId(id);
-    } else {
-      reflector(WifiInfoReflector.class, realObject).setNetworkId(id);
-    }
+    reflector(WifiInfoReflector.class, realObject).setNetworkId(id);
   }
 
   @ForType(WifiInfo.class)
@@ -137,5 +103,8 @@ public class ShadowWifiInfo {
 
     @Direct
     void setNetworkId(int id);
+
+    @Direct
+    void setFrequency(int frequency);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiP2pGroup.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiP2pGroup.java
@@ -1,26 +1,40 @@
 package org.robolectric.shadows;
 
-import static org.robolectric.shadow.api.Shadow.directlyOn;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.net.wifi.p2p.WifiP2pGroup;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
 
 @Implements(WifiP2pGroup.class)
 public class ShadowWifiP2pGroup {
 
-  @RealObject
-  private WifiP2pGroup realObject;
+  @RealObject private WifiP2pGroup realObject;
 
   public void setInterface(String intf) {
-    directlyOn(realObject, WifiP2pGroup.class).setInterface(intf);
+    reflector(WifiP2pGroupReflector.class, realObject).setInterface(intf);
   }
 
   public void setPassphrase(String passphrase) {
-    directlyOn(realObject, WifiP2pGroup.class).setInterface(passphrase);
+    reflector(WifiP2pGroupReflector.class, realObject).setInterface(passphrase);
   }
 
   public void setNetworkName(String networkName) {
-    directlyOn(realObject, WifiP2pGroup.class).setInterface(networkName);
+    reflector(WifiP2pGroupReflector.class, realObject).setInterface(networkName);
+  }
+
+  @ForType(WifiP2pGroup.class)
+  interface WifiP2pGroupReflector {
+
+    @Direct
+    void setInterface(String intf);
+
+    @Direct
+    void setPassphrase(String passphrase);
+
+    @Direct
+    void setNetworkName(String networkName);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindowManagerImpl.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindowManagerImpl.java
@@ -6,7 +6,6 @@ import static android.view.View.SYSTEM_UI_FLAG_VISIBLE;
 import static android.view.ViewRootImpl.NEW_INSETS_MODE_FULL;
 import static android.view.WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING;
 import static org.robolectric.RuntimeEnvironment.getApiLevel;
-import static org.robolectric.shadow.api.Shadow.directlyOn;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.content.Context;
@@ -88,7 +87,7 @@ public class ShadowWindowManagerImpl extends ShadowWindowManager {
   @Implementation(maxSdk = JELLY_BEAN)
   public Display getDefaultDisplay() {
     if (getApiLevel() > JELLY_BEAN) {
-      return directlyOn(realObject, WindowManagerImpl.class).getDefaultDisplay();
+      return reflector(ReflectorWindowManagerImpl.class, realObject).getDefaultDisplay();
     } else {
       return defaultDisplayJB;
     }
@@ -146,6 +145,9 @@ public class ShadowWindowManagerImpl extends ShadowWindowManager {
 
     @Direct
     void removeViewImmediate(View view);
+
+    @Direct
+    Display getDefaultDisplay();
 
     @Accessor("mContext")
     Context getContext();


### PR DESCRIPTION
Converting the proxy version of directlyOn(...) to @Direct with reflector(...).

This change is a continuation of the migration towards Reflector. It was preceded by the conversion of the String version of directlyOn(...). Based on testing, this change should improve performance by another 4 or 5% for the top 25% of tests. The main problem with the proxy version of directlyOn(...) was the overhead of class definition and instance creation. Proxy classes had to be constantly regenerated by ASM because they are not cached across tests and instantiating new proxy instances for large classes (Activity, View, TextView, Resources, etc.) is slow.
