### PR TITLE
fix: Avoid referring to Android S's TelephonyCallback

### DIFF
--- a/integration_tests/compat-target28/src/test/java/org/robolectric/integration/compat/target28/NormalCompatibilityTest.kt
+++ b/integration_tests/compat-target28/src/test/java/org/robolectric/integration/compat/target28/NormalCompatibilityTest.kt
@@ -35,4 +35,10 @@ class NormalCompatibilityTest {
   fun `Initialize Activity succeed`() {
     Robolectric.setupActivity(TestActivity::class.java)
   }
+
+  @Test
+  fun `Initialize TelephonyManager succeed`() {
+    val telephonyManager = application.getSystemService(Context.TELEPHONY_SERVICE)
+    assertThat(telephonyManager).isNotNull()
+  }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
@@ -77,7 +77,8 @@ public class ShadowTelephonyManager {
   @RealObject protected TelephonyManager realTelephonyManager;
 
   private final Map<PhoneStateListener, Integer> phoneStateRegistrations = new HashMap<>();
-  private final List<TelephonyCallback> telephonyCallbackRegistrations = new ArrayList<>();
+  private final /*List<TelephonyCallback>*/ List<Object> telephonyCallbackRegistrations =
+      new ArrayList<>();
   private final Map<Integer, String> slotIndexToDeviceId = new HashMap<>();
   private final Map<Integer, String> slotIndexToImei = new HashMap<>();
   private final Map<Integer, String> slotIndexToMeid = new HashMap<>();
@@ -87,7 +88,7 @@ public class ShadowTelephonyManager {
       new HashMap<>();
 
   private PhoneStateListener lastListener;
-  private TelephonyCallback lastTelephonyCallback;
+  private /*TelephonyCallback*/ Object lastTelephonyCallback;
   private int lastEventFlags;
 
   private String deviceId;
@@ -225,7 +226,10 @@ public class ShadowTelephonyManager {
   }
 
   @Implementation(minSdk = S)
-  public void registerTelephonyCallback(Executor executor, TelephonyCallback callback) {
+  public void registerTelephonyCallback(
+      /*Executor*/ Object executor, /*TelephonyCallback*/ Object callback) {
+    Preconditions.checkArgument(executor instanceof Executor);
+    Preconditions.checkArgument(callback instanceof TelephonyCallback);
     lastTelephonyCallback = callback;
     initTelephonyCallback(callback);
     telephonyCallbackRegistrations.add(callback);
@@ -233,17 +237,20 @@ public class ShadowTelephonyManager {
 
   @Implementation(minSdk = TIRAMISU)
   protected void registerTelephonyCallback(
-      int includeLocationData, Executor executor, TelephonyCallback callback) {
+      /*int*/ Object includeLocationData, /*Executor*/
+      Object executor, /*TelephonyCallback*/
+      Object callback) {
+    Preconditions.checkArgument(includeLocationData instanceof Integer);
     registerTelephonyCallback(executor, callback);
   }
 
   @Implementation(minSdk = S)
-  public void unregisterTelephonyCallback(TelephonyCallback callback) {
+  public void unregisterTelephonyCallback(/*TelephonyCallback*/ Object callback) {
     telephonyCallbackRegistrations.remove(callback);
   }
 
   /** Returns the most recent callback passed to #registerTelephonyCallback(). */
-  public TelephonyCallback getLastTelephonyCallback() {
+  public /*TelephonyCallback*/ Object getLastTelephonyCallback() {
     return lastTelephonyCallback;
   }
 
@@ -701,7 +708,7 @@ public class ShadowTelephonyManager {
   }
 
   @CallSuper
-  protected void initTelephonyCallback(TelephonyCallback callback) {
+  protected void initTelephonyCallback(Object callback) {
     if (VERSION.SDK_INT < S) {
       return;
     }


### PR DESCRIPTION
### Overview
fix #7665 
add test #7666 

compatibility problem like #5835
Avoid referring to Android S's TelephonyCallback
On some JVMs when running with SDK < 31
```
resources.arsc in APK '/Users/.m2/repository/org/robolectric/android-all-instrumented/11-robolectric-6757853-i4/android-all-instrumented-11-robolectric-6757853-i4.jar' is compressed.
Exception in thread "TrackMainThread" java.lang.NoClassDefFoundError: android/telephony/TelephonyCallback
	at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3166)
	at java.base/java.lang.Class.getDeclaredMethod(Class.java:2473)
	at org.robolectric.internal.bytecode.ShadowWrangler.findShadowMethodDeclaredOnClass(ShadowWrangler.java:385)
	at org.robolectric.internal.bytecode.ShadowWrangler.findShadowMethod(ShadowWrangler.java:354)
	at org.robolectric.internal.bytecode.ShadowWrangler.pickShadowMethod(ShadowWrangler.java:331)
	at org.robolectric.internal.bytecode.ShadowWrangler.classInitializing(ShadowWrangler.java:190)
	at org.robolectric.internal.bytecode.RobolectricInternals.classInitializing(RobolectricInternals.java:21)
	at android.telephony.TelephonyManager.<clinit>(TelephonyManager.java)
	at android.telephony.TelephonyFrameworkInitializer.lambda$registerServiceWrappers$0(TelephonyFrameworkInitializer.java:68)
	at android.app.SystemServiceRegistry$121.createService(SystemServiceRegistry.java:1630)
	at android.app.SystemServiceRegistry$CachedServiceFetcher.getService(SystemServiceRegistry.java:1702)
	at android.app.SystemServiceRegistry.getSystemService(SystemServiceRegistry.java:1382)
	at android.app.ContextImpl.getSystemService(ContextImpl.java:1918)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.robolectric.shadows.ShadowContextImpl$_ContextImpl_$$Reflector4.getSystemService(Unknown Source)
	at org.robolectric.shadows.ShadowContextImpl.getSystemService(ShadowContextImpl.java:88)
	at android.app.ContextImpl.getSystemService(ContextImpl.java)
	at android.content.ContextWrapper.getSystemService(ContextWrapper.java:803)
```

https://github.com/robolectric/robolectric/blob/4091c1ce382ad1a829f485045908d9f367e9e55d/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java#L323 
Class#getDeclaredMethod will causes the class in the return value and parameter to be loaded
```
java -version
openjdk version "11.0.15" 2022-04-19
OpenJDK Runtime Environment GraalVM CE 22.1.0 (build 11.0.15+10-jvmci-22.1-b06)
OpenJDK 64-Bit Server VM GraalVM CE 22.1.0 (build 11.0.15+10-jvmci-22.1-b06, mixed mode)
```
```
// use -XX:+TraceClassLoading
// Main.java
public class Main {
    public static void main(String[] args) throws Exception{
        ShadowTelephonyManager.class.getDeclaredMethod("init");
    }
}
// Param.java
public class Param {
}
// ReturnValue.java
public class ReturnValue {
}

// ShadowTelephonyManager.java
public class ShadowTelephonyManager {

    public ReturnValue method(Param param) { return null;}

    public void init() {}
}
```
```
[0.050s][info   ][class,load] ShadowTelephonyManager source: ...
[0.050s][info   ][class,load] Param source: ...
[0.050s][info   ][class,load] ReturnValue source: ...
```
