### PR TITLE
Disable the universal library for Mac OS

### DIFF
--- a/nativeruntime/build.gradle
+++ b/nativeruntime/build.gradle
@@ -52,8 +52,6 @@ task configureICU {
         environment "CXXFLAGS", "-fPIC"
         commandLine './runConfigureICU', 'Linux', '--enable-static', '--disable-shared'
       } else if (os.contains("mac")) {
-        environment "CFLAGS", "-arch x86_64 -arch arm64"
-        environment "CXXFLAGS", "-arch x86_64 -arch arm64"
         commandLine './runConfigureICU', 'MacOSX', '--enable-static', '--disable-shared'
       } else {
         println("Skipping the nativeruntime build for OS '${System.getProperty("os.name")}'")
@@ -97,12 +95,7 @@ task copyNativeRuntime {
       rename { String fileName ->
         fileName.replace("libnativeruntime", "librobolectric-nativeruntime")
       }
-      def os = osName()
-      def arch = arch()
-      if (os.contains("mac")) {
-        arch = "universal"
-      }
-      into project.file("$buildDir/resources/main/native/${os}/${arch}/")
+      into project.file("$buildDir/resources/main/native/${osName()}/${arch()}/")
     }
   }
 }

--- a/nativeruntime/cpp/CMakeLists.txt
+++ b/nativeruntime/cpp/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64") # Universal libraries for Mac OS
 
 project(nativeruntime)
 

--- a/nativeruntime/src/main/java/org/robolectric/nativeruntime/NativeRuntimeLoader.java
+++ b/nativeruntime/src/main/java/org/robolectric/nativeruntime/NativeRuntimeLoader.java
@@ -52,9 +52,6 @@ public final class NativeRuntimeLoader {
   private static String nativeLibraryPath() {
     String os = osName();
     String arch = arch();
-    if (os.equals("mac")) {
-      arch = "universal"; // use the universal library
-    }
     return String.format(
         "native/%s/%s/%s", os, arch, System.mapLibraryName("robolectric-nativeruntime"));
   }


### PR DESCRIPTION
It is currently not possible to build the universal library on the Mac
GitHub CI runners. Also, building for multiple architectures doubles the
time of compilation for libutc, which can take a very long time on
GitHub CI. It may even be more efficient to have separate mac libraries
to avoid copying an extra 35 MiB when extracting the dylib from
resources for loading.
