### PR TITLE
Bump preinstrumented version to 5

### DIFF
--- a/.github/workflows/copybara_build_and_test.yml
+++ b/.github/workflows/copybara_build_and_test.yml
@@ -36,6 +36,5 @@ jobs:
             -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
             -Drobolectric.enabledSdks=34 \
             -Dorg.gradle.workers.max=2 \
-            -Drobolectric.usePreinstrumentedJars=false \
             -x :integration_tests:nativegraphics:test \
           )

--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -41,7 +41,6 @@ jobs:
           --parallel \
           --no-watch-fs \
           -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
-          -Drobolectric.usePreinstrumentedJars=false \
           -Dorg.gradle.workers.max=2
 
       - name: Upload Test Results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,6 @@ jobs:
           --no-watch-fs \
           -Drobolectric.enabledSdks=${{ matrix.api-versions }} \
           -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
-          -Drobolectric.usePreinstrumentedJars=false \
           -Dorg.gradle.workers.max=2 \
           -x :integration_tests:nativegraphics:test \
           -x :integration_tests:roborazzi:test

--- a/buildSrc/src/main/groovy/AndroidSdk.groovy
+++ b/buildSrc/src/main/groovy/AndroidSdk.groovy
@@ -1,5 +1,5 @@
 class AndroidSdk implements Comparable<AndroidSdk> {
-    static final PREINSTRUMENTED_VERSION = 4
+    static final PREINSTRUMENTED_VERSION = 5
 
     static final KITKAT = new AndroidSdk(19, "4.4_r1", "r2")
     static final LOLLIPOP = new AndroidSdk(21, "5.0.2_r3", "r0")

--- a/preinstrumented/build.gradle
+++ b/preinstrumented/build.gradle
@@ -46,11 +46,11 @@ tasks.register('instrumentAll') {
     }
 }
 
-tasks.register('sourcesJar', Jar) {
+tasks.register('emptySourcesJar', Jar) {
     archiveClassifier = "sources"
 }
 
-tasks.register('javadocJar', Jar) {
+tasks.register('emptyJavadocJar', Jar) {
     archiveClassifier = "javadoc"
 }
 
@@ -68,8 +68,8 @@ if (System.getenv('PUBLISH_PREINSTRUMENTED_JARS') == "true") {
                 "sdk${androidSdk.apiLevel}"(MavenPublication) {
                     artifact "${buildDir}/${androidSdk.preinstrumentedJarFileName}"
                     artifactId 'android-all-instrumented'
-                    artifact sourcesJar
-                    artifact javadocJar
+                    artifact emptySourcesJar
+                    artifact emptyJavadocJar
                     version androidSdk.preinstrumentedVersion
 
                     pom {
@@ -118,6 +118,20 @@ if (System.getenv('PUBLISH_PREINSTRUMENTED_JARS') == "true") {
             sign publishing.publications."sdk${androidSdk.apiLevel}"
         }
     }
+
+
+  // Workaround for https://github.com/gradle/gradle/issues/26132
+  // For some reason, Gradle has inferred that all publishing tasks depend on all signing tasks,
+  // so we must explicitly declare this here.
+  afterEvaluate {
+    tasks.all {
+      if (name.startsWith("publishSdk")) {
+        sdksToInstrument().each { androidSdk ->
+          dependsOn(tasks.named("signSdk${androidSdk.apiLevel}Publication"))
+        }
+      }
+    }
+  }
 }
 
 static def sdksToInstrument() {

--- a/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
@@ -46,7 +46,7 @@ public class DefaultSdkProvider implements SdkProvider {
 
   private static final int RUNNING_JAVA_VERSION = Util.getJavaVersion();
 
-  private static final int PREINSTRUMENTED_VERSION = 4;
+  private static final int PREINSTRUMENTED_VERSION = 5;
 
   private final DependencyResolver dependencyResolver;
 


### PR DESCRIPTION
Bump preinstrumented version to 5

Enough changes have accumulated in Robolectric's instrumentation that a version
bump is required. This is mostly due to the updated native method
instrumentation.

Version 5 of the preinstrumented jars have already been deployed to maven.

Also, include a workaround to the preinstrumented build.gradle that fixes the
ability for preinstrumented jars to be signed.
