### PR TITLE
Fix InlineMe warnings for ShadowDefaultRequestDirector

### DIFF
--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
@@ -138,12 +138,16 @@ public class ShadowDefaultRequestDirector {
    * Get the sent {@link HttpRequest} for the given index.
    *
    * @param index The index
-   * @deprecated Use {@link FakeHttp#getSentHttpRequestInfo(int)} instead.)
+   * @deprecated Use {@link FakeHttp#getSentHttpRequestInfo(int)} instead. This method will be
+   *     removed in Robolectric 4.13.
    * @return HttpRequest
    */
   @Deprecated
+  @InlineMe(
+      replacement = "FakeHttp.getFakeHttpLayer().getSentHttpRequestInfo(index).getHttpRequest()",
+      imports = "org.robolectric.shadows.httpclient.FakeHttp")
   public static HttpRequest getSentHttpRequest(int index) {
-    return getSentHttpRequestInfo(index).getHttpRequest();
+    return FakeHttp.getFakeHttpLayer().getSentHttpRequestInfo(index).getHttpRequest();
   }
 
   public static HttpRequest getLatestSentHttpRequest() {
@@ -159,14 +163,15 @@ public class ShadowDefaultRequestDirector {
    * Get the sent {@link HttpRequestInfo} for the given index.
    *
    * @param index The index
-   * @deprecated Use {@link FakeHttp#getSentHttpRequest(int)} instead.)
+   * @deprecated Use {@link FakeHttp#getSentHttpRequest(int)} instead. This method will be removed
+   *     in Robolectric 4.13.
    * @return HttpRequestInfo
    */
   @Deprecated
   @InlineMe(
       replacement = "FakeHttp.getFakeHttpLayer().getSentHttpRequestInfo(index)",
       imports = "org.robolectric.shadows.httpclient.FakeHttp")
-  public static final HttpRequestInfo getSentHttpRequestInfo(int index) {
+  public static HttpRequestInfo getSentHttpRequestInfo(int index) {
     return FakeHttp.getFakeHttpLayer().getSentHttpRequestInfo(index);
   }
 


### PR DESCRIPTION
We can remove related deprecated methods at 4.13.
