### PR TITLE
Ensure bc provider has higher priority for JDK17

### DIFF
--- a/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
@@ -153,18 +153,20 @@ public class AndroidTestEnvironment implements TestEnvironment {
       loggingInitialized = true;
     }
 
-    ConscryptMode.Mode conscryptMode = configuration.get(ConscryptMode.Mode.class);
-    Security.removeProvider(CONSCRYPT_PROVIDER);
-    if (conscryptMode != ConscryptMode.Mode.OFF) {
-
-      Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
-      if (Security.getProvider(CONSCRYPT_PROVIDER) == null) {
-        Security.insertProviderAt(new OpenSSLProvider(), 1);
-      }
+    // Installing BC provider first.
+    if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+      // The position is 1-based, so 1 is the top position.
+      // See
+      // https://docs.oracle.com/javase/8/docs/api/java/security/Security.html#insertProviderAt-java.security.Provider-int-.
+      Security.insertProviderAt(new BouncyCastleProvider(), 1);
     }
 
-    if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
-      Security.addProvider(new BouncyCastleProvider());
+    ConscryptMode.Mode conscryptMode = configuration.get(ConscryptMode.Mode.class);
+    Security.removeProvider(CONSCRYPT_PROVIDER);
+    // If user enables ConscryptMode, installing it Conscrypt provider with higher priority.
+    if (conscryptMode != ConscryptMode.Mode.OFF
+        && Security.getProvider(CONSCRYPT_PROVIDER) == null) {
+      Security.insertProviderAt(new OpenSSLProvider(), 1);
     }
 
     android.content.res.Configuration androidConfiguration =

--- a/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
@@ -121,7 +121,6 @@ public class AndroidTestEnvironmentTest {
   @ConscryptMode(ON)
   public void testWhenConscryptModeOn_ConscryptInstalled()
       throws CertificateException, NoSuchAlgorithmException {
-
     bootstrapWrapper.callSetUpApplicationState();
     CertificateFactory factory = CertificateFactory.getInstance("X.509");
     assertThat(factory.getProvider().getName()).isEqualTo("Conscrypt");
@@ -142,7 +141,6 @@ public class AndroidTestEnvironmentTest {
   @ConscryptMode(OFF)
   public void testWhenConscryptModeOff_ConscryptNotInstalled()
       throws CertificateException, NoSuchAlgorithmException {
-
     bootstrapWrapper.callSetUpApplicationState();
     CertificateFactory factory = CertificateFactory.getInstance("X.509");
     assertThat(factory.getProvider().getName()).isNotEqualTo("Conscrypt");
@@ -154,7 +152,6 @@ public class AndroidTestEnvironmentTest {
   @Test
   @ConscryptMode(OFF)
   public void testWhenConscryptModeOff_BouncyCastleInstalled() throws GeneralSecurityException {
-
     bootstrapWrapper.callSetUpApplicationState();
     MessageDigest digest = MessageDigest.getInstance("SHA256");
     assertThat(digest.getProvider().getName()).isEqualTo(BouncyCastleProvider.PROVIDER_NAME);


### PR DESCRIPTION
The Conscrypt provider has the highest priority when user enables it, and then bc provider. Both of them have higher priority than JDK17 built-in providers.
