### PR TITLE
Implement creating Activity, ContentProvider and Service using AppComponentFactory

### DIFF
--- a/integration_tests/androidx_test/src/sharedTest/AndroidManifest.xml
+++ b/integration_tests/androidx_test/src/sharedTest/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
 
-  <application>
+  <application
+      android:appComponentFactory="org.robolectric.integrationtests.axt.ActivityScenarioTest$CustomAppComponentFactory"
+      tools:replace="android:appComponentFactory">
     <activity
         android:name="org.robolectric.integrationtests.axt.ActivityTestRuleTest$TranscriptActivity"
         android:exported="true"/>
@@ -17,6 +20,9 @@
         android:exported="true"/>
     <activity
         android:name="org.robolectric.integrationtests.axt.ActivityScenarioTest$TranscriptActivity"
+        android:exported = "true"/>
+    <activity
+        android:name="org.robolectric.integrationtests.axt.ActivityScenarioTest$ActivityWithCustomConstructor"
         android:exported = "true"/>
     <activity-alias
         android:name="org.robolectric.integrationtests.axt.ActivityScenarioTestAlias"

--- a/integration_tests/androidx_test/src/test/AndroidManifest-ActivityScenario.xml
+++ b/integration_tests/androidx_test/src/test/AndroidManifest-ActivityScenario.xml
@@ -7,13 +7,17 @@
       android:minSdkVersion="19"
       android:targetSdkVersion="34"/>
 
-  <application>
+  <application
+        android:appComponentFactory="org.robolectric.integrationtests.axt.ActivityScenarioTest$CustomAppComponentFactory">
     <activity
         android:name="org.robolectric.integrationtests.axt.ActivityScenarioTest$LifecycleOwnerActivity"
         android:exported="true"/>
     <activity
         android:name="org.robolectric.integrationtests.axt.ActivityScenarioTest$TranscriptActivity"
         android:exported = "true"/>
+    <activity
+        android:name="org.robolectric.integrationtests.axt.ActivityScenarioTest$ActivityWithCustomConstructor"
+        android:exported="true"/>
     <activity-alias
         android:name="org.robolectric.integrationtests.axt.ActivityScenarioTestAlias"
         android:targetActivity="org.robolectric.integrationtests.axt.ActivityScenarioTest$TranscriptActivity" />

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/ActivityScenarioTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/ActivityScenarioTest.java
@@ -1,19 +1,23 @@
 package org.robolectric.integrationtests.axt;
 
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
+import static android.os.Build.VERSION_CODES.P;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import android.app.Activity;
+import android.app.AppComponentFactory;
 import android.app.UiAutomation;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.Looper;
-import androidx.fragment.app.Fragment;
-import androidx.appcompat.app.AppCompatActivity;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.R;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Lifecycle.State;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
@@ -104,6 +108,32 @@ public class ActivityScenarioTest {
   @Before
   public void setUp() {
     callbacks.clear();
+  }
+
+  public static class ActivityWithCustomConstructor extends Activity {
+    private final int intValue;
+
+    public ActivityWithCustomConstructor(int intValue) {
+      this.intValue = intValue;
+    }
+
+    public int getIntValue() {
+      return intValue;
+    }
+  }
+
+  public static class CustomAppComponentFactory extends AppComponentFactory {
+
+    @NonNull
+    @Override
+    public Activity instantiateActivity(
+        @NonNull ClassLoader cl, @NonNull String className, @Nullable Intent intent)
+        throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+      if (className.contains(ActivityWithCustomConstructor.class.getName())) {
+        return new ActivityWithCustomConstructor(100);
+      }
+      return super.instantiateActivity(cl, className, intent);
+    }
   }
 
   @Test
@@ -311,6 +341,19 @@ public class ActivityScenarioTest {
           activity -> {
             assertThat(activity.getCallingActivity().getPackageName())
                 .isEqualTo("org.robolectric.integrationtests.axt");
+          });
+    }
+  }
+
+  @Test
+  @Config(minSdk = P)
+  public void launchActivityWithCustomConstructor() {
+    try (ActivityScenario<ActivityWithCustomConstructor> activityScenario =
+        ActivityScenario.launch(ActivityWithCustomConstructor.class)) {
+      assertThat(activityScenario.getState()).isEqualTo(State.RESUMED);
+      activityScenario.onActivity(
+          activity -> {
+            assertThat(activity.getIntValue()).isEqualTo(100);
           });
     }
   }

--- a/integration_tests/compat-target28/src/main/AndroidManifest.xml
+++ b/integration_tests/compat-target28/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.robolectric.integrationtests.compattarget28">
-    <application />
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    package="org.robolectric.integrationtests.compattarget28"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:appComponentFactory="org.robolectric.integrationtests.compattarget28.TestAppComponentFactory"
+        tools:targetApi="p" />
 </manifest>

--- a/integration_tests/compat-target28/src/main/java/org/robolectric/integrationtests/compattarget28/MainActivity.java
+++ b/integration_tests/compat-target28/src/main/java/org/robolectric/integrationtests/compattarget28/MainActivity.java
@@ -1,0 +1,21 @@
+package org.robolectric.integrationtests.compattarget28;
+
+import android.app.Activity;
+
+public class MainActivity extends Activity {
+  public enum CreationSource {
+    DEFAULT_CONSTRUCTOR,
+    CUSTOM_CONSTRUCTOR
+  }
+
+  public final CreationSource creationSource;
+
+  @SuppressWarnings("unused")
+  public MainActivity() {
+    this(CreationSource.DEFAULT_CONSTRUCTOR);
+  }
+
+  public MainActivity(CreationSource creationSource) {
+    this.creationSource = creationSource;
+  }
+}

--- a/integration_tests/compat-target28/src/main/java/org/robolectric/integrationtests/compattarget28/TestAppComponentFactory.java
+++ b/integration_tests/compat-target28/src/main/java/org/robolectric/integrationtests/compattarget28/TestAppComponentFactory.java
@@ -1,0 +1,21 @@
+package org.robolectric.integrationtests.compattarget28;
+
+import android.app.Activity;
+import android.app.AppComponentFactory;
+import android.content.Intent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class TestAppComponentFactory extends AppComponentFactory {
+
+  @NotNull
+  @Override
+  public Activity instantiateActivity(
+      @NotNull ClassLoader cl, @NotNull String className, @Nullable Intent intent)
+      throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+    if (className.equals(MainActivity.class.getName())) {
+      return new MainActivity(MainActivity.CreationSource.CUSTOM_CONSTRUCTOR);
+    }
+    return super.instantiateActivity(cl, className, intent);
+  }
+}

--- a/integration_tests/compat-target28/src/test/java/org/robolectric/integration/compat/target28/NormalCompatibilityTest.kt
+++ b/integration_tests/compat-target28/src/test/java/org/robolectric/integration/compat/target28/NormalCompatibilityTest.kt
@@ -18,6 +18,9 @@ import org.robolectric.Robolectric.buildActivity
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.integrationtests.compattarget28.MainActivity
+import org.robolectric.integrationtests.compattarget28.MainActivity.CreationSource
 import org.robolectric.testapp.TestActivity
 
 @RunWith(RobolectricTestRunner::class)
@@ -78,5 +81,18 @@ class NormalCompatibilityTest {
       listener,
       Handler(Looper.getMainLooper())
     )
+  }
+
+  @Test
+  fun `MainActivity created correctly using AppComponentFactory`() {
+    val activity = Robolectric.setupActivity(MainActivity::class.java)
+    assertThat(activity.creationSource).isEqualTo(CreationSource.CUSTOM_CONSTRUCTOR)
+  }
+
+  @Test
+  @Config(minSdk = 19, maxSdk = 27)
+  fun `MainActivity created correctly using default constructor on api lower than 28`() {
+    val activity = Robolectric.setupActivity(MainActivity::class.java)
+    assertThat(activity.creationSource).isEqualTo(CreationSource.DEFAULT_CONSTRUCTOR)
   }
 }

--- a/robolectric/src/test/java/org/robolectric/CustomAppComponentFactory.java
+++ b/robolectric/src/test/java/org/robolectric/CustomAppComponentFactory.java
@@ -1,5 +1,6 @@
 package org.robolectric;
 
+import android.app.Activity;
 import android.app.AppComponentFactory;
 import android.app.Service;
 import android.content.BroadcastReceiver;
@@ -49,5 +50,16 @@ public final class CustomAppComponentFactory extends AppComponentFactory {
       }
     }
     return super.instantiateProvider(cl, className);
+  }
+
+  @Override
+  public Activity instantiateActivity(ClassLoader cl, String className, Intent intent)
+      throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+    if (className != null) {
+      if (className.contains(CustomConstructorActivity.class.getName())) {
+        return new CustomConstructorActivity(100);
+      }
+    }
+    return super.instantiateActivity(cl, className, intent);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/CustomAppComponentFactory.java
+++ b/robolectric/src/test/java/org/robolectric/CustomAppComponentFactory.java
@@ -3,6 +3,7 @@ package org.robolectric;
 import android.app.AppComponentFactory;
 import android.app.Service;
 import android.content.BroadcastReceiver;
+import android.content.ContentProvider;
 import android.content.Intent;
 import org.robolectric.CustomConstructorReceiverWrapper.CustomConstructorWithEmptyActionReceiver;
 import org.robolectric.CustomConstructorReceiverWrapper.CustomConstructorWithOneActionReceiver;
@@ -37,5 +38,16 @@ public final class CustomAppComponentFactory extends AppComponentFactory {
       }
     }
     return super.instantiateService(cl, className, intent);
+  }
+
+  @Override
+  public ContentProvider instantiateProvider(ClassLoader cl, String className)
+      throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+    if (className != null) {
+      if (className.contains(CustomConstructorContentProvider.class.getName())) {
+        return new CustomConstructorContentProvider(100);
+      }
+    }
+    return super.instantiateProvider(cl, className);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/CustomAppComponentFactory.java
+++ b/robolectric/src/test/java/org/robolectric/CustomAppComponentFactory.java
@@ -1,10 +1,14 @@
 package org.robolectric;
 
 import android.app.AppComponentFactory;
+import android.app.Service;
 import android.content.BroadcastReceiver;
 import android.content.Intent;
 import org.robolectric.CustomConstructorReceiverWrapper.CustomConstructorWithEmptyActionReceiver;
 import org.robolectric.CustomConstructorReceiverWrapper.CustomConstructorWithOneActionReceiver;
+import org.robolectric.CustomConstructorServices.CustomConstructorIntentService;
+import org.robolectric.CustomConstructorServices.CustomConstructorJobService;
+import org.robolectric.CustomConstructorServices.CustomConstructorService;
 
 public final class CustomAppComponentFactory extends AppComponentFactory {
   @Override
@@ -18,5 +22,20 @@ public final class CustomAppComponentFactory extends AppComponentFactory {
       }
     }
     return super.instantiateReceiver(cl, className, intent);
+  }
+
+  @Override
+  public Service instantiateService(ClassLoader cl, String className, Intent intent)
+      throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+    if (className != null) {
+      if (className.contains(CustomConstructorService.class.getName())) {
+        return new CustomConstructorService(100);
+      } else if (className.contains(CustomConstructorIntentService.class.getName())) {
+        return new CustomConstructorIntentService(100);
+      } else if (className.contains(CustomConstructorJobService.class.getName())) {
+        return new CustomConstructorJobService(100);
+      }
+    }
+    return super.instantiateService(cl, className, intent);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/CustomAppComponentFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/CustomAppComponentFactoryTest.java
@@ -3,7 +3,11 @@ package org.robolectric;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.app.Service;
+import android.content.ContentProvider;
+import android.content.ContentValues;
 import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
 import android.os.Build;
 import android.os.IBinder;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -44,6 +48,28 @@ public class CustomAppComponentFactoryTest {
     assertThat(service.isCreated).isTrue();
   }
 
+  @Test
+  public void instantiateContentProviderWithCustomConstructor() {
+    CustomConstructorContentProvider provider =
+        Robolectric.setupContentProvider(CustomConstructorContentProvider.class);
+    assertThat(provider.getIntValue()).isEqualTo(100);
+  }
+
+  @Test
+  public void instantiateContentProviderWithCustomConstructorAndAuthority() {
+    CustomConstructorContentProvider provider =
+        Robolectric.setupContentProvider(
+            CustomConstructorContentProvider.class, "org.robolectric.authority");
+    assertThat(provider.getIntValue()).isEqualTo(100);
+  }
+
+  @Test
+  public void instantiatePrivateContentProviderClass() {
+    PrivateContentProvider provider =
+        Robolectric.setupContentProvider(PrivateContentProvider.class);
+    assertThat(provider.isCreated).isTrue();
+  }
+
   private static class PrivateService extends Service {
     public boolean isCreated = false;
 
@@ -56,6 +82,41 @@ public class CustomAppComponentFactoryTest {
     @Override
     public IBinder onBind(Intent intent) {
       return null;
+    }
+  }
+
+  private static class PrivateContentProvider extends ContentProvider {
+    public boolean isCreated = false;
+
+    @Override
+    public boolean onCreate() {
+      isCreated = true;
+      return false;
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] strings, String s, String[] strings1, String s1) {
+      return null;
+    }
+
+    @Override
+    public String getType(Uri uri) {
+      return null;
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues contentValues) {
+      return null;
+    }
+
+    @Override
+    public int delete(Uri uri, String s, String[] strings) {
+      return 0;
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues contentValues, String s, String[] strings) {
+      return 0;
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/CustomAppComponentFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/CustomAppComponentFactoryTest.java
@@ -1,0 +1,61 @@
+package org.robolectric;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.CustomConstructorServices.CustomConstructorIntentService;
+import org.robolectric.CustomConstructorServices.CustomConstructorJobService;
+import org.robolectric.CustomConstructorServices.CustomConstructorService;
+import org.robolectric.annotation.Config;
+
+@RunWith(AndroidJUnit4.class)
+@Config(manifest = "TestAndroidManifestWithAppComponentFactory.xml", minSdk = Build.VERSION_CODES.P)
+public class CustomAppComponentFactoryTest {
+
+  @Test
+  public void instantiateServiceWithCustomConstructor() {
+    CustomConstructorService service = Robolectric.setupService(CustomConstructorService.class);
+    assertThat(service.getIntValue()).isEqualTo(100);
+  }
+
+  @Test
+  public void instantiateIntentServiceWithCustomConstructor() {
+    CustomConstructorIntentService service =
+        Robolectric.setupService(CustomConstructorIntentService.class);
+    assertThat(service.getIntValue()).isEqualTo(100);
+  }
+
+  @Test
+  public void instantiateJobServiceWithCustomConstructor() {
+    CustomConstructorJobService service =
+        Robolectric.setupService(CustomConstructorJobService.class);
+    assertThat(service.getIntValue()).isEqualTo(100);
+  }
+
+  @Test
+  public void instantiatePrivateServiceClass() {
+    PrivateService service = Robolectric.setupService(PrivateService.class);
+    assertThat(service.isCreated).isTrue();
+  }
+
+  private static class PrivateService extends Service {
+    public boolean isCreated = false;
+
+    @Override
+    public void onCreate() {
+      super.onCreate();
+      isCreated = true;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+      return null;
+    }
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/CustomConstructorActivity.java
+++ b/robolectric/src/test/java/org/robolectric/CustomConstructorActivity.java
@@ -1,0 +1,15 @@
+package org.robolectric;
+
+import android.app.Activity;
+
+public class CustomConstructorActivity extends Activity {
+  private final int intValue;
+
+  public CustomConstructorActivity(int intValue) {
+    this.intValue = intValue;
+  }
+
+  public int getIntValue() {
+    return intValue;
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/CustomConstructorContentProvider.java
+++ b/robolectric/src/test/java/org/robolectric/CustomConstructorContentProvider.java
@@ -1,0 +1,48 @@
+package org.robolectric;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+
+public class CustomConstructorContentProvider extends ContentProvider {
+  private final int intValue;
+
+  public CustomConstructorContentProvider(int intValue) {
+    this.intValue = intValue;
+  }
+
+  public int getIntValue() {
+    return intValue;
+  }
+
+  @Override
+  public boolean onCreate() {
+    return true;
+  }
+
+  @Override
+  public Cursor query(Uri uri, String[] strings, String s, String[] strings1, String s1) {
+    return null;
+  }
+
+  @Override
+  public String getType(Uri uri) {
+    return null;
+  }
+
+  @Override
+  public Uri insert(Uri uri, ContentValues contentValues) {
+    return null;
+  }
+
+  @Override
+  public int delete(Uri uri, String s, String[] strings) {
+    return 0;
+  }
+
+  @Override
+  public int update(Uri uri, ContentValues contentValues, String s, String[] strings) {
+    return 0;
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/CustomConstructorServices.java
+++ b/robolectric/src/test/java/org/robolectric/CustomConstructorServices.java
@@ -1,0 +1,67 @@
+package org.robolectric;
+
+import android.app.IntentService;
+import android.app.Service;
+import android.app.job.JobParameters;
+import android.app.job.JobService;
+import android.content.Intent;
+import android.os.IBinder;
+
+public class CustomConstructorServices {
+
+  public static class CustomConstructorService extends Service {
+    private final int intValue;
+
+    public CustomConstructorService(int intValue) {
+      this.intValue = intValue;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+      return null;
+    }
+
+    public int getIntValue() {
+      return intValue;
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  public static class CustomConstructorIntentService extends IntentService {
+    private final int intValue;
+
+    public CustomConstructorIntentService(int intValue) {
+      super("test");
+      this.intValue = intValue;
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {}
+
+    public int getIntValue() {
+      return intValue;
+    }
+  }
+
+  public static class CustomConstructorJobService extends JobService {
+    private final int intValue;
+
+    public CustomConstructorJobService(int intValue) {
+      this.intValue = intValue;
+    }
+
+    @Override
+    public boolean onStartJob(JobParameters jobParameters) {
+      return true;
+    }
+
+    @Override
+    public boolean onStopJob(JobParameters jobParameters) {
+      return true;
+    }
+
+    public int getIntValue() {
+      return intValue;
+    }
+  }
+}

--- a/robolectric/src/test/resources/TestAndroidManifestWithAppComponentFactory.xml
+++ b/robolectric/src/test/resources/TestAndroidManifestWithAppComponentFactory.xml
@@ -23,5 +23,8 @@
     <provider
       android:name=".CustomConstructorContentProvider"
       android:authorities="org.robolectric.authority" />
+    <activity
+      android:name=".CustomConstructorContentProvider"
+      android:authorities="org.robolectric.authority" />
   </application>
 </manifest>

--- a/robolectric/src/test/resources/TestAndroidManifestWithAppComponentFactory.xml
+++ b/robolectric/src/test/resources/TestAndroidManifestWithAppComponentFactory.xml
@@ -12,5 +12,13 @@
     </receiver>
     <receiver
       android:name=".CustomConstructorReceiverWrapper$CustomConstructorWithEmptyActionReceiver" />
+
+    <service
+      android:name=".CustomConstructorServices$CustomConstructorService" />
+    <service
+      android:name=".CustomConstructorServices$CustomConstructorIntentService" />
+    <service
+      android:name=".CustomConstructorServices$CustomConstructorJobService"
+      android:permission="android.permission.BIND_JOB_SERVICE"/>
   </application>
 </manifest>

--- a/robolectric/src/test/resources/TestAndroidManifestWithAppComponentFactory.xml
+++ b/robolectric/src/test/resources/TestAndroidManifestWithAppComponentFactory.xml
@@ -20,5 +20,8 @@
     <service
       android:name=".CustomConstructorServices$CustomConstructorJobService"
       android:permission="android.permission.BIND_JOB_SERVICE"/>
+    <provider
+      android:name=".CustomConstructorContentProvider"
+      android:authorities="org.robolectric.authority" />
   </application>
 </manifest>


### PR DESCRIPTION
As far as I understand, implementing `instantiateClassLoader` is not required for Robolectric tests.
`Application` instance is created in `AndroidTestEnvironment.installAndCreateApplication` earlier than getting `LoadedApk` instance, so I decided to not touch it leave `instantiateApplication` as not implemented.

I'm open to suggestions for other types of tests to check that everything is working correctly.

Fixes #8335