### PR TITLE
[warning] DefaultCharset warning fix

### DIFF
--- a/integration_tests/mockito-experimental/src/test/java/org/robolectric/integrationtests/mockito/experimental/MockitoMockJavaFrameworkTest.java
+++ b/integration_tests/mockito-experimental/src/test/java/org/robolectric/integrationtests/mockito/experimental/MockitoMockJavaFrameworkTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import javax.crypto.Cipher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,7 +24,7 @@ public class MockitoMockJavaFrameworkTest {
   @Test
   public void cipher_getIV_isMockable() {
     Cipher cipher = mock(Cipher.class);
-    doReturn("fake".getBytes()).when(cipher).getIV();
-    assertThat(cipher.getIV()).isEqualTo("fake".getBytes());
+    doReturn("fake".getBytes(StandardCharsets.UTF_8)).when(cipher).getIV();
+    assertThat(cipher.getIV()).isEqualTo("fake".getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/plugins/maven-dependency-resolver/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
+++ b/plugins/maven-dependency-resolver/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
@@ -234,12 +234,16 @@ public class MavenDependencyResolverTest {
     try {
       Files.createParentDirs(new File(REPOSITORY_DIR, mavenJarArtifact.jarPath()));
       String jarContents = mavenJarArtifact.toString() + " jar contents";
-      Files.write(jarContents.getBytes(), new File(REPOSITORY_DIR, mavenJarArtifact.jarPath()));
+      Files.write(
+          jarContents.getBytes(StandardCharsets.UTF_8),
+          new File(REPOSITORY_DIR, mavenJarArtifact.jarPath()));
       Files.write(
           sha512(jarContents).getBytes(),
           new File(REPOSITORY_DIR, mavenJarArtifact.jarSha512Path()));
       String pomContents = mavenJarArtifact.toString() + " pom contents";
-      Files.write(pomContents.getBytes(), new File(REPOSITORY_DIR, mavenJarArtifact.pomPath()));
+      Files.write(
+          pomContents.getBytes(StandardCharsets.UTF_8),
+          new File(REPOSITORY_DIR, mavenJarArtifact.pomPath()));
       Files.write(
           sha512(pomContents).getBytes(),
           new File(REPOSITORY_DIR, mavenJarArtifact.pomSha512Path()));
@@ -272,6 +276,6 @@ public class MavenDependencyResolverTest {
   }
 
   static String readFile(File file) throws IOException {
-    return new String(Files.asByteSource(file).read());
+    return new String(Files.asByteSource(file).read(), StandardCharsets.UTF_8);
   }
 }

--- a/processor/src/main/java/org/robolectric/annotation/processing/generator/JavadocJsonGenerator.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/generator/JavadocJsonGenerator.java
@@ -6,6 +6,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.processing.Messager;
@@ -69,7 +70,8 @@ public class JavadocJsonGenerator extends Generator {
     try {
       file.getParentFile().mkdirs();
 
-      try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+      try (BufferedWriter writer =
+          new BufferedWriter(new FileWriter(file, StandardCharsets.UTF_8))) {
         gson.toJson(object, writer);
       }
     } catch (IOException e) {

--- a/utils/src/main/java/org/robolectric/util/inject/PluginFinder.java
+++ b/utils/src/main/java/org/robolectric/util/inject/PluginFinder.java
@@ -7,6 +7,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Enumeration;
@@ -139,7 +140,8 @@ class PluginFinder {
                   while (urls.hasMoreElements()) {
                     URL url = urls.nextElement();
                     BufferedReader reader =
-                        new BufferedReader(new InputStreamReader(url.openStream()));
+                        new BufferedReader(
+                            new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
                     while (reader.ready()) {
                       String s = reader.readLine();
                       result.add(


### PR DESCRIPTION
### Overview
[DefaultCharset](https://errorprone.info/bugpattern/DefaultCharset) - Implicit use of the platform default charset, which can result in differing behavior between JVM executions or incorrect behavior if the encoding of the data source doesn't match expectations.

### Proposed Changes
For encoding and decoding, I've specified the  UTF-16 encoding over UTF-8 because it covers more code points.