### PR TITLE
Add support for Surface.lockHardwareCanvas in Android P

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-robolectric-nativeruntime-dist-compat = "1.0.11"
+robolectric-nativeruntime-dist-compat = "1.0.12"
 
 # https://developer.android.com/studio/releases
 android-gradle = "8.4.1"

--- a/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativeImageReaderTest.java
+++ b/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativeImageReaderTest.java
@@ -1,5 +1,6 @@
 package org.robolectric.shadows;
 
+import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.Q;
 import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.Shadows.shadowOf;
@@ -26,7 +27,7 @@ import org.robolectric.annotation.Config;
  * Test for {@link org.robolectric.shadows.ShadowNativeImageReader} and {@link
  * org.robolectric.shadows.ShadowNativeImageReaderSurfaceImage}.
  */
-@Config(minSdk = Q)
+@Config(minSdk = P)
 @RunWith(RobolectricTestRunner.class)
 public class ShadowNativeImageReaderTest {
 
@@ -95,7 +96,6 @@ public class ShadowNativeImageReaderTest {
     }
   }
 
-  @Config(minSdk = Q)
   @Test
   public void imageReader_lockHardwareCanvas_drawColor() {
     ImageReader reader = ImageReader.newInstance(100, 100, PixelFormat.RGBA_8888, 1);

--- a/nativeruntime/src/main/java/org/robolectric/nativeruntime/HardwareRendererNatives.java
+++ b/nativeruntime/src/main/java/org/robolectric/nativeruntime/HardwareRendererNatives.java
@@ -58,6 +58,8 @@ public final class HardwareRendererNatives {
 
   public static native void nSetSurface(long nativeProxy, Surface window, boolean discardBuffer);
 
+  public static native void nSetSurfacePtr(long nativeProxy, long surfacePtr);
+
   public static native void nSetSurfaceControl(long nativeProxy, long nativeSurfaceControl);
 
   public static native boolean nPause(long nativeProxy);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeImageReader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeImageReader.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import static android.os.Build.VERSION_CODES.Q;
+import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.S_V2;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
@@ -29,7 +29,7 @@ import org.robolectric.versioning.AndroidVersions.V;
 /** Shadow for {@link ImageReader} that is backed by native code */
 @Implements(
     value = ImageReader.class,
-    minSdk = Q,
+    minSdk = P,
     looseSignatures = true,
     isInAndroidSdk = false,
     shadowPicker = Picker.class,
@@ -164,7 +164,7 @@ public class ShadowNativeImageReader {
 
     @Override
     protected int getMinApiLevel() {
-      return Q;
+      return P;
     }
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeImageReaderSurfaceImage.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeImageReaderSurfaceImage.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import static android.os.Build.VERSION_CODES.Q;
+import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.R;
 import static android.os.Build.VERSION_CODES.S;
 
@@ -15,7 +15,7 @@ import org.robolectric.versioning.AndroidVersions.U;
 /** Shadow for {@code ImageReader.SurfaceImage} that is backed by native code. */
 @Implements(
     className = "android.media.ImageReader$SurfaceImage",
-    minSdk = Q,
+    minSdk = P,
     looseSignatures = true,
     isInAndroidSdk = false,
     shadowPicker = ShadowNativeImageReaderSurfaceImage.Picker.class,
@@ -67,7 +67,7 @@ public class ShadowNativeImageReaderSurfaceImage {
 
     @Override
     protected int getMinApiLevel() {
-      return Q;
+      return P;
     }
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeRecordingCanvasOP.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeRecordingCanvasOP.java
@@ -1,0 +1,370 @@
+package org.robolectric.shadows;
+
+import static android.os.Build.VERSION_CODES.P;
+
+import android.graphics.Bitmap;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.nativeruntime.BaseRecordingCanvasNatives;
+import org.robolectric.shadows.ShadowNativeRecordingCanvasOP.Picker;
+
+/**
+ * Shadow for android.view.RecordingCanvas. This class was renamed to {@link BaseRecordingCanvas} in
+ * Q.
+ */
+@Implements(
+    className = "android.view.RecordingCanvas",
+    isInAndroidSdk = false,
+    minSdk = P,
+    maxSdk = P,
+    shadowPicker = Picker.class)
+public class ShadowNativeRecordingCanvasOP extends ShadowNativeCanvas {
+  @Implementation
+  protected static void nDrawBitmap(
+      long nativeCanvas,
+      Bitmap bitmap,
+      float left,
+      float top,
+      long nativePaintOrZero,
+      int canvasDensity,
+      int screenDensity,
+      int bitmapDensity) {
+    BaseRecordingCanvasNatives.nDrawBitmap(
+        nativeCanvas,
+        bitmap.getNativeInstance(),
+        left,
+        top,
+        nativePaintOrZero,
+        canvasDensity,
+        screenDensity,
+        bitmapDensity);
+  }
+
+  @Implementation
+  protected static void nDrawBitmap(
+      long nativeCanvas,
+      Bitmap bitmap,
+      float srcLeft,
+      float srcTop,
+      float srcRight,
+      float srcBottom,
+      float dstLeft,
+      float dstTop,
+      float dstRight,
+      float dstBottom,
+      long nativePaintOrZero,
+      int screenDensity,
+      int bitmapDensity) {
+    BaseRecordingCanvasNatives.nDrawBitmap(
+        nativeCanvas,
+        bitmap.getNativeInstance(),
+        srcLeft,
+        srcTop,
+        srcRight,
+        srcBottom,
+        dstLeft,
+        dstTop,
+        dstRight,
+        dstBottom,
+        nativePaintOrZero,
+        screenDensity,
+        bitmapDensity);
+  }
+
+  @Implementation
+  protected static void nDrawBitmap(
+      long nativeCanvas,
+      int[] colors,
+      int offset,
+      int stride,
+      float x,
+      float y,
+      int width,
+      int height,
+      boolean hasAlpha,
+      long nativePaintOrZero) {
+    BaseRecordingCanvasNatives.nDrawBitmap(
+        nativeCanvas, colors, offset, stride, x, y, width, height, hasAlpha, nativePaintOrZero);
+  }
+
+  @Implementation
+  protected static void nDrawColor(long nativeCanvas, int color, int mode) {
+    BaseRecordingCanvasNatives.nDrawColor(nativeCanvas, color, mode);
+  }
+
+  @Implementation
+  protected static void nDrawPaint(long nativeCanvas, long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawPaint(nativeCanvas, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawPoint(long canvasHandle, float x, float y, long paintHandle) {
+    BaseRecordingCanvasNatives.nDrawPoint(canvasHandle, x, y, paintHandle);
+  }
+
+  @Implementation
+  protected static void nDrawPoints(
+      long canvasHandle, float[] pts, int offset, int count, long paintHandle) {
+    BaseRecordingCanvasNatives.nDrawPoints(canvasHandle, pts, offset, count, paintHandle);
+  }
+
+  @Implementation
+  protected static void nDrawLine(
+      long nativeCanvas, float startX, float startY, float stopX, float stopY, long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawLine(nativeCanvas, startX, startY, stopX, stopY, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawLines(
+      long canvasHandle, float[] pts, int offset, int count, long paintHandle) {
+    BaseRecordingCanvasNatives.nDrawLines(canvasHandle, pts, offset, count, paintHandle);
+  }
+
+  @Implementation
+  protected static void nDrawRect(
+      long nativeCanvas, float left, float top, float right, float bottom, long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawRect(nativeCanvas, left, top, right, bottom, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawOval(
+      long nativeCanvas, float left, float top, float right, float bottom, long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawOval(nativeCanvas, left, top, right, bottom, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawCircle(
+      long nativeCanvas, float cx, float cy, float radius, long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawCircle(nativeCanvas, cx, cy, radius, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawArc(
+      long nativeCanvas,
+      float left,
+      float top,
+      float right,
+      float bottom,
+      float startAngle,
+      float sweep,
+      boolean useCenter,
+      long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawArc(
+        nativeCanvas, left, top, right, bottom, startAngle, sweep, useCenter, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawRoundRect(
+      long nativeCanvas,
+      float left,
+      float top,
+      float right,
+      float bottom,
+      float rx,
+      float ry,
+      long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawRoundRect(
+        nativeCanvas, left, top, right, bottom, rx, ry, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawPath(long nativeCanvas, long nativePath, long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawPath(nativeCanvas, nativePath, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawRegion(long nativeCanvas, long nativeRegion, long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawRegion(nativeCanvas, nativeRegion, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawNinePatch(
+      long nativeCanvas,
+      long nativeBitmap,
+      long ninePatch,
+      float dstLeft,
+      float dstTop,
+      float dstRight,
+      float dstBottom,
+      long nativePaintOrZero,
+      int screenDensity,
+      int bitmapDensity) {
+    BaseRecordingCanvasNatives.nDrawNinePatch(
+        nativeCanvas,
+        nativeBitmap,
+        ninePatch,
+        dstLeft,
+        dstTop,
+        dstRight,
+        dstBottom,
+        nativePaintOrZero,
+        screenDensity,
+        bitmapDensity);
+  }
+
+  @Implementation
+  protected static void nDrawBitmapMatrix(
+      long nativeCanvas, Bitmap bitmap, long nativeMatrix, long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawBitmapMatrix(
+        nativeCanvas, bitmap.getNativeInstance(), nativeMatrix, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawBitmapMesh(
+      long nativeCanvas,
+      Bitmap bitmap,
+      int meshWidth,
+      int meshHeight,
+      float[] verts,
+      int vertOffset,
+      int[] colors,
+      int colorOffset,
+      long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawBitmapMesh(
+        nativeCanvas,
+        bitmap.getNativeInstance(),
+        meshWidth,
+        meshHeight,
+        verts,
+        vertOffset,
+        colors,
+        colorOffset,
+        nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawVertices(
+      long nativeCanvas,
+      int mode,
+      int n,
+      float[] verts,
+      int vertOffset,
+      float[] texs,
+      int texOffset,
+      int[] colors,
+      int colorOffset,
+      short[] indices,
+      int indexOffset,
+      int indexCount,
+      long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawVertices(
+        nativeCanvas,
+        mode,
+        n,
+        verts,
+        vertOffset,
+        texs,
+        texOffset,
+        colors,
+        colorOffset,
+        indices,
+        indexOffset,
+        indexCount,
+        nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawText(
+      long nativeCanvas,
+      char[] text,
+      int index,
+      int count,
+      float x,
+      float y,
+      int flags,
+      long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawText(
+        nativeCanvas, text, index, count, x, y, flags, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawText(
+      long nativeCanvas,
+      String text,
+      int start,
+      int end,
+      float x,
+      float y,
+      int flags,
+      long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawText(nativeCanvas, text, start, end, x, y, flags, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawTextRun(
+      long nativeCanvas,
+      String text,
+      int start,
+      int end,
+      int contextStart,
+      int contextEnd,
+      float x,
+      float y,
+      boolean isRtl,
+      long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawTextRun(
+        nativeCanvas, text, start, end, contextStart, contextEnd, x, y, isRtl, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawTextRun(
+      long nativeCanvas,
+      char[] text,
+      int start,
+      int count,
+      int contextStart,
+      int contextCount,
+      float x,
+      float y,
+      boolean isRtl,
+      long nativePaint,
+      long nativePrecomputedText) {
+    BaseRecordingCanvasNatives.nDrawTextRun(
+        nativeCanvas,
+        text,
+        start,
+        count,
+        contextStart,
+        contextCount,
+        x,
+        y,
+        isRtl,
+        nativePaint,
+        nativePrecomputedText);
+  }
+
+  @Implementation
+  protected static void nDrawTextOnPath(
+      long nativeCanvas,
+      char[] text,
+      int index,
+      int count,
+      long nativePath,
+      float hOffset,
+      float vOffset,
+      int bidiFlags,
+      long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawTextOnPath(
+        nativeCanvas, text, index, count, nativePath, hOffset, vOffset, bidiFlags, nativePaint);
+  }
+
+  @Implementation
+  protected static void nDrawTextOnPath(
+      long nativeCanvas,
+      String text,
+      long nativePath,
+      float hOffset,
+      float vOffset,
+      int flags,
+      long nativePaint) {
+    BaseRecordingCanvasNatives.nDrawTextOnPath(
+        nativeCanvas, text, nativePath, hOffset, vOffset, flags, nativePaint);
+  }
+
+  /** Shadow picker for android.view.RecordingCanvasOP. */
+  public static final class Picker extends GraphicsShadowPicker<Object> {
+    public Picker() {
+      super(null, ShadowNativeRecordingCanvasOP.class);
+    }
+  }
+}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeSurface.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeSurface.java
@@ -8,21 +8,23 @@ import static android.os.Build.VERSION_CODES.S;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.graphics.Canvas;
-import android.graphics.HardwareRenderer;
 import android.graphics.Rect;
-import android.graphics.RenderNode;
 import android.graphics.SurfaceTexture;
 import android.hardware.HardwareBuffer;
 import android.media.ImageReader;
 import android.os.Parcel;
 import android.view.Surface;
 import android.view.Surface.OutOfResourcesException;
+import android.view.animation.AnimationUtils;
+import java.util.concurrent.TimeUnit;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.nativeruntime.DefaultNativeRuntimeLoader;
+import org.robolectric.nativeruntime.HardwareRendererNatives;
+import org.robolectric.nativeruntime.RecordingCanvasNatives;
+import org.robolectric.nativeruntime.RenderNodeNatives;
 import org.robolectric.nativeruntime.SurfaceNatives;
-import org.robolectric.shadows.ShadowNativeHardwareRenderer.HardwareRendererReflector;
 import org.robolectric.shadows.ShadowNativeSurface.Picker;
 import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.Direct;
@@ -178,88 +180,61 @@ public class ShadowNativeSurface {
     }
   }
 
-  /**
-   * Shadow for {@link Surface$HwuiContext} for Q and below that invokes HardwareRenderer methods.
-   * In Q and below, HwuiContext had its own native methods.
-   */
-  @Implements(
-      className = "android.view.Surface$HwuiContext",
-      minSdk = Q,
-      maxSdk = Q,
-      isInAndroidSdk = false,
-      shadowPicker = ShadowNativeHwuiContext.Picker.class)
-  public static class ShadowNativeHwuiContext {
-    @RealObject Object realHwuiContext;
+  @Implementation(minSdk = P, maxSdk = Q)
+  protected static long nHwuiCreate(long contentRootNode, long surface, boolean isWideColorGamut) {
+    // Modeled after the HwuiContext constructor in R:
+    // https://cs.android.com/android/platform/superproject/+/android11-dev:frameworks/base/core/java/android/view/Surface.java;l=1005
 
-    // This object is a HardwareRenderer in Q, but is a ThreadedRenderer in O and P.
-    private Object hardwareRenderer;
+    // Set up the root render node.
+    long rootRenderNodePtr = HardwareRendererNatives.nCreateRootRenderNode();
+    RenderNodeNatives.nSetClipToBounds(rootRenderNodePtr, false);
 
-    @Implementation
-    protected void __constructor__(Surface surface, boolean isWideColorGamut) {
-      // Modeled after the HwuiContext constructor in R:
-      // https://cs.android.com/android/platform/superproject/+/android11-dev:frameworks/base/core/java/android/view/Surface.java
-      reflector(HwuiContextReflector.class, realHwuiContext)
-          .__constructor__(surface, isWideColorGamut);
-      HardwareRenderer hardwareRenderer = new HardwareRenderer();
-      RenderNode renderNode =
-          reflector(HwuiContextReflector.class, realHwuiContext).getRenderNode();
-      hardwareRenderer.setContentRoot(renderNode);
-      hardwareRenderer.setSurface(surface);
-      reflector(HardwareRendererReflector.class, hardwareRenderer).setWideGamut(isWideColorGamut);
-      hardwareRenderer.setLightSourceAlpha(0.0f, 0.0f);
-      hardwareRenderer.setLightSourceGeometry(0.0f, 0.0f, 0.0f, 0.0f);
-      this.hardwareRenderer = hardwareRenderer;
+    // Set up the HardwareRenderer
+    long renderer = HardwareRendererNatives.nCreateProxy(false, rootRenderNodePtr);
+
+    // Set up light-related properties.
+    HardwareRendererNatives.nSetLightAlpha(renderer, 0, 0);
+    HardwareRendererNatives.nSetLightGeometry(renderer, 0, 0, 0, 0);
+
+    // Draw the content render node onto the root render node.
+    long recordingCanvas = RecordingCanvasNatives.nCreateDisplayListCanvas(rootRenderNodePtr, 0, 0);
+    RecordingCanvasNatives.nDrawRenderNode(recordingCanvas, contentRootNode);
+    RecordingCanvasNatives.nFinishRecording(recordingCanvas, rootRenderNodePtr);
+
+    // Set the surface.
+    HardwareRendererNatives.nSetSurfacePtr(renderer, surface);
+    return renderer;
+  }
+
+  @Implementation(minSdk = O, maxSdk = O_MR1)
+  protected static long nHwuiCreate(long rootNode, long surface) {
+    return nHwuiCreate(rootNode, surface, false);
+  }
+
+  @Implementation(minSdk = O, maxSdk = Q)
+  protected static void nHwuiSetSurface(long renderer, long surface) {
+    if (surface != 0) {
+      HardwareRendererNatives.nSetSurfacePtr(renderer, surface);
     }
+  }
 
-    @Implementation
-    protected void unlockAndPost(Canvas canvas) {
-      RenderNode renderNode =
-          reflector(HwuiContextReflector.class, realHwuiContext).getRenderNode();
-      renderNode.endRecording();
-      reflector(HwuiContextReflector.class, realHwuiContext).setCanvas(null);
-      ((HardwareRenderer) hardwareRenderer)
-          .createRenderRequest()
-          .setVsyncTime(System.nanoTime())
-          .syncAndDraw();
-    }
+  @Implementation(minSdk = O, maxSdk = Q)
+  protected static void nHwuiDraw(long renderer) {
+    // FrameInfo changed packages from android.view.FrameInfo in P to android.graphics.FrameInfo in
+    // Q, so it's easier to just construct a long[] array with the frame data.
+    final long vsync = TimeUnit.MILLISECONDS.toNanos(AnimationUtils.currentAnimationTimeMillis());
+    final long[] frameInfo = new long[9];
+    frameInfo[0] = 1 << 2;
+    frameInfo[1] = vsync;
+    frameInfo[2] = vsync;
+    frameInfo[3] = Long.MAX_VALUE;
+    frameInfo[4] = 0;
+    HardwareRendererNatives.nSyncAndDrawFrame(renderer, frameInfo, 9);
+  }
 
-    @Implementation
-    protected void updateSurface() {
-      Surface surface = reflector(HwuiContextReflector.class, realHwuiContext).getOuterSurface();
-      long surfacePtr = reflector(SurfaceReflector.class, surface).getNativeObject();
-      // In Android Q and below, updateSurface was called when the Surface was freed, which is not
-      // possible in native code in S.
-      if (surfacePtr != 0) {
-        reflector(HardwareRendererReflector.class, hardwareRenderer).setSurface(surface);
-      }
-    }
-
-    @Implementation
-    protected void destroy() {
-      ((HardwareRenderer) hardwareRenderer).destroy();
-    }
-
-    @ForType(className = "android.view.Surface$HwuiContext")
-    interface HwuiContextReflector {
-      @Direct
-      void __constructor__(Surface surface, boolean isWideColorGamut);
-
-      @Accessor("mRenderNode")
-      RenderNode getRenderNode();
-
-      @Accessor("mCanvas")
-      void setCanvas(Canvas canvas);
-
-      @Accessor("this$0")
-      Surface getOuterSurface();
-    }
-
-    /** Shadow picker for HwuiContext. */
-    public static final class Picker extends GraphicsShadowPicker<Object> {
-      public Picker() {
-        super(null, ShadowNativeHwuiContext.class);
-      }
-    }
+  @Implementation(minSdk = O, maxSdk = Q)
+  protected static void nHwuiDestroy(long renderer) {
+    HardwareRendererNatives.nDeleteProxy(renderer);
   }
 
   @ForType(Surface.class)
@@ -269,11 +244,6 @@ public class ShadowNativeSurface {
 
     @Accessor("mNativeObject")
     long getNativeObject();
-  }
-
-  @Implementation(minSdk = Q, maxSdk = Q)
-  protected static long nHwuiCreate(long rootNode, long surface, boolean isWideColorGamut) {
-    return 0; // no-op
   }
 
   /** Shadow picker for {@link Surface}. */


### PR DESCRIPTION
Add support for Surface.lockHardwareCanvas in Android P

Update native shadows for Surface and add a new native-backed shadow for
android.view.RecordingCanvas to support Surface.lockHardwareCanvas in Android
P.

Previously, the shadow for Surface.HwuiContext was only compatible with Android
Q because it explicitly created HardwareRenderer objects. However, in Android
P, HardwareRenderer does not exist. Update ShadowNativeSurface to shadow native
HwuiContext methods directly.

This is a big part of supporting HW rendering in Android P and being able to
take HW rendering screenshots in P.
