### PR TITLE
Double duration of awaitFinalized in ShadowThemeTest

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowThemeTest.java
@@ -301,7 +301,7 @@ public class ShadowThemeTest {
 
   private static <T> void awaitFinalized(WeakReference<T> weakRef) {
     final CountDownLatch latch = new CountDownLatch(1);
-    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
     while (System.nanoTime() < deadline) {
       if (weakRef.get() == null) {
         return;


### PR DESCRIPTION
Looks like `shouldFreeNativeObjectInRegistry` becomes flaky with JDK17 sometimes on GitHub Actions.
