### PR TITLE
add a new annotation ClassName to be used to indicate the real type of the parameters

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/ClassName.java
+++ b/annotations/src/main/java/org/robolectric/annotation/ClassName.java
@@ -1,0 +1,20 @@
+package org.robolectric.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Parameters with types that can't be resolved at compile time may be annotated @ClassName. */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ClassName {
+
+  /**
+   * The class name intended for this parameter.
+   *
+   * <p>Use the value as returned from {@link Class#getName()}, not {@link
+   * Class#getCanonicalName()}; e.g. {@code Foo$Bar} instead of {@code Foo.Bar}.
+   */
+  String value();
+}


### PR DESCRIPTION
Add a new ClassName annotation

This annotation will be used to specify parameter types of shadow methods. The eventual goal is to use this to replace `looseSignatures`.
