### PR TITLE
Replace `androidx.test.annotation.Beta` with `com.google.common.annotations.Beta`

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedAsyncTask.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedAsyncTask.java
@@ -3,7 +3,7 @@ package org.robolectric.shadows;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.os.AsyncTask;
-import androidx.test.annotation.Beta;
+import com.google.common.annotations.Beta;
 import java.util.concurrent.Executor;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;


### PR DESCRIPTION
This commit replaces the `androidx.test.annotation.Beta` import with `com.google.common.annotations.Beta` in `ShadowPausedAsyncTask`.

The former is deprecated, while the latter is already used in other places in the project.