### PR TITLE
Bump bcprov-jdk15on from 1.70 to 1.72

### DIFF
--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     api project(":shadows:framework")
 
     implementation 'org.conscrypt:conscrypt-openjdk-uber:2.5.2'
-    api "org.bouncycastle:bcprov-jdk15on:1.70"
+    api "org.bouncycastle:bcprov-jdk18on:1.72"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
     compileOnly AndroidSdk.MAX_SDK.coordinates


### PR DESCRIPTION
Package name change from bcprov-jdk15on to bcprov-jdk18on in 1.71.
