### PR TITLE
Fix shadows framework gradle warnings

### DIFF
--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -40,6 +40,10 @@ jar {
     dependsOn copySqliteNatives
 }
 
+javadoc {
+    dependsOn copySqliteNatives
+}
+
 dependencies {
     api project(":annotations")
     api project(":nativeruntime")

--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -17,7 +17,7 @@ configurations {
 
 def sqlite4javaVersion = libs.versions.sqlite4java.get()
 
-task copySqliteNatives(type: Copy) {
+tasks.register('copySqliteNatives', Copy) {
     from project.configurations.sqlite4java {
         include '**/*.dll'
         include '**/*.so'


### PR DESCRIPTION
The dependsOn relationship should be declared explicit to avoid building error when migrating AGP to 8.x. 