### PR TITLE
Use Object to replace GnssAntennaInfo.Listener at ShadowLocationManager

### DIFF
--- a/integration_tests/compat-target29/build.gradle
+++ b/integration_tests/compat-target29/build.gradle
@@ -1,0 +1,19 @@
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+apply plugin: 'kotlin'
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+
+dependencies {
+    api project(":robolectric")
+    compileOnly AndroidSdk.Q.coordinates
+
+    testCompileOnly AndroidSdk.Q.coordinates
+    testRuntime AndroidSdk.Q.coordinates
+    testImplementation("androidx.test:core:$axtVersion")
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "com.google.truth:truth:$truthVersion"
+}

--- a/integration_tests/compat-target29/src/test/java/org/robolectric/integration/compat/target29/Target29CompatibilityTest.kt
+++ b/integration_tests/compat-target29/src/test/java/org/robolectric/integration/compat/target29/Target29CompatibilityTest.kt
@@ -1,0 +1,18 @@
+package org.robolectric.integration.compat.target29
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class Target29CompatibilityTest {
+    @Test
+    fun `Initialize LocationManager succeed`() {
+        val application = ApplicationProvider.getApplicationContext<Context>()
+        val locationManager = application.getSystemService(Context.LOCATION_SERVICE)
+        assertThat(locationManager).isNotNull()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,3 +33,4 @@ include ':integration_tests:ctesque'
 include ':integration_tests:security-providers'
 include ':testapp'
 include ":integration_tests:mockk"
+include ':integration_tests:compat-target29'


### PR DESCRIPTION
The `GnssAntennaInfo` and `GnssAntennaInfo.Listener` is added at API 30, and it will cause `NoClassDefFoundError` when running Robolectric with target SDK less than 30, for example 29. This PR try to use `Object` to replace `GnssAntennaInfo` and `GnssAntennaInfo.Listener` to avoid parsing those classes when loading `ShadowLocationManager`. 

This PR also adds integration test module to test integration with target 29. It is used to test changes such as this PR. 

Fix: https://github.com/robolectric/robolectric/issues/6604
