### PR TITLE
Disable auto-correct for EspressTest's EditText

### DIFF
--- a/integration_tests/androidx_test/src/main/java/org/robolectric/integrationtests/axt/EspressoActivity.java
+++ b/integration_tests/androidx_test/src/main/java/org/robolectric/integrationtests/axt/EspressoActivity.java
@@ -2,6 +2,7 @@ package org.robolectric.integrationtests.axt;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.text.InputType;
 import android.widget.Button;
 import android.widget.EditText;
 import org.robolectric.integration.axt.R;
@@ -20,6 +21,10 @@ public class EspressoActivity extends Activity {
     setContentView(R.layout.espresso_activity);
 
     editText = findViewById(R.id.edit_text);
+    // Disable auto-correct for EditText to avoid typed text is changed
+    // by these features when running tests.
+    editText.setInputType(editText.getInputType() & (~InputType.TYPE_TEXT_FLAG_AUTO_CORRECT));
+
     button = findViewById(R.id.button);
     button.setOnClickListener(view -> buttonClicked = true);
   }


### PR DESCRIPTION
Only removing `TYPE_TEXT_FLAG_AUTO_CORRECT` for `EditText`.

This PR tries to fix the flaky as https://github.com/robolectric/robolectric/issues/7428#issuecomment-1345107137 described.