### PR TITLE
Bring integration_tests/multidex back and make it work with test process

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,8 +102,12 @@ androidx-biometric = "1.1.0"
 androidx-constraintlayout = "2.1.4"
 androidx-core = "1.13.1"
 androidx-fragment = "1.8.1"
+androidx-multidex = "2.0.1"
 androidx-window = "1.3.0"
 androidx-room = "2.6.1"
+
+# https://maven.google.com/web/index.html?q=multidex#com.android.support:multidex
+android-multidex = "1.0.3"
 
 # https://github.com/android/android-test/tags
 androidx-test-core = "1.6.1"
@@ -205,6 +209,7 @@ androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayo
 androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }
 androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "androidx-fragment" }
 androidx-fragment-testing = { module = "androidx.fragment:fragment-testing", version.ref = "androidx-fragment" }
+androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }
 androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidx-room" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "androidx-room" }
@@ -227,6 +232,8 @@ play-services-base-for-shadows = { module = "com.google.android.gms:play-service
 play-services-basement-for-shadows = { module = "com.google.android.gms:play-services-basement", version.ref = "play-services-for-shadows" }
 
 play-services-basement = { module = "com.google.android.gms:play-services-basement", version.ref = "play-services-basement" }
+
+android-multidex = { module = "com.android.support:multidex", version.ref = "android-multidex"}
 
 [bundles]
 play-services-for-shadows = ["androidx-fragment-for-shadows", "play-services-auth-for-shadows", "play-services-base-for-shadows", "play-services-basement-for-shadows"]

--- a/integration_tests/multidex/build.gradle
+++ b/integration_tests/multidex/build.gradle
@@ -1,0 +1,44 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.robolectric.android.project)
+}
+
+android {
+    compileSdk 34
+    namespace 'org.robolectric.integrationtests.multidex'
+
+    defaultConfig {
+        minSdk 21
+        targetSdk 34
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    lintOptions {
+        abortOnError false
+    }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+}
+
+dependencies {
+    api project(":robolectric")
+    compileOnly AndroidSdk.MAX_SDK.coordinates
+
+    testRuntimeOnly AndroidSdk.MAX_SDK.coordinates
+    testImplementation libs.androidx.test.core
+    testImplementation libs.androidx.test.ext.junit
+    testImplementation libs.androidx.test.runner
+    testImplementation libs.junit4
+    testImplementation libs.truth
+    testImplementation libs.androidx.multidex
+    testImplementation libs.android.multidex
+}

--- a/integration_tests/multidex/src/test/AndroidManifest.xml
+++ b/integration_tests/multidex/src/test/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <uses-sdk
+      android:minSdkVersion="21"
+      android:targetSdkVersion="34"/>
+
+  <application />
+
+  <instrumentation
+      android:name="androidx.test.runner.AndroidJUnitRunner"
+      android:targetPackage="org.robolectric.integrationtests.multidex"/>
+
+</manifest>

--- a/integration_tests/multidex/src/test/java/android/support/multidex/MultiDexTest.java
+++ b/integration_tests/multidex/src/test/java/android/support/multidex/MultiDexTest.java
@@ -1,0 +1,17 @@
+package android.support.multidex;
+
+import static android.support.multidex.MultiDex.install;
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Integration tests for android.support.multidex.MultiDex Robolectric. */
+@RunWith(AndroidJUnit4.class)
+public class MultiDexTest {
+  @Test
+  public void testIntendedFailEmpty() {
+    install(getApplicationContext());
+  }
+}

--- a/integration_tests/multidex/src/test/java/androidx/multidex/MultiDexTest.java
+++ b/integration_tests/multidex/src/test/java/androidx/multidex/MultiDexTest.java
@@ -1,0 +1,17 @@
+package androidx.multidex;
+
+import static androidx.multidex.MultiDex.install;
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Integration tests for androidx.multidex.MultiDex Robolectric. */
+@RunWith(AndroidJUnit4.class)
+public class MultiDexTest {
+  @Test
+  public void testIntendedFailEmpty() {
+    install(getApplicationContext());
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -55,6 +55,7 @@ include ':integration_tests:security-providers'
 include ":integration_tests:mockk"
 include ":integration_tests:jacoco-offline"
 include ':integration_tests:sdkcompat'
+include ":integration_tests:multidex"
 include ":integration_tests:play_services"
 include ":integration_tests:sparsearray"
 include ":integration_tests:nativegraphics"


### PR DESCRIPTION
Robolectric has a special module to hook multidex to make it
work with Robolectric, and we need keep these tests for it.
    
This CL also adds necessary build.gradle for it to make it
work with normal building and testing command.
    
As Robolectric :shadows:multidex supports android.support.Multidex
and androidx.multidex.MultiDex, this CL add tests for both libraries
to ensure Robolectric's shadowing for these two libraries
work as expected.
