### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build_native_runtime.yml
+++ b/.github/workflows/build_native_runtime.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master, google ]
 
+permissions:
+  contents: read
+
 jobs:
   build_native_runtime:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/check_aggregateDocs.yml
+++ b/.github/workflows/check_aggregateDocs.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master, google ]
 
+permissions:
+  contents: read
+
 jobs:
   check_aggregateDocs:
     runs-on: ubuntu-18.04

--- a/.github/workflows/check_code_formatting.yml
+++ b/.github/workflows/check_code_formatting.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master, google ]
 
+permissions:
+  contents: read
+
 jobs:
   check_code_formatting:
     runs-on: ubuntu-18.04

--- a/.github/workflows/gradle_wrapper_validation.yml
+++ b/.github/workflows/gradle_wrapper_validation.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master, google ]
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     name: Validation


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
