### PR TITLE
Ignore androidx annotation auto-update from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,5 @@ updates:
        # don't auto update nativeruntime-dist-compat since it needs
        # to be updated with code changes together
        - dependency-name: "org.robolectric:nativeruntime-dist-compat"
+       # don't auto update androidx-annotation since it brings higher Kotlin dependency
+       - dependency-name: "androidx.annotation:annotation"


### PR DESCRIPTION
androidx annotation brings higher Kotlin dependency than we expect, and it is in core modules' dependency list, so we need to avoid its auto-update and update it based on our demand manually.
