### PR TITLE
[warning] Do not call suggester warning suppress

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/Asset.java
+++ b/resources/src/main/java/org/robolectric/res/android/Asset.java
@@ -394,16 +394,14 @@ public abstract class Asset {
     //   return pAsset;
   }
 
-
   /*
    * Create a new Asset from a compressed file on disk.  There is a fair chance
    * that the file doesn't actually exist.
    *
    * We currently support gzip files.  We might want to handle .bz2 someday.
    */
-  static Asset createFromCompressedFile(final String fileName,
-      AccessMode mode)
-  {
+  @SuppressWarnings("DoNotCallSuggester")
+  static Asset createFromCompressedFile(final String fileName, AccessMode mode) {
     throw new UnsupportedOperationException();
     // _CompressedAsset pAsset;
     // int result;
@@ -1009,6 +1007,7 @@ static Asset createFromCompressedMap(FileMap dataMap,
       }
     }
 
+    @SuppressWarnings("DoNotCallSuggester")
     final byte[] ensureAlignment(FileMap map) {
       throw new UnsupportedOperationException();
       //   void* data = map.getDataPtr();

--- a/resources/src/main/java/org/robolectric/res/android/CppApkAssets.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppApkAssets.java
@@ -131,10 +131,10 @@ public class CppApkAssets {
   // data.
   // If `system` is true, the package is marked as a system package, and allows some functions to
   // filter out this package when computing what configurations/resources are available.
-// std::unique_ptr<const ApkAssets> ApkAssets::LoadOverlay(const std::string& idmap_path,
-//                                                         bool system) {
-  public static CppApkAssets LoadOverlay(String idmap_path,
-      boolean system) {
+  // std::unique_ptr<const ApkAssets> ApkAssets::LoadOverlay(const std::string& idmap_path,
+  //                                                         bool system) {
+  @SuppressWarnings("DoNotCallSuggester")
+  public static CppApkAssets LoadOverlay(String idmap_path, boolean system) {
     throw new UnsupportedOperationException();
     // Asset idmap_asset = CreateAssetFromFile(idmap_path);
     // if (idmap_asset == null) {
@@ -159,17 +159,18 @@ public class CppApkAssets {
   // If `system` is true, the package is marked as a system package, and allows some functions to
   // filter out this package when computing what configurations/resources are available.
   // If `force_shared_lib` is true, any package with ID 0x7f is loaded as a shared library.
-// std::unique_ptr<const ApkAssets> ApkAssets::LoadFromFd(unique_fd fd,
-//                                                        const std::string& friendly_name,
-//                                                        bool system, bool force_shared_lib) {
-//   public static ApkAssets LoadFromFd(unique_fd fd,
-//       String friendly_name,
-//       boolean system, boolean force_shared_lib) {
-//     return LoadImpl(std.move(fd), friendly_name, null /*idmap_asset*/, null /*loaded_idmap*/,
-//         system, force_shared_lib);
-//   }
+  // std::unique_ptr<const ApkAssets> ApkAssets::LoadFromFd(unique_fd fd,
+  //                                                        const std::string& friendly_name,
+  //                                                        bool system, bool force_shared_lib) {
+  //   public static ApkAssets LoadFromFd(unique_fd fd,
+  //       String friendly_name,
+  //       boolean system, boolean force_shared_lib) {
+  //     return LoadImpl(std.move(fd), friendly_name, null /*idmap_asset*/, null /*loaded_idmap*/,
+  //         system, force_shared_lib);
+  //   }
 
   // std::unique_ptr<Asset> ApkAssets::CreateAssetFromFile(const std::string& path) {
+  @SuppressWarnings("DoNotCallSuggester")
   static Asset CreateAssetFromFile(String path) {
     throw new UnsupportedOperationException();
     // unique_fd fd(base.utf8.open(path.c_str(), O_RDONLY | O_BINARY | O_CLOEXEC));

--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
@@ -1204,6 +1204,7 @@ public class CppAssetManager2 {
     }
   }
 
+  @SuppressWarnings("DoNotCallSuggester")
   static boolean Utf8ToUtf16(final String str, Ref<String> out) {
     throw new UnsupportedOperationException();
     // ssize_t len =

--- a/resources/src/main/java/org/robolectric/res/android/Idmap.java
+++ b/resources/src/main/java/org/robolectric/res/android/Idmap.java
@@ -89,6 +89,7 @@ class Idmap {
       return (offset & 0x03) == 0;
     }
 
+    @SuppressWarnings("DoNotCallSuggester")
     static boolean IsValidIdmapHeader(StringPiece data) {
       throw new UnsupportedOperationException();
 //   if (!is_word_aligned(data.data())) {


### PR DESCRIPTION
### Overview
[DoNotCallSuggester](https://errorprone.info/bugpattern/DoNotCallSuggester) - Method that always throws exception annotated with `@DoNotCall` to avoid the exception at runtime and throwing right away at runtime.

### Proposed Changes
So, If I add this annotation code is not compiling because it is throwing an exception, so instead can we suppress it? and I wonder why robolectric has methods that only throw exceptions but still if we need those methods then we can suppress this warning to reduce the noise.