### PR TITLE
Keep dependency the same as robolectric.org for Windows building

### DIFF
--- a/.github/workflows/build_native_runtime.yml
+++ b/.github/workflows/build_native_runtime.yml
@@ -30,11 +30,10 @@ jobs:
           platform-check-severity: warn
           location: D:\
           install: >-
-            make
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-ninja
+            base-devel
+            mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-make
+            mingw-w64-x86_64-ninja
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3


### PR DESCRIPTION
See https://robolectric.org/building-robolectric/ for details.