### PR TITLE
Deprecate ShadowSwipeRefreshLayout.

### DIFF
--- a/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowSwipeRefreshLayout.java
+++ b/shadows/supportv4/src/main/java/org/robolectric/shadows/support/v4/ShadowSwipeRefreshLayout.java
@@ -8,7 +8,12 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowViewGroup;
 
+/**
+ * Deprecated. Use SwipeRefreshLayout#setRefreshing to trigger a OnRefreshListener.onRefresh call
+ * instead.
+ */
 @Implements(SwipeRefreshLayout.class)
+@Deprecated
 public class ShadowSwipeRefreshLayout extends ShadowViewGroup {
   @RealObject SwipeRefreshLayout realObject;
   private OnRefreshListener listener;


### PR DESCRIPTION
See #4578

Rebase pushed commit at https://github.com/robolectric/robolectric/issues/4578. This PR deprecates `ShadowSwipeRefreshLayout` and there should be another PR to delete it at next release cycle.

Close https://github.com/robolectric/robolectric/issues/4578.
