### PR TITLE
Replace looseSignature with a better and fine grained annotation

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/ClassName.java
+++ b/annotations/src/main/java/org/robolectric/annotation/ClassName.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /** Parameters with types that can't be resolved at compile time may be annotated @ClassName. */
-@Target(ElementType.PARAMETER)
+@Target({ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ClassName {
 

--- a/shadows/framework/src/main/java/org/robolectric/android/controller/ActivityController.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/controller/ActivityController.java
@@ -29,6 +29,7 @@ import android.view.WindowManager;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import javax.annotation.Nullable;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowActivity;
 import org.robolectric.shadows.ShadowContextThemeWrapper;
@@ -39,7 +40,6 @@ import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
-import org.robolectric.util.reflector.WithType;
 
 /**
  * ActivityController provides low-level APIs to control activity's lifecycle.
@@ -99,7 +99,7 @@ public class ActivityController<T extends Activity>
 
   private ActivityController<T> attach(
       @Nullable Bundle activityOptions,
-      @Nullable @WithType("android.app.Activity$NonConfigurationInstances")
+      @Nullable @ClassName("android.app.Activity$NonConfigurationInstances")
           Object lastNonConfigurationInstances,
       @Nullable Configuration overrideConfig) {
     if (attached) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -61,6 +61,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -75,10 +76,9 @@ import org.robolectric.shadows.ShadowInstrumentation.TargetAndRequestCode;
 import org.robolectric.shadows.ShadowLoadedApk._LoadedApk_;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.reflector.ForType;
-import org.robolectric.util.reflector.WithType;
 
 @SuppressWarnings("NewApi")
-@Implements(value = Activity.class, looseSignatures = true)
+@Implements(value = Activity.class)
 public class ShadowActivity extends ShadowContextThemeWrapper {
 
   @RealObject protected Activity realActivity;
@@ -129,7 +129,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   public void callAttach(
       Intent intent,
       @Nullable Bundle activityOptions,
-      @Nullable @WithType("android.app.Activity$NonConfigurationInstances")
+      @Nullable @ClassName("android.app.Activity$NonConfigurationInstances")
           Object lastNonConfigurationInstances) {
     callAttach(
         intent,
@@ -141,7 +141,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   public void callAttach(
       Intent intent,
       @Nullable Bundle activityOptions,
-      @Nullable @WithType("android.app.Activity$NonConfigurationInstances")
+      @Nullable @ClassName("android.app.Activity$NonConfigurationInstances")
           Object lastNonConfigurationInstances,
       @Nullable Configuration overrideConfig) {
     Application application = RuntimeEnvironment.getApplication();
@@ -417,7 +417,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
    * @return fake SplashScreen
    */
   @Implementation(minSdk = S)
-  protected synchronized Object getSplashScreen() {
+  protected synchronized @ClassName("android.window.SplashScreen") Object getSplashScreen() {
     if (splashScreen == null) {
       splashScreen = new RoboSplashScreen();
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -42,14 +43,14 @@ import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
 import org.robolectric.util.reflector.Reflector;
 
-@Implements(value = ActivityThread.class, isInAndroidSdk = false, looseSignatures = true)
+@Implements(value = ActivityThread.class, isInAndroidSdk = false)
 public class ShadowActivityThread {
   private static ApplicationInfo applicationInfo;
   @RealObject protected ActivityThread realActivityThread;
   @ReflectorObject protected _ActivityThread_ activityThreadReflector;
 
   @Implementation
-  public static Object getPackageManager() {
+  public static @ClassName("android.content.pm.IPackageManager") Object getPackageManager() {
     ClassLoader classLoader = ShadowActivityThread.class.getClassLoader();
     Class<?> iPackageManagerClass;
     try {
@@ -111,7 +112,7 @@ public class ShadowActivityThread {
   }
 
   @Implementation
-  public static Object currentActivityThread() {
+  public static @ClassName("android.app.ActivityThread") Object currentActivityThread() {
     return RuntimeEnvironment.getActivityThread();
   }
 
@@ -133,7 +134,7 @@ public class ShadowActivityThread {
   }
 
   @Implementation(minSdk = R)
-  public static Object getPermissionManager() {
+  public static @ClassName("android.permission.IPermissionManager") Object getPermissionManager() {
     ClassLoader classLoader = ShadowActivityThread.class.getClassLoader();
     Class<?> iPermissionManagerClass;
     try {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppOpsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppOpsManager.java
@@ -51,6 +51,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.IntStream;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -63,7 +64,7 @@ import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
 
 /** Shadow for {@link AppOpsManager}. */
-@Implements(value = AppOpsManager.class, looseSignatures = true)
+@Implements(value = AppOpsManager.class)
 public class ShadowAppOpsManager {
 
   // OpEntry fields that the shadow doesn't currently allow the test to configure.
@@ -414,18 +415,18 @@ public class ShadowAppOpsManager {
   @RequiresApi(api = S)
   @Implementation(minSdk = S)
   protected int noteProxyOpNoThrow(
-      Object op, Object attributionSource, Object message, Object ignoredSkipProxyOperation) {
-    Preconditions.checkArgument(op instanceof Integer);
+      int op,
+      @ClassName("android.content.AttributionSource") Object attributionSource,
+      String message,
+      boolean ignoredSkipProxyOperation) {
     Preconditions.checkArgument(attributionSource instanceof AttributionSource);
-    Preconditions.checkArgument(message == null || message instanceof String);
-    Preconditions.checkArgument(ignoredSkipProxyOperation instanceof Boolean);
     AttributionSource castedAttributionSource = (AttributionSource) attributionSource;
     return noteProxyOpNoThrow(
-        (int) op,
+        op,
         castedAttributionSource.getNextPackageName(),
         castedAttributionSource.getNextUid(),
         castedAttributionSource.getNextAttributionTag(),
-        (String) message);
+        message);
   }
 
   @Implementation

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscApkAssets9.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscApkAssets9.java
@@ -14,6 +14,7 @@ import java.io.FileDescriptor;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -37,8 +38,7 @@ import org.robolectric.util.reflector.Static;
     value = ApkAssets.class,
     minSdk = P,
     shadowPicker = Picker.class,
-    isInAndroidSdk = false,
-    looseSignatures = true)
+    isInAndroidSdk = false)
 public class ShadowArscApkAssets9 extends ShadowApkAssets {
   // #define ATRACE_TAG ATRACE_TAG_RESOURCES
   //
@@ -149,12 +149,16 @@ public class ShadowArscApkAssets9 extends ShadowApkAssets {
   }
 
   @Implementation(minSdk = R)
-  protected static Object nativeLoad(
-      Object format, Object javaPath, Object flags, Object assetsProvider) throws IOException {
-    boolean system = ((int) flags & PROPERTY_SYSTEM) == PROPERTY_SYSTEM;
-    boolean overlay = ((int) flags & PROPERTY_OVERLAY) == PROPERTY_OVERLAY;
-    boolean forceSharedLib = ((int) flags & PROPERTY_DYNAMIC) == PROPERTY_DYNAMIC;
-    return nativeLoad((String) javaPath, system, forceSharedLib, overlay);
+  protected static long nativeLoad(
+      int format,
+      String javaPath,
+      int flags,
+      @ClassName("android.content.res.loader.AssetsProvider") Object assetsProvider)
+      throws IOException {
+    boolean system = (flags & PROPERTY_SYSTEM) == PROPERTY_SYSTEM;
+    boolean overlay = (flags & PROPERTY_OVERLAY) == PROPERTY_OVERLAY;
+    boolean forceSharedLib = (flags & PROPERTY_DYNAMIC) == PROPERTY_DYNAMIC;
+    return nativeLoad(javaPath, system, forceSharedLib, overlay);
   }
 
   // static jlong NativeLoadFromFd(JNIEnv* env, jclass /*clazz*/, jobject file_descriptor,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -49,7 +50,7 @@ import org.robolectric.util.reflector.Constructor;
 import org.robolectric.util.reflector.ForType;
 
 @SuppressWarnings({"UnusedDeclaration"})
-@Implements(value = AudioManager.class, looseSignatures = true)
+@Implements(value = AudioManager.class)
 public class ShadowAudioManager {
   @RealObject AudioManager realAudioManager;
 
@@ -902,7 +903,8 @@ public class ShadowAudioManager {
   @HiddenApi
   @Implementation(minSdk = P)
   @RequiresPermission(android.Manifest.permission.MODIFY_AUDIO_ROUTING)
-  protected int registerAudioPolicy(@NonNull Object audioPolicy) {
+  protected int registerAudioPolicy(
+      @NonNull @ClassName("android.media.audiopolicy.AudioPolicy") Object audioPolicy) {
     Preconditions.checkNotNull(audioPolicy, "Illegal null AudioPolicy argument");
     AudioPolicy policy = (AudioPolicy) audioPolicy;
     String id = getIdForAudioPolicy(audioPolicy);
@@ -916,7 +918,8 @@ public class ShadowAudioManager {
 
   @HiddenApi
   @Implementation(minSdk = Q)
-  protected void unregisterAudioPolicy(@NonNull Object audioPolicy) {
+  protected void unregisterAudioPolicy(
+      @NonNull @ClassName("android.media.audiopolicy.AudioPolicy") Object audioPolicy) {
     Preconditions.checkNotNull(audioPolicy, "Illegal null AudioPolicy argument");
     AudioPolicy policy = (AudioPolicy) audioPolicy;
     registeredAudioPolicies.remove(getIdForAudioPolicy(policy));

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioTrack.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioTrack.java
@@ -50,7 +50,7 @@ import org.robolectric.versioning.AndroidVersions.U;
  * other methods are expected run through the real class. The two {@link WriteMode} are treated the
  * same.
  */
-@Implements(value = AudioTrack.class, looseSignatures = true)
+@Implements(value = AudioTrack.class)
 public class ShadowAudioTrack {
 
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
@@ -132,9 +132,9 @@ public class ShadowBluetoothAdapter {
     return reflector(BluetoothAdapterReflector.class).getDefaultAdapter();
   }
 
-  /** Requires LooseSignatures because of {@link AttributionSource} parameter */
   @Implementation(minSdk = VERSION_CODES.TIRAMISU)
-  protected static Object createAdapter(Object attributionSource) {
+  protected static /*android.bluetooth.BluetoothAdapter*/ Object createAdapter(
+      /*android.content.AttributionSource*/ Object attributionSource) {
     IBluetoothManager service =
         ReflectionHelpers.createDelegatingProxy(
             IBluetoothManager.class, new BluetoothManagerDelegate());
@@ -376,16 +376,17 @@ public class ShadowBluetoothAdapter {
     return true;
   }
 
-  /**
-   * Needs looseSignatures because in Android T the return value of this method was changed from
-   * bool to int.
-   */
-  @Implementation(maxSdk = S_V2)
-  protected boolean setScanMode(int scanMode) {
-    boolean result =
-        scanMode == BluetoothAdapter.SCAN_MODE_CONNECTABLE
-            || scanMode == BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE
-            || scanMode == BluetoothAdapter.SCAN_MODE_NONE;
+  /** T return value changed from {@code int} to {@link Duration} starting in T. */
+  @Implementation
+  protected Object setScanMode(int scanMode) {
+    // TODO Support ClassName for different return values in different SDKs.
+    boolean result = true;
+    if (scanMode != BluetoothAdapter.SCAN_MODE_CONNECTABLE
+        && scanMode != BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE
+        && scanMode != BluetoothAdapter.SCAN_MODE_NONE) {
+      result = false;
+    }
+
     this.scanMode = scanMode;
     return result;
   }
@@ -415,12 +416,10 @@ public class ShadowBluetoothAdapter {
     return scanMode;
   }
 
-  /**
-   * Needs looseSignatures because the return value changed from {@code int} to {@link Duration}
-   * starting in T.
-   */
+  /** In Android T the return value of this method was changed from bool to int. */
   @Implementation
   protected Object getDiscoverableTimeout() {
+    // TODO Support ClassName for different return values in different SDKs.
     if (RuntimeEnvironment.getApiLevel() <= S_V2) {
       return (int) discoverableTimeout.toSeconds();
     } else {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManager.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.Bootstrap;
 import org.robolectric.android.internal.DisplayConfig;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -42,7 +43,7 @@ import org.robolectric.util.reflector.ForType;
  * For tests, display properties may be changed and devices may be added or removed
  * programmatically.
  */
-@Implements(value = DisplayManager.class, looseSignatures = true)
+@Implements(value = DisplayManager.class)
 public class ShadowDisplayManager {
 
   @RealObject private DisplayManager realDisplayManager;
@@ -318,14 +319,17 @@ public class ShadowDisplayManager {
 
   @Implementation(minSdk = P)
   @HiddenApi
-  protected void setBrightnessConfiguration(Object config) {
+  protected void setBrightnessConfiguration(
+      @ClassName("android.hardware.display.BrightnessConfiguration") Object config) {
     setBrightnessConfigurationForUser(config, 0, context.getPackageName());
   }
 
   @Implementation(minSdk = P)
   @HiddenApi
   protected void setBrightnessConfigurationForUser(
-      Object config, Object userId, Object packageName) {
+      @ClassName("android.hardware.display.BrightnessConfiguration") Object config,
+      int userId,
+      String packageName) {
     getShadowDisplayManagerGlobal().setBrightnessConfigurationForUser(config, userId, packageName);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManagerGlobal.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManagerGlobal.java
@@ -24,6 +24,7 @@ import java.util.TreeMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.annotation.Nullable;
 import org.robolectric.android.Bootstrap;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -34,10 +35,7 @@ import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
 
 /** Shadow for {@link DisplayManagerGlobal}. */
-@Implements(
-    value = DisplayManagerGlobal.class,
-    isInAndroidSdk = false,
-    looseSignatures = true)
+@Implements(value = DisplayManagerGlobal.class, isInAndroidSdk = false)
 public class ShadowDisplayManagerGlobal {
   private static DisplayManagerGlobal instance;
 
@@ -234,14 +232,17 @@ public class ShadowDisplayManagerGlobal {
   @Implementation(minSdk = P)
   @HiddenApi
   protected void setBrightnessConfigurationForUser(
-      Object configObject, Object userId, Object packageName) {
+      @ClassName("android.hardware.display.BrightnessConfiguration") Object configObject,
+      int userId,
+      String packageName) {
     BrightnessConfiguration config = (BrightnessConfiguration) configObject;
-    brightnessConfiguration.put((int) userId, config);
+    brightnessConfiguration.put(userId, config);
   }
 
   @Implementation(minSdk = P)
   @HiddenApi
-  protected Object getBrightnessConfigurationForUser(int userId) {
+  protected @ClassName("android.hardware.display.BrightnessConfiguration") Object
+      getBrightnessConfigurationForUser(int userId) {
     BrightnessConfiguration config = brightnessConfiguration.get(userId);
     if (config != null) {
       return config;
@@ -252,7 +253,8 @@ public class ShadowDisplayManagerGlobal {
 
   @Implementation(minSdk = P)
   @HiddenApi
-  protected Object getDefaultBrightnessConfiguration() {
+  protected @ClassName("android.hardware.display.BrightnessConfiguration") Object
+      getDefaultBrightnessConfiguration() {
     return defaultBrightnessConfiguration;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowHardwareRenderer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowHardwareRenderer.java
@@ -40,6 +40,7 @@ public class ShadowHardwareRenderer {
   // need to use loose signatures here to account for signature changes
   @Implementation(minSdk = S)
   protected static long nCreateProxy(Object translucent, Object rootRenderNode) {
+    // TODO Find an approach to support the same method with disconnected range
     return nCreateProxy((boolean) translucent, (long) rootRenderNode);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageParser.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageParser.java
@@ -99,8 +99,7 @@ public class ShadowPackageParser {
         long firstInstallTime,
         long lastUpdateTime,
         HashSet<String> grantedPermissions,
-        @WithType("android.content.pm.PackageUserState")
-            Object state);
+        @WithType("android.content.pm.PackageUserState") Object state);
 
     // LOLLIPOP_MR1
     @Static
@@ -111,8 +110,7 @@ public class ShadowPackageParser {
         long firstInstallTime,
         long lastUpdateTime,
         ArraySet<String> grantedPermissions,
-        @WithType("android.content.pm.PackageUserState")
-            Object state);
+        @WithType("android.content.pm.PackageUserState") Object state);
 
     @Static
     PackageInfo generatePackageInfo(

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPaint.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPaint.java
@@ -17,6 +17,7 @@ import android.graphics.Paint.FontMetricsInt;
 import android.graphics.PathEffect;
 import android.graphics.Shader;
 import android.graphics.Typeface;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.InDevelopment;
@@ -29,7 +30,7 @@ import org.robolectric.versioning.AndroidVersions.U;
 import org.robolectric.versioning.AndroidVersions.V;
 
 @SuppressWarnings({"UnusedDeclaration"})
-@Implements(value = Paint.class, looseSignatures = true)
+@Implements(value = Paint.class)
 public class ShadowPaint {
 
   private int color;
@@ -505,8 +506,11 @@ public class ShadowPaint {
   }
 
   @Implementation(minSdk = N, maxSdk = N_MR1)
-  protected int nGetFontMetricsInt(Object nativePaint, Object nativeTypeface, Object fmi) {
-    return nGetFontMetricsInt((long) nativePaint, (FontMetricsInt) fmi);
+  protected int nGetFontMetricsInt(
+      long nativePaint,
+      long nativeTypeface,
+      @ClassName("android.graphics.Paint.FontMetricsInt") Object fmi) {
+    return nGetFontMetricsInt(nativePaint, (FontMetricsInt) fmi);
   }
 
   @Implementation(maxSdk = M)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPhoneWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPhoneWindow.java
@@ -13,11 +13,11 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.reflector.ForType;
 
-/**
- * Shadow for PhoneWindow for APIs 23+
- */
-@Implements(className = "com.android.internal.policy.PhoneWindow", isInAndroidSdk = false,
-    minSdk = M, looseSignatures = true)
+/** Shadow for PhoneWindow for APIs 23+ */
+@Implements(
+    className = "com.android.internal.policy.PhoneWindow",
+    isInAndroidSdk = false,
+    minSdk = M)
 public class ShadowPhoneWindow extends ShadowWindow {
   protected @RealObject Window realWindow;
   protected boolean decorFitsSystemWindows = true;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPhoneWindowFor22.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPhoneWindowFor22.java
@@ -8,11 +8,11 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.util.reflector.ForType;
 
-/**
- * Shadow for the API 16-22 PhoneWindow.li
- */
-@Implements(className = "com.android.internal.policy.impl.PhoneWindow", maxSdk = LOLLIPOP_MR1,
-    looseSignatures = true, isInAndroidSdk = false)
+/** Shadow for the API 16-22 PhoneWindow.li */
+@Implements(
+    className = "com.android.internal.policy.impl.PhoneWindow",
+    maxSdk = LOLLIPOP_MR1,
+    isInAndroidSdk = false)
 public class ShadowPhoneWindowFor22 extends ShadowPhoneWindow {
 
   @Override @Implementation(maxSdk = LOLLIPOP_MR1)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -52,7 +53,7 @@ import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
 
 /** Shadow of PowerManager */
-@Implements(value = PowerManager.class, looseSignatures = true)
+@Implements(value = PowerManager.class)
 public class ShadowPowerManager {
 
   @RealObject private PowerManager realPowerManager;
@@ -218,7 +219,8 @@ public class ShadowPowerManager {
 
   /** This function adds a listener for thermal status change. */
   @Implementation(minSdk = Q)
-  protected void addThermalStatusListener(Object listener) {
+  protected void addThermalStatusListener(
+      @ClassName("android.os.PowerManager.OnThermalStatusChangedListener") Object listener) {
     checkState(
         listener instanceof PowerManager.OnThermalStatusChangedListener,
         "Listener must implement PowerManager.OnThermalStatusChangedListener");
@@ -232,7 +234,8 @@ public class ShadowPowerManager {
 
   /** This function removes a listener for thermal status change. */
   @Implementation(minSdk = Q)
-  protected void removeThermalStatusListener(Object listener) {
+  protected void removeThermalStatusListener(
+      @ClassName("android.os.PowerManager.OnThermalStatusChangedListener") Object listener) {
     checkState(
         listener instanceof PowerManager.OnThermalStatusChangedListener,
         "Listener must implement PowerManager.OnThermalStatusChangedListener");
@@ -607,7 +610,8 @@ public class ShadowPowerManager {
   }
 
   @Implementation(minSdk = UPSIDE_DOWN_CAKE)
-  protected Object /* LowPowerStandbyPortsLock */ newLowPowerStandbyPortsLock(
+  protected @ClassName("android.os.PowerManager.LowPowerStandbyPortsLock")
+  Object /* LowPowerStandbyPortsLock */ newLowPowerStandbyPortsLock(
       List<LowPowerStandbyPortDescription> ports) {
     PowerManager.LowPowerStandbyPortsLock lock =
         Shadow.newInstanceOf(PowerManager.LowPowerStandbyPortsLock.class);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRotationWatcherFor22.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRotationWatcherFor22.java
@@ -2,18 +2,20 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
 
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
-/**
- * Shadow for RotationWatcher for API 16-22
- */
-@Implements(className = "com.android.internal.policy.impl.PhoneWindow$RotationWatcher",
-    isInAndroidSdk = false, maxSdk = LOLLIPOP_MR1, looseSignatures = true)
+/** Shadow for RotationWatcher for API 16-22 */
+@Implements(
+    className = "com.android.internal.policy.impl.PhoneWindow$RotationWatcher",
+    isInAndroidSdk = false,
+    maxSdk = LOLLIPOP_MR1)
 public class ShadowRotationWatcherFor22 {
 
   @Implementation
-  protected void addWindow(Object phoneWindow) {
+  protected void addWindow(
+      @ClassName("com.android.internal.policy.impl.PhoneWindow") Object phoneWindow) {
     // ignore
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
@@ -21,13 +21,14 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
-@Implements(value = SensorManager.class, looseSignatures = true)
+@Implements(value = SensorManager.class)
 public class ShadowSensorManager {
   public boolean forceListenersToFail = false;
   private final Multimap<Integer, Sensor> sensorMap =
@@ -241,7 +242,8 @@ public class ShadowSensorManager {
   }
 
   @Implementation(minSdk = O)
-  protected Object createDirectChannel(MemoryFile mem) {
+  protected @ClassName("android.hardware.SensorDirectChannel") Object createDirectChannel(
+      MemoryFile mem) {
     return ReflectionHelpers.callConstructor(SensorDirectChannel.class,
         ClassParameter.from(SensorManager.class, realObject),
         ClassParameter.from(int.class, 0),

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStaticLayout.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStaticLayout.java
@@ -9,6 +9,7 @@ import static org.robolectric.util.reflector.Reflector.reflector;
 import android.text.DynamicLayout;
 import android.text.StaticLayout;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -18,7 +19,7 @@ import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
 
 /** Shadow for android.text.StaticLayout */
-@Implements(value = StaticLayout.class, looseSignatures = true)
+@Implements(value = StaticLayout.class)
 public class ShadowStaticLayout {
 
   @ForType(className = "android.text.StaticLayout$LineBreaks")
@@ -45,37 +46,37 @@ public class ShadowStaticLayout {
   @HiddenApi
   @Implementation(minSdk = M, maxSdk = O_MR1)
   public static int nComputeLineBreaks(
-      Object nativePtr,
-      Object recycle,
-      Object recycleBreaks,
-      Object recycleWidths,
-      Object recycleFlags,
-      Object recycleLength) {
+      long nativePtr,
+      @ClassName("android.text.StaticLayout.LineBreaks") Object recycle,
+      int[] recycleBreaks,
+      float[] recycleWidths,
+      int[] recycleFlags,
+      int recycleLength) {
     return 1;
   }
 
   @HiddenApi
   @Implementation(minSdk = P, maxSdk = P)
   protected static int nComputeLineBreaks(
-      Object nativePtr,
-      Object text,
-      Object measuredTextPtr,
-      Object length,
-      Object firstWidth,
-      Object firstWidthLineCount,
-      Object restWidth,
-      Object variableTabStops,
-      Object defaultTabStop,
-      Object indentsOffset,
-      Object recycle,
-      Object recycleLength,
-      Object recycleBreaks,
-      Object recycleWidths,
-      Object recycleAscents,
-      Object recycleDescents,
-      Object recycleFlags,
-      Object charWidths) {
-    reflector(LineBreaksReflector.class, recycle).setBreaks(new int[] {((char[]) text).length});
+      long nativePtr,
+      char[] text,
+      long measuredTextPtr,
+      int length,
+      float firstWidth,
+      int firstWidthLineCount,
+      float restWidth,
+      int[] variableTabStops,
+      int defaultTabStop,
+      int indentsOffset,
+      @ClassName("android.text.StaticLayout.LineBreaks") Object recycle,
+      int recycleLength,
+      int[] recycleBreaks,
+      float[] recycleWidths,
+      float[] recycleAscents,
+      float[] recycleDescents,
+      int[] recycleFlags,
+      float[] charWidths) {
+    reflector(LineBreaksReflector.class, recycle).setBreaks(new int[] {text.length});
     return 1;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemClock.java
@@ -9,6 +9,7 @@ import android.os.SystemClock;
 import java.time.DateTimeException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.LooperMode;
@@ -17,12 +18,11 @@ import org.robolectric.annotation.LooperMode.Mode;
 /**
  * The shadow API for {@link SystemClock}.
  *
- * The behavior of SystemClock in Robolectric will differ based on the current {@link
+ * <p>The behavior of SystemClock in Robolectric will differ based on the current {@link
  * LooperMode}. See {@link ShadowLegacySystemClock} and {@link ShadowPausedSystemClock} for more
  * details.
  */
-@Implements(value = SystemClock.class, shadowPicker = ShadowSystemClock.Picker.class,
-    looseSignatures = true)
+@Implements(value = SystemClock.class, shadowPicker = ShadowSystemClock.Picker.class)
 public abstract class ShadowSystemClock {
   protected static boolean networkTimeAvailable = true;
   private static boolean gnssTimeAvailable = true;
@@ -96,7 +96,7 @@ public abstract class ShadowSystemClock {
   }
 
   @Implementation(minSdk = Q)
-  protected static Object currentGnssTimeClock() {
+  protected static @ClassName("java.time.Clock") Object currentGnssTimeClock() {
     if (gnssTimeAvailable) {
       return new SimpleClock(UTC) {
         @Override

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemServiceRegistry.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemServiceRegistry.java
@@ -6,6 +6,7 @@ import static org.robolectric.util.reflector.Reflector.reflector;
 import android.content.Context;
 import android.os.Build;
 import java.util.Map;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
@@ -15,7 +16,6 @@ import org.robolectric.util.reflector.ForType;
 @Implements(
   className = "android.app.SystemServiceRegistry",
   isInAndroidSdk = false,
-  looseSignatures = true,
   minSdk = Build.VERSION_CODES.M
 )
 public class ShadowSystemServiceRegistry {
@@ -128,7 +128,8 @@ public class ShadowSystemServiceRegistry {
   }
 
   @Implementation(minSdk = O)
-  protected static void onServiceNotFound(/* ServiceNotFoundException */ Object e0) {
+  protected static void onServiceNotFound(
+      @ClassName("android.os.ServiceManager.ServiceNotFoundException") Object e0) {
     // otherwise the full stacktrace might be swallowed...
     Exception e = (Exception) e0;
     e.printStackTrace();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
@@ -70,6 +70,7 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -80,7 +81,7 @@ import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.versioning.AndroidVersions.U;
 import org.robolectric.versioning.AndroidVersions.V;
 
-@Implements(value = TelephonyManager.class, looseSignatures = true)
+@Implements(value = TelephonyManager.class)
 public class ShadowTelephonyManager {
 
   @RealObject protected TelephonyManager realTelephonyManager;
@@ -250,12 +251,13 @@ public class ShadowTelephonyManager {
   @Implementation(minSdk = S)
   @HiddenApi
   public void bootstrapAuthenticationRequest(
-      Object appType,
-      Object nafId,
-      Object securityProtocol,
-      Object forceBootStrapping,
-      Object e,
-      Object callback) {
+      int appType,
+      Uri nafId,
+      @ClassName("android.telephony.gba.UaSecurityProtocolIdentifier") Object securityProtocol,
+      boolean forceBootStrapping,
+      Executor e,
+      @ClassName("android.telephony.TelephonyManager.BootstrapAuthenticationCallback")
+          Object callback) {
     this.callback = callback;
   }
 
@@ -265,7 +267,7 @@ public class ShadowTelephonyManager {
 
   @Implementation(minSdk = S)
   @HiddenApi
-  public /*PhoneCapability*/ Object getPhoneCapability() {
+  public @ClassName("android.telephony.PhoneCapability") Object getPhoneCapability() {
     return phoneCapability;
   }
 
@@ -306,7 +308,8 @@ public class ShadowTelephonyManager {
 
   @Implementation(minSdk = S)
   public void registerTelephonyCallback(
-      /*Executor*/ Object executor, /*TelephonyCallback*/ Object callback) {
+      @ClassName("java.util.concurrent.Executor") Object executor,
+      @ClassName("android.telephony.TelephonyCallback") Object callback) {
     Preconditions.checkArgument(executor instanceof Executor);
     Preconditions.checkArgument(callback instanceof TelephonyCallback);
     lastTelephonyCallback = callback;
@@ -316,15 +319,15 @@ public class ShadowTelephonyManager {
 
   @Implementation(minSdk = TIRAMISU)
   protected void registerTelephonyCallback(
-      /*int*/ Object includeLocationData, /*Executor*/
-      Object executor, /*TelephonyCallback*/
-      Object callback) {
-    Preconditions.checkArgument(includeLocationData instanceof Integer);
+      int includeLocationData,
+      @ClassName("java.util.concurrent.Executor") Object executor,
+      @ClassName("android.telephony.TelephonyCallback") Object callback) {
     registerTelephonyCallback(executor, callback);
   }
 
   @Implementation(minSdk = S)
-  public void unregisterTelephonyCallback(/*TelephonyCallback*/ Object callback) {
+  public void unregisterTelephonyCallback(
+      @ClassName("android.telephony.TelephonyCallback") Object callback) {
     telephonyCallbackRegistrations.remove(callback);
   }
 
@@ -634,7 +637,7 @@ public class ShadowTelephonyManager {
   /** Returns the UICC slots information set by {@link #setUiccSlotsInfo}. */
   @Implementation(minSdk = P)
   @HiddenApi
-  protected /*UiccSlotInfo[]*/ Object getUiccSlotsInfo() {
+  protected @ClassName("android.telephony.UiccSlotInfo[]") Object getUiccSlotsInfo() {
     return uiccSlotInfos;
   }
 
@@ -646,7 +649,7 @@ public class ShadowTelephonyManager {
   /** Returns the UICC cards information set by {@link #setUiccCardsInfo}. */
   @Implementation(minSdk = Q)
   @HiddenApi
-  protected /*List<UiccCardInfo>*/ Object getUiccCardsInfo() {
+  protected @ClassName("java.util.List<android.telephony.UiccCardInfo>") Object getUiccCardsInfo() {
     return uiccCardsInfo;
   }
 
@@ -804,8 +807,10 @@ public class ShadowTelephonyManager {
    * TelephonyManager#NETWORK_TYPE_UNKNOWN} if it was never called.
    */
   @Implementation(minSdk = Q)
-  protected void requestCellInfoUpdate(Object cellInfoExecutor, Object cellInfoCallback) {
-    Executor executor = (Executor) cellInfoExecutor;
+  protected void requestCellInfoUpdate(
+      Executor cellInfoExecutor,
+      @ClassName("android.telephony.TelephonyManager.CellInfoCallback") Object cellInfoCallback) {
+    Executor executor = cellInfoExecutor;
     List<CellInfo> callbackCellInfos = ShadowTelephonyManager.callbackCellInfos;
     if (callbackCellInfos == null) {
       // ignore
@@ -905,7 +910,8 @@ public class ShadowTelephonyManager {
   }
 
   @CallSuper
-  protected void initTelephonyCallback(Object callback) {
+  protected void initTelephonyCallback(
+      @ClassName("android.telephony.TelephonyCallback") Object callback) {
     if (VERSION.SDK_INT < S) {
       return;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowThreadedRenderer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowThreadedRenderer.java
@@ -5,6 +5,7 @@ import static android.os.Build.VERSION_CODES.P;
 
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.shadow.api.Shadow;
@@ -12,15 +13,14 @@ import org.robolectric.shadow.api.Shadow;
 @Implements(
     className = "android.view.ThreadedRenderer",
     isInAndroidSdk = false,
-    looseSignatures = true,
     minSdk = O,
     maxSdk = P)
 public class ShadowThreadedRenderer {
 
   @Implementation
   protected static Bitmap createHardwareBitmap(
-      /*RenderNode*/ Object node, /*int*/ Object width, /*int*/ Object height) {
-    return createHardwareBitmap((int) width, (int) height);
+      @ClassName("android.view.RenderNode") Object node, int width, int height) {
+    return createHardwareBitmap(width, height);
   }
 
   private static Bitmap createHardwareBitmap(int width, int height) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeZoneFinder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeZoneFinder.java
@@ -18,8 +18,7 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
     className = "libcore.util.TimeZoneFinder",
     minSdk = O,
     maxSdk = P,
-    isInAndroidSdk = false,
-    looseSignatures = true)
+    isInAndroidSdk = false)
 public class ShadowTimeZoneFinder {
 
   private static final String TZLOOKUP_PATH = "/usr/share/zoneinfo/tzlookup.xml";

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeZoneFinderQ.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeZoneFinderQ.java
@@ -14,8 +14,7 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
     className = "libcore.timezone.TimeZoneFinder",
     minSdk = Q,
     maxSdk = R,
-    isInAndroidSdk = false,
-    looseSignatures = true)
+    isInAndroidSdk = false)
 public class ShadowTimeZoneFinderQ {
 
   @Implementation

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeZoneFinderS.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeZoneFinderS.java
@@ -8,21 +8,18 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /** Shadow for TimeZoneFinder on S or above. */
-@Implements(
-    value = TimeZoneFinder.class,
-    minSdk = S,
-    isInAndroidSdk = false,
-    looseSignatures = true)
+@Implements(className = "android.timezone.TimeZoneFinder", minSdk = S, isInAndroidSdk = false)
 public class ShadowTimeZoneFinderS {
 
   private static final String TZLOOKUP_PATH = "/usr/share/zoneinfo/tzlookup.xml";
 
   @Implementation
-  protected static Object getInstance() {
+  protected static @ClassName("android.timezone.TimeZoneFinder") Object getInstance() {
     return TimeZoneFinder.createInstanceForTests(readTzlookup());
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsageStatsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsageStatsManager.java
@@ -595,7 +595,7 @@ public class ShadowUsageStatsManager {
   @SuppressWarnings("unchecked")
   @Implementation(minSdk = TIRAMISU)
   protected Object /* List<BroadcastResponseStats> */ queryBroadcastResponseStats(
-      @Nullable Object packageName, Object id) {
+      @Nullable String packageName, long id) {
     List<BroadcastResponseStats> result = new ArrayList<>();
     for (Map.Entry<String, Map<Long, Object /*BroadcastResponseStats*/>> entry :
         appBroadcastStats.entrySet()) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsbManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsbManager.java
@@ -187,7 +187,7 @@ public class ShadowUsbManager {
 
   @Implementation(minSdk = M)
   @HiddenApi
-  protected /* UsbPort[] */ Object getPorts() {
+  protected /*List<UsbPort> from SDK29 and UsbPort[] before SDK29*/ Object getPorts() {
     if (RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.Q) {
       return new ArrayList<>(usbPortStatuses.keySet());
     }
@@ -255,28 +255,29 @@ public class ShadowUsbManager {
    * portId} if present; otherwise returns {@code null}.
    */
   @Nullable
-  public /* UsbPortStatus */ Object getPortStatus(String portId) {
+  public /*ndroid.hardware.usb.UsbPortStatus*/ Object getPortStatus(String portId) {
     return usbPortStatuses.get(usbPorts.get(portId));
   }
 
   @Implementation(minSdk = M)
   @HiddenApi
-  protected /* UsbPortStatus */ Object getPortStatus(/* UsbPort */ Object port) {
+  protected /*android.hardware.usb.UsbPortStatus*/ Object getPortStatus(
+      /*android.hardware.usb.UsbPort*/ Object port) {
     return usbPortStatuses.get(port);
   }
 
   @Implementation(minSdk = M)
   @HiddenApi
   protected void setPortRoles(
-      /* UsbPort */ Object port, /* int */ Object powerRole, /* int */ Object dataRole) {
+      /*android.hardware.usb.UsbPort*/ Object port, Object powerRole, Object dataRole) {
     UsbPortStatus status = usbPortStatuses.get(port);
     usbPortStatuses.put(
         (UsbPort) port,
         (UsbPortStatus)
             createUsbPortStatus(
                 status.getCurrentMode(),
-                (int) powerRole,
-                (int) dataRole,
+                (Integer) powerRole,
+                (Integer) dataRole,
                 status.getSupportedRoleCombinations()));
     RuntimeEnvironment.getApplication()
         .sendBroadcast(new Intent(UsbManager.ACTION_USB_PORT_CHANGED));

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -54,7 +55,7 @@ import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.ReflectionHelpers;
 
 /** Shadow for {@link android.net.wifi.WifiManager}. */
-@Implements(value = WifiManager.class, looseSignatures = true)
+@Implements(value = WifiManager.class)
 @SuppressWarnings("AndroidConcurrentHashMap")
 public class ShadowWifiManager {
   private static final int LOCAL_HOST = 2130706433;
@@ -577,8 +578,10 @@ public class ShadowWifiManager {
 
   @Implementation(minSdk = Q)
   @HiddenApi
-  protected void addOnWifiUsabilityStatsListener(Object executorObject, Object listenerObject) {
-    Executor executor = (Executor) executorObject;
+  protected void addOnWifiUsabilityStatsListener(
+      Executor executor,
+      @ClassName("android.net.wifi.WifiManager.OnWifiUsabilityStatsListener")
+          Object listenerObject) {
     WifiManager.OnWifiUsabilityStatsListener listener =
         (WifiManager.OnWifiUsabilityStatsListener) listenerObject;
     wifiUsabilityStatsListeners.put(listener, executor);
@@ -586,7 +589,9 @@ public class ShadowWifiManager {
 
   @Implementation(minSdk = Q)
   @HiddenApi
-  protected void removeOnWifiUsabilityStatsListener(Object listenerObject) {
+  protected void removeOnWifiUsabilityStatsListener(
+      @ClassName("android.net.wifi.WifiManager.OnWifiUsabilityStatsListener")
+          Object listenerObject) {
     WifiManager.OnWifiUsabilityStatsListener listener =
         (WifiManager.OnWifiUsabilityStatsListener) listenerObject;
     wifiUsabilityStatsListeners.remove(listener);
@@ -606,7 +611,9 @@ public class ShadowWifiManager {
    */
   @Implementation(minSdk = R)
   @HiddenApi
-  protected boolean setWifiConnectedNetworkScorer(Object executorObject, Object scorerObject) {
+  protected boolean setWifiConnectedNetworkScorer(
+      Executor executorObject,
+      @ClassName("android.net.wifi.WifiManager.WifiConnectedNetworkScorer") Object scorerObject) {
     if (networkScorer == null) {
       networkScorer = scorerObject;
       return true;
@@ -849,15 +856,18 @@ public class ShadowWifiManager {
   @Implementation(minSdk = TIRAMISU)
   @HiddenApi
   protected void setExternalPnoScanRequest(
-      Object ssids, Object frequencies, Object executor, Object callback) {
+      @ClassName("java.util.List<android.net.wifi.WifiSsid>") Object ssids,
+      int[] frequencies,
+      Executor executor,
+      @ClassName("android.net.wifi.WifiManager.PnoScanResultsCallback") Object callback) {
     synchronized (pnoRequestLock) {
       if (callback == null) {
         throw new IllegalArgumentException("callback cannot be null");
       }
 
       List<WifiSsid> pnoSsids = (List<WifiSsid>) ssids;
-      int[] pnoFrequencies = (int[]) frequencies;
-      Executor pnoExecutor = (Executor) executor;
+      int[] pnoFrequencies = frequencies;
+      Executor pnoExecutor = executor;
       InternalPnoScanResultsCallback pnoCallback = new InternalPnoScanResultsCallback(callback);
 
       if (pnoExecutor == null) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindowManagerGlobal.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindowManagerGlobal.java
@@ -35,6 +35,7 @@ import java.io.Closeable;
 import java.lang.reflect.Proxy;
 import java.util.List;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
@@ -46,7 +47,7 @@ import org.robolectric.util.reflector.Static;
 
 /** Shadow for {@link WindowManagerGlobal}. */
 @SuppressWarnings("unused") // Unused params are implementations of Android SDK methods.
-@Implements(value = WindowManagerGlobal.class, isInAndroidSdk = false, looseSignatures = true)
+@Implements(value = WindowManagerGlobal.class, isInAndroidSdk = false)
 public class ShadowWindowManagerGlobal {
   private static WindowSessionDelegate windowSessionDelegate = new WindowSessionDelegate();
   private static IWindowSession windowSession;
@@ -326,7 +327,8 @@ public class ShadowWindowManagerGlobal {
   }
 
   @Implementation
-  public static Object getWindowManagerService() throws RemoteException {
+  public static @ClassName("android.view.IWindowManager") Object getWindowManagerService()
+      throws RemoteException {
     IWindowManager service =
         reflector(WindowManagerGlobalReflector.class).getWindowManagerService();
     if (service == null) {


### PR DESCRIPTION
If one method of a shadow class uses the Class that brought by newer SDK than user's `compileSdk`, and it will cause compiling error for user because Robolectri's `Shadows` loads this shadow class, and trigger this shadow class to load this new Class. In previous experience, we use `looseSignatures` to mark shadow class and use `Object` to replace all input parameters of this method to avoid compiling error and ensure `ShadowWrangle` can find this method. `looseSignatures` work fine now, but it's coarse-grained. `ClassName` can be used to mark the input parameter that has new Class type only, and `ShadowWrangle` will provide type checking for real input parameter to ensure real passed input parameters match to expected class types. 

Close https://github.com/robolectric/robolectric/issues/6888.

Moved from https://github.com/robolectric/robolectric/pull/7770 with a correct branch name.