### PR TITLE
Fix an edge case when PackageManager.getApplicationInfo is called

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -1063,6 +1063,13 @@ public class ShadowPackageManagerTest {
   }
 
   @Test
+  public void getApplicationInfo_nullPackage_shouldThrowNameNotFoundException() {
+    assertThrows(
+        PackageManager.NameNotFoundException.class,
+        () -> packageManager.getApplicationInfo(null, 0));
+  }
+
+  @Test
   public void getApplicationInfo_otherApplication() throws Exception {
     PackageInfo packageInfo = new PackageInfo();
     packageInfo.packageName = TEST_PACKAGE_NAME;


### PR DESCRIPTION
Historically, in Robolectric, if:

    PackageManager.getApplicationInfo(null, 0)

was called, a NameNotFoundException would result. Update the ShadowApplicationPackageManager.getApplicationInfo methods to retain this behavior.

### Overview

### Proposed Changes
