### PR TITLE
Switch to ubuntu-20.04 for GitHub Actions

### DIFF
--- a/.github/workflows/build_native_runtime.yml
+++ b/.github/workflows/build_native_runtime.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04, macos-latest, self-hosted, windows-2019 ]
+        os: [ ubuntu-20.04, macos-latest, self-hosted, windows-2019 ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/check_aggregateDocs.yml
+++ b/.github/workflows/check_aggregateDocs.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   check_aggregateDocs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/check_code_formatting.yml
+++ b/.github/workflows/check_code_formatting.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   check_code_formatting:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
           ./gradlew clean assemble testClasses --parallel --stacktrace --no-watch-fs
 
   unit-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: build
     strategy:
       fail-fast: false


### PR DESCRIPTION
ubuntu 18.04 is deprecated, and will be unsupported from 4/1/2023.
