### PR TITLE
Migrate shadows/playservices to AndroidX

### DIFF
--- a/shadows/playservices/build.gradle
+++ b/shadows/playservices/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     api project(":annotations")
     api "com.google.guava:guava:$guavaJREVersion"
 
-    compileOnly "com.android.support:support-fragment:28.0.0"
+    compileOnly "androidx.fragment:fragment:1.2.0"
     compileOnly "com.google.android.gms:play-services-base:8.4.0"
     compileOnly "com.google.android.gms:play-services-basement:8.4.0"
 
@@ -30,7 +30,7 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     testImplementation "com.google.truth:truth:$truthVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testRuntimeOnly "com.android.support:support-fragment:28.0.0"
+    testRuntimeOnly "androidx.fragment:fragment:1.2.0"
     testRuntimeOnly "com.google.android.gms:play-services-base:8.4.0"
     testRuntimeOnly "com.google.android.gms:play-services-basement:8.4.0"
 

--- a/shadows/playservices/src/main/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtil.java
+++ b/shadows/playservices/src/main/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtil.java
@@ -7,7 +7,7 @@ import android.content.Context;
 import android.content.DialogInterface.OnCancelListener;
 import android.content.Intent;
 import android.content.res.Resources;
-import android.support.v4.app.Fragment;
+import androidx.fragment.app.Fragment;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 import com.google.common.base.Preconditions;


### PR DESCRIPTION
### Overview

We are trying to remove jetifier from our builds.

I could not make this work:
`compileOnly "androidx.fragment:fragment:$fragmentVersion"`

```
      > No matching variant of androidx.fragment:fragment:1.5.3 was found. The consumer was configured to find an API of a library compatible with Java 8, preferably in the form of class files, preferably optimized for standard JVMs, and its dependencies declared externally, as well as attribute 'artifactType' with value 'jar' but:
          - Variant 'releaseVariantReleaseApiPublication' capability androidx.fragment:fragment:1.5.3 declares an API of a library, and its dependencies declared externally:
              - Incompatible because this component declares a component, with the library elements 'aar' and the consumer needed a component, preferably in the form of class files
              - Other compatible attributes:
                  - Doesn't say anything about artifactType (required 'jar')
                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
          - Variant 'releaseVariantReleaseRuntimePublication' capability androidx.fragment:fragment:1.5.3 declares a runtime of a library, and its dependencies declared externally:
              - Incompatible because this component declares a component, with the library elements 'aar' and the consumer needed a component, preferably in the form of class files
              - Other compatible attributes:
                  - Doesn't say anything about artifactType (required 'jar')
                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
          - Variant 'sourcesElements' capability androidx.fragment:fragment:1.5.3 declares a runtime of a component, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about artifactType (required 'jar')
                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them preferably in the form of class files)
```

It seems that gradle does not respect the AarDepsPlugin `registerTransform` for androidx.fragment:fragment releases after 1.2.0 which have gradle-module-metadata published.

### Proposed Changes

Migrate legacy support import to AndroidX.
