### PR TITLE
Bump apiCompatVersion to 4.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 thisVersion=4.8-SNAPSHOT
 
-apiCompatVersion=4.2
+apiCompatVersion=4.7
 
 errorproneVersion=2.9.0
 errorproneJavacVersion=9+181-r4173-1


### PR DESCRIPTION
It is used for next replease to compare API changes with command:

```
./gradlew :robolectric:checkForApiChanges
```
