### PR TITLE
Clean up ctesque

### DIFF
--- a/integration_tests/ctesque/src/sharedTest/java/android/app/ActivityTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/app/ActivityTest.java
@@ -33,8 +33,7 @@ public class ActivityTest {
   }
 
   @Test
-  public void whenSetOnActivityInManifest_activityGetsThemeFromActivityInManifest()
-      throws Exception {
+  public void whenSetOnActivityInManifest_activityGetsThemeFromActivityInManifest() {
     Activity activity = activityWithAnotherThemeRule.launchActivity(null);
     Button theButton = activity.findViewById(R.id.button);
     ColorDrawable background = (ColorDrawable) theButton.getBackground();
@@ -42,8 +41,8 @@ public class ActivityTest {
   }
 
   @Test
-  public void whenExplicitlySetOnActivity_afterSetContentView_activityGetsThemeFromActivityInManifest()
-      throws Exception {
+  public void
+      whenExplicitlySetOnActivity_afterSetContentView_activityGetsThemeFromActivityInManifest() {
     Activity activity = activityWithAnotherThemeRule.launchActivity(null);
     activity.setTheme(R.style.Theme_Robolectric);
     Button theButton = activity.findViewById(R.id.button);
@@ -52,8 +51,7 @@ public class ActivityTest {
   }
 
   @Test
-  public void whenExplicitlySetOnActivity_beforeSetContentView_activityUsesNewTheme()
-      throws Exception {
+  public void whenExplicitlySetOnActivity_beforeSetContentView_activityUsesNewTheme() {
     ActivityWithAnotherTheme.setThemeBeforeContentView = R.style.Theme_Robolectric;
     Activity activity = activityWithAnotherThemeRule.launchActivity(null);
     Button theButton = activity.findViewById(R.id.button);
@@ -62,12 +60,10 @@ public class ActivityTest {
   }
 
   @Test
-  public void whenNotSetOnActivityInManifest_activityGetsThemeFromApplicationInManifest()
-      throws Exception {
+  public void whenNotSetOnActivityInManifest_activityGetsThemeFromApplicationInManifest() {
     Activity activity = activityWithoutThemeRule.launchActivity(null);
     Button theButton = activity.findViewById(R.id.button);
     ColorDrawable background = (ColorDrawable) theButton.getBackground();
     assertThat(background.getColor()).isEqualTo(0xff00ff00);
   }
-
 }

--- a/integration_tests/ctesque/src/sharedTest/java/android/content/res/ResourcesTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/content/res/ResourcesTest.java
@@ -1048,8 +1048,7 @@ public class ResourcesTest {
   @Ignore(
       "currently ids are always automatically assigned a value; to fix this we'd need to check "
           + "layouts for +@id/___, which is expensive")
-  public void whenCalledForIdWithNameNotInRClassOrXml_getResourceIdentifier_shouldReturnZero()
-      throws Exception {
+  public void whenCalledForIdWithNameNotInRClassOrXml_getResourceIdentifier_shouldReturnZero() {
     assertThat(
         resources.getIdentifier(
             "org.robolectric:id/idThatDoesntExistAnywhere", "other", "other"))
@@ -1058,8 +1057,7 @@ public class ResourcesTest {
 
   @Test
   public void
-  whenIdIsAbsentInXmlButPresentInRClass_getResourceIdentifier_shouldReturnIdFromRClass_probablyBecauseItWasDeclaredInALayout()
-      throws Exception {
+      whenIdIsAbsentInXmlButPresentInRClass_getResourceIdentifier_shouldReturnIdFromRClass_probablyBecauseItWasDeclaredInALayout() {
     assertThat(
         resources.getIdentifier("id_declared_in_layout", "id", context.getPackageName()))
         .isEqualTo(R.id.id_declared_in_layout);

--- a/integration_tests/ctesque/src/sharedTest/java/android/content/res/ThemeTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/content/res/ThemeTest.java
@@ -6,10 +6,9 @@ import android.content.Context;
 import android.content.res.Resources.Theme;
 import android.graphics.Color;
 import android.util.TypedValue;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.internal.DoNotInstrument;
@@ -27,18 +26,18 @@ public class ThemeTest {
 
   @Before
   public void setup() throws Exception {
-    context = InstrumentationRegistry.getTargetContext();
+    context = InstrumentationRegistry.getInstrumentation().getTargetContext();
     resources = context.getResources();
   }
 
   @Test
-  public void withEmptyTheme_returnsEmptyAttributes() throws Exception {
+  public void withEmptyTheme_returnsEmptyAttributes() {
     assertThat(resources.newTheme().obtainStyledAttributes(new int[] {R.attr.string1}).hasValue(0))
         .isFalse();
   }
 
   @Test
-  public void shouldLookUpStylesFromStyleResId() throws Exception {
+  public void shouldLookUpStylesFromStyleResId() {
     Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_AnotherTheme, true);
     TypedArray a = theme.obtainStyledAttributes(R.style.MyCustomView, R.styleable.CustomView);
@@ -48,7 +47,7 @@ public class ThemeTest {
   }
 
   @Test
-  public void shouldApplyStylesFromResourceReference() throws Exception {
+  public void shouldApplyStylesFromResourceReference() {
     Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_AnotherTheme, true);
     TypedArray a =
@@ -60,7 +59,7 @@ public class ThemeTest {
   }
 
   @Test
-  public void shouldApplyStylesFromAttributeReference() throws Exception {
+  public void shouldApplyStylesFromAttributeReference() {
     Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_ThirdTheme, true);
     TypedArray a =
@@ -72,7 +71,7 @@ public class ThemeTest {
   }
 
   @Test
-  public void shouldGetValuesFromAttributeReference() throws Exception {
+  public void shouldGetValuesFromAttributeReference() {
     Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_ThirdTheme, true);
 
@@ -89,7 +88,7 @@ public class ThemeTest {
   }
 
   @Test
-  public void withResolveRefsFalse_shouldResolveValue() throws Exception {
+  public void withResolveRefsFalse_shouldResolveValue() {
     Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_AnotherTheme, true);
 
@@ -102,7 +101,7 @@ public class ThemeTest {
   }
 
   @Test
-  public void withResolveRefsFalse_shouldNotResolveResource() throws Exception {
+  public void withResolveRefsFalse_shouldNotResolveResource() {
     Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_AnotherTheme, true);
 
@@ -115,7 +114,7 @@ public class ThemeTest {
   }
 
   @Test
-  public void withResolveRefsTrue_shouldResolveResource() throws Exception {
+  public void withResolveRefsTrue_shouldResolveResource() {
     Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_AnotherTheme, true);
 
@@ -129,7 +128,7 @@ public class ThemeTest {
   }
 
   @Test
-  public void failToResolveCircularReference() throws Exception {
+  public void failToResolveCircularReference() {
     Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_AnotherTheme, true);
 
@@ -140,7 +139,7 @@ public class ThemeTest {
   }
 
   @Test
-  public void canResolveAttrReferenceToDifferentPackage() throws Exception {
+  public void canResolveAttrReferenceToDifferentPackage() {
     Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_AnotherTheme, true);
 
@@ -153,8 +152,7 @@ public class ThemeTest {
   }
 
   @Test
-  @Ignore("todo: incorrect behavior on robolectric vs framework?")
-  public void forStylesWithImplicitParents_shouldInheritValuesNotDefinedInChild() throws Exception {
+  public void forStylesWithImplicitParents_shouldInheritValuesNotDefinedInChild() {
     Resources.Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_Robolectric_ImplicitChild, true);
     assertThat(theme.obtainStyledAttributes(new int[] {R.attr.string1}).getString(0))
@@ -164,15 +162,14 @@ public class ThemeTest {
   }
 
   @Test
-  public void whenAThemeHasExplicitlyEmptyParentAttr_shouldHaveNoParent() throws Exception {
+  public void whenAThemeHasExplicitlyEmptyParentAttr_shouldHaveNoParent() {
     Resources.Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_Robolectric_EmptyParent, true);
     assertThat(theme.obtainStyledAttributes(new int[] {R.attr.string1}).hasValue(0)).isFalse();
   }
 
   @Test
-  @Ignore("todo: incorrect behavior on robolectric vs framework?")
-  public void shouldApplyParentStylesFromAttrs() throws Exception {
+  public void shouldApplyParentStylesFromAttrs() {
     Resources.Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_AnotherTheme, true);
     assertThat(theme.obtainStyledAttributes(new int[] {R.attr.string1}).getString(0))
@@ -182,8 +179,7 @@ public class ThemeTest {
   }
 
   @Test
-  @Ignore("todo: incorrect behavior on robolectric vs framework?")
-  public void setTo_shouldCopyAllAttributesToEmptyTheme() throws Exception {
+  public void setTo_shouldCopyAllAttributesToEmptyTheme() {
     Resources.Theme theme1 = resources.newTheme();
     theme1.applyStyle(R.style.Theme_Robolectric, false);
     assertThat(theme1.obtainStyledAttributes(new int[] {R.attr.string1}).getString(0))
@@ -197,8 +193,7 @@ public class ThemeTest {
   }
 
   @Test
-  @Ignore("todo: incorrect behavior on robolectric vs framework?")
-  public void setTo_whenDestThemeIsModified_sourceThemeShouldNotMutate() throws Exception {
+  public void setTo_whenDestThemeIsModified_sourceThemeShouldNotMutate() {
     Resources.Theme sourceTheme = resources.newTheme();
     sourceTheme.applyStyle(R.style.Theme_Robolectric, false);
     assertThat(sourceTheme.obtainStyledAttributes(new int[] {R.attr.string1}).getString(0))
@@ -213,8 +208,7 @@ public class ThemeTest {
   }
 
   @Test
-  @Ignore("todo: incorrect behavior on robolectric vs framework?")
-  public void setTo_whenSourceThemeIsModified_destThemeShouldNotMutate() throws Exception {
+  public void setTo_whenSourceThemeIsModified_destThemeShouldNotMutate() {
     Resources.Theme sourceTheme = resources.newTheme();
     sourceTheme.applyStyle(R.style.Theme_Robolectric, false);
     assertThat(sourceTheme.obtainStyledAttributes(new int[] {R.attr.string1}).getString(0))
@@ -229,9 +223,7 @@ public class ThemeTest {
   }
 
   @Test
-  @Ignore("todo: incorrect behavior on robolectric vs framework?")
-  public void applyStyle_withForceFalse_shouldApplyButNotOverwriteExistingAttributeValues()
-      throws Exception {
+  public void applyStyle_withForceFalse_shouldApplyButNotOverwriteExistingAttributeValues() {
     Resources.Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_Robolectric, false);
     assertThat(theme.obtainStyledAttributes(new int[] {R.attr.string1}).getString(0))
@@ -245,9 +237,7 @@ public class ThemeTest {
   }
 
   @Test
-  @Ignore("todo: incorrect behavior on robolectric vs framework?")
-  public void applyStyle_withForceTrue_shouldApplyAndOverwriteExistingAttributeValues()
-      throws Exception {
+  public void applyStyle_withForceTrue_shouldApplyAndOverwriteExistingAttributeValues() {
     Resources.Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_Robolectric, false);
     assertThat(theme.obtainStyledAttributes(new int[] {R.attr.string1}).getString(0))
@@ -264,7 +254,7 @@ public class ThemeTest {
   }
 
   @Test
-  public void shouldFindInheritedAndroidAttributeInTheme() throws Exception {
+  public void shouldFindInheritedAndroidAttributeInTheme() {
     context.setTheme(R.style.Theme_AnotherTheme);
     Resources.Theme theme1 = context.getTheme();
 
@@ -275,7 +265,7 @@ public class ThemeTest {
   }
 
   @Test
-  public void themesShouldBeApplyableAcrossResources() throws Exception {
+  public void themesShouldBeApplyableAcrossResources() {
     Resources.Theme themeFromSystem = Resources.getSystem().newTheme();
     themeFromSystem.applyStyle(android.R.style.Theme_Light, true);
 
@@ -307,7 +297,7 @@ public class ThemeTest {
   }
 
   @Test
-  public void styleResolutionShouldIgnoreThemes() throws Exception {
+  public void styleResolutionShouldIgnoreThemes() {
     Resources.Theme themeFromSystem = resources.newTheme();
     themeFromSystem.applyStyle(android.R.style.Theme_DeviceDefault, true);
     themeFromSystem.applyStyle(R.style.ThemeWithSelfReferencingTextAttr, true);

--- a/integration_tests/ctesque/src/sharedTest/java/android/graphics/BitmapFactoryTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/graphics/BitmapFactoryTest.java
@@ -1,6 +1,5 @@
 package android.graphics;
 
-import static androidx.test.InstrumentationRegistry.getTargetContext;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.content.res.Resources;
@@ -8,10 +7,10 @@ import android.graphics.Bitmap.CompressFormat;
 import android.graphics.BitmapFactory.Options;
 import android.os.Build;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 import com.google.common.truth.TruthJUnit;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import org.junit.Before;
@@ -33,7 +32,7 @@ public class BitmapFactoryTest {
 
   @Before
   public void setUp() {
-    resources = getTargetContext().getResources();
+    resources = InstrumentationRegistry.getInstrumentation().getTargetContext().getResources();
   }
 
   @Test
@@ -88,7 +87,7 @@ public class BitmapFactoryTest {
    * can be enabled for Robolectric.
    */
   @Test
-  public void decodeStream_options_setsOutWidthToMinusOne() throws IOException {
+  public void decodeStream_options_setsOutWidthToMinusOne() {
     TruthJUnit.assume().that(Build.FINGERPRINT).isNotEqualTo("robolectric");
     byte[] invalidBitmapPixels = "invalid bitmap pixels".getBytes(Charset.defaultCharset());
     ByteArrayInputStream inputStream = new ByteArrayInputStream(invalidBitmapPixels);

--- a/integration_tests/ctesque/src/sharedTest/java/android/view/MotionEventTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/view/MotionEventTest.java
@@ -22,7 +22,6 @@ import com.google.common.truth.Subject;
 import com.google.common.truth.Truth;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.internal.DoNotInstrument;
@@ -322,7 +321,6 @@ public class MotionEventTest {
   }
 
   @Test
-  @Ignore // doesn't actually fail when expected on emulator API 23
   public void testReadFromParcelWithInvalidSampleSize() {
     Parcel parcel = Parcel.obtain();
     motionEvent2.writeToParcel(parcel, Parcelable.PARCELABLE_WRITE_RETURN_VALUE);


### PR DESCRIPTION
1. Enable some ignored tests because they can run now.
2. Remove unused Exceptions.
3. Migrate deprecated `InstrumentationRegistry` to platform package.