### PR TITLE
[warning] InvalidInlineTag warning fix

### DIFF
--- a/pluginapi/src/main/java/org/robolectric/pluginapi/config/ConfigurationStrategy.java
+++ b/pluginapi/src/main/java/org/robolectric/pluginapi/config/ConfigurationStrategy.java
@@ -14,7 +14,7 @@ public interface ConfigurationStrategy {
   /**
    * Determine the configuration for the given test class and method.
    *
-   * Since a method may be run on multiple test subclasses, {@param testClass} indicates which
+   * <p>Since a method may be run on multiple test subclasses, {@code testClass} indicates which
    * test case is currently being evaluated.
    *
    * @param testClass the test class being evaluated; this might be a subclass of the method's


### PR DESCRIPTION
### Overview
[InvalidInlineTag](https://errorprone.info/bugpattern/InvalidInlineTag) - This tag is invalid.

### Proposed Changes
Added the right tag to render the code-related part in the JavaDoc properly.