### PR TITLE
Ignore nativeruntime-dist-compat from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
        - dependency-name: "*guava*"
        # don't auto update errorprone since it requires updating guava
        - dependency-name: "*errorprone*"
+       # don't auto update nativeruntime-dist-compat since it needs
+       # to be updated with code changes together
+       - dependency-name: "org.robolectric:nativeruntime-dist-compat"


### PR DESCRIPTION
We often need to update this library with code changes together,  so Dependabot's auto updating will fail on CI very often.
