### PR TITLE
Add CI job to check aggregateDocs

### DIFF
--- a/.github/workflows/check_aggregateDocs.yml
+++ b/.github/workflows/check_aggregateDocs.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          submodules: recursive
 
       - name: Set up JDK 
         uses: actions/setup-java@v2

--- a/.github/workflows/check_aggregateDocs.yml
+++ b/.github/workflows/check_aggregateDocs.yml
@@ -1,0 +1,30 @@
+name: Check aggregateDocs
+
+on:
+  push:
+    branches: [ master ]
+
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  check_aggregateDocs:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        java: [ '13', '14', '15'] # OpenJDK fixed broken javadoc from 13
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu' # zulu suports complete JDK list
+          java-version: ${{ matrix.java }}
+          cache: 'gradle'
+
+      - name: Run aggregateDocs
+        run: ./gradlew clean aggregateDocs

--- a/.github/workflows/check_aggregateDocs.yml
+++ b/.github/workflows/check_aggregateDocs.yml
@@ -10,9 +10,6 @@ on:
 jobs:
   check_aggregateDocs:
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        java: [ '13', '14', '15'] # OpenJDK fixed broken javadoc from 13
 
     steps:
       - uses: actions/checkout@v2
@@ -24,7 +21,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu' # zulu suports complete JDK list
-          java-version: ${{ matrix.java }}
+          java-version: 14
           cache: 'gradle'
 
       - name: Run aggregateDocs

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ gradle.projectsEvaluated {
                 source("8")
                 header = headerHtml
                 footer = headerHtml
-//                bottom = "<link rel=\"stylesheet\" href=\"http://robolectric.org/assets/css/main.css\">"
+                // bottom = "<link rel=\"stylesheet\" href=\"http://robolectric.org/assets/css/main.css\">"
                 version = thisVersion
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,9 @@ gradle.projectsEvaluated {
                         "https://docs.oracle.com/javase/8/docs/api/",
                         "https://developer.android.com/reference/",
                 ]
+                // Set javadoc source to JDK 8 to avoid unnamed module problem
+                // when running aggregateJavadoc with OpenJDK 13+.
+                source("8")
                 header = headerHtml
                 footer = headerHtml
 //                bottom = "<link rel=\"stylesheet\" href=\"http://robolectric.org/assets/css/main.css\">"


### PR DESCRIPTION
We upgraded our AGP to 7.1.x with gradle 7.2 that needs OpenJDK 11. But OpenJDK 11 has problem to aggregate javadocs with correct link, and it is fixed from OpenJDK 13. This PR adds a new CI job to check aggregateDocs for different OpenJDK 13 and above versions to ensure this task can be run correctly.