### PR TITLE
Use offset from BufferInfo instead of ByteBuffer for ShadowMediaMuxer#writeSampleData

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaMuxer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaMuxer.java
@@ -125,9 +125,14 @@ public class ShadowMediaMuxer {
       int size,
       long presentationTimeUs,
       @MediaCodec.BufferFlag int flags) {
-    int toWrite = size - offset;
-    byte[] bytes = new byte[toWrite];
-    byteBuf.get(bytes, 0, toWrite);
+    byte[] bytes = new byte[size];
+    int oldPosition = byteBuf.position();
+    // The offset is the start-offset of the data in the buffer. We should use input offset for
+    // byteBuf to read bytes, instead of byteBuf current offset.
+    // See https://developer.android.com/reference/android/media/MediaCodec.BufferInfo#offset.
+    byteBuf.position(offset);
+    byteBuf.get(bytes, 0, size);
+    byteBuf.position(oldPosition);
 
     try {
       getStream(nativeObject).write(bytes);


### PR DESCRIPTION
[The offset from `BufferInfo` is the start-offset of the data in the buffer](https://developer.android.com/reference/android/media/MediaCodec.BufferInfo#offset.). We should use this offset for input `ByteBuffer` to read bytes, instead of using current `ByteBuffer` offset. We also can check its logic from https://cs.android.com/android/platform/superproject/+/master:frameworks/base/media/jni/android_media_MediaMuxer.cpp;l=87-124;drc=master?q=nativeWriteSampleData&ss=android:

```C++
    void *dst = env->GetDirectBufferAddress(byteBuf);

    jlong dstSize;
    jbyteArray byteArray = NULL;

    if (dst == NULL) {

        byteArray =
            (jbyteArray)env->CallObjectMethod(byteBuf, gFields.arrayID);

        if (byteArray == NULL) {
            jniThrowException(env, "java/lang/IllegalArgumentException",
                              "byteArray is null");
            return;
        }

        jboolean isCopy;
        dst = env->GetByteArrayElements(byteArray, &isCopy);

        dstSize = env->GetArrayLength(byteArray);
    } else {
        dstSize = env->GetDirectBufferCapacity(byteBuf);
    }

    if (dstSize < (offset + size)) {
        ALOGE("writeSampleData saw wrong dstSize %lld, size  %d, offset %d",
              (long long)dstSize, size, offset);
        if (byteArray != NULL) {
            env->ReleaseByteArrayElements(byteArray, (jbyte *)dst, 0);
        }
        jniThrowException(env, "java/lang/IllegalArgumentException",
                          "sample has a wrong size");
        return;
    }

    sp<ABuffer> buffer = new ABuffer((char *)dst + offset, size);

    status_t err = muxer->writeSampleData(buffer, trackIndex, timeUs, flags);
```

It uses array start address + offset as start address for `buffer`. 

Fix https://github.com/robolectric/robolectric/issues/6676.