### PR TITLE
Remove force for dependency statements

### DIFF
--- a/.github/workflows/gradle_tasks_validation.yml
+++ b/.github/workflows/gradle_tasks_validation.yml
@@ -15,6 +15,23 @@ permissions:
   contents: read
 
 jobs:
+  run_checkForApiChanges:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - uses: gradle/gradle-build-action@v2
+
+      - name: Run checkForApiChanges
+        run: ./gradlew checkForApiChanges
+
   run_aggregateDocs:
     runs-on: ubuntu-20.04
 

--- a/buildSrc/src/main/groovy/CheckApiChangesPlugin.groovy
+++ b/buildSrc/src/main/groovy/CheckApiChangesPlugin.groovy
@@ -28,7 +28,6 @@ class CheckApiChangesPlugin implements Plugin<Project> {
             project.checkApiChanges.from.each {
                 project.dependencies.checkApiChangesFrom(it) {
                     transitive = false
-                    force = true
                 }
             }
 

--- a/errorprone/build.gradle
+++ b/errorprone/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation "com.google.errorprone:error_prone_refaster:$errorproneVersion"
     implementation "com.google.errorprone:error_prone_check_api:$errorproneVersion"
     compileOnly "com.google.auto.service:auto-service-annotations:$autoServiceVersion"
-    compileOnly(AndroidSdk.MAX_SDK.coordinates) { force = true }
+    compileOnly(AndroidSdk.MAX_SDK.coordinates)
 
     annotationProcessor "com.google.auto.service:auto-service:$autoServiceVersion"
     annotationProcessor "com.google.errorprone:error_prone_core:$errorproneVersion"
@@ -41,5 +41,5 @@ dependencies {
     testImplementation("com.google.errorprone:error_prone_test_helpers:${errorproneVersion}") {
         exclude group: 'junit', module: 'junit' // because it depends on a snapshot!?
     }
-    testCompileOnly(AndroidSdk.MAX_SDK.coordinates) { force = true }
+    testCompileOnly(AndroidSdk.MAX_SDK.coordinates)
 }

--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation "com.google.errorprone:error_prone_annotations:$errorproneVersion"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
     api "com.almworks.sqlite4java:sqlite4java:$sqlite4javaVersion"
-    compileOnly(AndroidSdk.MAX_SDK.coordinates) { force = true }
+    compileOnly(AndroidSdk.MAX_SDK.coordinates)
     api "com.ibm.icu:icu4j:72.1"
     api "androidx.annotation:annotation:1.1.0"
     api "com.google.auto.value:auto-value-annotations:1.10.1"

--- a/shadows/httpclient/build.gradle
+++ b/shadows/httpclient/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     // We should keep httpclient version for low level API compatibility.
     earlyRuntime "org.apache.httpcomponents:httpcore:4.0.1"
     api "org.apache.httpcomponents:httpclient:4.0.3"
-    compileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates) { force = true }
+    compileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates)
 
     testImplementation project(":robolectric")
     testImplementation "junit:junit:${junitVersion}"
@@ -31,7 +31,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testImplementation "androidx.test.ext:junit:$axtJunitVersion@aar"
 
-    testCompileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates) { force = true }
+    testCompileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates)
     testRuntimeOnly AndroidSdk.S.coordinates
 }
 


### PR DESCRIPTION
It will be read-only from Gradle 8.x(see https://github.com/gradle/gradle/blob/24e7a737d0c20bf31f06abc145d3ad630c8b613b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java#L90).

This CL also adds a CI job to test `checkForApiChanges` because it is affected by `force`.
