### PR TITLE
Use \R as regex's linebreak matcher for ExpectedLogMessagesRuleTest

### DIFF
--- a/robolectric/src/test/java/org/robolectric/junit/rules/ExpectedLogMessagesRuleTest.java
+++ b/robolectric/src/test/java/org/robolectric/junit/rules/ExpectedLogMessagesRuleTest.java
@@ -179,7 +179,7 @@ public final class ExpectedLogMessagesRuleTest {
             + "\\s+tag='Mytag'"
             + "\\s+msg='message2'"
             + "\\s+throwable=java.lang.IllegalArgumentException"
-            + "(\\s+at .*\\)\\n)+"
+            + "(\\s+at .*\\)\\R)+"
             + "\\s+}][\\s\\S]*";
     String expectedNotObservedPattern =
         "[\\s\\S]*Expected, but not observed:"


### PR DESCRIPTION
From JDK 8, there is a new line break matcher `\R` that can be used to match linebreak on most common using OSes, for example Linux's `\n` and Windows' `\r\n`. `ExpectedLogMessagesRuleTest` uses `\n` as linebreak matcher and it will fail on Windows platform. This CL uses `\R` to replace `\n` to gain better supporting of `ExpectedLogMessagesRuleTest` on common OSes. With this CL, we can run `ExpectedLogMessagesRuleTest` without failures on Windows now.

See https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#lineending.

Fixes: https://github.com/robolectric/robolectric/issues/6751.