### PR TITLE
Avoid toImmutableSet and toImmutableList collectors

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothHeadset.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothHeadset.java
@@ -3,16 +3,15 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.S;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toCollection;
 
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothHeadset;
 import android.bluetooth.BluetoothProfile;
 import android.content.Intent;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Ints;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -81,11 +80,14 @@ public class ShadowBluetoothHeadset {
 
   @Implementation
   protected List<BluetoothDevice> getDevicesMatchingConnectionStates(int[] states) {
-    ImmutableSet<Integer> statesSet = stream(states).boxed().collect(toImmutableSet());
-    return bluetoothDevices.entrySet().stream()
-        .filter(entry -> statesSet.contains(entry.getValue()))
-        .map(Entry::getKey)
-        .collect(toImmutableList());
+    ImmutableSet<Integer> statesSet = ImmutableSet.copyOf(Ints.asList(states));
+    List<BluetoothDevice> matchingDevices = new ArrayList<>();
+    for (Map.Entry<BluetoothDevice, Integer> entry : bluetoothDevices.entrySet()) {
+      if (statesSet.contains(entry.getValue())) {
+        matchingDevices.add(entry.getKey());
+      }
+    }
+    return ImmutableList.copyOf(matchingDevices);
   }
 
   /**


### PR DESCRIPTION
Avoid toImmutableSet and toImmutableList collectors

For some reason these have issues in Guava 31.1 in a Gradle environment:

java.lang.NoSuchMethodError: 'java.util.stream.Collector com.google.common.collect.ImmutableSet.toImmutableSet()'
