### PR TITLE
Add regression test for mockito spy

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ truthVersion=1.1.3
 
 junitVersion=4.13.2
 
-mockitoVersion=3.5.11
+mockitoVersion=4.1.0
 
 guavaJREVersion=27.0.1-jre
 

--- a/integration_tests/mockito-experimental/src/test/java/org/robolectric/integrationtests/mockito/experimental/MockitoSpyTest.java
+++ b/integration_tests/mockito-experimental/src/test/java/org/robolectric/integrationtests/mockito/experimental/MockitoSpyTest.java
@@ -1,13 +1,18 @@
 package org.robolectric.integrationtests.mockito.experimental;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import android.app.Activity;
+import android.content.Context;
+import android.view.inputmethod.InputMethodManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 /** Tests the ability to mock final classes and methods with mockito-inline. */
@@ -21,5 +26,15 @@ public class MockitoSpyTest {
     Activity activity = Robolectric.setupActivity(Activity.class);
     Activity spyActivity = spy(activity);
     assertThat(activity.getBaseContext()).isEqualTo(spyActivity.getBaseContext());
+  }
+
+  @Test
+  public void spyContext_canSpyGetSystemService() {
+    Context context = spy(RuntimeEnvironment.getApplication());
+    InputMethodManager expected = mock(InputMethodManager.class);
+    when(context.getSystemService(Context.INPUT_METHOD_SERVICE)).thenReturn(expected);
+    InputMethodManager actual =
+        (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+    assertThat(actual).isSameInstanceAs(expected);
   }
 }


### PR DESCRIPTION
Flutter uses mockito(4.1.0) to spy `context#getSystemService`, so this PR is created to add regression test for this occasion.