### PR TITLE
Support customized implementation method name

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/Implementation.java
+++ b/annotations/src/main/java/org/robolectric/annotation/Implementation.java
@@ -21,4 +21,18 @@ public @interface Implementation {
 
   /** The annotated shadow method will be invoked only for the specified SDK or lesser. */
   int maxSdk() default DEFAULT_SDK;
+
+  /**
+   * The implemented method name.
+   *
+   * <p>Sometimes internal methods return different types for different SDKs. It's safe because
+   * these methods are internal/private methods, not public methods. To support different return
+   * types of a method for different SDKs, we often use looseSignature method, although all return
+   * types are common types like bool and int. This field/property can be used to fix this issue by
+   * using different real methods for different SDKs.
+   *
+   * @return The expected implemented method name. If it is empty/null, the Robolectric will uses
+   *     the method's name that marked by @Implementation as the implemented method name.
+   */
+  String methodName() default "";
 }

--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/SdkStore.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/SdkStore.java
@@ -542,7 +542,14 @@ public class SdkStore {
       } else if (STATIC_INITIALIZER_METHOD_NAME.equals(name)) {
         return "<clinit>";
       } else {
-        return name;
+        Implementation implementation = methodElement.getAnnotation(Implementation.class);
+        String methodName = implementation == null ? "" : implementation.methodName();
+        methodName = methodName == null ? "" : methodName.trim();
+        if (methodName.isEmpty()) {
+          return name;
+        } else {
+          return methodName;
+        }
       }
     }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
@@ -380,21 +380,21 @@ public class ShadowBluetoothAdapter {
    * Needs looseSignatures because in Android T the return value of this method was changed from
    * bool to int.
    */
-  @Implementation
-  protected Object setScanMode(int scanMode) {
-    boolean result = true;
-    if (scanMode != BluetoothAdapter.SCAN_MODE_CONNECTABLE
-        && scanMode != BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE
-        && scanMode != BluetoothAdapter.SCAN_MODE_NONE) {
-      result = false;
-    }
-
+  @Implementation(maxSdk = S_V2)
+  protected boolean setScanMode(int scanMode) {
+    boolean result =
+        scanMode == BluetoothAdapter.SCAN_MODE_CONNECTABLE
+            || scanMode == BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE
+            || scanMode == BluetoothAdapter.SCAN_MODE_NONE;
     this.scanMode = scanMode;
-    if (RuntimeEnvironment.getApiLevel() >= VERSION_CODES.TIRAMISU) {
-      return result ? BluetoothStatusCodes.SUCCESS : BluetoothStatusCodes.ERROR_UNKNOWN;
-    } else {
-      return result;
-    }
+    return result;
+  }
+
+  @Implementation(minSdk = TIRAMISU, methodName = "setScanMode")
+  protected int setScanModeFromT(int scanMode) {
+    return setScanMode(scanMode)
+        ? BluetoothStatusCodes.SUCCESS
+        : BluetoothStatusCodes.ERROR_UNKNOWN;
   }
 
   @Implementation(maxSdk = Q)


### PR DESCRIPTION
  Sometimes internal methods return different types for different SDKs. It's safe because
  these methods are internal/private methods, not public methods. To support different return
  types of a method for different SDKs, we often use looseSignature method, although all return
  types are common types like bool and int. This field/property can be used to fix this issue by
  using different real methods for different SDKs.