### PR TITLE
Remove SDK 33 Emulator tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 29, 33 ]
+        api-level: [ 29 ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
It's frequent flaky. I don't think it's a great idea to retry it manually multiple times to make CI green.