### PR TITLE
gitignore: Ignore .kotlin brought by Kotlin 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ release.properties
 .gradle/
 build
 
+# Kotlin
+.kotlin
+
 # Android Profiling
 *.hprof
 


### PR DESCRIPTION
See https://github.com/JetBrains/kotlin/blob/master/.gitignore.