### PR TITLE
Use uninterruptibly acquire for ResTable's lock

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/ResTable.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResTable.java
@@ -2695,11 +2695,7 @@ public class ResTable {
   }
 
   public void lock() {
-    try {
-      mLock.acquire();
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
+    mLock.acquireUninterruptibly();
   }
 
   public void unlock() {


### PR DESCRIPTION
In complex CI environment, the thread that parsing resource might be interrupted with unknown reason, and old interruptable acquire method throws InterruptException and causes a RuntimeException in ResTable#lock(). That might cause flaky tests. This CL selects to use un-interruptable acquire method to avoid this occasion.
