### PR TITLE
Improve the friendliness of code names for Util.java

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/RangingSessionBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/RangingSessionBuilder.java
@@ -1,6 +1,5 @@
 package org.robolectric.shadows;
 
-
 import android.uwb.IUwbAdapter;
 import android.uwb.RangingSession;
 import android.uwb.SessionHandle;

--- a/utils/src/main/java/org/robolectric/util/Util.java
+++ b/utils/src/main/java/org/robolectric/util/Util.java
@@ -99,11 +99,11 @@ public class Util {
   }
 
   public static List<Integer> intArrayToList(int[] ints) {
-    List<Integer> youSuckJava = new ArrayList<>();
-    for (int attr1 : ints) {
-      youSuckJava.add(attr1);
+    List<Integer> list = new ArrayList<>();
+    for (int value : ints) {
+      list.add(value);
     }
-    return youSuckJava;
+    return list;
   }
 
   public static int parseInt(String valueFor) {


### PR DESCRIPTION
The `Util.java` is released to users. IMO, it's not a great practice that released code including words like "youSuckJava". I'm not familiar with slang, and please let me know if I understand wrong.