### PR TITLE
Integrate the necessary AGP internal classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 }
 
 plugins {
+    id("com.android.library") version libs.versions.android.gradle apply false
     id("com.diffplug.gradle.spotless") version libs.versions.spotless.gradle apply false
     id("idea")
     id("io.github.takahirom.roborazzi") version libs.versions.roborazzi apply false

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -42,7 +42,9 @@ dependencies {
     implementation localGroovy()
 
     implementation libs.asm.tree
-    implementation libs.android.gradle
+    implementation libs.android.gradle.api
+    implementation libs.android.tools.common
+    implementation libs.guava
 }
 
 java {

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/AarDepsPlugin.java
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/AarDepsPlugin.java
@@ -2,7 +2,6 @@ package org.robolectric.gradle;
 
 import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE;
 
-import com.android.build.gradle.internal.dependency.ExtractAarTransform;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +17,7 @@ import org.gradle.api.artifacts.transform.TransformOutputs;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.jetbrains.annotations.NotNull;
+import org.robolectric.gradle.agp.ExtractAarTransform;
 
 /** Resolve aar dependencies into jars for non-Android projects. */
 public class AarDepsPlugin implements Plugin<Project> {

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/agp/ExtractAarTransform.java
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/agp/ExtractAarTransform.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This class comes from AGP internals:
+ * https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/internal/dependency/ExtractAarTransform.kt;bpv=0
+ */
+
+package org.robolectric.gradle.agp;
+
+import com.android.SdkConstants;
+import com.android.utils.FileUtils;
+import com.google.common.io.Files;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import org.gradle.api.artifacts.transform.InputArtifact;
+import org.gradle.api.artifacts.transform.TransformAction;
+import org.gradle.api.artifacts.transform.TransformOutputs;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.work.DisableCachingByDefault;
+import org.jetbrains.annotations.NotNull;
+
+// TODO Keep the original Kotlin implementation when `buildSrc` is migrated to Kotlin.
+@DisableCachingByDefault(because = "Copy task")
+public abstract class ExtractAarTransform implements TransformAction<GenericTransformParameters> {
+  @Classpath
+  @InputArtifact
+  public abstract Provider<FileSystemLocation> getAarFile();
+
+  @Override
+  public void transform(@NotNull TransformOutputs outputs) {
+    // TODO(b/162813654) record transform execution span
+    File inputFile = getAarFile().get().getAsFile();
+    String inputFileNameWithoutExtension = Files.getNameWithoutExtension(inputFile.getName());
+    File outputDir = outputs.dir(inputFileNameWithoutExtension);
+    FileUtils.mkdirs(outputDir);
+    new AarExtractor().extract(inputFile, outputDir);
+  }
+}
+
+class AarExtractor {
+  private static final String LIBS_PREFIX = SdkConstants.LIBS_FOLDER + '/';
+  private static final int LIBS_PREFIX_LENGTH = LIBS_PREFIX.length();
+  private static final int JARS_PREFIX_LENGTH = SdkConstants.FD_JARS.length() + 1;
+
+  // Note:
+  //  - A jar doesn't need a manifest entry, but if we ever want to create a manifest entry, be
+  //    sure to set a fixed timestamp for it so that the jar is deterministic (see b/315336689).
+  //  - This empty jar takes up only ~22 bytes, so we don't need to GC it at the end of the build.
+  private static final byte[] emptyJar;
+
+  /**
+   * {@link StringBuilder} used to construct all paths. It gets truncated back to {@link
+   * JARS_PREFIX_LENGTH} on every calculation.
+   */
+  private final StringBuilder stringBuilder = new StringBuilder(60);
+
+  static {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    //noinspection EmptyTryBlock
+    try (JarOutputStream outputStream = new JarOutputStream(byteArrayOutputStream)) {
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    emptyJar = byteArrayOutputStream.toByteArray();
+  }
+
+  AarExtractor() {
+    stringBuilder.append(SdkConstants.FD_JARS);
+    stringBuilder.append(File.separatorChar);
+  }
+
+  private String choosePathInOutput(@NotNull String entryName) {
+    stringBuilder.setLength(JARS_PREFIX_LENGTH);
+
+    if (entryName.equals(SdkConstants.FN_CLASSES_JAR)
+        || entryName.equals(SdkConstants.FN_LINT_JAR)) {
+      stringBuilder.append(entryName);
+
+      return stringBuilder.toString();
+    } else if (entryName.startsWith(LIBS_PREFIX)) {
+      // In case we have libs/classes.jar we are going to rename them, due an issue in
+      // Gradle.
+      // TODO: stop doing this once this is fixed in gradle. b/65298222
+      String pathWithinLibs = entryName.substring(LIBS_PREFIX_LENGTH);
+
+      if (pathWithinLibs.equals(SdkConstants.FN_CLASSES_JAR)) {
+        stringBuilder.append(LIBS_PREFIX).append("classes-2" + SdkConstants.DOT_JAR);
+      } else if (pathWithinLibs.equals(SdkConstants.FN_LINT_JAR)) {
+        stringBuilder.append(LIBS_PREFIX).append("lint-2" + SdkConstants.DOT_JAR);
+      } else {
+        stringBuilder.append(LIBS_PREFIX).append(pathWithinLibs);
+      }
+
+      return stringBuilder.toString();
+    } else {
+      return entryName;
+    }
+  }
+
+  /**
+   * Extracts an AAR file into a directory.
+   *
+   * <p>Note: There are small adjustments made to the extracted contents. For example, classes.jar
+   * inside the AAR will be extracted to jars/classes.jar, and if the jar does not exist, we will
+   * create an empty classes.jar.
+   */
+  void extract(@NotNull File aar, @NotNull File outputDir) {
+    try (ZipInputStream zipInputStream =
+        new ZipInputStream(java.nio.file.Files.newInputStream(aar.toPath()))) {
+      while (true) {
+        ZipEntry entry = zipInputStream.getNextEntry();
+        if (entry == null) {
+          break;
+        }
+
+        if (entry.isDirectory() || entry.getName().contains("../") || entry.getName().isEmpty()) {
+          continue;
+        }
+
+        String path = FileUtils.toSystemDependentPath(choosePathInOutput(entry.getName()));
+        File outputFile = new File(outputDir, path);
+        Files.createParentDirs(outputFile);
+        Files.asByteSink(outputFile).writeFrom(zipInputStream);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    // If classes.jar does not exist, create an empty one
+    File classesJar = resolve(outputDir, SdkConstants.FD_JARS + "/" + SdkConstants.FN_CLASSES_JAR);
+    if (!classesJar.exists()) {
+      try {
+        Files.createParentDirs(classesJar);
+        Files.write(emptyJar, classesJar);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @NotNull
+  private File resolve(@NotNull File source, @NotNull String relative) {
+    Path baseDir = source.toPath();
+    Path relativeFile = Paths.get(relative);
+    Path resolvedFile = baseDir.resolve(relativeFile);
+
+    return resolvedFile.toFile();
+  }
+}

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/agp/GenericTransformParameters.java
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/agp/GenericTransformParameters.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This class comes from AGP internals:
+ * https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/internal/dependency/GenericTransformParameters.kt;bpv=0
+ */
+
+package org.robolectric.gradle.agp;
+
+import org.gradle.api.artifacts.transform.TransformParameters;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Internal;
+
+/** Generic {@link TransformParameters} for all of our Artifact Transforms. */
+// TODO Keep the original Kotlin implementation when `buildSrc` is migrated to Kotlin.
+public interface GenericTransformParameters extends TransformParameters {
+  @Internal
+  Property<String> getProjectName();
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,8 @@ robolectric-nativeruntime-dist-compat = "1.0.11"
 # https://developer.android.com/studio/releases
 android-gradle = "8.5.0"
 
+android-tools-common = "31.5.0"
+
 # https://github.com/google/conscrypt/tags
 conscrypt = "2.5.2"
 
@@ -124,7 +126,9 @@ play-services-for-shadows = "17.0.0"
 play-services-basement = "18.0.1"
 
 [libraries]
-android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
+android-gradle-api = { module = "com.android.tools.build:gradle-api", version.ref = "android-gradle" }
+
+android-tools-common = { module = "com.android.tools:common", version.ref = "android-tools-common" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }


### PR DESCRIPTION
The `AarDepsPlugin` plugin was using internal classes from AGP. This would cause build issues when trying to switch all plugins to the version catalog.
This will no longer be supported by AGP in a future version: https://developer.android.com/build/releases/gradle-plugin-roadmap#agp_100_2025

For now, I've copied the necessary code, ported to Java, inside this repository. Let me know if an other approach should be used instead.

This change comes in the scope of #9189.