### PR TITLE
Remove maxSdk restrition for ShadowBiometricManager#canAuthenticate implementation

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBiometricManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBiometricManager.java
@@ -33,7 +33,7 @@ public class ShadowBiometricManager {
 
   @SuppressWarnings("deprecation")
   @RequiresPermission(USE_BIOMETRIC)
-  @Implementation(maxSdk = Q)
+  @Implementation
   protected int canAuthenticate() {
     if (RuntimeEnvironment.getApiLevel() >= R) {
       return reflector(BiometricManagerReflector.class, realBiometricManager).canAuthenticate();


### PR DESCRIPTION
It was deprecated from SDK 30, but not removed.
