### PR TITLE
Added code to stop gl thread

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGLSurfaceView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGLSurfaceView.java
@@ -1,15 +1,50 @@
 package org.robolectric.shadows;
 
 import android.opengl.GLSurfaceView;
+import android.util.Log;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /** Fake implementation of GLSurfaceView */
 @Implements(GLSurfaceView.class)
 public class ShadowGLSurfaceView extends ShadowSurfaceView {
+
+  private static final String TAG = "ShadowGLSurfaceView";
+
   @Implementation
   protected void onPause() {}
 
   @Implementation
   protected void onResume() {}
+
+  @Implementation
+  protected void onDetachedFromWindow() {
+    stopGLThread();
+  }
+
+  @Implementation
+  protected void finalize() throws Throwable {
+    try {
+      stopGLThread();
+    } finally {
+      super.finalize();
+    }
+  }
+
+  private void stopGLThread() {
+    try {
+      Field glThreadField = GLSurfaceView.class.getDeclaredField("mGLThread");
+      glThreadField.setAccessible(true);
+      Thread glThread = (Thread) glThreadField.get(realView);
+      if (glThread != null) {
+        Method requestExitAndWait = glThread.getClass().getMethod("requestExitAndWait");
+        requestExitAndWait.invoke(glThread);
+      }
+    } catch (Exception e) {
+      Log.e(TAG, "Exception occurred while stopping GLThread: " + e.getMessage());
+      e.printStackTrace();
+    }
+  }
 }


### PR DESCRIPTION
fixes #7194 

I added fields to hold the renderer and the GL thread.

In onPause(), I interrupt the GL thread if it's not null.

In onResume(), I start a new GL thread only if the renderer is not null.

I added a setRenderer() method to set the renderer externally.

I introduced a reset() method, annotated with @Resetter, which you can use to clean up resources and terminate the GL thread if needed after each test.


