### PR TITLE
Exclude kotlin-stdlib dependency from utils generated .pom

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,6 +30,7 @@ guavaJREVersion=31.1-jre
 asmVersion=9.2
 
 kotlinVersion=1.5.20
+kotlin.stdlib.default.dependency=false
 
 autoServiceVersion=1.0-rc6
 multidexVersion=2.0.1

--- a/integration_tests/mockito-kotlin/build.gradle
+++ b/integration_tests/mockito-kotlin/build.gradle
@@ -20,5 +20,6 @@ dependencies {
     testImplementation "androidx.test.ext:junit:$axtJunitVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "com.google.truth:truth:$truthVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }

--- a/integration_tests/sparsearray/build.gradle
+++ b/integration_tests/sparsearray/build.gradle
@@ -43,4 +43,5 @@ dependencies {
     testImplementation project(":robolectric")
     testImplementation "junit:junit:$junitVersion"
     testImplementation "com.google.truth:truth:$truthVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -30,5 +30,6 @@ dependencies {
 
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
 }


### PR DESCRIPTION
We can test it with local maven.