### PR TITLE
Remove unused destinationDirectory configuration for Kotlin

### DIFF
--- a/plugins/maven-dependency-resolver/build.gradle
+++ b/plugins/maven-dependency-resolver/build.gradle
@@ -21,12 +21,6 @@ tasks.withType(GenerateModuleMetadata).configureEach {
 }
 
 compileKotlin {
-    // Use java/main classes directory to replace default kotlin/main to
-    // avoid d8 error when dexing & desugaring kotlin classes with non-exist
-    // kotlin/main directory because utils module doesn't have kotlin code
-    // in production. If utils module starts to add Kotlin code in main source
-    // set, we can remove this destinationDirectory modification.
-    destinationDirectory = file("${projectDir}/build/classes/java/main")
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8
 }
 

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -21,12 +21,6 @@ tasks.withType(GenerateModuleMetadata).configureEach {
 }
 
 compileKotlin {
-    // Use java/main classes directory to replace default kotlin/main to
-    // avoid d8 error when dexing & desugaring kotlin classes with non-exist
-    // kotlin/main directory because utils module doesn't have kotlin code
-    // in production. If utils module starts to add Kotlin code in main source
-    // set, we can remove this destinationDirectory modification.
-    destinationDirectory = file("${projectDir}/build/classes/java/main")
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8
 }
 


### PR DESCRIPTION
Looks like new Gradle and Kotlin version fix this issue.