### PR TITLE
Support custom ConnectionService inside TelecomManager

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/testing/TestConnectionService.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/testing/TestConnectionService.java
@@ -11,6 +11,8 @@ public class TestConnectionService extends ConnectionService {
 
   /** Listens for calls to {@link TestConnectionService} methods. */
   public interface Listener {
+    default void onCreate() {}
+
     @Nullable
     default Connection onCreateIncomingConnection(
         PhoneAccountHandle connectionManagerPhoneAccount, ConnectionRequest request) {
@@ -34,6 +36,11 @@ public class TestConnectionService extends ConnectionService {
 
   public static void setListener(Listener listener) {
     TestConnectionService.listener = listener == null ? new Listener() {} : listener;
+  }
+
+  @Override
+  public void onCreate() {
+    listener.onCreate();
   }
 
   @Override

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelecomManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelecomManager.java
@@ -95,6 +95,7 @@ public class ShadowTelecomManager {
   private boolean readPhoneStatePermission = true;
   private boolean callPhonePermission = true;
   private boolean handleMmiValue = false;
+  private ConnectionService connectionService;
 
   public CallRequestMode getCallRequestMode() {
     return callRequestMode;
@@ -458,7 +459,7 @@ public class ShadowTelecomManager {
 
     PhoneAccountHandle phoneAccount = verifyNotNull(call.phoneAccount);
     ConnectionRequest request = buildConnectionRequestForIncomingCall(call);
-    ConnectionService service = setupConnectionService(phoneAccount);
+    ConnectionService service = getConnectionService(phoneAccount);
     return service.onCreateIncomingConnection(phoneAccount, request);
   }
 
@@ -477,7 +478,7 @@ public class ShadowTelecomManager {
 
     PhoneAccountHandle phoneAccount = verifyNotNull(call.phoneAccount);
     ConnectionRequest request = buildConnectionRequestForIncomingCall(call);
-    ConnectionService service = setupConnectionService(phoneAccount);
+    ConnectionService service = getConnectionService(phoneAccount);
     service.onCreateIncomingConnectionFailed(phoneAccount, request);
   }
 
@@ -537,7 +538,7 @@ public class ShadowTelecomManager {
 
     PhoneAccountHandle phoneAccount = verifyNotNull(call.phoneAccount);
     ConnectionRequest request = buildConnectionRequestForOutgoingCall(call);
-    ConnectionService service = setupConnectionService(phoneAccount);
+    ConnectionService service = getConnectionService(phoneAccount);
     return service.onCreateOutgoingConnection(phoneAccount, request);
   }
 
@@ -556,7 +557,7 @@ public class ShadowTelecomManager {
 
     PhoneAccountHandle phoneAccount = verifyNotNull(call.phoneAccount);
     ConnectionRequest request = buildConnectionRequestForOutgoingCall(call);
-    ConnectionService service = setupConnectionService(phoneAccount);
+    ConnectionService service = getConnectionService(phoneAccount);
     service.onCreateOutgoingConnectionFailed(phoneAccount, request);
   }
 
@@ -591,6 +592,25 @@ public class ShadowTelecomManager {
 
   public UnknownCallRecord getOnlyUnknownCall() {
     return Iterables.getOnlyElement(unknownCalls);
+  }
+
+  /**
+   * Set connection service.
+   * <p>
+   * This method can be used in case, when you already created connection service
+   * and would like to use it in telecom manager instead of creating new one.
+   *
+   * @param service existing connection service
+   */
+  public void setConnectionService(ConnectionService service) {
+    connectionService = service;
+  }
+
+  private ConnectionService getConnectionService(PhoneAccountHandle phoneAccount) {
+    if (connectionService == null) {
+      connectionService = setupConnectionService(phoneAccount);
+    }
+    return connectionService;
   }
 
   private static ConnectionService setupConnectionService(PhoneAccountHandle phoneAccount) {


### PR DESCRIPTION
### Overview
Hello!

My name is Alexey, and I use robolectric a lot. I'm writing voip application, and I need to write unit tests for logic uses TelecomManager. I found ShadowTelecomManager working with ConnectionService other way, not like in real life. For example, `ShadowTelecomManager` creates `ConnectionService` every time it executes `allowIncomingCall`. But in real life TelecomManager makes bind to `ConnectionService`, then creates connections through it (may be several connections), and then when there are no live calls it makes unbind from ConnectionService (see [more](https://developer.android.com/reference/android/telecom/ConnectionService)). 

In case, when `ConnectionService` was started through `Context.startService`, `ConnectionService` will live after unbind, until manually stopping (see [more](https://developer.android.com/guide/components/bound-services)).

### Proposed Changes
- Add ability to override `ConnectionService` via `ShadowTelecomManager`, because it can be created by someone else
- Cache already created `ConnectionService`