### PR TITLE
Update Truth to 1.4.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,7 @@ guava-jre = "31.1-jre"
 gson = "2.11.0"
 
 # https://github.com/google/truth/releases
-truth = "1.4.0"
+truth = "1.4.2"
 
 # https://github.com/unicode-org/icu/releases
 icu4j = "75.1"
@@ -201,7 +201,6 @@ sqlite4java-linux-i386 = { module = "com.almworks.sqlite4java:libsqlite4java-lin
 sqlite4java-win32-x86 = { module = "com.almworks.sqlite4java:sqlite4java-win32-x86", version.ref = "sqlite4java" }
 
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
-truth-java8-extension = { module = "com.google.truth.extensions:truth-java8-extension", version.ref = "truth" }
 
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito" }

--- a/integration_tests/memoryleaks/build.gradle
+++ b/integration_tests/memoryleaks/build.gradle
@@ -31,5 +31,5 @@ dependencies {
     testImplementation libs.junit4
     testImplementation libs.guava.testlib
     testImplementation libs.androidx.fragment
-    testImplementation 'com.google.truth:truth:1.1.3'
+    testImplementation libs.truth
 }

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     testImplementation libs.androidx.annotation
     testImplementation libs.junit4
     testImplementation libs.truth
-    testImplementation libs.truth.java8.extension
     testImplementation libs.mockito
     testImplementation libs.hamcrest.junit
     testImplementation "androidx.test:core:$axtCoreVersion@aar"


### PR DESCRIPTION
This PR updates the Truth dependency to its latest version.

`integration_tests/memoryleaks` now uses the Truth declaration from the Gradle version catalog, instead of an old version.
`robolectric` no longer depends on Truth Java8 extensions, since these APIs have been merged in Truth. The corresponding declaration in the Gradle version catalog has been deleted.

This PR replaces #9113