### PR TITLE
Bring integration_tests to API 32

### DIFF
--- a/integration_tests/agp/build.gradle
+++ b/integration_tests/agp/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 32
     }
 
     compileOptions {

--- a/integration_tests/agp/testsupport/build.gradle
+++ b/integration_tests/agp/testsupport/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 32
     }
 
     compileOptions {

--- a/integration_tests/androidx/build.gradle
+++ b/integration_tests/androidx/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 32
     }
 
     compileOptions {

--- a/integration_tests/androidx_test/build.gradle
+++ b/integration_tests/androidx_test/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 32
     }
 
     compileOptions {

--- a/integration_tests/ctesque/build.gradle
+++ b/integration_tests/ctesque/build.gradle
@@ -22,19 +22,19 @@ android {
             includeAndroidResources = true
         }
         devices {
-            // ./gradlew -Pandroid.sdk.channel=3 nexusOneApi28DebugAndroidTest
-            nexusOneApi28(ManagedVirtualDevice) {
+            // ./gradlew -Pandroid.sdk.channel=3 nexusOneApi29DebugAndroidTest
+            nexusOneApi29(ManagedVirtualDevice) {
                 device = "Nexus One"
-                apiLevel = 28
+                apiLevel = 29
                 systemImageSource = "aosp"
                 abi = "x86"
             }
-            // ./gradlew -Pandroid.sdk.channel=3 nexusOneApi30DebugAndroidTest
-            nexusOneApi30(ManagedVirtualDevice) {
+            // ./gradlew -Pandroid.sdk.channel=3 nexusOneApi32DebugAndroidTest
+            nexusOneApi32(ManagedVirtualDevice) {
                 device = "Nexus One"
-                apiLevel = 30
-                systemImageSource = "aosp-atd"
-                abi = "x86"
+                apiLevel = 32
+                systemImageSource = "google"
+                abi = "x86_64"
             }
         }
     }

--- a/integration_tests/ctesque/build.gradle
+++ b/integration_tests/ctesque/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/integration_tests/memoryleaks/build.gradle
+++ b/integration_tests/memoryleaks/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 32
     }
 
     compileOptions {

--- a/integration_tests/sparsearray/build.gradle
+++ b/integration_tests/sparsearray/build.gradle
@@ -13,11 +13,11 @@ spotless {
 }
 
 android {
-    compileSdk 31
+    compileSdk 32
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 32
     }
 
     compileOptions {


### PR DESCRIPTION
1. Bump targetSdk and compileSdk to 32 for integration_tests.
2. Bump ATD to API 32 for GMD.