### PR TITLE
Make integration_tests:jacoco-offline resilient to jacoco version changes

### DIFF
--- a/integration_tests/jacoco-offline/build.gradle
+++ b/integration_tests/jacoco-offline/build.gradle
@@ -32,7 +32,7 @@ def javaDirPath = "${buildDir.path}/classes/java/main"
 
 def kotlinDirPath = "${buildDir.path}/classes/kotlin/main"
 
-def jacocoInstrumentedClassesOutputDirPath = "${buildDir.path}/classes/java/classes-instrumented"
+def jacocoInstrumentedClassesOutputDirPath = "${buildDir.path}/$jacocoVersion/classes/java/classes-instrumented"
 
 // make sure it's evaluated after the AGP evaluation.
 afterEvaluate {


### PR DESCRIPTION
Previously, the following sequence of commands would result in a test error:

1 ./gradlew :integration_tests:jacoco-offline:test
2. Update jacoco version in libs.versions.toml
3. Re-run ./gradlew :integration_tests:jacoco-offline:test

Update the instrumented classes path to include the jacoco version.
