### PR TITLE
Remove explicit binary mode declaration for affected test modules

### DIFF
--- a/integration_tests/mockito-experimental/build.gradle
+++ b/integration_tests/mockito-experimental/build.gradle
@@ -2,10 +2,6 @@ import org.robolectric.gradle.RoboJavaModulePlugin
 
 apply plugin: RoboJavaModulePlugin
 
-test {
-    systemProperty "robolectric.resourcesMode", "binary"
-}
-
 dependencies {
     api project(":robolectric")
     compileOnly AndroidSdk.MAX_SDK.coordinates

--- a/integration_tests/mockito/build.gradle
+++ b/integration_tests/mockito/build.gradle
@@ -2,10 +2,6 @@ import org.robolectric.gradle.RoboJavaModulePlugin
 
 apply plugin: RoboJavaModulePlugin
 
-test {
-    systemProperty "robolectric.resourcesMode", "binary"
-}
-
 dependencies {
     api project(":robolectric")
     compileOnly AndroidSdk.MAX_SDK.coordinates

--- a/shadows/supportv4/build.gradle
+++ b/shadows/supportv4/build.gradle
@@ -15,10 +15,6 @@ configurations {
     earlyTestRuntime
 }
 
-test {
-    systemProperty "robolectric.resourcesMode", "binary"
-}
-
 def supportLibraryVersions = "28.0.0"
 
 dependencies {


### PR DESCRIPTION
Current binary mode doesn't support run without real app manifest. And
those declarations skipped those test modules, including
integration_tests/mockito, integration_tests/mockito-experimental, and
shadows/supportv4. Those test modules are important for regression
tests, so this CL remove those declarations to make those test modules run
again firstly.

For https://github.com/robolectric/robolectric/issues/6934.
