### PR TITLE
Add support for Android S V2 in Robolectric

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-versions: ['16,17,18', '19,21,22', '23,24,25', '26,27,28', '29,30,31']
+        api-versions: ['16,17,18', '19,21,22', '23,24,25', '26,27,28', '29,30', '31,32']
 
     steps:
       - uses: actions/checkout@v2

--- a/buildSrc/src/main/groovy/AndroidSdk.groovy
+++ b/buildSrc/src/main/groovy/AndroidSdk.groovy
@@ -16,10 +16,11 @@ class AndroidSdk implements Comparable<AndroidSdk> {
     static final Q = new AndroidSdk(29, "10", "5803371");
     static final R = new AndroidSdk(30, "11", "6757853");
     static final S = new AndroidSdk(31, "12", "7732740");
+    static final S_V2 = new AndroidSdk(32, "12.1", "8229987");
 
     static final List<AndroidSdk> ALL_SDKS = [
             JELLY_BEAN, JELLY_BEAN_MR1, JELLY_BEAN_MR2, KITKAT,
-            LOLLIPOP, LOLLIPOP_MR1, M, N, N_MR1, O, O_MR1, P, Q, R, S
+            LOLLIPOP, LOLLIPOP_MR1, M, N, N_MR1, O, O_MR1, P, Q, R, S, S_V2
     ]
 
     static final MAX_SDK = Collections.max(ALL_SDKS)

--- a/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
@@ -15,6 +15,7 @@ import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.Q;
 import static android.os.Build.VERSION_CODES.R;
 import static android.os.Build.VERSION_CODES.S;
+import static android.os.Build.VERSION_CODES.S_V2;
 
 import com.google.auto.service.AutoService;
 import com.google.common.base.Preconditions;
@@ -78,6 +79,7 @@ public class DefaultSdkProvider implements SdkProvider {
     knownSdks.put(Q, new DefaultSdk(Q, "10", "5803371", "REL", 9));
     knownSdks.put(R, new DefaultSdk(R, "11", "6757853", "REL", 9));
     knownSdks.put(S, new DefaultSdk(S, "12", "7732740", "REL", 9));
+    knownSdks.put(S_V2, new DefaultSdk(S_V2, "12.1", "8229987", "REL", 9));
   }
 
   @Override

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothAdapterTest.java
@@ -7,6 +7,7 @@ import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.Q;
 import static android.os.Build.VERSION_CODES.R;
 import static android.os.Build.VERSION_CODES.S;
+import static android.os.Build.VERSION_CODES.S_V2;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -167,14 +168,14 @@ public class ShadowBluetoothAdapterTest {
   }
 
   @Test
-  @Config(maxSdk = 32)
+  @Config(maxSdk = S_V2)
   public void scanMode_getAndSet_connectable() throws Exception {
     assertThat(bluetoothAdapter.setScanMode(BluetoothAdapter.SCAN_MODE_CONNECTABLE)).isTrue();
     assertThat(bluetoothAdapter.getScanMode()).isEqualTo(BluetoothAdapter.SCAN_MODE_CONNECTABLE);
   }
 
   @Test
-  @Config(maxSdk = 32)
+  @Config(maxSdk = S_V2)
   public void scanMode_getAndSet_discoverable() throws Exception {
     assertThat(bluetoothAdapter.setScanMode(BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE))
         .isTrue();
@@ -183,14 +184,14 @@ public class ShadowBluetoothAdapterTest {
   }
 
   @Test
-  @Config(maxSdk = 32)
+  @Config(maxSdk = S_V2)
   public void scanMode_getAndSet_none() throws Exception {
     assertThat(bluetoothAdapter.setScanMode(BluetoothAdapter.SCAN_MODE_NONE)).isTrue();
     assertThat(bluetoothAdapter.getScanMode()).isEqualTo(BluetoothAdapter.SCAN_MODE_NONE);
   }
 
   @Test
-  @Config(maxSdk = 32)
+  @Config(maxSdk = S_V2)
   public void scanMode_getAndSet_invalid() throws Exception {
     assertThat(bluetoothAdapter.setScanMode(9999)).isFalse();
   }
@@ -212,7 +213,7 @@ public class ShadowBluetoothAdapterTest {
     assertThat(bluetoothAdapter.getDiscoverableTimeout()).isEqualTo(42);
   }
 
-  @Config(minSdk = R, maxSdk = 32)
+  @Config(minSdk = R, maxSdk = S_V2)
   @Test
   public void scanMode_withDiscoverableTimeout_R() {
     assertThat(

--- a/shadows/framework/src/main/java/org/robolectric/android/controller/ActivityController.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/controller/ActivityController.java
@@ -4,6 +4,7 @@ import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.N_MR1;
 import static android.os.Build.VERSION_CODES.O_MR1;
 import static android.os.Build.VERSION_CODES.P;
+import static android.os.Build.VERSION_CODES.S_V2;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.robolectric.shadow.api.Shadow.extract;
 import static org.robolectric.util.reflector.Reflector.reflector;
@@ -233,8 +234,7 @@ public class ActivityController<T extends Activity>
       callDispatchResized(root);
     }
 
-    // if sdk <= S_V2
-    if (RuntimeEnvironment.getApiLevel() <= 32) {
+    if (RuntimeEnvironment.getApiLevel() <= S_V2) {
       reflector(ViewRootImplActivityControllerReflector.class, root)
           .windowFocusChanged(hasFocus, ShadowWindowManagerGlobal.getInTouchMode());
     } else {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/RangingSessionBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/RangingSessionBuilder.java
@@ -1,6 +1,7 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.S;
+import static android.os.Build.VERSION_CODES.S_V2;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 import android.uwb.IUwbAdapter;
@@ -52,7 +53,7 @@ public class RangingSessionBuilder {
 
   public RangingSession build() {
     int apiLevel = RuntimeEnvironment.getApiLevel();
-    if (apiLevel >= S && apiLevel <= 32) {
+    if (apiLevel >= S && apiLevel <= S_V2) {
       return new RangingSession(executor, callback, adapter1, handle);
     } else if (apiLevel >= 33) {
       try {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -32,6 +32,7 @@ import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.Q;
 import static android.os.Build.VERSION_CODES.R;
 import static android.os.Build.VERSION_CODES.S;
+import static android.os.Build.VERSION_CODES.S_V2;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.robolectric.annotation.GetInstallerPackageNameMode.Mode.REALISTIC;
 import static org.robolectric.util.reflector.Reflector.reflector;
@@ -458,7 +459,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   @Implementation(minSdk = S)
   protected PackageInfo getPackageArchiveInfo(String archiveFilePath, int flags) {
     int apiLevel = RuntimeEnvironment.getApiLevel();
-    if (apiLevel == S || apiLevel == 32) {
+    if (apiLevel == S || apiLevel == S_V2) {
 
       PackageInfo shadowPackageInfo = getShadowPackageArchiveInfo(archiveFilePath, flags);
       if (shadowPackageInfo != null) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCompatibility.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCompatibility.java
@@ -1,0 +1,42 @@
+package org.robolectric.shadows;
+
+import static org.robolectric.util.reflector.Reflector.reflector;
+
+import android.compat.Compatibility;
+import android.compat.annotation.ChangeId;
+import android.os.Build.VERSION_CODES;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.ForType;
+import org.robolectric.util.reflector.Static;
+
+/**
+ * Robolectric shadow to disable CALL_ACTIVITY_RESULT_BEFORE_RESUME using Compatibility's
+ * isChangeEnabled.
+ */
+@Implements(value = Compatibility.class, isInAndroidSdk = false)
+public class ShadowCompatibility {
+
+  private static final long CALL_ACTIVITY_RESULT_BEFORE_RESUME = 78294732L;
+
+  @RealObject protected static Compatibility realCompatibility;
+
+  @Implementation(minSdk = VERSION_CODES.S_V2)
+  protected static boolean isChangeEnabled(@ChangeId long changeId) {
+    if (changeId == CALL_ACTIVITY_RESULT_BEFORE_RESUME) {
+      return false;
+    }
+    return reflector(CompatibilityReflector.class).isChangeEnabled(changeId);
+  }
+
+  /** Reflector interface for {@link Compatibility}'s isChangeEnabled function. */
+  @ForType(Compatibility.class)
+  private interface CompatibilityReflector {
+
+    @Direct
+    @Static
+    boolean isChangeEnabled(@ChangeId long changeId);
+  }
+}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacySQLiteConnection.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacySQLiteConnection.java
@@ -6,6 +6,7 @@ import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.O_MR1;
 import static android.os.Build.VERSION_CODES.Q;
+import static android.os.Build.VERSION_CODES.S_V2;
 import static org.robolectric.RuntimeEnvironment.castNativePtr;
 
 import android.database.sqlite.SQLiteAbortException;
@@ -163,7 +164,7 @@ public class ShadowLegacySQLiteConnection extends ShadowSQLiteConnection {
     nativeExecute((long) connectionPtr, (long) statementPtr);
   }
 
-  @Implementation(minSdk = LOLLIPOP, maxSdk = 32)
+  @Implementation(minSdk = LOLLIPOP, maxSdk = S_V2)
   protected static void nativeExecute(final long connectionPtr, final long statementPtr) {
     CONNECTIONS.executeStatement(connectionPtr, statementPtr);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeSQLiteConnection.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeSQLiteConnection.java
@@ -6,6 +6,7 @@ import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.O_MR1;
 import static android.os.Build.VERSION_CODES.R;
+import static android.os.Build.VERSION_CODES.S_V2;
 
 import android.database.sqlite.SQLiteConnection;
 import java.util.function.BinaryOperator;
@@ -147,7 +148,7 @@ public class ShadowNativeSQLiteConnection extends ShadowSQLiteConnection {
     nativeExecute(PreLPointers.get(connectionPtr), PreLPointers.get(statementPtr));
   }
 
-  @Implementation(minSdk = LOLLIPOP, maxSdk = 32)
+  @Implementation(minSdk = LOLLIPOP, maxSdk = S_V2)
   protected static void nativeExecute(final long connectionPtr, final long statementPtr) {
     PerfStatsCollector.getInstance()
         .measure(

--- a/shadows/framework/src/main/java/org/robolectric/shadows/StorageVolumeBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/StorageVolumeBuilder.java
@@ -123,7 +123,7 @@ public final class StorageVolumeBuilder {
           from(UserHandle.class, owner), // UserHandle owner,
           from(String.class, fsUuid), //  String fsUuid,
           from(String.class, state)); // String state
-    } else if (apiLevel > VERSION_CODES.R && apiLevel <= 32) {
+    } else if (apiLevel > VERSION_CODES.R && apiLevel <= VERSION_CODES.S_V2) {
       return ReflectionHelpers.callConstructor(
           StorageVolume.class,
           from(String.class, id), // String id,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/VibrationAttributesBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/VibrationAttributesBuilder.java
@@ -1,6 +1,7 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.S;
+import static android.os.Build.VERSION_CODES.S_V2;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 
 import android.media.AudioAttributes;
@@ -33,7 +34,7 @@ public final class VibrationAttributesBuilder {
 
   public VibrationAttributes build() {
     int apiLevel = RuntimeEnvironment.getApiLevel();
-    if (apiLevel >= S && apiLevel <= 32) {
+    if (apiLevel >= S && apiLevel <= S_V2) {
       return new VibrationAttributes.Builder(audioAttributes, vibrationEffect).build();
     } else if (apiLevel >= 33) {
       return ReflectionHelpers.callConstructor(


### PR DESCRIPTION
Add support for Android S V2 in Robolectric

There was only one additional shadow required, ShadowCompatibility, to disable
the feature where Android attempts to get an Activity into a RESUMED state
using ActivityThread transactions before delivering activity results. This
shadow will be temporary, as there will be a forthcoming change to perform
ActivityThread bookkeeping for Activities.
