### PR TITLE
Use macos12 to run graphics test

### DIFF
--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   graphics_tests:
-    runs-on: self-hosted
+    runs-on: macos-12
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
For https://github.com/robolectric/robolectric/issues/8260.

@hoisie Before M1 environment has been updated, I decide to switch to use macos runner provided by GitHub Actions to make graphics test work as temporary solution.