### PR TITLE
Support Object array and Iterable as return type for single parameter

### DIFF
--- a/robolectric/src/main/java/org/robolectric/ParameterizedRobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/ParameterizedRobolectricTestRunner.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -303,7 +304,12 @@ public final class ParameterizedRobolectricTestRunner extends Suite {
   @SuppressWarnings("unchecked")
   private static List<Object> getParametersList(TestClass testClass, ClassLoader classLoader)
       throws Throwable {
-    return (List<Object>) getParametersMethod(testClass, classLoader).invokeExplosively(null);
+    Object parameters = getParametersMethod(testClass, classLoader).invokeExplosively(null);
+    if (parameters != null && parameters.getClass().isArray()) {
+      return Arrays.asList((Object[]) parameters);
+    } else {
+      return (List<Object>) parameters;
+    }
   }
 
   private static FrameworkMethod getParametersMethod(TestClass testClass, ClassLoader classLoader)

--- a/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerIterableSingleParameterTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerIterableSingleParameterTest.java
@@ -1,0 +1,29 @@
+package org.robolectric;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameter;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
+
+/**
+ * Tests for the single parameter test with {@link Iterable} as return type.
+ *
+ * <p>See https://github.com/junit-team/junit4/wiki/parameterized-tests#tests-with-single-parameter.
+ */
+@RunWith(ParameterizedRobolectricTestRunner.class)
+public class ParameterizedRobolectricTestRunnerIterableSingleParameterTest {
+  @Parameter public int intValue;
+
+  @Test
+  public void parameters_shouldHaveValues() {
+    assertThat(intValue).isNotEqualTo(0);
+  }
+
+  @Parameters
+  public static Iterable<?> parameters() {
+    return Arrays.asList(1, 2, 3, 4, 5);
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerObjectArraySingleParameterTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerObjectArraySingleParameterTest.java
@@ -1,0 +1,28 @@
+package org.robolectric;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameter;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
+
+/**
+ * Tests for the single parameter test with {@link Object} array as return type.
+ *
+ * <p>See https://github.com/junit-team/junit4/wiki/parameterized-tests#tests-with-single-parameter.
+ */
+@RunWith(ParameterizedRobolectricTestRunner.class)
+public class ParameterizedRobolectricTestRunnerObjectArraySingleParameterTest {
+  @Parameter public int intValue;
+
+  @Test
+  public void parameters_shouldHaveValues() {
+    assertThat(intValue).isNotEqualTo(0);
+  }
+
+  @Parameters
+  public static Object[] parameters() {
+    return new Object[] {1, 2, 3, 4, 5};
+  }
+}


### PR DESCRIPTION
As [junit4 
Tests with single parameter section](https://github.com/junit-team/junit4/wiki/parameterized-tests#tests-with-single-parameter) said, it supports `Iterable<? extends Object>` and `Object[]` as return type for single parameter generator method:

```java
@Parameters
public static Iterable<? extends Object> data() {
    return Arrays.asList("first test", "second test");
}
```
or
```
@Parameters
public static Object[] data() {
    return new Object[] { "first test", "second test" };
}
```
Current master branch supports `Iterable<? extends Object>` because it use `List<Object>` to store generated parameters, so one commit of this PR adds test for it. But current `ParameterizedRobolectricTestRunner` doesn't support `Object[]` because `List<Object>` can't been cast to `List<Object>`. So there is another commit to add support for identify the return type of parameter generator method, and transfer `Object[]` to `List<Object>` to support `Object[]` as parameter generator method's return type.

Fix https://github.com/robolectric/robolectric/issues/4718.