### PR TITLE
Keep parameter name of noteProxyOpNoThrow same as origin method

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppOpsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppOpsManager.java
@@ -418,7 +418,7 @@ public class ShadowAppOpsManager {
       int op,
       @ClassName("android.content.AttributionSource") Object attributionSource,
       String message,
-      boolean ignoredSkipProxyOperation) {
+      boolean skipProxyOperation) {
     Preconditions.checkArgument(attributionSource instanceof AttributionSource);
     AttributionSource castedAttributionSource = (AttributionSource) attributionSource;
     return noteProxyOpNoThrow(


### PR DESCRIPTION
See
https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/app/AppOpsManager.java;l=9144-9145?q=AppOpsManager&ss=android.
