### PR TITLE
Remove looseSignatures usage from ShadowAppOpsManager

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppOpsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppOpsManager.java
@@ -51,6 +51,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.IntStream;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -63,7 +64,7 @@ import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
 
 /** Shadow for {@link AppOpsManager}. */
-@Implements(value = AppOpsManager.class, looseSignatures = true)
+@Implements(value = AppOpsManager.class)
 public class ShadowAppOpsManager {
 
   // OpEntry fields that the shadow doesn't currently allow the test to configure.
@@ -414,18 +415,18 @@ public class ShadowAppOpsManager {
   @RequiresApi(api = S)
   @Implementation(minSdk = S)
   protected int noteProxyOpNoThrow(
-      Object op, Object attributionSource, Object message, Object ignoredSkipProxyOperation) {
-    Preconditions.checkArgument(op instanceof Integer);
+      int op,
+      @ClassName("android.content.AttributionSource") Object attributionSource,
+      String message,
+      boolean ignoredSkipProxyOperation) {
     Preconditions.checkArgument(attributionSource instanceof AttributionSource);
-    Preconditions.checkArgument(message == null || message instanceof String);
-    Preconditions.checkArgument(ignoredSkipProxyOperation instanceof Boolean);
     AttributionSource castedAttributionSource = (AttributionSource) attributionSource;
     return noteProxyOpNoThrow(
-        (int) op,
+        op,
         castedAttributionSource.getNextPackageName(),
         castedAttributionSource.getNextUid(),
         castedAttributionSource.getNextAttributionTag(),
-        (String) message);
+        message);
   }
 
   @Implementation


### PR DESCRIPTION
Use @Classname annotation instead of looseSignatures.

### Overview

The corresponding function definition:
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-31/blob/master/android/app/AppOpsManager.java#L8370

### Proposed Changes
