### PR TITLE
ci: Improve Emulator testing's configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,7 +127,7 @@ jobs:
           arch: x86_64
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
+          disable-animations: true
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run device tests
@@ -140,11 +140,10 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          disable-spellchecker: true
 
           profile: Nexus One
           script: |
-            ./gradlew cAT || ./gradlew cAT || ./gradlew cAT || exit 1
+            SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew cAT --info --stacktrace --no-watch-fs
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
1. Add some SKIP_* for commands to speed up.
2. Remove retry for Emulator testings as Linux runner is more stable and faster now.
