### PR TITLE
Don't prevent shadowed classes from being serialised

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,7 @@ jobs:
           --no-watch-fs \
           -Drobolectric.enabledSdks=${{ matrix.api-versions }} \
           -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+          -Drobolectric.usePreinstrumentedJars=false \
           -Dorg.gradle.workers.max=2 \
           -x :integration_tests:nativegraphics:test \
           -x :integration_tests:roborazzi:test

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowDecorator.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowDecorator.java
@@ -22,7 +22,7 @@ public class ShadowDecorator implements ClassInstrumentor.Decorator {
     mutableClass.addField(
         0,
         new FieldNode(
-            Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC,
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC | Opcodes.ACC_TRANSIENT,
             ShadowConstants.CLASS_HANDLER_DATA_FIELD_NAME,
             OBJECT_DESC,
             OBJECT_DESC,

--- a/sandbox/src/test/java/org/robolectric/internal/bytecode/ClassInstrumentorTest.java
+++ b/sandbox/src/test/java/org/robolectric/internal/bytecode/ClassInstrumentorTest.java
@@ -15,7 +15,9 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.robolectric.shadow.api.Shadow;
 
@@ -40,6 +42,26 @@ public class ClassInstrumentorTest {
   }
 
   @Test
+  public void instrumentRegularMethod() {
+    ClassNode classNode = createClassWithRegularMethod();
+    MutableClass clazz =
+        new MutableClass(
+            classNode, InstrumentationConfiguration.newBuilder().build(), classNodeProvider);
+    instrumentor.instrument(clazz);
+
+    String someFunctionName = Shadow.directMethodName("org.example.MyClass", "someFunction");
+    MethodNode methodNode = findMethodNode(classNode, someFunctionName);
+
+    assertThat(clazz.classNode.interfaces).contains(Type.getInternalName(ShadowedObject.class));
+    assertRoboDataField(clazz.getFields().get(0));
+
+    // Side effect: original method has been made private.
+    assertThat(methodNode.access & Opcodes.ACC_PRIVATE).isNotEqualTo(0);
+    // Side effect: instructions have been rewritten to return 0.
+    assertThat(methodNode.instructions).isEmpty();
+  }
+
+  @Test
   public void instrumentNativeMethod_legacy() {
     ClassNode classNode = createClassWithNativeMethod();
     MutableClass clazz =
@@ -49,6 +71,9 @@ public class ClassInstrumentorTest {
 
     String someFunctionName = Shadow.directMethodName("org.example.MyClass", "someFunction");
     MethodNode methodNode = findMethodNode(classNode, someFunctionName);
+
+    assertThat(clazz.classNode.interfaces).contains(Type.getInternalName(ShadowedObject.class));
+    assertRoboDataField(clazz.getFields().get(0));
 
     // Side effect: original method has been made private.
     assertThat(methodNode.access & Opcodes.ACC_PRIVATE).isNotEqualTo(0);
@@ -79,6 +104,10 @@ public class ClassInstrumentorTest {
 
     String someFunctionName = Shadow.directMethodName("org.example.MyClass", "someFunction");
     MethodNode methodNode = findMethodNode(classNode, someFunctionName);
+
+    assertThat(clazz.classNode.interfaces).contains(Type.getInternalName(ShadowedObject.class));
+    assertRoboDataField(clazz.getFields().get(0));
+
     // Side effect: original method has been made private.
     assertThat(methodNode.access & Opcodes.ACC_PRIVATE).isNotEqualTo(0);
     // Side effect: instructions have been rewritten to throw and return.
@@ -116,6 +145,9 @@ public class ClassInstrumentorTest {
     String someFunctionName = Shadow.directMethodName("org.example.MyClass", "someFunction");
     MethodNode methodNode = findMethodNode(classNode, someFunctionName);
 
+    assertThat(clazz.classNode.interfaces).contains(Type.getInternalName(ShadowedObject.class));
+    assertRoboDataField(clazz.getFields().get(0));
+
     // Side effect: original method has been made private.
     assertThat(methodNode.access & Opcodes.ACC_PRIVATE).isNotEqualTo(0);
     // Side effect: instructions have been rewritten to return 0.
@@ -135,9 +167,19 @@ public class ClassInstrumentorTest {
     String nativeMethodName = Shadow.directNativeMethodName("org.example.MyClass", "someFunction");
     MethodNode methodNode = findMethodNode(classNode, nativeMethodName);
 
+    assertThat(clazz.classNode.interfaces).contains(Type.getInternalName(ShadowedObject.class));
+    assertRoboDataField(clazz.getFields().get(0));
+
     assertThat(methodNode.access & Opcodes.ACC_NATIVE).isNotEqualTo(0);
     assertThat(methodNode.access & Opcodes.ACC_PRIVATE).isNotEqualTo(0);
     assertThat(methodNode.access & Opcodes.ACC_SYNTHETIC).isNotEqualTo(0);
+  }
+
+  private static ClassNode createClassWithRegularMethod() {
+    ClassNode classNode = new ClassNode();
+    classNode.name = "org/example/MyClass";
+    classNode.methods.add(new MethodNode(Opcodes.ACC_PUBLIC, "someFunction", "()I", null, null));
+    return classNode;
   }
 
   private static ClassNode createClassWithNativeMethod() {
@@ -150,5 +192,14 @@ public class ClassInstrumentorTest {
 
   private static MethodNode findMethodNode(ClassNode classNode, String name) {
     return Iterables.find(classNode.methods, input -> input.name.equals(name));
+  }
+
+  private static void assertRoboDataField(FieldNode fieldNode) {
+    assertThat(fieldNode.access)
+        .isEqualTo(Opcodes.ACC_PUBLIC | Opcodes.ACC_SYNTHETIC | Opcodes.ACC_TRANSIENT);
+    assertThat(fieldNode.name).isEqualTo(ShadowConstants.CLASS_HANDLER_DATA_FIELD_NAME);
+    assertThat(fieldNode.desc).isEqualTo(Type.getDescriptor(Object.class));
+    assertThat(fieldNode.signature).isEqualTo(Type.getDescriptor(Object.class));
+    assertThat(fieldNode.value).isNull();
   }
 }

--- a/sandbox/src/test/java/org/robolectric/internal/bytecode/SandboxClassLoaderTest.java
+++ b/sandbox/src/test/java/org/robolectric/internal/bytecode/SandboxClassLoaderTest.java
@@ -147,6 +147,7 @@ public class SandboxClassLoaderTest {
     Field roboDataField = exampleClass.getField(ShadowConstants.CLASS_HANDLER_DATA_FIELD_NAME);
     assertNotNull(roboDataField);
     assertThat(Modifier.isPublic(roboDataField.getModifiers())).isTrue();
+    assertThat(Modifier.isTransient(roboDataField.getModifiers())).isTrue();
 
     // Java 9 doesn't allow updates to final fields from outside <init> or <clinit>:
     // https://bugs.openjdk.java.net/browse/JDK-8157181


### PR DESCRIPTION
As discussed in https://github.com/robolectric/robolectric/pull/8818#pullrequestreview-1875964854, this PR updates the `__robo_data__` field, so it doesn't prevent the shadowed class from being serialised (given that the class is `Serializable` itself).
To do this, I'm making the `__robo_data__` field `transient`, so it is not taken into consideration during the (de)serialisation process.

## Changes made

- Make the `__robo_data__` field `transient`
- Restore the missing serialisation tests in `RationalTest`
- Add some tests to `ClassInstrumentorTest` and `SandboxClassLoaderTest` to validate the changes made