### PR TITLE
Remove unused Exception from tests of ShadowConnectivityManager

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
@@ -72,7 +72,7 @@ public class ShadowConnectivityManagerTest {
   }
 
   @Test
-  public void getNetworkInfo_shouldReturnDefaultNetworks() throws Exception {
+  public void getNetworkInfo_shouldReturnDefaultNetworks() {
     NetworkInfo wifi = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
     assertThat(wifi.getDetailedState()).isEqualTo(NetworkInfo.DetailedState.DISCONNECTED);
 
@@ -80,8 +80,9 @@ public class ShadowConnectivityManagerTest {
     assertThat(mobile.getDetailedState()).isEqualTo(NetworkInfo.DetailedState.CONNECTED);
   }
 
-  @Test @Config(minSdk = LOLLIPOP)
-  public void getNetworkInfo_shouldReturnSomeForAllNetworks() throws Exception {
+  @Test
+  @Config(minSdk = LOLLIPOP)
+  public void getNetworkInfo_shouldReturnSomeForAllNetworks() {
     Network[] allNetworks = connectivityManager.getAllNetworks();
     for (Network network: allNetworks) {
       NetworkInfo networkInfo = connectivityManager.getNetworkInfo(network);
@@ -89,8 +90,9 @@ public class ShadowConnectivityManagerTest {
     }
   }
 
-  @Test @Config(minSdk = LOLLIPOP)
-  public void getNetworkInfo_shouldReturnAddedNetwork() throws Exception {
+  @Test
+  @Config(minSdk = LOLLIPOP)
+  public void getNetworkInfo_shouldReturnAddedNetwork() {
     Network vpnNetwork = ShadowNetwork.newInstance(123);
     NetworkInfo vpnNetworkInfo =
         ShadowNetworkInfo.newInstance(
@@ -105,8 +107,9 @@ public class ShadowConnectivityManagerTest {
     assertThat(returnedNetworkInfo).isSameInstanceAs(vpnNetworkInfo);
   }
 
-  @Test @Config(minSdk = LOLLIPOP)
-  public void getNetworkInfo_shouldNotReturnRemovedNetwork() throws Exception {
+  @Test
+  @Config(minSdk = LOLLIPOP)
+  public void getNetworkInfo_shouldNotReturnRemovedNetwork() {
     Network wifiNetwork = ShadowNetwork.newInstance(ShadowConnectivityManager.NET_ID_WIFI);
     shadowOf(connectivityManager).removeNetwork(wifiNetwork);
 
@@ -124,14 +127,14 @@ public class ShadowConnectivityManagerTest {
   }
 
   @Test
-  public void shouldGetAndSetBackgroundDataSetting() throws Exception {
+  public void shouldGetAndSetBackgroundDataSetting() {
     assertThat(connectivityManager.getBackgroundDataSetting()).isFalse();
     shadowOf(connectivityManager).setBackgroundDataSetting(true);
     assertThat(connectivityManager.getBackgroundDataSetting()).isTrue();
   }
 
   @Test
-  public void setActiveNetworkInfo_shouldSetActiveNetworkInfo() throws Exception {
+  public void setActiveNetworkInfo_shouldSetActiveNetworkInfo() {
     shadowOf(connectivityManager).setActiveNetworkInfo(null);
     assertThat(connectivityManager.getActiveNetworkInfo()).isNull();
     shadowOf(connectivityManager)
@@ -166,7 +169,7 @@ public class ShadowConnectivityManagerTest {
 
   @Test
   @Config(minSdk = M)
-  public void setActiveNetworkInfo_shouldSetActiveNetwork() throws Exception {
+  public void setActiveNetworkInfo_shouldSetActiveNetwork() {
     shadowOf(connectivityManager).setActiveNetworkInfo(null);
     assertThat(connectivityManager.getActiveNetworkInfo()).isNull();
     shadowOf(connectivityManager)
@@ -188,7 +191,7 @@ public class ShadowConnectivityManagerTest {
   }
 
   @Test
-  public void getAllNetworkInfo_shouldReturnAllNetworkInterfaces() throws Exception {
+  public void getAllNetworkInfo_shouldReturnAllNetworkInterfaces() {
     NetworkInfo[] infos = connectivityManager.getAllNetworkInfo();
     assertThat(infos).asList().hasSize(2);
     assertThat(infos).asList().contains(connectivityManager.getActiveNetworkInfo());
@@ -199,7 +202,7 @@ public class ShadowConnectivityManagerTest {
 
   @Test
   @Config(minSdk = LOLLIPOP)
-  public void getAllNetworkInfo_shouldEqualGetAllNetworks() throws Exception {
+  public void getAllNetworkInfo_shouldEqualGetAllNetworks() {
     // Update the active network so that we're no longer in the default state.
     NetworkInfo networkInfo =
         ShadowNetworkInfo.newInstance(
@@ -227,21 +230,24 @@ public class ShadowConnectivityManagerTest {
     assertThat(connectivityManager.getAllNetworkInfo()).isNull();
   }
 
-  @Test @Config(minSdk = LOLLIPOP)
-  public void getAllNetworks_shouldReturnAllNetworks() throws Exception {
+  @Test
+  @Config(minSdk = LOLLIPOP)
+  public void getAllNetworks_shouldReturnAllNetworks() {
     Network[] networks = connectivityManager.getAllNetworks();
     assertThat(networks).asList().hasSize(2);
   }
 
-  @Test @Config(minSdk = LOLLIPOP)
-  public void getAllNetworks_shouldReturnNoNetworksWhenCleared() throws Exception {
+  @Test
+  @Config(minSdk = LOLLIPOP)
+  public void getAllNetworks_shouldReturnNoNetworksWhenCleared() {
     shadowOf(connectivityManager).clearAllNetworks();
     Network[] networks = connectivityManager.getAllNetworks();
     assertThat(networks).isEmpty();
   }
 
-  @Test @Config(minSdk = LOLLIPOP)
-  public void getAllNetworks_shouldReturnAddedNetworks() throws Exception {
+  @Test
+  @Config(minSdk = LOLLIPOP)
+  public void getAllNetworks_shouldReturnAddedNetworks() {
     // Let's start clear.
     shadowOf(connectivityManager).clearAllNetworks();
 
@@ -266,8 +272,9 @@ public class ShadowConnectivityManagerTest {
     assertThat(returnedNetworkInfo).isSameInstanceAs(vpnNetworkInfo);
   }
 
-  @Test @Config(minSdk = LOLLIPOP)
-  public void getAllNetworks_shouldNotReturnRemovedNetworks() throws Exception {
+  @Test
+  @Config(minSdk = LOLLIPOP)
+  public void getAllNetworks_shouldNotReturnRemovedNetworks() {
     Network wifiNetwork = ShadowNetwork.newInstance(ShadowConnectivityManager.NET_ID_WIFI);
     shadowOf(connectivityManager).removeNetwork(wifiNetwork);
 
@@ -280,13 +287,13 @@ public class ShadowConnectivityManagerTest {
   }
 
   @Test
-  public void getNetworkPreference_shouldGetDefaultValue() throws Exception {
+  public void getNetworkPreference_shouldGetDefaultValue() {
     assertThat(connectivityManager.getNetworkPreference()).isEqualTo(ConnectivityManager.DEFAULT_NETWORK_PREFERENCE);
   }
 
   @Test
   @Config(minSdk = M)
-  public void getReportedNetworkConnectivity() throws Exception {
+  public void getReportedNetworkConnectivity() {
     Network wifiNetwork = ShadowNetwork.newInstance(ShadowConnectivityManager.NET_ID_WIFI);
     connectivityManager.reportNetworkConnectivity(wifiNetwork, true);
 
@@ -303,15 +310,16 @@ public class ShadowConnectivityManagerTest {
   }
 
   @Test
-  public void setNetworkPreference_shouldSetDefaultValue() throws Exception {
+  public void setNetworkPreference_shouldSetDefaultValue() {
     connectivityManager.setNetworkPreference(ConnectivityManager.TYPE_MOBILE);
     assertThat(connectivityManager.getNetworkPreference()).isEqualTo(connectivityManager.getNetworkPreference());
     connectivityManager.setNetworkPreference(ConnectivityManager.TYPE_WIFI);
     assertThat(connectivityManager.getNetworkPreference()).isEqualTo(ConnectivityManager.TYPE_WIFI);
   }
 
-  @Test @Config(minSdk = LOLLIPOP)
-  public void getNetworkCallbacks_shouldHaveEmptyDefault() throws Exception {
+  @Test
+  @Config(minSdk = LOLLIPOP)
+  public void getNetworkCallbacks_shouldHaveEmptyDefault() {
     assertThat(shadowOf(connectivityManager).getNetworkCallbacks()).isEmpty();
   }
 
@@ -330,15 +338,16 @@ public class ShadowConnectivityManagerTest {
 
   @Test
   @Config(minSdk = LOLLIPOP)
-  public void requestNetwork_shouldAddCallback() throws Exception {
+  public void requestNetwork_shouldAddCallback() {
     NetworkRequest.Builder builder = new NetworkRequest.Builder();
     ConnectivityManager.NetworkCallback callback = createSimpleCallback();
     connectivityManager.requestNetwork(builder.build(), callback);
     assertThat(shadowOf(connectivityManager).getNetworkCallbacks()).hasSize(1);
   }
 
-  @Test @Config(minSdk = LOLLIPOP)
-  public void registerCallback_shouldAddCallback() throws Exception {
+  @Test
+  @Config(minSdk = LOLLIPOP)
+  public void registerCallback_shouldAddCallback() {
     NetworkRequest.Builder builder = new NetworkRequest.Builder();
     ConnectivityManager.NetworkCallback callback = createSimpleCallback();
     connectivityManager.registerNetworkCallback(builder.build(), callback);
@@ -347,7 +356,7 @@ public class ShadowConnectivityManagerTest {
 
   @Test
   @Config(minSdk = M)
-  public void registerCallback_withPendingIntent_shouldAddCallback() throws Exception {
+  public void registerCallback_withPendingIntent_shouldAddCallback() {
     NetworkRequest.Builder builder = new NetworkRequest.Builder();
     PendingIntent pendingIntent = createSimplePendingIntent();
     connectivityManager.registerNetworkCallback(builder.build(), pendingIntent);
@@ -356,7 +365,7 @@ public class ShadowConnectivityManagerTest {
 
   @Test
   @Config(minSdk = O)
-  public void requestNetwork_withTimeout_shouldAddCallback() throws Exception {
+  public void requestNetwork_withTimeout_shouldAddCallback() {
     NetworkRequest.Builder builder = new NetworkRequest.Builder();
     ConnectivityManager.NetworkCallback callback = createSimpleCallback();
     connectivityManager.requestNetwork(builder.build(), callback, 0);
@@ -365,7 +374,7 @@ public class ShadowConnectivityManagerTest {
 
   @Test
   @Config(minSdk = O)
-  public void requestNetwork_withHandler_shouldAddCallback() throws Exception {
+  public void requestNetwork_withHandler_shouldAddCallback() {
     NetworkRequest.Builder builder = new NetworkRequest.Builder();
     ConnectivityManager.NetworkCallback callback = createSimpleCallback();
     connectivityManager.requestNetwork(builder.build(), callback, new Handler());
@@ -374,7 +383,7 @@ public class ShadowConnectivityManagerTest {
 
   @Test
   @Config(minSdk = O)
-  public void requestNetwork_withHandlerAndTimer_shouldAddCallback() throws Exception {
+  public void requestNetwork_withHandlerAndTimer_shouldAddCallback() {
     NetworkRequest.Builder builder = new NetworkRequest.Builder();
     ConnectivityManager.NetworkCallback callback = createSimpleCallback();
     connectivityManager.requestNetwork(builder.build(), callback, new Handler(), 0);
@@ -383,14 +392,15 @@ public class ShadowConnectivityManagerTest {
 
   @Test
   @Config(minSdk = N)
-  public void registerDefaultCallback_shouldAddCallback() throws Exception {
+  public void registerDefaultCallback_shouldAddCallback() {
     ConnectivityManager.NetworkCallback callback = createSimpleCallback();
     connectivityManager.registerDefaultNetworkCallback(callback);
     assertThat(shadowOf(connectivityManager).getNetworkCallbacks()).hasSize(1);
   }
 
-  @Test @Config(minSdk = LOLLIPOP)
-  public void unregisterCallback_shouldRemoveCallbacks() throws Exception {
+  @Test
+  @Config(minSdk = LOLLIPOP)
+  public void unregisterCallback_shouldRemoveCallbacks() {
     NetworkRequest.Builder builder = new NetworkRequest.Builder();
     // Add two different callbacks.
     ConnectivityManager.NetworkCallback callback1 = createSimpleCallback();
@@ -407,7 +417,7 @@ public class ShadowConnectivityManagerTest {
 
   @Test
   @Config(minSdk = M)
-  public void unregisterCallback_withPendingIntent_shouldRemoveCallbacks() throws Exception {
+  public void unregisterCallback_withPendingIntent_shouldRemoveCallbacks() {
     NetworkRequest.Builder builder = new NetworkRequest.Builder();
     // Add two pendingIntents, should treat them as equal based on Intent#filterEquals
     PendingIntent pendingIntent1 = createSimplePendingIntent();
@@ -420,15 +430,16 @@ public class ShadowConnectivityManagerTest {
     assertThat(shadowOf(connectivityManager).getNetworkCallbackPendingIntents()).isEmpty();
   }
 
-  @Test(expected=IllegalArgumentException.class) @Config(minSdk = LOLLIPOP)
-  public void unregisterCallback_shouldNotAllowNullCallback() throws Exception {
+  @Test(expected = IllegalArgumentException.class)
+  @Config(minSdk = LOLLIPOP)
+  public void unregisterCallback_shouldNotAllowNullCallback() {
     // Verify that exception is thrown.
     connectivityManager.unregisterNetworkCallback((ConnectivityManager.NetworkCallback) null);
   }
 
   @Test
   @Config(minSdk = M)
-  public void unregisterCallback_withPendingIntent_shouldNotAllowNullCallback() throws Exception {
+  public void unregisterCallback_withPendingIntent_shouldNotAllowNullCallback() {
     // Verify that exception is thrown.
     assertThrows(
         IllegalArgumentException.class,
@@ -496,7 +507,7 @@ public class ShadowConnectivityManagerTest {
 
   @Test
   @Config(minSdk = LOLLIPOP)
-  public void addDefaultNetworkActiveListener_shouldAddListener() throws Exception {
+  public void addDefaultNetworkActiveListener_shouldAddListener() {
     ConnectivityManager.OnNetworkActiveListener listener1 =
         spy(createSimpleOnNetworkActiveListener());
     ConnectivityManager.OnNetworkActiveListener listener2 =
@@ -512,7 +523,7 @@ public class ShadowConnectivityManagerTest {
 
   @Test
   @Config(minSdk = LOLLIPOP)
-  public void removeDefaultNetworkActiveListener_shouldRemoveListeners() throws Exception {
+  public void removeDefaultNetworkActiveListener_shouldRemoveListeners() {
     // Add two different callbacks.
     ConnectivityManager.OnNetworkActiveListener listener1 =
         spy(createSimpleOnNetworkActiveListener());
@@ -543,14 +554,14 @@ public class ShadowConnectivityManagerTest {
 
   @Test(expected = IllegalArgumentException.class)
   @Config(minSdk = LOLLIPOP)
-  public void removeDefaultNetworkActiveListener_shouldNotAllowNullListener() throws Exception {
+  public void removeDefaultNetworkActiveListener_shouldNotAllowNullListener() {
     // Verify that exception is thrown.
     connectivityManager.removeDefaultNetworkActiveListener(null);
   }
 
   @Test
   @Config(minSdk = LOLLIPOP)
-  public void getNetworkCapabilities() throws Exception {
+  public void getNetworkCapabilities() {
     NetworkCapabilities nc = ShadowNetworkCapabilities.newInstance();
     shadowOf(nc).addCapability(NetworkCapabilities.NET_CAPABILITY_MMS);
 
@@ -566,7 +577,7 @@ public class ShadowConnectivityManagerTest {
 
   @Test
   @Config(minSdk = LOLLIPOP)
-  public void getNetworkCapabilities_shouldReturnDefaultCapabilities() throws Exception {
+  public void getNetworkCapabilities_shouldReturnDefaultCapabilities() {
     for (Network network : connectivityManager.getAllNetworks()) {
       NetworkCapabilities nc = connectivityManager.getNetworkCapabilities(network);
       assertThat(nc).isNotNull();
@@ -652,18 +663,18 @@ public class ShadowConnectivityManagerTest {
 
   @Test(expected = IllegalArgumentException.class)
   @Config(minSdk = N)
-  public void setRestrictBackgroundStatus_throwsExceptionOnIncorrectStatus0() throws Exception{
+  public void setRestrictBackgroundStatus_throwsExceptionOnIncorrectStatus0() {
     shadowOf(connectivityManager).setRestrictBackgroundStatus(0);
   }
 
   @Test(expected = IllegalArgumentException.class)
   @Config(minSdk = N)
-  public void setRestrictBackgroundStatus_throwsExceptionOnIncorrectStatus4() throws Exception{
+  public void setRestrictBackgroundStatus_throwsExceptionOnIncorrectStatus4() {
     shadowOf(connectivityManager).setRestrictBackgroundStatus(4);
   }
 
   @Test
-  public void checkPollingTetherThreadNotCreated() throws Exception {
+  public void checkPollingTetherThreadNotCreated() {
     for (StackTraceElement[] elements : Thread.getAllStackTraces().values()) {
       for (StackTraceElement element : elements) {
         if (element.toString().contains("android.net.TetheringManager")) {


### PR DESCRIPTION
1. Remove unused Exception from tests.
2. Format `ShadowConnectivityManager`.