### PR TITLE
[warning] VariableNameSameAsType warning fix

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager.java
@@ -1766,20 +1766,20 @@ public class CppAssetManager {
   public List<AssetPath> getAssetPaths() {
     synchronized (mLock) {
       ArrayList<AssetPath> assetPaths = new ArrayList<>(mAssetPaths.size());
-      for (asset_path asset_path : mAssetPaths) {
+      for (asset_path assetPath : mAssetPaths) {
         Path path;
-        switch (asset_path.type) {
+        switch (assetPath.type) {
           case kFileTypeDirectory:
-            path = Fs.fromUrl(asset_path.path.string());
+            path = Fs.fromUrl(assetPath.path.string());
             break;
           case kFileTypeRegular:
-            path = Fs.fromUrl(asset_path.path.string());
+            path = Fs.fromUrl(assetPath.path.string());
             break;
           default:
-            throw new IllegalStateException("Unsupported type " + asset_path.type + " for + "
-                + asset_path.path.string());
+            throw new IllegalStateException(
+                "Unsupported type " + assetPath.type + " for + " + assetPath.path.string());
         }
-        assetPaths.add(new AssetPath(path, asset_path.isSystemAsset));
+        assetPaths.add(new AssetPath(path, assetPath.isSystemAsset));
       }
       return assetPaths;
     }

--- a/resources/src/main/java/org/robolectric/res/android/ResTableTheme.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResTableTheme.java
@@ -196,8 +196,8 @@ public class ResTableTheme {
     final int end = N;
     int bagIndex = 0;
     while (bagIndex < end) {
-      bag_entry bag_entry = bag.get()[bagIndex];
-      final int attrRes = bag_entry.map.name.ident;
+      bag_entry bagEntry = bag.get()[bagIndex];
+      final int attrRes = bagEntry.map.name.ident;
       final int p = Res_GETPACKAGE(attrRes);
       final int t = Res_GETTYPE(attrRes);
       final int e = Res_GETENTRY(attrRes);
@@ -252,7 +252,7 @@ public class ResTableTheme {
       if (styleDebug) {
         ResourceName outName = new ResourceName();
         mTable.getResourceName(attrRes, true, outName);
-        System.out.println("  " + outName + "(" + attrRes + ")" + " := " + bag_entry.map.value);
+        System.out.println("  " + outName + "(" + attrRes + ")" + " := " + bagEntry.map.value);
       }
 
       if (kDebugTableNoisy) {
@@ -262,9 +262,9 @@ public class ResTableTheme {
       }
       if (force || (curEntry.value.dataType == TYPE_NULL
           && curEntry.value.data != Res_value.DATA_NULL_EMPTY)) {
-        curEntry.stringBlock = bag_entry.stringBlock;
+        curEntry.stringBlock = bagEntry.stringBlock;
         curEntry.typeSpecFlags |= bagTypeSpecFlags.get();
-        curEntry.value = new Res_value(bag_entry.map.value);
+        curEntry.value = new Res_value(bagEntry.map.value);
       }
 
       bagIndex++;


### PR DESCRIPTION
### Overview
[VariableNameSameAsType](https://errorprone.info/bugpattern/VariableNameSameAsType) - variableName and type with the same name would refer to the static field instead of the class.

### Proposed Changes
Changed the variable names where it's the same as the data type. For example `Integer Integer`.
