### PR TITLE
Enable version catalogs

### DIFF
--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -5,6 +5,6 @@ apply plugin: RoboJavaModulePlugin
 apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
-    compileOnly "com.google.code.findbugs:jsr305:3.0.2"
+    compileOnly libs.findbugs.jsr305
     compileOnly AndroidSdk.MAX_SDK.coordinates
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,11 @@ buildscript {
 
     dependencies {
         gradle
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath libs.android.gradle
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:3.1.0'
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.18.0"
+        classpath libs.kotlin.gradle
+        classpath libs.spotless.gradle
     }
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
 
-    api "com.google.guava:guava:31.1-jre"
+    api libs.guava
     api 'org.jetbrains:annotations:24.0.1'
-    implementation "org.ow2.asm:asm-tree:9.5"
-    implementation 'com.android.tools.build:gradle:7.4.2'
+    implementation libs.asm.tree
+    implementation libs.android.gradle
 }

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/RoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/RoboJavaModulePlugin.groovy
@@ -13,8 +13,8 @@ class RoboJavaModulePlugin implements Plugin<Project> {
         if (!skipErrorprone) {
           apply plugin: "net.ltgt.errorprone"
           project.dependencies {
-            errorprone("com.google.errorprone:error_prone_core:$errorproneVersion")
-            errorproneJavac("com.google.errorprone:javac:$errorproneJavacVersion")
+            errorprone(libs.error.prone.core)
+            errorproneJavac(libs.error.prone.javac)
           }
         }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,40 +1,11 @@
 ext {
-    apiCompatVersion='4.10'
+    apiCompatVersion = '4.10'
 
-    errorproneVersion='2.18.0'
-    errorproneJavacVersion='9+181-r4173-1'
-
-    // AndroidX test versions
-    axtMonitorVersion='1.6.1'
-    axtRunnerVersion='1.5.2'
-    axtRulesVersion='1.5.0'
-    axtCoreVersion='1.5.0'
-    axtTruthVersion='1.5.0'
-    espressoVersion='3.5.1'
-    axtJunitVersion='1.1.5'
-    axtTestServicesVersion='1.4.2'
-
-    // AndroidX versions
-    coreVersion='1.10.0'
-    appCompatVersion='1.6.1'
-    constraintlayoutVersion='2.1.4'
-    windowVersion='1.0.0'
-    fragmentVersion='1.5.7'
-
-    truthVersion='1.1.3'
-
-    junitVersion='4.13.2'
-
-    mockitoVersion='4.11.0'
-
-    jacocoVersion='0.8.8'
-
-    guavaJREVersion='31.1-jre'
-
-    asmVersion='9.5'
-
-    kotlinVersion='1.8.10'
-    autoServiceVersion='1.0.1'
-    multidexVersion='2.0.1'
-    sqlite4javaVersion='1.0.392'
+    // https://github.com/gradle/gradle/issues/21267
+    axtCoreVersion = libs.versions.androidx.test.core.get()
+    axtJunitVersion = libs.versions.androidx.test.ext.junit.get()
+    axtMonitorVersion = libs.versions.androidx.test.monitor.get()
+    axtRunnerVersion = libs.versions.androidx.test.runner.get()
+    axtTruthVersion = libs.versions.androidx.test.ext.truth.get()
+    espressoVersion = libs.versions.androidx.test.espresso.get()
 }

--- a/errorprone/build.gradle
+++ b/errorprone/build.gradle
@@ -20,14 +20,14 @@ dependencies {
     implementation project(":shadowapi")
 
     // Compile dependencies
-    implementation "com.google.errorprone:error_prone_annotation:$errorproneVersion"
-    implementation "com.google.errorprone:error_prone_refaster:$errorproneVersion"
-    implementation "com.google.errorprone:error_prone_check_api:$errorproneVersion"
-    compileOnly "com.google.auto.service:auto-service-annotations:$autoServiceVersion"
+    implementation libs.error.prone.annotations
+    implementation libs.error.prone.refaster
+    implementation libs.error.prone.check.api
+    compileOnly libs.auto.service.annotations
     compileOnly(AndroidSdk.MAX_SDK.coordinates)
 
-    annotationProcessor "com.google.auto.service:auto-service:$autoServiceVersion"
-    annotationProcessor "com.google.errorprone:error_prone_core:$errorproneVersion"
+    annotationProcessor libs.auto.service
+    annotationProcessor libs.error.prone.core
 
     // in jdk 9, tools.jar disappears!
     def toolsJar = Jvm.current().getToolsJar()
@@ -36,9 +36,9 @@ dependencies {
     }
 
     // Testing dependencies
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "com.google.truth:truth:${truthVersion}"
-    testImplementation("com.google.errorprone:error_prone_test_helpers:${errorproneVersion}") {
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation(libs.error.prone.test.helpers) {
         exclude group: 'junit', module: 'junit' // because it depends on a snapshot!?
     }
     testCompileOnly(AndroidSdk.MAX_SDK.coordinates)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,166 @@
+[versions]
+# https://developer.android.com/studio/releases
+android-gradle = "7.4.2"
+
+# https://github.com/google/conscrypt/tags
+conscrypt = "2.5.2"
+
+# https://github.com/bcgit/bc-java/tags
+bouncycastle = "1.73"
+
+# https://github.com/findbugsproject/findbugs/tags
+findbugs-jsr305 = "3.0.2"
+
+# https://github.com/hamcrest/JavaHamcrest/releases
+hamcrest = "2.0.0.0"
+
+# https://github.com/google/error-prone/releases
+error-prone = "2.18.0"
+error-prone-javac = "9+181-r4173-1"
+
+# https://kotlinlang.org/docs/releases.html#release-details
+kotlin = "1.8.10"
+
+# https://github.com/diffplug/spotless/blob/main/CHANGES.md
+spotless-gradle = "6.18.0"
+
+# https://asm.ow2.io/versions.html
+asm = "9.5"
+
+# https://github.com/google/auto/releases
+auto-common = "1.2.1"
+auto-service = "1.0.1"
+auto-value = "1.10.1"
+
+compile-testing = "0.21.0"
+
+# https://github.com/google/guava/releases
+guava-jre = "31.1-jre"
+
+# https://github.com/google/gson/releases
+gson = "2.10.1"
+
+# https://github.com/google/truth/releases
+truth = "1.1.3"
+
+jacoco = "0.8.8"
+
+# https://junit.org/junit4/
+junit4 = "4.13.2"
+
+# https://github.com/mockito/mockito/releases
+mockito = "4.11.0"
+
+# https://github.com/mockk/mockk/releases
+mockk = "1.13.5"
+
+sqlite4java = "1.0.392"
+
+# https://developer.android.com/jetpack/androidx/versions
+androidx-annotation = "1.3.0"
+androidx-appcompat = "1.6.1"
+androidx-constraintlayout = "2.1.4"
+androidx-core = "1.10.0"
+androidx-fragment = "1.5.7"
+androidx-multidex = "2.0.1"
+androidx-window = "1.0.0"
+
+# https://github.com/android/android-test/tags
+androidx-test-annotation = "1.0.1"
+androidx-test-core = "1.5.0"
+androidx-test-espresso = "3.5.1"
+androidx-test-ext-junit = "1.1.5"
+androidx-test-ext-truth = "1.5.0"
+androidx-test-monitor="1.6.1"
+androidx-test-orchestrator="1.4.2"
+androidx-test-runner = "1.5.2"
+androidx-test-services = "1.4.2"
+
+
+[libraries]
+android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
+kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+spotless-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless-gradle" }
+
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+
+auto-common = { module = "com.google.auto:auto-common", version.ref = "auto-common" }
+auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "auto-service" }
+auto-service = { module = "com.google.auto.service:auto-service", version.ref = "auto-service" }
+auto-value-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "auto-value" }
+auto-value = { module = "com.google.auto.value:auto-value", version.ref = "auto-value" }
+
+asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
+asm-commons = { module = "org.ow2.asm:asm-commons", version.ref = "asm" }
+asm-util = { module = "org.ow2.asm:asm-util", version.ref = "asm" }
+asm-tree = { module = "org.ow2.asm:asm-tree", version.ref = "asm" }
+
+compile-testing = { module = "com.google.testing.compile:compile-testing", version.ref = "compile-testing" }
+
+error-prone-core =  { module = "com.google.errorprone:error_prone_core", version.ref = "error-prone" }
+error-prone-annotations = { module = "com.google.errorprone:error_prone_annotation", version.ref = "error-prone" }
+error-prone-refaster= { module = "com.google.errorprone:error_prone_refaster", version.ref = "error-prone" }
+error-prone-check-api = { module = "com.google.errorprone:error_prone_check_api", version.ref = "error-prone" }
+error-prone-test-helpers = { module = "com.google.errorprone:error_prone_test_helpers", version.ref = "error-prone" }
+error-prone-javac =  { module = "com.google.errorprone:javac", version.ref = "error-prone-javac" }
+
+conscrypt-openjdk-uber = { module = "org.conscrypt:conscrypt-openjdk-uber", version.ref = "conscrypt" }
+bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+findbugs-jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "findbugs-jsr305" }
+
+guava = { module = "com.google.guava:guava", version.ref = "guava-jre" }
+guava-testlib = { module = "com.google.guava:guava-testlib", version.ref = "guava-jre" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+hamcrest-junit = { module = "org.hamcrest:hamcrest-junit", version.ref = "hamcrest" }
+
+jacoco-agent = { module = "org.jacoco:org.jacoco.agent", version.ref = "jacoco" }
+junit4 = { module = "junit:junit", version.ref = "junit4" }
+
+sqlite4java = { module = "com.almworks.sqlite4java:sqlite4java", version.ref = "sqlite4java" }
+sqlite4java-osx = { module = "com.almworks.sqlite4java:libsqlite4java-osx", version.ref = "sqlite4java" }
+sqlite4java-linux-amd64 = { module = "com.almworks.sqlite4java:libsqlite4java-linux-amd64", version.ref = "sqlite4java" }
+sqlite4java-win32-x64 = { module = "com.almworks.sqlite4java:sqlite4java-win32-x64", version.ref = "sqlite4java" }
+sqlite4java-linux-i386 = { module = "com.almworks.sqlite4java:libsqlite4java-linux-i386", version.ref = "sqlite4java" }
+sqlite4java-win32-x86 = { module = "com.almworks.sqlite4java:sqlite4java-win32-x86", version.ref = "sqlite4java" }
+
+truth = { module = "com.google.truth:truth", version.ref = "truth" }
+truth-java8-extension = { module = "com.google.truth.extensions:truth-java8-extension", version.ref = "truth" }
+
+mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+
+androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
+androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }
+androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "androidx-fragment" }
+androidx-fragment-testing = { module = "androidx.fragment:fragment-testing", version.ref = "androidx-fragment" }
+androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }
+androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
+
+androidx-test-annotation = { module = "androidx.test:annotation", version.ref = "androidx-test-annotation" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
+androidx-test-monitor = { module = "androidx.test:monitor", version.ref = "androidx-test-monitor" }
+androidx-test-orchestrator = { module = "androidx.test:orchestrator", version.ref = "androidx-test-orchestrator" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test-core" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
+androidx-test-services = { module = "androidx.test.services:test-services", version.ref = "androidx-test-services" }
+androidx-test-services-storage = { module = "androidx.test.services:storage", version.ref = "androidx-test-services" }
+
+androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-test-espresso" }
+androidx-test-espresso-accessibility = { module = "androidx.test.espresso:espresso-accessibility", version.ref = "androidx-test-espresso" }
+androidx-test-espresso-contrib = { module = "androidx.test.espresso:espresso-contrib", version.ref = "androidx-test-espresso" }
+androidx-test-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "androidx-test-espresso" }
+androidx-test-espresso-remote = { module = "androidx.test.espresso:espresso-remote", version.ref = "androidx-test-espresso" }
+androidx-test-espresso-web = { module = "androidx.test.espresso:espresso-web", version.ref = "androidx-test-espresso" }
+
+androidx-test-espresso-idling-resource = { module = "androidx.test.espresso:espresso-idling-resource", version.ref = "androidx-test-espresso" }
+androidx-test-espresso-idling-concurrent = { module = "androidx.test.espresso.idling:idling-concurrent", version.ref = "androidx-test-espresso" }
+androidx-test-espresso-idling-net = { module = "androidx.test.espresso.idling:idling-net", version.ref = "androidx-test-espresso" }
+
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext-junit" }
+androidx-test-ext-truth = { module = "androidx.test.ext:truth", version.ref = "androidx-test-ext-truth" }
+
+
+[plugins]

--- a/integration_tests/agp/build.gradle
+++ b/integration_tests/agp/build.gradle
@@ -26,8 +26,8 @@ dependencies {
     testImplementation project(":robolectric")
     testImplementation project(":integration_tests:agp:testsupport")
 
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation("androidx.test:core:$axtCoreVersion")
-    testImplementation("androidx.test:runner:$axtRunnerVersion")
-    testImplementation("androidx.test.ext:junit:$axtJunitVersion")
+    testImplementation libs.junit4
+    testImplementation libs.androidx.test.core
+    testImplementation libs.androidx.test.runner
+    testImplementation libs.androidx.test.ext.junit
 }

--- a/integration_tests/androidx/build.gradle
+++ b/integration_tests/androidx/build.gradle
@@ -26,19 +26,19 @@ android {
 }
 
 dependencies {
-    implementation("androidx.appcompat:appcompat:$appCompatVersion")
-    implementation("androidx.window:window:$windowVersion")
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.window
 
     // Testing dependencies
     testImplementation project(path: ':testapp')
     testImplementation project(":robolectric")
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation("androidx.test:core:$axtCoreVersion")
-    testImplementation("androidx.core:core:$coreVersion")
-    testImplementation("androidx.test:runner:$axtRunnerVersion")
-    testImplementation("androidx.test:rules:$axtRulesVersion")
-    testImplementation("androidx.test.espresso:espresso-intents:$espressoVersion")
-    testImplementation("androidx.test.ext:truth:$axtTruthVersion")
-    testImplementation("androidx.test.ext:junit:$axtJunitVersion")
-    testImplementation("com.google.truth:truth:$truthVersion")
+    testImplementation libs.junit4
+    testImplementation libs.androidx.test.core
+    testImplementation libs.androidx.core
+    testImplementation libs.androidx.test.runner
+    testImplementation libs.androidx.test.rules
+    testImplementation libs.androidx.test.espresso.intents
+    testImplementation libs.androidx.test.ext.truth
+    testImplementation libs.androidx.test.ext.junit
+    testImplementation libs.truth
 }

--- a/integration_tests/androidx_test/build.gradle
+++ b/integration_tests/androidx_test/build.gradle
@@ -42,33 +42,33 @@ android {
 }
 
 dependencies {
-    implementation "androidx.appcompat:appcompat:$appCompatVersion"
-    implementation "androidx.constraintlayout:constraintlayout:$constraintlayoutVersion"
-    implementation "androidx.multidex:multidex:$multidexVersion"
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.constraintlayout
+    implementation libs.androidx.multidex
 
     // Testing dependencies
     testImplementation project(":robolectric")
-    testImplementation "androidx.test:runner:$axtRunnerVersion"
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "androidx.test:rules:$axtRulesVersion"
-    testImplementation "androidx.test.espresso:espresso-intents:$espressoVersion"
-    testImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
-    testImplementation "androidx.test.ext:truth:$axtTruthVersion"
-    testImplementation "androidx.test:core:$axtCoreVersion"
-    testImplementation "androidx.fragment:fragment:$fragmentVersion"
-    testImplementation "androidx.fragment:fragment-testing:$fragmentVersion"
-    testImplementation "androidx.test.ext:junit:$axtJunitVersion"
-    testImplementation "com.google.truth:truth:$truthVersion"
+    testImplementation libs.androidx.test.runner
+    testImplementation libs.junit4
+    testImplementation libs.androidx.test.rules
+    testImplementation libs.androidx.test.espresso.intents
+    testImplementation libs.androidx.test.espresso.core
+    testImplementation libs.androidx.test.ext.truth
+    testImplementation libs.androidx.test.core
+    testImplementation libs.androidx.fragment
+    testImplementation libs.androidx.fragment.testing
+    testImplementation libs.androidx.test.ext.junit
+    testImplementation libs.truth
 
     androidTestImplementation project(':annotations')
-    androidTestImplementation "androidx.test:runner:$axtRunnerVersion"
-    androidTestImplementation "junit:junit:$junitVersion"
-    androidTestImplementation "androidx.test:rules:$axtRulesVersion"
-    androidTestImplementation "androidx.test.espresso:espresso-intents:$espressoVersion"
-    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
-    androidTestImplementation "androidx.test.ext:truth:$axtTruthVersion"
-    androidTestImplementation "androidx.test:core:$axtCoreVersion"
-    androidTestImplementation "androidx.test.ext:junit:$axtJunitVersion"
-    androidTestImplementation "com.google.truth:truth:$truthVersion"
-    androidTestUtil "androidx.test.services:test-services:$axtTestServicesVersion"
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.junit4
+    androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.androidx.test.espresso.intents
+    androidTestImplementation libs.androidx.test.espresso.core
+    androidTestImplementation libs.androidx.test.ext.truth
+    androidTestImplementation libs.androidx.test.core
+    androidTestImplementation libs.androidx.test.ext.junit
+    androidTestImplementation libs.truth
+    androidTestUtil libs.androidx.test.services
 }

--- a/integration_tests/compat-target28/build.gradle
+++ b/integration_tests/compat-target28/build.gradle
@@ -31,10 +31,10 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation libs.kotlin.stdlib
 
     testImplementation project(path: ':testapp')
     testImplementation project(":robolectric")
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "com.google.truth:truth:$truthVersion"
+    testImplementation libs.junit4
+    testImplementation libs.truth
 }

--- a/integration_tests/ctesque/build.gradle
+++ b/integration_tests/ctesque/build.gradle
@@ -49,26 +49,26 @@ dependencies {
     implementation project(':testapp')
 
     testImplementation project(':robolectric')
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation("androidx.test:monitor:$axtMonitorVersion")
-    testImplementation("androidx.test:runner:$axtRunnerVersion")
-    testImplementation("androidx.test:rules:$axtRulesVersion")
-    testImplementation("androidx.test.ext:junit:$axtJunitVersion")
-    testImplementation("androidx.test.ext:truth:$axtTruthVersion")
-    testImplementation("androidx.test:core:$axtCoreVersion")
-    testImplementation("androidx.test.espresso:espresso-core:$espressoVersion")
-    testImplementation("com.google.truth:truth:${truthVersion}")
-    testImplementation("com.google.guava:guava:$guavaJREVersion")
+    testImplementation libs.junit4
+    testImplementation libs.androidx.test.monitor
+    testImplementation libs.androidx.test.runner
+    testImplementation libs.androidx.test.rules
+    testImplementation libs.androidx.test.ext.junit
+    testImplementation libs.androidx.test.ext.truth
+    testImplementation libs.androidx.test.core
+    testImplementation libs.androidx.test.espresso.core
+    testImplementation libs.truth
+    testImplementation libs.guava
 
     // Testing dependencies
     androidTestImplementation project(':shadowapi')
-    androidTestImplementation("androidx.test:monitor:$axtMonitorVersion")
-    androidTestImplementation("androidx.test:runner:$axtRunnerVersion")
-    androidTestImplementation("androidx.test:rules:$axtRulesVersion")
-    androidTestImplementation("androidx.test.ext:junit:$axtJunitVersion")
-    androidTestImplementation("androidx.test.ext:truth:$axtTruthVersion")
-    androidTestImplementation("androidx.test.espresso:espresso-core:$espressoVersion")
-    androidTestImplementation("com.google.truth:truth:${truthVersion}")
-    androidTestImplementation("com.google.guava:guava:$guavaJREVersion")
-    androidTestUtil "androidx.test.services:test-services:$axtTestServicesVersion"
+    androidTestImplementation libs.androidx.test.monitor
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.androidx.test.ext.junit
+    androidTestImplementation libs.androidx.test.ext.truth
+    androidTestImplementation libs.androidx.test.espresso.core
+    androidTestImplementation libs.truth
+    androidTestImplementation libs.guava
+    androidTestUtil libs.androidx.test.services
 }

--- a/integration_tests/dependency-on-stubs/build.gradle
+++ b/integration_tests/dependency-on-stubs/build.gradle
@@ -6,13 +6,13 @@ apply plugin: RoboJavaModulePlugin
 
 dependencies {
     api project(":robolectric")
-    api "junit:junit:${junitVersion}"
+    api libs.junit4
 
     testImplementation files("${System.getenv("ANDROID_HOME")}/platforms/android-29/android.jar")
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates // compile against latest Android SDK
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
-    testImplementation "com.google.truth:truth:${truthVersion}"
-    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
-    testImplementation "org.hamcrest:hamcrest-junit:2.0.0.0"
+    testImplementation libs.truth
+    testImplementation libs.mockito
+    testImplementation libs.hamcrest.junit
 }

--- a/integration_tests/jacoco-offline/build.gradle
+++ b/integration_tests/jacoco-offline/build.gradle
@@ -3,6 +3,8 @@ import org.robolectric.gradle.RoboJavaModulePlugin
 apply plugin: RoboJavaModulePlugin
 apply plugin: "jacoco"
 
+def jacocoVersion = libs.versions.jacoco.get()
+
 jacoco {
     toolVersion = jacocoVersion
 }
@@ -18,7 +20,7 @@ dependencies {
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
 
     testImplementation project(":robolectric")
-    testImplementation "junit:junit:$junitVersion"
+    testImplementation libs.junit4
     testImplementation "org.jacoco:org.jacoco.agent:$jacocoVersion:runtime"
 }
 

--- a/integration_tests/kotlin/build.gradle
+++ b/integration_tests/kotlin/build.gradle
@@ -21,8 +21,8 @@ dependencies {
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "com.google.truth:truth:$truthVersion"
+    testImplementation libs.kotlin.stdlib
+    testImplementation libs.junit4
+    testImplementation libs.truth
     testImplementation "androidx.test:core:$axtCoreVersion@aar"
 }

--- a/integration_tests/libphonenumber/build.gradle
+++ b/integration_tests/libphonenumber/build.gradle
@@ -4,10 +4,10 @@ apply plugin: RoboJavaModulePlugin
 
 dependencies {
     api project(":robolectric")
-    api "junit:junit:${junitVersion}"
+    api libs.junit4
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
-    testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation libs.truth
     testImplementation 'com.googlecode.libphonenumber:libphonenumber:8.13.11'
 }

--- a/integration_tests/memoryleaks/build.gradle
+++ b/integration_tests/memoryleaks/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     // Testing dependencies
     testImplementation project(path: ':testapp')
     testImplementation project(":robolectric")
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "com.google.guava:guava-testlib:$guavaJREVersion"
-    testImplementation "androidx.fragment:fragment:$fragmentVersion"
+    testImplementation libs.junit4
+    testImplementation libs.guava.testlib
+    testImplementation libs.androidx.fragment
 }

--- a/integration_tests/mockito-experimental/build.gradle
+++ b/integration_tests/mockito-experimental/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "com.google.truth:truth:${truthVersion}"
-    testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.mockito.inline
 }

--- a/integration_tests/mockito-kotlin/build.gradle
+++ b/integration_tests/mockito-kotlin/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
     testImplementation "androidx.test.ext:junit:$axtJunitVersion@aar"
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "com.google.truth:truth:$truthVersion"
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.kotlin.stdlib
+    testImplementation libs.mockito
 }

--- a/integration_tests/mockito/build.gradle
+++ b/integration_tests/mockito/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "com.google.truth:truth:${truthVersion}"
-    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.mockito
 }

--- a/integration_tests/mockk/build.gradle
+++ b/integration_tests/mockk/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "com.google.truth:truth:${truthVersion}"
-    testImplementation 'io.mockk:mockk:1.13.5'
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.mockk
 }

--- a/integration_tests/nativegraphics/build.gradle
+++ b/integration_tests/nativegraphics/build.gradle
@@ -33,9 +33,9 @@ dependencies {
     testImplementation AndroidSdk.MAX_SDK.coordinates
     testImplementation project(':robolectric')
 
-    testImplementation "androidx.core:core:$coreVersion"
-    testImplementation "androidx.test.ext:junit:$axtJunitVersion"
-    testImplementation "com.google.truth:truth:${truthVersion}"
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation libs.androidx.core
+    testImplementation libs.androidx.test.ext.junit
+    testImplementation libs.truth
+    testImplementation libs.junit4
+    testImplementation libs.mockito
 }

--- a/integration_tests/play_services/build.gradle
+++ b/integration_tests/play_services/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "com.google.truth:truth:$truthVersion"
+    testImplementation libs.junit4
+    testImplementation libs.truth
     testImplementation "com.google.android.gms:play-services-basement:18.0.1"
 }

--- a/integration_tests/powermock/build.gradle
+++ b/integration_tests/powermock/build.gradle
@@ -7,8 +7,8 @@ dependencies {
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation libs.junit4
+    testImplementation libs.truth
 
     testImplementation "org.powermock:powermock-module-junit4:2.0.9"
     testImplementation "org.powermock:powermock-module-junit4-rule:2.0.9"

--- a/integration_tests/security-providers/build.gradle
+++ b/integration_tests/security-providers/build.gradle
@@ -4,12 +4,12 @@ apply plugin: RoboJavaModulePlugin
 
 dependencies {
     api project(":robolectric")
-    api "junit:junit:${junitVersion}"
+    api libs.junit4
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
-    testImplementation "com.google.truth:truth:${truthVersion}"
-    testImplementation "org.conscrypt:conscrypt-openjdk-uber:2.5.2"
+    testImplementation libs.truth
+    testImplementation libs.conscrypt.openjdk.uber
     testImplementation "com.squareup.okhttp3:okhttp"
     testImplementation platform("com.squareup.okhttp3:okhttp-bom:4.11.0")
 }

--- a/integration_tests/sparsearray/build.gradle
+++ b/integration_tests/sparsearray/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
     testImplementation project(":robolectric")
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "com.google.truth:truth:$truthVersion"
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.kotlin.stdlib
 }

--- a/junit/build.gradle
+++ b/junit/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     api project(":shadowapi")
     api project(":utils:reflector")
 
-    compileOnly "com.google.code.findbugs:jsr305:3.0.2"
-    compileOnly "junit:junit:${junitVersion}"
+    compileOnly libs.findbugs.jsr305
+    compileOnly libs.junit4
 }

--- a/nativeruntime/build.gradle
+++ b/nativeruntime/build.gradle
@@ -64,17 +64,17 @@ if (System.getenv('PUBLISH_NATIVERUNTIME_DIST_COMPAT') == "true") {
 dependencies {
   api project(":utils")
   api project(":utils:reflector")
-  api "com.google.guava:guava:$guavaJREVersion"
+  api libs.guava
 
   implementation "org.robolectric:nativeruntime-dist-compat:1.0.1"
 
-  annotationProcessor "com.google.auto.service:auto-service:$autoServiceVersion"
-  compileOnly "com.google.auto.service:auto-service-annotations:$autoServiceVersion"
+  annotationProcessor libs.auto.service
+  compileOnly libs.auto.service.annotations
   compileOnly AndroidSdk.MAX_SDK.coordinates
 
   testCompileOnly AndroidSdk.MAX_SDK.coordinates
   testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
   testImplementation project(":robolectric")
-  testImplementation "junit:junit:${junitVersion}"
-  testImplementation "com.google.truth:truth:${truthVersion}"
+  testImplementation libs.junit4
+  testImplementation libs.truth
 }

--- a/pluginapi/build.gradle
+++ b/pluginapi/build.gradle
@@ -5,11 +5,11 @@ apply plugin: RoboJavaModulePlugin
 apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
-    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+    compileOnly libs.findbugs.jsr305
     api project(":annotations")
-    api "com.google.guava:guava:$guavaJREVersion"
+    api libs.guava
 
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "com.google.truth:truth:${truthVersion}"
-    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.mockito
 }

--- a/plugins/maven-dependency-resolver/build.gradle
+++ b/plugins/maven-dependency-resolver/build.gradle
@@ -49,10 +49,10 @@ afterEvaluate {
 dependencies {
     api project(":pluginapi")
     api project(":utils")
-    api "com.google.guava:guava:$guavaJREVersion"
+    api libs.guava
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testImplementation "com.google.truth:truth:$truthVersion"
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    testImplementation libs.junit4
+    testImplementation libs.mockito
+    testImplementation libs.truth
+    testImplementation libs.kotlin.stdlib
 }

--- a/preinstrumented/build.gradle
+++ b/preinstrumented/build.gradle
@@ -17,7 +17,7 @@ java {
 }
 
 dependencies {
-    implementation "com.google.guava:guava:$guavaJREVersion"
+    implementation libs.guava
     implementation project(":sandbox")
 }
 

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -35,12 +35,12 @@ dependencies {
     api project(":annotations")
     api project(":shadowapi")
 
-    compileOnly "com.google.code.findbugs:jsr305:3.0.2"
-    api "org.ow2.asm:asm:${asmVersion}"
-    api "org.ow2.asm:asm-commons:${asmVersion}"
-    api "com.google.guava:guava:$guavaJREVersion"
-    api "com.google.code.gson:gson:2.10.1"
-    implementation 'com.google.auto:auto-common:1.2.1'
+    compileOnly libs.findbugs.jsr305
+    api libs.asm
+    api libs.asm.commons
+    api libs.guava
+    api libs.gson
+    implementation libs.auto.common
 
     def toolsJar = Jvm.current().getToolsJar()
     if (toolsJar != null) {
@@ -48,8 +48,8 @@ dependencies {
     }
 
     testImplementation "javax.annotation:jsr250-api:1.0"
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
-    testImplementation "com.google.testing.compile:compile-testing:0.21.0"
-    testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation libs.junit4
+    testImplementation libs.mockito
+    testImplementation libs.compile.testing
+    testImplementation libs.truth
 }

--- a/resources/build.gradle
+++ b/resources/build.gradle
@@ -9,11 +9,11 @@ dependencies {
     api project(":annotations")
     api project(":pluginapi")
 
-    api "com.google.guava:guava:$guavaJREVersion"
-    compileOnly "com.google.code.findbugs:jsr305:3.0.2"
+    api libs.guava
+    compileOnly libs.findbugs.jsr305
 
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "com.google.truth:truth:${truthVersion}"
-    testImplementation "com.google.testing.compile:compile-testing:0.21.0"
-    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.compile.testing
+    testImplementation libs.mockito
 }

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -5,8 +5,8 @@ apply plugin: RoboJavaModulePlugin
 apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
-    annotationProcessor "com.google.auto.service:auto-service:$autoServiceVersion"
-    annotationProcessor "com.google.errorprone:error_prone_core:$errorproneVersion"
+    annotationProcessor libs.auto.service
+    annotationProcessor libs.error.prone.core
 
     api project(":annotations")
     api project(":junit")
@@ -17,32 +17,33 @@ dependencies {
     api project(":utils:reflector")
     api project(":plugins:maven-dependency-resolver")
     api "javax.inject:javax.inject:1"
-    compileOnly "com.google.auto.service:auto-service-annotations:$autoServiceVersion"
+    compileOnly libs.auto.service.annotations
     api "javax.annotation:javax.annotation-api:1.3.2"
 
     // We need to have shadows-framework.jar on the runtime system classpath so ServiceLoader
     //   can find its META-INF/services/org.robolectric.shadows.ShadowAdapter.
     api project(":shadows:framework")
 
-    implementation 'org.conscrypt:conscrypt-openjdk-uber:2.5.2'
-    api "org.bouncycastle:bcprov-jdk18on:1.73"
-    compileOnly "com.google.code.findbugs:jsr305:3.0.2"
+    implementation libs.conscrypt.openjdk.uber
+    api libs.bcprov.jdk18on
+    compileOnly libs.findbugs.jsr305
 
     compileOnly AndroidSdk.MAX_SDK.coordinates
-    compileOnly "junit:junit:${junitVersion}"
+    compileOnly libs.junit4
+
     api "androidx.test:monitor:$axtMonitorVersion@aar"
     implementation "androidx.test.espresso:espresso-idling-resource:$espressoVersion@aar"
 
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "com.google.truth:truth:${truthVersion}"
-    testImplementation "com.google.truth.extensions:truth-java8-extension:${truthVersion}"
-    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
-    testImplementation "org.hamcrest:hamcrest-junit:2.0.0.0"
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.truth.java8.extension
+    testImplementation libs.mockito
+    testImplementation libs.hamcrest.junit
     testImplementation "androidx.test:core:$axtCoreVersion@aar"
     testImplementation "androidx.test.ext:junit:$axtJunitVersion@aar"
     testImplementation "androidx.test.ext:truth:$axtTruthVersion@aar"
     testImplementation "androidx.test:runner:$axtRunnerVersion@aar"
-    testImplementation("com.google.guava:guava:$guavaJREVersion")
+    testImplementation libs.guava
     testCompileOnly AndroidSdk.MAX_SDK.coordinates // compile against latest Android SDK
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates // run against whatever this JDK supports
 }

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -5,24 +5,24 @@ apply plugin: RoboJavaModulePlugin
 apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
-    annotationProcessor "com.google.auto.service:auto-service:$autoServiceVersion"
-    annotationProcessor "com.google.errorprone:error_prone_core:$errorproneVersion"
+    annotationProcessor libs.auto.service
+    annotationProcessor libs.error.prone.core
 
     api project(":annotations")
     api project(":utils")
     api project(":shadowapi")
     api project(":utils:reflector")
-    compileOnly "com.google.auto.service:auto-service-annotations:$autoServiceVersion"
+    compileOnly libs.auto.service.annotations
     api "javax.annotation:javax.annotation-api:1.3.2"
     api "javax.inject:javax.inject:1"
 
-    api "org.ow2.asm:asm:${asmVersion}"
-    api "org.ow2.asm:asm-commons:${asmVersion}"
-    api "com.google.guava:guava:$guavaJREVersion"
-    compileOnly "com.google.code.findbugs:jsr305:3.0.2"
+    api libs.asm
+    api libs.asm.commons
+    api libs.guava
+    compileOnly libs.findbugs.jsr305
 
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "com.google.truth:truth:${truthVersion}"
-    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.mockito
     testImplementation project(":junit")
 }

--- a/shadowapi/build.gradle
+++ b/shadowapi/build.gradle
@@ -5,11 +5,11 @@ apply plugin: RoboJavaModulePlugin
 apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
-    compileOnly "com.google.code.findbugs:jsr305:3.0.2"
+    compileOnly libs.findbugs.jsr305
 
     api project(":annotations")
     api project(":utils")
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "com.google.truth:truth:${truthVersion}"
-    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.mockito
 }

--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -15,6 +15,8 @@ configurations {
     sqlite4java
 }
 
+def sqlite4javaVersion = libs.versions.sqlite4java.get()
+
 task copySqliteNatives(type: Copy) {
     from project.configurations.sqlite4java {
         include '**/*.dll'
@@ -47,20 +49,21 @@ dependencies {
     api project(":shadowapi")
     api project(":utils")
     api project(":utils:reflector")
+
     api "androidx.test:monitor:$axtMonitorVersion@aar"
 
-    implementation "com.google.errorprone:error_prone_annotations:$errorproneVersion"
-    compileOnly "com.google.code.findbugs:jsr305:3.0.2"
-    api "com.almworks.sqlite4java:sqlite4java:$sqlite4javaVersion"
+    implementation libs.error.prone.annotations
+    compileOnly libs.findbugs.jsr305
+    api libs.sqlite4java
     compileOnly(AndroidSdk.MAX_SDK.coordinates)
     api "com.ibm.icu:icu4j:73.1"
-    api "androidx.annotation:annotation:1.3.0"
-    api "com.google.auto.value:auto-value-annotations:1.10.1"
-    annotationProcessor "com.google.auto.value:auto-value:1.10.1"
+    api libs.androidx.annotation
+    api libs.auto.value.annotations
+    annotationProcessor libs.auto.value
 
-    sqlite4java "com.almworks.sqlite4java:libsqlite4java-osx:$sqlite4javaVersion"
-    sqlite4java "com.almworks.sqlite4java:libsqlite4java-linux-amd64:$sqlite4javaVersion"
-    sqlite4java "com.almworks.sqlite4java:sqlite4java-win32-x64:$sqlite4javaVersion"
-    sqlite4java "com.almworks.sqlite4java:libsqlite4java-linux-i386:$sqlite4javaVersion"
-    sqlite4java "com.almworks.sqlite4java:sqlite4java-win32-x86:$sqlite4javaVersion"
+    sqlite4java libs.sqlite4java.osx
+    sqlite4java libs.sqlite4java.linux.amd64
+    sqlite4java libs.sqlite4java.win32.x64
+    sqlite4java libs.sqlite4java.linux.i386
+    sqlite4java libs.sqlite4java.win32.x86
 }

--- a/shadows/httpclient/build.gradle
+++ b/shadows/httpclient/build.gradle
@@ -26,9 +26,9 @@ dependencies {
     compileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates)
 
     testImplementation project(":robolectric")
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "com.google.truth:truth:${truthVersion}"
-    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.mockito
     testImplementation "androidx.test.ext:junit:$axtJunitVersion@aar"
 
     testCompileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates)

--- a/shadows/playservices/build.gradle
+++ b/shadows/playservices/build.gradle
@@ -14,7 +14,7 @@ shadows {
 dependencies {
     compileOnly project(":shadows:framework")
     api project(":annotations")
-    api "com.google.guava:guava:$guavaJREVersion"
+    api libs.guava
 
     compileOnly "androidx.fragment:fragment:1.2.0"
     compileOnly "com.google.android.gms:play-services-base:8.4.0"
@@ -27,9 +27,9 @@ dependencies {
     testCompileOnly "com.google.android.gms:play-services-basement:8.4.0"
 
     testImplementation project(":robolectric")
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "com.google.truth:truth:$truthVersion"
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.mockito
     testRuntimeOnly "androidx.fragment:fragment:1.2.0"
     testRuntimeOnly "com.google.android.gms:play-services-base:8.4.0"
     testRuntimeOnly "com.google.android.gms:play-services-basement:8.4.0"

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -53,15 +53,15 @@ dependencies {
     api "javax.annotation:javax.annotation-api:1.3.2"
 
     // For @VisibleForTesting and ByteStreams
-    implementation "com.google.guava:guava:$guavaJREVersion"
-    compileOnly "com.google.code.findbugs:jsr305:3.0.2"
+    implementation libs.guava
+    compileOnly libs.findbugs.jsr305
 
-    testCompileOnly "com.google.auto.service:auto-service-annotations:$autoServiceVersion"
-    testAnnotationProcessor "com.google.auto.service:auto-service:$autoServiceVersion"
-    testAnnotationProcessor "com.google.errorprone:error_prone_core:$errorproneVersion"
-    implementation "com.google.errorprone:error_prone_annotations:$errorproneVersion"
+    testCompileOnly libs.auto.service.annotations
+    testAnnotationProcessor libs.auto.service
+    testAnnotationProcessor libs.error.prone.core
+    implementation libs.error.prone.annotations
 
-    testImplementation "junit:junit:$junitVersion"
-    testImplementation "com.google.truth:truth:$truthVersion"
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.kotlin.stdlib
 }

--- a/utils/reflector/build.gradle
+++ b/utils/reflector/build.gradle
@@ -5,12 +5,12 @@ apply plugin: RoboJavaModulePlugin
 apply plugin: DeployedRoboJavaModulePlugin
 
 dependencies {
-    api "org.ow2.asm:asm:${asmVersion}"
-    api "org.ow2.asm:asm-commons:${asmVersion}"
-    api "org.ow2.asm:asm-util:${asmVersion}"
+    api libs.asm
+    api libs.asm.commons
+    api libs.asm.util
     api project(":utils")
 
     testImplementation project(":shadowapi")
-    testImplementation "junit:junit:${junitVersion}"
-    testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation libs.junit4
+    testImplementation libs.truth
 }


### PR DESCRIPTION
### Overview
Enable Version Catalogs
Fix #7196

### Proposed Changes
* Added `gradle/libs.versions.toml`
* Added `buildSrc/settings.gradle` to use `gradle/libs.versions.toml` on `buildSrc`
* Migrate `build.gradle` scripts to use Version Catalogs
* Version Catalogs cannot still support artifact type such as `@aar` :  https://github.com/gradle/gradle/issues/21267
  * So, version name of these artifacts still exposed on `dependencies.gradle`, but imported from Version Catalogs