### PR TITLE
Fixed PFD testGetFd_canRead test failed on macOS.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelFileDescriptorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelFileDescriptorTest.java
@@ -8,6 +8,7 @@ import android.os.ParcelFileDescriptor;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.io.File;
+import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -16,6 +17,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.util.ReflectionHelpers;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowParcelFileDescriptorTest {
@@ -261,7 +263,12 @@ public class ShadowParcelFileDescriptorTest {
     pfd = ParcelFileDescriptor.open(readOnlyFile, ParcelFileDescriptor.MODE_READ_ONLY);
     int fd = pfd.getFd();
     assertThat(fd).isGreaterThan(0);
-    FileInputStream is = new FileInputStream(new File("/proc/self/fd/" + fd));
+
+    final FileDescriptor fileDescriptor = pfd.getFileDescriptor();
+    assertThat(fileDescriptor.valid()).isTrue();
+    assertThat(fd).isEqualTo(ReflectionHelpers.getField(fileDescriptor, "fd"));
+
+    FileInputStream is = new FileInputStream(fileDescriptor);
     assertThat(is.read()).isEqualTo(READ_ONLY_FILE_CONTENTS);
     is.close();
   }


### PR DESCRIPTION
### Overview

Fixed PFD testGetFd_canRead test failed on macOS.  
Avoid depending on Linux file system details, and make full use of Java cross platform feature.

### Proposed Changes

Used `new FileInputStream(FileDescriptor)` instead of `new FileInputStream(String)`.

Note that it can still run failed on Windows.

Closes #7130 
