### PR TITLE
 Remove lifecycle-common dependency

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -18,7 +18,6 @@ ext {
     appCompatVersion='1.4.1'
     constraintlayoutVersion='2.1.4'
     windowVersion='1.0.0'
-    lifecycleVersion='2.2.0'
     fragmentVersion='1.5.3'
 
     truthVersion='1.1.3'

--- a/integration_tests/androidx/build.gradle
+++ b/integration_tests/androidx/build.gradle
@@ -38,8 +38,6 @@ dependencies {
     testImplementation("androidx.test:rules:$axtRulesVersion")
     testImplementation("androidx.test.espresso:espresso-intents:$espressoVersion")
     testImplementation("androidx.test.ext:truth:$axtTruthVersion")
-    // TODO: this should be a transitive dependency of core...
-    testImplementation("androidx.lifecycle:lifecycle-common:$lifecycleVersion")
     testImplementation("androidx.test.ext:junit:$axtJunitVersion")
     testImplementation("com.google.truth:truth:$truthVersion")
 }

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testImplementation "org.hamcrest:hamcrest-junit:2.0.0.0"
     testImplementation "androidx.test:core:$axtCoreVersion@aar"
-    testImplementation "androidx.lifecycle:lifecycle-common:2.5.1"
     testImplementation "androidx.test.ext:junit:$axtJunitVersion@aar"
     testImplementation "androidx.test.ext:truth:$axtTruthVersion@aar"
     testImplementation "androidx.test:runner:$axtRunnerVersion@aar"


### PR DESCRIPTION
`lifeycle-common` is a transitive dependency of `androidx.test:core`, and we don't need to declare it explicitly.

We can see this relationship with `./gradlew :integration_tests:androidx:dependencies`:

```
+--- androidx.test:core:1.5.0
|    +--- androidx.annotation:annotation:1.2.0 -> 1.3.0
|    +--- androidx.test:monitor:1.6.0 (*)
|    +--- androidx.test.services:storage:1.4.2
|    |    +--- androidx.annotation:annotation:1.2.0 -> 1.3.0
|    |    +--- androidx.test:monitor:1.6.0 (*)
|    |    +--- com.google.code.findbugs:jsr305:2.0.2 -> 3.0.2
|    |    \--- androidx.test:annotation:1.0.1 (*)
|    +--- androidx.lifecycle:lifecycle-common:2.3.1 -> 2.4.0
|    |    \--- androidx.annotation:annotation:1.1.0 -> 1.3.0
|    +--- androidx.tracing:tracing:1.0.0 (*)
|    +--- com.google.guava:listenablefuture:1.0 -> 9999.0-empty-to-avoid-conflict-with-guava
|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 (*)
|    \--- androidx.concurrent:concurrent-futures:1.1.0
|         +--- androidx.annotation:annotation:1.1.0 -> 1.3.0
|         \--- com.google.guava:listenablefuture:1.0 -> 9999.0-empty-to-avoid-conflict-with-guava
```