### PR TITLE
[warning] Byte buffer backing array warning fix

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/ResourceString.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResourceString.java
@@ -60,6 +60,7 @@ public final class ResourceString {
    * followed by the actual string is located.
    *
    * <p>Here's an example UTF-8-encoded string of ab©:
+   *
    * <pre>
    * 03 04 61 62 C2 A9 00
    * ^ Offset should be here
@@ -70,6 +71,7 @@ public final class ResourceString {
    * @param type The encoding type that the {@link ResourceString} is encoded in.
    * @return The decoded string.
    */
+  @SuppressWarnings("ByteBufferBackingArray")
   public static String decodeString(ByteBuffer buffer, int offset, Type type) {
     int length;
     int characterCount = decodeLength(buffer, offset, type);


### PR DESCRIPTION
### Overview
Tried to fix the `ByteBufferBackingArray` ⚠️ which is basically is avoid us to access the `.array()` because there is the possibility that it could be direct ByteBuffer (built using off-heap directly mapped to memory) too.

### Proposed Changes
To avoid this situation, I'm checking first if `buffer.hasArray()` which checks it doesn't have a `null` byte array, and if it's not a read-only ByteBuffer(basically checking if its a heap buffer) 

### Problem
Even after doing what is mentioned above, that warning still exists. But as soon as I invoke the `buffer.arrayOffset()`(which might throw an exception if its a heap buffer) before calling `buffer.array()` the warning is gone

```
if(buffer.hasArray()){ // It's checking if byte array is not  null and not read only.
try {
      buffer.arrayOffset(); // Also check byte array in ByteBuffer is not null and its not readomly.
    } catch (ReadOnlyBufferException e) {
      return null;
    }
// ..... further code
}
```

and if I don't call the `buffer.arrayOffset()` warning exists.

Thanks for the help in advance 🙇‍♂️