### PR TITLE
Add tests to `ShadowSharedPreferences`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSharedPreferencesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSharedPreferencesTest.java
@@ -146,6 +146,7 @@ public class ShadowSharedPreferencesTest {
     editor.commit();
 
     assertThat(sharedPreferences.getString("deleteMe", null)).isNull();
+    assertThat(sharedPreferences.contains("deleteMe")).isFalse();
   }
 
   @Test
@@ -156,6 +157,7 @@ public class ShadowSharedPreferencesTest {
     editor.commit();
 
     assertThat(sharedPreferences.getStringSet("deleteMe", null)).isNull();
+    assertThat(sharedPreferences.contains("deleteMe")).isFalse();
   }
 
   @Test


### PR DESCRIPTION
As reported in #9286, there was an issue in Robolectric < 4.13 when trying to remove a key from `SharedPreferences`. If one was using `editor.putString("key", null);`, and then check `preferences.contains("key");`, the result would be `true` instead of `false`.

This has been fixed in Roboletric 4.13.
This PR adds a couple of assertions to prevent regression in the future.