### PR TITLE
[Warning] Eliminated AnnotateFormatMethod warnings

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/Asset.java
+++ b/resources/src/main/java/org/robolectric/res/android/Asset.java
@@ -560,7 +560,7 @@ static Asset createFromCompressedMap(FileMap dataMap,
     }
 
     if (newOffset < 0 || newOffset > maxPosn) {
-      ALOGW("seek out of range: want %ld, end=%ld\n",
+      ALOGW("seek out of range: want %d, end=%d\n",
           (long) newOffset, (long) maxPosn);
       return (long) -1;
     }
@@ -784,7 +784,7 @@ static Asset createFromCompressedMap(FileMap dataMap,
         // if (ftell(mFp) != mStart + mOffset) {
         try {
           if (mFp.getFilePointer() != mStart + mOffset) {
-            ALOGE("Hosed: %ld != %ld+%ld\n",
+            ALOGE("Hosed: %d != %d+%d\n",
                 mFp.getFilePointer(), (long) mStart, (long) mOffset);
             assert(false);
           }
@@ -897,7 +897,7 @@ static Asset createFromCompressedMap(FileMap dataMap,
 
         buf = new byte[allocLen];
         if (buf == null) {
-          ALOGE("alloc of %ld bytes failed\n", (long) allocLen);
+          ALOGE("alloc of %d bytes failed\n", (long) allocLen);
           return null;
         }
 
@@ -910,7 +910,7 @@ static Asset createFromCompressedMap(FileMap dataMap,
             mFp.seek(mStart);
             // if (fread(buf, 1, mLength, mFp) != (size_t) mLength) {
             if (mFp.read(buf, 0, toIntExact(mLength)) != (int) mLength) {
-              ALOGE("failed reading %ld bytes\n", (long) mLength);
+              ALOGE("failed reading %d bytes\n", (long) mLength);
               // delete[] buf;
               return null;
             }
@@ -1280,8 +1280,7 @@ static Asset createFromCompressedMap(FileMap dataMap,
 
       // compute new position within chunk
       newPosn = handleSeek(offset, whence, mOffset, mUncompressedLen);
-      if (newPosn == (long) -1)
-      return newPosn;
+      if (newPosn == -1) return newPosn;
 
       // if (mZipInflater) {
       //   mZipInflater.seekAbsolute(newPosn);

--- a/resources/src/main/java/org/robolectric/res/android/AttributeResolution.java
+++ b/resources/src/main/java/org/robolectric/res/android/AttributeResolution.java
@@ -66,7 +66,7 @@ public class AttributeResolution {
                                      int srcValuesLength, int[] attrs,
                                      int attrsLength, int[] outValues, int[] outIndices) {
     if (kDebugStyles) {
-      ALOGI("APPLY STYLE: theme=0x%p defStyleAttr=0x%x defStyleRes=0x%x", theme,
+      ALOGI("APPLY STYLE: theme=0x%s defStyleAttr=0x%x defStyleRes=0x%x", theme,
           defStyleAttr, defStyleRes);
     }
 

--- a/resources/src/main/java/org/robolectric/res/android/AttributeResolution10.java
+++ b/resources/src/main/java/org/robolectric/res/android/AttributeResolution10.java
@@ -94,7 +94,7 @@ public class AttributeResolution10 {
             int src_values_length, int[] attrs,
             int attrs_length, int[] out_values, int[] out_indices) {
         if (kDebugStyles) {
-            ALOGI("APPLY STYLE: theme=0x%p defStyleAttr=0x%x defStyleRes=0x%x", theme,
+            ALOGI("APPLY STYLE: theme=0x%s defStyleAttr=0x%x defStyleRes=0x%x", theme,
                     def_style_attr, def_style_res);
         }
 

--- a/resources/src/main/java/org/robolectric/res/android/AttributeResolution9.java
+++ b/resources/src/main/java/org/robolectric/res/android/AttributeResolution9.java
@@ -91,7 +91,7 @@ public class AttributeResolution9 {
                                      int src_values_length, int[] attrs,
                                      int attrs_length, int[] out_values, int[] out_indices) {
     if (kDebugStyles) {
-      ALOGI("APPLY STYLE: theme=0x%p defStyleAttr=0x%x defStyleRes=0x%x", theme,
+      ALOGI("APPLY STYLE: theme=0x%s defStyleAttr=0x%x defStyleRes=0x%x", theme,
           def_style_attr, def_style_res);
     }
 

--- a/resources/src/main/java/org/robolectric/res/android/ResStringPool.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResStringPool.java
@@ -117,7 +117,7 @@ public class ResStringPool {
 
     // The chunk must be at least the size of the string pool header.
     if (size < ResStringPool_header.SIZEOF) {
-      ALOGW("Bad string block: data size %zu is too small to be a string block", size);
+      ALOGW("Bad string block: data size %d is too small to be a string block", size);
       return (mError=BAD_TYPE);
     }
 

--- a/resources/src/main/java/org/robolectric/res/android/ResTable.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResTable.java
@@ -251,7 +251,7 @@ public class ResTable {
     final boolean notDeviceEndian = htods((short) 0xf0) != 0xf0;
 
     if (kDebugLoadTableNoisy) {
-      ALOGV("Adding resources to ResTable: data=%s, size=0x%x, cookie=%d, copy=%d " +
+      ALOGV("Adding resources to ResTable: data=%s, size=0x%x, cookie=%d, copy=%b " +
           "idmap=%s\n", data, dataSize, cookie, copyData, idmapData);
     }
 

--- a/resources/src/main/java/org/robolectric/res/android/ResXMLParser.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResXMLParser.java
@@ -414,7 +414,7 @@ final String getAttributeStringValue(int idx, Ref<Integer> outLen)
           final String curNs = getAttributeNamespace8(i, curNsLen);
           final String curAttr = getAttributeName8(i, curAttrLen);
           if (kDebugStringPoolNoisy) {
-            ALOGI("  curNs=%s (0x%x), curAttr=%s (0x%x)", curNs, curNsLen, curAttr, curAttrLen);
+            ALOGI("  curNs=%s (0x%x), curAttr=%s (0x%x)", curNs, curNsLen.get(), curAttr, curAttrLen.get());
           }
           if (curAttr != null && curNsLen.get() == nsLen && curAttrLen.get() == attrLen
               && memcmp(attr8.string(), curAttr, attrLen) == 0) {
@@ -449,8 +449,8 @@ final String getAttributeStringValue(int idx, Ref<Integer> outLen)
                 final String curAttr = getAttributeName(i, curAttrLen);
           if (kDebugStringPoolNoisy) {
             ALOGI("  curNs=%s (0x%x), curAttr=%s (0x%x)",
-                curNs /*String8(curNs, curNsLen).string()*/, curNsLen,
-                curAttr /*String8(curAttr, curAttrLen).string()*/, curAttrLen);
+                curNs /*String8(curNs, curNsLen).string()*/, curNsLen.get(),
+                curAttr /*String8(curAttr, curAttrLen).string()*/, curAttrLen.get());
           }
           if (curAttr != null && curNsLen.get() == nsLen && curAttrLen.get() == attrLen
               && (memcmp(attr, curAttr, attrLen*SIZEOF_CHAR/*sizeof(char16_t)*/) == 0)) {

--- a/resources/src/main/java/org/robolectric/res/android/Util.java
+++ b/resources/src/main/java/org/robolectric/res/android/Util.java
@@ -1,5 +1,7 @@
 package org.robolectric.res.android;
 
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
 import java.nio.ByteOrder;
 
 public class Util {
@@ -52,33 +54,39 @@ public class Util {
     return o != null;
   }
 
-  static void ALOGD(String message, Object... args) {
+  @FormatMethod
+  static void ALOGD(@FormatString String message, Object... args) {
     if (DEBUG) {
       System.out.println("DEBUG: " + String.format(message, args));
     }
   }
 
-  static void ALOGW(String message, Object... args) {
+  @FormatMethod
+  static void ALOGW(@FormatString String message, Object... args) {
     System.out.println("WARN: " + String.format(message, args));
   }
 
-  public static void ALOGV(String message, Object... args) {
+  @FormatMethod
+  public static void ALOGV(@FormatString String message, Object... args) {
     if (DEBUG) {
       System.out.println("VERBOSE: " + String.format(message, args));
     }
   }
 
-  public static void ALOGI(String message, Object... args) {
+  @FormatMethod
+  public static void ALOGI(@FormatString String message, Object... args) {
     if (DEBUG) {
       System.out.println("INFO: " + String.format(message, args));
     }
   }
 
-  static void ALOGE(String message, Object... args) {
+  @FormatMethod
+  static void ALOGE(@FormatString String message, Object... args) {
     System.out.println("ERROR: " + String.format(message, args));
   }
 
-  static void LOG_FATAL_IF(boolean assertion, String message, Object... args) {
+  @FormatMethod
+  static void LOG_FATAL_IF(boolean assertion, @FormatString String message, Object... args) {
     assert !assertion : String.format(message, args);
   }
 


### PR DESCRIPTION
### Overview
Eliminated the [AnnotateFormatMethod](https://errorprone.info/bugpattern/AnnotateFormatMethod) across the entire project.

### Proposed Changes

Added the changes in the following files to fix the error-prone warning
- [Asset.java](https://github.com/robolectric/robolectric/compare/master...hellosagar:annotate-format-method-warning-fix?expand=1#diff-44e9f48ffcff0d656e07849a5a4a98c21efd1bb1751c24aa56fc528392c4dc01)
- [AttributeResolution.java](https://github.com/robolectric/robolectric/compare/master...hellosagar:annotate-format-method-warning-fix?expand=1#diff-b56eec5dd95db47a23a731b3eb1b3586f1e7867917ad542766eb2f5e585512e2)
- [AttributeResolution10.java](https://github.com/robolectric/robolectric/compare/master...hellosagar:annotate-format-method-warning-fix?expand=1#diff-3930f55797eab3fea048baf3c70ec8bcbfdc5518abd4558275ff92f516681946)
- [AttributeResolution9.java](https://github.com/robolectric/robolectric/compare/master...hellosagar:annotate-format-method-warning-fix?expand=1#diff-c4aa6fcdea8db54d4b765b5712ae4fa6c8bc7d118af1d7eb0b7e4953bc385924)
- [ResStringPool.java](https://github.com/robolectric/robolectric/compare/master...hellosagar:annotate-format-method-warning-fix?expand=1#diff-d908defabbb3f2d6f9bc45de445bbc61c223a88e3f1bb7f3bae692a7287c6a39)
- [ResTable.java](https://github.com/robolectric/robolectric/compare/master...hellosagar:annotate-format-method-warning-fix?expand=1#diff-8c7f527ae0e668f2fd8a1eb4f288318bcd63862c70374426fe3307069ceed4b4)
- [ResXMLParser.java](https://github.com/robolectric/robolectric/compare/master...hellosagar:annotate-format-method-warning-fix?expand=1#diff-1d1a02e0e0e0ef4578fccfe8247dcd1a3ef0c42d5403efcfde93f15da323ac30)
- [Util.java](https://github.com/robolectric/robolectric/compare/master...hellosagar:annotate-format-method-warning-fix?expand=1#diff-48bfa6ff48c8f002369075c214ef80a1cf8435ee90bc86d7f63a1dd012ab4f01)