### PR TITLE
Add SdkSuppress to some tests in ThemeTest and MotionEventTest

### DIFF
--- a/integration_tests/ctesque/src/sharedTest/java/android/content/res/ThemeTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/content/res/ThemeTest.java
@@ -1,5 +1,6 @@
 package android.content.res;
 
+import static android.os.Build.VERSION_CODES.O;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
@@ -7,6 +8,7 @@ import android.content.res.Resources.Theme;
 import android.graphics.Color;
 import android.util.TypedValue;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SdkSuppress;
 import androidx.test.platform.app.InstrumentationRegistry;
 import org.junit.Before;
 import org.junit.Test;
@@ -151,6 +153,7 @@ public class ThemeTest {
     assertThat(value.data).isEqualTo(R.style.Widget_AnotherTheme_Button);
   }
 
+  @SdkSuppress(minSdkVersion = O)
   @Test
   public void forStylesWithImplicitParents_shouldInheritValuesNotDefinedInChild() {
     Resources.Theme theme = resources.newTheme();
@@ -168,6 +171,7 @@ public class ThemeTest {
     assertThat(theme.obtainStyledAttributes(new int[] {R.attr.string1}).hasValue(0)).isFalse();
   }
 
+  @SdkSuppress(minSdkVersion = O)
   @Test
   public void shouldApplyParentStylesFromAttrs() {
     Resources.Theme theme = resources.newTheme();
@@ -178,6 +182,7 @@ public class ThemeTest {
         .isEqualTo("string 3 from Theme.Robolectric");
   }
 
+  @SdkSuppress(minSdkVersion = O)
   @Test
   public void setTo_shouldCopyAllAttributesToEmptyTheme() {
     Resources.Theme theme1 = resources.newTheme();
@@ -192,6 +197,7 @@ public class ThemeTest {
         .isEqualTo("string 1 from Theme.Robolectric");
   }
 
+  @SdkSuppress(minSdkVersion = O)
   @Test
   public void setTo_whenDestThemeIsModified_sourceThemeShouldNotMutate() {
     Resources.Theme sourceTheme = resources.newTheme();
@@ -207,6 +213,7 @@ public class ThemeTest {
         .isEqualTo("string 1 from Theme.Robolectric");
   }
 
+  @SdkSuppress(minSdkVersion = O)
   @Test
   public void setTo_whenSourceThemeIsModified_destThemeShouldNotMutate() {
     Resources.Theme sourceTheme = resources.newTheme();
@@ -223,6 +230,7 @@ public class ThemeTest {
   }
 
   @Test
+  @SdkSuppress(minSdkVersion = O)
   public void applyStyle_withForceFalse_shouldApplyButNotOverwriteExistingAttributeValues() {
     Resources.Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_Robolectric, false);
@@ -237,6 +245,7 @@ public class ThemeTest {
   }
 
   @Test
+  @SdkSuppress(minSdkVersion = O)
   public void applyStyle_withForceTrue_shouldApplyAndOverwriteExistingAttributeValues() {
     Resources.Theme theme = resources.newTheme();
     theme.applyStyle(R.style.Theme_Robolectric, false);

--- a/integration_tests/ctesque/src/sharedTest/java/android/view/MotionEventTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/view/MotionEventTest.java
@@ -1,5 +1,6 @@
 package android.view;
 
+import static android.os.Build.VERSION_CODES.N;
 import static androidx.test.ext.truth.view.MotionEventSubject.assertThat;
 import static androidx.test.ext.truth.view.PointerCoordsSubject.assertThat;
 import static androidx.test.ext.truth.view.PointerPropertiesSubject.assertThat;
@@ -17,6 +18,7 @@ import android.view.MotionEvent.PointerProperties;
 import androidx.test.core.view.PointerCoordsBuilder;
 import androidx.test.core.view.PointerPropertiesBuilder;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SdkSuppress;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.Subject;
 import com.google.common.truth.Truth;
@@ -321,6 +323,7 @@ public class MotionEventTest {
   }
 
   @Test
+  @SdkSuppress(minSdkVersion = N)
   public void testReadFromParcelWithInvalidSampleSize() {
     Parcel parcel = Parcel.obtain();
     motionEvent2.writeToParcel(parcel, Parcelable.PARCELABLE_WRITE_RETURN_VALUE);


### PR DESCRIPTION
MotionEventTest.testReadFromParcelWithInvalidSampleSize does not work in
SDK < N.

Also, several tests in ThemeTest do not work in SDK < O.
