### PR TITLE
Try to improve ci stable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,7 @@ jobs:
           -Drobolectric.enabledSdks=${{ matrix.api-versions }} \
           -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
           -Dorg.gradle.workers.max=2 \
+          -Dorg.gradle.jvmargs=-Xmx12288M \
           -x :integration_tests:nativegraphics:test \
           -x :integration_tests:roborazzi:test
 
@@ -143,7 +144,7 @@ jobs:
 
           profile: Nexus One
           script: |
-            SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew cAT --info --stacktrace --no-watch-fs -Dorg.gradle.workers.max=2
+            SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew cAT --info --stacktrace --no-watch-fs -Dorg.gradle.workers.max=2 -Dorg.gradle.jvmargs=-Xmx12288M
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
1. Restrict cAT task with max 2 threads.
2. Try max heap 12GB memory for test tasks on CI. We only can use 12GB for Linux and Windows now. See https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/.