### PR TITLE
Enable version catalogs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ buildscript {
     dependencies {
         gradle
         classpath libs.android.gradle
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:3.1.0'
-        classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
+        classpath libs.error.prone.gradle
+        classpath libs.aggregate.javadocs.gradle
         classpath libs.kotlin.gradle
         classpath libs.spotless.gradle
     }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation localGroovy()
 
     api libs.guava
-    api 'org.jetbrains:annotations:24.0.1'
+    api libs.jetbrains.annotations
     implementation libs.asm.tree
     implementation libs.android.gradle
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    apiCompatVersion = '4.10'
+    apiCompatVersion = libs.versions.robolectric.compat.get()
 
     // https://github.com/gradle/gradle/issues/21267
     axtCoreVersion = libs.versions.androidx.test.core.get()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,7 @@
 [versions]
+robolectric-compat = "4.10.2"
+robolectric-nativeruntime-dist-compat = "1.0.1"
+
 # https://developer.android.com/studio/releases
 android-gradle = "7.4.2"
 
@@ -14,15 +17,25 @@ findbugs-jsr305 = "3.0.2"
 # https://github.com/hamcrest/JavaHamcrest/releases
 hamcrest = "2.0.0.0"
 
+# https://github.com/nebula-plugins/gradle-aggregate-javadocs-plugin/releases
+aggregate-javadocs-gradle = "3.0.1"
+
 # https://github.com/google/error-prone/releases
 error-prone = "2.18.0"
 error-prone-javac = "9+181-r4173-1"
+
+# https://github.com/tbroyer/gradle-errorprone-plugin/releases
+error-prone-gradle = "3.1.0"
 
 # https://kotlinlang.org/docs/releases.html#release-details
 kotlin = "1.8.10"
 
 # https://github.com/diffplug/spotless/blob/main/CHANGES.md
 spotless-gradle = "6.18.0"
+
+# https://hc.apache.org/news.html
+apache-http-core = "4.0.1"
+apache-http-client = "4.0.3"
 
 # https://asm.ow2.io/versions.html
 asm = "9.5"
@@ -43,16 +56,36 @@ gson = "2.10.1"
 # https://github.com/google/truth/releases
 truth = "1.1.3"
 
+# https://github.com/unicode-org/icu/releases
+icu4j = "73.1"
+
 jacoco = "0.8.10"
+
+# https://github.com/javaee/javax.annotation/tags
+javax-annotation-api = "1.3.2"
+javax-annotation-jsr250-api = "1.0"
+javax-inject = "1"
+
+# https://github.com/JetBrains/java-annotations/releases
+jetbrains-annotations = "24.0.1"
 
 # https://junit.org/junit4/
 junit4 = "4.13.2"
+
+# https://github.com/google/libphonenumber/releases
+libphonenumber = "8.13.11"
 
 # https://github.com/mockito/mockito/releases
 mockito = "4.11.0"
 
 # https://github.com/mockk/mockk/releases
 mockk = "1.13.5"
+
+# https://square.github.io/okhttp/changelogs/changelog/
+okhttp = "4.11.0"
+
+# https://github.com/powermock/powermock/releases
+powermock = "2.0.9"
 
 sqlite4java = "1.0.392"
 
@@ -76,6 +109,9 @@ androidx-test-orchestrator="1.4.2"
 androidx-test-runner = "1.5.2"
 androidx-test-services = "1.4.2"
 
+# for shadows/playservices/build.gradle
+androidx-fragment-for-shadows = "1.2.0"
+play-services-base-for-shadows = "8.4.0"
 
 [libraries]
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
@@ -90,6 +126,9 @@ auto-service = { module = "com.google.auto.service:auto-service", version.ref = 
 auto-value-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "auto-value" }
 auto-value = { module = "com.google.auto.value:auto-value", version.ref = "auto-value" }
 
+apache-http-core = { module = "org.apache.httpcomponents:httpcore", version.ref = "apache-http-core" }
+apache-http-client = { module = "org.apache.httpcomponents:httpclient", version.ref = "apache-http-client" }
+
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 asm-commons = { module = "org.ow2.asm:asm-commons", version.ref = "asm" }
 asm-util = { module = "org.ow2.asm:asm-util", version.ref = "asm" }
@@ -97,12 +136,16 @@ asm-tree = { module = "org.ow2.asm:asm-tree", version.ref = "asm" }
 
 compile-testing = { module = "com.google.testing.compile:compile-testing", version.ref = "compile-testing" }
 
+aggregate-javadocs-gradle = { module = "com.netflix.nebula:gradle-aggregate-javadocs-plugin", version.ref = "aggregate-javadocs-gradle" }
+
 error-prone-core =  { module = "com.google.errorprone:error_prone_core", version.ref = "error-prone" }
 error-prone-annotations = { module = "com.google.errorprone:error_prone_annotation", version.ref = "error-prone" }
 error-prone-refaster= { module = "com.google.errorprone:error_prone_refaster", version.ref = "error-prone" }
 error-prone-check-api = { module = "com.google.errorprone:error_prone_check_api", version.ref = "error-prone" }
 error-prone-test-helpers = { module = "com.google.errorprone:error_prone_test_helpers", version.ref = "error-prone" }
 error-prone-javac =  { module = "com.google.errorprone:javac", version.ref = "error-prone-javac" }
+
+error-prone-gradle = { module = "net.ltgt.gradle:gradle-errorprone-plugin", version.ref = "error-prone-gradle" }
 
 conscrypt-openjdk-uber = { module = "org.conscrypt:conscrypt-openjdk-uber", version.ref = "conscrypt" }
 bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
@@ -113,8 +156,28 @@ guava-testlib = { module = "com.google.guava:guava-testlib", version.ref = "guav
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 hamcrest-junit = { module = "org.hamcrest:hamcrest-junit", version.ref = "hamcrest" }
 
+icu4j = { module = "com.ibm.icu:icu4j", version.ref = "icu4j" }
+
 jacoco-agent = { module = "org.jacoco:org.jacoco.agent", version.ref = "jacoco" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
+
+javax-annotation-api = { module = "javax.annotation:javax.annotation-api", version.ref = "javax-annotation-api" }
+javax-annotation-jsr250-api = { module = "javax.annotation:jsr250-api", version.ref = "javax-annotation-jsr250-api" }
+javax-inject = { module = "javax.inject:javax.inject", version.ref = "javax.inject" }
+
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
+
+libphonenumber = { module = "com.googlecode.libphonenumber:libphonenumber", version.ref = "libphonenumber" }
+
+okhttp = { module = "com.squareup.okhttp3:okhttp" }
+okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
+
+powermock-module-junit4 = { module = "org.powermock:powermock-module-junit4", version.ref = "powermock" }
+powermock-module-junit4-rule = { module = "org.powermock:powermock-module-junit4-rule", version.ref = "powermock" }
+powermock-api-mockito2 = { module = "org.powermock:powermock-api-mockito2", version.ref = "powermock" }
+powermock-classloading-xstream = { module = "org.powermock:powermock-classloading-xstream", version.ref = "powermock" }
+
+robolectric-nativeruntime-dist-compat = { module = "org.robolectric:nativeruntime-dist-compat", version.ref = "robolectric-nativeruntime-dist-compat" }
 
 sqlite4java = { module = "com.almworks.sqlite4java:sqlite4java", version.ref = "sqlite4java" }
 sqlite4java-osx = { module = "com.almworks.sqlite4java:libsqlite4java-osx", version.ref = "sqlite4java" }
@@ -162,5 +225,13 @@ androidx-test-espresso-idling-net = { module = "androidx.test.espresso.idling:id
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext-junit" }
 androidx-test-ext-truth = { module = "androidx.test.ext:truth", version.ref = "androidx-test-ext-truth" }
 
+androidx-fragment-for-shadows = { module = "androidx.fragment:fragment", version.ref = "androidx-fragment-for-shadows" }
+play-services-base-for-shadows = { module = "com.google.android.gms:play-services-base", version.ref = "play-services-base-for-shadows" }
+play-services-basement-for-shadows = { module = "com.google.android.gms:play-services-basement", version.ref = "play-services-base-for-shadows" }
+
+[bundles]
+play-services-base-for-shadows = [ "androidx-fragment-for-shadows", "play-services-base-for-shadows", "play-services-basement-for-shadows" ]
+powermock = [ "powermock-module-junit4", "powermock-module-junit4-rule", "powermock-api-mockito2", "powermock-classloading-xstream" ]
+sqlite4java-native = [ "sqlite4java-osx", "sqlite4java-linux-amd64", "sqlite4java-win32-x64", "sqlite4java-linux-i386", "sqlite4java-win32-x86" ]
 
 [plugins]

--- a/integration_tests/libphonenumber/build.gradle
+++ b/integration_tests/libphonenumber/build.gradle
@@ -9,5 +9,5 @@ dependencies {
 
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
     testImplementation libs.truth
-    testImplementation 'com.googlecode.libphonenumber:libphonenumber:8.13.11'
+    testImplementation libs.libphonenumber
 }

--- a/integration_tests/powermock/build.gradle
+++ b/integration_tests/powermock/build.gradle
@@ -10,8 +10,5 @@ dependencies {
     testImplementation libs.junit4
     testImplementation libs.truth
 
-    testImplementation "org.powermock:powermock-module-junit4:2.0.9"
-    testImplementation "org.powermock:powermock-module-junit4-rule:2.0.9"
-    testImplementation "org.powermock:powermock-api-mockito2:2.0.9"
-    testImplementation "org.powermock:powermock-classloading-xstream:2.0.9"
+    testImplementation libs.bundles.powermock
 }

--- a/integration_tests/security-providers/build.gradle
+++ b/integration_tests/security-providers/build.gradle
@@ -10,6 +10,6 @@ dependencies {
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
     testImplementation libs.truth
     testImplementation libs.conscrypt.openjdk.uber
-    testImplementation "com.squareup.okhttp3:okhttp"
-    testImplementation platform("com.squareup.okhttp3:okhttp-bom:4.11.0")
+    testImplementation libs.okhttp
+    testImplementation platform(libs.okhttp.bom)
 }

--- a/nativeruntime/build.gradle
+++ b/nativeruntime/build.gradle
@@ -66,7 +66,7 @@ dependencies {
   api project(":utils:reflector")
   api libs.guava
 
-  implementation "org.robolectric:nativeruntime-dist-compat:1.0.1"
+  implementation libs.robolectric.nativeruntime.dist.compat
 
   annotationProcessor libs.auto.service
   compileOnly libs.auto.service.annotations

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -47,7 +47,7 @@ dependencies {
         implementation files(toolsJar)
     }
 
-    testImplementation "javax.annotation:jsr250-api:1.0"
+    testImplementation libs.javax.annotation.jsr250.api
     testImplementation libs.junit4
     testImplementation libs.mockito
     testImplementation libs.compile.testing

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -16,9 +16,9 @@ dependencies {
     api project(":utils")
     api project(":utils:reflector")
     api project(":plugins:maven-dependency-resolver")
-    api "javax.inject:javax.inject:1"
+    api libs.javax.inject
     compileOnly libs.auto.service.annotations
-    api "javax.annotation:javax.annotation-api:1.3.2"
+    api libs.javax.annotation.api
 
     // We need to have shadows-framework.jar on the runtime system classpath so ServiceLoader
     //   can find its META-INF/services/org.robolectric.shadows.ShadowAdapter.

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     api project(":shadowapi")
     api project(":utils:reflector")
     compileOnly libs.auto.service.annotations
-    api "javax.annotation:javax.annotation-api:1.3.2"
-    api "javax.inject:javax.inject:1"
+    api libs.javax.annotation.api
+    api libs.javax.inject
 
     api libs.asm
     api libs.asm.commons

--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -56,14 +56,10 @@ dependencies {
     compileOnly libs.findbugs.jsr305
     api libs.sqlite4java
     compileOnly(AndroidSdk.MAX_SDK.coordinates)
-    api "com.ibm.icu:icu4j:73.1"
+    api libs.icu4j
     api libs.androidx.annotation
     api libs.auto.value.annotations
     annotationProcessor libs.auto.value
 
-    sqlite4java libs.sqlite4java.osx
-    sqlite4java libs.sqlite4java.linux.amd64
-    sqlite4java libs.sqlite4java.win32.x64
-    sqlite4java libs.sqlite4java.linux.i386
-    sqlite4java libs.sqlite4java.win32.x86
+    sqlite4java libs.bundles.sqlite4java.native
 }

--- a/shadows/httpclient/build.gradle
+++ b/shadows/httpclient/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     api project(":utils")
 
     // We should keep httpclient version for low level API compatibility.
-    earlyRuntime "org.apache.httpcomponents:httpcore:4.0.1"
-    api "org.apache.httpcomponents:httpclient:4.0.3"
+    earlyRuntime libs.apache.http.core
+    api libs.apache.http.client
     compileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates)
 
     testImplementation project(":robolectric")

--- a/shadows/playservices/build.gradle
+++ b/shadows/playservices/build.gradle
@@ -16,23 +16,18 @@ dependencies {
     api project(":annotations")
     api libs.guava
 
-    compileOnly "androidx.fragment:fragment:1.2.0"
-    compileOnly "com.google.android.gms:play-services-base:8.4.0"
-    compileOnly "com.google.android.gms:play-services-basement:8.4.0"
+    compileOnly libs.bundles.play.services.base.for.shadows
 
     compileOnly AndroidSdk.MAX_SDK.coordinates
 
     testCompileOnly AndroidSdk.MAX_SDK.coordinates
-    testCompileOnly "com.google.android.gms:play-services-base:8.4.0"
-    testCompileOnly "com.google.android.gms:play-services-basement:8.4.0"
+    testCompileOnly libs.bundles.play.services.base.for.shadows
 
     testImplementation project(":robolectric")
     testImplementation libs.junit4
     testImplementation libs.truth
     testImplementation libs.mockito
-    testRuntimeOnly "androidx.fragment:fragment:1.2.0"
-    testRuntimeOnly "com.google.android.gms:play-services-base:8.4.0"
-    testRuntimeOnly "com.google.android.gms:play-services-basement:8.4.0"
+    testRuntimeOnly libs.bundles.play.services.base.for.shadows
 
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
 }

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -49,8 +49,8 @@ afterEvaluate {
 dependencies {
     api project(":annotations")
     api project(":pluginapi")
-    api "javax.inject:javax.inject:1"
-    api "javax.annotation:javax.annotation-api:1.3.2"
+    api libs.javax.inject
+    api libs.javax.annotation.api
 
     // For @VisibleForTesting and ByteStreams
     implementation libs.guava


### PR DESCRIPTION
### Overview
Continual work from #8199

### Proposed Changes
* Move version declaring of `apiCompatVersion`
* Use [Dependency Bundle](https://docs.gradle.org/current/userguide/platforms.html#sec:dependency-bundles) for several artifacts
  * Powermock
  * sqlite4java
  * gms-services-base for shadows

After this PR is merged, I'll rebase #6554, too.
