### PR TITLE
Run graphics tests on Ubuntu and M1

### DIFF
--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -16,7 +16,10 @@ permissions:
 
 jobs:
   graphics_tests:
-    runs-on: macos-12
+    strategy:
+      matrix:
+        device: [ macos-12, ubuntu-20.04, self-hosted ]
+    runs-on: ${{ matrix.device }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
nativegraphics support multiple OS and architectures, it's great to run it on multiple OS and architectures. This CL adds Ubuntu x64 and macOS M1.
