### PR TITLE
Switch to use macos-12 for instrumentation-tests on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
           path: '**/build/test-results/**/TEST-*.xml'
 
   instrumentation-tests:
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 60
     needs: build
 


### PR DESCRIPTION
See https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md for details.