### PR TITLE
Disable shadowOf generation for DisplayHashManager

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayHashManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayHashManager.java
@@ -9,7 +9,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /** Shadow of {@link android.view.displayhash.DisplayHashManager}. */
-@Implements(value = DisplayHashManager.class)
+@Implements(value = DisplayHashManager.class, isInAndroidSdk = false)
 public class ShadowDisplayHashManager {
 
   private static VerifiedDisplayHash verifyDisplayHashResult;


### PR DESCRIPTION
DisplayHashManager was added in SDK 31. Turn off shadowOf generation for
it for apps that have compileSdkVersion < 31.