### PR TITLE
Ignore long lines containing links

### DIFF
--- a/.github/workflows/validate_commit_message.yml
+++ b/.github/workflows/validate_commit_message.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
           for line in $commit_body; do
-            if [ "${#line}" -gt 120 ]; then
+            if [ "${#line}" -gt 120 ] && [[ ! "$line" =~ (https?://|www\.) ]]; then
               echo "Error: the following line of the commit body is too long (max: 120 characters):"
               echo "> $line"
               exit 1


### PR DESCRIPTION
Following the discussion initiated in https://github.com/robolectric/robolectric/pull/8849#issuecomment-1955895951, this PR block long lines in the commit body, unless it contains a link (ie. it contains `https://` or `www.`).