### PR TITLE
Support Activity#overrideActivityTransition introduced in API level 34

### DIFF
--- a/integration_tests/compat-target28/src/test/java/org/robolectric/integration/compat/target28/NormalCompatibilityTest.kt
+++ b/integration_tests/compat-target28/src/test/java/org/robolectric/integration/compat/target28/NormalCompatibilityTest.kt
@@ -14,8 +14,10 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
+import org.robolectric.Robolectric.buildActivity
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows
 import org.robolectric.testapp.TestActivity
 
 @RunWith(RobolectricTestRunner::class)
@@ -40,8 +42,11 @@ class NormalCompatibilityTest {
   }
 
   @Test
-  fun `Initialize Activity succeed`() {
-    Robolectric.setupActivity(TestActivity::class.java)
+  fun `Initialize Activity and its shadow succeed`() {
+    buildActivity(TestActivity::class.java).use { controller ->
+      val activity = controller.setup().get()
+      Shadows.shadowOf(activity)
+    }
   }
 
   @Test


### PR DESCRIPTION
Before API level 34 developers were able to override pending enter/exit activity animations with help of Activity#overridePendingTransition and Robolectric supported it in ShadowActivity.

Since API level 34 that method got deprecated and new methods were introduced to handle the animations: Activity#overrideActivityTransition (overloaded with and without passing a background color) and Activity#clearOverrideActivityTransition.

With this commit a ShadowActivity is able now to tell if an opening or closing activity animations were overridden and can get recorded parameters.

Since the real Activity#overrideActivityTransition and respectively Activity#clearOverrideActivityTransition methods have additional checks inside for validation of the incoming "overrideType" parameter (potentially throwing an exception), from ShadowActivity we call the real android implementation to avoid logic duplication (skipping the checks would make behaviour inconsistent between robolectric tests and actual devices).

To support both Activity#overrideActivityTransition overloaded methods robolectric needs to provide an @Implementation of only the most specified version (with the background color argument) because the other method calls it internally.