### PR TITLE
Remove JDK requirements statement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,6 @@ Robolectric is built using Gradle. Both IntelliJ and Android Studio can import t
 
 ### Prerequisites
 
-Those software configurations are recommended and tested.
-
-- JDK 17. Gradle JVM should be set to Java 17.
-  - For command line, make sure the environment variable `JAVA_HOME` is correctly point to JDK17, or set the build environment by [Gradle CLI option](https://docs.gradle.org/current/userguide/command_line_interface.html#sec:environment_options) `-Dorg.gradle.java.home="YourJdkHomePath"` or by [Gradle Properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties) `org.gradle.java.home=YourJdkHomePath`.
-  - For both IntelliJ and Android Studio, see _Settings/Preferences | Build, Execution, Deployment | Build Tools | Gradle_.
-
 See [Building Robolectric](http://robolectric.org/building-robolectric/) for more details about setting up a build environment for Robolectric.
 
 ### Building


### PR DESCRIPTION
The AGP will tell the developer if still use JDK < 17.