### PR TITLE
[warning] Empty catch warning fix

### DIFF
--- a/resources/src/main/java/org/robolectric/res/ResType.java
+++ b/resources/src/main/java/org/robolectric/res/ResType.java
@@ -2,6 +2,7 @@ package org.robolectric.res;
 
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+import org.robolectric.util.Logger;
 
 public enum ResType {
   DRAWABLE,
@@ -54,13 +55,16 @@ public enum ResType {
       try {
         Integer.parseInt(value);
         return INTEGER;
-      } catch (NumberFormatException nfe) {}
+      } catch (NumberFormatException nfe) {
+        Logger.error("Failed to infer int from value", nfe);
+      }
 
       try {
         Float.parseFloat(value);
         return FRACTION;
-      } catch (NumberFormatException nfe) {}
-
+      } catch (NumberFormatException nfe) {
+        Logger.error("Failed to infer float from value", nfe);
+      }
 
       return CHAR_SEQUENCE;
     }

--- a/utils/src/main/java/org/robolectric/util/TempDirectory.java
+++ b/utils/src/main/java/org/robolectric/util/TempDirectory.java
@@ -107,6 +107,7 @@ public class TempDirectory {
       clearDirectory(basePath);
       Files.delete(basePath);
     } catch (IOException ignored) {
+      Logger.error("Failed to destroy temp directory", ignored);
     }
   }
 


### PR DESCRIPTION
### Overview
[EmptyCatch](https://errorprone.info/bugpattern/EmptyCatch) - Caught exceptions should not be ignored.

### Proposed Changes
To avoid this, I've added the logger in the catch, as these `try-catch` can't be deleted because we are doing some parsing and io operation in that try block.
