### PR TITLE
Add Roborazzi Integration Tests for Robolectric

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,6 +86,9 @@ mockito = "4.11.0"
 # https://github.com/mockk/mockk/releases
 mockk = "1.13.7"
 
+# https://github.com/takahirom/roborazzi/releases
+roborazzi = "1.9.0-alpha-2"
+
 # https://square.github.io/okhttp/changelogs/changelog/
 okhttp = "4.12.0"
 
@@ -201,6 +204,8 @@ truth-java8-extension = { module = "com.google.truth.extensions:truth-java8-exte
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+
+roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version.ref = "roborazzi" }
 
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }

--- a/integration_tests/roborazzi/build.gradle
+++ b/integration_tests/roborazzi/build.gradle
@@ -1,0 +1,47 @@
+import org.robolectric.gradle.AndroidProjectConfigPlugin
+
+apply plugin: 'com.android.library'
+apply plugin: AndroidProjectConfigPlugin
+apply plugin: 'kotlin-android'
+apply plugin: "com.diffplug.spotless"
+
+spotless {
+    kotlin {
+        target '**/*.kt'
+        ktfmt('0.42').googleStyle()
+    }
+}
+
+android {
+    compileSdk 34
+    namespace 'org.robolectric.integration.roborazzi'
+
+    defaultConfig {
+        minSdk 21
+        targetSdk 34
+    }
+
+
+    compileOptions {
+        sourceCompatibility = '1.8'
+        targetCompatibility = '1.8'
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+}
+
+dependencies {
+    api project(":robolectric")
+    testImplementation libs.androidx.test.core
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.roborazzi
+}

--- a/integration_tests/roborazzi/src/test/java/org/robolectric/integration/roborazzi/RoborazziCaptureTest.kt
+++ b/integration_tests/roborazzi/src/test/java/org/robolectric/integration/roborazzi/RoborazziCaptureTest.kt
@@ -1,0 +1,226 @@
+package org.robolectric.integration.roborazzi
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.app.Application
+import android.content.ComponentName
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import android.graphics.Rect
+import android.graphics.drawable.ColorDrawable
+import android.os.Build.VERSION_CODES.S
+import android.os.Bundle
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.takahirom.roborazzi.DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.RoborazziTaskType
+import com.github.takahirom.roborazzi.captureScreenRoboImage
+import com.github.takahirom.roborazzi.roboOutputName
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Integration Test for Roborazzi
+ *
+ * This test is not intended to obstruct the release of Robolectric. In the event that issues are
+ * detected which do not stem from Robolectric, the test can be temporarily disabled, and an issue
+ * can be reported on the Roborazzi repository.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [S])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@OptIn(ExperimentalRoborazziApi::class)
+class RoborazziCaptureTest {
+  @Test
+  fun checkViewWithElevationRendering() {
+    hardwareRendererEnvironment {
+      registerActivityToPackageManager(RoborazziViewWithElevationTestActivity::class.java.name)
+      val activityScenario =
+        ActivityScenario.launch(RoborazziViewWithElevationTestActivity::class.java)
+
+      captureScreenWithRoborazzi()
+
+      // View the screenshots at build/output/roborazzi/*.png
+      val bitmap =
+        BitmapFactory.decodeFile("${DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH}/${roboOutputName()}.png")
+      activityScenario.onActivity { activity ->
+        val locationOnScreen = IntArray(2)
+        activity.view?.getLocationOnScreen(locationOnScreen)
+        // Check the background color of the FrameLayout
+        bitmap.getPixel(locationOnScreen[0] + 1, locationOnScreen[1] + 1).let {
+          assertThat(it).isEqualTo(activity.expectedViewBackgroundColor)
+        }
+      }
+    }
+  }
+
+  @Test
+  fun checkDialogRendering() {
+    hardwareRendererEnvironment {
+      registerActivityToPackageManager(RoborazziDialogTestActivity::class.java.name)
+      val activityScenario = ActivityScenario.launch(RoborazziDialogTestActivity::class.java)
+
+      captureScreenWithRoborazzi()
+
+      // View the screenshots at build/output/roborazzi/*.png
+      val bitmap =
+        BitmapFactory.decodeFile("${DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH}/${roboOutputName()}.png")
+      activityScenario.onActivity { activity ->
+        val dialogContentView = activity.dialogContentView
+        val (left, top) = dialogContentView.getLocationInScreen(activity)
+        bitmap.getPixel(left + 1, top + 1).let {
+          assertThat(it).isEqualTo(activity.expectedDialogContentBackgroundColor)
+        }
+      }
+    }
+  }
+
+  private fun captureScreenWithRoborazzi() {
+    captureScreenRoboImage(
+      roborazziOptions =
+        RoborazziOptions(
+          // roborazziOptions.taskType can modify the behavior.
+          // The default is RoborazziTaskType.None, meaning no screenshot capture.
+          // Normally, setting roborazziOptions.taskType to RoborazziTaskType.Record is unnecessary,
+          // as the Roborazzi Plugin automatically configures it.
+          // However, for this test case, we want to bypass the Roborazzi Plugin,
+          // focusing solely on the screenshot capture.
+          // Hence, we set roborazziOptions.taskType to RoborazziTaskType.Record.
+          taskType = RoborazziTaskType.Record
+        )
+    )
+  }
+
+  companion object {
+    const val USE_HARDWARE_RENDERER_NATIVE_ENV = "robolectric.screenshot.hwrdr.native"
+  }
+}
+
+private fun View?.getLocationInScreen(activity: RoborazziDialogTestActivity): Pair<Int, Int> {
+  val viewLocationOnWindow = IntArray(2)
+  // We can't get the location of the dialogContentView so we use the location in the window
+  // and calculate the location of the dialogContentView.
+  // This will return wrong value activity.dialogContentView?.getLocationOnScreen(locationOnScreen)
+  this?.getLocationInWindow(viewLocationOnWindow)
+  val windowLocationOnScreen = Rect()
+  val layoutParams = (this?.rootView?.layoutParams as WindowManager.LayoutParams)
+  Gravity.apply(
+    layoutParams.gravity,
+    this.rootView?.width ?: 0,
+    this.rootView?.height ?: 0,
+    Rect(0, 0, activity.window?.decorView?.width ?: 0, activity.window?.decorView?.height ?: 0),
+    windowLocationOnScreen
+  )
+  // Check the background color of the FrameLayout
+  val left = windowLocationOnScreen.left + viewLocationOnWindow[0]
+  val top = windowLocationOnScreen.top + viewLocationOnWindow[1]
+  return Pair(left, top)
+}
+
+private fun registerActivityToPackageManager(activity: String) {
+  val appContext: Application =
+    InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
+  Shadows.shadowOf(appContext.packageManager)
+    .addActivityIfNotPresent(
+      ComponentName(
+        appContext.packageName,
+        activity,
+      )
+    )
+}
+
+private fun hardwareRendererEnvironment(block: () -> Unit) {
+  val originalHwrdrOption =
+    System.getProperty(RoborazziCaptureTest.USE_HARDWARE_RENDERER_NATIVE_ENV, null)
+  // This cause ClassNotFoundException: java.nio.NioUtils
+  // System.setProperty(USE_HARDWARE_RENDERER_NATIVE_ENV, "true")
+  try {
+    block()
+  } finally {
+    if (originalHwrdrOption == null) {
+      System.clearProperty(RoborazziCaptureTest.USE_HARDWARE_RENDERER_NATIVE_ENV)
+    } else {
+      System.setProperty(RoborazziCaptureTest.USE_HARDWARE_RENDERER_NATIVE_ENV, originalHwrdrOption)
+    }
+  }
+}
+
+private class RoborazziViewWithElevationTestActivity : Activity() {
+
+  var view: FrameLayout? = null
+  val expectedViewBackgroundColor: Int = Color.MAGENTA
+  override fun onCreate(savedInstanceState: Bundle?) {
+    setTheme(android.R.style.Theme_Light_NoTitleBar)
+    super.onCreate(savedInstanceState)
+    setContentView(
+      LinearLayout(this).apply {
+        orientation = LinearLayout.VERTICAL
+        fun Int.toDp(): Int = (this * resources.displayMetrics.density).toInt()
+
+        // View with elevation
+        addView(
+          FrameLayout(this@RoborazziViewWithElevationTestActivity)
+            .apply {
+              background = ColorDrawable(expectedViewBackgroundColor)
+              elevation = 10f
+              addView(TextView(this.context).apply { text = "Roborazzi" })
+            }
+            .also { view = it },
+          LinearLayout.LayoutParams(
+              LinearLayout.LayoutParams.MATCH_PARENT,
+              LinearLayout.LayoutParams.MATCH_PARENT
+            )
+            .apply { setMargins(10.toDp(), 10.toDp(), 10.toDp(), 10.toDp()) }
+        )
+      }
+    )
+  }
+}
+
+private class RoborazziDialogTestActivity : Activity() {
+  var dialogContentView: View? = null
+  val expectedDialogContentBackgroundColor: Int = Color.MAGENTA
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(
+      LinearLayout(this).apply {
+        orientation = LinearLayout.VERTICAL
+        fun Int.toDp(): Int = (this * resources.displayMetrics.density).toInt()
+
+        // View with elevation
+        addView(
+          TextView(this.context).apply { text = "Under the dialog" },
+          LinearLayout.LayoutParams(
+              LinearLayout.LayoutParams.WRAP_CONTENT,
+              LinearLayout.LayoutParams.WRAP_CONTENT
+            )
+            .apply { setMargins(10.toDp(), 10.toDp(), 10.toDp(), 10.toDp()) }
+        )
+      }
+    )
+    AlertDialog.Builder(this)
+      .setTitle("Title")
+      .setView(
+        TextView(this).apply {
+          dialogContentView = this
+          text = "Roborazzi"
+          setBackgroundColor(expectedDialogContentBackgroundColor)
+        }
+      )
+      .setPositiveButton("OK") { _, _ -> }
+      .show()
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,6 +30,7 @@ include ":integration_tests:mockito"
 include ":integration_tests:mockito-kotlin"
 include ":integration_tests:mockito-experimental"
 include ":integration_tests:powermock"
+include ":integration_tests:roborazzi"
 include ':integration_tests:androidx'
 include ':integration_tests:androidx_test'
 include ':integration_tests:ctesque'


### PR DESCRIPTION
### Overview
This pull request introduces an integration test for Roborazzi within the Robolectric framework. Motivated by the growing intersection of Roborazzi and Robolectric usage, this test aims to identify compatibility issues([※1](https://github.com/robolectric/robolectric/issues/8081#issuecomment-1858622981) [※2](https://github.com/robolectric/robolectric/issues/8577)) early in the development cycle. However, it's recognized that the integration of new tests can bring complexities and unforeseen challenges. Should this integration prove to be more burdensome than beneficial, we are open to reevaluating and potentially removing it to maintain the overall health and efficiency of the test suite.

### Proposed Changes
* Implementation of a new integration test that uses Roborazzi's capture feature.
* The test will focus on capturing specific UI components, such as elevation effects and dialog presentations, within an Activity.
* Incorporation of pixel color verification to ensure the fidelity of the captured images.
* The test is designed for early detection of issues, streamlining the development process.
* In case of detected problems that do not originate from Robolectric, the test can be commented out, and an issue can be raised on the Roborazzi repository.

| | |
|---|---|
| RoborazziCaptureTest checkViewWithElevationRendering.png | ![org robolectric integration roborazzi RoborazziCaptureTest checkViewWithElevationRendering](https://github.com/robolectric/robolectric/assets/1386930/3290cc5c-518a-4e35-94ee-3c3f630ce9a0) |
| RoborazziCaptureTest checkDialogRendering.png | ![org robolectric integration roborazzi RoborazziCaptureTest checkDialogRendering](https://github.com/robolectric/robolectric/assets/1386930/0ec749c1-dd74-4f45-8fad-edf143f1a0b4) |



Note: Due to known [crashes reported in the issues](https://github.com/robolectric/robolectric/issues/8081#issuecomment-1858726896), the robolectric.screenshot.hwrdr.native is not enabled currently.