### PR TITLE
build: bump errorprone plugin version from 1.3.0 to 2.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     dependencies {
         gradle
         classpath 'com.android.tools.build:gradle:7.1.0'
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:1.3.0'
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:2.0.2'
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
         classpath "com.github.ben-manes:gradle-versions-plugin:0.42.0"


### PR DESCRIPTION
### Overview
Increase the error-prone plugin version to `2.0.2` because in their release of `1.3.1` they have fixed a few bugs which will reduce the noise in the warnings
![Screenshot 2022-04-05 at 9 42 02 PM](https://user-images.githubusercontent.com/50016799/161798562-94d8c07e-cbf0-49c8-b2fe-0139d20af25c.png)


### Proposed Changes

For this, I've increased the version to `2.0.2` in the project-level `build.gradle`
`classpath 'net.ltgt.gradle:gradle-errorprone-plugin:2.0.2'`