### PR TITLE
Keep to use Ubuntu 18.04 for nativeruntime

### DIFF
--- a/.github/workflows/build_native_runtime.yml
+++ b/.github/workflows/build_native_runtime.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-latest, self-hosted, windows-2019 ]
+        os: [ ubuntu-18.04, macos-latest, self-hosted, windows-2019 ]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The newer Ubuntu version might introduce newer libm.so dependency that needs newer glibc. But some users' OS version might not meet this requirement especially their OS in Docker. Keep to use Ubuntu 18.04 to reduce the headache to upgrade OS' toolchain as much as possible.

For https://github.com/robolectric/robolectric/issues/7879.
