### PR TITLE
[warning] EmptyBlockTag warning fix

### DIFF
--- a/pluginapi/src/main/java/org/robolectric/pluginapi/Sdk.java
+++ b/pluginapi/src/main/java/org/robolectric/pluginapi/Sdk.java
@@ -118,7 +118,6 @@ public abstract class Sdk implements Comparable<Sdk> {
    * throw org.junit.AssumptionViolatedException to just skip execution of tests on the SDK, with a
    * warning, or throw a RuntimeException to fail the test.
    *
-   * @param testClassName
    */
   public abstract void verifySupportedSdk(String testClassName);
 }

--- a/shadowapi/src/main/java/org/robolectric/util/ReflectionHelpers.java
+++ b/shadowapi/src/main/java/org/robolectric/util/ReflectionHelpers.java
@@ -316,12 +316,13 @@ public class ReflectionHelpers {
   /**
    * Helper method for calling a static method using a class from a custom class loader
    *
-   * @param classLoader
-   * @param fullyQualifiedClassName
-   * @param methodName
-   * @param classParameters
-   * @param <R>
-   * @return
+   * @param classLoader The ClassLoader used to load class
+   * @param fullyQualifiedClassName The full qualified class name with package name of the
+   *     ClassLoader will load
+   * @param methodName The method name will be called
+   * @param classParameters The input parameters will be used for method calling
+   * @param <R> Return type of the method
+   * @return Return the value of the method
    */
   public static <R> R callStaticMethod(
       ClassLoader classLoader,


### PR DESCRIPTION
### Overview
[EmptyBlockTag](https://google.github.io/styleguide/javaguide.html#s7.1.3-javadoc-block-tags) - This tag is invalid.

### Proposed Changes
For this, I've added the description for the empty tags.