### PR TITLE
[Warning] Eliminated AlmostJavadoc warnings across project

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/CppApkAssets.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppApkAssets.java
@@ -88,31 +88,31 @@ public class CppApkAssets {
   Asset idmap_asset_;
   private LoadedArsc loaded_arsc_;
   // };
-//
-// }  // namespace android
-//
-// #endif /* APKASSETS_H_ */
-//
-// #define ATRACE_TAG ATRACE_TAG_RESOURCES
-//
-// #include "androidfw/ApkAssets.h"
-//
-// #include <algorithm>
-//
-// #include "android-base/logging.h"
-// #include "utils/FileMap.h"
-// #include "utils/Trace.h"
-// #include "ziparchive/zip_archive.h"
-//
-// #include "androidfw/Asset.h"
-// #include "androidfw/Util.h"
-//
-// namespace android {
-//
-// Creates an ApkAssets.
-// If `system` is true, the package is marked as a system package, and allows some functions to
-// filter out this package when computing what configurations/resources are available.
-// std::unique_ptr<const ApkAssets> ApkAssets::Load(const String& path, bool system) {
+  //
+  // }  // namespace android
+  //
+  // #endif // APKASSETS_H_
+  //
+  // #define ATRACE_TAG ATRACE_TAG_RESOURCES
+  //
+  // #include "androidfw/ApkAssets.h"
+  //
+  // #include <algorithm>
+  //
+  // #include "android-base/logging.h"
+  // #include "utils/FileMap.h"
+  // #include "utils/Trace.h"
+  // #include "ziparchive/zip_archive.h"
+  //
+  // #include "androidfw/Asset.h"
+  // #include "androidfw/Util.h"
+  //
+  // namespace android {
+  //
+  // Creates an ApkAssets.
+  // If `system` is true, the package is marked as a system package, and allows some functions to
+  // filter out this package when computing what configurations/resources are available.
+  // std::unique_ptr<const ApkAssets> ApkAssets::Load(const String& path, bool system) {
   public static CppApkAssets Load(String path, boolean system) {
     return LoadImpl(/*{}*/-1 /*fd*/, path, null, null, system, false /*load_as_shared_library*/);
   }

--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
@@ -205,36 +205,35 @@ public class CppAssetManager2 {
   // which involves some calculation.
 //  private std.unordered_map<int, util.unique_cptr<ResolvedBag>> cached_bags_;
   final private Map<Integer, ResolvedBag> cached_bags_ = new HashMap<>();
-//  };
+  //  };
 
-//final ResolvedBag.Entry* begin(final ResolvedBag* bag) { return bag.entries; }
-//
-//final ResolvedBag.Entry* end(final ResolvedBag* bag) {
-//  return bag.entries + bag.entry_count;
-//}
-//
-//}  // namespace android
-//
-//#endif /* ANDROIDFW_ASSETMANAGER2_H_ */
-
+  // final ResolvedBag.Entry* begin(final ResolvedBag* bag) { return bag.entries; }
+  //
+  // final ResolvedBag.Entry* end(final ResolvedBag* bag) {
+  //  return bag.entries + bag.entry_count;
+  // }
+  //
+  // }  // namespace android
+  //
+  // #endif // ANDROIDFW_ASSETMANAGER2_H_
 
   //
-//  #include <set>
-//
-//  #include "android-base/logging.h"
-//  #include "android-base/stringprintf.h"
-//  #include "utils/ByteOrder.h"
-//  #include "utils/Trace.h"
-//
-//  #ifdef _WIN32
-//  #ifdef ERROR
-//  #undef ERROR
-//  #endif
-//  #endif
-//
-//  #include "androidfw/ResourceUtils.h"
-//
-//  namespace android {
+  //  #include <set>
+  //
+  //  #include "android-base/logging.h"
+  //  #include "android-base/stringprintf.h"
+  //  #include "utils/ByteOrder.h"
+  //  #include "utils/Trace.h"
+  //
+  //  #ifdef _WIN32
+  //  #ifdef ERROR
+  //  #undef ERROR
+  //  #endif
+  //  #endif
+  //
+  //  #include "androidfw/ResourceUtils.h"
+  //
+  //  namespace android {
   static class FindEntryResult {
     // A pointer to the resource table entry for this resource.
     // If the size of the entry is > sizeof(ResTable_entry), it can be cast to

--- a/resources/src/main/java/org/robolectric/res/android/LoadedArsc.java
+++ b/resources/src/main/java/org/robolectric/res/android/LoadedArsc.java
@@ -135,41 +135,40 @@ public class LoadedArsc {
   final ResStringPool global_string_pool_ = new ResStringPool();
   final List<LoadedPackage> packages_ = new ArrayList<>();
   boolean system_ = false;
-//};
-//
-//}  // namespace android
-//
-//#endif /* LOADEDARSC_H_ */
+  // };
+  //
+  // }  // namespace android
+  //
+  // #endif // LOADEDARSC_H_
 
-//  #define ATRACE_TAG ATRACE_TAG_RESOURCES
-//
-//  #include "androidfw/LoadedArsc.h"
-//
-//  #include <cstddef>
-//  #include <limits>
-//
-//  #include "android-base/logging.h"
-//  #include "android-base/stringprintf.h"
-//  #include "utils/ByteOrder.h"
-//  #include "utils/Trace.h"
-//
-//  #ifdef _WIN32
-//  #ifdef ERROR
-//  #undef ERROR
-//  #endif
-//  #endif
-//
-//  #include "androidfw/ByteBucketArray.h"
-//  #include "androidfw/Chunk.h"
-//  #include "androidfw/ResourceUtils.h"
-//  #include "androidfw/Util.h"
-//
-//  using android::base::StringPrintf;
-//
-//  namespace android {
+  //  #define ATRACE_TAG ATRACE_TAG_RESOURCES
+  //
+  //  #include "androidfw/LoadedArsc.h"
+  //
+  //  #include <cstddef>
+  //  #include <limits>
+  //
+  //  #include "android-base/logging.h"
+  //  #include "android-base/stringprintf.h"
+  //  #include "utils/ByteOrder.h"
+  //  #include "utils/Trace.h"
+  //
+  //  #ifdef _WIN32
+  //  #ifdef ERROR
+  //  #undef ERROR
+  //  #endif
+  //  #endif
+  //
+  //  #include "androidfw/ByteBucketArray.h"
+  //  #include "androidfw/Chunk.h"
+  //  #include "androidfw/ResourceUtils.h"
+  //  #include "androidfw/Util.h"
+  //
+  //  using android::base::StringPrintf;
+  //
+  //  namespace android {
 
   static final int kAppPackageId = 0x7f;
-
 
 //  namespace {
 


### PR DESCRIPTION
### Overview
Eliminated the [AlmostJavadoc](https://errorprone.info/bugpattern/AnnotateFormatMethod) across the entire project from error-prone warnings.

### Proposed Changes

Added the changes in the following files to fix the error-prone warning
- [CppApkAssets.java](https://github.com/robolectric/robolectric/compare/master...hellosagar:almostjavadoc-warning-fix?expand=1#diff-63779c53fd92fe4eea8da36ee86c8ee5035b73234e4818d9b95f0398ae5de984)
- [CppAssetManager2.java](https://github.com/robolectric/robolectric/compare/master...hellosagar:almostjavadoc-warning-fix?expand=1#diff-5f5dbc57e078308b17d64f2bd2a0e7b1033b308008bf1a24ad768cbfd297a94c)
- [LoadedArsc.java](https://github.com/robolectric/robolectric/compare/master...hellosagar:almostjavadoc-warning-fix?expand=1#diff-5f0a24ab3b2600db4eee4bbabcbb82982c0b4defe643cd4173c0adacf7234685)