### PR TITLE
Tweak precondition check in NotificationManager.updateAutomaticZenRule

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
@@ -479,6 +479,48 @@ public class ShadowNotificationManagerTest {
   }
 
   @Test
+  @Config(minSdk = Build.VERSION_CODES.Q)
+  public void updateAutomaticZenRule_nullOwnerWithConfigurationActivity_updateRuleAndReturnTrue() {
+    shadowOf(notificationManager).setNotificationPolicyAccessGranted(true);
+    AutomaticZenRule rule1 =
+        new AutomaticZenRule(
+            "name1",
+            /* owner= */ null,
+            new ComponentName("pkg1", "cls1"),
+            Uri.parse("condition://id1"),
+            new ZenPolicy.Builder().build(),
+            NotificationManager.INTERRUPTION_FILTER_PRIORITY,
+            /* enabled= */ true);
+    AutomaticZenRule rule2 =
+        new AutomaticZenRule(
+            "name2",
+            /* owner= */ null,
+            new ComponentName("pkg2", "cls2"),
+            Uri.parse("condition://id2"),
+            new ZenPolicy.Builder().build(),
+            NotificationManager.INTERRUPTION_FILTER_ALARMS,
+            /* enabled= */ false);
+    String id1 = notificationManager.addAutomaticZenRule(rule1);
+    String id2 = notificationManager.addAutomaticZenRule(rule2);
+
+    AutomaticZenRule updatedRule =
+        new AutomaticZenRule(
+            "updated_name",
+            /* owner= */ null,
+            new ComponentName("updated_pkg", "updated_cls"),
+            Uri.parse("condition://updated_id"),
+            new ZenPolicy.Builder().build(),
+            NotificationManager.INTERRUPTION_FILTER_ALL,
+            /* enabled= */ false);
+    assertThat(notificationManager.updateAutomaticZenRule(id2, updatedRule)).isTrue();
+
+    assertThat(notificationManager.getAutomaticZenRule(id1)).isEqualTo(rule1);
+    assertThat(notificationManager.getAutomaticZenRule(id2)).isEqualTo(updatedRule);
+    assertThat(notificationManager.getAutomaticZenRules())
+        .containsExactly(id1, rule1, id2, updatedRule);
+  }
+
+  @Test
   @Config(minSdk = Build.VERSION_CODES.N)
   public void removeAutomaticZenRule_notificationAccessDenied_shouldThrowSecurityException() {
     try {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -33,6 +33,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.util.ReflectionHelpers;
 
+/** Shadows for NotificationManager. */
 @SuppressWarnings({"UnusedDeclaration", "AndroidConcurrentHashMap"})
 @Implements(value = NotificationManager.class, looseSignatures = true)
 public class ShadowNotificationManager {
@@ -347,7 +348,9 @@ public class ShadowNotificationManager {
     // NotificationManagerService doesn't check that id is non-null.
     Preconditions.checkNotNull(automaticZenRule);
     Preconditions.checkNotNull(automaticZenRule.getName());
-    Preconditions.checkNotNull(automaticZenRule.getOwner());
+    Preconditions.checkState(
+        automaticZenRule.getOwner() != null || automaticZenRule.getConfigurationActivity() != null,
+        "owner/configurationActivity cannot be null at the same time");
     Preconditions.checkNotNull(automaticZenRule.getConditionId());
     enforcePolicyAccess();
 


### PR DESCRIPTION
It is possible to update an AutomaticZenRule without owner, but with a
configurationActivity.

PiperOrigin-RevId: 420002841
