### PR TITLE
Allow Matrix.setValues to be called with array size >9.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMatrixTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMatrixTest.java
@@ -153,6 +153,35 @@ public class ShadowMatrixTest {
   }
 
   @Test
+  public void testGetSetValues_withLargeArray() {
+    final Matrix matrix = new Matrix();
+    final float[] values = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+    matrix.setValues(values);
+    final float[] matrixValues = new float[10];
+    matrix.getValues(matrixValues);
+    // First 9 elements should match.
+    for (int i = 0; i < 9; i++) {
+      assertThat(matrixValues[i]).isEqualTo(values[i]);
+    }
+    // The last element should not have been set.
+    assertThat(matrixValues[9]).isEqualTo(0);
+  }
+
+  @Test(expected = ArrayIndexOutOfBoundsException.class)
+  public void testGetValues_withSmallArray() {
+    final Matrix matrix = new Matrix();
+    final float[] matrixValues = new float[8];
+    matrix.getValues(matrixValues);
+  }
+
+  @Test(expected = ArrayIndexOutOfBoundsException.class)
+  public void testSetValues_withSmallArray() {
+    final Matrix matrix = new Matrix();
+    final float[] values = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f};
+    matrix.setValues(values);
+  }
+
+  @Test
   public void testSet() {
     final Matrix matrix1 = new Matrix();
     matrix1.postScale(2.0f, 2.0f);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyMatrix.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyMatrix.java
@@ -426,7 +426,7 @@ public class ShadowLegacyMatrix extends ShadowMatrix {
     }
 
     private SimpleMatrix(float[] values) {
-      if (values.length != 9) {
+      if (values.length < 9) {
         throw new ArrayIndexOutOfBoundsException();
       }
       mValues = Arrays.copyOf(values, 9);


### PR DESCRIPTION
If the array is <9, and ArrayIndexOutOfBoundsException is still thrown.

Tested by new tests in `ShadowMatrixTest`.

Fixes #8369
