### PR TITLE
Fix some Java Lint naming errors

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/Chunk.java
+++ b/resources/src/main/java/org/robolectric/res/android/Chunk.java
@@ -7,12 +7,12 @@ import static org.robolectric.res.android.Util.isTruthy;
 import java.nio.ByteBuffer;
 import org.robolectric.res.android.ResourceTypes.ResChunk_header;
 import org.robolectric.res.android.ResourceTypes.ResStringPool_header;
+import org.robolectric.res.android.ResourceTypes.ResTableStagedAliasEntry;
+import org.robolectric.res.android.ResourceTypes.ResTableStagedAliasHeader;
 import org.robolectric.res.android.ResourceTypes.ResTable_header;
 import org.robolectric.res.android.ResourceTypes.ResTable_lib_entry;
 import org.robolectric.res.android.ResourceTypes.ResTable_lib_header;
 import org.robolectric.res.android.ResourceTypes.ResTable_package;
-import org.robolectric.res.android.ResourceTypes.ResTable_staged_alias_entry;
-import org.robolectric.res.android.ResourceTypes.ResTable_staged_alias_header;
 import org.robolectric.res.android.ResourceTypes.ResTable_type;
 import org.robolectric.res.android.ResourceTypes.WithOffset;
 
@@ -121,17 +121,17 @@ class Chunk {
     }
   }
 
-  public ResTable_staged_alias_header asResTable_staged_alias_header() {
-    if (header_size() >= ResTable_staged_alias_header.SIZEOF) {
-      return new ResTable_staged_alias_header(device_chunk_.myBuf(), device_chunk_.myOffset());
+  public ResTableStagedAliasHeader asResTableStagedAliasHeader() {
+    if (header_size() >= ResTableStagedAliasHeader.SIZEOF) {
+      return new ResTableStagedAliasHeader(device_chunk_.myBuf(), device_chunk_.myOffset());
     } else {
       return null;
     }
   }
 
-  public ResTable_staged_alias_entry asResTable_staged_alias_entry() {
-    if (data_size() >= ResTable_staged_alias_entry.SIZEOF) {
-      return new ResTable_staged_alias_entry(
+  public ResTableStagedAliasEntry asResTableStagedAliasEntry() {
+    if (data_size() >= ResTableStagedAliasEntry.SIZEOF) {
+      return new ResTableStagedAliasEntry(
           device_chunk_.myBuf(), device_chunk_.myOffset() + header_size());
     } else {
       return null;

--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
@@ -350,7 +350,7 @@ public class CppAssetManager2 {
         // that compile against the framework.
         for (ConfiguredPackage pkg : iter.packages_) {
           for (Map.Entry<Integer, Integer> entry :
-              pkg.loaded_package_.GetAliasResourceIdMap().entrySet()) {
+              pkg.loaded_package_.getAliasResourceIdMap().entrySet()) {
             iter2.dynamic_ref_table.addAlias(entry.getKey(), entry.getValue());
           }
         }

--- a/resources/src/main/java/org/robolectric/res/android/DynamicRefTable.java
+++ b/resources/src/main/java/org/robolectric/res/android/DynamicRefTable.java
@@ -102,11 +102,11 @@ public class DynamicRefTable
     int res = resId.get();
     int packageId = Res_GETPACKAGE(res) + 1;
 
-    Integer alias_id = mAliasId.get(res);
-    if (alias_id != null) {
+    Integer aliasId = mAliasId.get(res);
+    if (aliasId != null) {
       // Rewrite the resource id to its alias resource id. Since the alias resource id is a
       // compile-time id, it still needs to be resolved further.
-      res = alias_id;
+      res = aliasId;
     }
 
     if (packageId == SYS_PACKAGE_ID || (packageId == APP_PACKAGE_ID && !mAppAsLib)) {

--- a/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
@@ -1508,15 +1508,15 @@ public static class ResTable_ref
    * A map that allows rewriting staged (non-finalized) resource ids to their finalized
    * counterparts.
    */
-  static class ResTable_staged_alias_header extends WithOffset {
+  static class ResTableStagedAliasHeader extends WithOffset {
     public static final int SIZEOF = ResChunk_header.SIZEOF + 4;
 
     ResChunk_header header;
 
-    // The number of ResTable_staged_alias_entry that follow this header.
+    // The number of ResTableStagedAliasEntry that follow this header.
     int count;
 
-    ResTable_staged_alias_header(ByteBuffer buf, int offset) {
+    ResTableStagedAliasHeader(ByteBuffer buf, int offset) {
       super(buf, offset);
 
       header = new ResChunk_header(buf, offset);
@@ -1525,7 +1525,7 @@ public static class ResTable_ref
   }
 
   /** Maps the staged (non-finalized) resource id to its finalized resource id. */
-  static class ResTable_staged_alias_entry extends WithOffset {
+  static class ResTableStagedAliasEntry extends WithOffset {
     public static final int SIZEOF = 8;
 
     // The compile-time staged resource id to rewrite.
@@ -1534,7 +1534,7 @@ public static class ResTable_ref
     // The compile-time finalized resource id to which the staged resource id should be rewritten.
     int finalizedResId;
 
-    ResTable_staged_alias_entry(ByteBuffer buf, int offset) {
+    ResTableStagedAliasEntry(ByteBuffer buf, int offset) {
       super(buf, offset);
 
       stagedResId = buf.getInt(offset);

--- a/resources/src/test/java/org/robolectric/res/android/LoadedArscTest.java
+++ b/resources/src/test/java/org/robolectric/res/android/LoadedArscTest.java
@@ -44,12 +44,12 @@ public class LoadedArscTest {
               (short) RES_TABLE_STAGED_ALIAS_TYPE,
               () -> {
                 // header
-                buf.putInt(1); // ResTable_staged_alias_header.count
+                buf.putInt(1); // ResTableStagedAliasHeader.count
               },
               () -> {
                 // contents
-                buf.putInt(stagedResId); // ResTable_staged_alias_entry.stagedResId
-                buf.putInt(finalizedResId); // ResTable_staged_alias_entry.finalizedResId
+                buf.putInt(stagedResId); // ResTableStagedAliasEntry.stagedResId
+                buf.putInt(finalizedResId); // ResTableStagedAliasEntry.finalizedResId
               });
         });
     final Chunk chunk = new Chunk(new ResChunk_header(buf, 0));
@@ -57,7 +57,7 @@ public class LoadedArscTest {
         LoadedArsc.LoadedPackage.Load(
             chunk, null /* loaded_idmap */, true /* system */, false /* load_as_shared_library */);
 
-    final Map<Integer, Integer> aliasIdMap = loadedPackage.GetAliasResourceIdMap();
+    final Map<Integer, Integer> aliasIdMap = loadedPackage.getAliasResourceIdMap();
     assertEquals(finalizedResId, (int) aliasIdMap.get(stagedResId));
   }
 }


### PR DESCRIPTION
This is a pure naming change made by find/replace in bash.

The current binary resources system is transliterated from C++ code, and changes often trigger Lint errors.

Long-term the naming and spacing should be updated to follow Java conventions.

