### PR TITLE
Fix commit body validation

### DIFF
--- a/.github/workflows/validate_commit_message.yml
+++ b/.github/workflows/validate_commit_message.yml
@@ -45,10 +45,10 @@ jobs:
             exit 1
           fi
 
-          for line in $commit_body; do
+          while read -r line; do
             if [ "${#line}" -gt 120 ] && [[ ! "$line" =~ (https?://|www\.) ]]; then
               echo "Error: the following line of the commit body is too long (max: 120 characters):"
               echo "> $line"
               exit 1
             fi
-          done
+          done <<< $commit_body


### PR DESCRIPTION
As reported in https://github.com/robolectric/robolectric/pull/8903#issuecomment-2001917662, the validation of the commit body was broken, and long message body were not blocked.
The issue was that the script was checking each work of the body individually, instead of each line. So unless there was a word with more than 120 characters, it would never fail.