### PR TITLE
Use SHA-512 instead of SHA-1 in MavenArtifactFetcher

### DIFF
--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenJarArtifact.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenJarArtifact.java
@@ -9,9 +9,9 @@ public class MavenJarArtifact {
   private final String artifactId;
   private final String version;
   private final String jarPath;
-  private final String jarSha1Path;
+  private final String jarSha512Path;
   private final String pomPath;
-  private final String pomSha1Path;
+  private final String pomSha512Path;
 
   public MavenJarArtifact(DependencyJar dependencyJar) {
     this.groupId = dependencyJar.getGroupId();
@@ -21,25 +21,25 @@ public class MavenJarArtifact {
         String.format("%s/%s/%s", this.groupId.replace(".", "/"), this.artifactId, this.version);
     String baseName = String.format("%s-%s", this.artifactId, this.version);
     this.jarPath = String.format("%s/%s.jar", basePath, baseName);
-    this.jarSha1Path = String.format("%s/%s.jar.sha1", basePath, baseName);
+    this.jarSha512Path = String.format("%s/%s.jar.sha512", basePath, baseName);
     this.pomPath = String.format("%s/%s.pom", basePath, baseName);
-    this.pomSha1Path = String.format("%s/%s.pom.sha1", basePath, baseName);
+    this.pomSha512Path = String.format("%s/%s.pom.sha512", basePath, baseName);
   }
 
   public String jarPath() {
     return jarPath;
   }
 
-  public String jarSha1Path() {
-    return jarSha1Path;
+  public String jarSha512Path() {
+    return jarSha512Path;
   }
 
   public String pomPath() {
     return pomPath;
   }
 
-  public String pomSha1Path() {
-    return pomSha1Path;
+  public String pomSha512Path() {
+    return pomSha512Path;
   }
 
   @Override

--- a/plugins/maven-dependency-resolver/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
+++ b/plugins/maven-dependency-resolver/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
@@ -27,7 +27,7 @@ public class MavenDependencyResolverTest {
   private static final String REPOSITORY_URL;
   private static final String REPOSITORY_USERNAME = "username";
   private static final String REPOSITORY_PASSWORD = "password";
-  private static final HashFunction SHA1 = Hashing.sha1();
+  private static final HashFunction SHA512 = Hashing.sha512();
 
   private static DependencyJar[] successCases =
       new DependencyJar[] {
@@ -120,16 +120,16 @@ public class MavenDependencyResolverTest {
   private void checkJarArtifact(MavenJarArtifact artifact) throws Exception {
     File jar = new File(localRepositoryDir, artifact.jarPath());
     File pom = new File(localRepositoryDir, artifact.pomPath());
-    File jarSha1 = new File(localRepositoryDir, artifact.jarSha1Path());
-    File pomSha1 = new File(localRepositoryDir, artifact.pomSha1Path());
+    File jarSha512 = new File(localRepositoryDir, artifact.jarSha512Path());
+    File pomSha512 = new File(localRepositoryDir, artifact.pomSha512Path());
     assertThat(jar.exists()).isTrue();
     assertThat(readFile(jar)).isEqualTo(artifact.toString() + " jar contents");
     assertThat(pom.exists()).isTrue();
     assertThat(readFile(pom)).isEqualTo(artifact.toString() + " pom contents");
-    assertThat(jarSha1.exists()).isTrue();
-    assertThat(readFile(jarSha1)).isEqualTo(sha1(artifact.toString() + " jar contents"));
+    assertThat(jarSha512.exists()).isTrue();
+    assertThat(readFile(jarSha512)).isEqualTo(sha512(artifact.toString() + " jar contents"));
     assertThat(pom.exists()).isTrue();
-    assertThat(readFile(pomSha1)).isEqualTo(sha1(artifact.toString() + " pom contents"));
+    assertThat(readFile(pomSha512)).isEqualTo(sha512(artifact.toString() + " pom contents"));
   }
 
   @Test
@@ -153,9 +153,9 @@ public class MavenDependencyResolverTest {
   }
 
   @Test
-  public void getLocalArtifactUrl_handlesInvalidSha1() throws Exception {
-    DependencyJar dependencyJar = new DependencyJar("group", "artifact-invalid-sha1", "1");
-    addTestArtifactInvalidSha1(dependencyJar);
+  public void getLocalArtifactUrl_handlesInvalidSha512() throws Exception {
+    DependencyJar dependencyJar = new DependencyJar("group", "artifact-invalid-sha512", "1");
+    addTestArtifactInvalidSha512(dependencyJar);
     assertThrows(
         AssertionError.class, () -> mavenDependencyResolver.getLocalArtifactUrl(dependencyJar));
   }
@@ -236,37 +236,39 @@ public class MavenDependencyResolverTest {
       String jarContents = mavenJarArtifact.toString() + " jar contents";
       Files.write(jarContents.getBytes(), new File(REPOSITORY_DIR, mavenJarArtifact.jarPath()));
       Files.write(
-          sha1(jarContents).getBytes(), new File(REPOSITORY_DIR, mavenJarArtifact.jarSha1Path()));
+          sha512(jarContents).getBytes(),
+          new File(REPOSITORY_DIR, mavenJarArtifact.jarSha512Path()));
       String pomContents = mavenJarArtifact.toString() + " pom contents";
       Files.write(pomContents.getBytes(), new File(REPOSITORY_DIR, mavenJarArtifact.pomPath()));
       Files.write(
-          sha1(pomContents).getBytes(), new File(REPOSITORY_DIR, mavenJarArtifact.pomSha1Path()));
+          sha512(pomContents).getBytes(),
+          new File(REPOSITORY_DIR, mavenJarArtifact.pomSha512Path()));
     } catch (MalformedURLException e) {
       throw new AssertionError(e);
     }
   }
 
-  static void addTestArtifactInvalidSha1(DependencyJar dependencyJar) throws IOException {
+  static void addTestArtifactInvalidSha512(DependencyJar dependencyJar) throws IOException {
     MavenJarArtifact mavenJarArtifact = new MavenJarArtifact(dependencyJar);
     try {
       Files.createParentDirs(new File(REPOSITORY_DIR, mavenJarArtifact.jarPath()));
       String jarContents = mavenJarArtifact.toString() + " jar contents";
       Files.write(jarContents.getBytes(), new File(REPOSITORY_DIR, mavenJarArtifact.jarPath()));
       Files.write(
-          sha1("No the same content").getBytes(),
-          new File(REPOSITORY_DIR, mavenJarArtifact.jarSha1Path()));
+          sha512("No the same content").getBytes(),
+          new File(REPOSITORY_DIR, mavenJarArtifact.jarSha512Path()));
       String pomContents = mavenJarArtifact.toString() + " pom contents";
       Files.write(pomContents.getBytes(), new File(REPOSITORY_DIR, mavenJarArtifact.pomPath()));
       Files.write(
-          sha1("Really not the same content").getBytes(),
-          new File(REPOSITORY_DIR, mavenJarArtifact.pomSha1Path()));
+          sha512("Really not the same content").getBytes(),
+          new File(REPOSITORY_DIR, mavenJarArtifact.pomSha512Path()));
     } catch (MalformedURLException e) {
       throw new AssertionError(e);
     }
   }
 
-  static String sha1(String contents) {
-    return SHA1.hashString(contents, StandardCharsets.UTF_8).toString();
+  static String sha512(String contents) {
+    return SHA512.hashString(contents, StandardCharsets.UTF_8).toString();
   }
 
   static String readFile(File file) throws IOException {


### PR DESCRIPTION
Use SHA-512 instead of SHA-1 in MavenArtifactFetcher

Fixes #7543
