### PR TITLE
Remove allocation in ShadowCursorWindow.Data init

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCursorWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCursorWindow.java
@@ -244,7 +244,7 @@ public class ShadowCursorWindow {
 
     public Data(String name, int cursorWindowSize) {
       this.name = name;
-      this.rows = new ArrayList<Row>(cursorWindowSize);
+      this.rows = new ArrayList<Row>();
     }
 
     public Value value(int rowN, int colN) {


### PR DESCRIPTION
### Overview

Short version: Fixes an issue where ShadowCursorWindow allocates an array with a large initial capacity (~2 million entries) upon creation.

More details can be found in this issue: https://github.com/robolectric/robolectric/issues/6704

### Proposed Changes

Remove the initialCapacity from the ArrayList creation.

The initialCapacity is a hint of how many elements the ArrayList will contain, used to avoid unnecessary copying as the list grows. The supplied value - cursorWindowSize - does not reflect the expected array size and can be quite large (~2 million).

Note that removing the initialCapacity will not affect functionality, it will just improve memory efficiency. For that reason, there are no additional tests in this PR.

Fixes #6704 