### PR TITLE
Support ResTable staged alias type

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/Chunk.java
+++ b/resources/src/main/java/org/robolectric/res/android/Chunk.java
@@ -11,6 +11,8 @@ import org.robolectric.res.android.ResourceTypes.ResTable_header;
 import org.robolectric.res.android.ResourceTypes.ResTable_lib_entry;
 import org.robolectric.res.android.ResourceTypes.ResTable_lib_header;
 import org.robolectric.res.android.ResourceTypes.ResTable_package;
+import org.robolectric.res.android.ResourceTypes.ResTable_staged_alias_entry;
+import org.robolectric.res.android.ResourceTypes.ResTable_staged_alias_header;
 import org.robolectric.res.android.ResourceTypes.ResTable_type;
 import org.robolectric.res.android.ResourceTypes.WithOffset;
 
@@ -114,6 +116,23 @@ class Chunk {
   public ResTable_lib_entry asResTable_lib_entry() {
     if (header_size() >= ResTable_lib_entry.SIZEOF) {
       return new ResTable_lib_entry(device_chunk_.myBuf(), device_chunk_.myOffset());
+    } else {
+      return null;
+    }
+  }
+
+  public ResTable_staged_alias_header asResTable_staged_alias_header() {
+    if (header_size() >= ResTable_staged_alias_header.SIZEOF) {
+      return new ResTable_staged_alias_header(device_chunk_.myBuf(), device_chunk_.myOffset());
+    } else {
+      return null;
+    }
+  }
+
+  public ResTable_staged_alias_entry asResTable_staged_alias_entry() {
+    if (data_size() >= ResTable_staged_alias_entry.SIZEOF) {
+      return new ResTable_staged_alias_entry(
+          device_chunk_.myBuf(), device_chunk_.myOffset() + header_size());
     } else {
       return null;
     }

--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
@@ -343,6 +343,17 @@ public class CppAssetManager2 {
       for (PackageGroup iter2 : package_groups_) {
         iter2.dynamic_ref_table.addMapping(package_name,
             iter.dynamic_ref_table.mAssignedPackageId);
+
+        // Add the alias resources to the dynamic reference table of every package group. Since
+        // staging aliases can only be defined by the framework package (which is not a shared
+        // library), the compile-time package id of the framework is the same across all packages
+        // that compile against the framework.
+        for (ConfiguredPackage pkg : iter.packages_) {
+          for (Map.Entry<Integer, Integer> entry :
+              pkg.loaded_package_.GetAliasResourceIdMap().entrySet()) {
+            iter2.dynamic_ref_table.addAlias(entry.getKey(), entry.getValue());
+          }
+        }
       }
     }
   }

--- a/resources/src/main/java/org/robolectric/res/android/DynamicRefTable.java
+++ b/resources/src/main/java/org/robolectric/res/android/DynamicRefTable.java
@@ -92,14 +92,26 @@ public class DynamicRefTable
     return NO_ERROR;
   }
 
+  void addAlias(int stagedId, int finalizedId) {
+    mAliasId.put(stagedId, finalizedId);
+  }
+
 //  // Performs the actual conversion of build-time resource ID to run-time
 //  // resource ID.
   int lookupResourceId(Ref<Integer> resId) {
     int res = resId.get();
     int packageId = Res_GETPACKAGE(res) + 1;
 
-    if (packageId == APP_PACKAGE_ID && !mAppAsLib) {
-      // No lookup needs to be done, app package IDs are absolute.
+    Integer alias_id = mAliasId.get(res);
+    if (alias_id != null) {
+      // Rewrite the resource id to its alias resource id. Since the alias resource id is a
+      // compile-time id, it still needs to be resolved further.
+      res = alias_id;
+    }
+
+    if (packageId == SYS_PACKAGE_ID || (packageId == APP_PACKAGE_ID && !mAppAsLib)) {
+      // No lookup needs to be done, app and framework package IDs are absolute.
+      resId.set(res);
       return NO_ERROR;
     }
 
@@ -179,4 +191,5 @@ public class DynamicRefTable
   final byte[]                         mLookupTable = new byte[256];
   final Map<String, Byte> mEntries = new HashMap<>();
   boolean                            mAppAsLib;
+  final Map<Integer, Integer> mAliasId = new HashMap<>();
 }

--- a/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
@@ -161,6 +161,7 @@ public class ResourceTypes {
   public static final int RES_TABLE_TYPE_TYPE         = 0x0201;
   public static final int RES_TABLE_TYPE_SPEC_TYPE    = 0x0202;
   public static final int RES_TABLE_LIBRARY_TYPE      = 0x0203;
+  public static final int RES_TABLE_STAGED_ALIAS_TYPE = 0x0206;
 
   /**
    * Macros for building/splitting resource identifiers.
@@ -1502,6 +1503,44 @@ public static class ResTable_ref
       }
     }
   };
+
+  /**
+   * A map that allows rewriting staged (non-finalized) resource ids to their finalized
+   * counterparts.
+   */
+  static class ResTable_staged_alias_header extends WithOffset {
+    public static final int SIZEOF = ResChunk_header.SIZEOF + 4;
+
+    ResChunk_header header;
+
+    // The number of ResTable_staged_alias_entry that follow this header.
+    int count;
+
+    ResTable_staged_alias_header(ByteBuffer buf, int offset) {
+      super(buf, offset);
+
+      header = new ResChunk_header(buf, offset);
+      count = buf.getInt(offset + ResChunk_header.SIZEOF);
+    }
+  }
+
+  /** Maps the staged (non-finalized) resource id to its finalized resource id. */
+  static class ResTable_staged_alias_entry extends WithOffset {
+    public static final int SIZEOF = 8;
+
+    // The compile-time staged resource id to rewrite.
+    int stagedResId;
+
+    // The compile-time finalized resource id to which the staged resource id should be rewritten.
+    int finalizedResId;
+
+    ResTable_staged_alias_entry(ByteBuffer buf, int offset) {
+      super(buf, offset);
+
+      stagedResId = buf.getInt(offset);
+      finalizedResId = buf.getInt(offset + 4);
+    }
+  }
 
   // struct alignas(uint32_t) Idmap_header {
   static class Idmap_header extends WithOffset {

--- a/resources/src/test/java/org/robolectric/res/android/LoadedArscTest.java
+++ b/resources/src/test/java/org/robolectric/res/android/LoadedArscTest.java
@@ -1,0 +1,63 @@
+package org.robolectric.res.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.robolectric.res.android.ResourceTypes.RES_TABLE_PACKAGE_TYPE;
+import static org.robolectric.res.android.ResourceTypes.RES_TABLE_STAGED_ALIAS_TYPE;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.robolectric.res.android.ResourceTypes.ResChunk_header;
+
+@RunWith(JUnit4.class)
+public class LoadedArscTest {
+
+  @Test
+  public void testResTableStagedAliasType() {
+    final int stagedResId = 0x123;
+    final int finalizedResId = 0x456;
+
+    final ByteBuffer buf = ByteBuffer.allocate(1024);
+
+    ResChunk_header.write(
+        buf,
+        (short) RES_TABLE_PACKAGE_TYPE,
+        () -> {
+          // header
+          buf.putInt(0x01); // ResTable_package.id
+          // ResTable_package.name
+          for (int i = 0; i < 128; i++) {
+            buf.putChar('\0');
+          }
+          buf.putInt(0); // ResTable_package.typeStrings
+          buf.putInt(0); // ResTable_package.lastPublicType
+          buf.putInt(0); // ResTable_package.keyStrings
+          buf.putInt(0); // ResTable_package.lastPublicKey
+          buf.putInt(0); // ResTable_package.typeIdOffset
+        },
+        () -> {
+          // contents
+          ResChunk_header.write(
+              buf,
+              (short) RES_TABLE_STAGED_ALIAS_TYPE,
+              () -> {
+                // header
+                buf.putInt(1); // ResTable_staged_alias_header.count
+              },
+              () -> {
+                // contents
+                buf.putInt(stagedResId); // ResTable_staged_alias_entry.stagedResId
+                buf.putInt(finalizedResId); // ResTable_staged_alias_entry.finalizedResId
+              });
+        });
+    final Chunk chunk = new Chunk(new ResChunk_header(buf, 0));
+    final LoadedArsc.LoadedPackage loadedPackage =
+        LoadedArsc.LoadedPackage.Load(
+            chunk, null /* loaded_idmap */, true /* system */, false /* load_as_shared_library */);
+
+    final Map<Integer, Integer> aliasIdMap = loadedPackage.GetAliasResourceIdMap();
+    assertEquals(finalizedResId, (int) aliasIdMap.get(stagedResId));
+  }
+}


### PR DESCRIPTION
### Overview

This non-fatal warning is printed when loading resources.asrc from the Android 13 jar: `[WARN] Unknown chunk type '200'` from:
https://github.com/robolectric/robolectric/blob/6899b8cedbe6c89cfd8723983e88d0d52a992ab9/resources/src/main/java/org/robolectric/res/android/LoadedArsc.java#L752-L754

The warning message logic is actually wrong -- it should print `child_chunk.type()` not `chunk.type()` based on the `switch` statement (though this is a bug in the original `LoadedArsc.cpp`). The `child_chunk.type()` value is `0x206` and corresponds to `RES_TABLE_STAGED_ALIAS_TYPE`.

### Proposed Changes

Add support for the new staged alias type, used by aapt2 to map pre-release resource IDs to IDs set in the final release. This is essentially a transliteration of the modifications to `libs/androidfw` in https://cs.android.com/android/_/android/platform/frameworks/base/+/2fedba9a32d9e92344eaf6e9faf5b43e1bc2ae70

Tested by running a test with latest SDK 33:
```
val resources = ApplicationProvider.getApplicationContext<Context>().resources
// pre-release resource ID
println(resources. getResourceEntryName(31391775)) // "knownActivityEmbeddingCerts"
```
Can also dump `mAliasId` map -- there are 58 entries whose keys are pre-release SDK 33 resource IDs.
Also no more warning printed.

Unrelated - I believe there is a bug in the existing `ResTable_lib_entry` logic where the first entry should be constructed with offset after the header size, and the iteration end condition should include `* ResTable_lib_entry.SIZEOF` similarly. I wasn't sure how to test this path.
