### PR TITLE
Fix some lint errors in Target29CompatibilityTest

### DIFF
--- a/integration_tests/compat-target29/src/test/java/org/robolectric/integration/compat/target29/Target29CompatibilityTest.kt
+++ b/integration_tests/compat-target29/src/test/java/org/robolectric/integration/compat/target29/Target29CompatibilityTest.kt
@@ -5,12 +5,11 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class Target29CompatibilityTest {
-    private val application = ApplicationProvider.getApplicationContext<Context>();
+    private val application = ApplicationProvider.getApplicationContext<Context>()
 
     @Test
     fun `Initialize LocationManager succeed`() {
@@ -20,7 +19,7 @@ class Target29CompatibilityTest {
 
     @Test
     fun `Initialize AppOpsManager succeed`() {
-        val appOpsManager = application.getSystemService(Context.APP_OPS_SERVICE);
-        assertThat(appOpsManager).isNotNull();
+        val appOpsManager = application.getSystemService(Context.APP_OPS_SERVICE)
+        assertThat(appOpsManager).isNotNull()
     }
 }


### PR DESCRIPTION
Remove an unused import and some semicolons.
