### PR TITLE
Fix kotlin code style violations.

### DIFF
--- a/utils/src/test/java/org/robolectric/util/SchedulerTest.kt
+++ b/utils/src/test/java/org/robolectric/util/SchedulerTest.kt
@@ -426,7 +426,7 @@ class SchedulerTest {
     scheduler.advanceToLastPostedRunnable()
     assertThat(actualOrder).isEqualTo(ImmutableList.copyOf(Iterables.concat(orderCheck.values)))
     watch.stop()
-    assertThat(watch.elapsed().toMillis()).isLessThan(2000L);
+    assertThat(watch.elapsed().toMillis()).isLessThan(2000L)
   }
 
   @Test(timeout = 1000)


### PR DESCRIPTION
GitHub CI is failing with the following violation
```
Execution failed for task ':spotlessKotlinCheck'.
> The following files had format violations:
      utils/src/test/java/org/robolectric/util/SchedulerTest.kt
          @@ -426,7 +426,7 @@
          -····assertThat(watch.elapsed().toMillis()).isLessThan(2000L);
          +····assertThat(watch.elapsed().toMillis()).isLessThan(2000L)
           ··}
```

This commit removes the unnecessary semicolon.

This cherry-picks https://github.com/robolectric/robolectric/commit/ecbba377b440e49182ae4c406569c01832d8e6be