### PR TITLE
Create a separate task to prefetch non-instrumented SDKs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,25 @@ afterEvaluate {
 task prefetchSdks() {
     AndroidSdk.ALL_SDKS.each { androidSdk ->
         doLast {
+            println("Prefetching ${androidSdk.coordinates}...")
+            // prefetch into maven local repo...
+            def mvnCommand = "mvn -q dependency:get -DrepoUrl=http://maven.google.com \
+                -DgroupId=${androidSdk.groupId} -DartifactId=${androidSdk.artifactId} \
+                -Dversion=${androidSdk.version}"
+            shellExec(mvnCommand)
+
+            // prefetch into gradle local cache...
+            def config = configurations.create("sdk${androidSdk.apiLevel}")
+            dependencies.add("sdk${androidSdk.apiLevel}", androidSdk.coordinates)
+            // causes dependencies to be resolved:
+            config.files
+        }
+    }
+}
+
+task prefetchInstrumentedSdks() {
+    AndroidSdk.ALL_SDKS.each { androidSdk ->
+        doLast {
             println("Prefetching ${androidSdk.preinstrumentedCoordinates}...")
             // prefetch into maven local repo...
             def mvnCommand = "mvn -q dependency:get -DrepoUrl=http://maven.google.com \


### PR DESCRIPTION
This is needed to update the preinstrumented sdks.

./gradlew prefetchSdks fetches the regular (non-instrumented) ones.
./gradlew prefetchInstrumentedSdks fetches the instrumented ones.

