### PR TITLE
Add tests for RNG in GitHub actions

### DIFF
--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -1,0 +1,47 @@
+name: Graphics Tests
+
+on:
+  push:
+    branches: [ master, 'robolectric-*.x' ]
+    paths-ignore:
+      - '**.md'
+
+  pull_request:
+    branches: [ master, google ]
+    paths-ignore:
+      - '**.md'
+
+permissions:
+  contents: read
+
+jobs:
+  graphics_tests:
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - uses: gradle/gradle-build-action@v2
+
+      - name: Run unit tests
+        run: |
+          SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew :integration_tests:nativegraphics:testDebugUnitTest \
+          --info --stacktrace --continue \
+          --parallel \
+          --no-watch-fs \
+          -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+          -Dorg.gradle.workers.max=2
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test_results
+          path: '**/build/test-results/**/TEST-*.xml'
+


### PR DESCRIPTION
Currently it runs on Mac M1 only to avoid overloading the existing CI workflows.
