### PR TITLE
Trimming the localrepository string.

### DIFF
--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
@@ -146,7 +146,12 @@ public class MavenDependencyResolver implements DependencyResolver {
 
       if (nodeList.getLength() != 0) {
         Node node = nodeList.item(0);
-        return node.getTextContent().trim();
+        String repository = node.getTextContent();
+
+        if (repository == null) {
+          return null;
+        }
+        return repository.trim();
       }
     } catch (ParserConfigurationException | IOException | SAXException e) {
       Logger.error("Error reading settings.xml", e);

--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
@@ -146,7 +146,7 @@ public class MavenDependencyResolver implements DependencyResolver {
 
       if (nodeList.getLength() != 0) {
         Node node = nodeList.item(0);
-        return node.getTextContent();
+        return node.getTextContent().trim();
       }
     } catch (ParserConfigurationException | IOException | SAXException e) {
       Logger.error("Error reading settings.xml", e);


### PR DESCRIPTION
### Overview
When the maven settings.xml is read, remove starting and end space. This avoid an error when fecthing the additional jar.

### Proposed Changes
Added trim when the string inside the xml is returned.
