### PR TITLE
Make ValueCallbacks in RoboCookieManager nullable

### DIFF
--- a/shadows/framework/src/main/java/android/webkit/RoboCookieManager.java
+++ b/shadows/framework/src/main/java/android/webkit/RoboCookieManager.java
@@ -34,9 +34,11 @@ public class RoboCookieManager extends CookieManager {
   }
 
   @Override
-  public void setCookie(String url, String value, ValueCallback<Boolean> valueCallback) {
+  public void setCookie(String url, String value, @Nullable ValueCallback<Boolean> valueCallback) {
     setCookie(url, value);
-    valueCallback.onReceiveValue(true);
+    if (valueCallback != null) {
+      valueCallback.onReceiveValue(true);
+    }
   }
 
   @Override
@@ -48,7 +50,7 @@ public class RoboCookieManager extends CookieManager {
   }
 
   @Override
-  public void removeAllCookies(ValueCallback<Boolean> valueCallback) {
+  public void removeAllCookies(@Nullable ValueCallback<Boolean> valueCallback) {
     store.clear();
     if (valueCallback != null) {
       valueCallback.onReceiveValue(Boolean.TRUE);
@@ -59,12 +61,14 @@ public class RoboCookieManager extends CookieManager {
   public void flush() {}
 
   @Override
-  public void removeSessionCookies(ValueCallback<Boolean> valueCallback) {
+  public void removeSessionCookies(@Nullable ValueCallback<Boolean> valueCallback) {
     boolean value;
     synchronized (store) {
       value = clearAndAddPersistentCookies();
     }
-    valueCallback.onReceiveValue(value);
+    if (valueCallback != null) {
+      valueCallback.onReceiveValue(value);
+    }
   }
 
   @Override


### PR DESCRIPTION
### Overview
`CookieManager`'s doc states that its methods that receive `ValueCallbacks`s should be able to receive null callbacks:
> You can pass null as the callback if you don't need to know when the operation completes or whether any cookie were removed, and in this case it is safe to call the method from a thread without a Looper.

https://developer.android.com/reference/android/webkit/CookieManager

### Proposed Changes
- Add missing `@Nullable` annotations
- Check if callbacks are null before calling them

Fixes https://github.com/robolectric/robolectric/issues/7472