### PR TITLE
Retrieve algorithms with BC provider name for special tests

### DIFF
--- a/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
@@ -121,7 +121,6 @@ public class AndroidTestEnvironmentTest {
   @ConscryptMode(ON)
   public void testWhenConscryptModeOn_ConscryptInstalled()
       throws CertificateException, NoSuchAlgorithmException {
-
     bootstrapWrapper.callSetUpApplicationState();
     CertificateFactory factory = CertificateFactory.getInstance("X.509");
     assertThat(factory.getProvider().getName()).isEqualTo("Conscrypt");
@@ -142,7 +141,6 @@ public class AndroidTestEnvironmentTest {
   @ConscryptMode(OFF)
   public void testWhenConscryptModeOff_ConscryptNotInstalled()
       throws CertificateException, NoSuchAlgorithmException {
-
     bootstrapWrapper.callSetUpApplicationState();
     CertificateFactory factory = CertificateFactory.getInstance("X.509");
     assertThat(factory.getProvider().getName()).isNotEqualTo("Conscrypt");
@@ -154,12 +152,12 @@ public class AndroidTestEnvironmentTest {
   @Test
   @ConscryptMode(OFF)
   public void testWhenConscryptModeOff_BouncyCastleInstalled() throws GeneralSecurityException {
-
     bootstrapWrapper.callSetUpApplicationState();
-    MessageDigest digest = MessageDigest.getInstance("SHA256");
+    MessageDigest digest = MessageDigest.getInstance("SHA256", BouncyCastleProvider.PROVIDER_NAME);
     assertThat(digest.getProvider().getName()).isEqualTo(BouncyCastleProvider.PROVIDER_NAME);
 
-    Cipher aesCipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
+    Cipher aesCipher =
+        Cipher.getInstance("AES/CBC/PKCS7Padding", BouncyCastleProvider.PROVIDER_NAME);
     assertThat(aesCipher.getProvider().getName()).isEqualTo(BouncyCastleProvider.PROVIDER_NAME);
   }
 


### PR DESCRIPTION
JDK 17 has built-in providers that support SHA256 and AES, and we can't install BC with the highest priority to avoid maven downloading issues when running code with JDK 17. This CL uses BC provider name to retrieve SHA256 and AES algorithms for
`testWhenConscryptModeOff_BouncyCastleInstalled` to make it run with JDK 17 and keep compatibility.
