### PR TITLE
Use specific version of gradle/gradle-build-action for codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
           distribution: 'zulu'
           java-version: 17
 
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/gradle-build-action@v2.9.0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
It can remove warnings from GitHub Security.
