### PR TITLE
Enable Implements validation on Gradle again

### DIFF
--- a/buildSrc/src/main/groovy/ShadowsPlugin.groovy
+++ b/buildSrc/src/main/groovy/ShadowsPlugin.groovy
@@ -32,6 +32,7 @@ class ShadowsPlugin implements Plugin<Project> {
             options.compilerArgs.add("-Aorg.robolectric.annotation.processing.jsonDocsDir=${project.buildDir}/docs/json")
             options.compilerArgs.add("-Aorg.robolectric.annotation.processing.shadowPackage=${project.shadows.packageName}")
             options.compilerArgs.add("-Aorg.robolectric.annotation.processing.sdkCheckMode=${project.shadows.sdkCheckMode}")
+            options.compilerArgs.add("-Aorg.robolectric.annotation.processing.sdks=${project.rootProject.buildDir}/sdks.txt")
         }
 
         // include generated sources in javadoc jar


### PR DESCRIPTION
Current building that run with Gradle can't find `sdks.txt`, and `SdkStore` can't load any SDKs. It causes that there are not existing methods of an shadow class will be validated because that sdk matching process failed. This PR adds generated sdks.txt by `processor` module's `generateSdksFile` task to annotation processor to trigger shadow class' implement validation. 