### PR TITLE
Ensure ShadowSpeechRecognizer can work with SDK 28

### DIFF
--- a/integration_tests/compat-target28/src/test/java/org/robolectric/integration/compat/target28/NormalCompatibilityTest.kt
+++ b/integration_tests/compat-target28/src/test/java/org/robolectric/integration/compat/target28/NormalCompatibilityTest.kt
@@ -2,6 +2,7 @@ package org.robolectric.integration.compat.target28
 
 import android.content.Context
 import android.os.Build
+import android.speech.SpeechRecognizer
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,5 +41,10 @@ class NormalCompatibilityTest {
   fun `Initialize TelephonyManager succeed`() {
     val telephonyManager = application.getSystemService(Context.TELEPHONY_SERVICE)
     assertThat(telephonyManager).isNotNull()
+  }
+
+  @Test
+  fun `Create speech recognizer succeed`() {
+    assertThat(SpeechRecognizer.createSpeechRecognizer(application)).isNotNull()
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSpeechRecognizer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSpeechRecognizer.java
@@ -45,7 +45,7 @@ public class ShadowSpeechRecognizer {
 
   /**
    * Returns the latest SpeechRecognizer. This method can only be called after {@link
-   * SpeechRecognizer#createSpeechRecognizer()} is called.
+   * SpeechRecognizer#createSpeechRecognizer(Context)} is called.
    */
   public static SpeechRecognizer getLatestSpeechRecognizer() {
     return latestSpeechRecognizer;


### PR DESCRIPTION
1. Use `looseSignature` and `Object` to replace `RecognitionSupportCallback` and `RecognitionSupport` to avoid `NoClassDefFoundError`.
2. Fix API signature of `SpeechRecognizer#createSpeechRecognizer` in doc.

Fixes: https://github.com/robolectric/robolectric/issues/7832.