### PR TITLE
Fix SDK compat issues in 4.12

### DIFF
--- a/integration_tests/sdkcompat/src/test/java/org/robolectric/integrationtests/sdkcompat/JavaClassResolveCompatibilityTest.java
+++ b/integration_tests/sdkcompat/src/test/java/org/robolectric/integrationtests/sdkcompat/JavaClassResolveCompatibilityTest.java
@@ -6,6 +6,8 @@ import android.os.Build;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
 
 /**
  * Test class for Java's class resolve compatibility test. We must keep it with Java instead of
@@ -21,8 +23,6 @@ public class JavaClassResolveCompatibilityTest {
   @Test
   public void shadowOf() {
     // https://github.com/robolectric/robolectric/issues/7095
-    // Enable this assertion when resolving all shadowOf compatibility problem
-    // assertThat(Shadows.shadowOf((Application) ApplicationProvider.getApplicationContext()))
-    //     .isNotNull();
+    assertThat(Shadows.shadowOf(RuntimeEnvironment.getApplication())).isNotNull();
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowVpnManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowVpnManagerTest.java
@@ -1,7 +1,6 @@
 package org.robolectric.shadows;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.robolectric.Shadows.shadowOf;
 
 import android.content.Intent;
 import android.net.Ikev2VpnProfile;
@@ -15,6 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadow.api.Shadow;
 
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = VERSION_CODES.R)
@@ -25,7 +25,7 @@ public class ShadowVpnManagerTest {
   @Before
   public void setUp() throws Exception {
     vpnManager = ApplicationProvider.getApplicationContext().getSystemService(VpnManager.class);
-    shadowVpnManager = shadowOf(vpnManager);
+    shadowVpnManager = Shadow.extract(vpnManager);
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInformationElement.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInformationElement.java
@@ -5,7 +5,10 @@ import android.os.Build.VERSION_CODES;
 import org.robolectric.annotation.Implements;
 
 /** Shadow for {@link android.net.wifi.ScanResult.InformationElement}. */
-@Implements(value = ScanResult.InformationElement.class, minSdk = VERSION_CODES.R)
+@Implements(
+    value = ScanResult.InformationElement.class,
+    minSdk = VERSION_CODES.R,
+    isInAndroidSdk = false)
 public class ShadowInformationElement {
   /**
    * A builder for creating ShadowInformationElement objects. Use build() to return the

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativePositionedGlyphs.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativePositionedGlyphs.java
@@ -15,6 +15,7 @@ import org.robolectric.versioning.AndroidVersions.V;
     value = PositionedGlyphs.class,
     minSdk = S.SDK_INT,
     shadowPicker = Picker.class,
+    isInAndroidSdk = false,
     callNativeMethodsByDefault = true)
 public class ShadowNativePositionedGlyphs {
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeRenderEffect.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeRenderEffect.java
@@ -16,6 +16,7 @@ import org.robolectric.versioning.AndroidVersions.U;
     value = RenderEffect.class,
     minSdk = O,
     shadowPicker = Picker.class,
+    isInAndroidSdk = false,
     callNativeMethodsByDefault = true)
 public class ShadowNativeRenderEffect {
   static {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeRuntimeShader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeRuntimeShader.java
@@ -22,6 +22,7 @@ import org.robolectric.versioning.AndroidVersions.U;
     value = RuntimeShader.class,
     minSdk = O,
     shadowPicker = Picker.class,
+    isInAndroidSdk = false,
     callNativeMethodsByDefault = true)
 public class ShadowNativeRuntimeShader {
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeTextRunShaper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeTextRunShaper.java
@@ -14,6 +14,7 @@ import org.robolectric.versioning.AndroidVersions.U;
     value = TextRunShaper.class,
     minSdk = S.SDK_INT,
     shadowPicker = Picker.class,
+    isInAndroidSdk = false,
     callNativeMethodsByDefault = true)
 public class ShadowNativeTextRunShaper {
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTranslationManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTranslationManager.java
@@ -11,7 +11,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /** Shadow for {@link TranslationManager}. */
-@Implements(value = TranslationManager.class, minSdk = VERSION_CODES.S)
+@Implements(value = TranslationManager.class, minSdk = VERSION_CODES.S, isInAndroidSdk = false)
 public class ShadowTranslationManager {
   private final Table<Integer, Integer, ImmutableSet<TranslationCapability>>
       onDeviceTranslationCapabilities = HashBasedTable.create();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVpnManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVpnManager.java
@@ -11,7 +11,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /** Shadow for {@link VpnManager}. */
-@Implements(value = VpnManager.class, minSdk = VERSION_CODES.R)
+@Implements(value = VpnManager.class, minSdk = VERSION_CODES.R, isInAndroidSdk = false)
 public class ShadowVpnManager {
 
   private VpnProfileState vpnProfileState;


### PR DESCRIPTION
Update several shadows to use `isInAndroidSdk=false`, which disables shadowOf method generation. This fixes compile issues for apps that have compileSdkVersion < Q.
