### PR TITLE
Add apt output dir as source directly in sourcesJar task

### DIFF
--- a/buildSrc/src/main/groovy/ShadowsPlugin.groovy
+++ b/buildSrc/src/main/groovy/ShadowsPlugin.groovy
@@ -19,8 +19,6 @@ class ShadowsPlugin implements Plugin<Project> {
         // write generated Java into its own dir... see https://github.com/gradle/gradle/issues/4956
         def generatedSrcDir = project.file("build/generated/src/apt/main")
 
-        project.sourceSets.main.java { srcDir generatedSrcDir }
-
         project.tasks.named("compileJava").configure { task ->
             task.options.annotationProcessorGeneratedSourcesDirectory = generatedSrcDir
 
@@ -47,6 +45,7 @@ class ShadowsPlugin implements Plugin<Project> {
         }
 
         project.tasks.named("sourcesJar").configure { task ->
+            task.from(generatedSrcDir)
             task.doLast {
                 def shadowPackageNameDir = project.shadows.packageName.replaceAll(/\./, '/')
                 checkForFile(task.archivePath, "${shadowPackageNameDir}/Shadows.java")


### PR DESCRIPTION
Code generation and subsequent compilation is performed within a single java compiler call. Gradle, on the other hand, checks whether the inputs of a task have changed before starting the task. So if we call compileJava for the first time after cleaning build dir before starting the task, Gradle sees that generatedSrcDir is empty and remembers that. When we call compileJava again, Gradle sees that new files have been added to generatedSrcDir and restarts compilation. On the third compileJava call in a row, nothing has changed for Gradle and it marks the task as up to date.
As far as I understand, adding generatedSrcDir as sourceSet is only needed to include generated sources in sourcesJar. So instead of adding generatedSrcDir as sourceSet, we can add it directly to sourcesJar.

Closes #8839