### PR TITLE
Remove looseSignature from ShadowSystemClock

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
@@ -6,6 +6,7 @@ import static org.robolectric.shadows.ShadowLooper.assertLooperMode;
 
 import android.os.SimpleClock;
 import android.os.SystemClock;
+import java.time.Clock;
 import java.time.DateTimeException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -17,12 +18,11 @@ import org.robolectric.annotation.LooperMode.Mode;
 /**
  * The shadow API for {@link SystemClock}.
  *
- * The behavior of SystemClock in Robolectric will differ based on the current {@link
+ * <p>The behavior of SystemClock in Robolectric will differ based on the current {@link
  * LooperMode}. See {@link ShadowLegacySystemClock} and {@link ShadowPausedSystemClock} for more
  * details.
  */
-@Implements(value = SystemClock.class, shadowPicker = ShadowSystemClock.Picker.class,
-    looseSignatures = true)
+@Implements(value = SystemClock.class, shadowPicker = ShadowSystemClock.Picker.class)
 public abstract class ShadowSystemClock {
   protected static boolean networkTimeAvailable = true;
   private static boolean gnssTimeAvailable = true;
@@ -96,7 +96,7 @@ public abstract class ShadowSystemClock {
   }
 
   @Implementation(minSdk = Q)
-  protected static Object currentGnssTimeClock() {
+  protected static Clock currentGnssTimeClock() {
     if (gnssTimeAvailable) {
       return new SimpleClock(UTC) {
         @Override


### PR DESCRIPTION
Replace `Object` to `Clock` as developers can access Clock. After it, we can remove `looseSignature` from `ShadowSystemClock`.