### PR TITLE
Update GitHub CI workflows for Copybara PRs on the 'google' branch

### DIFF
--- a/.github/workflows/copybara_build_and_test.yml
+++ b/.github/workflows/copybara_build_and_test.yml
@@ -1,0 +1,42 @@
+name: Copybara tests
+
+on:
+  pull_request:
+    branches: [ google ]
+    paths-ignore:
+      - '**.md'
+
+permissions:
+  contents: read
+
+jobs:
+  copybara-tests:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - uses: gradle/gradle-build-action@v2
+
+      - name: Build
+        run: |
+          SKIP_ERRORPRONE=true SKIP_JAVADOC=true \
+          ./gradlew assemble testClasses --parallel --stacktrace --no-watch-fs
+
+      - name: Integration tests
+        run: |
+          # Only run integration tests on Copybara PRs
+          (cd integration_tests && \
+            SKIP_ERRORPRONE=true SKIP_JAVADOC=true \
+            ../gradlew test --info --stacktrace --continue --parallel --no-watch-fs \
+            -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+            -Drobolectric.enabledSdks=34 \
+            -Dorg.gradle.workers.max=2 \
+            -x :integration_tests:nativegraphics:test \
+          )

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,12 +2,12 @@ name: Tests
 
 on:
   push:
-    branches: [ master, 'robolectric-*.x' ]
+    branches: [ master, 'robolectric-*.x', 'google' ]
     paths-ignore:
       - '**.md'
 
   pull_request:
-    branches: [ master, google ]
+    branches: [ master ]
     paths-ignore:
       - '**.md'
 
@@ -35,7 +35,7 @@ jobs:
       - name: Build
         run: |
           SKIP_ERRORPRONE=true SKIP_JAVADOC=true \
-          ./gradlew clean assemble testClasses --parallel --stacktrace --no-watch-fs
+          ./gradlew assemble testClasses --parallel --stacktrace --no-watch-fs
 
   unit-tests:
     runs-on: ubuntu-22.04

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/AndroidProjectConfigPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/AndroidProjectConfigPlugin.groovy
@@ -2,6 +2,7 @@ package org.robolectric.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
 
 public class AndroidProjectConfigPlugin implements Plugin<Project> {
     @Override
@@ -63,5 +64,11 @@ public class AndroidProjectConfigPlugin implements Plugin<Project> {
                 }
             }
         }
+
+        // Only run tests in the debug variant. This is to avoid running tests twice when `./gradlew test` is run at the top-level.
+        project.tasks.withType(Test) {
+            onlyIf { variantName.toLowerCase().contains('debug') }
+        }
     }
 }
+


### PR DESCRIPTION
Update GitHub CI workflows for Copybara PRs on the 'google' branch

When a Robolectric change is made by a Googler, all Robolectric tests are
already run on Google's infrastructure. It is redundant to re-run tests on
GitHub actions.

With this change, when a PR is made by the Copybara service:
1) The PR will be built to ensure that there are no compile errors.
2) All integration tests will be run on the latest SDK version.
3) GitHub CI tests will be run when the commit is pushed to the 'google' branch.

This will reduce the amount of contention for GitHub CI and will significantly
decrease the amount of time required for Copybara PRs to be merged.

Also, update AndroidProjectConfigPlugin.groovy to avoid running tests on
the 'release' variant.
