### PR TITLE
Enable integration_tests:sparsearray tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,6 +118,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Set up JDK 11.0.8
         uses: actions/setup-java@v1

--- a/integration_tests/sparsearray/build.gradle
+++ b/integration_tests/sparsearray/build.gradle
@@ -1,6 +1,8 @@
-import org.robolectric.gradle.RoboJavaModulePlugin
+import org.robolectric.gradle.AndroidProjectConfigPlugin
 
-apply plugin: RoboJavaModulePlugin
+apply plugin: 'com.android.library'
+apply plugin: AndroidProjectConfigPlugin
+apply plugin: 'kotlin-android'
 apply plugin: "com.diffplug.spotless"
 
 spotless {
@@ -10,11 +12,35 @@ spotless {
     }
 }
 
-dependencies {
-    api project(":robolectric")
-    compileOnly AndroidSdk.MAX_SDK.coordinates
+android {
+    compileSdk 31
 
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 31
+    }
+
+    compileOptions {
+        sourceCompatibility = '1.8'
+        targetCompatibility = '1.8'
+    }
+
+    android {
+        testOptions {
+            unitTests {
+                includeAndroidResources = true
+            }
+        }
+    }
+}
+
+dependencies {
+    compileOnly AndroidSdk.MAX_SDK.coordinates
+    implementation project(path: ':shadowapi', configuration: 'default')
+
+    testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation project(":robolectric")
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "com.google.truth:truth:$truthVersion"
 }

--- a/integration_tests/sparsearray/src/main/AndroidManifest.xml
+++ b/integration_tests/sparsearray/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="org.robolectric.sparsearray">
+    <application />
+</manifest>

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,6 +33,8 @@ include ':integration_tests:androidx'
 include ':integration_tests:androidx_test'
 include ':integration_tests:ctesque'
 include ':integration_tests:security-providers'
-include ':testapp'
 include ":integration_tests:mockk"
 include ':integration_tests:compat-target29'
+include ":integration_tests:multidex"
+include ":integration_tests:sparsearray"
+include ':testapp'


### PR DESCRIPTION
After included, Android Studio will mark directories for source code correctly.