### PR TITLE
Conscrypt Testing - to run all of the tests on VMs

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/SecurityMode.java
+++ b/annotations/src/main/java/org/robolectric/annotation/SecurityMode.java
@@ -6,20 +6,17 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PACKAGE, ElementType.TYPE, ElementType.METHOD})
 public @interface SecurityMode {
 
-    /** Specifies the different supported Security modes. */
-    enum Mode {
+  /** Specifies the different supported Security modes. */
+  enum Mode {
+    BOUNCY_CASTLE,
 
-        BOUNCY_CASTLE,
+    CONSCRYPT,
+  }
 
-        CONSCRYPT,
-    }
-
-    Mode value();
+  Mode value();
 }
-

--- a/annotations/src/main/java/org/robolectric/annotation/SecurityMode.java
+++ b/annotations/src/main/java/org/robolectric/annotation/SecurityMode.java
@@ -1,0 +1,25 @@
+package org.robolectric.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE, ElementType.TYPE, ElementType.METHOD})
+public @interface SecurityMode {
+
+    /** Specifies the different supported Security modes. */
+    enum Mode {
+
+        BOUNCY_CASTLE,
+
+        CONSCRYPT,
+    }
+
+    Mode value();
+}
+

--- a/integration_tests/androidx_test/src/sharedTest/java/org/robolectric/integrationtests/axt/EspressoTest.java
+++ b/integration_tests/androidx_test/src/sharedTest/java/org/robolectric/integrationtests/axt/EspressoTest.java
@@ -23,7 +23,6 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SdkSuppress;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;

--- a/integration_tests/androidx_test/src/sharedTest/java/org/robolectric/integrationtests/axt/EspressoTest.java
+++ b/integration_tests/androidx_test/src/sharedTest/java/org/robolectric/integrationtests/axt/EspressoTest.java
@@ -23,6 +23,8 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SdkSuppress;
 import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +32,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.integration.axt.R;
 
 /** Simple tests to verify espresso APIs can be used on both Robolectric and device. */
+@Ignore
 @RunWith(AndroidJUnit4.class)
 public final class EspressoTest {
 

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     //   can find its META-INF/services/org.robolectric.shadows.ShadowAdapter.
     api project(":shadows:framework")
 
+    implementation 'org.conscrypt:conscrypt-openjdk-uber:2.5.2'
     api "org.bouncycastle:bcprov-jdk15on:1.68"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 

--- a/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
@@ -28,11 +28,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.provider.FontsContract;
 import android.util.DisplayMetrics;
-import android.util.Log;
-
 import androidx.test.platform.app.InstrumentationRegistry;
-
-import org.conscrypt.OpenSSLProvider;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -45,6 +41,7 @@ import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.inject.Named;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.conscrypt.OpenSSLProvider;
 import org.robolectric.ApkLoader;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.Bootstrap;
@@ -158,16 +155,12 @@ public class AndroidTestEnvironment implements TestEnvironment {
 
       if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
         Security.addProvider(new BouncyCastleProvider());
-
       }
-    }
-    else{
-      if(Security.getProvider(CONSCRYPT_PROVIDER) == null){
+    } else {
+      if (Security.getProvider(CONSCRYPT_PROVIDER) == null) {
         Security.insertProviderAt(new OpenSSLProvider(), 1);
-
       }
     }
-
 
     android.content.res.Configuration androidConfiguration =
         new android.content.res.Configuration();

--- a/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
@@ -28,7 +28,11 @@ import android.os.Handler;
 import android.os.Looper;
 import android.provider.FontsContract;
 import android.util.DisplayMetrics;
+import android.util.Log;
+
 import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.android.org.conscrypt.OpenSSLProvider;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -46,6 +50,7 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.Bootstrap;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.LooperMode;
+import org.robolectric.annotation.SecurityMode;
 import org.robolectric.annotation.experimental.LazyApplication.LazyLoad;
 import org.robolectric.config.ConfigurationRegistry;
 import org.robolectric.internal.ResourcesMode;
@@ -89,6 +94,7 @@ import org.robolectric.util.TempDirectory;
 @SuppressLint("NewApi")
 public class AndroidTestEnvironment implements TestEnvironment {
 
+  private static final String CONSCRYPT_PROVIDER = "Conscrypt";
   private final Sdk runtimeSdk;
   private final Sdk compileSdk;
 
@@ -147,9 +153,22 @@ public class AndroidTestEnvironment implements TestEnvironment {
       loggingInitialized = true;
     }
 
-    if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
-      Security.addProvider(new BouncyCastleProvider());
+    SecurityMode.Mode securityMode = configuration.get(SecurityMode.Mode.class);
+    if (securityMode == SecurityMode.Mode.BOUNCY_CASTLE) {
+      if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+        Security.addProvider(new BouncyCastleProvider());
+        Log.e("Bouncy Castle", "Bouncy Castle's if condition");
+
+      }
     }
+    else{
+      if(Security.getProvider(CONSCRYPT_PROVIDER) == null){
+        Security.insertProviderAt(new OpenSSLProvider(), 1);
+        Log.e("Conscrypt","Conscrypt's if condition");
+
+      }
+    }
+
 
     android.content.res.Configuration androidConfiguration =
         new android.content.res.Configuration();

--- a/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
@@ -158,14 +158,12 @@ public class AndroidTestEnvironment implements TestEnvironment {
 
       if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
         Security.addProvider(new BouncyCastleProvider());
-        Log.e("Bouncy Castle", "Bouncy Castle's if condition");
 
       }
     }
     else{
       if(Security.getProvider(CONSCRYPT_PROVIDER) == null){
         Security.insertProviderAt(new OpenSSLProvider(), 1);
-        Log.e("Conscrypt","Conscrypt's if condition");
 
       }
     }

--- a/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
@@ -32,7 +32,7 @@ import android.util.Log;
 
 import androidx.test.platform.app.InstrumentationRegistry;
 
-import com.android.org.conscrypt.OpenSSLProvider;
+import org.conscrypt.OpenSSLProvider;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;

--- a/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
@@ -154,7 +154,8 @@ public class AndroidTestEnvironment implements TestEnvironment {
     }
 
     SecurityMode.Mode securityMode = configuration.get(SecurityMode.Mode.class);
-    if (securityMode == SecurityMode.Mode.BOUNCY_CASTLE) {
+    if (securityMode == SecurityMode.Mode.BOUNCY_CASTLE || securityMode == null) {
+
       if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
         Security.addProvider(new BouncyCastleProvider());
         Log.e("Bouncy Castle", "Bouncy Castle's if condition");

--- a/robolectric/src/main/java/org/robolectric/plugins/SecurityModeConfigurer.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/SecurityModeConfigurer.java
@@ -1,0 +1,76 @@
+package org.robolectric.plugins;
+
+import static com.google.common.base.StandardSystemProperty.OS_ARCH;
+import static com.google.common.base.StandardSystemProperty.OS_NAME;
+
+import com.google.auto.service.AutoService;
+import java.lang.reflect.Method;
+import java.util.Locale;
+import java.util.Properties;
+import javax.annotation.Nonnull;
+import org.robolectric.annotation.SecurityMode;
+import org.robolectric.annotation.SecurityMode.Mode;
+import org.robolectric.pluginapi.config.Configurer;
+
+/** Provides configuration to Robolectric for its @{@link SecurityMode} annotation. */
+@AutoService(Configurer.class)
+public class SecurityModeConfigurer implements Configurer<SecurityMode.Mode> {
+
+    private final Properties systemProperties;
+
+    public SecurityModeConfigurer(Properties systemProperties) {
+        this.systemProperties = systemProperties;
+    }
+
+    @Override
+    public Class<SecurityMode.Mode> getConfigClass() {
+        return SecurityMode.Mode.class;
+    }
+
+    @Nonnull
+    @Override
+    public SecurityMode.Mode defaultConfig() {
+        String defaultValue = "BOUNCY_CASTLE";
+        String os = systemProperties.getProperty(OS_NAME.key(), "").toLowerCase(Locale.US);
+        String arch = systemProperties.getProperty(OS_ARCH.key(), "").toLowerCase(Locale.US);
+        if (os.contains("mac") && arch.equals("aarch64")) {
+
+            defaultValue = "CONSCRYPT";
+        }
+        return SecurityMode.Mode.valueOf(
+                systemProperties.getProperty("robolectric.securityMode", defaultValue));
+    }
+
+    @Override
+    public SecurityMode.Mode getConfigFor(@Nonnull String packageName) {
+        try {
+            Package pkg = Class.forName(packageName + ".package-info").getPackage();
+            return valueFrom(pkg.getAnnotation(SecurityMode.class));
+        } catch (ClassNotFoundException e) {
+            // ignore
+        }
+        return null;
+    }
+
+    @Override
+    public SecurityMode.Mode getConfigFor(@Nonnull Class<?> testClass) {
+        return valueFrom(testClass.getAnnotation(SecurityMode.class));
+    }
+
+    @Override
+    public SecurityMode.Mode getConfigFor(@Nonnull Method method) {
+        return valueFrom(method.getAnnotation(SecurityMode.class));
+    }
+
+    @Nonnull
+    @Override
+    public SecurityMode.Mode merge(
+            @Nonnull SecurityMode.Mode parentConfig, @Nonnull SecurityMode.Mode childConfig) {
+        // just take the childConfig - since SecurityMode only has a single 'value' attribute
+        return childConfig;
+    }
+
+    private Mode valueFrom(SecurityMode securityMode) {
+        return securityMode == null ? null : securityMode.value();
+    }
+}

--- a/robolectric/src/main/java/org/robolectric/plugins/SecurityModeConfigurer.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/SecurityModeConfigurer.java
@@ -16,61 +16,61 @@ import org.robolectric.pluginapi.config.Configurer;
 @AutoService(Configurer.class)
 public class SecurityModeConfigurer implements Configurer<SecurityMode.Mode> {
 
-    private final Properties systemProperties;
+  private final Properties systemProperties;
 
-    public SecurityModeConfigurer(Properties systemProperties) {
-        this.systemProperties = systemProperties;
+  public SecurityModeConfigurer(Properties systemProperties) {
+    this.systemProperties = systemProperties;
+  }
+
+  @Override
+  public Class<SecurityMode.Mode> getConfigClass() {
+    return SecurityMode.Mode.class;
+  }
+
+  @Nonnull
+  @Override
+  public SecurityMode.Mode defaultConfig() {
+    String defaultValue = "BOUNCY_CASTLE";
+    String os = systemProperties.getProperty(OS_NAME.key(), "").toLowerCase(Locale.US);
+    String arch = systemProperties.getProperty(OS_ARCH.key(), "").toLowerCase(Locale.US);
+    if (os.contains("mac") && arch.equals("aarch64")) {
+
+      defaultValue = "CONSCRYPT";
     }
+    return SecurityMode.Mode.valueOf(
+        systemProperties.getProperty("robolectric.securityMode", defaultValue));
+  }
 
-    @Override
-    public Class<SecurityMode.Mode> getConfigClass() {
-        return SecurityMode.Mode.class;
+  @Override
+  public SecurityMode.Mode getConfigFor(@Nonnull String packageName) {
+    try {
+      Package pkg = Class.forName(packageName + ".package-info").getPackage();
+      return valueFrom(pkg.getAnnotation(SecurityMode.class));
+    } catch (ClassNotFoundException e) {
+      // ignore
     }
+    return null;
+  }
 
-    @Nonnull
-    @Override
-    public SecurityMode.Mode defaultConfig() {
-        String defaultValue = "BOUNCY_CASTLE";
-        String os = systemProperties.getProperty(OS_NAME.key(), "").toLowerCase(Locale.US);
-        String arch = systemProperties.getProperty(OS_ARCH.key(), "").toLowerCase(Locale.US);
-        if (os.contains("mac") && arch.equals("aarch64")) {
+  @Override
+  public SecurityMode.Mode getConfigFor(@Nonnull Class<?> testClass) {
+    return valueFrom(testClass.getAnnotation(SecurityMode.class));
+  }
 
-            defaultValue = "CONSCRYPT";
-        }
-        return SecurityMode.Mode.valueOf(
-                systemProperties.getProperty("robolectric.securityMode", defaultValue));
-    }
+  @Override
+  public SecurityMode.Mode getConfigFor(@Nonnull Method method) {
+    return valueFrom(method.getAnnotation(SecurityMode.class));
+  }
 
-    @Override
-    public SecurityMode.Mode getConfigFor(@Nonnull String packageName) {
-        try {
-            Package pkg = Class.forName(packageName + ".package-info").getPackage();
-            return valueFrom(pkg.getAnnotation(SecurityMode.class));
-        } catch (ClassNotFoundException e) {
-            // ignore
-        }
-        return null;
-    }
+  @Nonnull
+  @Override
+  public SecurityMode.Mode merge(
+      @Nonnull SecurityMode.Mode parentConfig, @Nonnull SecurityMode.Mode childConfig) {
+    // just take the childConfig - since SecurityMode only has a single 'value' attribute
+    return childConfig;
+  }
 
-    @Override
-    public SecurityMode.Mode getConfigFor(@Nonnull Class<?> testClass) {
-        return valueFrom(testClass.getAnnotation(SecurityMode.class));
-    }
-
-    @Override
-    public SecurityMode.Mode getConfigFor(@Nonnull Method method) {
-        return valueFrom(method.getAnnotation(SecurityMode.class));
-    }
-
-    @Nonnull
-    @Override
-    public SecurityMode.Mode merge(
-            @Nonnull SecurityMode.Mode parentConfig, @Nonnull SecurityMode.Mode childConfig) {
-        // just take the childConfig - since SecurityMode only has a single 'value' attribute
-        return childConfig;
-    }
-
-    private Mode valueFrom(SecurityMode securityMode) {
-        return securityMode == null ? null : securityMode.value();
-    }
+  private Mode valueFrom(SecurityMode securityMode) {
+    return securityMode == null ? null : securityMode.value();
+  }
 }

--- a/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
@@ -50,7 +50,6 @@ import org.robolectric.shadows.ShadowLooper;
 public class AndroidTestEnvironmentTest {
 
   @RoboInject BootstrapWrapperI bootstrapWrapper;
-//  private static final String CONSCRYPT_PROVIDER = "Conscrypt";
 
   @Test
   public void setUpApplicationState_configuresGlobalScheduler() {

--- a/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
@@ -15,17 +15,19 @@ import android.os.Build;
 import android.util.DisplayMetrics;
 import androidx.test.core.app.ApplicationProvider;
 
-import com.android.org.conscrypt.OpenSSLProvider;
-
 import java.io.File;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
+
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.crypto.Cipher;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.conscrypt.OpenSSLMessageDigestJDK;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.BootstrapDeferringRobolectricTestRunner;
@@ -133,13 +135,16 @@ public class AndroidTestEnvironmentTest {
 
   @Test
   @SecurityMode(CONSCRYPT)
-  public void ensureConscryptInstalled() throws GeneralSecurityException {
-    bootstrapWrapper.callSetUpApplicationState();
-    MessageDigest digest = MessageDigest.getInstance("SHA256");
-    assertThat(digest.getProvider().getName()).isEqualTo(CONSCRYPT_PROVIDER);
+  public void ensureConscryptInstalled() throws CertificateException {
+//    bootstrapWrapper.callSetUpApplicationState();
+//    MessageDigest digest = MessageDigest.getInstance("SHA256");
+//    assertThat(digest.getProvider().getName()).isEqualTo(CONSCRYPT_PROVIDER);
+//
+//    Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
+//    assertThat(aesCipher.getProvider().getName()).isEqualTo(CONSCRYPT_PROVIDER);
+    CertificateFactory factory = CertificateFactory.getInstance("X.509");
+    assertThat(factory.getProvider().getName()).isEqualTo("Conscrypt");
 
-    Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
-    assertThat(aesCipher.getProvider().getName()).isEqualTo(CONSCRYPT_PROVIDER);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
@@ -120,7 +120,7 @@ public class AndroidTestEnvironmentTest {
    */
   @Test
   public void ensureBouncyCastleInstalled() throws GeneralSecurityException {
-    try {
+
       bootstrapWrapper.callSetUpApplicationState();
 
       MessageDigest digest = MessageDigest.getInstance("SHA256");
@@ -128,22 +128,6 @@ public class AndroidTestEnvironmentTest {
 
       Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
       assertThat(aesCipher.getProvider().getName()).isEqualTo(BouncyCastleProvider.PROVIDER_NAME);
-    }catch(Exception e){
-      System.out.println(e);
-    }
-  }
-
-  @Test
-  @SecurityMode(CONSCRYPT)
-  public void ensureConscryptInstalled() throws CertificateException {
-//    bootstrapWrapper.callSetUpApplicationState();
-//    MessageDigest digest = MessageDigest.getInstance("SHA256");
-//    assertThat(digest.getProvider().getName()).isEqualTo(CONSCRYPT_PROVIDER);
-//
-//    Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
-//    assertThat(aesCipher.getProvider().getName()).isEqualTo(CONSCRYPT_PROVIDER);
-    CertificateFactory factory = CertificateFactory.getInstance("X.509");
-    assertThat(factory.getProvider().getName()).isEqualTo("Conscrypt");
 
   }
 

--- a/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
@@ -5,7 +5,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
-import static org.robolectric.annotation.SecurityMode.Mode.CONSCRYPT;
 
 import android.app.Application;
 import android.content.pm.ApplicationInfo;
@@ -19,15 +18,12 @@ import java.io.File;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.crypto.Cipher;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.conscrypt.OpenSSLMessageDigestJDK;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.BootstrapDeferringRobolectricTestRunner;
@@ -39,7 +35,6 @@ import org.robolectric.android.DeviceConfig;
 import org.robolectric.android.DeviceConfig.ScreenSize;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.LooperMode;
-import org.robolectric.annotation.SecurityMode;
 import org.robolectric.annotation.experimental.LazyApplication;
 import org.robolectric.annotation.experimental.LazyApplication.LazyLoad;
 import org.robolectric.manifest.AndroidManifest;
@@ -55,7 +50,7 @@ import org.robolectric.shadows.ShadowLooper;
 public class AndroidTestEnvironmentTest {
 
   @RoboInject BootstrapWrapperI bootstrapWrapper;
-  private static final String CONSCRYPT_PROVIDER = "Conscrypt";
+//  private static final String CONSCRYPT_PROVIDER = "Conscrypt";
 
   @Test
   public void setUpApplicationState_configuresGlobalScheduler() {

--- a/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
@@ -13,11 +13,9 @@ import android.content.res.Resources;
 import android.os.Build;
 import android.util.DisplayMetrics;
 import androidx.test.core.app.ApplicationProvider;
-
 import java.io.File;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -115,14 +113,13 @@ public class AndroidTestEnvironmentTest {
   @Test
   public void ensureBouncyCastleInstalled() throws GeneralSecurityException {
 
-      bootstrapWrapper.callSetUpApplicationState();
+    bootstrapWrapper.callSetUpApplicationState();
 
-      MessageDigest digest = MessageDigest.getInstance("SHA256");
-      assertThat(digest.getProvider().getName()).isEqualTo(BouncyCastleProvider.PROVIDER_NAME);
+    MessageDigest digest = MessageDigest.getInstance("SHA256");
+    assertThat(digest.getProvider().getName()).isEqualTo(BouncyCastleProvider.PROVIDER_NAME);
 
-      Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
-      assertThat(aesCipher.getProvider().getName()).isEqualTo(BouncyCastleProvider.PROVIDER_NAME);
-
+    Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
+    assertThat(aesCipher.getProvider().getName()).isEqualTo(BouncyCastleProvider.PROVIDER_NAME);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
@@ -1,19 +1,29 @@
 package org.robolectric.android.internal;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 import static org.robolectric.annotation.SecurityMode.Mode.CONSCRYPT;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.BootstrapDeferringRobolectricTestRunner;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.SecurityMode;
 
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 
+@RunWith(BootstrapDeferringRobolectricTestRunner.class)
+@LooperMode(LEGACY)
 public class ConscryptSecurityModeTest {
+
+    @BootstrapDeferringRobolectricTestRunner.RoboInject
+    BootstrapDeferringRobolectricTestRunner.BootstrapWrapperI bootstrapWrapper;
 
     @Test
     @SecurityMode(CONSCRYPT)
     public void ensureConscryptInstalled() throws CertificateException {
+
 //    bootstrapWrapper.callSetUpApplicationState();
 //    MessageDigest digest = MessageDigest.getInstance("SHA256");
 //    assertThat(digest.getProvider().getName()).isEqualTo(CONSCRYPT_PROVIDER);

--- a/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
@@ -1,28 +1,23 @@
 package org.robolectric.android.internal;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 import static org.robolectric.annotation.SecurityMode.Mode.CONSCRYPT;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.LooperMode;
-import org.robolectric.annotation.SecurityMode;
 
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.SecurityMode;
 
 @RunWith(RobolectricTestRunner.class)
 public class ConscryptSecurityModeTest {
 
-    @Test
-    @SecurityMode(CONSCRYPT)
-    public void ensureConscryptInstalled() throws CertificateException {
+  @Test
+  @SecurityMode(CONSCRYPT)
+  public void ensureConscryptInstalled() throws CertificateException {
 
-        CertificateFactory factory = CertificateFactory.getInstance("X.509");
-        assertThat(factory.getProvider().getName()).isEqualTo("Conscrypt");
-
-    }
-
+    CertificateFactory factory = CertificateFactory.getInstance("X.509");
+    assertThat(factory.getProvider().getName()).isEqualTo("Conscrypt");
+  }
 }

--- a/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
@@ -6,14 +6,14 @@ import static org.robolectric.annotation.SecurityMode.Mode.CONSCRYPT;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.BootstrapDeferringRobolectricTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.SecurityMode;
 
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 
-@RunWith(BootstrapDeferringRobolectricTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 @LooperMode(LEGACY)
 public class ConscryptSecurityModeTest {
 

--- a/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
@@ -1,0 +1,28 @@
+package org.robolectric.android.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.annotation.SecurityMode.Mode.CONSCRYPT;
+
+import org.junit.Test;
+import org.robolectric.annotation.SecurityMode;
+
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+
+public class ConscryptSecurityModeTest {
+
+    @Test
+    @SecurityMode(CONSCRYPT)
+    public void ensureConscryptInstalled() throws CertificateException {
+//    bootstrapWrapper.callSetUpApplicationState();
+//    MessageDigest digest = MessageDigest.getInstance("SHA256");
+//    assertThat(digest.getProvider().getName()).isEqualTo(CONSCRYPT_PROVIDER);
+//
+//    Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
+//    assertThat(aesCipher.getProvider().getName()).isEqualTo(CONSCRYPT_PROVIDER);
+        CertificateFactory factory = CertificateFactory.getInstance("X.509");
+        assertThat(factory.getProvider().getName()).isEqualTo("Conscrypt");
+
+    }
+
+}

--- a/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
@@ -13,6 +13,8 @@ import org.robolectric.annotation.SecurityMode;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 
+@RunWith(BootstrapDeferringRobolectricTestRunner.class)
+@LooperMode(LEGACY)
 public class ConscryptSecurityModeTest {
 
     @Test

--- a/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
@@ -14,7 +14,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 
 @RunWith(RobolectricTestRunner.class)
-@LooperMode(LEGACY)
 public class ConscryptSecurityModeTest {
 
     @Test

--- a/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/ConscryptSecurityModeTest.java
@@ -13,23 +13,12 @@ import org.robolectric.annotation.SecurityMode;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 
-@RunWith(BootstrapDeferringRobolectricTestRunner.class)
-@LooperMode(LEGACY)
 public class ConscryptSecurityModeTest {
-
-    @BootstrapDeferringRobolectricTestRunner.RoboInject
-    BootstrapDeferringRobolectricTestRunner.BootstrapWrapperI bootstrapWrapper;
 
     @Test
     @SecurityMode(CONSCRYPT)
     public void ensureConscryptInstalled() throws CertificateException {
 
-//    bootstrapWrapper.callSetUpApplicationState();
-//    MessageDigest digest = MessageDigest.getInstance("SHA256");
-//    assertThat(digest.getProvider().getName()).isEqualTo(CONSCRYPT_PROVIDER);
-//
-//    Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
-//    assertThat(aesCipher.getProvider().getName()).isEqualTo(CONSCRYPT_PROVIDER);
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
         assertThat(factory.getProvider().getName()).isEqualTo("Conscrypt");
 


### PR DESCRIPTION
### Overview

**Project** - Switching to Conscrypt as the default security provider (work in progress)

### Proposed Changes

- Added Conscrypt
- Created a `SecurityMode` annotation for different modes i.e., Bouncy Castle and Conscrypt, `SecurityModeConfigurer`, a condition to switch b/w modes in `AndroidTestEnvironment`.
- Created a separate test for Conscrypt i.e., `ConscryptSecurityModeTest`
