### PR TITLE
Bump multiple dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:2.0.2'
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.9.1"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.12.0"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     dependencies {
         gradle
         classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:2.0.2'
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:3.0.1'
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:6.12.0"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -31,7 +31,7 @@ ext {
 
     asmVersion='9.4'
 
-    kotlinVersion='1.7.20'
+    kotlinVersion='1.7.22'
     autoServiceVersion='1.0.1'
     multidexVersion='2.0.1'
     sqlite4javaVersion='1.0.392'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/integration_tests/compat-target28/build.gradle
+++ b/integration_tests/compat-target28/build.gradle
@@ -8,7 +8,7 @@ apply plugin: "com.diffplug.spotless"
 spotless {
     kotlin {
         target '**/*.kt'
-        ktfmt('0.34').googleStyle()
+        ktfmt('0.42').googleStyle()
     }
 }
 

--- a/integration_tests/mockito-kotlin/build.gradle
+++ b/integration_tests/mockito-kotlin/build.gradle
@@ -7,7 +7,7 @@ apply plugin: "com.diffplug.spotless"
 spotless {
     kotlin {
         target '**/*.kt'
-        ktfmt('0.34').googleStyle()
+        ktfmt('0.42').googleStyle()
     }
 }
 

--- a/integration_tests/mockk/build.gradle
+++ b/integration_tests/mockk/build.gradle
@@ -7,7 +7,7 @@ apply plugin: "com.diffplug.spotless"
 spotless {
     kotlin {
         target '**/*.kt'
-        ktfmt('0.34').googleStyle()
+        ktfmt('0.42').googleStyle()
     }
 }
 

--- a/integration_tests/sparsearray/build.gradle
+++ b/integration_tests/sparsearray/build.gradle
@@ -8,7 +8,7 @@ apply plugin: "com.diffplug.spotless"
 spotless {
     kotlin {
         target '**/*.kt'
-        ktfmt('0.34').googleStyle()
+        ktfmt('0.42').googleStyle()
     }
 }
 

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -9,7 +9,7 @@ apply plugin: "com.diffplug.spotless"
 spotless {
     kotlin {
         target '**/*.kt'
-        ktfmt('0.34').googleStyle()
+        ktfmt('0.42').googleStyle()
     }
 }
 


### PR DESCRIPTION
1. Bump spotless to 6.12.0.
2. Bump Kotlin to 1.7.22.
3. Bump gradle-errorprone-plugin to 3.0.1.
4. Bump Gradle to 7.6.
5. Bump ktfmt to 0.42.