### PR TITLE
Bump AGP to 7.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
     dependencies {
         gradle
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.0'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:2.0.2'
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     api "com.google.guava:guava:31.1-jre"
     api 'org.jetbrains:annotations:16.0.2'
     implementation "org.ow2.asm:asm-tree:9.2"
-    implementation 'com.android.tools.build:gradle:7.2.2'
+    implementation 'com.android.tools.build:gradle:7.3.0'
 }

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/GradleManagedDevicePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/GradleManagedDevicePlugin.groovy
@@ -14,14 +14,12 @@ class GradleManagedDevicePlugin implements Plugin<Project> {
                     device = "Nexus One"
                     apiLevel = 29
                     systemImageSource = "aosp"
-                    abi = "x86"
                 }
                 // ./gradlew -Pandroid.sdk.channel=3 nexusOneApi32DebugAndroidTest
                 nexusOneApi32(ManagedVirtualDevice) {
                     device = "Nexus One"
                     apiLevel = 32
                     systemImageSource = "google"
-                    abi = "x86_64"
                 }
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ guavaJREVersion=31.1-jre
 
 asmVersion=9.2
 
-kotlinVersion=1.4.31
+kotlinVersion=1.5.20
 
 autoServiceVersion=1.0-rc6
 multidexVersion=2.0.1


### PR DESCRIPTION
Close https://github.com/robolectric/robolectric/issues/7383.

We can run instrumentation tests on headless Emulator with GMD + ATD on macOS with apple silicon chip now:

```
./gradlew -Pandroid.sdk.channel=3 nexusOneApi29DebugAndroidTest
./gradlew -Pandroid.sdk.channel=3 nexusOneApi32DebugAndroidTest
```