### PR TITLE
Added junit dependency in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ If you'd like to start a new project with Robolectric tests you can refer to `de
 #### build.gradle:
 
 ```groovy
+testImplementation "junit:junit:4.13.2"
 testImplementation "org.robolectric:robolectric:4.7.3"
 ```
 


### PR DESCRIPTION
Robolectric depends on JUnit in test runtime. A runtime class not exception could occur when JUnit is missed.

See: https://github.com/robolectric/robolectric/blob/c2557193faf145797fb88b5beeb9268c7fdac3e6/robolectric/build.gradle#L45

Make it the same as http://robolectric.org/getting-started/.

Signed-off-by: ZSmallX <diosmallx@gmail.com>
