### PR TITLE
[warning] Catch and print stack trace warning fix

### DIFF
--- a/junit/src/main/java/org/robolectric/internal/SandboxTestRunner.java
+++ b/junit/src/main/java/org/robolectric/internal/SandboxTestRunner.java
@@ -231,6 +231,7 @@ public class SandboxTestRunner extends BlockJUnit4ClassRunner {
   }
 
   @Override
+  @SuppressWarnings("CatchAndPrintStackTrace")
   protected Statement methodBlock(final FrameworkMethod method) {
     return new Statement() {
       @Override
@@ -305,6 +306,7 @@ public class SandboxTestRunner extends BlockJUnit4ClassRunner {
     };
   }
 
+  @SuppressWarnings("CatchAndPrintStackTrace")
   private void reportPerfStats(PerfStatsCollector perfStatsCollector) {
     if (perfStatsReporters.isEmpty()) {
       return;


### PR DESCRIPTION
### Overview
This warning prefers logging or rethrowing exceptions instead of directly printing the stack trace. Altho, the exact reason is not shared why it's better I think having a log with a message directly showing the intention of the error instead of reading through the entire stack trace.

### Proposed Changes
I've used the   [Logger.error](https://github.com/robolectric/robolectric/blob/9f8fe3abd557261d02272e70a6b837904d8b62ba/utils/src/main/java/org/robolectric/util/Logger.java#L58) to log the error.