### PR TITLE
Remove specific clang/clang++ env for build_native_runtime.yml

### DIFF
--- a/.github/workflows/build_native_runtime.yml
+++ b/.github/workflows/build_native_runtime.yml
@@ -1,9 +1,5 @@
 name: Build Native Runtime
 
-env:
-  CXX: clang++
-  CC: clang
-
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
We support gcc/g++ now(https://github.com/robolectric/robolectric/pull/6900), and don't need specific clang/clang++ for `building_native_runtime.yml`.