### PR TITLE
Set jvm target for maven-dependency-resolver compileTestKotlin

### DIFF
--- a/plugins/maven-dependency-resolver/build.gradle
+++ b/plugins/maven-dependency-resolver/build.gradle
@@ -30,6 +30,10 @@ compileKotlin {
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8
 }
 
+compileTestKotlin {
+    compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+}
+
 afterEvaluate {
     configurations {
         runtimeElements {


### PR DESCRIPTION
It is needed from AGP 8.x + Gradle 8.x.