### PR TITLE
Remove plugin GradleManagedDevicePlugin from nativegraphics

### DIFF
--- a/integration_tests/nativegraphics/build.gradle
+++ b/integration_tests/nativegraphics/build.gradle
@@ -1,9 +1,7 @@
 import org.robolectric.gradle.AndroidProjectConfigPlugin
-import org.robolectric.gradle.GradleManagedDevicePlugin
 
 apply plugin: 'com.android.library'
 apply plugin: AndroidProjectConfigPlugin
-apply plugin: GradleManagedDevicePlugin
 
 android {
     compileSdk 34


### PR DESCRIPTION
nativegraphics doesn't have androidTests, and it doesn't need GradleManagedDevicePlugin.
