### PR TITLE
Switch to use Adopt OpenJDK on CI

### DIFF
--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'adopt'
           java-version: 17
 
       - name: Download google-java-format 1.9

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'adopt'
           java-version: 17
 
       - uses: gradle/gradle-build-action@v2.11.1

--- a/.github/workflows/copybara_build_and_test.yml
+++ b/.github/workflows/copybara_build_and_test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'adopt'
           java-version: 17
 
       - uses: gradle/gradle-build-action@v2.11.1

--- a/.github/workflows/gradle_tasks_validation.yml
+++ b/.github/workflows/gradle_tasks_validation.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'adopt'
           java-version: 17
 
       - uses: gradle/gradle-build-action@v2.11.1
@@ -41,7 +41,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'adopt'
           java-version: 17
 
       - uses: gradle/gradle-build-action@v2.11.1
@@ -61,7 +61,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'adopt'
           java-version: 17
 
       - uses: gradle/gradle-build-action@v2.11.1

--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'adopt'
           java-version: 17
 
       - uses: gradle/gradle-build-action@v2.11.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'adopt'
           java-version: 17
 
       - uses: gradle/gradle-build-action@v2.11.1
@@ -51,7 +51,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'adopt'
           java-version: 17
 
       - uses: gradle/gradle-build-action@v2.11.1
@@ -92,7 +92,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'adopt'
           java-version: 17
 
       - uses: gradle/gradle-build-action@v2.11.1
@@ -162,7 +162,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'adopt'
           java-version: 17
 
       - uses: gradle/gradle-build-action@v2.11.1


### PR DESCRIPTION
Zulu JDK17 often crashes on CI, and this CL tries another common used OpenJDK.
