### PR TITLE
Use -Os when building the native runtime

### DIFF
--- a/.github/workflows/build_native_runtime.yml
+++ b/.github/workflows/build_native_runtime.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          ICU_ROOT_DIR=$HOME/icu-bin cmake -B . -S ../nativeruntime/cpp
+          ICU_ROOT_DIR=$HOME/icu-bin cmake -B . -S ../nativeruntime/cpp -DCMAKE_C_FLAGS=-Os -DCMAKE_CXX_FLAGS=-Os
           make
 
       - name: Rename libnativeruntime for Linux


### PR DESCRIPTION
This enables most of the -O2 optimizations, except those that increase
the size of the library.
