### PR TITLE
[warning] JavaLangClash warning fix

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
@@ -1372,7 +1372,7 @@ public class CppAssetManager2 {
     private final CppAssetManager2 asset_manager_;
     private int type_spec_flags_ = 0;
     //  std.array<std.unique_ptr<Package>, kPackageCount> packages_;
-    private Package[] packages_ = new Package[kPackageCount];
+    private ThemePackage[] packages_ = new ThemePackage[kPackageCount];
 
     public Theme(CppAssetManager2 cppAssetManager2) {
       asset_manager_ = cppAssetManager2;
@@ -1398,7 +1398,7 @@ public class CppAssetManager2 {
     //  static final int kTypeCount = std.numeric_limits<byte>.max() + 1;
     static final int kTypeCount = 256;
 
-    private static class Package {
+    private static class ThemePackage {
       // Each element of Type will be a dynamically sized object
       // allocated to have the entries stored contiguously with the Type.
       // std::array<util::unique_cptr<ThemeType>, kTypeCount> types;
@@ -1425,7 +1425,7 @@ public class CppAssetManager2 {
 
       int last_type_idx = -1;
       int last_package_idx = -1;
-      Package last_package = null;
+      ThemePackage last_package = null;
       ThemeType last_type = null;
 
       // Iterate backwards, because each bag is sorted in ascending key ID order, meaning we will only
@@ -1454,9 +1454,9 @@ public class CppAssetManager2 {
         int entry_idx = get_entry_id(attr_resid);
 
         if (last_package_idx != package_idx) {
-          Package package_ = packages_[package_idx];
+          ThemePackage package_ = packages_[package_idx];
           if (package_ == null) {
-            package_ = packages_[package_idx] = new Package();
+            package_ = packages_[package_idx] = new ThemePackage();
           }
           last_package_idx = package_idx;
           last_package = package_;
@@ -1527,7 +1527,7 @@ public class CppAssetManager2 {
 
       do {
         int package_idx = get_package_id(resid);
-        Package package_ = packages_[package_idx];
+        ThemePackage package_ = packages_[package_idx];
         if (package_ != null) {
           // The themes are constructed with a 1-based type ID, so no need to decrement here.
           int type_idx = get_type_id(resid);
@@ -1618,16 +1618,16 @@ public class CppAssetManager2 {
       // for (int p = 0; p < packages_.size(); p++) {
       //   final Package package_ = o.packages_[p].get();
       for (int p = 0; p < packages_.length; p++) {
-        Package package_ = o.packages_[p];
+        ThemePackage package_ = o.packages_[p];
         if (package_ == null || (copy_only_system && p != 0x01)) {
           // The other theme doesn't have this package, clear ours.
-          packages_[p] = new Package();
+          packages_[p] = new ThemePackage();
           continue;
         }
 
         if (packages_[p] == null) {
           // The other theme has this package, but we don't. Make one.
-          packages_[p] = new Package();
+          packages_[p] = new ThemePackage();
         }
 
         // for (int t = 0; t < package_.types.size(); t++) {

--- a/resources/src/main/java/org/robolectric/res/android/ResTable.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResTable.java
@@ -532,7 +532,7 @@ public class ResTable {
 
     ResTable_type bestType = null;
     int bestOffset = ResTable_type.NO_ENTRY;
-    Package bestPackage = null;
+    ResTablePackage bestPackage = null;
     int specFlags = 0;
     byte actualTypeIndex = (byte) typeIndex;
     ResTable_config bestConfig = null;
@@ -780,7 +780,7 @@ public class ResTable {
     }
 
     PackageGroup group = null;
-    Package _package = new Package(this, header, pkg);
+    ResTablePackage _package = new ResTablePackage(this, header, pkg);
     if (_package == NULL) {
     return (mError=NO_MEMORY);
   }
@@ -1241,7 +1241,7 @@ public class ResTable {
         }
         continue;
       }
-      for (Package pkg : group.packages) {
+      for (ResTablePackage pkg : group.packages) {
         String targetType = type;
 
         do {
@@ -2568,7 +2568,7 @@ public class ResTable {
     // This is mainly used to keep track of the loaded packages
     // and to clean them up properly. Accessing resources happens from
     // the 'types' array.
-    List<Package> packages = new ArrayList<>();
+    List<ResTablePackage> packages = new ArrayList<>();
 
     public final Map<Integer, List<Type>> types = new HashMap<>();
 
@@ -2636,7 +2636,7 @@ public class ResTable {
     ResTable_entry entry;
     ResTable_type type;
     int specFlags;
-    Package _package_;
+    ResTablePackage _package_;
 
     StringPoolRef typeStr;
     StringPoolRef keyStr;
@@ -2646,17 +2646,17 @@ public class ResTable {
   public static class Type {
 
     final Header header;
-    final Package _package_;
+    final ResTablePackage _package_;
     public final int entryCount;
     public ResTable_typeSpec typeSpec;
     public int[] typeSpecFlags;
     public IdmapEntries idmapEntries = new IdmapEntries();
     public List<ResTable_type> configs;
 
-    public Type(final Header _header, final Package _package, int count)
-  //        : header(_header), package(_package), entryCount(count),
-  //  typeSpec(NULL), typeSpecFlags(NULL) { }
-    {
+    public Type(final Header _header, final ResTablePackage _package, int count)
+          //        : header(_header), package(_package), entryCount(count),
+          //  typeSpec(NULL), typeSpecFlags(NULL) { }
+        {
       this.header = _header;
       _package_ = _package;
       this.entryCount = count;
@@ -2666,17 +2666,17 @@ public class ResTable {
     }
   }
 
-//  struct ResTable::Package
-  public static class Package {
-//    Package(ResTable* _owner, final Header* _header, final ResTable_package* _package)
-//        : owner(_owner), header(_header), package(_package), typeIdOffset(0) {
-//    if (dtohs(package.header.headerSize) == sizeof(package)) {
-//      // The package structure is the same size as the definition.
-//      // This means it contains the typeIdOffset field.
-//      typeIdOffset = package.typeIdOffset;
-//    }
+  //  struct ResTable::Package
+  public static class ResTablePackage {
+    //    Package(ResTable* _owner, final Header* _header, final ResTable_package* _package)
+    //        : owner(_owner), header(_header), package(_package), typeIdOffset(0) {
+    //    if (dtohs(package.header.headerSize) == sizeof(package)) {
+    //      // The package structure is the same size as the definition.
+    //      // This means it contains the typeIdOffset field.
+    //      typeIdOffset = package.typeIdOffset;
+    //    }
 
-    public Package(ResTable owner, Header header, ResTable_package _package) {
+    public ResTablePackage(ResTable owner, Header header, ResTable_package _package) {
       this.owner = owner;
       this.header = header;
       this._package_ = _package;


### PR DESCRIPTION
### Overview
[JavaLangClash](https://errorprone.info/bugpattern/JavaLangClash) - Never reuse class names from java.lang

### Proposed Changes
Changed the names of the class which is similar to `java.lang` classes