### PR TITLE
Skip to initialize new instance if it doesn't have an empty constructor

### DIFF
--- a/robolectric/src/test/java/org/robolectric/CustomConstructorReceiver.java
+++ b/robolectric/src/test/java/org/robolectric/CustomConstructorReceiver.java
@@ -1,0 +1,18 @@
+package org.robolectric;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class CustomConstructorReceiver extends BroadcastReceiver {
+  private final int intValue;
+
+  public CustomConstructorReceiver(int intValue) {
+    // We don't use intValue actually, and we only want to use this class to test the initialization
+    // of BroadcastReceiver with a custom constructor.
+    this.intValue = intValue;
+  }
+
+  @Override
+  public void onReceive(Context context, Intent intent) {}
+}

--- a/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
+++ b/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
@@ -78,7 +78,7 @@ public class AndroidManifestTest {
   @Test
   public void parseManifest_shouldReadBroadcastReceivers() throws Exception {
     AndroidManifest config = newConfig("TestAndroidManifestWithReceivers.xml");
-    assertThat(config.getBroadcastReceivers()).hasSize(8);
+    assertThat(config.getBroadcastReceivers()).hasSize(9);
 
     assertThat(config.getBroadcastReceivers().get(0).getName())
         .isEqualTo("org.robolectric.ConfigTestReceiver.InnerReceiver");
@@ -121,6 +121,11 @@ public class AndroidManifestTest {
         .isEqualTo("org.robolectric.ConfigTestReceiverPermissionsAndActions");
     assertThat(config.getBroadcastReceivers().get(7).getActions())
         .contains("org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE");
+
+    assertThat(config.getBroadcastReceivers().get(8).getName())
+        .isEqualTo("org.robolectric.CustomConstructorReceiver");
+    assertThat(config.getBroadcastReceivers().get(8).getActions())
+        .contains("org.robolectric.ACTION_CUSTOM_CONSTRUCTOR");
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
@@ -46,6 +46,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.ConfigTestReceiver;
+import org.robolectric.CustomConstructorReceiver;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
@@ -92,6 +93,12 @@ public class ShadowContextWrapperTest {
     ShadowLooper.shadowMainLooper().idle();
 
     assertThat(receiver.intentsReceived).hasSize(1);
+  }
+
+  @Test
+  public void registerReceiver_shouldGetReceiverWithCustomConstructor() {
+    BroadcastReceiver receiver = getReceiverOfClass(CustomConstructorReceiver.class);
+    assertThat(receiver).isInstanceOf(CustomConstructorReceiver.class);
   }
 
   @Test

--- a/robolectric/src/test/resources/TestAndroidManifestWithReceivers.xml
+++ b/robolectric/src/test/resources/TestAndroidManifestWithReceivers.xml
@@ -65,5 +65,11 @@
         <action android:name="org.robolectric.ACTION_RECEIVER_PERMISSION_PACKAGE"/>
       </intent-filter>
     </receiver>
+
+    <receiver android:name=".CustomConstructorReceiver">
+      <intent-filter>
+        <action android:name="org.robolectric.ACTION_CUSTOM_CONSTRUCTOR"/>
+      </intent-filter>
+    </receiver>
   </application>
 </manifest>


### PR DESCRIPTION
This PR also adds a `BroadcastReceiver` class without empty constructor to test this behavior.

For https://github.com/robolectric/robolectric/issues/7581.