### PR TITLE
Switch to the new `gradle/actions/wrapper-validation` action

### DIFF
--- a/.github/workflows/gradle_wrapper_validation.yml
+++ b/.github/workflows/gradle_wrapper_validation.yml
@@ -24,4 +24,4 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v3


### PR DESCRIPTION
This action replaces `gradle/wrapper-validation-action` as of version [3.3.0](https://github.com/gradle/actions/releases/tag/v3.3.0).