### PR TITLE
Bump gradle-versions-plugin to 0.42.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:1.3.0'
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.39.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.42.0"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:6.3.0"
     }
 }


### PR DESCRIPTION
It's very strange that `./gradlew dependencyUpdates -Drevision=release --info` always failed at my laptop with keystore problem:

```
Caused by: java.security.NoSuchAlgorithmException: Error constructing implementation (algorithm: Default, provider: SunJSSE, class: sun.security.ssl.SSLContextImpl$DefaultSSLContext)
        at java.base/java.security.Provider$Service.newInstance(Provider.java:1900)
        at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:236)
        at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:164)
        at java.base/javax.net.ssl.SSLContext.getInstance(SSLContext.java:184)
        at java.base/javax.net.ssl.SSLContext.getDefault(SSLContext.java:110)
        at org.gradle.internal.resource.transport.http.HttpClientConfigurer.jdkSupportsTLSProtocol(HttpClientConfigurer.java:114)
        ... 233 more
Caused by: java.security.KeyManagementException: problem accessing trust store
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:78)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
```

Hi @hoisie, could you help to verify it at your development machine when you have time? Thanks.