### PR TITLE
gradle: Switch to use plugins

### DIFF
--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -1,8 +1,7 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+}
 
 dependencies {
     compileOnly libs.findbugs.jsr305

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 import org.gradle.plugins.ide.idea.model.IdeaModel
-import org.robolectric.gradle.SpotlessPlugin
+import org.robolectric.gradle.ShadowsPlugin
+
 buildscript {
     apply from: 'dependencies.gradle'
 
@@ -21,6 +22,13 @@ buildscript {
     }
 }
 
+plugins {
+    id("idea")
+    id("org.robolectric.gradle.SpotlessPlugin")
+}
+// nebula-aggregate-javadocs doesn't support plugins
+apply plugin: "nebula-aggregate-javadocs"
+
 allprojects {
     repositories {
         google()
@@ -31,10 +39,6 @@ allprojects {
     group = "org.robolectric"
     version = thisVersion
 }
-
-apply plugin: 'idea'
-// apply SpotlessPlugin
-apply plugin: SpotlessPlugin
 
 project.ext.configAnnotationProcessing = []
 project.afterEvaluate {
@@ -78,8 +82,6 @@ project.afterEvaluate {
         }
     }
 }
-
-apply plugin: 'nebula-aggregate-javadocs'
 
 rootProject.gradle.projectsEvaluated {
     rootProject.tasks.named("aggregateJavadocs").configure {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,10 +1,46 @@
-apply plugin: "java-library"
-apply plugin: "groovy"
+plugins {
+    id("groovy")
+    id("java-library")
+    id("java-gradle-plugin")
+}
 
 repositories {
     google()
     mavenCentral()
     gradlePluginPortal()
+}
+
+gradlePlugin {
+    plugins {
+        AarDepsPlugin {
+            id = "org.robolectric.gradle.AarDepsPlugin"
+            implementationClass = "org.robolectric.gradle.AarDepsPlugin"
+        }
+        AndrodiProjectConfigPlugin {
+            id = "org.robolectric.gradle.AndroidProjectConfigPlugin"
+            implementationClass = "org.robolectric.gradle.AndroidProjectConfigPlugin"
+        }
+        DeployedRoboJavaModulePlugin {
+            id = "org.robolectric.gradle.DeployedRoboJavaModulePlugin"
+            implementationClass = "org.robolectric.gradle.DeployedRoboJavaModulePlugin"
+        }
+        GradleManagedDevicePlugin {
+            id = "org.robolectric.gradle.GradleManagedDevicePlugin"
+            implementationClass = "org.robolectric.gradle.GradleManagedDevicePlugin"
+        }
+        RoboJavaModulePlugin {
+            id = "org.robolectric.gradle.RoboJavaModulePlugin"
+            implementationClass = "org.robolectric.gradle.RoboJavaModulePlugin"
+        }
+        SpotlessPlugin {
+            id = "org.robolectric.gradle.SpotlessPlugin"
+            implementationClass = "org.robolectric.gradle.SpotlessPlugin"
+        }
+        ShadowsPlugin {
+            id = "org.robolectric.gradle.ShadowsPlugin"
+            implementationClass = "org.robolectric.gradle.ShadowsPlugin"
+        }
+    }
 }
 
 dependencies {

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/ShadowsPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/ShadowsPlugin.groovy
@@ -1,3 +1,5 @@
+package org.robolectric.gradle
+
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.compile.JavaCompile

--- a/errorprone/build.gradle
+++ b/errorprone/build.gradle
@@ -1,9 +1,9 @@
 import org.gradle.internal.jvm.Jvm
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
 
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+}
 
 // Disable annotation processor for tests
 compileTestJava {

--- a/integration_tests/agp/build.gradle
+++ b/integration_tests/agp/build.gradle
@@ -1,7 +1,7 @@
-import org.robolectric.gradle.AndroidProjectConfigPlugin
-
-apply plugin: 'com.android.library'
-apply plugin: AndroidProjectConfigPlugin
+plugins {
+    id("com.android.library")
+    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+}
 
 android {
     compileSdk 34

--- a/integration_tests/androidx/build.gradle
+++ b/integration_tests/androidx/build.gradle
@@ -1,7 +1,7 @@
-import org.robolectric.gradle.AndroidProjectConfigPlugin
-
-apply plugin: 'com.android.library'
-apply plugin: AndroidProjectConfigPlugin
+plugins {
+    id("com.android.library")
+    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+}
 
 android {
     compileSdk 34

--- a/integration_tests/androidx_test/build.gradle
+++ b/integration_tests/androidx_test/build.gradle
@@ -1,9 +1,8 @@
-import org.robolectric.gradle.AndroidProjectConfigPlugin
-import org.robolectric.gradle.GradleManagedDevicePlugin
-
-apply plugin: 'com.android.library'
-apply plugin: AndroidProjectConfigPlugin
-apply plugin: GradleManagedDevicePlugin
+plugins {
+    id("com.android.library")
+    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+    id("org.robolectric.gradle.GradleManagedDevicePlugin")
+}
 
 android {
     compileSdk 34

--- a/integration_tests/ctesque/build.gradle
+++ b/integration_tests/ctesque/build.gradle
@@ -1,9 +1,8 @@
-import org.robolectric.gradle.AndroidProjectConfigPlugin
-import org.robolectric.gradle.GradleManagedDevicePlugin
-
-apply plugin: 'com.android.library'
-apply plugin: AndroidProjectConfigPlugin
-apply plugin: GradleManagedDevicePlugin
+plugins {
+    id("com.android.library")
+    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+    id("org.robolectric.gradle.GradleManagedDevicePlugin")
+}
 
 android {
     compileSdk 34

--- a/integration_tests/dependency-on-stubs/build.gradle
+++ b/integration_tests/dependency-on-stubs/build.gradle
@@ -1,7 +1,7 @@
-import org.robolectric.gradle.AndroidProjectConfigPlugin
-
-apply plugin: 'com.android.library'
-apply plugin: AndroidProjectConfigPlugin
+plugins {
+    id("com.android.library")
+    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+}
 
 // test with a project that depends on the stubs jar, not org.robolectric:android-all
 

--- a/integration_tests/jacoco-offline/build.gradle
+++ b/integration_tests/jacoco-offline/build.gradle
@@ -1,7 +1,7 @@
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: "jacoco"
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("jacoco")
+}
 
 def jacocoVersion = libs.versions.jacoco.get()
 

--- a/integration_tests/kotlin/build.gradle
+++ b/integration_tests/kotlin/build.gradle
@@ -1,11 +1,11 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.robolectric.gradle.RoboJavaModulePlugin
-import org.robolectric.gradle.SpotlessPlugin
 
-apply plugin: RoboJavaModulePlugin
-apply plugin: 'kotlin'
-apply plugin: SpotlessPlugin
-apply plugin: "io.gitlab.arturbosch.detekt"
+plugins {
+    id("kotlin")
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.SpotlessPlugin")
+    id("io.gitlab.arturbosch.detekt")
+}
 
 compileKotlin {
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8

--- a/integration_tests/libphonenumber/build.gradle
+++ b/integration_tests/libphonenumber/build.gradle
@@ -1,6 +1,6 @@
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+}
 
 dependencies {
     api project(":robolectric")

--- a/integration_tests/memoryleaks/build.gradle
+++ b/integration_tests/memoryleaks/build.gradle
@@ -1,7 +1,7 @@
-import org.robolectric.gradle.AndroidProjectConfigPlugin
-
-apply plugin: 'com.android.library'
-apply plugin: AndroidProjectConfigPlugin
+plugins {
+    id("com.android.library")
+    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+}
 
 android {
     compileSdk 34

--- a/integration_tests/mockito-experimental/build.gradle
+++ b/integration_tests/mockito-experimental/build.gradle
@@ -1,6 +1,6 @@
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+}
 
 dependencies {
     api project(":robolectric")

--- a/integration_tests/mockito-kotlin/build.gradle
+++ b/integration_tests/mockito-kotlin/build.gradle
@@ -1,11 +1,11 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.robolectric.gradle.RoboJavaModulePlugin
-import org.robolectric.gradle.SpotlessPlugin
 
-apply plugin: RoboJavaModulePlugin
-apply plugin: 'kotlin'
-apply plugin: SpotlessPlugin
-apply plugin: "io.gitlab.arturbosch.detekt"
+plugins {
+    id("kotlin")
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.SpotlessPlugin")
+    id("io.gitlab.arturbosch.detekt")
+}
 
 compileKotlin {
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8

--- a/integration_tests/mockito/build.gradle
+++ b/integration_tests/mockito/build.gradle
@@ -1,6 +1,6 @@
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+}
 
 dependencies {
     api project(":robolectric")

--- a/integration_tests/mockk/build.gradle
+++ b/integration_tests/mockk/build.gradle
@@ -1,11 +1,11 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.robolectric.gradle.RoboJavaModulePlugin
-import org.robolectric.gradle.SpotlessPlugin
 
-apply plugin: RoboJavaModulePlugin
-apply plugin: 'kotlin'
-apply plugin: SpotlessPlugin
-apply plugin: "io.gitlab.arturbosch.detekt"
+plugins {
+    id("kotlin")
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.SpotlessPlugin")
+    id("io.gitlab.arturbosch.detekt")
+}
 
 compileKotlin {
     compilerOptions.jvmTarget = JvmTarget.JVM_1_8

--- a/integration_tests/nativegraphics/build.gradle
+++ b/integration_tests/nativegraphics/build.gradle
@@ -1,7 +1,7 @@
-import org.robolectric.gradle.AndroidProjectConfigPlugin
-
-apply plugin: 'com.android.library'
-apply plugin: AndroidProjectConfigPlugin
+plugins {
+    id("com.android.library")
+    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+}
 
 android {
     compileSdk 34

--- a/integration_tests/play_services/build.gradle
+++ b/integration_tests/play_services/build.gradle
@@ -1,6 +1,6 @@
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+}
 
 dependencies {
     api project(":robolectric")

--- a/integration_tests/powermock/build.gradle
+++ b/integration_tests/powermock/build.gradle
@@ -1,6 +1,6 @@
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+}
 
 dependencies {
     api project(":robolectric")

--- a/integration_tests/roborazzi/build.gradle
+++ b/integration_tests/roborazzi/build.gradle
@@ -1,12 +1,11 @@
-import org.robolectric.gradle.AndroidProjectConfigPlugin
-import org.robolectric.gradle.SpotlessPlugin
-
-apply plugin: 'com.android.library'
-apply plugin: AndroidProjectConfigPlugin
-apply plugin: 'kotlin-android'
-apply plugin: "io.github.takahirom.roborazzi"
-apply plugin: SpotlessPlugin
-apply plugin: "io.gitlab.arturbosch.detekt"
+plugins {
+    id("com.android.library")
+    id("kotlin-android")
+    id("io.github.takahirom.roborazzi")
+    id("io.gitlab.arturbosch.detekt")
+    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+    id("org.robolectric.gradle.SpotlessPlugin")
+}
 
 android {
     compileSdk 34

--- a/integration_tests/room/build.gradle
+++ b/integration_tests/room/build.gradle
@@ -1,7 +1,7 @@
-import org.robolectric.gradle.AndroidProjectConfigPlugin
-
-apply plugin: 'com.android.library'
-apply plugin: AndroidProjectConfigPlugin
+plugins {
+    id("com.android.library")
+    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+}
 
 android {
     compileSdk 34

--- a/integration_tests/sdkcompat/build.gradle
+++ b/integration_tests/sdkcompat/build.gradle
@@ -1,11 +1,11 @@
-import org.robolectric.gradle.AndroidProjectConfigPlugin
-import org.robolectric.gradle.SpotlessPlugin
+plugins {
+    id("com.android.library")
+    id("kotlin-android")
+    id("io.gitlab.arturbosch.detekt")
+    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+    id("org.robolectric.gradle.SpotlessPlugin")
+}
 
-apply plugin: 'com.android.library'
-apply plugin: AndroidProjectConfigPlugin
-apply plugin: 'kotlin-android'
-apply plugin: SpotlessPlugin
-apply plugin: "io.gitlab.arturbosch.detekt"
 
 android {
     compileSdk 29

--- a/integration_tests/security-providers/build.gradle
+++ b/integration_tests/security-providers/build.gradle
@@ -1,6 +1,6 @@
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+}
 
 dependencies {
     api project(":robolectric")

--- a/integration_tests/sparsearray/build.gradle
+++ b/integration_tests/sparsearray/build.gradle
@@ -1,11 +1,11 @@
-import org.robolectric.gradle.AndroidProjectConfigPlugin
-import org.robolectric.gradle.SpotlessPlugin
+plugins {
+    id("com.android.library")
+    id("kotlin-android")
+    id("io.gitlab.arturbosch.detekt")
+    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+    id("org.robolectric.gradle.SpotlessPlugin")
+}
 
-apply plugin: 'com.android.library'
-apply plugin: AndroidProjectConfigPlugin
-apply plugin: 'kotlin-android'
-apply plugin: SpotlessPlugin
-apply plugin: "io.gitlab.arturbosch.detekt"
 
 android {
     compileSdk 34

--- a/integration_tests/versioning/build.gradle
+++ b/integration_tests/versioning/build.gradle
@@ -1,8 +1,7 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+}
 
 configurations {
     earlyRuntime

--- a/junit/build.gradle
+++ b/junit/build.gradle
@@ -1,8 +1,7 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+}
 
 dependencies {
     api project(":annotations")

--- a/nativeruntime/build.gradle
+++ b/nativeruntime/build.gradle
@@ -1,8 +1,7 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
+plugins {
+  id("org.robolectric.gradle.RoboJavaModulePlugin")
+  id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+}
 
 if (System.getenv('PUBLISH_NATIVERUNTIME_DIST_COMPAT') == "true") {
   apply plugin: 'maven-publish'

--- a/pluginapi/build.gradle
+++ b/pluginapi/build.gradle
@@ -1,8 +1,7 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+}
 
 dependencies {
     compileOnly libs.findbugs.jsr305

--- a/plugins/maven-dependency-resolver/build.gradle
+++ b/plugins/maven-dependency-resolver/build.gradle
@@ -1,13 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-import org.robolectric.gradle.SpotlessPlugin
 
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
-apply plugin: 'kotlin'
-apply plugin: SpotlessPlugin
-apply plugin: "io.gitlab.arturbosch.detekt"
+plugins {
+    id("kotlin")
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    id("org.robolectric.gradle.SpotlessPlugin")
+    id("io.gitlab.arturbosch.detekt")
+}
 
 tasks.withType(GenerateModuleMetadata).configureEach {
     // We don't want to release gradle module metadata now to avoid

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -1,9 +1,9 @@
 import org.gradle.internal.jvm.Jvm
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
 
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+}
 
 class GenerateSdksFileTask extends DefaultTask {
     @OutputFile

--- a/resources/build.gradle
+++ b/resources/build.gradle
@@ -1,8 +1,7 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+}
 
 dependencies {
     api project(":utils")

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -1,8 +1,7 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+}
 
 dependencies {
     annotationProcessor libs.auto.service

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -1,8 +1,7 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+}
 
 dependencies {
     annotationProcessor libs.auto.service

--- a/shadowapi/build.gradle
+++ b/shadowapi/build.gradle
@@ -1,8 +1,7 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+}
 
 dependencies {
     compileOnly libs.findbugs.jsr305

--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -1,10 +1,8 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
-
-apply plugin: ShadowsPlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    id("org.robolectric.gradle.ShadowsPlugin")
+}
 
 shadows {
     packageName "org.robolectric"

--- a/shadows/httpclient/build.gradle
+++ b/shadows/httpclient/build.gradle
@@ -1,10 +1,8 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
-
-apply plugin: ShadowsPlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    id("org.robolectric.gradle.ShadowsPlugin")
+}
 
 shadows {
     packageName "org.robolectric.shadows.httpclient"

--- a/shadows/multidex/build.gradle
+++ b/shadows/multidex/build.gradle
@@ -1,10 +1,8 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
-
-apply plugin: ShadowsPlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    id("org.robolectric.gradle.ShadowsPlugin")
+}
 
 shadows {
     packageName "org.robolectric.shadows.multidex"

--- a/shadows/playservices/build.gradle
+++ b/shadows/playservices/build.gradle
@@ -1,10 +1,8 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
-
-apply plugin: ShadowsPlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    id("org.robolectric.gradle.ShadowsPlugin")
+}
 
 shadows {
     packageName "org.robolectric.shadows.gms"

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -1,13 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-import org.robolectric.gradle.SpotlessPlugin
 
-apply plugin: RoboJavaModulePlugin
-apply plugin: 'kotlin'
-apply plugin: DeployedRoboJavaModulePlugin
-apply plugin: SpotlessPlugin
-apply plugin: "io.gitlab.arturbosch.detekt"
+plugins {
+    id("kotlin")
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    id("org.robolectric.gradle.SpotlessPlugin")
+    id("io.gitlab.arturbosch.detekt")
+}
 
 tasks.withType(GenerateModuleMetadata).configureEach {
     // We don't want to release gradle module metadata now to avoid

--- a/utils/reflector/build.gradle
+++ b/utils/reflector/build.gradle
@@ -1,8 +1,7 @@
-import org.robolectric.gradle.DeployedRoboJavaModulePlugin
-import org.robolectric.gradle.RoboJavaModulePlugin
-
-apply plugin: RoboJavaModulePlugin
-apply plugin: DeployedRoboJavaModulePlugin
+plugins {
+    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+}
 
 dependencies {
     api libs.asm


### PR DESCRIPTION
1. Move ShadowsPlugin to package org.robolectric.gradle.
2. Create gradlePlugin for all internal plugins in buildSrc.
3. Switch to use plugins for all internal and external plugins as much as possible.
4. Keep using apply plugin for nebula-aggregate-javadocs as it doesn't support plugins.
