### PR TITLE
Include :integration_tests:play_services for Android Studio

### DIFF
--- a/integration_tests/play_services/build.gradle
+++ b/integration_tests/play_services/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
-    testImplementation "junit:junit:${junitVersion}"
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "com.google.truth:truth:$truthVersion"
     testImplementation "com.google.android.gms:play-services-basement:18.0.1"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,5 +35,6 @@ include ':integration_tests:security-providers'
 include ":integration_tests:mockk"
 include ':integration_tests:compat-target28'
 include ":integration_tests:multidex"
+include ":integration_tests:play_services"
 include ":integration_tests:sparsearray"
 include ':testapp'


### PR DESCRIPTION
Android Studio can recognize `play_services` module and we can run `play_services` tests with gradle now.