### PR TITLE
Support to open fd for uncompressed file in asset

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         gradle
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.1.0-alpha08'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:1.3.0'
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         gradle
-        classpath 'com.android.tools.build:gradle:7.1.0-alpha08'
+        classpath 'com.android.tools.build:gradle:7.1.0-alpha12'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:1.3.0'
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,6 +11,8 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
 
+    api "com.google.guava:guava:27.0.1-jre"
+    api 'org.jetbrains:annotations:16.0.2'
     implementation "org.ow2.asm:asm-tree:9.0"
-    implementation 'com.android.tools.build:gradle:4.1.3'
+    implementation 'com.android.tools.build:gradle:7.1.0-alpha08'
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     api "com.google.guava:guava:27.0.1-jre"
     api 'org.jetbrains:annotations:16.0.2'
     implementation "org.ow2.asm:asm-tree:9.0"
-    implementation 'com.android.tools.build:gradle:7.1.0-alpha08'
+    implementation 'com.android.tools.build:gradle:7.1.0-alpha12'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Sep 05 18:28:10 CST 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/integration_tests/agp/build.gradle
+++ b/integration_tests/agp/build.gradle
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     // Testing dependencies
-    testImplementation project(path: ':testapp', configuration: 'default')
+    testImplementation project(path: ':testapp')
     testImplementation project(":robolectric")
     testImplementation project(":integration_tests:agp:testsupport")
 

--- a/integration_tests/androidx/build.gradle
+++ b/integration_tests/androidx/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.2.0")
 
     // Testing dependencies
-    testImplementation project(path: ':testapp', configuration: 'default')
+    testImplementation project(path: ':testapp')
     testImplementation project(":robolectric")
     testImplementation "junit:junit:${junitVersion}"
     testImplementation("androidx.test:core:$axtVersion")

--- a/integration_tests/ctesque/build.gradle
+++ b/integration_tests/ctesque/build.gradle
@@ -29,10 +29,14 @@ android {
     defaultConfig {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
+    aaptOptions {
+        noCompress 'txt'
+    }
 }
 
 dependencies {
-    implementation project(path: ':testapp', configuration: 'default')
+    implementation project(path: ':testapp')
     implementation project(path: ':shadowapi', configuration: 'default')
 
     testImplementation project(":robolectric")

--- a/integration_tests/ctesque/src/test/java/android/content/res/AssetManagerTest.java
+++ b/integration_tests/ctesque/src/test/java/android/content/res/AssetManagerTest.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -61,12 +60,14 @@ public class AssetManagerTest {
 
   @Test
   public void open_withAccessMode_shouldOpenFile() throws IOException {
-    final String contents = CharStreams.toString(
-        new InputStreamReader(assetManager.open("assetsHome.txt", AssetManager.ACCESS_BUFFER), UTF_8));
+    final String contents =
+        CharStreams.toString(
+            new InputStreamReader(
+                assetManager.open("assetsHome.txt", AssetManager.ACCESS_BUFFER), UTF_8));
     assertThat(contents).isEqualTo("assetsHome!");
   }
 
-  @Test @Ignore("TODO(xian): re-enable; see https://github.com/robolectric/robolectric/issues/4091")
+  @Test
   public void openFd_shouldProvideFileDescriptorForAsset() throws Exception {
     AssetFileDescriptor assetFileDescriptor = assetManager.openFd("assetsHome.txt");
     assertThat(CharStreams.toString(new InputStreamReader(assetFileDescriptor.createInputStream(), UTF_8)))

--- a/integration_tests/dependency-on-stubs/build.gradle
+++ b/integration_tests/dependency-on-stubs/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation files("${System.getenv("ANDROID_HOME")}/platforms/android-29/android.jar")
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates // compile against latest Android SDK
-    testRuntime AndroidSdk.MAX_SDK.coordinates
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
     testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testImplementation "org.hamcrest:hamcrest-junit:2.0.0.0"

--- a/integration_tests/libphonenumber/build.gradle
+++ b/integration_tests/libphonenumber/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api "junit:junit:${junitVersion}"
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
-    testRuntime AndroidSdk.MAX_SDK.coordinates
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
     testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation 'com.googlecode.libphonenumber:libphonenumber:8.0.0'
 }

--- a/integration_tests/memoryleaks/build.gradle
+++ b/integration_tests/memoryleaks/build.gradle
@@ -26,7 +26,7 @@ android {
 
 dependencies {
     // Testing dependencies
-    testImplementation project(path: ':testapp', configuration: 'default')
+    testImplementation project(path: ':testapp')
     testImplementation project(":robolectric")
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "com.google.guava:guava-testlib:29.0-jre"

--- a/integration_tests/mockito-experimental/build.gradle
+++ b/integration_tests/mockito-experimental/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
-    testRuntime AndroidSdk.MAX_SDK.coordinates
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-inline:${mockitoVersion}"

--- a/integration_tests/mockito/build.gradle
+++ b/integration_tests/mockito/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
-    testRuntime AndroidSdk.MAX_SDK.coordinates
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"

--- a/integration_tests/powermock/build.gradle
+++ b/integration_tests/powermock/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     api project(":robolectric")
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
-    testRuntime AndroidSdk.MAX_SDK.coordinates
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "com.google.truth:truth:${truthVersion}"
 

--- a/integration_tests/security-providers/build.gradle
+++ b/integration_tests/security-providers/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api "junit:junit:${junitVersion}"
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
-    testRuntime AndroidSdk.MAX_SDK.coordinates
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
     testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.conscrypt:conscrypt-openjdk-uber:2.4.0"
     testImplementation "com.squareup.okhttp3:okhttp"

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     testImplementation "androidx.test:runner:$axtVersion"
     testImplementation("com.google.guava:guava:27.0.1-jre")
     testCompileOnly AndroidSdk.MAX_SDK.coordinates // compile against latest Android SDK
-    testRuntime AndroidSdk.MAX_SDK.coordinates // run against whatever this JDK supports
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates // run against whatever this JDK supports
 }
 
 test {

--- a/shadows/httpclient/build.gradle
+++ b/shadows/httpclient/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testImplementation "androidx.test.ext:junit:$axtJunitVersion"
 
     testCompileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates) { force = true }
-    testRuntime AndroidSdk.LOLLIPOP_MR1.coordinates
+    testRuntimeOnly AndroidSdk.LOLLIPOP_MR1.coordinates
 }
 
 // httpcore needs to come before android-all on runtime classpath; the gradle IntelliJ plugin

--- a/shadows/playservices/build.gradle
+++ b/shadows/playservices/build.gradle
@@ -30,9 +30,9 @@ dependencies {
     testImplementation "junit:junit:4.13.1"
     testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:2.5.4"
-    testRuntime "com.android.support:support-fragment:28.0.0"
-    testRuntime "com.google.android.gms:play-services-base:8.4.0"
-    testRuntime "com.google.android.gms:play-services-basement:8.4.0"
+    testRuntimeOnly "com.android.support:support-fragment:28.0.0"
+    testRuntimeOnly "com.google.android.gms:play-services-base:8.4.0"
+    testRuntimeOnly "com.google.android.gms:play-services-basement:8.4.0"
 
-    testRuntime AndroidSdk.MAX_SDK.coordinates
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
 }

--- a/shadows/supportv4/build.gradle
+++ b/shadows/supportv4/build.gradle
@@ -51,13 +51,13 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
 
     earlyTestRuntime "org.hamcrest:hamcrest-junit:2.0.0.0"
-    testRuntime AndroidSdk.MAX_SDK.coordinates
-    testRuntime "com.android.support:support-v4:${supportLibraryVersions}"
-    testRuntime "com.android.support:support-compat:${supportLibraryVersions}"
-    testRuntime "com.android.support:support-core-ui:${supportLibraryVersions}"
-    testRuntime "com.android.support:support-core-utils:${supportLibraryVersions}"
-    testRuntime "com.android.support:support-fragment:${supportLibraryVersions}"
-    testRuntime "com.android.support:support-media-compat:${supportLibraryVersions}"
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
+    testRuntimeOnly "com.android.support:support-v4:${supportLibraryVersions}"
+    testRuntimeOnly "com.android.support:support-compat:${supportLibraryVersions}"
+    testRuntimeOnly "com.android.support:support-core-ui:${supportLibraryVersions}"
+    testRuntimeOnly "com.android.support:support-core-utils:${supportLibraryVersions}"
+    testRuntimeOnly "com.android.support:support-fragment:${supportLibraryVersions}"
+    testRuntimeOnly "com.android.support:support-media-compat:${supportLibraryVersions}"
 }
 
 // hamcrest needs to come before junit on runtime classpath; the gradle IntelliJ plugin


### PR DESCRIPTION
### Overview

This PR tries to support open asset file with fd for uncompressed file. 

### Proposed Changes

Re-enable ignore test for open asset file with fd and use local header extra length to calculate file content offset in zip for `FileMap` to ensure it can read correct content from zip. Because AGP-7.1.0-alpha08 fixes `noCompress` support for unit test build, so this PR also update ctesque module AGP version to it, and add `noCompress` for test files.

Fix: https://github.com/robolectric/robolectric/issues/5442, https://github.com/robolectric/robolectric/issues/4091