### PR TITLE
Move plugins definition to the version catalog

### DIFF
--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -16,14 +16,15 @@ buildscript {
 }
 
 plugins {
-    id("com.android.library") version libs.versions.android.gradle apply false
-    id("com.diffplug.gradle.spotless") version libs.versions.spotless.gradle apply false
-    id("idea")
-    id("io.github.takahirom.roborazzi") version libs.versions.roborazzi apply false
-    id("io.gitlab.arturbosch.detekt") version libs.versions.detekt.gradle apply false
-    id("net.ltgt.errorprone") version libs.versions.error.prone.gradle
-    id("org.jetbrains.kotlin.android") version libs.versions.kotlin apply false
-    id("org.robolectric.gradle.SpotlessPlugin")
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.error.prone)
+    alias(libs.plugins.idea)
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.robolectric.spotless)
+    alias(libs.plugins.roborazzi) apply false
+    alias(libs.plugins.spotless) apply false
 }
 
 // nebula-aggregate-javadocs doesn't support plugins

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id("groovy")
-    id("java-library")
-    id("java-gradle-plugin")
+    alias(libs.plugins.groovy)
+    alias(libs.plugins.java.gradle.plugin)
+    alias(libs.plugins.java.library)
 }
 
 gradlePlugin {

--- a/buildSrc/src/main/groovy/org/robolectric/gradle/DeployedRoboJavaModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/robolectric/gradle/DeployedRoboJavaModulePlugin.groovy
@@ -10,6 +10,10 @@ class DeployedRoboJavaModulePlugin implements Plugin<Project> {
         project.apply plugin: "signing"
         project.apply plugin: "maven-publish"
 
+        if (!project.plugins.hasPlugin("org.robolectric.gradle.RoboJavaModulePlugin")) {
+            project.apply plugin: "org.robolectric.gradle.RoboJavaModulePlugin"
+        }
+
         task('sourcesJar', type: Jar, dependsOn: classes) {
             archiveClassifier = "sources"
             from sourceSets.main.allJava

--- a/errorprone/build.gradle
+++ b/errorprone/build.gradle
@@ -1,8 +1,8 @@
 import org.gradle.internal.jvm.Jvm
 
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
 }
 
 // Disable annotation processor for tests

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -241,3 +241,23 @@ powermock = ["powermock-module-junit4", "powermock-module-junit4-rule", "powermo
 sqlite4java-native = ["sqlite4java-osx", "sqlite4java-linux-amd64", "sqlite4java-win32-x64", "sqlite4java-linux-i386", "sqlite4java-win32-x86"]
 
 [plugins]
+android-library = { id = "com.android.library", version.ref = "android-gradle" }
+application = { id = "application" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt-gradle" }
+error-prone = { id = "net.ltgt.errorprone", version.ref = "error-prone-gradle" }
+groovy = { id = "groovy" }
+idea = { id = "idea" }
+jacoco = { id = "jacoco" }
+java = { id = "java" }
+java-gradle-plugin = { id = "java-gradle-plugin" }
+java-library = { id = "java-library" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+robolectric-android-project = { id = "org.robolectric.gradle.AndroidProjectConfigPlugin" }
+robolectric-deployed-java-module = { id = "org.robolectric.gradle.DeployedRoboJavaModulePlugin" }
+robolectric-gradle-managed-device = { id = "org.robolectric.gradle.GradleManagedDevicePlugin" }
+robolectric-java-module = { id = "org.robolectric.gradle.RoboJavaModulePlugin" }
+robolectric-spotless = { id = "org.robolectric.gradle.SpotlessPlugin" }
+robolectric-shadows = { id = "org.robolectric.gradle.ShadowsPlugin" }
+roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless-gradle" }

--- a/integration_tests/agp/build.gradle
+++ b/integration_tests/agp/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("com.android.library")
-    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.robolectric.android.project)
 }
 
 android {

--- a/integration_tests/agp/testsupport/build.gradle
+++ b/integration_tests/agp/testsupport/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 
 android {

--- a/integration_tests/androidx/build.gradle
+++ b/integration_tests/androidx/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("com.android.library")
-    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.robolectric.android.project)
 }
 
 android {

--- a/integration_tests/androidx_test/build.gradle
+++ b/integration_tests/androidx_test/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id("com.android.library")
-    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
-    id("org.robolectric.gradle.GradleManagedDevicePlugin")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.robolectric.android.project)
+    alias(libs.plugins.robolectric.gradle.managed.device)
 }
 
 android {

--- a/integration_tests/ctesque/build.gradle
+++ b/integration_tests/ctesque/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id("com.android.library")
-    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
-    id("org.robolectric.gradle.GradleManagedDevicePlugin")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.robolectric.android.project)
+    alias(libs.plugins.robolectric.gradle.managed.device)
 }
 
 android {

--- a/integration_tests/dependency-on-stubs/build.gradle
+++ b/integration_tests/dependency-on-stubs/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("com.android.library")
-    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.robolectric.android.project)
 }
 
 // test with a project that depends on the stubs jar, not org.robolectric:android-all

--- a/integration_tests/jacoco-offline/build.gradle
+++ b/integration_tests/jacoco-offline/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("jacoco")
+    alias(libs.plugins.jacoco)
+    alias(libs.plugins.robolectric.java.module)
 }
 
 def jacocoVersion = libs.versions.jacoco.get()

--- a/integration_tests/kotlin/build.gradle
+++ b/integration_tests/kotlin/build.gradle
@@ -1,10 +1,10 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("kotlin")
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.SpotlessPlugin")
-    id("io.gitlab.arturbosch.detekt")
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.robolectric.java.module)
+    alias(libs.plugins.robolectric.spotless)
 }
 
 compileKotlin {

--- a/integration_tests/libphonenumber/build.gradle
+++ b/integration_tests/libphonenumber/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {

--- a/integration_tests/memoryleaks/build.gradle
+++ b/integration_tests/memoryleaks/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("com.android.library")
-    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.robolectric.android.project)
 }
 
 android {

--- a/integration_tests/mockito-experimental/build.gradle
+++ b/integration_tests/mockito-experimental/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {

--- a/integration_tests/mockito-kotlin/build.gradle
+++ b/integration_tests/mockito-kotlin/build.gradle
@@ -1,10 +1,10 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("kotlin")
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.SpotlessPlugin")
-    id("io.gitlab.arturbosch.detekt")
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.robolectric.java.module)
+    alias(libs.plugins.robolectric.spotless)
 }
 
 compileKotlin {

--- a/integration_tests/mockito/build.gradle
+++ b/integration_tests/mockito/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {

--- a/integration_tests/mockk/build.gradle
+++ b/integration_tests/mockk/build.gradle
@@ -1,10 +1,10 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("kotlin")
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.SpotlessPlugin")
-    id("io.gitlab.arturbosch.detekt")
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.robolectric.java.module)
+    alias(libs.plugins.robolectric.spotless)
 }
 
 compileKotlin {

--- a/integration_tests/nativegraphics/build.gradle
+++ b/integration_tests/nativegraphics/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("com.android.library")
-    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.robolectric.android.project)
 }
 
 android {

--- a/integration_tests/play_services/build.gradle
+++ b/integration_tests/play_services/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {

--- a/integration_tests/powermock/build.gradle
+++ b/integration_tests/powermock/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {

--- a/integration_tests/roborazzi/build.gradle
+++ b/integration_tests/roborazzi/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id("com.android.library")
-    id("kotlin-android")
-    id("io.github.takahirom.roborazzi")
-    id("io.gitlab.arturbosch.detekt")
-    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
-    id("org.robolectric.gradle.SpotlessPlugin")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.robolectric.android.project)
+    alias(libs.plugins.robolectric.spotless)
+    alias(libs.plugins.roborazzi)
 }
 
 android {

--- a/integration_tests/room/build.gradle
+++ b/integration_tests/room/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("com.android.library")
-    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.robolectric.android.project)
 }
 
 android {

--- a/integration_tests/sdkcompat/build.gradle
+++ b/integration_tests/sdkcompat/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-    id("com.android.library")
-    id("kotlin-android")
-    id("io.gitlab.arturbosch.detekt")
-    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
-    id("org.robolectric.gradle.SpotlessPlugin")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.robolectric.android.project)
+    alias(libs.plugins.robolectric.spotless)
 }
 
 

--- a/integration_tests/security-providers/build.gradle
+++ b/integration_tests/security-providers/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {

--- a/integration_tests/sparsearray/build.gradle
+++ b/integration_tests/sparsearray/build.gradle
@@ -1,11 +1,10 @@
 plugins {
-    id("com.android.library")
-    id("kotlin-android")
-    id("io.gitlab.arturbosch.detekt")
-    id("org.robolectric.gradle.AndroidProjectConfigPlugin")
-    id("org.robolectric.gradle.SpotlessPlugin")
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.robolectric.android.project)
+    alias(libs.plugins.robolectric.spotless)
 }
-
 
 android {
     compileSdk 34

--- a/integration_tests/versioning/build.gradle
+++ b/integration_tests/versioning/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
 }
 
 configurations {
@@ -8,7 +8,8 @@ configurations {
 }
 
 dependencies {
-    compileOnly AndroidSdk.MAX_SDK.coordinates // compile against latest Android SDK (AndroidSdk.s.coordinates) { force = true }
+    // compile against latest Android SDK (AndroidSdk.s.coordinates) { force = true }
+    compileOnly AndroidSdk.MAX_SDK.coordinates
     testImplementation project(":robolectric")
     testImplementation libs.truth
     testImplementation "androidx.test.ext:junit:$axtJunitVersion@aar"

--- a/junit/build.gradle
+++ b/junit/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {

--- a/nativeruntime/build.gradle
+++ b/nativeruntime/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
 }
 
 if (System.getenv('PUBLISH_NATIVERUNTIME_DIST_COMPAT') == "true") {

--- a/pluginapi/build.gradle
+++ b/pluginapi/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {

--- a/plugins/maven-dependency-resolver/build.gradle
+++ b/plugins/maven-dependency-resolver/build.gradle
@@ -1,11 +1,11 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("kotlin")
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
-    id("org.robolectric.gradle.SpotlessPlugin")
-    id("io.gitlab.arturbosch.detekt")
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
+    alias(libs.plugins.robolectric.spotless)
 }
 
 tasks.withType(GenerateModuleMetadata).configureEach {

--- a/preinstrumented/build.gradle
+++ b/preinstrumented/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("application")
-    id("java")
+    alias(libs.plugins.application)
+    alias(libs.plugins.java)
 }
 
 ext {

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -1,8 +1,8 @@
 import org.gradle.internal.jvm.Jvm
 
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
 }
 
 class GenerateSdksFileTask extends DefaultTask {

--- a/resources/build.gradle
+++ b/resources/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {

--- a/robolectric/build.gradle
+++ b/robolectric/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {

--- a/sandbox/build.gradle
+++ b/sandbox/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {

--- a/shadowapi/build.gradle
+++ b/shadowapi/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {

--- a/shadows/framework/build.gradle
+++ b/shadows/framework/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
-    id("org.robolectric.gradle.ShadowsPlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
+    alias(libs.plugins.robolectric.shadows)
 }
 
 shadows {

--- a/shadows/httpclient/build.gradle
+++ b/shadows/httpclient/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
-    id("org.robolectric.gradle.ShadowsPlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
+    alias(libs.plugins.robolectric.shadows)
 }
 
 shadows {

--- a/shadows/multidex/build.gradle
+++ b/shadows/multidex/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
-    id("org.robolectric.gradle.ShadowsPlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
+    alias(libs.plugins.robolectric.shadows)
 }
 
 shadows {

--- a/shadows/playservices/build.gradle
+++ b/shadows/playservices/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
-    id("org.robolectric.gradle.ShadowsPlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
+    alias(libs.plugins.robolectric.shadows)
 }
 
 shadows {

--- a/testapp/build.gradle
+++ b/testapp/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library")
+    alias(libs.plugins.android.library)
 }
 
 android {

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -1,11 +1,11 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("kotlin")
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
-    id("org.robolectric.gradle.SpotlessPlugin")
-    id("io.gitlab.arturbosch.detekt")
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
+    alias(libs.plugins.robolectric.spotless)
 }
 
 tasks.withType(GenerateModuleMetadata).configureEach {

--- a/utils/reflector/build.gradle
+++ b/utils/reflector/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("org.robolectric.gradle.RoboJavaModulePlugin")
-    id("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+    alias(libs.plugins.robolectric.deployed.java.module)
+    alias(libs.plugins.robolectric.java.module)
 }
 
 dependencies {


### PR DESCRIPTION
This PR moves plugin declarations to Gradle's Version Catalog.
Plugins applied in custom plugins are untouched for now. I'll see in an upcoming PR if they can be changed too.

This comes in the scope of #9189.