### PR TITLE
[warning] UnnecessaryLambda warning fix

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
@@ -1603,6 +1603,4 @@ public static class ResTable_ref
       buf.putShort(position, value);
     }
   }
-
-  private static final Runnable NO_OP = () -> {};
 }


### PR DESCRIPTION
### Overview
[UnnecessaryLambda](http://errorprone.info/bugpattern/UnnecessaryLambda) - Returning a lambda from a helper method or saving it in a constant is unnecessary; prefer to implement the functional interface method directly and use a method reference instead.

### Proposed Changes
Removed the redundant lambda.
