### PR TITLE
Annotate ShadowBackdropFrameRenderer with isInAndroidSdk = false

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBackdropFrameRenderer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBackdropFrameRenderer.java
@@ -15,7 +15,7 @@ import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 
 /** Shadow for {@link BackdropFrameRenderer} */
-@Implements(value = BackdropFrameRenderer.class, minSdk = S)
+@Implements(value = BackdropFrameRenderer.class, minSdk = S, isInAndroidSdk = false)
 public class ShadowBackdropFrameRenderer {
 
   // Updated to the real value in the generated Shadow constructor


### PR DESCRIPTION
### Overview
Fix #7286

### Proposed Changes
`com.android.internal.policy.BackdropFrameRenderer` class is not provided from Android Platform SDK.
So, `isInAndroidSdk` parameter should be set in `@Implements` annotation