### PR TITLE
Fix RecordingCanvas.nFinishRecording for Q and R

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeRenderNode.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeRenderNode.java
@@ -459,6 +459,14 @@ public class ShadowNativeRenderNode {
     return RenderNodeNatives.nGetUniqueId(renderNode);
   }
 
+  @Implementation(minSdk = Q, maxSdk = R)
+  protected static void nSetDisplayList(long renderNode, long newData) {
+    // No-op in Q and R
+    // In S and above, the functionality of nSetDisplayList is a part of
+    // RecordingCanvas.finishRecording (which gets called just prior to this). So this method is a
+    // no-op.
+  }
+
   /** Shadow picker for {@link RenderNode}. */
   public static final class Picker extends GraphicsShadowPicker<Object> {
     public Picker() {


### PR DESCRIPTION
Fix RecordingCanvas.nFinishRecording for Q and R

Previously, the native RecordingCanvas.nFinishRecording was a no-op for Q and
R. Add an implementation that calls into the S version of nFinishRecording. To
do this, we need to keep track of the current render nodes associated with
recording canvases.
