### PR TITLE
Remove use-sdk from androidx_test/sharedTest/AndroidManifest.xml

### DIFF
--- a/integration_tests/androidx_test/src/sharedTest/AndroidManifest.xml
+++ b/integration_tests/androidx_test/src/sharedTest/AndroidManifest.xml
@@ -3,10 +3,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.robolectric.integrationtests.axt">
 
-  <uses-sdk
-      android:minSdkVersion="14"
-      android:targetSdkVersion="27"/>
-
   <application>
     <activity
         android:name="org.robolectric.integrationtests.axt.ActivityTestRuleTest$TranscriptActivity"


### PR DESCRIPTION
It will be overrided by Gradle configuration. And this CL removes it and remove building warnings.