### PR TITLE
Migrate testRuntime to testRuntimeOnly

### DIFF
--- a/integration_tests/mockk/build.gradle
+++ b/integration_tests/mockk/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
-    testRuntime AndroidSdk.MAX_SDK.coordinates
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation 'io.mockk:mockk:1.9.3'


### PR DESCRIPTION
The `testRuntime` is deprecated, and Gradle recommends to use `testRuntimeOnly`, see https://docs.gradle.org/current/userguide/upgrading_version_6.html.