### PR TITLE
Remove ShadowsPlugin from supportv4/build.gradle

### DIFF
--- a/shadows/supportv4/build.gradle
+++ b/shadows/supportv4/build.gradle
@@ -4,13 +4,6 @@ import org.robolectric.gradle.RoboJavaModulePlugin
 apply plugin: RoboJavaModulePlugin
 apply plugin: DeployedRoboJavaModulePlugin
 
-apply plugin: ShadowsPlugin
-
-shadows {
-    packageName "org.robolectric.shadows.support.v4"
-    sdkCheckMode "OFF"
-}
-
 configurations {
     earlyTestRuntime
 }


### PR DESCRIPTION
The ShadowsPlugin was causing an error during maven publication for the
supportv4 package.

The ShadowsPlugin only applies if a Java module has shadow classes, but
the supportv4 shadows have been removed.

RE #6185

