### PR TITLE
ShadowView - invoke onScrollChanged after internal var update

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowView.java
@@ -588,11 +588,11 @@ public class ShadowView {
     if (useRealScrolling()) {
       reflector(_View_.class, realView).scrollTo(x, y);
     } else {
-      reflector(_View_.class, realView)
-          .onScrollChanged(x, y, scrollToCoordinates.x, scrollToCoordinates.y);
       scrollToCoordinates = new Point(x, y);
       reflector(_View_.class, realView).setMemberScrollX(x);
       reflector(_View_.class, realView).setMemberScrollY(y);
+      reflector(_View_.class, realView)
+          .onScrollChanged(x, y, scrollToCoordinates.x, scrollToCoordinates.y);
     }
   }
 


### PR DESCRIPTION
### Overview
ShadowView - invoke onScrollChanged after internal var update

### Proposed Changes
Original View.java first sets member attributes (mScrollX, mScrollY) before listener is called. In that way, when listener accesses these variables, they are correctly set.
