### PR TITLE
Improve AudioManager's context instance tests

### DIFF
--- a/integration_tests/ctesque/src/androidTest/java/android/app/ActivityInstrTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/ActivityInstrTest.java
@@ -2,13 +2,9 @@ package android.app;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
-import android.media.AudioManager;
-import android.util.Log;
 import android.widget.Button;
 import androidx.test.core.app.ActivityScenario;
-import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,7 +13,6 @@ import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.testapp.ActivityWithAnotherTheme;
 import org.robolectric.testapp.ActivityWithoutTheme;
 import org.robolectric.testapp.R;
-import org.robolectric.testapp.TestActivity;
 
 @DoNotInstrument
 @RunWith(AndroidJUnit4.class)
@@ -80,37 +75,6 @@ public class ActivityInstrTest {
             ColorDrawable background = (ColorDrawable) theButton.getBackground();
             assertThat(background.getColor()).isEqualTo(0xff00ff00);
           });
-    }
-  }
-
-  @Test
-  public void audioManager_activityContextEnabled() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
-    try {
-      AudioManager applicationAudioManager =
-          (AudioManager)
-              ApplicationProvider.getApplicationContext().getSystemService(Context.AUDIO_SERVICE);
-      Log.d("Test", "Initial applicationAudioManager mode: " + applicationAudioManager.getMode());
-
-      try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
-        scenario.onActivity(
-            activity -> {
-              AudioManager activityAudioManager =
-                  (AudioManager) activity.getSystemService(Context.AUDIO_SERVICE);
-              assertThat(applicationAudioManager).isNotSameInstanceAs(activityAudioManager);
-              Log.d("TestActivity", "Setting mode to RINGTONE on activityAudioManager");
-              activityAudioManager.setMode(AudioManager.MODE_RINGTONE);
-              Log.d("TestActivity", "activityAudioManager mode: " + activityAudioManager.getMode());
-              Log.d(
-                  "TestActivity",
-                  "applicationAudioManager mode: " + applicationAudioManager.getMode());
-              assertThat(activityAudioManager.getMode()).isEqualTo(AudioManager.MODE_RINGTONE);
-              assertThat(applicationAudioManager.getMode()).isEqualTo(AudioManager.MODE_RINGTONE);
-            });
-      }
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/integration_tests/ctesque/src/androidTest/java/android/app/ContextTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/ContextTest.java
@@ -1,0 +1,73 @@
+package android.app;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.Manifest;
+import android.content.Context;
+import android.media.AudioManager;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.GrantPermissionRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.testapp.TestActivity;
+
+@RunWith(AndroidJUnit4.class)
+public class ContextTest {
+  @Rule
+  public GrantPermissionRule mRuntimePermissionRule =
+      GrantPermissionRule.grant(Manifest.permission.MODIFY_AUDIO_SETTINGS);
+
+  @Test
+  public void audioManager_applicationInstance_isNotSameAsActivityInstance() {
+    AudioManager applicationAudioManager =
+        (AudioManager)
+            ApplicationProvider.getApplicationContext().getSystemService(Context.AUDIO_SERVICE);
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            AudioManager activityAudioManager =
+                (AudioManager) activity.getSystemService(Context.AUDIO_SERVICE);
+            assertThat(applicationAudioManager).isNotSameInstanceAs(activityAudioManager);
+          });
+    }
+  }
+
+  @Test
+  public void audioManager_activityInstance_isSameAsActivityInstance() {
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            AudioManager activityAudioManager =
+                (AudioManager) activity.getSystemService(Context.AUDIO_SERVICE);
+            AudioManager anotherActivityAudioManager =
+                (AudioManager) activity.getSystemService(Context.AUDIO_SERVICE);
+            assertThat(anotherActivityAudioManager).isSameInstanceAs(activityAudioManager);
+          });
+    }
+  }
+
+  @Test
+  public void audioManager_instance_changesAffectEachOther() {
+    AudioManager applicationAudioManager =
+        (AudioManager)
+            ApplicationProvider.getApplicationContext().getSystemService(Context.AUDIO_SERVICE);
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            AudioManager activityAudioManager =
+                (AudioManager) activity.getSystemService(Context.AUDIO_SERVICE);
+
+            activityAudioManager.setMode(AudioManager.MODE_RINGTONE);
+            assertThat(activityAudioManager.getMode()).isEqualTo(AudioManager.MODE_RINGTONE);
+            assertThat(applicationAudioManager.getMode()).isEqualTo(AudioManager.MODE_RINGTONE);
+
+            applicationAudioManager.setMode(AudioManager.MODE_NORMAL);
+            assertThat(activityAudioManager.getMode()).isEqualTo(AudioManager.MODE_NORMAL);
+            assertThat(applicationAudioManager.getMode()).isEqualTo(AudioManager.MODE_NORMAL);
+          });
+    }
+  }
+}

--- a/integration_tests/ctesque/src/main/AndroidManifest.xml
+++ b/integration_tests/ctesque/src/main/AndroidManifest.xml
@@ -3,6 +3,6 @@
   Manifest for ctesque tests
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
+  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
   <application />
 </manifest>

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAudioManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAudioManagerTest.java
@@ -1542,7 +1542,7 @@ public class ShadowAudioManagerTest {
 
   @Test
   @Config(minSdk = O)
-  public void audioManager_activityContextEnabled() {
+  public void audioManager_activityContextEnabled_applicationInstanceIsNotSameAsActivityInstance() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
     try {
@@ -1550,9 +1550,43 @@ public class ShadowAudioManagerTest {
       Activity activity = Robolectric.setupActivity(Activity.class);
       AudioManager activityAudioManager = activity.getSystemService(AudioManager.class);
       assertThat(applicationAudioManager).isNotSameInstanceAs(activityAudioManager);
+    } finally {
+      System.setProperty("robolectric.createActivityContexts", originalProperty);
+    }
+  }
+
+  @Test
+  @Config(minSdk = O)
+  public void audioManager_activityContextEnabled_activityInstanceIsSameAsActivityInstance() {
+    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
+    System.setProperty("robolectric.createActivityContexts", "true");
+    try {
+      Activity activity = Robolectric.setupActivity(Activity.class);
+      AudioManager activityAudioManager = activity.getSystemService(AudioManager.class);
+      AudioManager anotherActivityAudioManager = activity.getSystemService(AudioManager.class);
+      assertThat(anotherActivityAudioManager).isSameInstanceAs(activityAudioManager);
+    } finally {
+      System.setProperty("robolectric.createActivityContexts", originalProperty);
+    }
+  }
+
+  @Test
+  @Config(minSdk = O)
+  public void audioManager_activityContextEnabled_differentInstancesChangesAffectEachOther() {
+    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
+    System.setProperty("robolectric.createActivityContexts", "true");
+    try {
+      AudioManager applicationAudioManager = appContext.getSystemService(AudioManager.class);
+      Activity activity = Robolectric.setupActivity(Activity.class);
+      AudioManager activityAudioManager = activity.getSystemService(AudioManager.class);
+
       activityAudioManager.setMode(AudioManager.MODE_RINGTONE);
       assertThat(activityAudioManager.getMode()).isEqualTo(AudioManager.MODE_RINGTONE);
       assertThat(applicationAudioManager.getMode()).isEqualTo(AudioManager.MODE_RINGTONE);
+
+      applicationAudioManager.setMode(AudioManager.MODE_NORMAL);
+      assertThat(activityAudioManager.getMode()).isEqualTo(AudioManager.MODE_NORMAL);
+      assertThat(applicationAudioManager.getMode()).isEqualTo(AudioManager.MODE_NORMAL);
     } finally {
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }

--- a/testapp/src/main/AndroidManifest.xml
+++ b/testapp/src/main/AndroidManifest.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <!-- Adding MODIFY_AUDIO_SETTINGS permission -->
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-
     <application
         android:theme="@style/Theme.Robolectric" android:enabled="true">
       <activity android:name=".TestActivity" android:exported="true">

--- a/testapp/src/main/java/org/robolectric/testapp/TestActivity.java
+++ b/testapp/src/main/java/org/robolectric/testapp/TestActivity.java
@@ -1,29 +1,6 @@
 package org.robolectric.testapp;
 
 import android.app.Activity;
-import android.media.AudioManager;
-import android.os.Bundle;
-import android.util.Log;
 
 /** Test activity that is enabled in the manifest. */
-public class TestActivity extends Activity {
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    setContentView(R.layout.styles_button_layout);
-    Log.d("TestActivity", "onCreate called");
-
-    setupAudioManager();
-  }
-
-  private void setupAudioManager() {
-    AudioManager audioManager = (AudioManager) getSystemService(AUDIO_SERVICE);
-    if (audioManager != null) {
-      Log.d("TestActivity", "Current mode: " + audioManager.getMode());
-      // Example to set audio mode
-      audioManager.setMode(AudioManager.MODE_RINGTONE);
-    } else {
-      Log.d("TestActivity", "AudioManager is null");
-    }
-  }
-}
+public class TestActivity extends Activity {}


### PR DESCRIPTION
1. Split the mono test to multiple single tests.
2. Append test for comparing between application instance and activity instance.
3. Split the test for change affection between different instances.
4. Move AudioManager configuration to ctesque module from testapp module.
