### PR TITLE
Create dependencies groups for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -9,11 +10,18 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      androidx-test:
+        patterns:
+          - "androidx.test*"
+      androidx:
+        patterns:
+          - "androidx.*"
     ignore:
-       # don't auto update guava since it requires updating gradle
-       - dependency-name: "*guava*"
-       # don't auto update errorprone since it requires updating guava
-       - dependency-name: "*errorprone*"
-       # don't auto update nativeruntime-dist-compat since it needs
-       # to be updated with code changes together
-       - dependency-name: "org.robolectric:nativeruntime-dist-compat"
+      # don't auto update guava since it requires updating gradle
+      - dependency-name: "*guava*"
+      # don't auto update errorprone since it requires updating guava
+      - dependency-name: "*errorprone*"
+      # don't auto update nativeruntime-dist-compat since it needs
+      # to be updated with code changes together
+      - dependency-name: "org.robolectric:nativeruntime-dist-compat"


### PR DESCRIPTION
This PR creates the following groups for Dependabot:
- `androidx-test` for packages starting with `androidx.test`.
- `androidx` for packages starting with `androidx.`.

As suggested in https://github.com/robolectric/robolectric/pull/9244#issuecomment-2200050947

Let me know if you can think of other meaningful groups.
