### PR TITLE
Bump Kotlin to 1.9.0-RC

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ error-prone-javac = "9+181-r4173-1"
 error-prone-gradle = "3.1.0"
 
 # https://kotlinlang.org/docs/releases.html#release-details
-kotlin = "1.9.0-Beta"
+kotlin = "1.9.0-RC"
 
 # https://github.com/diffplug/spotless/blob/main/CHANGES.md
 spotless-gradle = "6.19.0"


### PR DESCRIPTION
See https://github.com/JetBrains/kotlin/releases/tag/v1.9.0-RC.
