### PR TITLE
Remove redundant name from BugPattern for RobolectricShadow

### DIFF
--- a/errorprone/src/main/java/org/robolectric/errorprone/bugpatterns/RobolectricShadow.java
+++ b/errorprone/src/main/java/org/robolectric/errorprone/bugpatterns/RobolectricShadow.java
@@ -44,12 +44,11 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /**
- * Ensure Robolectric shadow's method marked with {@code @Implemenetation} is protected
+ * Ensure Robolectric shadow's method marked with {@code @Implementation} is protected
  *
  * @author christianw@google.com (Christian Williams)
  */
 @BugPattern(
-    name = "RobolectricShadow",
     summary = "Robolectric @Implementation methods should be protected.",
     severity = SUGGESTION,
     documentSuppression = false,


### PR DESCRIPTION
See 
```
> Task :errorprone:compileJava
~/robolectric/errorprone/src/main/java/org/robolectric/errorprone/bugpatterns/RobolectricShadow.java:51: warning: [BugPatternNaming] Setting @BugPattern.name to the class name of the check is redundant @BugPattern(
^
    (see https://errorprone.info/bugpattern/BugPatternNaming)
  Did you mean 'summary = "Robolectric @Implementation methods should be protected.",'?
1 warning
```