### PR TITLE
Use JDK 19 to run snapshot publish job

### DIFF
--- a/.github/workflows/gradle_tasks_validation.yml
+++ b/.github/workflows/gradle_tasks_validation.yml
@@ -42,12 +42,15 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 19
 
       - uses: gradle/gradle-build-action@v2
 
       - name: Run aggregateDocs
         run: ./gradlew clean aggregateDocs
+
+      - name: Run javadocJar
+        run: ./gradlew :shadows:framework:javadocJar
 
   run_instrumentAll:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,7 +162,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 19
 
       - uses: gradle/gradle-build-action@v2
 


### PR DESCRIPTION
The JDK 17 has a bug when resolving invalid javadoc. 
See
https://bugs.openjdk.org/browse/JDK-8281944?jql=text%20~%20%22ERRONEOUS%22
https://bugs.openjdk.org/browse/JDK-8282352
