### PR TITLE
Remove redundant SKIP_ICU_BUILD environment variable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
           make install
 
       - name: Build
-        run: ICU_ROOT_DIR=$HOME/icu-bin SKIP_ICU_BUILD=true SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew clean assemble testClasses --parallel --stacktrace --no-watch-fs
+        run: ICU_ROOT_DIR=$HOME/icu-bin SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew clean assemble testClasses --parallel --stacktrace --no-watch-fs
 
   unit-tests:
     runs-on: ubuntu-18.04
@@ -95,7 +95,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          ICU_ROOT_DIR=$HOME/icu-bin SKIP_ICU_BUILD=true SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew test --info --stacktrace --continue \
+          ICU_ROOT_DIR=$HOME/icu-bin SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew test --info --stacktrace --continue \
           --parallel \
           --no-watch-fs \
           -Drobolectric.enabledSdks=${{ matrix.api-versions }} \

--- a/nativeruntime/build.gradle
+++ b/nativeruntime/build.gradle
@@ -35,7 +35,7 @@ task cmakeNativeRuntime {
 }
 
 task configureICU {
-  onlyIf { !System.getenv('SKIP_ICU_BUILD') }
+  onlyIf { !System.getenv('ICU_ROOT_DIR') }
   doLast {
     def os = osName()
     if (!file("$projectDir/external/icu/icu4c/source").exists()) {
@@ -57,7 +57,7 @@ task configureICU {
 }
 
 task buildICU {
-  onlyIf { !System.getenv('SKIP_ICU_BUILD') }
+  onlyIf { !System.getenv('ICU_ROOT_DIR') }
   dependsOn configureICU
   doLast {
     exec {


### PR DESCRIPTION
Use ICU_ROOT_DIR to convey that ICU does not need to be built locally
from the submodule.
