### PR TITLE
Revert "Fixed warnings in Gradle files"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,8 @@ project.afterEvaluate {
         // prevent compiler from complaining about duplicate classes...
         def excludeFromCompile = compilerConfiguration.appendNode 'excludeFromCompile'
         configAnnotationProcessing.each { Project subProject ->
-            def buildDirectory = subProject.layout.buildDirectory.get().asFile
             excludeFromCompile.appendNode('directory',
-                    [url: "file://$buildDirectory/classes/java/main/generated", includeSubdirectories: "true"])
+                    [url: "file://${subProject.buildDir}/classes/java/main/generated", includeSubdirectories: "true"])
         }
 
         // replace existing annotationProcessing tag with a new one...
@@ -74,16 +73,13 @@ project.afterEvaluate {
                         processor(name: "org.robolectric.annotation.processing.RobolectricProcessor")
 
                         processorPath(useClasspath: "false") {
-                            project.project(":processor")
-                                    .configurations.named("runtime")
-                                    .configure { runtimeConfiguration ->
-                                        runtimeConfiguration.allArtifacts.each { artifact ->
-                                            entry(name: artifact.file)
-                                        }
-                                        runtimeConfiguration.files.each { file ->
-                                            entry(name: file)
-                                        }
-                                    }
+                            def processorRuntimeCfg = project.project(":processor").configurations['runtime']
+                            processorRuntimeCfg.allArtifacts.each { artifact ->
+                                entry(name: artifact.file)
+                            }
+                            processorRuntimeCfg.files.each { file ->
+                                entry(name: file)
+                            }
                         }
                     }
                 }
@@ -95,9 +91,7 @@ project.afterEvaluate {
 apply plugin: 'nebula-aggregate-javadocs'
 
 rootProject.gradle.projectsEvaluated {
-    rootProject.tasks.named("aggregateJavadocs").configure {
-        it.failOnError = false
-    }
+    rootProject.tasks['aggregateJavadocs'].failOnError = false
 }
 
 gradle.projectsEvaluated {
@@ -128,10 +122,10 @@ gradle.projectsEvaluated {
 gradle.projectsEvaluated {
     tasks.register('aggregateJsondocs', Copy) {
         project.subprojects.findAll { it.plugins.hasPlugin(ShadowsPlugin) }.each { subproject ->
-            dependsOn subproject.tasks.named("compileJava")
-            from subproject.layout.buildDirectory.dir("docs/json")
+            dependsOn subproject.tasks["compileJava"]
+            from "${subproject.buildDir}/docs/json"
         }
-        into layout.buildDirectory.dir("docs/json")
+        into "$buildDir/docs/json"
     }
 }
 

--- a/buildSrc/src/main/groovy/AndroidSdk.groovy
+++ b/buildSrc/src/main/groovy/AndroidSdk.groovy
@@ -9,13 +9,13 @@ class AndroidSdk implements Comparable<AndroidSdk> {
     static final N_MR1 = new AndroidSdk(25, "7.1.0_r7", "r1")
     static final O = new AndroidSdk(26, "8.0.0_r4", "r1")
     static final O_MR1 = new AndroidSdk(27, "8.1.0", "4611349")
-    static final P = new AndroidSdk(28, "9", "4913185-2")
-    static final Q = new AndroidSdk(29, "10", "5803371")
-    static final R = new AndroidSdk(30, "11", "6757853")
-    static final S = new AndroidSdk(31, "12", "7732740")
-    static final S_V2 = new AndroidSdk(32, "12.1", "8229987")
-    static final TIRAMISU = new AndroidSdk(33, "13", "9030017")
-    static final U = new AndroidSdk(34, "14", "10818077")
+    static final P = new AndroidSdk(28, "9", "4913185-2");
+    static final Q = new AndroidSdk(29, "10", "5803371");
+    static final R = new AndroidSdk(30, "11", "6757853");
+    static final S = new AndroidSdk(31, "12", "7732740");
+    static final S_V2 = new AndroidSdk(32, "12.1", "8229987");
+    static final TIRAMISU = new AndroidSdk(33, "13", "9030017");
+    static final U = new AndroidSdk(34, "14", "10818077");
 
     static final List<AndroidSdk> ALL_SDKS = [
             KITKAT,
@@ -26,7 +26,7 @@ class AndroidSdk implements Comparable<AndroidSdk> {
     static final MAX_SDK = Collections.max(ALL_SDKS)
 
     public final int apiLevel
-    public final String androidVersion
+    private final String androidVersion
     private final String frameworkSdkBuildVersion
 
     AndroidSdk(int apiLevel, String androidVersion, String frameworkSdkBuildVersion) {

--- a/buildSrc/src/main/groovy/ProvideBuildClasspathTask.groovy
+++ b/buildSrc/src/main/groovy/ProvideBuildClasspathTask.groovy
@@ -6,18 +6,18 @@ class ProvideBuildClasspathTask extends DefaultTask {
     @OutputFile File outFile
 
     @TaskAction
-    void writeProperties() throws Exception {
+    public void writeProperties() throws Exception {
         final Properties props = new Properties()
 
-        String preinstrumentedKey = "robolectric.usePreinstrumentedJars"
+        String preinstrumentedKey = "robolectric.usePreinstrumentedJars";
         boolean usePreinstrumentedJars =
             Boolean.parseBoolean(
-              System.getProperty(preinstrumentedKey, "true"))
+              System.getProperty(preinstrumentedKey, "true"));
 
         AndroidSdk.ALL_SDKS.each { androidSdk ->
             String coordinates =
               usePreinstrumentedJars ?
-                androidSdk.preinstrumentedCoordinates : androidSdk.coordinates
+                androidSdk.preinstrumentedCoordinates : androidSdk.coordinates;
             def config =
                 project.configurations.create("sdk${androidSdk.apiLevel}")
             project.dependencies.add(

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/AarDepsPlugin.java
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/AarDepsPlugin.java
@@ -57,9 +57,9 @@ public class AarDepsPlugin implements Plugin<Project> {
             // incremental compile breaks (run `gradlew -i classes` twice to see impact):
             t ->
                 t.doFirst(
-                    new Action<>() {
+                    new Action<Task>() {
                       @Override
-                      public void execute(@NotNull Task task) {
+                      public void execute(Task task) {
                         List<File> aarFiles = AarDepsPlugin.this.findAarFiles(t.getClasspath());
                         if (!aarFiles.isEmpty()) {
                           throw new IllegalStateException(
@@ -91,9 +91,8 @@ public class AarDepsPlugin implements Plugin<Project> {
       super.transform(
           new TransformOutputs() {
             // This is the one that ExtractAarTransform calls.
-            @NotNull
             @Override
-            public File dir(@NotNull Object o) {
+            public File dir(Object o) {
               // ExtractAarTransform needs a place to extract the AAR. We don't really need to
               // register this as an output, but it'd be tricky to avoid it.
               File dir = outputs.dir(o);
@@ -106,9 +105,8 @@ public class AarDepsPlugin implements Plugin<Project> {
               return outputs.dir(o);
             }
 
-            @NotNull
             @Override
-            public File file(@NotNull Object o) {
+            public File file(Object o) {
               throw new IllegalStateException("shouldn't be called");
             }
           });

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/AndroidProjectConfigPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/AndroidProjectConfigPlugin.groovy
@@ -4,9 +4,9 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 
-class AndroidProjectConfigPlugin implements Plugin<Project> {
+public class AndroidProjectConfigPlugin implements Plugin<Project> {
     @Override
-    void apply(Project project) {
+    public void apply(Project project) {
         project.android.testOptions.unitTests.all {
             // TODO: DRY up code with RoboJavaModulePlugin...
             testLogging {
@@ -26,8 +26,8 @@ class AndroidProjectConfigPlugin implements Plugin<Project> {
             }
 
             def forwardedSystemProperties = System.properties
-                    .findAll { k, v -> k.startsWith("robolectric.") }
-                    .collect { k, v -> "-D$k=$v" }
+                    .findAll { k,v -> k.startsWith("robolectric.") }
+                    .collect { k,v -> "-D$k=$v" }
             jvmArgs = forwardedSystemProperties
             jvmArgs += [
                     '--add-opens=java.base/java.lang=ALL-UNNAMED',
@@ -51,8 +51,8 @@ class AndroidProjectConfigPlugin implements Plugin<Project> {
         }
 
         project.task('provideBuildClasspath', type: ProvideBuildClasspathTask) {
-            File outDir = project.layout.buildDirectory.dir("generated/robolectric").get().asFile
-            outFile = new File(outDir, "robolectric-deps.properties")
+            File outDir = new File(project.buildDir, "generated/robolectric")
+            outFile = new File(outDir, 'robolectric-deps.properties')
 
             project.android.sourceSets['test'].resources.srcDir(outDir)
         }
@@ -66,7 +66,7 @@ class AndroidProjectConfigPlugin implements Plugin<Project> {
         }
 
         // Only run tests in the debug variant. This is to avoid running tests twice when `./gradlew test` is run at the top-level.
-        project.tasks.withType(Test).configureEach {
+        project.tasks.withType(Test) {
             onlyIf { variantName.toLowerCase().contains('debug') }
         }
     }

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/RoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/RoboJavaModulePlugin.groovy
@@ -11,11 +11,11 @@ class RoboJavaModulePlugin implements Plugin<Project> {
 
         def skipErrorprone = System.getenv('SKIP_ERRORPRONE') == "true"
         if (!skipErrorprone) {
-            apply plugin: "net.ltgt.errorprone"
-            project.dependencies {
-                errorprone(libs.error.prone.core)
-                errorproneJavac(libs.error.prone.javac)
-            }
+          apply plugin: "net.ltgt.errorprone"
+          project.dependencies {
+            errorprone(libs.error.prone.core)
+            errorproneJavac(libs.error.prone.javac)
+          }
         }
 
         apply plugin: AarDepsPlugin
@@ -23,7 +23,7 @@ class RoboJavaModulePlugin implements Plugin<Project> {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
 
-        tasks.withType(JavaCompile).configureEach { task ->
+        tasks.withType(JavaCompile) { task ->
             sourceCompatibility = JavaVersion.VERSION_1_8
             targetCompatibility = JavaVersion.VERSION_1_8
 
@@ -68,8 +68,8 @@ class RoboJavaModulePlugin implements Plugin<Project> {
             }
 
             def forwardedSystemProperties = System.properties
-                    .findAll { k, v -> k.startsWith("robolectric.") }
-                    .collect { k, v -> "-D$k=$v" }
+                    .findAll { k,v -> k.startsWith("robolectric.") }
+                    .collect { k,v -> "-D$k=$v" }
             jvmArgs = forwardedSystemProperties
             jvmArgs += [
                     '--add-opens=java.base/java.lang=ALL-UNNAMED',

--- a/integration_tests/jacoco-offline/build.gradle
+++ b/integration_tests/jacoco-offline/build.gradle
@@ -27,68 +27,67 @@ def unitTestTaskName = "test"
 
 def compileSourceTaskName = "classes"
 
-def javaDir = layout.buildDirectory.dir("classes/java/main").get().asFile
+def javaDirPath = "${buildDir.path}/classes/java/main"
 
-def kotlinDir = layout.buildDirectory.dir("classes/kotlin/main").get().asFile
+def kotlinDirPath = "${buildDir.path}/classes/kotlin/main"
 
-def jacocoInstrumentedClassesOutputDir = layout.buildDirectory.dir("$jacocoVersion/classes/java/classes-instrumented").get().asFile
+def jacocoInstrumentedClassesOutputDirPath = "${buildDir.path}/$jacocoVersion/classes/java/classes-instrumented"
 
 // make sure it's evaluated after the AGP evaluation.
 afterEvaluate {
-    tasks.named(compileSourceTaskName).configure { task ->
-        task.doLast {
-            println "[JaCoCo]:Generating JaCoCo instrumented classes for the build."
+    tasks[compileSourceTaskName].doLast {
+        println "[JaCoCo]:Generating JaCoCo instrumented classes for the build."
 
-            if (jacocoInstrumentedClassesOutputDir.exists()) {
-                println "[JaCoCo]:Classes had been instrumented."
-                return
+        def jacocoInstrumentOutputDirPathFile = new File(jacocoInstrumentedClassesOutputDirPath)
+        if (jacocoInstrumentOutputDirPathFile.exists()) {
+            println "[JaCoCo]:Classes had been instrumented."
+            return
+        }
+
+        ant.taskdef(name: 'instrument',
+                classname: 'org.jacoco.ant.InstrumentTask',
+                classpath: configurations.jacocoAnt.asPath)
+
+        def classesDirPathFile = new File(javaDirPath)
+        if (classesDirPathFile.exists()) {
+            ant.instrument(destdir: jacocoInstrumentedClassesOutputDirPath) {
+                fileset(
+                        dir: javaDirPath,
+                        excludes: []
+                )
             }
+        } else {
+            println "Classes directory with path: " + classesDirPathFile + " was not existed."
+        }
 
-            ant.taskdef(name: 'instrument',
-                    classname: 'org.jacoco.ant.InstrumentTask',
-                    classpath: configurations.jacocoAnt.asPath)
-
-            if (javaDir.exists()) {
-                ant.instrument(destdir: jacocoInstrumentedClassesOutputDir.path) {
-                    fileset(
-                            dir: javaDir.path,
-                            excludes: []
-                    )
-                }
-            } else {
-                println "Classes directory with path: $javaDir does not existed."
+        def classesDirPathFileKotlin = new File(kotlinDirPath)
+        if (classesDirPathFileKotlin.exists()) {
+            ant.instrument(destdir: jacocoInstrumentedClassesOutputDirPath) {
+                fileset(
+                        dir: kotlinDirPath,
+                        excludes: []
+                )
             }
-
-            if (kotlinDir.exists()) {
-                ant.instrument(destdir: jacocoInstrumentedClassesOutputDir.path) {
-                    fileset(
-                            dir: kotlinDir.path,
-                            excludes: []
-                    )
-                }
-            } else {
-                println "Classes directory with path: $kotlinDir does not existed."
-            }
+        } else {
+            println "Classes directory with path: " + classesDirPathFileKotlin + " was not existed."
         }
     }
 
-    def executionDataFilePath = layout.buildDirectory.dir("jacoco").get().file("${unitTestTaskName}.exec").getAsFile().path
+    def executionDataFilePath = "${buildDir.path}/jacoco/${unitTestTaskName}.exec"
 
     // put JaCoCo instrumented classes and JaCoCoRuntime to the beginning of the JVM classpath.
-    tasks.named(unitTestTaskName).configure { task ->
-        task.doFirst {
-            jacoco {
-                // disable JaCoCo on-the-fly from Gradle JaCoCo plugin.
-                enabled = false
-            }
-
-            println "[JaCoCo]:Modifying classpath of tests JVM."
-
-            systemProperty 'jacoco-agent.destfile', executionDataFilePath
-
-            classpath = files(jacocoInstrumentedClassesOutputDir.path) + classpath + configurations.jacocoRuntime
-
-            println "Final test JVM classpath is ${classpath.getAsPath()}"
+    tasks["${unitTestTaskName}"].doFirst {
+        jacoco {
+            // disable JaCoCo on-the-fly from Gradle JaCoCo plugin.
+            enabled = false
         }
+
+        println "[JaCoCo]:Modifying classpath of tests JVM."
+
+        systemProperty 'jacoco-agent.destfile', executionDataFilePath
+
+        classpath = files(jacocoInstrumentedClassesOutputDirPath) + classpath + configurations.jacocoRuntime
+
+        println "Final test JVM classpath is ${classpath.getAsPath()}"
     }
 }

--- a/preinstrumented/build.gradle
+++ b/preinstrumented/build.gradle
@@ -35,7 +35,7 @@ tasks.register('instrumentAll') {
         sdksToInstrument().each { androidSdk ->
             println("Instrumenting ${androidSdk.coordinates}")
             def inputPath = "${androidAllMavenLocal}/${androidSdk.version}/${androidSdk.jarFileName}"
-            def outputPath = layout.buildDirectory.file(androidSdk.preinstrumentedJarFileName).get().asFile.path
+            def outputPath = "${buildDir}/${androidSdk.preinstrumentedJarFileName}"
 
             javaexec {
                 classpath = sourceSets.main.runtimeClasspath
@@ -66,7 +66,7 @@ if (System.getenv('PUBLISH_PREINSTRUMENTED_JARS') == "true") {
         publications {
             sdksToInstrument().each { androidSdk ->
                 "sdk${androidSdk.apiLevel}"(MavenPublication) {
-                    artifact = layout.buildDirectory.file(androidSdk.preinstrumentedJarFileName).get().asFile.path
+                    artifact "${buildDir}/${androidSdk.preinstrumentedJarFileName}"
                     artifactId 'android-all-instrumented'
                     artifact emptySourcesJar
                     artifact emptyJavadocJar
@@ -120,34 +120,34 @@ if (System.getenv('PUBLISH_PREINSTRUMENTED_JARS') == "true") {
     }
 
 
-    // Workaround for https://github.com/gradle/gradle/issues/26132
-    // For some reason, Gradle has inferred that all publishing tasks depend on all signing tasks,
-    // so we must explicitly declare this here.
-    afterEvaluate {
-        tasks.configureEach {
-            if (name.startsWith("publishSdk")) {
-                sdksToInstrument().each { androidSdk ->
-                    dependsOn(tasks.named("signSdk${androidSdk.apiLevel}Publication"))
-                }
-            }
+  // Workaround for https://github.com/gradle/gradle/issues/26132
+  // For some reason, Gradle has inferred that all publishing tasks depend on all signing tasks,
+  // so we must explicitly declare this here.
+  afterEvaluate {
+    tasks.all {
+      if (name.startsWith("publishSdk")) {
+        sdksToInstrument().each { androidSdk ->
+          dependsOn(tasks.named("signSdk${androidSdk.apiLevel}Publication"))
         }
+      }
     }
+  }
 }
 
 static def sdksToInstrument() {
-    var result = AndroidSdk.ALL_SDKS
-    var preInstrumentedSdkVersions = (System.getenv('PREINSTRUMENTED_SDK_VERSIONS') ?: "")
-    if (preInstrumentedSdkVersions.length() > 0) {
-        var sdkFilter = preInstrumentedSdkVersions.split(",").collect { it as Integer }
-        if (sdkFilter.size > 0) {
-            result = result.findAll { sdkFilter.contains(it.apiLevel) }
-        }
+  var result = AndroidSdk.ALL_SDKS
+  var preInstrumentedSdkVersions = (System.getenv('PREINSTRUMENTED_SDK_VERSIONS') ?: "")
+  if (preInstrumentedSdkVersions.length() > 0) {
+    var sdkFilter = preInstrumentedSdkVersions.split(",").collect { it as Integer }
+    if (sdkFilter.size > 0) {
+      result = result.findAll { sdkFilter.contains(it.apiLevel) }
     }
-    return result
+  }
+  return result
 }
 
 clean.doFirst {
     AndroidSdk.ALL_SDKS.each { androidSdk ->
-        delete layout.buildDirectory.file(androidSdk.preinstrumentedJarFileName)
+        delete "${buildDir}/${androidSdk.preinstrumentedJarFileName}"
     }
 }

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -6,11 +6,10 @@ apply plugin: RoboJavaModulePlugin
 apply plugin: DeployedRoboJavaModulePlugin
 
 class GenerateSdksFileTask extends DefaultTask {
-    @OutputFile
-    File outFile
+    @OutputFile File outFile
 
     @TaskAction
-    void writeProperties() throws Exception {
+    public void writeProperties() throws Exception {
         File outDir = outFile.parentFile
         if (!outDir.directory) outDir.mkdirs()
         outFile.withPrintWriter { out ->
@@ -27,12 +26,10 @@ class GenerateSdksFileTask extends DefaultTask {
 }
 
 task('generateSdksFile', type: GenerateSdksFileTask) {
-    outFile = project.rootProject.layout.buildDirectory.file('sdks.txt').get().asFile
+    outFile = new File(project.rootProject.buildDir, 'sdks.txt')
 }
 
-tasks.named("classes").configure { task ->
-    task.dependsOn(generateSdksFile)
-}
+tasks['classes'].dependsOn(generateSdksFile)
 
 dependencies {
     api project(":annotations")

--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -33,7 +33,7 @@ tasks.register('copySqliteNatives', Copy) {
             }
         }
     }
-    into project.file(layout.buildDirectory.dir("resources/main/sqlite4java"))
+    into project.file("$buildDir/resources/main/sqlite4java")
 }
 
 jar {


### PR DESCRIPTION
Reverts robolectric/robolectric#8850

The origin PR causes publisToSnapshot task failed on CI:

```
113 actionable tasks: 113 executed
* What went wrong:
Execution failed for task ':shadows:framework:sourcesJar'.
> Missing file org/robolectric/Shadows.java in /home/runner/work/robolectric/robolectric/shadows/framework/build/libs/shadows-framework-4.12-SNAPSHOT-sources.jar
* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org./
* Exception is:
```