### PR TITLE
Remove unused code for ReflectionHelperTest

### DIFF
--- a/shadowapi/src/test/java/org/robolectric/util/ReflectionHelpersTest.java
+++ b/shadowapi/src/test/java/org/robolectric/util/ReflectionHelpersTest.java
@@ -124,8 +124,6 @@ public class ReflectionHelpersTest {
 
   @Test
   public void setFinalStaticFieldReflectively_withFieldName_setsStaticFields() {
-    int startingValue = ReflectionHelpers.getStaticField(ExampleWithFinalStatic.class, "FIELD");
-
     RuntimeException thrown =
         assertThrows(
             RuntimeException.class,


### PR DESCRIPTION
`startingValue` is not used anymore, because Robolectric doesn't support set final field.