### PR TITLE
[warning] InvalidBlockTag warning fix

### DIFF
--- a/robolectric/src/main/java/org/robolectric/junit/rules/BackgroundTestRule.java
+++ b/robolectric/src/main/java/org/robolectric/junit/rules/BackgroundTestRule.java
@@ -12,6 +12,7 @@ import org.junit.runners.model.Statement;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.util.concurrent.BackgroundExecutor;
 
+@SuppressWarnings("InvalidBlockTag")
 /**
  * Let tests to run on background thread, if it has annotation {@link BackgroundTest}.
  *

--- a/utils/src/main/java/org/robolectric/util/SimpleFuture.java
+++ b/utils/src/main/java/org/robolectric/util/SimpleFuture.java
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit;
  * A Future represents the result of an asynchronous computation.
  *
  * @param <T> The result type returned by this Future's get method.
- * @deprecation This class can introduce deadlocks, since its lock is held while invoking run().
+ * @deprecated This class can introduce deadlocks, since its lock is held while invoking run().
  */
 @Deprecated
 public class SimpleFuture<T> {


### PR DESCRIPTION
### Overview
[InvalidBlockTag](https://errorprone.info/bugpattern/InvalidBlockTag) - This tag is invalid.

### Proposed Changes
Fixed the invalid tags in the Javadoc, mainly found two issues:
- Escape the `@` in the Javadoc properly.
- Replaced the `@deprecation` with `@deprecated` for the proper java rendering