### PR TITLE
Remove CMake/Clang/GCC requirements from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,6 @@ Those software configurations are recommended and tested.
 - JDK 11. Gradle JVM should be set to Java 11.
   - For command line, make sure the environment variable `JAVA_HOME` is correctly point to JDK11, or set the build environment by [Gradle CLI option](https://docs.gradle.org/current/userguide/command_line_interface.html#sec:environment_options) `-Dorg.gradle.java.home="YourJdkHomePath"` or by [Gradle Properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties) `org.gradle.java.home=YourJdkHomePath`.
   - For both IntelliJ and Android Studio, see _Settings/Preferences | Build, Execution, Deployment | Build Tools | Gradle_.
-- Ninja 1.10.2+. Check it by `ninja --version`.
-- CMake 3.22.1+. Check it by `cmake --version`.
-- GCC 7.5.0+ on Linux or Apple clang 12.0.0+ on macOS. Check it by `gcc --version`.
 
 See [Building Robolectric](http://robolectric.org/building-robolectric/) for more details about setting up a build environment for Robolectric.
 


### PR DESCRIPTION
The nativeruntime has been moved to AOSP, and Robolectric doesn't need to build it anymore. So we don't need these prerequisites for building Robolectric.