### PR TITLE
Optimizes getFd and close behaviors for ParcelFileDescriptor

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelFileDescriptorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelFileDescriptorTest.java
@@ -1,6 +1,7 @@
 package org.robolectric.shadows;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeThat;
 
 import android.os.ParcelFileDescriptor;
@@ -189,7 +190,16 @@ public class ShadowParcelFileDescriptorTest {
     pfd = ParcelFileDescriptor.open(file, -1);
     pfd.close();
     assertThat(pfd.getFileDescriptor().valid()).isFalse();
-    assertThat(pfd.getFd()).isEqualTo(-1);
+  }
+
+  @Test
+  public void testClose_twice() throws Exception {
+    pfd = ParcelFileDescriptor.open(file, -1);
+    pfd.close();
+    assertThat(pfd.getFileDescriptor().valid()).isFalse();
+
+    pfd.close();
+    assertThat(pfd.getFileDescriptor().valid()).isFalse();
   }
 
   @Test
@@ -254,5 +264,16 @@ public class ShadowParcelFileDescriptorTest {
     FileInputStream is = new FileInputStream(new File("/proc/self/fd/" + fd));
     assertThat(is.read()).isEqualTo(READ_ONLY_FILE_CONTENTS);
     is.close();
+  }
+
+  @Test
+  public void testGetFd_alreadyClosed() throws Exception {
+    pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_WRITE);
+    assertThat(pfd).isNotNull();
+    assertThat(pfd.getFileDescriptor().valid()).isTrue();
+
+    pfd.close();
+
+    assertThrows(IllegalStateException.class, () -> pfd.getFd());
   }
 }


### PR DESCRIPTION
### Overview

PFD getFd and close behaviors are not the same as AOSP.

Expected Behaviors:
- Throws IllegalStateException in ALL API levels.
- Do not call close for a closed PFD.

Current Behaviors:
- Not throws IllegalStateException in ALL API levels.
- Call close for a closed PFD.


AOSP source code link:  
https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/os/ParcelFileDescriptor.java;l=738
https://cs.android.com/android/_/android/platform/frameworks/base/+/c9119f5034d36f548bbddd8f60291e24ab4e270b

### Proposed Changes

- Added `closed` status for PFD, and update it in close method, and check it in getFd() and close()
- Removed illegal getFd checks in tests
- Added tests for both cases.
