### PR TITLE
Remove instrumentation tests on API 34

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 29, 34 ]
+        api-level: [ 29 ]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The Android emulator is failing to start with API 34, so disable tests on that API level for now.

As suggested in https://github.com/robolectric/robolectric/pull/8805#issuecomment-1932103190