### PR TITLE
[warning] Equals get class warning fix

### DIFF
--- a/pluginapi/src/main/java/org/robolectric/pluginapi/perf/Metric.java
+++ b/pluginapi/src/main/java/org/robolectric/pluginapi/perf/Metric.java
@@ -69,7 +69,7 @@ public class Metric {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Metric)) {
       return false;
     }
 

--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/SdkStore.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/SdkStore.java
@@ -409,7 +409,7 @@ public class SdkStore {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof MethodInfo)) {
         return false;
       }
       MethodInfo that = (MethodInfo) o;
@@ -453,7 +453,7 @@ public class SdkStore {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof MethodExtraInfo)) {
         return false;
       }
       MethodExtraInfo that = (MethodExtraInfo) o;

--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -739,7 +739,7 @@ public class AndroidManifest implements UsesSdk {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof AndroidManifest)) {
       return false;
     }
 

--- a/resources/src/main/java/org/robolectric/res/ResName.java
+++ b/resources/src/main/java/org/robolectric/res/ResName.java
@@ -38,7 +38,8 @@ public class ResName {
     name = matcher.group(NAME).trim();
 
     hashCode = computeHashCode();
-    if (packageName.equals("xmlns")) throw new IllegalStateException("\"" + fullyQualifiedName + "\" unexpected");
+    if (packageName.equals("xmlns"))
+      throw new IllegalStateException("\"" + fullyQualifiedName + "\" unexpected");
   }
 
   /**
@@ -115,7 +116,7 @@ public class ResName {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof ResName)) return false;
 
     ResName resName = (ResName) o;
 
@@ -153,7 +154,8 @@ public class ResName {
 
   public void mustBe(String expectedType) {
     if (!type.equals(expectedType)) {
-      throw new RuntimeException("expected " + getFullyQualifiedName() + " to be a " + expectedType + ", is a " + type);
+      throw new RuntimeException(
+          "expected " + getFullyQualifiedName() + " to be a " + expectedType + ", is a " + type);
     }
   }
 

--- a/resources/src/main/java/org/robolectric/res/ResourcePath.java
+++ b/resources/src/main/java/org/robolectric/res/ResourcePath.java
@@ -49,7 +49,7 @@ public class ResourcePath {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof ResourcePath)) return false;
 
     ResourcePath that = (ResourcePath) o;
 

--- a/resources/src/main/java/org/robolectric/res/android/String8.java
+++ b/resources/src/main/java/org/robolectric/res/android/String8.java
@@ -424,7 +424,7 @@ public String getPathExtension()
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof String8)) {
       return false;
     }
 

--- a/utils/src/main/java/org/robolectric/util/PerfStatsCollector.java
+++ b/utils/src/main/java/org/robolectric/util/PerfStatsCollector.java
@@ -170,7 +170,7 @@ public class PerfStatsCollector {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof MetricKey)) {
         return false;
       }
 

--- a/utils/src/main/java/org/robolectric/util/SimplePerfStatsReporter.java
+++ b/utils/src/main/java/org/robolectric/util/SimplePerfStatsReporter.java
@@ -94,7 +94,7 @@ public class SimplePerfStatsReporter implements PerfStatsReporter {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof MetricKey)) {
         return false;
       }
 


### PR DESCRIPTION
### Overview
[EqualsGetClass](https://errorprone.info/bugpattern/EqualsGetClass) - Prefer instanceof to getClass when implementing Object#equals.

### Proposed Changes
I've replaced the code snippet below in `equals` method
```
if (o == null || getClass() != o.getClass()) {
       return false;
}
```

to this

```
if (!(o instanceof MethodInfo)) {
        return false;
}
```

**Why**: Because it will not only check for the same class type but also for its's subtypes, and this is what warning trying to solve.
**Note**: Even if a class is final still warning suggests using the `instanceof` comparison operator.
