### PR TITLE
Remove DoNotInstrument from explict test files

### DIFF
--- a/integration_tests/androidx/src/test/java/org/robolectric/integrationtests/androidx/BuildCompatTest.java
+++ b/integration_tests/androidx/src/test/java/org/robolectric/integrationtests/androidx/BuildCompatTest.java
@@ -8,10 +8,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /** Compatibility test for {@link BuildCompat} */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class BuildCompatTest {
 

--- a/integration_tests/ctesque/src/androidTest/java/android/app/ActivityInstrTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/ActivityInstrTest.java
@@ -9,12 +9,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.testapp.ActivityWithAnotherTheme;
 import org.robolectric.testapp.ActivityWithoutTheme;
 import org.robolectric.testapp.R;
 
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class ActivityInstrTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/animation/AnimationTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/animation/AnimationTest.java
@@ -11,11 +11,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.testapp.ActivityWithoutTheme;
 
 /** Compatibility test for animation-related logic. */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public final class AnimationTest {
 
@@ -62,7 +60,6 @@ public final class AnimationTest {
   }
 
   /** Private class with a public member. */
-  @DoNotInstrument
   @SuppressWarnings("unused")
   private static class PropertyBag {
     public float x;

--- a/integration_tests/ctesque/src/sharedTest/java/android/app/ActivityTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/app/ActivityTest.java
@@ -10,13 +10,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.testapp.AbstractTestActivity;
 import org.robolectric.testapp.ActivityWithAnotherTheme;
 import org.robolectric.testapp.ActivityWithoutTheme;
 import org.robolectric.testapp.R;
 
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class ActivityTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/app/InstrumentationTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/app/InstrumentationTest.java
@@ -13,13 +13,11 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.LooperMode;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /**
  * Tests to verify android.app.Instrumentation APIs behave consistently between Robolectric and
  * device.
  */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 @LooperMode(PAUSED)
 public final class InstrumentationTest {

--- a/integration_tests/ctesque/src/sharedTest/java/android/app/UiAutomationTest.kt
+++ b/integration_tests/ctesque/src/sharedTest/java/android/app/UiAutomationTest.kt
@@ -8,11 +8,9 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.internal.DoNotInstrument
 import org.robolectric.testapp.TestActivity
 
 @Suppress("DEPRECATION")
-@DoNotInstrument
 @RunWith(AndroidJUnit4::class)
 class UiAutomationTest {
   @Test

--- a/integration_tests/ctesque/src/sharedTest/java/android/content/pm/PackageManagerTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/content/pm/PackageManagerTest.java
@@ -26,11 +26,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.testapp.TestService;
 
 /** Compatibility test for {@link PackageManager} */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public final class PackageManagerTest {
   private Context context;

--- a/integration_tests/ctesque/src/sharedTest/java/android/content/res/AssetManagerTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/content/res/AssetManagerTest.java
@@ -16,12 +16,10 @@ import java.nio.charset.Charset;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /**
  * Compatibility test for {@link AssetManager}
  */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class AssetManagerTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/content/res/ResourcesTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/content/res/ResourcesTest.java
@@ -52,7 +52,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.testapp.R;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
@@ -60,7 +59,6 @@ import org.xmlpull.v1.XmlPullParserException;
 /**
  * Compatibility test for {@link Resources}
  */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class ResourcesTest {
   private Resources resources;

--- a/integration_tests/ctesque/src/sharedTest/java/android/content/res/ThemeTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/content/res/ThemeTest.java
@@ -13,13 +13,11 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.testapp.R;
 
 /**
  * Compatibility test for {@link Resources.Theme}
  */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class ThemeTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/database/SQLiteDatabaseTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/database/SQLiteDatabaseTest.java
@@ -26,10 +26,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /** Compatibility test for {@link android.database.sqlite.SQLiteDatabase} */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class SQLiteDatabaseTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/graphics/BitmapFactoryTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/graphics/BitmapFactoryTest.java
@@ -17,11 +17,9 @@ import java.nio.charset.Charset;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.testapp.R;
 
 /** Compatibility test for {@link BitmapFactory} */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class BitmapFactoryTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/graphics/BitmapTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/graphics/BitmapTest.java
@@ -29,11 +29,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.testapp.R;
 
 /** Compatibility test for {@link Bitmap} */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class BitmapTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/graphics/CanvasTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/graphics/CanvasTest.java
@@ -5,10 +5,8 @@ import static com.google.common.truth.Truth.assertThat;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /** Compatibility tests for {@link Canvas} */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class CanvasTest {
   @Test

--- a/integration_tests/ctesque/src/sharedTest/java/android/graphics/ColorTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/graphics/ColorTest.java
@@ -5,10 +5,8 @@ import static com.google.common.truth.Truth.assertThat;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /** Compatibility tests for {@link Color} */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class ColorTest {
   @Test

--- a/integration_tests/ctesque/src/sharedTest/java/android/graphics/MatrixTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/graphics/MatrixTest.java
@@ -7,10 +7,8 @@ import android.graphics.Matrix.ScaleToFit;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /** Compatibility test for {@link Matrix} */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public final class MatrixTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/graphics/PathTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/graphics/PathTest.java
@@ -5,10 +5,8 @@ import static com.google.common.truth.Truth.assertThat;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /** Compatibility test for {@link Path} */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class PathTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/os/LooperTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/os/LooperTest.java
@@ -9,10 +9,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.LooperMode.Mode;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /** Tests to verify INSTRUMENTATION_TEST mode Looper behaves like a looping Looper. */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class LooperTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/text/format/DateFormatTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/text/format/DateFormatTest.java
@@ -14,11 +14,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /** Tests that Robolectric's android.text.format.DateFormat support is consistent with device. */
 @RunWith(AndroidJUnit4.class)
-@DoNotInstrument
 @Config(qualifiers = "+en-rUS")
 public class DateFormatTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/text/format/LineBreakerTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/text/format/LineBreakerTest.java
@@ -12,10 +12,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /** Tests that Robolectric's android.graphics.text.LineBreaker support is consistent with device. */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class LineBreakerTest {
   @Test

--- a/integration_tests/ctesque/src/sharedTest/java/android/text/format/StaticLayoutTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/text/format/StaticLayoutTest.java
@@ -8,10 +8,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /** Tests that Robolectric's android.text.StaticLayout support is consistent with device. */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class StaticLayoutTest {
   @Test

--- a/integration_tests/ctesque/src/sharedTest/java/android/text/format/TimeTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/text/format/TimeTest.java
@@ -14,9 +14,7 @@ import java.util.TimeZone;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class TimeTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/util/RationalTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/util/RationalTest.java
@@ -37,7 +37,6 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /**
  * CTS tests for {@link Rational}.
@@ -45,7 +44,6 @@ import org.robolectric.annotation.internal.DoNotInstrument;
  * <p>Copied from <a
  * href="https://cs.android.com/android/platform/superproject/main/+/main:cts/tests/tests/util/src/android/util/cts/RationalTest.java">RationalTest</a>
  */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class RationalTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/view/KeyCharacterMapTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/view/KeyCharacterMapTest.java
@@ -8,14 +8,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /**
  * Test {@link android.view.KeyCharacterMap}.
  *
  * <p>Inspired from Android cts/tests/tests/view/src/android/view/cts/KeyCharacterMap.java
  */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public final class KeyCharacterMapTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/view/KeyEventTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/view/KeyEventTest.java
@@ -8,14 +8,12 @@ import android.os.Build.VERSION_CODES;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /**
  * Test {@link KeyEventTest}.
  *
  * <p>Inspired from Android cts/tests/tests/view/src/android/view/cts/KeyEventTest.java
  */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public final class KeyEventTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/view/MotionEventTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/view/MotionEventTest.java
@@ -26,14 +26,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /**
  * Test {@link android.view.MotionEvent}.
  *
  * <p>Baselined from Android cts/tests/tests/view/src/android/view/cts/MotionEventTest.java
  */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class MotionEventTest {
   private MotionEvent motionEvent1;

--- a/integration_tests/ctesque/src/sharedTest/java/android/view/ViewConfigurationTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/view/ViewConfigurationTest.java
@@ -14,10 +14,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /** Tests that {@link android.view.ViewConfiguration} behavior is consistent with real Android. */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public final class ViewConfigurationTest {
 

--- a/integration_tests/ctesque/src/sharedTest/java/android/view/accessibility/AccessibilityEventTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/view/accessibility/AccessibilityEventTest.java
@@ -27,7 +27,6 @@ import junit.framework.TestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /**
  * CTS for {@link AccessibilityEvent}.
@@ -38,7 +37,6 @@ import org.robolectric.annotation.internal.DoNotInstrument;
  *
  * <p>But this test class migrates assertions from junit to Google Truth.
  */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class AccessibilityEventTest {
   @Test

--- a/integration_tests/ctesque/src/sharedTest/java/android/view/accessibility/AccessibilityNodeInfoTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/view/accessibility/AccessibilityNodeInfoTest.java
@@ -25,7 +25,6 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /**
  * CTS for {@link AccessibilityNodeInfo}.
@@ -35,7 +34,6 @@ import org.robolectric.annotation.internal.DoNotInstrument;
  *
  * <p>But this test class migrates assertions from junit to Google Truth.
  */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class AccessibilityNodeInfoTest {
   @Test

--- a/integration_tests/ctesque/src/sharedTest/java/android/webkit/CookieManagerTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/webkit/CookieManagerTest.java
@@ -6,10 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
 /** Compatibility test for {@link CookieManager} */
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class CookieManagerTest {
 

--- a/robolectric/src/test/java/org/robolectric/TestRunnerSequenceTest.java
+++ b/robolectric/src/test/java/org/robolectric/TestRunnerSequenceTest.java
@@ -19,7 +19,6 @@ import org.junit.runners.JUnit4;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.internal.DoNotInstrument;
 import org.robolectric.internal.bytecode.InstrumentationConfiguration;
 import org.robolectric.internal.bytecode.Sandbox;
 
@@ -132,7 +131,6 @@ public class TestRunnerSequenceTest {
     }
   }
 
-  @DoNotInstrument
   public static class MyTestLifecycle extends DefaultTestLifecycle {
 
     @Override public void beforeTest(Method method) {

--- a/robolectric/src/test/java/org/robolectric/fakes/RoboWebSettingsTest.java
+++ b/robolectric/src/test/java/org/robolectric/fakes/RoboWebSettingsTest.java
@@ -6,9 +6,7 @@ import android.webkit.WebSettings;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.internal.DoNotInstrument;
 
-@DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class RoboWebSettingsTest {
   private final RoboWebSettings webSettings = new RoboWebSettings();


### PR DESCRIPTION
If one class has Test suffix, it will be marked as test, and Robolectric will skip it automatically. We don't need to add DoNotInstrument for these files to avoid instrumentation.
