### PR TITLE
RoboCookieManager supports override cookie has the same key

### DIFF
--- a/integration_tests/ctesque/src/sharedTest/java/android/webkit/CookieManagerTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/webkit/CookieManagerTest.java
@@ -50,6 +50,16 @@ public class CookieManagerTest {
   }
 
   @Test
+  public void setCookie_overrideCookieHasTheSameKey() {
+    final String httpsUrl = "https://robolectric.org/";
+    final CookieManager cookieManager = CookieManager.getInstance();
+    cookieManager.setCookie(httpsUrl, "A=100;");
+    cookieManager.setCookie(httpsUrl, "A=200;");
+    String cookie = cookieManager.getCookie(httpsUrl);
+    assertThat(cookie).isEqualTo("A=200");
+  }
+
+  @Test
   public void getCookie_doesNotReturnAttributes() {
     final String httpsUrl = "https://robolectric.org/";
     final CookieManager cookieManager = CookieManager.getInstance();

--- a/shadows/framework/src/main/java/android/webkit/RoboCookieManager.java
+++ b/shadows/framework/src/main/java/android/webkit/RoboCookieManager.java
@@ -10,6 +10,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -29,6 +30,20 @@ public class RoboCookieManager extends CookieManager {
   public void setCookie(String url, String value) {
     Cookie cookie = parseCookie(url, value);
     if (cookie != null) {
+      Cookie existingCookie = null;
+      for (Cookie c : store) {
+        if (c == null) {
+          continue;
+        }
+        if (Objects.equals(c.getName(), cookie.getName())
+            && Objects.equals(c.mHostname, cookie.mHostname)) {
+          existingCookie = c;
+          break;
+        }
+      }
+      if (existingCookie != null) {
+        store.remove(existingCookie);
+      }
       store.add(cookie);
     }
   }
@@ -208,7 +223,7 @@ public class RoboCookieManager extends CookieManager {
       String field = fields[i].trim();
       if (field.startsWith(EXPIRATION_FIELD_NAME)) {
         expiration = getExpiration(field);
-      } else if (field.toUpperCase().equals(SECURE_ATTR_NAME)) {
+      } else if (field.equalsIgnoreCase(SECURE_ATTR_NAME)) {
         isSecure = true;
       }
     }


### PR DESCRIPTION
See https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/webkit/CookieManager.java;l=120?q=setCookie%5C(&ss=android.

The current implementation of RoboCookieManager only supports the host name and the key name of
the Cookie. But it doesn't support path of the cookie. So this CL only compares the host name and the key name for the Cookie.

Fixes: https://github.com/robolectric/robolectric/issues/3464.
