### PR TITLE
Fix integration_tests/mockk compile error on Java 21

### DIFF
--- a/integration_tests/mockk/build.gradle
+++ b/integration_tests/mockk/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.robolectric.gradle.RoboJavaModulePlugin
 
 apply plugin: RoboJavaModulePlugin
@@ -12,8 +13,12 @@ spotless {
     }
 }
 
+compileKotlin {
+    compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+}
+
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    compilerOptions.jvmTarget = JvmTarget.JVM_1_8
 }
 
 dependencies {


### PR DESCRIPTION
Previously, when trying to run integration_tests/mockk on Java 21, there would be an error message:

> Unknown Kotlin JVM target: 21

Update the compile options to target JVM 1.8 bytecode.
