### PR TITLE
Bump preinstrumented jars to version 4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,6 @@ jobs:
           --no-watch-fs \
           -Drobolectric.enabledSdks=${{ matrix.api-versions }} \
           -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
-          -Drobolectric.usePreinstrumentedJars=false \
           -Dorg.gradle.workers.max=2
 
       - name: Upload Test Results

--- a/buildSrc/src/main/groovy/AndroidSdk.groovy
+++ b/buildSrc/src/main/groovy/AndroidSdk.groovy
@@ -1,5 +1,5 @@
 class AndroidSdk implements Comparable<AndroidSdk> {
-    static final PREINSTRUMENTED_VERSION = 3
+    static final PREINSTRUMENTED_VERSION = 4
 
     static final JELLY_BEAN = new AndroidSdk(16, "4.1.2_r1", "r1")
     static final JELLY_BEAN_MR1 = new AndroidSdk(17, "4.2.2_r1.2", "r1")

--- a/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
@@ -48,7 +48,7 @@ public class DefaultSdkProvider implements SdkProvider {
 
   private static final int RUNNING_JAVA_VERSION = Util.getJavaVersion();
 
-  private static final int PREINSTRUMENTED_VERSION = 3;
+  private static final int PREINSTRUMENTED_VERSION = 4;
 
   private final DependencyResolver dependencyResolver;
 


### PR DESCRIPTION
Version 4 contains support for SparseArray.set, fixes to constructor
instrumentation, and a couple of additional Android interceptors, such
as WeakReference.refersTo.
