### PR TITLE
Reuse bytecode of ClassWriter for ProxyMaker

### DIFF
--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ProxyMaker.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ProxyMaker.java
@@ -170,7 +170,7 @@ public class ProxyMaker {
     }
 
     try {
-      final Class<?> proxyClass = defineHiddenClass(targetClass, writer.toByteArray());
+      final Class<?> proxyClass = defineHiddenClass(targetClass, bytecode);
       final Field field = proxyClass.getDeclaredField(TARGET_FIELD);
       return new Factory() {
         @Override public <E> E createProxy(Class<E> targetClass, E target) {


### PR DESCRIPTION
The origin cherry-pick commit doesn't have DEBUG function for `ClassWriter`, so it uses `ClassWriter.toByteArray` directly for `defineHiddenClass`. But master in GitHub converts `ClassWriter` to bytecode for DEBUG purpose, and we can reuse it.