### PR TITLE
Fix typo of addExtensionMimeTypeMapping

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMimeTypeMapTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMimeTypeMapTest.java
@@ -24,13 +24,15 @@ public class ShadowMimeTypeMapTest {
   @Test
   public void shouldResetStaticStateBetweenTests() {
     assertFalse(MimeTypeMap.getSingleton().hasExtension(VIDEO_EXTENSION));
-    shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping(VIDEO_EXTENSION, VIDEO_MIMETYPE);
+    shadowOf(MimeTypeMap.getSingleton())
+        .addExtensionMimeTypeMapping(VIDEO_EXTENSION, VIDEO_MIMETYPE);
   }
 
   @Test
   public void shouldResetStaticStateBetweenTests_anotherTime() {
     assertFalse(MimeTypeMap.getSingleton().hasExtension(VIDEO_EXTENSION));
-    shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping(VIDEO_EXTENSION, VIDEO_MIMETYPE);
+    shadowOf(MimeTypeMap.getSingleton())
+        .addExtensionMimeTypeMapping(VIDEO_EXTENSION, VIDEO_MIMETYPE);
   }
 
   @Test
@@ -50,8 +52,8 @@ public class ShadowMimeTypeMapTest {
   @Test
   public void addingMappingShouldWorkCorrectly() {
     ShadowMimeTypeMap shadowMimeTypeMap = Shadows.shadowOf(MimeTypeMap.getSingleton());
-    shadowMimeTypeMap.addExtensionMimeTypMapping(VIDEO_EXTENSION, VIDEO_MIMETYPE);
-    shadowMimeTypeMap.addExtensionMimeTypMapping(IMAGE_EXTENSION, IMAGE_MIMETYPE);
+    shadowMimeTypeMap.addExtensionMimeTypeMapping(VIDEO_EXTENSION, VIDEO_MIMETYPE);
+    shadowMimeTypeMap.addExtensionMimeTypeMapping(IMAGE_EXTENSION, IMAGE_MIMETYPE);
 
     assertTrue(MimeTypeMap.getSingleton().hasExtension(VIDEO_EXTENSION));
     assertTrue(MimeTypeMap.getSingleton().hasExtension(IMAGE_EXTENSION));
@@ -68,8 +70,8 @@ public class ShadowMimeTypeMapTest {
   @Test
   public void clearMappingsShouldRemoveAllMappings() {
     ShadowMimeTypeMap shadowMimeTypeMap = Shadows.shadowOf(MimeTypeMap.getSingleton());
-    shadowMimeTypeMap.addExtensionMimeTypMapping(VIDEO_EXTENSION, VIDEO_MIMETYPE);
-    shadowMimeTypeMap.addExtensionMimeTypMapping(IMAGE_EXTENSION, IMAGE_MIMETYPE);
+    shadowMimeTypeMap.addExtensionMimeTypeMapping(VIDEO_EXTENSION, VIDEO_MIMETYPE);
+    shadowMimeTypeMap.addExtensionMimeTypeMapping(IMAGE_EXTENSION, IMAGE_MIMETYPE);
 
     shadowMimeTypeMap.clearMappings();
 
@@ -82,8 +84,8 @@ public class ShadowMimeTypeMapTest {
   @Test
   public void unknownExtensionShouldProvideNothing() {
     ShadowMimeTypeMap shadowMimeTypeMap = Shadows.shadowOf(MimeTypeMap.getSingleton());
-    shadowMimeTypeMap.addExtensionMimeTypMapping(VIDEO_EXTENSION, VIDEO_MIMETYPE);
-    shadowMimeTypeMap.addExtensionMimeTypMapping(IMAGE_EXTENSION, IMAGE_MIMETYPE);
+    shadowMimeTypeMap.addExtensionMimeTypeMapping(VIDEO_EXTENSION, VIDEO_MIMETYPE);
+    shadowMimeTypeMap.addExtensionMimeTypeMapping(IMAGE_EXTENSION, IMAGE_MIMETYPE);
 
     assertFalse(MimeTypeMap.getSingleton().hasExtension("foo"));
     assertNull(MimeTypeMap.getSingleton().getMimeTypeFromExtension("foo"));
@@ -92,8 +94,8 @@ public class ShadowMimeTypeMapTest {
   @Test
   public void unknownMimeTypeShouldProvideNothing() {
     ShadowMimeTypeMap shadowMimeTypeMap = Shadows.shadowOf(MimeTypeMap.getSingleton());
-    shadowMimeTypeMap.addExtensionMimeTypMapping(VIDEO_EXTENSION, VIDEO_MIMETYPE);
-    shadowMimeTypeMap.addExtensionMimeTypMapping(IMAGE_EXTENSION, IMAGE_MIMETYPE);
+    shadowMimeTypeMap.addExtensionMimeTypeMapping(VIDEO_EXTENSION, VIDEO_MIMETYPE);
+    shadowMimeTypeMap.addExtensionMimeTypeMapping(IMAGE_EXTENSION, IMAGE_MIMETYPE);
 
     assertFalse(MimeTypeMap.getSingleton().hasMimeType("foo/bar"));
     assertNull(MimeTypeMap.getSingleton().getExtensionFromMimeType("foo/bar"));

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMimeTypeMap.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMimeTypeMap.java
@@ -52,7 +52,7 @@ public class ShadowMimeTypeMap {
     return null;
   }
 
-  public void addExtensionMimeTypMapping(String extension, String mimeType) {
+  public void addExtensionMimeTypeMapping(String extension, String mimeType) {
     extensionToMimeTypeMap.put(extension, mimeType);
     mimeTypeToExtensionMap.put(mimeType, extension);
   }


### PR DESCRIPTION
### Overview
Fix typo of `addExtensionMimeTypeMapping`

### Proposed Changes
I found `addExtensionMimeTypeMapping` incorrectly coded as `addExtensionMimeTypMapping`. Therefore, I propose this correction.