### PR TITLE
Introduce a shadow for androidx.core.content.FileProvider

### DIFF
--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     testImplementation "androidx.test.ext:truth:$axtTruthVersion@aar"
     testImplementation "androidx.test:runner:$axtRunnerVersion@aar"
     testImplementation libs.guava
+    testImplementation libs.androidx.core
     testCompileOnly AndroidSdk.MAX_SDK.coordinates // compile against latest Android SDK
     testRuntimeOnly AndroidSdk.MAX_SDK.coordinates // run against whatever this JDK supports
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowFileProviderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowFileProviderTest.java
@@ -1,0 +1,34 @@
+package org.robolectric.shadows;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.content.Context;
+import android.net.Uri;
+import androidx.core.content.FileProvider;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.io.File;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+/** Tests for {@link ShadowFileProvider} */
+@RunWith(AndroidJUnit4.class)
+@Config(shadows = {ShadowFileProvider.class})
+public class ShadowFileProviderTest {
+
+  @Test
+  public void getUriForFile() throws Exception {
+    Context context = ApplicationProvider.getApplicationContext();
+    File cacheDir = context.getCacheDir();
+    File testFile = new File(cacheDir, "test");
+    String authority = "foo";
+    cacheDir.mkdirs();
+    testFile.createNewFile();
+
+    Uri uri = FileProvider.getUriForFile(context, authority, testFile);
+    assertThat(uri.getScheme()).isEqualTo("content");
+    assertThat(uri.getAuthority()).isEqualTo(authority);
+    assertThat(uri.getPath()).isEqualTo(testFile.getAbsolutePath());
+  }
+}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFileProvider.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFileProvider.java
@@ -1,0 +1,35 @@
+package org.robolectric.shadows;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.Build;
+import androidx.annotation.NonNull;
+import java.io.File;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * A shadow implementation of androidx.core.content.FileProvider.
+ *
+ * <p>Currently only supports getUriForFile(). The returned Uri will always have "content" as its
+ * scheme, authority matching to that of the given argument, and path matching to the absolute path
+ * of the given file instance.
+ */
+@Implements(
+    className = "androidx.core.content.FileProvider",
+    isInAndroidSdk = false,
+    minSdk = Build.VERSION_CODES.LOLLIPOP)
+@SuppressWarnings("robolectric.internal.IgnoreMissingClass")
+public class ShadowFileProvider extends ShadowContentProvider {
+
+  @SuppressWarnings("unused")
+  @Implementation
+  public static Uri getUriForFile(
+      @NonNull Context context, @NonNull String authority, @NonNull File file) {
+    return new Uri.Builder()
+        .scheme("content") // URIs produced by FileProvider always have "content" as its scheme.
+        .authority(authority)
+        .path(file.getAbsolutePath())
+        .build();
+  }
+}


### PR DESCRIPTION
### Overview

This MR addresses issue #2199 by introducing a shadow implementation for `androidx.core.content.FileProvider`.

### Proposed Changes

In the `:shadows:framework` module, a new shadow called `ShadowFileProvider` is defined. This shadow provides a mock implementation of the `getUriForFile()` method. When called, it returns a `Uri` that adheres to the following specifications:

- The `scheme` is always set to `content`.
- The `authority` matches the argument passed to the method.
- The `path` matches the absolute path of the provided `File` instance.