### PR TITLE
Ensure assertThrows clauses only have one statement.

### DIFF
--- a/robolectric/src/test/java/org/robolectric/junit/rules/TimeoutRuleTest.java
+++ b/robolectric/src/test/java/org/robolectric/junit/rules/TimeoutRuleTest.java
@@ -25,12 +25,12 @@ public final class TimeoutRuleTest {
 
   @Test
   public void testTimingOutIsInterrupted() {
-    Assert.assertThrows(
-        InterruptedException.class,
-        () -> {
-          Thread.sleep(1000);
-          throw new IllegalArgumentException();
-        });
+    try {
+      Thread.sleep(1000);
+      Assert.fail("Should never reach this statement");
+    } catch (InterruptedException e) {
+      // ignore expected
+    }
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
@@ -1507,10 +1507,7 @@ public class ShadowActivityTest {
         assertThrows(
             RuntimeException.class,
             () -> {
-              ActivityController<AbstractTestActivity> controller =
-                  Robolectric.buildActivity(AbstractTestActivity.class, null);
-              // This line will not be executed.
-              assertThat(controller).isNull();
+              Robolectric.buildActivity(AbstractTestActivity.class, null);
             });
     assertThat(throwable.getMessage())
         .isEqualTo("buildActivity must be called with non-abstract class");


### PR DESCRIPTION
It is ambiguous to have multiple statements in an assertThrows clause. Using such a pattern fails internal google lint checks.

This commit removes the unnecessary use of multiple statements in assertThrows.


