### PR TITLE
Removed `targetSdk` from AndroidManifest.xml

### DIFF
--- a/integration_tests/androidx/src/main/AndroidManifest.xml
+++ b/integration_tests/androidx/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.robolectric.integration.axt">
-    <uses-sdk android:targetSdkVersion="28"/>
 
     <application>
     </application>

--- a/integration_tests/androidx_test/src/main/AndroidManifest.xml
+++ b/integration_tests/androidx_test/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.robolectric.integration.axt">
-    <uses-sdk android:targetSdkVersion="28"/>
 
     <uses-permission android:name="android.permission.READ_CONTACTS"/>
 

--- a/integration_tests/ctesque/src/main/AndroidManifest.xml
+++ b/integration_tests/ctesque/src/main/AndroidManifest.xml
@@ -5,7 +5,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.robolectric.ctesque">
 
-  <uses-sdk android:targetSdkVersion="27"/>
-
   <application />
 </manifest>

--- a/integration_tests/memoryleaks/src/main/AndroidManifest.xml
+++ b/integration_tests/memoryleaks/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.robolectric.integrationtests.memoryleaks">
-    <uses-sdk android:targetSdkVersion="30"/>
 
     <application>
     </application>

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     package="org.robolectric.testapp"
     android:versionCode="123"
     android:versionName="aVersionName">
-    <uses-sdk android:targetSdkVersion="23"/>
 
     <application
         android:theme="@style/Theme.Robolectric" android:enabled="true">


### PR DESCRIPTION
### Overview
#6966 

### Proposed Changes
Removed `targetSdk` from AndroidManifest.xml and moved the version from the manifest to the defaultConfig in the build.gradle file.

> Affected Modules: parent.integration_tests.androidx, parent.integration_tests.androidx_test, parent.integration_tests.ctesque, parent.integration_tests.memoryleaks, parent.testapp
