### PR TITLE
Add new Shadow for android.hardware.biometrics.CryptoObject to avoid MethodNotFound errors

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,6 +92,7 @@ sqlite4java = "1.0.392"
 # https://developer.android.com/jetpack/androidx/versions
 androidx-annotation = "1.3.0"
 androidx-appcompat = "1.6.1"
+androidx-biometric = "1.1.0"
 androidx-constraintlayout = "2.1.4"
 androidx-core = "1.10.1"
 androidx-fragment = "1.5.7"
@@ -195,6 +196,7 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
+androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "androidx-biometric" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }
 androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "androidx-fragment" }

--- a/integration_tests/androidx_test/build.gradle
+++ b/integration_tests/androidx_test/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     testImplementation libs.androidx.test.espresso.core
     testImplementation libs.androidx.test.ext.truth
     testImplementation libs.androidx.test.core
+    testImplementation libs.androidx.biometric
     testImplementation libs.androidx.fragment
     testImplementation libs.androidx.fragment.testing
     testImplementation libs.androidx.test.ext.junit

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/CryptoObjectTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/CryptoObjectTest.java
@@ -1,0 +1,65 @@
+package org.robolectric.integrationtests.axt;
+
+import static org.junit.Assert.fail;
+
+import androidx.annotation.NonNull;
+import androidx.biometric.BiometricPrompt;
+import androidx.biometric.BiometricPrompt.PromptInfo;
+import androidx.fragment.app.FragmentActivity;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.Executor;
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.android.controller.ActivityController;
+
+/** Test intercepting classes not present in OpenJDK. */
+@RunWith(AndroidJUnit4.class)
+public class CryptoObjectTest {
+
+  private FragmentActivity fragmentActivity;
+
+  @Before
+  public void setUp() {
+    fragmentActivity =
+        ActivityController.of(new FragmentActivity()).create().resume().start().get();
+  }
+
+  @Test
+  public void biometricPromptAuthenticateShouldNotCrashWithNoSuchMethodError()
+      throws NoSuchPaddingException, NoSuchAlgorithmException {
+    BiometricPrompt biometricPrompt =
+        new BiometricPrompt(
+            fragmentActivity,
+            new Executor() {
+              @Override
+              public void execute(Runnable command) {}
+            },
+            new BiometricPrompt.AuthenticationCallback() {
+              @Override
+              public void onAuthenticationError(int errorCode, @NonNull CharSequence errString) {}
+
+              @Override
+              public void onAuthenticationSucceeded(
+                  @NonNull BiometricPrompt.AuthenticationResult result) {}
+
+              @Override
+              public void onAuthenticationFailed() {}
+            });
+
+    PromptInfo promptInfo =
+        new PromptInfo.Builder()
+            .setTitle("Set and not empty")
+            .setNegativeButtonText("Set and not empty")
+            .build();
+    try {
+      biometricPrompt.authenticate(
+          promptInfo, new BiometricPrompt.CryptoObject(Cipher.getInstance("RSA")));
+    } catch (NoSuchMethodError e) {
+      fail();
+    }
+  }
+}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCryptoObject.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCryptoObject.java
@@ -1,0 +1,19 @@
+package org.robolectric.shadows;
+
+import static android.os.Build.VERSION_CODES.P;
+
+import android.hardware.biometrics.CryptoObject;
+import org.robolectric.annotation.HiddenApi;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@SuppressWarnings("UnusedDeclaration")
+@Implements(value = CryptoObject.class, isInAndroidSdk = false, minSdk = P)
+public class ShadowCryptoObject {
+
+  @Implementation
+  @HiddenApi
+  protected final long getOpId() {
+    return 0L;
+  }
+}


### PR DESCRIPTION
### Overview
New attempt to fix [Intercept Cipher#getCurrentSpi to avoid running error](https://github.com/robolectric/robolectric/pull/8250/commits/c735405ce7814edfad265084bd8f9c3521870c90)

### Proposed Changes
New shadow