### PR TITLE
Enable Gradle's Build Cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,13 @@
 thisVersion=4.13-SNAPSHOT
+
+# This project uses AndroidX instead of Support Libraries
+# https://developer.android.com/jetpack/androidx/migrate#migrate_an_existing_project_using_android_studio
 android.useAndroidX=true
+
+# Don't include Kotlin's standard library by default
+# https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library
 kotlin.stdlib.default.dependency=false
+
+# Enable Gradle's Build Cache
+# https://docs.gradle.org/current/userguide/performance.html#enable_the_build_cache
+org.gradle.caching=true


### PR DESCRIPTION
As discussed in https://github.com/robolectric/robolectric/pull/6726#issuecomment-2038740330, enable Gradle's Build Cache by default: https://docs.gradle.org/current/userguide/performance.html#enable_the_build_cache

> [!NOTE]
> GitHub Actions caches are only written after a build on `master` (by default). So the impact of this PR will only be visible once merged.