### PR TITLE
Switch to use macos-13 for graphics tests on CI

### DIFF
--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -18,7 +18,7 @@ jobs:
   graphics_tests:
     strategy:
       matrix:
-        device: [ macos-12, ubuntu-22.04, self-hosted ]
+        device: [ macos-13, ubuntu-22.04, self-hosted ]
     runs-on: ${{ matrix.device }}
 
     steps:


### PR DESCRIPTION
See https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/.