### PR TITLE
Migrate kotlinOptions to compilerOptions

### DIFF
--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -26,9 +26,7 @@ compileKotlin {
     // in production. If utils module starts to add Kotlin code in main source
     // set, we can remove this destinationDirectory modification.
     destinationDirectory = file("${projectDir}/build/classes/java/main")
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
+    compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
 }
 
 afterEvaluate {


### PR DESCRIPTION
`kotlinOptions` has been deprecated, see https://github.com/JetBrains/kotlin/blob/a4ce2ced6d22086da756242ea114183dc702feab/buildSrc/src/main/kotlin/JvmToolchain.kt#L125-L128.