### PR TITLE
Migrate ARTIFACT_FORMAT to ARTIFACT_TYPE_ATTRIBUTE

### DIFF
--- a/buildSrc/src/main/groovy/org/robolectric/gradle/AarDepsPlugin.java
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/AarDepsPlugin.java
@@ -1,7 +1,14 @@
 package org.robolectric.gradle;
 
+import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE;
+
 import com.android.build.gradle.internal.dependency.ExtractAarTransform;
 import com.google.common.base.Joiner;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.inject.Inject;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -11,14 +18,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.jetbrains.annotations.NotNull;
 
-import javax.inject.Inject;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.gradle.api.internal.artifacts.ArtifactAttributes.ARTIFACT_FORMAT;
-
 /**
  * Resolve aar dependencies into jars for non-Android projects.
  */
@@ -27,11 +26,13 @@ public class AarDepsPlugin implements Plugin<Project> {
   public void apply(Project project) {
     project
         .getDependencies()
-        .registerTransform(ClassesJarExtractor.class, reg -> {
-          reg.getParameters().getProjectName().set(project.getName());
-          reg.getFrom().attribute(ARTIFACT_FORMAT, "aar");
-          reg.getTo().attribute(ARTIFACT_FORMAT, "jar");
-        });
+        .registerTransform(
+            ClassesJarExtractor.class,
+            reg -> {
+              reg.getParameters().getProjectName().set(project.getName());
+              reg.getFrom().attribute(ARTIFACT_TYPE_ATTRIBUTE, "aar");
+              reg.getTo().attribute(ARTIFACT_TYPE_ATTRIBUTE, "jar");
+            });
 
     project.afterEvaluate(
         p ->
@@ -42,7 +43,8 @@ public class AarDepsPlugin implements Plugin<Project> {
                       // I suspect we're meant to use the org.gradle.usage attribute, but this
                       // works.
                       if (c.getName().endsWith("Classpath")) {
-                        c.attributes(cfgAttrs -> cfgAttrs.attribute(ARTIFACT_FORMAT, "jar"));
+                        c.attributes(
+                            cfgAttrs -> cfgAttrs.attribute(ARTIFACT_TYPE_ATTRIBUTE, "jar"));
                       }
                     }));
 


### PR DESCRIPTION
Actually the deprecated ARTIFACT_FORMAT refers ARTIFACT_TYPE_ATTRIBUTE
directly now. See https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ArtifactAttributes.java#L26.
