### PR TITLE
Migrate compileSdkVersion to compileSdk

### DIFF
--- a/integration_tests/agp/build.gradle
+++ b/integration_tests/agp/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
 
 android {
-    compileSdkVersion 32
+    compileSdk 32
 
     defaultConfig {
         minSdkVersion 16

--- a/integration_tests/agp/testsupport/build.gradle
+++ b/integration_tests/agp/testsupport/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 32
+    compileSdk 32
 
     defaultConfig {
         minSdkVersion 16

--- a/integration_tests/androidx/build.gradle
+++ b/integration_tests/androidx/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
 
 android {
-    compileSdkVersion 32
+    compileSdk 32
 
     defaultConfig {
         minSdkVersion 16

--- a/integration_tests/androidx_test/build.gradle
+++ b/integration_tests/androidx_test/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
 
 android {
-    compileSdkVersion 32
+    compileSdk 32
 
     defaultConfig {
         minSdkVersion 16

--- a/integration_tests/ctesque/build.gradle
+++ b/integration_tests/ctesque/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
 
 android {
-    compileSdkVersion 32
+    compileSdk 32
 
     defaultConfig {
         minSdkVersion 16

--- a/integration_tests/memoryleaks/build.gradle
+++ b/integration_tests/memoryleaks/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
 
 android {
-    compileSdkVersion 32
+    compileSdk 32
 
     defaultConfig {
         minSdkVersion 16

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdk 30
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Overview

Migrated compileSdkVersion to compileSdk for Robolectric's tests.
Close: https://github.com/robolectric/robolectric/issues/6950

Proposed Changes

Robolectric uses AGP 7.1.0 and starting from the release of AGP 7.0.0, we can use compileSdk instead of compileSdkVersion.
So, i changed compileSdkVersion to compileSdk.