### PR TITLE
CI: Migrate set-output to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,7 +129,7 @@ jobs:
         id: determine-target
         run: |
           TARGET="google_apis"
-          echo "::set-output name=TARGET::$TARGET"
+          echo "TARGET=$TARGET" >> $GITHUB_OUTPUT
           
       - name: AVD cache
         uses: actions/cache@v3


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.
