### PR TITLE
Disable animation when running instrumentation tests

### DIFF
--- a/buildSrc/src/main/groovy/org/robolectric/gradle/GradleManagedDevicePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/GradleManagedDevicePlugin.groovy
@@ -8,6 +8,7 @@ class GradleManagedDevicePlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         project.android.testOptions {
+            animationsDisabled = true
             devices {
                 // ./gradlew -Pandroid.sdk.channel=3 nexusOneApi29DebugAndroidTest
                 nexusOneApi29(ManagedVirtualDevice) {


### PR DESCRIPTION
When animation enabled, Espresso tests will become flaky because complicated animation will affect views' focus state. If views are not focused, some view actions like `click` will be affected and it causes flaky tests.

Fix https://github.com/robolectric/robolectric/issues/7588.