### PR TITLE
Change the top level project name from parent to robolectric

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'parent'
+rootProject.name = 'robolectric'
 
 include ":robolectric"
 include ":sandbox"


### PR DESCRIPTION
### Overview
Changed top-level project name from parent to robolectric to avoid confusion while switching projects in Android Studio. Here is the reference issue - https://github.com/robolectric/robolectric/issues/7346

### Proposed Changes
