### PR TITLE
Skip to generate shadowOf for ShadowBackdropFrameRenderer

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBackdropFrameRenderer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBackdropFrameRenderer.java
@@ -15,7 +15,7 @@ import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 
 /** Shadow for {@link BackdropFrameRenderer} */
-@Implements(value = BackdropFrameRenderer.class, minSdk = S)
+@Implements(value = BackdropFrameRenderer.class, minSdk = S, isInAndroidSdk = false)
 public class ShadowBackdropFrameRenderer {
 
   // Updated to the real value in the generated Shadow constructor


### PR DESCRIPTION
The `BackdropFrameRenderer` is private/hidden/internal API, and we don't need to generate `shadowOf` for this class.
