### PR TITLE
Enable Emulator testing with SDK34

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 29 ]
+        api-level: [ 29, 34 ]
 
     steps:
       - uses: actions/checkout@v4
@@ -108,6 +108,9 @@ jobs:
         id: determine-target
         run: |
           TARGET="google_apis"
+          if [[ ${{ matrix.api-level }} -ge 34 ]]; then
+            TARGET="aosp_atd"
+          fi
           echo "TARGET=$TARGET" >> $GITHUB_OUTPUT
 
       - name: AVD cache

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/GradleManagedDevicePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/GradleManagedDevicePlugin.groovy
@@ -20,7 +20,7 @@ class GradleManagedDevicePlugin implements Plugin<Project> {
                 nexusOneApi34(ManagedVirtualDevice) {
                     device = "Nexus One"
                     apiLevel = 34
-                    systemImageSource = "aosp"
+                    systemImageSource = "aosp-atd"
                 }
             }
         }


### PR DESCRIPTION
I want to use online Emulator testing to check whether some Espresso tests' flaky still exist.

Close https://github.com/robolectric/robolectric/issues/7428.