### PR TITLE
Add solution log for unhandled PNG file

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ImageUtil.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ImageUtil.java
@@ -60,6 +60,10 @@ public class ImageUtil {
   }
 
   static RobolectricBufferedImage getImageFromStream(InputStream is) {
+    return getImageFromStream(null, is);
+  }
+
+  static RobolectricBufferedImage getImageFromStream(String fileName, InputStream is) {
     if (!initialized) {
       // Stops ImageIO from creating temp files when reading images
       // from input stream.
@@ -87,9 +91,12 @@ public class ImageUtil {
       }
     } catch (IOException e) {
       if (FORMAT_NAME_PNG.equalsIgnoreCase(format) && e instanceof IIOException) {
+        String pngFileName = "(" + (fileName == null ? "not given PNG file name" : fileName) + ")";
         System.err.println(
-            "Looks like your PNG file has format problem that OpenJDK can't process correctly. You"
-                + " can check https://github.com/robolectric/robolectric/issues/6812 for potential"
+            "Looks like your PNG file"
+                + pngFileName
+                + " has format problem that OpenJDK can't process correctly. You can check"
+                + " https://github.com/robolectric/robolectric/issues/6812 for potential"
                 + " solution.");
       }
       throw new RuntimeException(e);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ImageUtil.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ImageUtil.java
@@ -90,14 +90,17 @@ public class ImageUtil {
         reader.dispose();
       }
     } catch (IOException e) {
-      if (FORMAT_NAME_PNG.equalsIgnoreCase(format) && e instanceof IIOException) {
+      Throwable cause = e.getCause();
+      if (FORMAT_NAME_PNG.equalsIgnoreCase(format)
+          && cause instanceof IIOException
+          && cause.getMessage() != null
+          && cause.getMessage().contains("Invalid chunk length")) {
         String pngFileName = "(" + (fileName == null ? "not given PNG file name" : fileName) + ")";
         System.err.println(
-            "Looks like your PNG file"
+            "The PNG file"
                 + pngFileName
-                + " has format problem that OpenJDK can't process correctly. You can check"
-                + " https://github.com/robolectric/robolectric/issues/6812 for potential"
-                + " solution.");
+                + " cannot be decoded. This may be due to an OpenJDK issue with certain PNG files."
+                + " See https://github.com/robolectric/robolectric/issues/6812 for more details.");
       }
       throw new RuntimeException(e);
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -75,7 +75,8 @@ public class ShadowBitmapFactory {
     final TypedValue value = new TypedValue();
     InputStream is = res.openRawResource(id, value);
 
-    RobolectricBufferedImage image = getImageFromStream(res.getResourceName(id), is);
+    String resourceName = res.getResourceName(id);
+    RobolectricBufferedImage image = getImageFromStream(resourceName, is);
     if (!allowInvalidImageData && image == null) {
       if (options != null) {
         options.outWidth = -1;
@@ -83,7 +84,7 @@ public class ShadowBitmapFactory {
       }
       return null;
     }
-    Bitmap bitmap = create("resource:" + res.getResourceName(id), options, image);
+    Bitmap bitmap = create("resource:" + resourceName, options, image);
     ShadowBitmap shadowBitmap = Shadow.extract(bitmap);
     shadowBitmap.createdFromResId = id;
     return bitmap;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -75,7 +75,7 @@ public class ShadowBitmapFactory {
     final TypedValue value = new TypedValue();
     InputStream is = res.openRawResource(id, value);
 
-    RobolectricBufferedImage image = getImageFromStream(is);
+    RobolectricBufferedImage image = getImageFromStream(res.getResourceName(id), is);
     if (!allowInvalidImageData && image == null) {
       if (options != null) {
         options.outWidth = -1;
@@ -102,7 +102,7 @@ public class ShadowBitmapFactory {
     if (pathName != null && new File(pathName).exists()) {
       try (FileInputStream fileInputStream = new FileInputStream(pathName);
           BufferedInputStream bufferedInputStream = new BufferedInputStream(fileInputStream)) {
-        image = getImageFromStream(bufferedInputStream);
+        image = getImageFromStream(pathName, bufferedInputStream);
       } catch (IOException e) {
         Logger.warn("Error getting size of bitmap file", e);
       }


### PR DESCRIPTION
Close https://github.com/robolectric/robolectric/issues/6812.

I don't have related images without copyright problem for this change, so I tested it with demo at https://github.com/robolectric/robolectric/issues/6812. It will print a log for unhandled PNG file with link https://github.com/robolectric/robolectric/issues/6812. The developer can get potential solution from this issue's discussion.