### PR TITLE
Remove setOnLongClickListener call in EspressoActivity

### DIFF
--- a/integration_tests/androidx_test/src/main/java/org/robolectric/integrationtests/axt/EspressoActivity.java
+++ b/integration_tests/androidx_test/src/main/java/org/robolectric/integrationtests/axt/EspressoActivity.java
@@ -27,6 +27,5 @@ public class EspressoActivity extends Activity {
 
     button = findViewById(R.id.button);
     button.setOnClickListener(view -> buttonClicked = true);
-    button.setOnLongClickListener(v -> true);
   }
 }


### PR DESCRIPTION
This call to setOnLongClickListener causes Robolectric's EspressoTest to fail in a Bazel environment in SDKs 23-26. This indicates the same problem as #7816.

Remove this listener while the issue is investigated. When it is fixed, a long click listener will be added.
