### PR TITLE
Remove unused properties from `AndroidManifest.xml` files

### DIFF
--- a/integration_tests/agp/src/main/AndroidManifest.xml
+++ b/integration_tests/agp/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.robolectric.integrationtests.agp">
+<manifest>
   <application />
 </manifest>

--- a/integration_tests/agp/testsupport/src/main/AndroidManifest.xml
+++ b/integration_tests/agp/testsupport/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.robolectric.integrationtests.agp.testsupport">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <application>
     <activity android:name="TestActivity"/>
   </application>

--- a/integration_tests/compat-target28/src/main/AndroidManifest.xml
+++ b/integration_tests/compat-target28/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:tools="http://schemas.android.com/tools"
-    package="org.robolectric.integrationtests.compattarget28"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:appComponentFactory="org.robolectric.integrationtests.compattarget28.TestAppComponentFactory"

--- a/integration_tests/memoryleaks/src/main/AndroidManifest.xml
+++ b/integration_tests/memoryleaks/src/main/AndroidManifest.xml
@@ -2,9 +2,6 @@
 <!--
   Manifest for androidx memoryleaks test module
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.robolectric.integrationtests.memoryleaks">
-
-    <application>
-    </application>
+<manifest>
+    <application />
 </manifest>

--- a/integration_tests/nativegraphics/src/main/AndroidManifest.xml
+++ b/integration_tests/nativegraphics/src/main/AndroidManifest.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Manifest for native graphics tests -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.robolectric.integrationtests.nativegraphics">
-  <uses-sdk
-      android:minSdkVersion="26"
-      android:targetSdkVersion="34" />
+<manifest>
   <application />
 </manifest>

--- a/integration_tests/room/src/main/AndroidManifest.xml
+++ b/integration_tests/room/src/main/AndroidManifest.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Manifest for androidx memoryleaks test module
+  Manifest for androidx room test module
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.robolectric.integrationtests.room">
-
-    <application>
-    </application>
+<manifest>
+    <application />
 </manifest>

--- a/integration_tests/sparsearray/src/main/AndroidManifest.xml
+++ b/integration_tests/sparsearray/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.robolectric.sparsearray">
+<manifest>
     <application />
 </manifest>

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.robolectric.testapp"
-    android:versionCode="123"
-    android:versionName="aVersionName">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:theme="@style/Theme.Robolectric" android:enabled="true">


### PR DESCRIPTION
These properties have moved to the corresponding `build.gradle` files:
| `AndroidManifest.xml` property | `build.gradle` property |
|--------|--------|
| `manifest.package` | `android.namespace` |
| `manifest.uses-sdk.minSdkVersion` | `android.defaultConfig.minSdk` |
| `manifest.uses-sdk.targetSdkVersion` | `android.defaultConfig.targetSdk` |
| `manifest.versionCode` | `android.defaultConfig.versionCode` |
| `manifest.versionName` | `android.defaultConfig.versionName` |

The corresponding Gradle properties have already been set in the past. This PR only cleans up the remaining values in the `AndroidManifest` files, to avoid values being different.