### PR TITLE
Reland "Add support to set error message for ShadowGeocoder."

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowGeocoderTTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowGeocoderTTest.java
@@ -1,0 +1,82 @@
+package org.robolectric.shadows;
+
+import static android.os.Build.VERSION_CODES.TIRAMISU;
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.Context;
+import android.location.Address;
+import android.location.Geocoder;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import javax.annotation.Nullable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+@RunWith(AndroidJUnit4.class)
+public class ShadowGeocoderTTest {
+  private static final String GEOCODER_ERROR_MESSAGE = "Failed to get location";
+  private Geocoder geocoder;
+  private List<Address> decodedAddresses;
+  private String errorMessage = "";
+
+  @Before
+  public void setUp() throws Exception {
+    Context context = ApplicationProvider.getApplicationContext();
+    geocoder = new Geocoder(context);
+  }
+
+  @Test
+  @Config(minSdk = TIRAMISU)
+  public void getFromLocationSetsListenerWithTheOverwrittenListLimitingByMaxResults() {
+    ShadowGeocoder shadowGeocoder = shadowOf(geocoder);
+
+    List<Address> list =
+        Arrays.asList(new Address(Locale.getDefault()), new Address(Locale.CANADA));
+    shadowGeocoder.setFromLocation(list);
+
+    Geocoder.GeocodeListener geocodeListener = addresses -> decodedAddresses = addresses;
+
+    geocoder.getFromLocation(90.0, 90.0, 1, geocodeListener);
+    assertThat(decodedAddresses).containsExactly(list.get(0));
+
+    geocoder.getFromLocation(90.0, 90.0, 2, geocodeListener);
+    assertThat(decodedAddresses).containsExactly(list.get(0), list.get(1)).inOrder();
+
+    geocoder.getFromLocation(90.0, 90.0, 3, geocodeListener);
+    assertThat(decodedAddresses).containsExactly(list.get(0), list.get(1)).inOrder();
+  }
+
+  @Test
+  @Config(minSdk = TIRAMISU)
+  public void getFromLocation_onError() {
+    ShadowGeocoder shadowGeocoder = shadowOf(geocoder);
+
+    List<Address> list =
+        Arrays.asList(new Address(Locale.getDefault()), new Address(Locale.CANADA));
+    shadowGeocoder.setFromLocation(list);
+    shadowGeocoder.setErrorMessage(GEOCODER_ERROR_MESSAGE);
+
+    Geocoder.GeocodeListener geocodeListener =
+        new Geocoder.GeocodeListener() {
+          @Override
+          public void onGeocode(List<Address> list) {
+            decodedAddresses = list;
+          }
+
+          @Override
+          public void onError(@Nullable String message) {
+            errorMessage = message;
+          }
+        };
+
+    geocoder.getFromLocation(90.0, 90.0, 1, geocodeListener);
+    assertThat(decodedAddresses).isNull();
+    assertThat(errorMessage).isEqualTo(GEOCODER_ERROR_MESSAGE);
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowGeocoderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowGeocoderTest.java
@@ -1,6 +1,5 @@
 package org.robolectric.shadows;
 
-import static android.os.Build.VERSION_CODES.TIRAMISU;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 import static org.robolectric.Shadows.shadowOf;
@@ -8,7 +7,6 @@ import static org.robolectric.Shadows.shadowOf;
 import android.content.Context;
 import android.location.Address;
 import android.location.Geocoder;
-import android.location.Geocoder.GeocodeListener;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.io.IOException;
@@ -18,14 +16,11 @@ import java.util.Locale;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
 
 /** Unit test for {@link ShadowGeocoder}. */
 @RunWith(AndroidJUnit4.class)
 public class ShadowGeocoderTest {
-
   private Geocoder geocoder;
-  private List<Address> decodedAddresses;
 
   @Before
   public void setUp() throws Exception {
@@ -65,27 +60,6 @@ public class ShadowGeocoderTest {
 
     result = geocoder.getFromLocation(90.0, 90.0, 3);
     assertThat(result).hasSize(2);
-  }
-
-  @Test
-  @Config(minSdk = TIRAMISU)
-  public void getFromLocationSetsListenerWithTheOverwrittenListLimitingByMaxResults() {
-    ShadowGeocoder shadowGeocoder = shadowOf(geocoder);
-
-    List<Address> list =
-        Arrays.asList(new Address(Locale.getDefault()), new Address(Locale.CANADA));
-    shadowGeocoder.setFromLocation(list);
-
-    GeocodeListener geocodeListener = addresses -> decodedAddresses = addresses;
-
-    geocoder.getFromLocation(90.0, 90.0, 1, geocodeListener);
-    assertThat(decodedAddresses).containsExactly(list.get(0));
-
-    geocoder.getFromLocation(90.0, 90.0, 2, geocodeListener);
-    assertThat(decodedAddresses).containsExactly(list.get(0), list.get(1)).inOrder();
-
-    geocoder.getFromLocation(90.0, 90.0, 3, geocodeListener);
-    assertThat(decodedAddresses).containsExactly(list.get(0), list.get(1)).inOrder();
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGeocoder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGeocoder.java
@@ -9,6 +9,7 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
@@ -18,6 +19,7 @@ public final class ShadowGeocoder {
 
   private static boolean isPresent = true;
   private List<Address> fromLocation = new ArrayList<>();
+  private String errorMessage = null;
 
   /** @return true by default, or the value specified via {@link #setIsPresent(boolean)} */
   @Implementation
@@ -64,7 +66,11 @@ public final class ShadowGeocoder {
         longitude);
 
     // On real Android this callback will not happen synchronously.
-    listener.onGeocode(fromLocation.subList(0, Math.min(maxResults, fromLocation.size())));
+    if (errorMessage != null) {
+      listener.onError(errorMessage);
+    } else {
+      listener.onGeocode(fromLocation.subList(0, Math.min(maxResults, fromLocation.size())));
+    }
   }
 
   /**
@@ -79,6 +85,11 @@ public final class ShadowGeocoder {
   /** Sets the value to be returned by {@link Geocoder#getFromLocation(double, double, int)}. */
   public void setFromLocation(List<Address> list) {
     fromLocation = list;
+  }
+
+  /** Sets the value to be passed to {@link GeocodeListener#onError(String)}. */
+  public void setErrorMessage(@Nullable String message) {
+    errorMessage = message;
   }
 
   @Resetter


### PR DESCRIPTION
Android 12 and 12L android-all jars contain Geocoder.GeocodeListener too but Geocoder.GeocodeListener is internal private class not public interface as Android 13. So ClassLoader finds Geocoder.GeocodeListener from Android 12 and 12L android-all jars first and try to let Geocoder.GeocodeListener asynchronous instance in ShadowGeocoderTest to implement interface from a class. It's the main reason that code that looks fine cause un-expected failures on SDK 31 and 32.

This CL just splits ShadowGeocoderTest to two separate tests for ShadowGeocoder before Android 13 and from Android 13 to avoid this error. Hope there is a better solution to avoid this scenario.

Fixes: https://github.com/robolectric/robolectric/issues/8386.
