### PR TITLE
Bump Kotlin to 1.9.0-Beta

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ error-prone-javac = "9+181-r4173-1"
 error-prone-gradle = "3.1.0"
 
 # https://kotlinlang.org/docs/releases.html#release-details
-kotlin = "1.8.10"
+kotlin = "1.9.0-Beta"
 
 # https://github.com/diffplug/spotless/blob/main/CHANGES.md
 spotless-gradle = "6.19.0"

--- a/plugins/maven-dependency-resolver/build.gradle
+++ b/plugins/maven-dependency-resolver/build.gradle
@@ -21,33 +21,11 @@ tasks.withType(GenerateModuleMetadata).configureEach {
 }
 
 compileKotlin {
-    // Use java/main classes directory to replace default kotlin/main to
-    // avoid d8 error when dexing & desugaring kotlin classes with non-exist
-    // kotlin/main directory because this module doesn't have kotlin code
-    // in production. If utils module starts to add Kotlin code in main source
-    // set, we can remove this destinationDirectory modification.
-    destinationDirectory = file("${projectDir}/build/classes/java/main")
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8
 }
 
 compileTestKotlin {
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8
-}
-
-afterEvaluate {
-    configurations {
-        runtimeElements {
-            attributes {
-                // We should add artifactType with jar to ensure standard runtimeElements variant
-                // has a max priority selection sequence than other variants that brought by
-                // kotlin plugin.
-                attribute(
-                        Attribute.of("artifactType", String.class),
-                        ArtifactTypeDefinition.JAR_TYPE
-                )
-            }
-        }
-    }
 }
 
 dependencies {

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -21,33 +21,11 @@ tasks.withType(GenerateModuleMetadata).configureEach {
 }
 
 compileKotlin {
-    // Use java/main classes directory to replace default kotlin/main to
-    // avoid d8 error when dexing & desugaring kotlin classes with non-exist
-    // kotlin/main directory because utils module doesn't have kotlin code
-    // in production. If utils module starts to add Kotlin code in main source
-    // set, we can remove this destinationDirectory modification.
-    destinationDirectory = file("${projectDir}/build/classes/java/main")
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8
 }
 
 compileTestKotlin {
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8
-}
-
-afterEvaluate {
-    configurations {
-        runtimeElements {
-            attributes {
-                // We should add artifactType with jar to ensure standard runtimeElements variant
-                // has a max priority selection sequence than other variants that brought by
-                // kotlin plugin.
-                attribute(
-                        Attribute.of("artifactType", String.class),
-                        ArtifactTypeDefinition.JAR_TYPE
-                )
-            }
-        }
-    }
 }
 
 dependencies {


### PR DESCRIPTION
The Kotlin 1.8.20 and 1.8.21 have resolving issues for Kotlin and Java
mixed pure module, and 1.9.0-Beta fixes it. So this CL just jumps to
1.9.0-Beta. With 1.9.0-Beta, we can remove many temporary configurations
to make Java + Kotlin mixed work for our project.
