### PR TITLE
Fix an edge case in Jacoco detection logic for constructors.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -27,6 +27,8 @@ ext {
 
     mockitoVersion='4.11.0'
 
+    jacocoVersion='0.8.8'
+
     guavaJREVersion='31.1-jre'
 
     asmVersion='9.4'

--- a/integration_tests/jacoco-offline/build.gradle
+++ b/integration_tests/jacoco-offline/build.gradle
@@ -1,0 +1,112 @@
+import org.robolectric.gradle.AndroidProjectConfigPlugin
+
+apply plugin: 'com.android.library'
+apply plugin: AndroidProjectConfigPlugin
+apply plugin: "jacoco"
+
+android {
+    compileSdk 33
+
+    defaultConfig {
+        minSdk 16
+        targetSdk 33
+    }
+
+    compileOptions {
+        sourceCompatibility = '1.8'
+        targetCompatibility = '1.8'
+    }
+
+    testOptions.unitTests.includeAndroidResources true
+}
+
+jacoco {
+    toolVersion = jacocoVersion
+}
+
+configurations {
+    jacocoAnt
+    jacocoRuntime
+}
+
+
+dependencies {
+    api project(":robolectric")
+
+    compileOnly AndroidSdk.MAX_SDK.coordinates
+
+    testCompileOnly AndroidSdk.MAX_SDK.coordinates
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
+
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.jacoco:org.jacoco.agent:$jacocoVersion:runtime"
+}
+
+def unitTestTaskName = "testDebugUnitTest"
+
+def compileSourceTaskName = "compileDebugJavaWithJavac"
+
+def javaDirPath = "${buildDir.path}/intermediates/javac/debug/classes"
+
+def kotlinDirPath = "${buildDir.path}/classes/kotlin/main"
+
+def jacocoInstrumentedClassesOutputDirPath = "${buildDir.path}/classes/java/classes-instrumented"
+
+// make sure it's evaluated after the AGP evaluation.
+afterEvaluate {
+    tasks[compileSourceTaskName].doLast {
+        println "[JaCoCo]:Generating JaCoCo instrumented classes for the build."
+
+        def jacocoInstrumentOutputDirPathFile = new File(jacocoInstrumentedClassesOutputDirPath)
+        if (jacocoInstrumentOutputDirPathFile.exists()) {
+            println "[JaCoCo]:Classes had been instrumented."
+            return
+        }
+
+        ant.taskdef(name: 'instrument',
+                classname: 'org.jacoco.ant.InstrumentTask',
+                classpath: configurations.jacocoAnt.asPath)
+
+        def classesDirPathFile = new File(javaDirPath)
+        if (classesDirPathFile.exists()) {
+            ant.instrument(destdir: jacocoInstrumentedClassesOutputDirPath) {
+                fileset(
+                        dir: javaDirPath,
+                        excludes: []
+                )
+            }
+        } else {
+            println "Classes directory with path: " + classesDirPathFile + " was not existed."
+        }
+
+        def classesDirPathFileKotlin = new File(kotlinDirPath)
+        if (classesDirPathFileKotlin.exists()) {
+            ant.instrument(destdir: jacocoInstrumentedClassesOutputDirPath) {
+                fileset(
+                        dir: kotlinDirPath,
+                        excludes: []
+                )
+            }
+        } else {
+            println "Classes directory with path: " + classesDirPathFileKotlin + " was not existed."
+        }
+    }
+
+    def executionDataFilePath = "${buildDir.path}/jacoco/${unitTestTaskName}.exec"
+
+    // put JaCoCo instrumented classes and JaCoCoRuntime to the beginning of the JVM classpath.
+    tasks["${unitTestTaskName}"].doFirst {
+        jacoco {
+            // disable JaCoCo on-the-fly from Gradle JaCoCo plugin.
+            enabled = false
+        }
+
+        println "[JaCoCo]:Modifying classpath of tests JVM."
+
+        systemProperty 'jacoco-agent.destfile', executionDataFilePath
+
+        classpath = files(jacocoInstrumentedClassesOutputDirPath) + classpath + configurations.jacocoRuntime
+
+        println "Final test JVM classpath is ${classpath.getAsPath()}"
+    }
+}

--- a/integration_tests/jacoco-offline/src/main/AndroidManifest.xml
+++ b/integration_tests/jacoco-offline/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.robolectric.integrationtests.jacoco.offline">
+</manifest>

--- a/integration_tests/jacoco-offline/src/main/java/org/robolectric/integrationtests/jacoco/offline/JaCoCoOfflineTester.java
+++ b/integration_tests/jacoco-offline/src/main/java/org/robolectric/integrationtests/jacoco/offline/JaCoCoOfflineTester.java
@@ -1,0 +1,9 @@
+package org.robolectric.integrationtests.jacoco.offline;
+
+public class JaCoCoOfflineTester {
+  public static final int VALUE = 1;
+
+  public int getValue() {
+    return VALUE;
+  }
+}

--- a/integration_tests/jacoco-offline/src/test/java/org/robolectric/integrationtests/jacoco/offline/JaCoCoOfflineTesterTest.java
+++ b/integration_tests/jacoco-offline/src/test/java/org/robolectric/integrationtests/jacoco/offline/JaCoCoOfflineTesterTest.java
@@ -1,0 +1,14 @@
+package org.robolectric.integrationtests.jacoco.offline;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class JaCoCoOfflineTesterTest {
+  @Test
+  public void testGetValueBeforeShadow() {
+    Assert.assertEquals(JaCoCoOfflineTester.VALUE, new JaCoCoOfflineTester().getValue());
+  }
+}

--- a/integration_tests/jacoco-offline/src/test/java/org/robolectric/integrationtests/jacoco/offline/ShadowJaCoCoOfflineTester.java
+++ b/integration_tests/jacoco-offline/src/test/java/org/robolectric/integrationtests/jacoco/offline/ShadowJaCoCoOfflineTester.java
@@ -1,0 +1,14 @@
+package org.robolectric.integrationtests.jacoco.offline;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(JaCoCoOfflineTester.class)
+public class ShadowJaCoCoOfflineTester {
+  public static final int VALUE = 0;
+
+  @Implementation
+  public int getValue() {
+    return VALUE;
+  }
+}

--- a/integration_tests/jacoco-offline/src/test/java/org/robolectric/integrationtests/jacoco/offline/ShadowJaCoCoOfflineTesterTest.java
+++ b/integration_tests/jacoco-offline/src/test/java/org/robolectric/integrationtests/jacoco/offline/ShadowJaCoCoOfflineTesterTest.java
@@ -1,0 +1,20 @@
+package org.robolectric.integrationtests.jacoco.offline;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@Config(
+    shadows = {
+      ShadowJaCoCoOfflineTester.class,
+    })
+@RunWith(RobolectricTestRunner.class)
+public class ShadowJaCoCoOfflineTesterTest {
+  @Test
+  public void testGetValue() {
+    Assert.assertNotEquals(JaCoCoOfflineTester.VALUE, ShadowJaCoCoOfflineTester.VALUE);
+    Assert.assertEquals(ShadowJaCoCoOfflineTester.VALUE, new JaCoCoOfflineTester().getValue());
+  }
+}

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassInstrumentor.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassInstrumentor.java
@@ -212,8 +212,11 @@ public class ClassInstrumentor {
   }
 
   /**
-   * Checks if the first instruction is a Jacoco load instructions. Robolectric is not capable at
-   * the moment of re-instrumenting Jacoco-instrumented constructors.
+   * Checks if the first instruction is a Jacoco load instructions($jacocoData) or the first and
+   * second instructions are a LabelNode and a Jacoco invoke static($jacocoInit()).
+   *
+   * <p>Robolectric is not capable at the moment of re-instrumenting Jacoco-instrumented
+   * constructors.
    *
    * @param ctor constructor method node
    * @return whether or not the constructor can be instrumented
@@ -225,6 +228,10 @@ public class ClassInstrumentor {
           && ((LdcInsnNode) insns[0]).cst instanceof ConstantDynamic) {
         ConstantDynamic cst = (ConstantDynamic) ((LdcInsnNode) insns[0]).cst;
         return cst.getName().equals("$jacocoData");
+      } else if (insns.length > 1
+          && insns[0] instanceof LabelNode
+          && insns[1] instanceof MethodInsnNode) {
+        return "$jacocoInit".equals(((MethodInsnNode) insns[1]).name);
       }
     }
     return false;

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,6 +34,7 @@ include ':integration_tests:androidx_test'
 include ':integration_tests:ctesque'
 include ':integration_tests:security-providers'
 include ":integration_tests:mockk"
+include ":integration_tests:jacoco-offline"
 include ':integration_tests:compat-target28'
 include ":integration_tests:multidex"
 include ":integration_tests:play_services"


### PR DESCRIPTION
One of the edge cases could be Jacoco-instrumented constructor with the first instruction is LabelNode and the second instruction is invoke static($jacocoInit()).

According to JaCoCo docs, one of the followings should be the first instruction:
- Access field to $jacocoData.
- Access static method to $jacocoInit().

> To collect execution data JaCoCo instruments the classes under test which adds two members to the classes: A private static field $jacocoData and a private static method $jacocoInit(). Both members are marked as synthetic.

See https://www.eclemma.org/jacoco/trunk/doc/faq.html

Note that Robolectric does not check if both members are synthetic.

Tested by: jacoco-offline integration tests.

Fixes #8001 
