### PR TITLE
[warning] InlineMeSuggester warning fix

### DIFF
--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -829,9 +829,12 @@ public class AndroidManifest implements UsesSdk {
     return apkFile;
   }
 
-  /** @deprecated Do not use. */
+  /**
+   * @deprecated Do not use.
+   */
   @Deprecated
-  public boolean supportsLegacyResourcesMode() {
+  @SuppressWarnings("InlineMeSuggester")
+  public final boolean supportsLegacyResourcesMode() {
     return true;
   }
 

--- a/resources/src/main/java/org/robolectric/manifest/PackageItemData.java
+++ b/resources/src/main/java/org/robolectric/manifest/PackageItemData.java
@@ -1,5 +1,7 @@
 package org.robolectric.manifest;
 
+import com.google.errorprone.annotations.InlineMe;
+
 public class PackageItemData {
   protected final String name;
   protected final MetaData metaData;
@@ -13,9 +15,12 @@ public class PackageItemData {
     return name;
   }
 
-  /** @deprecated - Use {@link #getName()} instead. */
+  /**
+   * @deprecated - Use {@link #getName()} instead.
+   */
   @Deprecated
-  public String getClassName() {
+  @InlineMe(replacement = "this.getName()")
+  public final String getClassName() {
     return getName();
   }
 

--- a/resources/src/main/java/org/robolectric/res/Fs.java
+++ b/resources/src/main/java/org/robolectric/res/Fs.java
@@ -1,5 +1,6 @@
 package org.robolectric.res;
 
+import com.google.errorprone.annotations.InlineMe;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -33,14 +34,20 @@ abstract public class Fs {
   @GuardedBy("ZIP_FILESYSTEMS")
   private static final Map<Path, FsWrapper> ZIP_FILESYSTEMS = new HashMap<>();
 
-  /** @deprecated Use {@link File#toPath()} instead. */
+  /**
+   * @deprecated Use {@link File#toPath()} instead.
+   */
   @Deprecated
+  @InlineMe(replacement = "file.toPath()")
   public static Path newFile(File file) {
     return file.toPath();
   }
 
-  /** @deprecated Use {@link #fromUrl(String)} instead. */
+  /**
+   * @deprecated Use {@link #fromUrl(String)} instead.
+   */
   @Deprecated
+  @InlineMe(replacement = "Fs.fromUrl(path)", imports = "org.robolectric.res.Fs")
   public static Path fileFromPath(String path) {
     return Fs.fromUrl(path);
   }

--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -117,7 +117,8 @@ public class Robolectric {
    * @deprecated use {@link androidx.test.core.app.ActivityScenario}
    */
   @Deprecated
-  public static <T extends Activity> T setupActivity(Class<T> activityClass) {
+  @SuppressWarnings("InlineMeSuggester")
+  public static final <T extends Activity> T setupActivity(Class<T> activityClass) {
     return buildActivity(activityClass).setup().get();
   }
 

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -511,6 +511,7 @@ public class RobolectricTestRunner extends SandboxTestRunner {
    *     details.
    */
   @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
   protected Config buildGlobalConfig() {
     return new Config.Builder().build();
   }

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttp.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttp.java
@@ -1,5 +1,6 @@
 package org.robolectric.shadows.httpclient;
 
+import com.google.errorprone.annotations.InlineMe;
 import java.util.List;
 import org.apache.http.Header;
 import org.apache.http.HttpRequest;
@@ -25,13 +26,19 @@ public class FakeHttp {
   /**
    * Sets up an HTTP response to be returned by calls to Apache's {@code HttpClient} implementers.
    *
-   * @param statusCode   the status code of the response
+   * @param statusCode the status code of the response
    * @param responseBody the body of the response
-   * @param contentType  the contentType of the response
+   * @param contentType the contentType of the response
    * @deprecated use {@link #addPendingHttpResponse(int, String, org.apache.http.Header...)} instead
    */
   @Deprecated
-  public static void addPendingHttpResponseWithContentType(int statusCode, String responseBody, Header contentType) {
+  @InlineMe(
+      replacement =
+          "FakeHttp.getFakeHttpLayer().addPendingHttpResponse(statusCode, responseBody,"
+              + " contentType)",
+      imports = "org.robolectric.shadows.httpclient.FakeHttp")
+  public static final void addPendingHttpResponseWithContentType(
+      int statusCode, String responseBody, Header contentType) {
     getFakeHttpLayer().addPendingHttpResponse(statusCode, responseBody, contentType);
   }
 

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
@@ -1,5 +1,6 @@
 package org.robolectric.shadows.httpclient;
 
+import com.google.errorprone.annotations.InlineMe;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -158,7 +159,10 @@ public class ShadowDefaultRequestDirector {
    * @return HttpRequestInfo
    */
   @Deprecated
-  public static HttpRequestInfo getSentHttpRequestInfo(int index) {
+  @InlineMe(
+      replacement = "FakeHttp.getFakeHttpLayer().getSentHttpRequestInfo(index)",
+      imports = "org.robolectric.shadows.httpclient.FakeHttp")
+  public static final HttpRequestInfo getSentHttpRequestInfo(int index) {
     return FakeHttp.getFakeHttpLayer().getSentHttpRequestInfo(index);
   }
 

--- a/utils/src/main/java/org/robolectric/util/Scheduler.java
+++ b/utils/src/main/java/org/robolectric/util/Scheduler.java
@@ -345,6 +345,7 @@ public class Scheduler {
    *     Use {@link #setIdleState(IdleState)} instead to explicitly set the state.
    */
   @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
   public void idleConstantly(boolean shouldIdleConstantly) {
     setIdleState(shouldIdleConstantly ? CONSTANT_IDLE : UNPAUSED);
   }


### PR DESCRIPTION
### Overview
[InlineMeSuggester](https://errorprone.info/bugpattern/InlineMeSuggester) - This deprecated API looks inalienable. If you'd like the body of the API to be inlined to its callers, please annotate it with @InlineMe.

Another resource on how to use the `@Inlineme` annotation - [https://errorprone.info/docs/inlineme](https://errorprone.info/docs/inlineme)

### Proposed Changes

Added the `@Inline` annotation on the methods suggested by the warning.
