### PR TITLE
Use 'processResources' task instead of 'jar' task for nativeruntime

### DIFF
--- a/nativeruntime/build.gradle
+++ b/nativeruntime/build.gradle
@@ -81,28 +81,17 @@ task makeNativeRuntime {
   }
 }
 
-task copyNativeRuntime {
-  dependsOn makeNativeRuntime
-  doLast {
-    copy {
-      from ("$buildDir/cpp") {
-        include '*libnativeruntime.*'
-      }
-      rename { String fileName ->
-        fileName.replace("libnativeruntime", "librobolectric-nativeruntime")
-      }
-      into project.file("$buildDir/resources/main/native/${osName()}/${arch()}/")
-    }
-  }
-}
-
-jar {
-  def os = osName()
-  if (!System.getenv('SKIP_NATIVERUNTIME_BUILD') && (os.contains("linux") || os.contains("mac"))) {
-    dependsOn copyNativeRuntime
-  } else {
-    println("Skipping the nativeruntime build for OS '${System.getProperty("os.name")}'")
-  }
+processResources {
+ def os = osName()
+ onlyIf { !System.getenv('SKIP_NATIVERUNTIME_BUILD') && (os.contains("linux") || os.contains("mac")) }
+ dependsOn makeNativeRuntime
+ from ("$buildDir/cpp") {
+   include '*libnativeruntime.*'
+   rename { String fileName ->
+     fileName.replace("libnativeruntime", "librobolectric-nativeruntime")
+   }
+   into "native/${os}/${arch()}/"
+ }
 }
 
 dependencies {


### PR DESCRIPTION
The 'processResources' is better designed to copy resources. This solves
an issue with the 'jar' task rewriting the nativeruntime mac artifacts,
which have to be placed in the resources folder manually for building
the uber JAR.
