### PR TITLE
Disable shadowOf generation for FileIntegrityManager

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowFileIntegrityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowFileIntegrityManagerTest.java
@@ -2,7 +2,6 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.R;
 import static com.google.common.truth.Truth.assertThat;
-import static org.robolectric.Shadows.shadowOf;
 
 import android.security.FileIntegrityManager;
 import androidx.test.core.app.ApplicationProvider;
@@ -11,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadow.api.Shadow;
 
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = R)
@@ -31,7 +31,8 @@ public final class ShadowFileIntegrityManagerTest {
 
   @Test
   public void isApkVeritySupported_setFalse_returnsFalse() {
-    shadowOf(fileIntegrityManager).setIsApkVeritySupported(false);
+    ((ShadowFileIntegrityManager) Shadow.extract(fileIntegrityManager))
+        .setIsApkVeritySupported(false);
 
     assertThat(fileIntegrityManager.isApkVeritySupported()).isFalse();
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFileIntegrityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFileIntegrityManager.java
@@ -7,7 +7,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /** Shadow for {@link FileIntegrityManager}. */
-@Implements(value = FileIntegrityManager.class, minSdk = R)
+@Implements(value = FileIntegrityManager.class, minSdk = R, isInAndroidSdk = false)
 public class ShadowFileIntegrityManager {
 
   private boolean isApkVeritySupported = true;


### PR DESCRIPTION
FileIntegrityManager was added in Android R, and we are currently supporting shadowOf for compileSdk >= Q.