### PR TITLE
Remove looseSignatures usage from ShadowContentProvider

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentProvider.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentProvider.java
@@ -11,15 +11,15 @@ import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 
 /** Shadow for {@link ContentProvider}. */
-@Implements(value = ContentProvider.class, looseSignatures = true)
+@Implements(value = ContentProvider.class)
 public class ShadowContentProvider {
   @RealObject private ContentProvider realContentProvider;
 
   private String callingPackage;
 
   @Implementation(minSdk = Q, maxSdk = Q)
-  public Object setCallingPackage(Object callingPackage) {
-    this.callingPackage = (String) callingPackage;
+  public String setCallingPackage(String callingPackage) {
+    this.callingPackage = callingPackage;
     return callingPackage;
   }
 


### PR DESCRIPTION
We can directly use type of String.

### Overview

1, https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-29/blob/master/android/content/ContentProvider.java
2, why restricted that shadow function to only in API 29?

### Proposed Changes
