### PR TITLE
Add integration tests for JaCoCo on-the-fly instrumented.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -27,6 +27,8 @@ ext {
 
     mockitoVersion='4.11.0'
 
+    jacocoVersion='0.8.8'
+
     guavaJREVersion='31.1-jre'
 
     asmVersion='9.4'

--- a/integration_tests/jacoco-on-the-fly/build.gradle
+++ b/integration_tests/jacoco-on-the-fly/build.gradle
@@ -1,0 +1,41 @@
+import org.robolectric.gradle.AndroidProjectConfigPlugin
+
+apply plugin: 'com.android.library'
+apply plugin: AndroidProjectConfigPlugin
+apply plugin: "jacoco"
+
+android {
+    compileSdk 33
+
+    defaultConfig {
+        minSdk 16
+        targetSdk 33
+    }
+
+    compileOptions {
+        sourceCompatibility = '1.8'
+        targetCompatibility = '1.8'
+    }
+
+    testOptions.unitTests.includeAndroidResources true
+}
+
+jacoco {
+    toolVersion = jacocoVersion
+}
+
+dependencies {
+    api project(":robolectric")
+
+    compileOnly AndroidSdk.MAX_SDK.coordinates
+
+    testCompileOnly AndroidSdk.MAX_SDK.coordinates
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
+
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "com.google.truth:truth:$truthVersion"
+    testImplementation "androidx.test:core:$axtCoreVersion"
+    testImplementation "androidx.test:runner:$axtRunnerVersion"
+    testImplementation "androidx.test.ext:junit:$axtJunitVersion"
+    testImplementation "org.jacoco:org.jacoco.agent:$jacocoVersion:runtime"
+}

--- a/integration_tests/jacoco-on-the-fly/src/main/AndroidManifest.xml
+++ b/integration_tests/jacoco-on-the-fly/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.robolectric.integrationtests.jacoco.onthefly">
+</manifest>

--- a/integration_tests/jacoco-on-the-fly/src/main/java/org/robolectric/integrationtests/jacoco/onthefly/JaCoCoOnTheFlyTester.java
+++ b/integration_tests/jacoco-on-the-fly/src/main/java/org/robolectric/integrationtests/jacoco/onthefly/JaCoCoOnTheFlyTester.java
@@ -1,0 +1,9 @@
+package org.robolectric.integrationtests.jacoco.onthefly;
+
+public class JaCoCoOnTheFlyTester {
+  public static final int VALUE = 1;
+
+  public int getValue() {
+    return VALUE;
+  }
+}

--- a/integration_tests/jacoco-on-the-fly/src/test/java/org/robolectric/integrationtests/jacoco/onthefly/JaCoCoOnTheFlyTesterTest.java
+++ b/integration_tests/jacoco-on-the-fly/src/test/java/org/robolectric/integrationtests/jacoco/onthefly/JaCoCoOnTheFlyTesterTest.java
@@ -1,0 +1,14 @@
+package org.robolectric.integrationtests.jacoco.onthefly;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class JaCoCoOnTheFlyTesterTest {
+  @Test
+  public void testGetValueBeforeShadow() {
+    Assert.assertEquals(JaCoCoOnTheFlyTester.VALUE, new JaCoCoOnTheFlyTester().getValue());
+  }
+}

--- a/integration_tests/jacoco-on-the-fly/src/test/java/org/robolectric/integrationtests/jacoco/onthefly/ShadowJaCoCoOnTheFlyTester.java
+++ b/integration_tests/jacoco-on-the-fly/src/test/java/org/robolectric/integrationtests/jacoco/onthefly/ShadowJaCoCoOnTheFlyTester.java
@@ -1,0 +1,14 @@
+package org.robolectric.integrationtests.jacoco.onthefly;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(JaCoCoOnTheFlyTester.class)
+public class ShadowJaCoCoOnTheFlyTester {
+  public static final int VALUE = 0;
+
+  @Implementation
+  public int getValue() {
+    return VALUE;
+  }
+}

--- a/integration_tests/jacoco-on-the-fly/src/test/java/org/robolectric/integrationtests/jacoco/onthefly/ShadowJaCoCoOnTheFlyTesterTest.java
+++ b/integration_tests/jacoco-on-the-fly/src/test/java/org/robolectric/integrationtests/jacoco/onthefly/ShadowJaCoCoOnTheFlyTesterTest.java
@@ -1,0 +1,20 @@
+package org.robolectric.integrationtests.jacoco.onthefly;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@Config(
+    shadows = {
+      ShadowJaCoCoOnTheFlyTester.class,
+    })
+@RunWith(RobolectricTestRunner.class)
+public class ShadowJaCoCoOnTheFlyTesterTest {
+  @Test
+  public void testGetValue() {
+    Assert.assertNotEquals(JaCoCoOnTheFlyTester.VALUE, ShadowJaCoCoOnTheFlyTester.VALUE);
+    Assert.assertEquals(ShadowJaCoCoOnTheFlyTester.VALUE, new JaCoCoOnTheFlyTester().getValue());
+  }
+}

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassInstrumentor.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassInstrumentor.java
@@ -225,6 +225,10 @@ public class ClassInstrumentor {
           && ((LdcInsnNode) insns[0]).cst instanceof ConstantDynamic) {
         ConstantDynamic cst = (ConstantDynamic) ((LdcInsnNode) insns[0]).cst;
         return cst.getName().equals("$jacocoData");
+      } else if (insns.length > 1
+          && insns[0] instanceof LabelNode
+          && insns[1] instanceof MethodInsnNode) {
+        return "$jacocoInit".equals(((MethodInsnNode) insns[1]).name);
       }
     }
     return false;

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,6 +34,7 @@ include ':integration_tests:androidx_test'
 include ':integration_tests:ctesque'
 include ':integration_tests:security-providers'
 include ":integration_tests:mockk"
+include ":integration_tests:jacoco-on-the-fly"
 include ':integration_tests:compat-target28'
 include ":integration_tests:multidex"
 include ":integration_tests:play_services"


### PR DESCRIPTION
Add comparable tests for JaCoCo offline on custom shadows.

Note that when using both JaCoCo on-the-fly instrument and Robolectric, the code coverage from JaCoCo execution data can be 0.
