### PR TITLE
Add several new methods to ShadowPaint

### DIFF
--- a/integration_tests/androidx_test/src/main/res/layout/espresso_activity.xml
+++ b/integration_tests/androidx_test/src/main/res/layout/espresso_activity.xml
@@ -25,6 +25,27 @@
       android:layout_width="wrap_content"
       android:text="Text View"/>
 
+  <TextView
+      android:id="@+id/text_view_positive_scale_x"
+      android:layout_height="wrap_content"
+      android:layout_width="wrap_content"
+      android:textScaleX="1.5"
+      android:text="Text View with positive textScaleX"/>
+
+  <TextView
+      android:id="@+id/text_view_negative_scale_x"
+      android:layout_height="wrap_content"
+      android:layout_width="wrap_content"
+      android:textScaleX="-1.5"
+      android:text="Text View with negative textScaleX"/>
+
+  <TextView
+      android:id="@+id/text_view_letter_spacing"
+      android:layout_height="wrap_content"
+      android:layout_width="wrap_content"
+      android:letterSpacing="0.05"
+      android:text="Text View with letterSpacing"/>
+
   <EditText
       android:id="@+id/edit_text_phone"
       android:layout_height="wrap_content"

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoTest.java
@@ -15,6 +15,7 @@ import static com.google.common.truth.Truth.assertThat;
 import android.view.KeyEvent;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.TextView;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.espresso.Espresso;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -115,6 +116,42 @@ public final class EspressoTest {
               assertThat(view.getHeight()).isGreaterThan(0);
             });
     onView(withText("Text View")).check(matches(isCompletelyDisplayed()));
+  }
+
+  @Test
+  public void textViewWithPositiveScaleX() {
+    onView(withId(R.id.text_view_positive_scale_x))
+        .check(
+            (view, noViewFoundException) -> {
+              TextView textView = (TextView) view;
+              float expectedTextScaleX = 1.5f;
+              assertThat(textView.getTextScaleX()).isEqualTo(expectedTextScaleX);
+              float expectedTextWidth = ((float) textView.length()) * expectedTextScaleX;
+              assertThat(textView.getPaint().measureText(textView.getText().toString()))
+                  .isEqualTo(expectedTextWidth);
+            });
+  }
+
+  @Test
+  public void textViewWithNegativeScaleX() {
+    onView(withId(R.id.text_view_negative_scale_x))
+        .check(
+            (view, noViewFoundException) -> {
+              TextView textView = (TextView) view;
+              assertThat(textView.getTextScaleX()).isEqualTo(-1.5f);
+              assertThat(textView.getPaint().measureText(textView.getText().toString()))
+                  .isEqualTo(0f);
+            });
+  }
+
+  @Test
+  public void textViewWithLetterSpacing() {
+    onView(withId(R.id.text_view_letter_spacing))
+        .check(
+            (view, noViewFoundException) -> {
+              TextView textView = (TextView) view;
+              assertThat(textView.getLetterSpacing()).isEqualTo(0.05f);
+            });
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPaintTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPaintTest.java
@@ -79,6 +79,24 @@ public class ShadowPaintTest {
   }
 
   @Test
+  public void measureTextUsesTextScaleX() {
+    Paint paint = new Paint();
+    paint.setTextScaleX(1.5f);
+    assertThat(paint.measureText("Hello")).isEqualTo(7.5f);
+    assertThat(paint.measureText("Hello", 1, 3)).isEqualTo(3.0f);
+    assertThat(paint.measureText(new StringBuilder("Hello"), 1, 4)).isEqualTo(4.5f);
+  }
+
+  @Test
+  public void textWidthWithNegativeScaleXIsZero() {
+    Paint paint = new Paint();
+    paint.setTextScaleX(-1.5f);
+    assertThat(paint.measureText("Hello")).isEqualTo(0f);
+    assertThat(paint.measureText("Hello", 1, 3)).isEqualTo(0f);
+    assertThat(paint.measureText(new StringBuilder("Hello"), 1, 4)).isEqualTo(0f);
+  }
+
+  @Test
   public void createPaintFromPaint() {
     Paint origPaint = new Paint();
     assertThat(new Paint(origPaint).getTextLocale()).isSameInstanceAs(origPaint.getTextLocale());
@@ -111,5 +129,11 @@ public class ShadowPaintTest {
                 /*maxWidth=*/ 100,
                 /*measuredWidth=*/ null))
         .isGreaterThan(0);
+  }
+
+  @Test
+  public void defaultTextScaleXIsOne() {
+    Paint paint = new Paint();
+    assertThat(paint.getTextScaleX()).isEqualTo(1f);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPaint.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPaint.java
@@ -4,6 +4,7 @@ import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
 import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.KITKAT_WATCH;
+import static android.os.Build.VERSION_CODES.L;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
 import static android.os.Build.VERSION_CODES.M;
@@ -12,6 +13,7 @@ import static android.os.Build.VERSION_CODES.N_MR1;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.O_MR1;
 import static android.os.Build.VERSION_CODES.P;
+import static android.os.Build.VERSION_CODES.Q;
 import static org.robolectric.annotation.TextLayoutMode.Mode.REALISTIC;
 
 import android.graphics.ColorFilter;
@@ -48,6 +50,10 @@ public class ShadowPaint {
   private boolean dither;
   private int flags;
   private PathEffect pathEffect;
+  private float letterSpacing;
+  private float textScaleX = 1f;
+  private float textSkewX;
+  private float wordSpacing;
 
   @RealObject Paint paint;
   private Typeface typeface;
@@ -73,6 +79,10 @@ public class ShadowPaint {
     this.dither = otherShadowPaint.dither;
     this.flags = otherShadowPaint.flags;
     this.pathEffect = otherShadowPaint.pathEffect;
+    this.letterSpacing = otherShadowPaint.letterSpacing;
+    this.textScaleX = otherShadowPaint.textScaleX;
+    this.textSkewX = otherShadowPaint.textSkewX;
+    this.wordSpacing = otherShadowPaint.wordSpacing;
 
     Shadow.invokeConstructor(Paint.class, paint, ClassParameter.from(Paint.class, otherPaint));
   }
@@ -202,6 +212,46 @@ public class ShadowPaint {
   }
 
   @Implementation
+  protected float getTextScaleX() {
+    return textScaleX;
+  }
+
+  @Implementation
+  protected void setTextScaleX(float scaleX) {
+    this.textScaleX = scaleX;
+  }
+
+  @Implementation
+  protected float getTextSkewX() {
+    return textSkewX;
+  }
+
+  @Implementation
+  protected void setTextSkewX(float skewX) {
+    this.textSkewX = skewX;
+  }
+
+  @Implementation(minSdk = L)
+  protected float getLetterSpacing() {
+    return letterSpacing;
+  }
+
+  @Implementation(minSdk = L)
+  protected void setLetterSpacing(float letterSpacing) {
+    this.letterSpacing = letterSpacing;
+  }
+
+  @Implementation(minSdk = Q)
+  protected float getWordSpacing() {
+    return wordSpacing;
+  }
+
+  @Implementation(minSdk = Q)
+  protected void setWordSpacing(float wordSpacing) {
+    this.wordSpacing = wordSpacing;
+  }
+
+  @Implementation
   protected void setTextAlign(Paint.Align align) {
     textAlign = align;
   }
@@ -295,22 +345,26 @@ public class ShadowPaint {
 
   @Implementation
   protected float measureText(String text) {
-    return text.length();
+    return applyTextScaleX(text.length());
   }
 
   @Implementation
   protected float measureText(CharSequence text, int start, int end) {
-    return end - start;
+    return applyTextScaleX(end - start);
   }
 
   @Implementation
   protected float measureText(String text, int start, int end) {
-    return end - start;
+    return applyTextScaleX(end - start);
   }
 
   @Implementation
   protected float measureText(char[] text, int index, int count) {
-    return count;
+    return applyTextScaleX(count);
+  }
+
+  private float applyTextScaleX(float textWidth) {
+    return Math.max(0f, textScaleX) * textWidth;
   }
 
   @Implementation(maxSdk = JELLY_BEAN_MR1)


### PR DESCRIPTION
### Overview
Added requested methods from the issue to `ShadowPaint` class.
### Proposed Changes
In additional to the new methods I added an Espresso test to check them where it's possible.
Also It seemed more consistent to me to use `textScaleX` parameter to measure the width of text (in method `measureText`), but here I'm not sure it's worth bothering to much.

Fixes #7246 