### PR TITLE
Remove unused android:debuggable from AndroidManifest.xml

### DIFF
--- a/robolectric/src/test/resources/AndroidManifest.xml
+++ b/robolectric/src/test/resources/AndroidManifest.xml
@@ -39,7 +39,6 @@
          android:allowBackup="true"
          android:allowClearUserData="true"
          android:allowTaskReparenting="true"
-         android:debuggable="true"
          android:hasCode="true"
          android:killAfterRestore="true"
          android:persistent="true"

--- a/robolectric/src/test/resources/TestAndroidManifestWithFlags.xml
+++ b/robolectric/src/test/resources/TestAndroidManifestWithFlags.xml
@@ -5,7 +5,6 @@
       android:allowBackup="true"
       android:allowClearUserData="true"
       android:allowTaskReparenting="true"
-      android:debuggable="true"
       android:hasCode="true"
       android:killAfterRestore="true"
       android:persistent="true"


### PR DESCRIPTION
Hope it can fix debuggable warning.
