### PR TITLE
Migrate usage of legacy AndroidJUnit4 to ext one

### DIFF
--- a/integration_tests/ctesque/src/sharedTest/java/android/graphics/PathTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/graphics/PathTest.java
@@ -2,7 +2,7 @@ package android.graphics;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.internal.DoNotInstrument;

--- a/integration_tests/multidex/src/test/java/org/robolectric/integrationtests/multidex/MultiDexTest.java
+++ b/integration_tests/multidex/src/test/java/org/robolectric/integrationtests/multidex/MultiDexTest.java
@@ -2,7 +2,7 @@ package org.robolectric.integrationtests.multidex;
 
 import android.support.multidex.MultiDex;
 import androidx.test.core.app.ApplicationProvider;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 


### PR DESCRIPTION
The androidx.test.runner.AndroidJUnit4 is deprecated. See
https://developer.android.com/reference/androidx/test/runner/AndroidJUnit4.