### PR TITLE
Support partial AppComponentFactory in Robolectric

### DIFF
--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -51,6 +51,7 @@ public class AndroidManifest implements UsesSdk {
   private String processName;
   private String themeRef;
   private String labelRef;
+  private String appComponentFactory; // Added from SDK 28
   private Integer minSdkVersion;
   private Integer targetSdkVersion;
   private Integer maxSdkVersion;
@@ -184,6 +185,7 @@ public class AndroidManifest implements UsesSdk {
         rClassName = packageName + ".R";
 
         Node applicationNode = findApplicationNode(manifestDocument);
+        // Parse application node of the AndroidManifest.xml
         if (applicationNode != null) {
           NamedNodeMap attributes = applicationNode.getAttributes();
           int attrCount = attributes.getLength();
@@ -197,6 +199,7 @@ public class AndroidManifest implements UsesSdk {
           processName = applicationAttributes.get("android:process");
           themeRef = applicationAttributes.get("android:theme");
           labelRef = applicationAttributes.get("android:label");
+          appComponentFactory = applicationAttributes.get("android:appComponentFactory");
 
           parseReceivers(applicationNode);
           parseServices(applicationNode);
@@ -596,6 +599,11 @@ public class AndroidManifest implements UsesSdk {
 
   public String getLabelRef() {
     return labelRef;
+  }
+
+  public String getAppComponentFactory() {
+    parseAndroidManifest();
+    return appComponentFactory;
   }
 
   /**

--- a/robolectric/src/test/java/org/robolectric/CustomAppComponentFactory.java
+++ b/robolectric/src/test/java/org/robolectric/CustomAppComponentFactory.java
@@ -1,0 +1,22 @@
+package org.robolectric;
+
+import android.app.AppComponentFactory;
+import android.content.BroadcastReceiver;
+import android.content.Intent;
+import org.robolectric.CustomConstructorReceiverWrapper.CustomConstructorWithEmptyActionReceiver;
+import org.robolectric.CustomConstructorReceiverWrapper.CustomConstructorWithOneActionReceiver;
+
+public final class CustomAppComponentFactory extends AppComponentFactory {
+  @Override
+  public BroadcastReceiver instantiateReceiver(ClassLoader cl, String className, Intent intent)
+      throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+    if (className != null) {
+      if (className.contains(CustomConstructorWithOneActionReceiver.class.getName())) {
+        return new CustomConstructorWithOneActionReceiver(100);
+      } else if (className.contains(CustomConstructorWithEmptyActionReceiver.class.getName())) {
+        return new CustomConstructorWithEmptyActionReceiver(100);
+      }
+    }
+    return super.instantiateReceiver(cl, className, intent);
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/CustomConstructorReceiverWrapper.java
+++ b/robolectric/src/test/java/org/robolectric/CustomConstructorReceiverWrapper.java
@@ -1,0 +1,32 @@
+package org.robolectric;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class CustomConstructorReceiverWrapper {
+  private static class CustomConstructorReceiver extends BroadcastReceiver {
+    private final int intValue;
+
+    public CustomConstructorReceiver(int intValue) {
+      // We don't use intValue actually, and we only want to use this class to test the
+      // initialization of BroadcastReceiver with a custom constructor.
+      this.intValue = intValue;
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {}
+  }
+
+  public static class CustomConstructorWithOneActionReceiver extends CustomConstructorReceiver {
+    public CustomConstructorWithOneActionReceiver(int intValue) {
+      super(intValue);
+    }
+  }
+
+  public static class CustomConstructorWithEmptyActionReceiver extends CustomConstructorReceiver {
+    public CustomConstructorWithEmptyActionReceiver(int intValue) {
+      super(intValue);
+    }
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentCreateApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentCreateApplicationTest.java
@@ -88,7 +88,7 @@ public class AndroidTestEnvironmentCreateApplicationTest {
     Application application = AndroidTestEnvironment.createApplication(appManifest, null,
         new ApplicationInfo());
     shadowOf(application).callAttach(RuntimeEnvironment.systemContext);
-    registerBroadcastReceivers(application, appManifest);
+    registerBroadcastReceivers(application, appManifest, null);
 
     List<ShadowApplication.Wrapper> receivers = shadowOf(application).getRegisteredReceivers();
     assertThat(receivers).hasSize(1);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
@@ -4,6 +4,7 @@ import static android.content.pm.PackageManager.PERMISSION_DENIED;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.M;
+import static android.os.Build.VERSION_CODES.P;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
@@ -46,6 +47,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.ConfigTestReceiver;
+import org.robolectric.CustomConstructorReceiverWrapper.CustomConstructorWithEmptyActionReceiver;
+import org.robolectric.CustomConstructorReceiverWrapper.CustomConstructorWithOneActionReceiver;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
@@ -92,6 +95,20 @@ public class ShadowContextWrapperTest {
     ShadowLooper.shadowMainLooper().idle();
 
     assertThat(receiver.intentsReceived).hasSize(1);
+  }
+
+  @Test
+  @Config(manifest = "TestAndroidManifestWithAppComponentFactory.xml", minSdk = P)
+  public void registerReceiver_shouldGetReceiverWithCustomConstructorEmptyAction() {
+    BroadcastReceiver receiver = getReceiverOfClass(CustomConstructorWithEmptyActionReceiver.class);
+    assertThat(receiver).isInstanceOf(CustomConstructorWithEmptyActionReceiver.class);
+  }
+
+  @Test
+  @Config(manifest = "TestAndroidManifestWithAppComponentFactory.xml", minSdk = P)
+  public void registerReceiver_shouldGetReceiverWithCustomConstructorAndOneAction() {
+    BroadcastReceiver receiver = getReceiverOfClass(CustomConstructorWithOneActionReceiver.class);
+    assertThat(receiver).isInstanceOf(CustomConstructorWithOneActionReceiver.class);
   }
 
   @Test

--- a/robolectric/src/test/resources/TestAndroidManifestWithAppComponentFactory.xml
+++ b/robolectric/src/test/resources/TestAndroidManifestWithAppComponentFactory.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.robolectric">
+  <uses-sdk android:targetSdkVersion="18"/>
+
+  <application
+      android:appComponentFactory="org.robolectric.CustomAppComponentFactory">
+    <receiver
+        android:name=".CustomConstructorReceiverWrapper$CustomConstructorWithOneActionReceiver">
+      <intent-filter>
+        <action android:name="org.robolectric.ACTION_CUSTOM_CONSTRUCTOR"/>
+      </intent-filter>
+    </receiver>
+    <receiver
+      android:name=".CustomConstructorReceiverWrapper$CustomConstructorWithEmptyActionReceiver" />
+  </application>
+</manifest>

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLoadedApk.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLoadedApk.java
@@ -1,26 +1,73 @@
 package org.robolectric.shadows;
 
+import static org.robolectric.shadow.api.Shadow.newInstanceOf;
+import static org.robolectric.util.reflector.Reflector.reflector;
+
 import android.app.Application;
 import android.app.LoadedApk;
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Resources;
 import android.os.Build.VERSION_CODES;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
 import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
 
 @Implements(value = LoadedApk.class, isInAndroidSdk = false)
 public class ShadowLoadedApk {
+  @RealObject private LoadedApk realLoadedApk;
+  private boolean isClassLoaderInitialized = false;
+  private final Object classLoaderLock = new Object();
 
   @Implementation
   public ClassLoader getClassLoader() {
+    // The AppComponentFactory was introduced from SDK 28.
+    if (RuntimeEnvironment.getApiLevel() >= VERSION_CODES.P) {
+      synchronized (classLoaderLock) {
+        if (!isClassLoaderInitialized) {
+          isClassLoaderInitialized = true;
+          tryInitAppComponentFactory(realLoadedApk);
+        }
+      }
+    }
     return this.getClass().getClassLoader();
   }
 
   @Implementation(minSdk = VERSION_CODES.O)
   public ClassLoader getSplitClassLoader(String splitName) throws NameNotFoundException {
     return this.getClass().getClassLoader();
+  }
+
+  private void tryInitAppComponentFactory(LoadedApk realLoadedApk) {
+    if (RuntimeEnvironment.getApiLevel() >= VERSION_CODES.P) {
+      ApplicationInfo applicationInfo = realLoadedApk.getApplicationInfo();
+      if (applicationInfo == null || applicationInfo.appComponentFactory == null) {
+        return;
+      }
+      _LoadedApk_ loadedApkReflector = reflector(_LoadedApk_.class, realLoadedApk);
+      if (!loadedApkReflector.getIncludeCode()) {
+        return;
+      }
+      String fullQualifiedClassName =
+          calculateFullQualifiedClassName(
+              applicationInfo.appComponentFactory, applicationInfo.packageName);
+      android.app.AppComponentFactory factory =
+          (android.app.AppComponentFactory) newInstanceOf(fullQualifiedClassName);
+      if (factory == null) {
+        factory = new android.app.AppComponentFactory();
+      }
+      loadedApkReflector.setAppFactory(factory);
+    }
+  }
+
+  private String calculateFullQualifiedClassName(String className, String packageName) {
+    if (packageName == null) {
+      return className;
+    }
+    return className.startsWith(".") ? packageName + className : className;
   }
 
   /** Accessor interface for {@link LoadedApk}'s internals. */
@@ -32,5 +79,11 @@ public class ShadowLoadedApk {
 
     @Accessor("mResources")
     void setResources(Resources resources);
+
+    @Accessor("mIncludeCode")
+    boolean getIncludeCode();
+
+    @Accessor("mAppComponentFactory")
+    void setAppFactory(Object appFactory);
   }
 }


### PR DESCRIPTION
Support to use `AppComponentFactory` in Robolectric from SDK 28. This PR only supports `BroadcastReceiver` with custom `AppComponentFactory`. In Robolectric, developers use `Robolectric#setupService` or `Robolectric#buildService` to initialize `Service` instance, and these methods are static, so it's difficult to leverage custom `AppComponentFactory` to initialize `Service` instance with custom constructor. And I don't find proper usage scenarios to use custom `AppComponentFactory` to initialize `ContentProvider`, `Application`, `Activity` and `ClassLoader`. So I leave them as not implemented state.

Fixes: https://github.com/robolectric/robolectric/issues/7581.