### PR TITLE
Use GitHub Actions cached JDK distribution for instrumentation-tests if possible

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,8 +114,9 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 11.0.14
+          cache: 'gradle'
 
       - uses: gradle/gradle-build-action@v2
 


### PR DESCRIPTION
See
https://github.blog/changelog/2021-08-30-github-actions-setup-java-now-supports-dependency-caching/ and https://github.com/ben-manes/caffeine/commit/407340ef0864d1b50fc4197dd6b139974a74df8a.