### PR TITLE
Avoid re-running ICU ./configure if Makefile exists

### DIFF
--- a/nativeruntime/build.gradle
+++ b/nativeruntime/build.gradle
@@ -41,16 +41,20 @@ task configureICU {
     if (!file("$projectDir/external/icu/icu4c/source").exists()) {
       throw new GradleException("ICU submodule not detected. Please run `git submodule update --init`")
     }
-    exec {
-      workingDir "$projectDir/external/icu/icu4c/source"
-      if (os.contains("linux")) {
-        environment "CFLAGS", "-fPIC"
-        environment "CXXFLAGS", "-fPIC"
-        commandLine './runConfigureICU', 'Linux', '--enable-static', '--disable-shared'
-      } else if (os.contains("mac")) {
-        commandLine './runConfigureICU', 'MacOSX', '--enable-static', '--disable-shared'
-      } else {
-        println("Skipping the nativeruntime build for OS '${System.getProperty("os.name")}'")
+    if (file("$projectDir/external/icu/icu4c/source/Makefile").exists()) {
+      println("ICU Makefile detected, skipping ICU configure")
+    } else {
+      exec {
+        workingDir "$projectDir/external/icu/icu4c/source"
+        if (os.contains("linux")) {
+          environment "CFLAGS", "-fPIC"
+          environment "CXXFLAGS", "-fPIC"
+          commandLine './runConfigureICU', 'Linux', '--enable-static', '--disable-shared'
+        } else if (os.contains("mac")) {
+          commandLine './runConfigureICU', 'MacOSX', '--enable-static', '--disable-shared'
+        } else {
+          println("ICU configure not supported for OS '${System.getProperty("os.name")}'")
+        }
       }
     }
   }

--- a/nativeruntime/build.gradle
+++ b/nativeruntime/build.gradle
@@ -87,14 +87,19 @@ task makeNativeRuntime {
 
 processResources {
  def os = osName()
- onlyIf { !System.getenv('SKIP_NATIVERUNTIME_BUILD') && (os.contains("linux") || os.contains("mac")) }
- dependsOn makeNativeRuntime
- from ("$buildDir/cpp") {
-   include '*libnativeruntime.*'
-   rename { String fileName ->
-     fileName.replace("libnativeruntime", "librobolectric-nativeruntime")
+ if (System.getenv('SKIP_NATIVERUNTIME_BUILD')) {
+   println("Skipping the nativeruntime build");
+ } else if (!os.contains("linux") && !os.contains("mac")) {
+   println("Building the nativeruntime not supported for OS '${System.getProperty("os.name")}'")
+ } else {
+   dependsOn makeNativeRuntime
+   from ("$buildDir/cpp") {
+     include '*libnativeruntime.*'
+     rename { String fileName ->
+       fileName.replace("libnativeruntime", "librobolectric-nativeruntime")
+     }
+     into "native/${os}/${arch()}/"
    }
-   into "native/${os}/${arch()}/"
  }
 }
 


### PR DESCRIPTION
This makes running `./gradlew :nativeruntime:processResources` much,
much faster after ICU has been built.