### PR TITLE
Add shadow for LocaleManager#getSystemLocales

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocaleManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocaleManager.java
@@ -1,8 +1,11 @@
 package org.robolectric.shadows;
 
 import android.app.LocaleManager;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.Build.VERSION_CODES;
 import android.os.LocaleList;
+import androidx.annotation.RequiresApi;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -30,6 +33,7 @@ public class ShadowLocaleManager {
    * @see #enforceInstallerCheck
    * @see #setCallerAsInstallerForPackage
    */
+  @RequiresApi(api = VERSION_CODES.N)
   @Implementation
   protected LocaleList getApplicationLocales(String packageName) {
     if (enforceInstallerCheck) {
@@ -49,6 +53,16 @@ public class ShadowLocaleManager {
   @Implementation
   protected void setApplicationLocales(String packageName, LocaleList locales) {
     appLocales.put(packageName, locales);
+  }
+
+  @RequiresApi(api = VERSION_CODES.N)
+  @Implementation
+  protected LocaleList getSystemLocales() {
+    Configuration configuration = Resources.getSystem().getConfiguration();
+    if (configuration != null) {
+      return configuration.getLocales();
+    }
+    return LocaleList.getEmptyLocaleList();
   }
 
   /**


### PR DESCRIPTION
Fixes: https://github.com/robolectric/robolectric/issues/7803.

From https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/app/LocaleManager.java;l=159-166?q=getSystemLocales&ss=android we can know that `LocaleManager#getSystemLocales()` calls `LocaleManagerService.getSystemLocales()` directly. And `LocaleManagerService.getSystemLocales()` calls https://cs.android.com/android/platform/superproject/+/master:frameworks/base/services/core/java/com/android/server/locales/LocaleManagerService.java;l=455-465;drc=b45a2ea782074944f79fc388df20b06e01f265f7;bpv=1;bpt=1 to get `LocaleList` from `ActivityManagerService`'s `Configuration`. System resources got from `Resources.getSystem().getConfiguration()` can be a proper alternation for real implementation. This PR uses `Resources.getSystem().getConfiguration()` to get `LocaleList` to simulate system `LocaleList`.