### PR TITLE
Remove unused Exception from example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here's an example of a simple test written using Robolectric:
 public class MyActivityTest {
 
   @Test
-  public void clickingButton_shouldChangeResultsViewText() throws Exception {
+  public void clickingButton_shouldChangeResultsViewText() {
     Activity activity = Robolectric.setupActivity(MyActivity.class);
 
     Button button = (Button) activity.findViewById(R.id.press_me_button);


### PR DESCRIPTION
The methods used by example code don't have `throws` signature, and we don't need add `Exception` for it. 