### PR TITLE
Remove looseSignatures usage from ShadowAudioTrack

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioTrack.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioTrack.java
@@ -50,7 +50,7 @@ import org.robolectric.versioning.AndroidVersions.U;
  * other methods are expected run through the real class. The two {@link WriteMode} are treated the
  * same.
  */
-@Implements(value = AudioTrack.class, looseSignatures = true)
+@Implements(value = AudioTrack.class)
 public class ShadowAudioTrack {
 
   /**


### PR DESCRIPTION
Use @Classname annotation instead of looseSignatures.

### Overview

There are two `native_setup` functions in the shadow class, they are using Object parameter type because the shadowed function(s) are also use Object parameter type

https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-28/blob/master/android/media/AudioTrack.java#L3184
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-31/blob/master/android/media/AudioTrack.java#L4248

### Proposed Changes
