### PR TITLE
Update `google-java-format` to 1.22.0

### DIFF
--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -33,10 +33,10 @@ jobs:
           distribution: 'adopt'
           java-version: 17
 
-      - name: Download google-java-format 1.9
+      - name: Download google-java-format
         run: |
-          curl -L -o $HOME/google-java-format.jar https://github.com/google/google-java-format/releases/download/v1.15.0/google-java-format-1.15.0-all-deps.jar
-          curl -L -o $HOME/google-java-format-diff.py https://raw.githubusercontent.com/google/google-java-format/v1.15.0/scripts/google-java-format-diff.py
+          curl -L -o $HOME/google-java-format.jar https://github.com/google/google-java-format/releases/download/v1.22.0/google-java-format-1.22.0-all-deps.jar
+          curl -L -o $HOME/google-java-format-diff.py https://raw.githubusercontent.com/google/google-java-format/v1.22.0/scripts/google-java-format-diff.py
           chmod +x $HOME/google-java-format-diff.py
 
       - name: Check Java formatting


### PR DESCRIPTION
This updates the `check_code_style.xml` workflow to use `google-java-format` 1.22.0 (previously 1.15.0).
No code change/reformatting was made in this commit.

This is the first step for #9163.
Next will be to prepare a PR to reformat the project, and test it internally at Google.