### PR TITLE
Remove duplicated gradle plugin maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,6 @@ buildscript {
         google()
         mavenCentral()
         gradlePluginPortal()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
     }
 
     dependencies {


### PR DESCRIPTION
We have gradlePluginPortal.
