### PR TITLE
Improve Spotless ktfmt & detekt integration

### DIFF
--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -55,6 +55,6 @@ jobs:
         run: |
           ./gradlew spotlessCheck
 
-      - name: Check Kotlin Code Style
+      - name: Check Kotlin Quality
         run: |
           ./gradlew detekt

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/SpotlessPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/SpotlessPlugin.groovy
@@ -11,7 +11,7 @@ class SpotlessPlugin implements Plugin<Project> {
             kotlin {
                 // Add configurations for Kotlin files
                 target '**/*.kt'
-                ktfmt('0.42').googleStyle()
+                ktfmt('0.49').googleStyle()
             }
             groovy {
                 // Add configurations for Groovy files
@@ -21,7 +21,6 @@ class SpotlessPlugin implements Plugin<Project> {
                 // Add configurations for Groovy Gradle files
                 target('*.gradle', "**/*.gradle")
             }
-
         }
     }
 }

--- a/integration_tests/kotlin/build.gradle
+++ b/integration_tests/kotlin/build.gradle
@@ -1,7 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.robolectric.gradle.RoboJavaModulePlugin
+import org.robolectric.gradle.SpotlessPlugin
+
 apply plugin: RoboJavaModulePlugin
 apply plugin: 'kotlin'
+apply plugin: SpotlessPlugin
+apply plugin: "io.gitlab.arturbosch.detekt"
+
 compileKotlin {
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8
 }

--- a/integration_tests/kotlin/src/test/kotlin/org/robolectric/integrationtests/kotlin/CustomShadowImageViewTest.kt
+++ b/integration_tests/kotlin/src/test/kotlin/org/robolectric/integrationtests/kotlin/CustomShadowImageViewTest.kt
@@ -22,7 +22,6 @@ class CustomShadowImageViewTest {
     val shadowImageView = Shadow.extract<CustomShadowImageView>(imageView)
     assertThat(shadowImageView).isNotNull()
     assertThat(shadowImageView.realImageView).isSameInstanceAs(imageView)
-    val resourceId = Int.MAX_VALUE
     imageView.performLongClick()
     assertThat(shadowImageView.longClickPerformed).isTrue()
   }

--- a/integration_tests/mockito-kotlin/build.gradle
+++ b/integration_tests/mockito-kotlin/build.gradle
@@ -1,17 +1,11 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.robolectric.gradle.RoboJavaModulePlugin
+import org.robolectric.gradle.SpotlessPlugin
 
 apply plugin: RoboJavaModulePlugin
 apply plugin: 'kotlin'
-apply plugin: "com.diffplug.spotless"
+apply plugin: SpotlessPlugin
 apply plugin: "io.gitlab.arturbosch.detekt"
-
-spotless {
-    kotlin {
-        target '**/*.kt'
-        ktfmt('0.42').googleStyle()
-    }
-}
 
 compileKotlin {
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8

--- a/integration_tests/mockk/build.gradle
+++ b/integration_tests/mockk/build.gradle
@@ -1,17 +1,11 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.robolectric.gradle.RoboJavaModulePlugin
+import org.robolectric.gradle.SpotlessPlugin
 
 apply plugin: RoboJavaModulePlugin
 apply plugin: 'kotlin'
-apply plugin: "com.diffplug.spotless"
+apply plugin: SpotlessPlugin
 apply plugin: "io.gitlab.arturbosch.detekt"
-
-spotless {
-    kotlin {
-        target '**/*.kt'
-        ktfmt('0.42').googleStyle()
-    }
-}
 
 compileKotlin {
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8

--- a/integration_tests/roborazzi/build.gradle
+++ b/integration_tests/roborazzi/build.gradle
@@ -1,8 +1,13 @@
 import org.robolectric.gradle.AndroidProjectConfigPlugin
+import org.robolectric.gradle.SpotlessPlugin
+
 apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
 apply plugin: 'kotlin-android'
 apply plugin: "io.github.takahirom.roborazzi"
+apply plugin: SpotlessPlugin
+apply plugin: "io.gitlab.arturbosch.detekt"
+
 android {
     compileSdk 34
     namespace 'org.robolectric.integration.roborazzi'

--- a/integration_tests/roborazzi/src/test/java/org/robolectric/integration/roborazzi/RoborazziCaptureTest.kt
+++ b/integration_tests/roborazzi/src/test/java/org/robolectric/integration/roborazzi/RoborazziCaptureTest.kt
@@ -114,6 +114,7 @@ private fun registerActivityToPackageManager(activity: String) {
     .addActivityIfNotPresent(ComponentName(appContext.packageName, activity))
 }
 
+@Suppress("ForbiddenComment")
 private fun hardwareRendererEnvironment(block: () -> Unit) {
   val originalHwrdrOption =
     System.getProperty(RoborazziCaptureTest.USE_HARDWARE_RENDERER_NATIVE_ENV, null)

--- a/integration_tests/sdkcompat/build.gradle
+++ b/integration_tests/sdkcompat/build.gradle
@@ -1,17 +1,11 @@
 import org.robolectric.gradle.AndroidProjectConfigPlugin
+import org.robolectric.gradle.SpotlessPlugin
 
 apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
 apply plugin: 'kotlin-android'
-apply plugin: "com.diffplug.spotless"
+apply plugin: SpotlessPlugin
 apply plugin: "io.gitlab.arturbosch.detekt"
-
-spotless {
-    kotlin {
-        target '**/*.kt'
-        ktfmt('0.42').googleStyle()
-    }
-}
 
 android {
     compileSdk 29

--- a/integration_tests/sparsearray/build.gradle
+++ b/integration_tests/sparsearray/build.gradle
@@ -1,8 +1,12 @@
 import org.robolectric.gradle.AndroidProjectConfigPlugin
+import org.robolectric.gradle.SpotlessPlugin
+
 apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
 apply plugin: 'kotlin-android'
+apply plugin: SpotlessPlugin
 apply plugin: "io.gitlab.arturbosch.detekt"
+
 android {
     compileSdk 34
     namespace 'org.robolectric.sparsearray'
@@ -27,6 +31,7 @@ android {
         }
     }
 }
+
 dependencies {
     compileOnly AndroidSdk.MAX_SDK.coordinates
     implementation project(path: ':shadowapi', configuration: 'default')

--- a/plugins/maven-dependency-resolver/build.gradle
+++ b/plugins/maven-dependency-resolver/build.gradle
@@ -1,18 +1,13 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.robolectric.gradle.DeployedRoboJavaModulePlugin
 import org.robolectric.gradle.RoboJavaModulePlugin
+import org.robolectric.gradle.SpotlessPlugin
 
 apply plugin: RoboJavaModulePlugin
 apply plugin: DeployedRoboJavaModulePlugin
 apply plugin: 'kotlin'
-apply plugin: "com.diffplug.spotless"
-
-spotless {
-    kotlin {
-        target '**/*.kt'
-        ktfmt('0.42').googleStyle()
-    }
-}
+apply plugin: SpotlessPlugin
+apply plugin: "io.gitlab.arturbosch.detekt"
 
 tasks.withType(GenerateModuleMetadata).configureEach {
     // We don't want to release gradle module metadata now to avoid

--- a/plugins/maven-dependency-resolver/src/test/java/org/robolectric/MavenRoboSettingsTest.kt
+++ b/plugins/maven-dependency-resolver/src/test/java/org/robolectric/MavenRoboSettingsTest.kt
@@ -15,6 +15,7 @@ class MavenRoboSettingsTest {
   private var originalMavenRepositoryPassword: String? = null
   private var originalMavenRepositoryProxyHost: String? = null
   private var originalMavenProxyPort = 0
+
   @Before
   fun setUp() {
     originalMavenRepositoryId = MavenRoboSettings.getMavenRepositoryId()

--- a/plugins/maven-dependency-resolver/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.kt
+++ b/plugins/maven-dependency-resolver/src/test/java/org/robolectric/internal/dependency/MavenDependencyResolverTest.kt
@@ -39,7 +39,7 @@ class MavenDependencyResolverTest {
         PROXY_HOST,
         PROXY_PORT,
         localRepositoryDir,
-        executorService
+        executorService,
       )
     mavenDependencyResolver = TestMavenDependencyResolver()
   }
@@ -151,7 +151,7 @@ class MavenDependencyResolverTest {
       proxyHost: String?,
       proxyPort: Int,
       localRepositoryDir: File,
-      executorService: ExecutorService
+      executorService: ExecutorService,
     ): MavenArtifactFetcher {
       return mavenArtifactFetcher
     }
@@ -169,6 +169,7 @@ class MavenDependencyResolverTest {
     }
   }
 
+  @Suppress("LongParameterList")
   internal class TestMavenArtifactFetcher(
     repositoryUrl: String?,
     repositoryUserName: String?,
@@ -176,7 +177,7 @@ class MavenDependencyResolverTest {
     proxyHost: String?,
     proxyPort: Int,
     localRepositoryDir: File,
-    private val executorService: ExecutorService
+    private val executorService: ExecutorService,
   ) :
     MavenArtifactFetcher(
       repositoryUrl,
@@ -185,7 +186,7 @@ class MavenDependencyResolverTest {
       proxyHost,
       proxyPort,
       localRepositoryDir,
-      executorService
+      executorService,
     ) {
     var numRequests = 0
       private set
@@ -199,7 +200,7 @@ class MavenDependencyResolverTest {
             return super.call()
           }
         },
-        executorService
+        executorService,
       )
     }
   }
@@ -216,7 +217,7 @@ class MavenDependencyResolverTest {
       arrayOf(
         DependencyJar("group", "artifact", "1"),
         DependencyJar("org.group2", "artifact2-name", "2.4.5"),
-        DependencyJar("org.robolectric", "android-all", "10-robolectric-5803371")
+        DependencyJar("org.robolectric", "android-all", "10-robolectric-5803371"),
       )
 
     init {
@@ -240,20 +241,20 @@ class MavenDependencyResolverTest {
         val jarContents = "$mavenJarArtifact jar contents"
         Files.write(
           jarContents.toByteArray(StandardCharsets.UTF_8),
-          File(REPOSITORY_DIR, mavenJarArtifact.jarPath())
+          File(REPOSITORY_DIR, mavenJarArtifact.jarPath()),
         )
         Files.write(
           sha512(jarContents).toByteArray(),
-          File(REPOSITORY_DIR, mavenJarArtifact.jarSha512Path())
+          File(REPOSITORY_DIR, mavenJarArtifact.jarSha512Path()),
         )
         val pomContents = "$mavenJarArtifact pom contents"
         Files.write(
           pomContents.toByteArray(StandardCharsets.UTF_8),
-          File(REPOSITORY_DIR, mavenJarArtifact.pomPath())
+          File(REPOSITORY_DIR, mavenJarArtifact.pomPath()),
         )
         Files.write(
           sha512(pomContents).toByteArray(),
-          File(REPOSITORY_DIR, mavenJarArtifact.pomSha512Path())
+          File(REPOSITORY_DIR, mavenJarArtifact.pomSha512Path()),
         )
       } catch (e: MalformedURLException) {
         throw AssertionError(e)
@@ -269,13 +270,13 @@ class MavenDependencyResolverTest {
         Files.write(jarContents.toByteArray(), File(REPOSITORY_DIR, mavenJarArtifact.jarPath()))
         Files.write(
           sha512("No the same content").toByteArray(),
-          File(REPOSITORY_DIR, mavenJarArtifact.jarSha512Path())
+          File(REPOSITORY_DIR, mavenJarArtifact.jarSha512Path()),
         )
         val pomContents = "$mavenJarArtifact pom contents"
         Files.write(pomContents.toByteArray(), File(REPOSITORY_DIR, mavenJarArtifact.pomPath()))
         Files.write(
           sha512("Really not the same content").toByteArray(),
-          File(REPOSITORY_DIR, mavenJarArtifact.pomSha512Path())
+          File(REPOSITORY_DIR, mavenJarArtifact.pomSha512Path()),
         )
       } catch (e: MalformedURLException) {
         throw AssertionError(e)

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -1,19 +1,13 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.robolectric.gradle.DeployedRoboJavaModulePlugin
 import org.robolectric.gradle.RoboJavaModulePlugin
+import org.robolectric.gradle.SpotlessPlugin
 
 apply plugin: RoboJavaModulePlugin
 apply plugin: 'kotlin'
 apply plugin: DeployedRoboJavaModulePlugin
-apply plugin: "com.diffplug.spotless"
+apply plugin: SpotlessPlugin
 apply plugin: "io.gitlab.arturbosch.detekt"
-
-spotless {
-    kotlin {
-        target '**/*.kt'
-        ktfmt('0.42').googleStyle()
-    }
-}
 
 tasks.withType(GenerateModuleMetadata).configureEach {
     // We don't want to release gradle module metadata now to avoid

--- a/utils/src/test/java/org/robolectric/util/PerfStatsCollectorTest.kt
+++ b/utils/src/test/java/org/robolectric/util/PerfStatsCollectorTest.kt
@@ -109,6 +109,7 @@ class PerfStatsCollectorTest {
 
   private class FakeClock : Clock {
     private var timeNs = 0
+
     override fun nanoTime(): Long {
       return timeNs.toLong()
     }

--- a/utils/src/test/java/org/robolectric/util/SchedulerTest.kt
+++ b/utils/src/test/java/org/robolectric/util/SchedulerTest.kt
@@ -212,10 +212,10 @@ class SchedulerTest {
             transcript.add("two")
             scheduler.postDelayed(AddToTranscript("three"), 1000)
           },
-          1000
+          1000,
         )
       },
-      1000
+      1000,
     )
     scheduler.advanceBy(1000)
     assertThat(transcript).containsExactly("one")
@@ -278,7 +278,7 @@ class SchedulerTest {
         scheduler.post { order.add(4) }
         order.add(2)
       },
-      0
+      0,
     )
     scheduler.postDelayed({ order.add(3) }, 0)
     scheduler.runOneTask()
@@ -302,7 +302,7 @@ class SchedulerTest {
         scheduler.post { order.add(3) }
         order.add(2)
       },
-      0
+      0,
     )
     assertWithMessage("order").that(order).containsExactly(1, 2, 3)
     assertWithMessage("size").that(scheduler.size()).isEqualTo(0)
@@ -317,7 +317,7 @@ class SchedulerTest {
         scheduler.postAtFrontOfQueue { order.add(3) }
         order.add(2)
       },
-      0
+      0,
     )
     scheduler.postDelayed({ order.add(4) }, 0)
     scheduler.advanceToLastPostedRunnable()
@@ -335,7 +335,7 @@ class SchedulerTest {
         scheduler.postAtFrontOfQueue { order.add(3) }
         order.add(2)
       },
-      0
+      0,
     )
     assertWithMessage("order").that(order).containsExactly(1, 2, 3)
     assertWithMessage("size").that(scheduler.size()).isEqualTo(0)
@@ -351,7 +351,7 @@ class SchedulerTest {
         scheduler.postDelayed({ order.add(3) }, 1)
         order.add(2)
       },
-      0
+      0,
     )
     assertWithMessage("order:before").that(order).containsExactly(1, 2)
     assertWithMessage("size:before").that(scheduler.size()).isEqualTo(1)
@@ -371,7 +371,7 @@ class SchedulerTest {
         scheduler.postDelayed({ order.add(3) }, 1)
         order.add(2)
       },
-      0
+      0,
     )
     assertWithMessage("order").that(order).containsExactly(1, 2, 3)
     assertWithMessage("size").that(scheduler.size()).isEqualTo(0)

--- a/utils/src/test/java/org/robolectric/util/inject/PluginFinderTest.kt
+++ b/utils/src/test/java/org/robolectric/util/inject/PluginFinderTest.kt
@@ -27,7 +27,7 @@ class PluginFinderTest {
         ImplMinus1::class.java,
         ImplZeroA::class.java,
         ImplOne::class.java,
-        ImplZeroB::class.java
+        ImplZeroB::class.java,
       )
     )
     Truth.assertThat(pluginFinder.findPlugin(Iface::class.java)).isEqualTo(ImplOne::class.java)
@@ -55,7 +55,7 @@ class PluginFinderTest {
         ImplMinus1::class.java,
         ImplZeroA::class.java,
         ImplOne::class.java,
-        ImplZeroB::class.java
+        ImplZeroB::class.java,
       )
     )
     Truth.assertThat(pluginFinder.findPlugins(Iface::class.java))
@@ -63,7 +63,7 @@ class PluginFinderTest {
         ImplOne::class.java,
         ImplZeroA::class.java,
         ImplZeroB::class.java,
-        ImplMinus1::class.java
+        ImplMinus1::class.java,
       )
       .inOrder()
   }
@@ -77,7 +77,7 @@ class PluginFinderTest {
         ImplZeroXSupercedesA::class.java,
         ImplZeroA::class.java,
         ImplOne::class.java,
-        ImplZeroB::class.java
+        ImplZeroB::class.java,
       )
     )
     val plugins = pluginFinder.findPlugins(Iface::class.java)
@@ -86,7 +86,7 @@ class PluginFinderTest {
         ImplOne::class.java,
         ImplZeroB::class.java,
         ImplZeroXSupercedesA::class.java,
-        ImplMinus1::class.java
+        ImplMinus1::class.java,
       )
       .inOrder()
   }
@@ -95,10 +95,12 @@ class PluginFinderTest {
   @Priority(-1) private class ImplMinus1 : Iface
 
   @Priority(0) private class ImplZeroA : Iface
+
   private class ImplZeroB : Iface
 
   @Priority(1) private class ImplOne : Iface
 
   @Supercedes(ImplZeroA::class) private class ImplZeroXSupercedesA : Iface
+
   private interface Iface
 }


### PR DESCRIPTION
1. Let integration_tests to use SpotlessPlugin.
2. Bump ktfmt to 0.49.
3. Re-format existing Kotlin files with new ktfmt.
4. Add detekt to modules with Kotlin code.
5. Fix existing detekt issues with some Suppress.
