### PR TITLE
[warning] StringSplitter warning fix

### DIFF
--- a/junit/src/main/java/org/robolectric/internal/SandboxTestRunner.java
+++ b/junit/src/main/java/org/robolectric/internal/SandboxTestRunner.java
@@ -3,6 +3,7 @@ package org.robolectric.internal;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 
+import com.google.common.base.Splitter;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -174,7 +175,7 @@ public class SandboxTestRunner extends BlockJUnit4ClassRunner {
             .doNotAcquirePackage("org.junit");
 
     String customPackages = System.getProperty("org.robolectric.packagesToNotAcquire", "");
-    for (String pkg : customPackages.split(",")) {
+    for (String pkg : Splitter.on(',').split(customPackages)) {
       if (!pkg.isEmpty()) {
         builder.doNotAcquirePackage(pkg);
       }


### PR DESCRIPTION
### Overview
[StringSplitter](https://errorprone.info/bugpattern/StringSplitter) - String.split(String) has surprising behavior.

### Proposed Changes
Replaced `input.split("x")` with `Splitter.on('x').split(input)`.
