### PR TITLE
Add shadow functions to support autocancel, localonly and alertonce in nofication 

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTestBase.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTestBase.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
+import static android.os.Build.VERSION_CODES.KITKAT_WATCH;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.N;
 import static com.google.common.truth.Truth.assertThat;
@@ -246,5 +247,43 @@ public abstract class ShadowNotificationBuilderTestBase {
         .build();
 
     assertThat(shadowOf(notification).getBigPicture().sameAs(bigPicture)).isTrue();
+  }
+
+  @Test
+  public void build_whenAutoCancelNotSet_leaveAutoCancelAsFalse() {
+    Notification notification = builder.build();
+    assertThat(shadowOf(notification).isAutoCancel()).isFalse();
+  }
+
+  @Test
+  public void build_whenAutoCancelSet_setAutoCancelAsTrue() {
+    Notification notification = builder.setAutoCancel(true).build();
+    assertThat(shadowOf(notification).isAutoCancel()).isTrue();
+  }
+
+  @Test
+  @Config(minSdk = KITKAT_WATCH)
+  public void build_whenLocalOnlyNotSet_leaveLocalOnlyAsFalse() {
+    Notification notification = builder.build();
+    assertThat(shadowOf(notification).isLocalOnly()).isFalse();
+  }
+
+  @Test
+  @Config(minSdk = KITKAT_WATCH)
+  public void build_whenLocalOnlySet_setLocalOnlyAsTrue() {
+    Notification notification = builder.setLocalOnly(true).build();
+    assertThat(shadowOf(notification).isLocalOnly()).isTrue();
+  }
+
+  @Test
+  public void build_whenOnlyAlertOnceNotSet_leaveOnlyAlertOnceAsFalse() {
+    Notification notification = builder.build();
+    assertThat(shadowOf(notification).isOnlyAlertOnce()).isFalse();
+  }
+
+  @Test
+  public void build_whenOnlyAlertOnceSet_setOnlyAlertOnceAsTrue() {
+    Notification notification = builder.setOnlyAlertOnce(true).build();
+    assertThat(shadowOf(notification).isOnlyAlertOnce()).isTrue();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
@@ -14,6 +14,7 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import androidx.annotation.RequiresApi;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import org.robolectric.RuntimeEnvironment;
@@ -147,5 +148,20 @@ public class ShadowNotification {
           "no id." + resourceName + " found in view:\n" + buf.toString());
     }
     return subView;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.KITKAT_WATCH)
+  public boolean isAutoCancel() {
+    return (realNotification.flags & Notification.FLAG_AUTO_CANCEL)
+        == Notification.FLAG_AUTO_CANCEL;
+  }
+
+  public boolean isLocalOnly() {
+    return (realNotification.flags & Notification.FLAG_LOCAL_ONLY) == Notification.FLAG_LOCAL_ONLY;
+  }
+
+  public boolean isOnlyAlertOnce() {
+    return (realNotification.flags & Notification.FLAG_ONLY_ALERT_ONCE)
+        == Notification.FLAG_ONLY_ALERT_ONCE;
   }
 }


### PR DESCRIPTION
### Overview

- Add function `isAutoCancel` , `isLocalOnly`  and `isOnlyAlertOnce` in `ShadowNotification` class

I added these functions because in my project i cannot find the way to test `autoCancel` state like other `isOnGoing` so I added those functions. Appreciate any comment or advices if you have. 🙇 