### PR TITLE
Don't use isUserKeyUnlocked() after Android 14

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStorageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStorageManagerTest.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.N;
 import static android.os.Build.VERSION_CODES.TIRAMISU;
+import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
 import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.RuntimeEnvironment.getApplication;
 import static org.robolectric.Shadows.shadowOf;
@@ -91,10 +92,17 @@ public class ShadowStorageManagerTest {
   }
 
   @Test
-  @Config(minSdk = N)
+  @Config(minSdk = N, maxSdk = UPSIDE_DOWN_CAKE)
   public void isUserKeyUnlocked() {
     shadowOf(getApplication().getSystemService(UserManager.class)).setUserUnlocked(true);
-    assertThat(StorageManager.isUserKeyUnlocked(0)).isTrue();
+    // Use reflection, as this method is planned to be removed from StorageManager in V.
+    assertThat(
+            (boolean)
+                ReflectionHelpers.callStaticMethod(
+                    StorageManager.class,
+                    "isUserKeyUnlocked",
+                    ReflectionHelpers.ClassParameter.from(int.class, 0)))
+        .isTrue();
   }
 
   private StorageVolume buildAndGetStorageVolume(File file, String description) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStorageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStorageManager.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.N;
 import static android.os.Build.VERSION_CODES.TIRAMISU;
+import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
 
 import android.os.UserManager;
 import android.os.storage.StorageManager;
@@ -101,8 +102,9 @@ public class ShadowStorageManager {
     isFileEncryptionSupported = isSupported;
   }
 
+  // Use maxSdk=U, as this method is planned to be removed from StorageManager in V.
   @HiddenApi
-  @Implementation(minSdk = N)
+  @Implementation(minSdk = N, maxSdk = UPSIDE_DOWN_CAKE)
   protected static boolean isUserKeyUnlocked(int userId) {
     ShadowUserManager extract =
         Shadow.extract(RuntimeEnvironment.getApplication().getSystemService(UserManager.class));


### PR DESCRIPTION
The TestApi StorageManager#isUserKeyUnlocked() is being superseded by StorageManager#isCeStorageUnlocked().  Since isUserKeyUnlocked() will soon have no callers other than robolectric, the plan is to remove it. This commit unblocks that plan by making robolectric stop depending on this method at build time.
