### PR TITLE
Add ShadowBuild support for missing supported ABI fields

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBuildTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBuildTest.java
@@ -1,5 +1,6 @@
 package org.robolectric.shadows;
 
+import static android.os.Build.VERSION_CODES.L;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.R;
@@ -130,6 +131,30 @@ public class ShadowBuildTest {
     assertThat(Build.getSerial()).isEqualTo("unknown");
     ShadowBuild.setSerial("robo_serial");
     assertThat(Build.getSerial()).isEqualTo("robo_serial");
+  }
+
+  @Test
+  @Config(minSdk = L)
+  public void supported32BitAbis() {
+    assertThat(Build.SUPPORTED_32_BIT_ABIS).isEqualTo(new String[] {"armeabi-v7a", "armeabi"});
+    ShadowBuild.setSupported32BitAbis(new String[] {"x86"});
+    assertThat(Build.SUPPORTED_32_BIT_ABIS).isEqualTo(new String[] {"x86"});
+  }
+
+  @Test
+  @Config(minSdk = L)
+  public void supported64BitAbis() {
+    assertThat(Build.SUPPORTED_64_BIT_ABIS).isEqualTo(new String[] {"armeabi-v7a", "armeabi"});
+    ShadowBuild.setSupported64BitAbis(new String[] {"x86_64"});
+    assertThat(Build.SUPPORTED_64_BIT_ABIS).isEqualTo(new String[] {"x86_64"});
+  }
+
+  @Test
+  @Config(minSdk = L)
+  public void supportedAbis() {
+    assertThat(Build.SUPPORTED_ABIS).isEqualTo(new String[] {"armeabi-v7a"});
+    ShadowBuild.setSupportedAbis(new String[] {"x86"});
+    assertThat(Build.SUPPORTED_ABIS).isEqualTo(new String[] {"x86"});
   }
 
   /** Verifies that each test gets a fresh set of Build values. */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBuild.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBuild.java
@@ -176,6 +176,16 @@ public class ShadowBuild {
   }
 
   /**
+   * Sets the value of the {@link Build#SUPPORTED_32_BIT_ABIS} field. Available in Android L+.
+   *
+   * <p>It will be reset for the next test.
+   */
+  @TargetApi(LOLLIPOP)
+  public static void setSupported32BitAbis(String[] supported32BitAbis) {
+    ReflectionHelpers.setStaticField(Build.class, "SUPPORTED_32_BIT_ABIS", supported32BitAbis);
+  }
+
+  /**
    * Sets the value of the {@link Build#SUPPORTED_64_BIT_ABIS} field. Available in Android L+.
    *
    * <p>It will be reset for the next test.
@@ -183,6 +193,16 @@ public class ShadowBuild {
   @TargetApi(LOLLIPOP)
   public static void setSupported64BitAbis(String[] supported64BitAbis) {
     ReflectionHelpers.setStaticField(Build.class, "SUPPORTED_64_BIT_ABIS", supported64BitAbis);
+  }
+
+  /**
+   * Sets the value of the {@link Build#SUPPORTED_ABIS} field. Available in Android L+.
+   *
+   * <p>It will be reset for the next test.
+   */
+  @TargetApi(LOLLIPOP)
+  public static void setSupportedAbis(String[] supportedAbis) {
+    ReflectionHelpers.setStaticField(Build.class, "SUPPORTED_ABIS", supportedAbis);
   }
 
   /**


### PR DESCRIPTION
Adding support for the other supported ABI fields introduced in SDK 21: https://developer.android.com/reference/android/os/Build#SUPPORTED_32_BIT_ABIS https://developer.android.com/reference/android/os/Build#SUPPORTED_ABIS