### PR TITLE
Adding proxy settings to fetching artifacts

### DIFF
--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/MavenRoboSettings.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/MavenRoboSettings.java
@@ -7,11 +7,13 @@ package org.robolectric;
  */
 @Deprecated
 public class MavenRoboSettings {
-
+  private static final int DEFAULT_PROXY_PORT = 0;
   private static String mavenRepositoryId;
   private static String mavenRepositoryUrl;
   private static String mavenRepositoryUserName;
   private static String mavenRepositoryPassword;
+  private static String mavenProxyHost = "";
+  private static int mavenProxyPort = DEFAULT_PROXY_PORT;
 
   static {
     mavenRepositoryId = System.getProperty("robolectric.dependency.repo.id", "mavenCentral");
@@ -19,6 +21,20 @@ public class MavenRoboSettings {
         System.getProperty("robolectric.dependency.repo.url", "https://repo1.maven.org/maven2");
     mavenRepositoryUserName = System.getProperty("robolectric.dependency.repo.username");
     mavenRepositoryPassword = System.getProperty("robolectric.dependency.repo.password");
+
+    String proxyHost = System.getProperty("robolectric.dependency.proxy.host");
+    if (proxyHost != null && !proxyHost.isEmpty()) {
+      mavenProxyHost = proxyHost;
+    }
+
+    String proxyPort = System.getProperty("robolectric.dependency.proxy.port");
+    if (proxyPort != null && !proxyPort.isEmpty()) {
+      try {
+        mavenProxyPort = Integer.parseInt(proxyPort);
+      } catch (NumberFormatException numberFormatException) {
+        mavenProxyPort = DEFAULT_PROXY_PORT;
+      }
+    }
   }
 
   public static String getMavenRepositoryId() {
@@ -51,5 +67,21 @@ public class MavenRoboSettings {
 
   public static void setMavenRepositoryPassword(String mavenRepositoryPassword) {
     MavenRoboSettings.mavenRepositoryPassword = mavenRepositoryPassword;
+  }
+
+  public static String getMavenProxyHost() {
+    return mavenProxyHost;
+  }
+
+  public static void setMavenProxyHost(String mavenProxyHost) {
+    MavenRoboSettings.mavenProxyHost = mavenProxyHost;
+  }
+
+  public static int getMavenProxyPort() {
+    return mavenProxyPort;
+  }
+
+  public static void setMavenProxyPort(int mavenProxyPort) {
+    MavenRoboSettings.mavenProxyPort = mavenProxyPort;
   }
 }

--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
@@ -44,11 +44,22 @@ public class MavenDependencyResolver implements DependencyResolver {
   private final File localRepositoryDir;
 
   public MavenDependencyResolver() {
-    this(MavenRoboSettings.getMavenRepositoryUrl(), MavenRoboSettings.getMavenRepositoryId(), MavenRoboSettings
-        .getMavenRepositoryUserName(), MavenRoboSettings.getMavenRepositoryPassword());
+    this(
+        MavenRoboSettings.getMavenRepositoryUrl(),
+        MavenRoboSettings.getMavenRepositoryId(),
+        MavenRoboSettings.getMavenRepositoryUserName(),
+        MavenRoboSettings.getMavenRepositoryPassword(),
+        MavenRoboSettings.getMavenProxyHost(),
+        MavenRoboSettings.getMavenProxyPort());
   }
 
-  public MavenDependencyResolver(String repositoryUrl, String repositoryId, String repositoryUserName, String repositoryPassword) {
+  public MavenDependencyResolver(
+      String repositoryUrl,
+      String repositoryId,
+      String repositoryUserName,
+      String repositoryPassword,
+      String proxyHost,
+      int proxyPort) {
     this.executorService = createExecutorService();
     this.localRepositoryDir = getLocalRepositoryDir();
     this.mavenArtifactFetcher =
@@ -56,6 +67,8 @@ public class MavenDependencyResolver implements DependencyResolver {
             repositoryUrl,
             repositoryUserName,
             repositoryPassword,
+            proxyHost,
+            proxyPort,
             localRepositoryDir,
             this.executorService);
   }
@@ -163,10 +176,18 @@ public class MavenDependencyResolver implements DependencyResolver {
       String repositoryUrl,
       String repositoryUserName,
       String repositoryPassword,
+      String proxyHost,
+      int proxyPort,
       File localRepositoryDir,
       ExecutorService executorService) {
     return new MavenArtifactFetcher(
-        repositoryUrl, repositoryUserName, repositoryPassword, localRepositoryDir, executorService);
+        repositoryUrl,
+        repositoryUserName,
+        repositoryPassword,
+        proxyHost,
+        proxyPort,
+        localRepositoryDir,
+        executorService);
   }
 
   protected ExecutorService createExecutorService() {

--- a/plugins/maven-dependency-resolver/src/test/java/org/robolectric/MavenRoboSettingsTest.java
+++ b/plugins/maven-dependency-resolver/src/test/java/org/robolectric/MavenRoboSettingsTest.java
@@ -15,6 +15,8 @@ public class MavenRoboSettingsTest {
   private String originalMavenRepositoryUrl;
   private String originalMavenRepositoryUserName;
   private String originalMavenRepositoryPassword;
+  private String originalMavenRepositoryProxyHost;
+  private int originalMavenProxyPort;
 
   @Before
   public void setUp() {
@@ -22,6 +24,8 @@ public class MavenRoboSettingsTest {
     originalMavenRepositoryUrl = MavenRoboSettings.getMavenRepositoryUrl();
     originalMavenRepositoryUserName = MavenRoboSettings.getMavenRepositoryUserName();
     originalMavenRepositoryPassword = MavenRoboSettings.getMavenRepositoryPassword();
+    originalMavenRepositoryProxyHost = MavenRoboSettings.getMavenProxyHost();
+    originalMavenProxyPort = MavenRoboSettings.getMavenProxyPort();
   }
 
   @After
@@ -30,6 +34,8 @@ public class MavenRoboSettingsTest {
     MavenRoboSettings.setMavenRepositoryUrl(originalMavenRepositoryUrl);
     MavenRoboSettings.setMavenRepositoryUserName(originalMavenRepositoryUserName);
     MavenRoboSettings.setMavenRepositoryPassword(originalMavenRepositoryPassword);
+    MavenRoboSettings.setMavenProxyHost(originalMavenRepositoryProxyHost);
+    MavenRoboSettings.setMavenProxyPort(originalMavenProxyPort);
   }
 
   @Test
@@ -64,5 +70,17 @@ public class MavenRoboSettingsTest {
   public void setMavenRepositoryPassword() {
     MavenRoboSettings.setMavenRepositoryPassword("password");
     assertEquals("password", MavenRoboSettings.getMavenRepositoryPassword());
+  }
+
+  @Test
+  public void setMavenProxyHost() {
+    MavenRoboSettings.setMavenProxyHost("123.4.5.678");
+    assertEquals("123.4.5.678", MavenRoboSettings.getMavenProxyHost());
+  }
+
+  @Test
+  public void setMavenProxyPort() {
+    MavenRoboSettings.setMavenProxyPort(9000);
+    assertEquals(9000, MavenRoboSettings.getMavenProxyPort());
   }
 }

--- a/plugins/maven-dependency-resolver/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
+++ b/plugins/maven-dependency-resolver/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.java
@@ -27,6 +27,8 @@ public class MavenDependencyResolverTest {
   private static final String REPOSITORY_URL;
   private static final String REPOSITORY_USERNAME = "username";
   private static final String REPOSITORY_PASSWORD = "password";
+  private static final String PROXY_HOST = "123.4.5.678";
+  private static final int PROXY_PORT = 9000;
   private static final HashFunction SHA512 = Hashing.sha512();
 
   private static DependencyJar[] successCases =
@@ -65,6 +67,8 @@ public class MavenDependencyResolverTest {
             REPOSITORY_URL,
             REPOSITORY_USERNAME,
             REPOSITORY_PASSWORD,
+            PROXY_HOST,
+            PROXY_PORT,
             localRepositoryDir,
             executorService);
     mavenDependencyResolver = new TestMavenDependencyResolver();
@@ -167,6 +171,8 @@ public class MavenDependencyResolverTest {
         String repositoryUrl,
         String repositoryUserName,
         String repositoryPassword,
+        String proxyHost,
+        int proxyPort,
         File localRepositoryDir,
         ExecutorService executorService) {
       return mavenArtifactFetcher;
@@ -200,12 +206,16 @@ public class MavenDependencyResolverTest {
         String repositoryUrl,
         String repositoryUserName,
         String repositoryPassword,
+        String proxyHost,
+        int proxyPort,
         File localRepositoryDir,
         ExecutorService executorService) {
       super(
           repositoryUrl,
           repositoryUserName,
           repositoryPassword,
+          proxyHost,
+          proxyPort,
           localRepositoryDir,
           executorService);
       this.executorService = executorService;
@@ -214,7 +224,7 @@ public class MavenDependencyResolverTest {
     @Override
     protected ListenableFuture<Void> createFetchToFileTask(URL remoteUrl, File tempFile) {
       return Futures.submitAsync(
-          new FetchToFileTask(remoteUrl, tempFile, null, null) {
+          new FetchToFileTask(remoteUrl, tempFile, null, null, null, 0) {
             @Override
             public ListenableFuture<Void> call() throws Exception {
               numRequests += 1;


### PR DESCRIPTION
### Overview

Adding the possibility to add proxy settings for the download of maven artefacts

### Proposed Changes

Adding in the system properties listed [here](https://robolectric.org/configuring/#system-properties)

robolectric.dependency.proxy.host
robolectric.dependency.proxy.port
