### PR TITLE
Add integration tests for mokito-kotlin's regression

### DIFF
--- a/integration_tests/mockito-kotlin/build.gradle
+++ b/integration_tests/mockito-kotlin/build.gradle
@@ -1,0 +1,17 @@
+import org.robolectric.gradle.RoboJavaModulePlugin
+
+apply plugin: RoboJavaModulePlugin
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+
+dependencies {
+    api project(":robolectric")
+    compileOnly AndroidSdk.MAX_SDK.coordinates
+
+    testCompileOnly AndroidSdk.MAX_SDK.coordinates
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
+    testImplementation "androidx.test.ext:junit:$axtJunitVersion"
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "com.google.truth:truth:$truthVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+}

--- a/integration_tests/mockito-kotlin/src/test/java/org/robolectric/integrationtests/mockito/kotlin/MockitoKotlinFunctionTest.java
+++ b/integration_tests/mockito-kotlin/src/test/java/org/robolectric/integrationtests/mockito/kotlin/MockitoKotlinFunctionTest.java
@@ -1,0 +1,38 @@
+package org.robolectric.integrationtests.mockito.kotlin;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+
+import kotlin.Function;
+import kotlin.jvm.functions.Function0;
+import kotlin.jvm.functions.Function1;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class MockitoKotlinFunctionTest {
+  @Test
+  public void testFunctionMock() {
+    Function function = Mockito.mock(Function.class);
+    assertThat(function).isNotNull();
+  }
+
+  @Test
+  public void testFunction0Mock() {
+    Function0 function = Mockito.mock(Function0.class);
+    doReturn(null).when(function).invoke();
+    Object retVal = function.invoke();
+    assertThat(retVal).isNull();
+  }
+
+  @Test
+  public void testFunction1Mock() {
+    Function1 function = Mockito.mock(Function1.class);
+    doReturn(null).when(function).invoke(any());
+    Object retVal = function.invoke(null);
+    assertThat(retVal).isNull();
+  }
+}

--- a/integration_tests/mockito-kotlin/src/test/kotlin/org/robolectric/integrationtests/mockito/kotlin/MockitoKotlinFunctionInKotlinTest.kt
+++ b/integration_tests/mockito-kotlin/src/test/kotlin/org/robolectric/integrationtests/mockito/kotlin/MockitoKotlinFunctionInKotlinTest.kt
@@ -1,0 +1,18 @@
+package org.robolectric.integrationtests.mockito.kotlin
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class MockitoKotlinFunctionInKotlinTest {
+    @Test
+    fun testFunction1() {
+        val function = mock(Function1::class.java) as (String) -> Unit
+        function.invoke("test")
+        verify(function).invoke("test")
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,6 +26,7 @@ include ":integration_tests:dependency-on-stubs"
 include ":integration_tests:libphonenumber"
 include ":integration_tests:memoryleaks"
 include ":integration_tests:mockito"
+include ":integration_tests:mockito-kotlin"
 include ":integration_tests:mockito-experimental"
 include ":integration_tests:powermock"
 include ':integration_tests:androidx'


### PR DESCRIPTION
Those issues are about mocking Kotlin Function with Mockito and Robolectric in runtime.

#3688
#5076

Thus problem could be one of those modules.

We can close those issues if it does none bussiness with Robolectric.

Current modules version:
- Kotlin 1.4.31
- Mockito 4.1.0
- Robolectric latest dev

mockito-kotlin module is for Kotlin & Mockito related tests in some scenerios under Robolectric like:
- Using mockito to mock Kotlin class in Java or Kotlin.
- Using mockito-kotlin to mock in Kotlin.
- etc.


