### PR TITLE
Add support for changing NetworkSpecifier in NetworkCapabilities

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNetworkCapabilitiesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNetworkCapabilitiesTest.java
@@ -7,14 +7,20 @@ import static android.net.NetworkCapabilities.NET_CAPABILITY_TRUSTED;
 import static android.net.NetworkCapabilities.TRANSPORT_CELLULAR;
 import static android.net.NetworkCapabilities.TRANSPORT_WIFI;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.N;
+import static android.os.Build.VERSION_CODES.N_MR1;
+import static android.os.Build.VERSION_CODES.O;
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.net.NetworkCapabilities;
+import android.net.NetworkSpecifier;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
+import org.robolectric.util.ReflectionHelpers;
 
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = LOLLIPOP)
@@ -56,5 +62,31 @@ public class ShadowNetworkCapabilitiesTest {
     assertThat(networkCapabilities.hasCapability(NET_CAPABILITY_NOT_RESTRICTED)).isTrue();
     assertThat(networkCapabilities.hasCapability(NET_CAPABILITY_TRUSTED)).isTrue();
     assertThat(networkCapabilities.hasCapability(NET_CAPABILITY_NOT_VPN)).isTrue();
+  }
+
+  @Test
+  @Config(minSdk = O)
+  public void getNetworkSpecifier_shouldReturnTheSpecifiedValue_fromO() {
+    NetworkCapabilities networkCapabilities = ShadowNetworkCapabilities.newInstance();
+    // Required to set NetworkSpecifier
+    shadowOf(networkCapabilities).addTransportType(TRANSPORT_WIFI);
+
+    NetworkSpecifier testNetworkSpecifier = mock(NetworkSpecifier.class);
+    shadowOf(networkCapabilities).setNetworkSpecifier(testNetworkSpecifier);
+    assertThat(networkCapabilities.getNetworkSpecifier()).isEqualTo(testNetworkSpecifier);
+  }
+
+  @Test
+  @Config(minSdk = N, maxSdk = N_MR1)
+  public void getNetworkSpecifier_shouldReturnTheSpecifiedValue_beforeO() {
+    NetworkCapabilities networkCapabilities = ShadowNetworkCapabilities.newInstance();
+    // Required to set NetworkSpecifier
+    shadowOf(networkCapabilities).addTransportType(TRANSPORT_WIFI);
+
+    String testNetworkSpecifier = "testNetworkSpecifier";
+    shadowOf(networkCapabilities).setNetworkSpecifier(testNetworkSpecifier);
+    String checkedNetworkSpecifier =
+        ReflectionHelpers.callInstanceMethod(networkCapabilities, "getNetworkSpecifier");
+    assertThat(checkedNetworkSpecifier).isEqualTo(testNetworkSpecifier);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkCapabilities.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkCapabilities.java
@@ -1,9 +1,13 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.N;
+import static android.os.Build.VERSION_CODES.N_MR1;
+import static android.os.Build.VERSION_CODES.O;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.net.NetworkCapabilities;
+import android.net.NetworkSpecifier;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -54,6 +58,26 @@ public class ShadowNetworkCapabilities {
         .removeCapability(capability);
   }
 
+  /**
+   * Changes {@link NetworkSpecifier} for this network capabilities. Works only on Android O and
+   * higher. For lower versions use {@link #setNetworkSpecifier(String)}
+   */
+  @Implementation(minSdk = O)
+  public NetworkCapabilities setNetworkSpecifier(NetworkSpecifier networkSpecifier) {
+    return reflector(NetworkCapabilitiesReflector.class, realNetworkCapabilities)
+        .setNetworkSpecifier(networkSpecifier);
+  }
+
+  /**
+   * Changes {@link NetworkSpecifier} for this network capabilities. Works only on Android N_MR1 and
+   * lower. For higher versions use {@link #setNetworkSpecifier(NetworkSpecifier)}
+   */
+  @Implementation(minSdk = N, maxSdk = N_MR1)
+  public NetworkCapabilities setNetworkSpecifier(String networkSpecifier) {
+    return reflector(NetworkCapabilitiesReflector.class, realNetworkCapabilities)
+        .setNetworkSpecifier(networkSpecifier);
+  }
+
   @ForType(NetworkCapabilities.class)
   interface NetworkCapabilitiesReflector {
 
@@ -68,5 +92,11 @@ public class ShadowNetworkCapabilities {
 
     @Direct
     NetworkCapabilities removeCapability(int capability);
+
+    @Direct
+    NetworkCapabilities setNetworkSpecifier(NetworkSpecifier networkSpecifier);
+
+    @Direct
+    NetworkCapabilities setNetworkSpecifier(String networkSpecifier);
   }
 }


### PR DESCRIPTION
### Overview
Added method to change NetworkSpecifier in NetworkCapabilities as described in #7192.

### Proposed Changes
Method `setNetworkSpecifier` has different return type on API < 25 and 26+ so I created different 2 methods, but I'm not sure that the method `setNetworkSpecifier(String)` will be needed by anyone.
Testing method `setNetworkSpecifier(String)` was impossible without failing compilation so the test uses reflection and it seems to work as expected.

Fixes #7192