### PR TITLE
Remove unused recursive checkout parameter from GitHub Actions

### DIFF
--- a/.github/workflows/gradle_tasks_validation.yml
+++ b/.github/workflows/gradle_tasks_validation.yml
@@ -16,9 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          submodules: recursive
 
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -49,8 +47,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -90,8 +86,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3


### PR DESCRIPTION
We don't have submodule anymore.