### PR TITLE
[warning] JavaUtilDate warning fix

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
@@ -243,6 +243,7 @@ public class ShadowAlarmManagerTest {
   }
 
   @Test
+  @SuppressWarnings("JavaUtilDate")
   public void shouldSupportGetNextScheduledAlarm() {
     assertThat(shadowAlarmManager.getNextScheduledAlarm()).isNull();
 
@@ -257,6 +258,7 @@ public class ShadowAlarmManagerTest {
   }
 
   @Test
+  @SuppressWarnings("JavaUtilDate")
   public void getNextScheduledAlarm_shouldReturnRepeatingAlarms() {
     assertThat(shadowAlarmManager.getNextScheduledAlarm()).isNull();
 
@@ -271,6 +273,7 @@ public class ShadowAlarmManagerTest {
   }
 
   @Test
+  @SuppressWarnings("JavaUtilDate")
   public void peekNextScheduledAlarm_shouldReturnNextAlarm() {
     assertThat(shadowAlarmManager.getNextScheduledAlarm()).isNull();
 

--- a/utils/src/main/java/org/robolectric/util/Strftime.java
+++ b/utils/src/main/java/org/robolectric/util/Strftime.java
@@ -19,6 +19,7 @@ public class Strftime {
    * @param zone The timezone to use for formatting.
    * @return The formatted datetime.
    */
+  @SuppressWarnings("JavaUtilDate")
   public static String format(String format, final Date date, Locale locale, TimeZone zone) {
     StringBuilder buffer = new StringBuilder();
 


### PR DESCRIPTION
### Overview
[JavaUtilDate](https://errorprone.info/bugpattern/JavaUtilDate) - Date has a bad API that leads to bugs; prefer java.time.Instant or LocalDate.

### Proposed Changes
Replaced the `java.util.Date` with `java.time.Instant`
