### PR TITLE
[warning] ThreadLocalUsage warning fix

### DIFF
--- a/utils/src/main/java/org/robolectric/util/SoftThreadLocal.java
+++ b/utils/src/main/java/org/robolectric/util/SoftThreadLocal.java
@@ -9,11 +9,8 @@ import java.lang.ref.SoftReference;
  */
 public abstract class SoftThreadLocal<T> {
 
-  private final ThreadLocal<SoftReference<T>> threadLocal = new ThreadLocal<SoftReference<T>>() {
-    @Override protected SoftReference<T> initialValue() {
-      return new SoftReference<>(create());
-    }
-  };
+  private final ThreadLocal<SoftReference<T>> threadLocal =
+      ThreadLocal.withInitial(() -> new SoftReference<>(create()));
 
   synchronized public T get() {
     T item = threadLocal.get().get();


### PR DESCRIPTION
### Overview
[ThreadLocalUsage](https://errorprone.info/bugpattern/ThreadLocalUsage) - ThreadLocals should be stored in static fields.

### Proposed Changes
Instead of creating a new `ThreadLocal` with `new ThreadLocal()`  replaced it with `ThreadLocal.withInitial()` which is a static method so, if it's reinitialized again it will use the same thread.
