### PR TITLE
Add support for ImageDecoder.createSource(File)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-robolectric-nativeruntime-dist-compat = "1.0.12"
+robolectric-nativeruntime-dist-compat = "1.0.13"
 
 # https://developer.android.com/studio/releases
 android-gradle = "8.5.0"

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeImageDecoder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeImageDecoder.java
@@ -6,6 +6,7 @@ import static android.os.Build.VERSION_CODES.R;
 import static android.os.Build.VERSION_CODES.S;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
+import android.content.res.AssetFileDescriptor;
 import android.content.res.AssetManager.AssetInputStream;
 import android.graphics.Bitmap;
 import android.graphics.ColorSpace;
@@ -119,7 +120,13 @@ public class ShadowNativeImageDecoder {
 
   @Implementation(maxSdk = Q)
   protected static ImageDecoder nCreate(FileDescriptor fd, Source src) throws IOException {
-    throw new UnsupportedEncodingException();
+    return nCreate(fd, AssetFileDescriptor.UNKNOWN_LENGTH, false, src);
+  }
+
+  @Implementation(minSdk = R, maxSdk = R)
+  protected static ImageDecoder nCreate(FileDescriptor fd, boolean preferAnimation, Source src)
+      throws IOException {
+    return nCreate(fd, AssetFileDescriptor.UNKNOWN_LENGTH, preferAnimation, src);
   }
 
   @Implementation(minSdk = S, maxSdk = U.SDK_INT)


### PR DESCRIPTION
Add support for ImageDecoder.createSource(File)

Previously, calling ImageDecoder.decode* methods with a file source (created
using ImageDecoder.createSource(File)) was not supported in RNG. Add support
for it on all SDK levels and platorms.

See the corresponding AOSP commit for more details:
https://android.googlesource.com/platform/frameworks/base/+/f4b61b1d09d0221827787985cd4d7cdeac579e43
