### PR TITLE
Remove looseSignatures usage from ShadowContextHubManager

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextHubManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextHubManager.java
@@ -23,6 +23,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -35,11 +37,7 @@ import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
 
 /** Shadow for {@link ContextHubManager}. */
-@Implements(
-    value = ContextHubManager.class,
-    minSdk = VERSION_CODES.N,
-    isInAndroidSdk = false,
-    looseSignatures = true)
+@Implements(value = ContextHubManager.class, minSdk = VERSION_CODES.N, isInAndroidSdk = false)
 public class ShadowContextHubManager {
   private static final List<ContextHubInfo> contextHubInfoList = new ArrayList<>();
   private static final List<ContextHubClient> contextHubClientWithPendingIntentList =
@@ -91,13 +89,13 @@ public class ShadowContextHubManager {
 
   @Implementation(minSdk = VERSION_CODES.P)
   @HiddenApi
-  protected Object /* ContextHubClient */ createClient(
-      Object /* ContextHubInfo */ contextHubInfo,
-      Object /* ContextHubClientCallback */ contextHubClientCallback) {
+  protected @ClassName("android.hardware.location.ContextHubClient") Object createClient(
+      @ClassName("android.hardware.location.ContextHubInfo") Object hubInfo,
+      @ClassName("android.hardware.location.ContextHubClientCallback") Object callback) {
 
     if (Build.VERSION.SDK_INT >= VERSION_CODES.Q) {
       return reflector(ContextHubClientReflector.class)
-          .newContextHubClient((ContextHubInfo) contextHubInfo, false);
+          .newContextHubClient((ContextHubInfo) hubInfo, false);
     } else {
       return reflector(ContextHubClientReflector.class).newContextHubClient();
     }
@@ -105,13 +103,13 @@ public class ShadowContextHubManager {
 
   @Implementation(minSdk = VERSION_CODES.P)
   @HiddenApi
-  protected Object /* ContextHubClient */ createClient(
-      Object /* ContextHubInfo */ contextHubInfo,
-      Object /* ContextHubClientCallback */ contextHubClientCallback,
-      Object /* Executor */ executor) {
+  protected @ClassName("android.hardware.location.ContextHubClient") Object createClient(
+      @ClassName("android.hardware.location.ContextHubInfo") Object hubInfo,
+      @ClassName("android.hardware.location.ContextHubClientCallback") Object callback,
+      Executor executor) {
     if (Build.VERSION.SDK_INT >= VERSION_CODES.Q) {
       return reflector(ContextHubClientReflector.class)
-          .newContextHubClient((ContextHubInfo) contextHubInfo, false);
+          .newContextHubClient((ContextHubInfo) hubInfo, false);
     } else {
       return reflector(ContextHubClientReflector.class).newContextHubClient();
     }
@@ -119,14 +117,14 @@ public class ShadowContextHubManager {
 
   @Implementation(minSdk = VERSION_CODES.S)
   @HiddenApi
-  protected Object /* ContextHubClient */ createClient(
-      Object /* Context */ context,
-      Object /* ContextHubInfo */ contextHubInfo,
-      Object /* Executor */ executor,
-      Object /* ContextHubClientCallback */ contextHubClientCallback) {
+  protected @ClassName("android.hardware.location.ContextHubClient") Object createClient(
+      Context context,
+      @ClassName("android.hardware.location.ContextHubInfo") Object hubInfo,
+      Executor executor,
+      @ClassName("android.hardware.location.ContextHubClientCallback") Object callback) {
     ContextHubClient client =
         reflector(ContextHubClientReflector.class)
-            .newContextHubClient((ContextHubInfo) contextHubInfo, false);
+            .newContextHubClient((ContextHubInfo) hubInfo, false);
     if (context != null && ((Context) context).getAttributionTag() != null) {
       attributionTagToClientMap.put(((Context) context).getAttributionTag(), client);
     }
@@ -135,7 +133,7 @@ public class ShadowContextHubManager {
 
   @Implementation(minSdk = VERSION_CODES.S)
   @HiddenApi
-  protected Object /* ContextHubClient */ createClient(
+  protected @ClassName("android.hardware.location.ContextHubClient") Object createClient(
       Context context, ContextHubInfo hubInfo, PendingIntent pendingIntent, long nanoAppId) {
     ContextHubClient client =
         Shadow.newInstance(
@@ -163,7 +161,9 @@ public class ShadowContextHubManager {
 
   @Implementation(minSdk = VERSION_CODES.P)
   @HiddenApi
-  protected Object queryNanoApps(ContextHubInfo hubInfo) {
+  protected @ClassName(
+      "android.hardware.location.ContextHubTransaction<java.util.List<android.hardware.location.NanoAppState>>")
+  Object queryNanoApps(ContextHubInfo hubInfo) {
     @SuppressWarnings("unchecked")
     ContextHubTransaction<List<NanoAppState>> transaction =
         ReflectionHelpers.callConstructor(


### PR DESCRIPTION
Even shadow function `queryNanoApps` use @ClassName with generic type, the type argument will actually be ignored.

### Overview

Corresponding shadowed function definitions are
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-29/blob/master/android/hardware/location/ContextHubManager.java
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-31/blob/master/android/hardware/location/ContextHubManager.java

### Proposed Changes
