### PR TITLE
Improve resetter for NfcAdapter and CardEmulation

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCardEmulationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCardEmulationTest.java
@@ -30,7 +30,6 @@ public final class ShadowCardEmulationTest {
 
   @Before
   public void setUp() throws Exception {
-    ShadowCardEmulation.reset();
     Application context = ApplicationProvider.getApplicationContext();
     shadowOf(context.getPackageManager())
         .setSystemFeature(PackageManager.FEATURE_NFC, /* supported= */ true);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCardEmulation.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCardEmulation.java
@@ -1,8 +1,12 @@
 package org.robolectric.shadows;
 
+import static org.robolectric.util.reflector.Reflector.reflector;
+
 import android.annotation.Nullable;
 import android.app.Activity;
 import android.content.ComponentName;
+import android.content.Context;
+import android.nfc.INfcCardEmulation;
 import android.nfc.cardemulation.CardEmulation;
 import android.os.Build;
 import android.provider.Settings;
@@ -13,6 +17,9 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
+import org.robolectric.util.reflector.Accessor;
+import org.robolectric.util.reflector.ForType;
+import org.robolectric.util.reflector.Static;
 
 /** Shadow implementation of {@link CardEmulation}. */
 @Implements(CardEmulation.class)
@@ -72,5 +79,27 @@ public class ShadowCardEmulation {
   public static void reset() {
     defaultServiceForCategoryMap = new HashMap<>();
     preferredService = null;
+    CardEmulationReflector reflector = reflector(CardEmulationReflector.class);
+    reflector.setIsInitialized(false);
+    reflector.setService(null);
+    Map<Context, CardEmulation> cardEmus = reflector.getCardEmus();
+    if (cardEmus != null) {
+      cardEmus.clear();
+    }
+  }
+
+  @ForType(CardEmulation.class)
+  interface CardEmulationReflector {
+    @Static
+    @Accessor("sIsInitialized")
+    void setIsInitialized(boolean isInitialized);
+
+    @Static
+    @Accessor("sService")
+    void setService(INfcCardEmulation service);
+
+    @Static
+    @Accessor("sCardEmus")
+    Map<Context, CardEmulation> getCardEmus();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCardEmulation.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCardEmulation.java
@@ -79,12 +79,14 @@ public class ShadowCardEmulation {
   public static void reset() {
     defaultServiceForCategoryMap = new HashMap<>();
     preferredService = null;
-    CardEmulationReflector reflector = reflector(CardEmulationReflector.class);
-    reflector.setIsInitialized(false);
-    reflector.setService(null);
-    Map<Context, CardEmulation> cardEmus = reflector.getCardEmus();
-    if (cardEmus != null) {
-      cardEmus.clear();
+    if (RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.KITKAT) {
+      CardEmulationReflector reflector = reflector(CardEmulationReflector.class);
+      reflector.setIsInitialized(false);
+      reflector.setService(null);
+      Map<Context, CardEmulation> cardEmus = reflector.getCardEmus();
+      if (cardEmus != null) {
+        cardEmus.clear();
+      }
     }
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNfcAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNfcAdapter.java
@@ -12,11 +12,13 @@ import android.nfc.NfcAdapter;
 import android.nfc.Tag;
 import android.os.Build;
 import android.os.Bundle;
+import java.util.Map;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
+import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 import org.robolectric.util.reflector.Static;
@@ -210,10 +212,36 @@ public class ShadowNfcAdapter {
   @Resetter
   public static synchronized void reset() {
     hardwareExists = true;
+    NfcAdapterReflector nfcAdapterReflector = reflector(NfcAdapterReflector.class);
+    nfcAdapterReflector.setIsInitialized(false);
+    Map<Context, NfcAdapter> adapters = nfcAdapterReflector.getNfcAdapters();
+    if (adapters != null) {
+      adapters.clear();
+    }
+    if (RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.Q) {
+      nfcAdapterReflector.setHasNfcFeature(false);
+      nfcAdapterReflector.setHasBeamFeature(false);
+    }
   }
 
   @ForType(NfcAdapter.class)
   interface NfcAdapterReflector {
+    @Static
+    @Accessor("sIsInitialized")
+    void setIsInitialized(boolean isInitialized);
+
+    @Static
+    @Accessor("sHasNfcFeature")
+    void setHasNfcFeature(boolean hasNfcFeature);
+
+    @Static
+    @Accessor("sHasBeamFeature")
+    void setHasBeamFeature(boolean hasBeamFeature);
+
+    @Static
+    @Accessor("sNfcAdapters")
+    Map<Context, NfcAdapter> getNfcAdapters();
+
     @Direct
     @Static
     NfcAdapter getNfcAdapter(Context context);


### PR DESCRIPTION
It will help to fix the problem that `CarEmulation.getInstance` throws
unsupported exception, because `adapter.getCardEmulationService` is null,
what caused by old static fields set by other tests.
