### PR TITLE
ci: Remove unused submodule for actions/checkout

### DIFF
--- a/.github/workflows/gradle_tasks_validation.yml
+++ b/.github/workflows/gradle_tasks_validation.yml
@@ -58,9 +58,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: recursive
 
       - name: Set up JDK
         uses: actions/setup-java@v4


### PR DESCRIPTION
The Robolectric doesn't use submodule anymore.