### PR TITLE
[warning] RethrowReflectiveOperationExceptionAsLinkageError warning fix

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothDeviceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothDeviceTest.java
@@ -297,7 +297,7 @@ public class ShadowBluetoothDeviceTest {
       Method getAliasName = android.bluetooth.BluetoothDevice.class.getMethod("getAlias");
       assertThat((String) getAliasName.invoke(device)).isEqualTo(aliasName);
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError("Failure accessing getAlias via reflection", e);
+      throw new LinkageError("Failure accessing getAlias via reflection", e);
     }
   }
 
@@ -313,7 +313,7 @@ public class ShadowBluetoothDeviceTest {
       Method getAliasName = android.bluetooth.BluetoothDevice.class.getMethod("getAliasName");
       assertThat((String) getAliasName.invoke(device)).isEqualTo(aliasName);
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError("Failure accessing getAliasName via reflection", e);
+      throw new LinkageError("Failure accessing getAliasName via reflection", e);
     }
   }
 
@@ -481,7 +481,7 @@ public class ShadowBluetoothDeviceTest {
       // Expect the name if alias is null.
       assertThat((String) getAliasName.invoke(device)).isEqualTo(deviceName);
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError("Failure accessing getAliasName via reflection", e);
+      throw new LinkageError("Failure accessing getAliasName via reflection", e);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
@@ -1479,7 +1479,7 @@ public class ShadowMediaPlayerTest {
       idField.setAccessible(true);
       idField.setInt(handle, /* id= */ 1);
     } catch (ReflectiveOperationException e) {
-      throw new AssertionError(e);
+      throw new LinkageError(e.getMessage(), e);
     }
     return info;
   }

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/InvokeDynamicSupport.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/InvokeDynamicSupport.java
@@ -20,6 +20,7 @@ import java.lang.invoke.SwitchPoint;
 import java.lang.invoke.WrongMethodTypeException;
 import org.robolectric.util.ReflectionHelpers;
 
+@SuppressWarnings("RethrowReflectiveOperationExceptionAsLinkageError")
 public class InvokeDynamicSupport {
   @SuppressWarnings("unused")
   private static Interceptors INTERCEPTORS;

--- a/utils/reflector/src/main/java/org/robolectric/util/reflector/UnsafeAccess.java
+++ b/utils/reflector/src/main/java/org/robolectric/util/reflector/UnsafeAccess.java
@@ -24,6 +24,7 @@ public class UnsafeAccess {
     return DANGER.defineClass(iClass, reflectorClassName, bytecode);
   }
 
+  @SuppressWarnings("RethrowReflectiveOperationExceptionAsLinkageError")
   private static class DangerPre11 implements Danger {
     private final Unsafe unsafe;
     private final Method defineClassMethod;
@@ -48,7 +49,7 @@ public class UnsafeAccess {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "RethrowReflectiveOperationExceptionAsLinkageError"})
     public <T> Class<?> defineClass(Class<T> iClass, String reflectorClassName, byte[] bytecode) {
       // use reflection to call since this method does not exist on JDK11
       try {


### PR DESCRIPTION
### Overview
[RethrowReflectiveOperationExceptionAsLinkageError](https://errorprone.info/bugpattern/RethrowReflectiveOperationExceptionAsLinkageError) - Prefer LinkageError for rethrowing ReflectiveOperationException as unchecked.

### Proposed Changes
Replaced the generic assertion with LinkageError when class is not found using the exception.