### PR TITLE
Temporarily restore ShadowDisplay.setScaledDensity

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayTest.java
@@ -42,6 +42,7 @@ public class ShadowDisplayTest {
   public void shouldProvideDisplayMetrics() {
     shadow.setDensity(1.5f);
     shadow.setDensityDpi(DisplayMetrics.DENSITY_HIGH);
+    shadow.setScaledDensity(1.6f);
     shadow.setWidth(1024);
     shadow.setHeight(600);
     shadow.setRealWidth(1400);
@@ -56,6 +57,7 @@ public class ShadowDisplayTest {
 
     assertEquals(1.5f, metrics.density, 0.05);
     assertEquals(DisplayMetrics.DENSITY_HIGH, metrics.densityDpi);
+    assertEquals(1.6f, metrics.scaledDensity, 0.05);
     assertEquals(1024, metrics.widthPixels);
     assertEquals(600, metrics.heightPixels);
     assertEquals(183.0f, metrics.xdpi, 0.05);
@@ -67,6 +69,7 @@ public class ShadowDisplayTest {
 
     assertEquals(1.5f, metrics.density, 0.05);
     assertEquals(DisplayMetrics.DENSITY_HIGH, metrics.densityDpi);
+    assertEquals(1.6f, metrics.scaledDensity, 0.05);
     assertEquals(1400, metrics.widthPixels);
     assertEquals(900, metrics.heightPixels);
     assertEquals(183.0f, metrics.xdpi, 0.05);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplay.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplay.java
@@ -42,6 +42,47 @@ public class ShadowDisplay {
   @RealObject Display realObject;
 
   private Float refreshRate;
+  private Float scaledDensity;
+
+  /**
+   * If {@link #setScaledDensity(float)} has been called, {@link DisplayMetrics#scaledDensity} will
+   * be modified to reflect the value specified. Note that this is not a realistic state.
+   *
+   * @deprecated This behavior is deprecated and will be removed in Robolectric 4.13.
+   */
+  @Deprecated
+  @Implementation
+  protected void getMetrics(DisplayMetrics outMetrics) {
+    reflector(_Display_.class, realObject).getMetrics(outMetrics);
+    if (scaledDensity != null) {
+      outMetrics.scaledDensity = scaledDensity;
+    }
+  }
+
+  /**
+   * If {@link #setScaledDensity(float)} has been called, {@link DisplayMetrics#scaledDensity} will
+   * be modified to reflect the value specified. Note that this is not a realistic state.
+   *
+   * @deprecated This behavior is deprecated and will be removed in Robolectric 4.13.
+   */
+  @Deprecated
+  @Implementation
+  protected void getRealMetrics(DisplayMetrics outMetrics) {
+    reflector(_Display_.class, realObject).getRealMetrics(outMetrics);
+    if (scaledDensity != null) {
+      outMetrics.scaledDensity = scaledDensity;
+    }
+  }
+
+  /**
+   * Changes the scaled density for this display.
+   *
+   * @deprecated This method is deprecated and will be removed in Robolectric 4.13.
+   */
+  @Deprecated
+  public void setScaledDensity(float scaledDensity) {
+    this.scaledDensity = scaledDensity;
+  }
 
   /**
    * If {@link #setRefreshRate(float)} has been called, this method will return the specified value.
@@ -273,6 +314,11 @@ public class ShadowDisplay {
   /** Reflector interface for {@link Display}'s internals. */
   @ForType(Display.class)
   interface _Display_ {
+    @Direct
+    void getMetrics(DisplayMetrics outMetrics);
+
+    @Direct
+    void getRealMetrics(DisplayMetrics outMetrics);
 
     @Direct
     float getRefreshRate();


### PR DESCRIPTION
There is a bug in the `@Config(fontScale=...)` annotation that causes it to not be applied to the result of Display.getMetrics. Until that bug is fixed, there needs to be a way for tests to override the value of Display.scaledDensity.

RE #8851