### PR TITLE
Migrate repositories management to `settings.gradle`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,31 +11,24 @@ buildscript {
     }
 
     dependencies {
-        gradle
-        classpath libs.android.gradle
-        classpath libs.error.prone.gradle
         classpath libs.aggregate.javadocs.gradle
-        classpath libs.kotlin.gradle
-        classpath libs.spotless.gradle
-        classpath libs.detekt.gradle
-        classpath libs.roborazzi.gradle
     }
 }
 
 plugins {
+    id("com.diffplug.gradle.spotless") version libs.versions.spotless.gradle apply false
     id("idea")
+    id("io.github.takahirom.roborazzi") version libs.versions.roborazzi apply false
+    id("io.gitlab.arturbosch.detekt") version libs.versions.detekt.gradle apply false
+    id("net.ltgt.errorprone") version libs.versions.error.prone.gradle
+    id("org.jetbrains.kotlin.android") version libs.versions.kotlin apply false
     id("org.robolectric.gradle.SpotlessPlugin")
 }
+
 // nebula-aggregate-javadocs doesn't support plugins
 apply plugin: "nebula-aggregate-javadocs"
 
 allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
-    }
-
     group = "org.robolectric"
     version = thisVersion
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -4,12 +4,6 @@ plugins {
     id("java-gradle-plugin")
 }
 
-repositories {
-    google()
-    mavenCentral()
-    gradlePluginPortal()
-}
-
 gradlePlugin {
     plugins {
         AarDepsPlugin {

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,4 +1,13 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
 dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+
+    repositories {
+        google()
+        mavenCentral()
+    }
+
     versionCatalogs {
         libs {
             from(files("../gradle/libs.versions.toml"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,9 +125,6 @@ play-services-basement = "18.0.1"
 
 [libraries]
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
-kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-spotless-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless-gradle" }
-detekt-gradle = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt-gradle" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
@@ -157,8 +154,6 @@ error-prone-refaster = { module = "com.google.errorprone:error_prone_refaster", 
 error-prone-check-api = { module = "com.google.errorprone:error_prone_check_api", version.ref = "error-prone" }
 error-prone-test-helpers = { module = "com.google.errorprone:error_prone_test_helpers", version.ref = "error-prone" }
 error-prone-javac = { module = "com.google.errorprone:javac", version.ref = "error-prone-javac" }
-
-error-prone-gradle = { module = "net.ltgt.gradle:gradle-errorprone-plugin", version.ref = "error-prone-gradle" }
 
 conscrypt-openjdk-uber = { module = "org.conscrypt:conscrypt-openjdk-uber", version.ref = "conscrypt" }
 bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
@@ -204,7 +199,6 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version.ref = "roborazzi" }
 roborazzi-rule = { module = "io.github.takahirom.roborazzi:roborazzi-junit-rule", version.ref = "roborazzi" }
-roborazzi-gradle = { module = "io.github.takahirom.roborazzi:roborazzi-gradle-plugin", version.ref = "roborazzi" }
 
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
@@ -238,8 +232,8 @@ play-services-basement-for-shadows = { module = "com.google.android.gms:play-ser
 play-services-basement = { module = "com.google.android.gms:play-services-basement", version.ref = "play-services-basement" }
 
 [bundles]
-play-services-for-shadows = [ "androidx-fragment-for-shadows", "play-services-auth-for-shadows", "play-services-base-for-shadows", "play-services-basement-for-shadows" ]
-powermock = [ "powermock-module-junit4", "powermock-module-junit4-rule", "powermock-api-mockito2", "powermock-classloading-xstream" ]
-sqlite4java-native = [ "sqlite4java-osx", "sqlite4java-linux-amd64", "sqlite4java-win32-x64", "sqlite4java-linux-i386", "sqlite4java-win32-x86" ]
+play-services-for-shadows = ["androidx-fragment-for-shadows", "play-services-auth-for-shadows", "play-services-base-for-shadows", "play-services-basement-for-shadows"]
+powermock = ["powermock-module-junit4", "powermock-module-junit4-rule", "powermock-api-mockito2", "powermock-classloading-xstream"]
+sqlite4java-native = ["sqlite4java-osx", "sqlite4java-linux-amd64", "sqlite4java-win32-x64", "sqlite4java-linux-i386", "sqlite4java-win32-x86"]
 
 [plugins]

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,22 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'robolectric'
 
 include ":robolectric"


### PR DESCRIPTION
This commit is a first step to address #9189, by moving all repositories logic to `settings.gradle`. This aligns the project with what is done with recent Gradle versions, when creating a new project.
It also switches the remaining `classpath` declarations to the newer `plugins` block (when supported by the plugin).