### PR TITLE
Use JDK 11 instead of 11.0.14 for CI

### DIFF
--- a/.github/workflows/check_code_formatting.yml
+++ b/.github/workflows/check_code_formatting.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11.0.14
+          java-version: 11
 
       - uses: gradle/gradle-build-action@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11.0.14
+          java-version: 11
 
       - uses: gradle/gradle-build-action@v2
 
@@ -64,7 +64,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11.0.14
+          java-version: 11
 
       - uses: gradle/gradle-build-action@v2
 
@@ -115,7 +115,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11.0.14
+          java-version: 11
 
       - uses: gradle/gradle-build-action@v2
 


### PR DESCRIPTION
Looks like GitHub Action doesn't support 11.0.14 now, and it's safer to use JDK 11 instead of specific 11.0.14.
