### PR TITLE
Fix issue with publishing preinstrumented jars

### DIFF
--- a/.github/workflows/gradle_tasks_validation.yml
+++ b/.github/workflows/gradle_tasks_validation.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
 
       - name: Run aggregateDocs
-        run: ./gradlew clean aggregateDocs
+        run: ./gradlew clean aggregateDocs --parallel
 
   run_javadocJar:
     runs-on: ubuntu-22.04
@@ -51,7 +51,8 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
 
       - name: Run javadocJar
-        run: ./gradlew clean javadocJar
+        run: ./gradlew clean javadocJar --parallel
+
 
   run_instrumentAll:
     runs-on: ubuntu-22.04
@@ -72,6 +73,9 @@ jobs:
 
       - name: Run :preinstrumented:instrumentAll with SDK 33
         run: PREINSTRUMENTED_SDK_VERSIONS=33 ./gradlew :preinstrumented:instrumentAll
+
+      - name: Run :preinstrumented:publishToMavenLocal with SDK 33
+        run: PREINSTRUMENTED_SDK_VERSIONS=33 PUBLISH_PREINSTRUMENTED_JARS=true ./gradlew :preinstrumented:publishToMavenLocal
 
   run_publishToMavenLocal:
     runs-on: ubuntu-22.04

--- a/preinstrumented/build.gradle
+++ b/preinstrumented/build.gradle
@@ -66,7 +66,7 @@ if (System.getenv('PUBLISH_PREINSTRUMENTED_JARS') == "true") {
         publications {
             sdksToInstrument().each { androidSdk ->
                 "sdk${androidSdk.apiLevel}"(MavenPublication) {
-                    artifact = layout.buildDirectory.file(androidSdk.preinstrumentedJarFileName).get().asFile.path
+                    artifact layout.buildDirectory.file(androidSdk.preinstrumentedJarFileName).get().asFile.path
                     artifactId 'android-all-instrumented'
                     artifact emptySourcesJar
                     artifact emptyJavadocJar
@@ -114,6 +114,8 @@ if (System.getenv('PUBLISH_PREINSTRUMENTED_JARS') == "true") {
     }
 
     signing {
+        // Skip signing if a signing key is not configured.
+        required { project.hasProperty("signing.keyId") }
         sdksToInstrument().each { androidSdk ->
             sign publishing.publications."sdk${androidSdk.apiLevel}"
         }


### PR DESCRIPTION
In preinstrumented/build.gradle, it should be 'artifact <artifact_path>', not 'artifact = <artifact_path>'.
