### PR TITLE
Changed the tests from java to kotlin for utils module

### DIFF
--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -2,6 +2,7 @@ import org.robolectric.gradle.DeployedRoboJavaModulePlugin
 import org.robolectric.gradle.RoboJavaModulePlugin
 
 apply plugin: RoboJavaModulePlugin
+apply plugin: 'kotlin'
 apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
@@ -22,4 +23,28 @@ dependencies {
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+}
+
+buildscript {
+    ext.kotlin_version = '1.4.20'
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+repositories {
+    mavenCentral()
+}
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }


### PR DESCRIPTION
### Overview
I've converted the test cases from `java` to `Kotlin` for the `utils` module.

### Proposed Changes
For this, I've added the Kotlin Gradle plugin dependency to the `parent` build.gradle and a specific Kotlin plugin to the `utils` module build.gradle. 

### Thing I've doubt about
During the [discussion](https://github.com/robolectric/robolectric/discussions/7127#discussioncomment-2346565) its mentioned there that for kotlin code style robolectric uses `Spotless` + `ktmft` + `Google style to format Kotlin` I found out that

**Spotless**: It's a way to format the Kotlin code it has a [IntelliJ plugin](https://plugins.jetbrains.com/plugin/18321-spotless-gradle) to format easily and with their plugin, with one click I can format the code easily.

**Ktfmt**: It also reformats Kotlin source code to comply with the common community standard for Kotlin code and it also comes with the IntelliJ plugin with one click I can reformat the code.

**Google-style to format Kotlin**: It is basically a google standard on how to format the code.

Currently, all three are enabled in the Android Studio, and why we are using all three. Cant, we use one of them for example Ktfmt?


### Issue
 - Currently, 2 test cases are still failing which I'm unable to fix it so far because of a lack of code understandability.
<img width="1880" alt="Screenshot 2022-04-09 at 8 40 34 PM" src="https://user-images.githubusercontent.com/50016799/162579976-c9fa67d3-11ff-4a24-8709-405b5f15d15c.png">

 - Another issue IDK how it works but when I put the two interfaces `Thing` and `Umm` separate in their own file test cases are passed but if I make them as a nested interface in `InjectorTest` tests are failing, I think its related visibility issue but the reason I don't exactly.
