### PR TITLE
Make some fields of ShadowClipboardManager static for context level instance

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowClipboardManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowClipboardManagerTest.java
@@ -18,7 +18,9 @@ import java.time.Duration;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.testing.TestActivity;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowClipboardManagerTest {
@@ -152,5 +154,35 @@ public class ShadowClipboardManagerTest {
     assertThat(clipboardManager.getPrimaryClipDescription()).isNotNull();
     assertThat(clipboardManager.getPrimaryClipDescription().getTimestamp())
         .isEqualTo(currentUptimeMs + 42 * 1000);
+  }
+
+  @Test
+  @Config(minSdk = android.os.Build.VERSION_CODES.O)
+  public void clipboardManager_instance_retrievesSamePrimaryClip() {
+    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
+    System.setProperty("robolectric.createActivityContexts", "true");
+    TestActivity activity = null;
+    try {
+      ClipboardManager applicationClipboardManager =
+          (ClipboardManager)
+              ApplicationProvider.getApplicationContext()
+                  .getSystemService(Context.CLIPBOARD_SERVICE);
+      ClipData clipData = ClipData.newPlainText("label", "text");
+      applicationClipboardManager.setPrimaryClip(clipData);
+
+      activity = Robolectric.setupActivity(TestActivity.class);
+      ClipboardManager activityClipboardManager =
+          (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
+
+      ClipData applicationClipData = applicationClipboardManager.getPrimaryClip();
+      ClipData activityClipData = activityClipboardManager.getPrimaryClip();
+
+      assertThat(activityClipData.toString()).isEqualTo(applicationClipData.toString());
+    } finally {
+      if (activity != null) {
+        activity.finish();
+      }
+      System.setProperty("robolectric.createActivityContexts", originalProperty);
+    }
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowClipboardManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowClipboardManager.java
@@ -16,6 +16,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
+import org.robolectric.annotation.Resetter;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 import org.robolectric.util.reflector.ForType;
@@ -23,10 +24,26 @@ import org.robolectric.util.reflector.ForType;
 @SuppressWarnings("UnusedDeclaration")
 @Implements(ClipboardManager.class)
 public class ShadowClipboardManager {
-  @RealObject private ClipboardManager realClipboardManager;
-  private final Collection<OnPrimaryClipChangedListener> listeners =
+  private static final Collection<OnPrimaryClipChangedListener> listeners =
       new CopyOnWriteArrayList<OnPrimaryClipChangedListener>();
-  private ClipData clip;
+  private static ClipData clip;
+  @RealObject private ClipboardManager realClipboardManager;
+
+  @Resetter
+  public static void reset() {
+    clip = null;
+    listeners.clear();
+  }
+
+  @Implementation(minSdk = P)
+  protected void clearPrimaryClip() {
+    setPrimaryClip(null);
+  }
+
+  @Implementation
+  protected ClipData getPrimaryClip() {
+    return clip;
+  }
 
   @Implementation
   protected void setPrimaryClip(ClipData clip) {
@@ -58,16 +75,6 @@ public class ShadowClipboardManager {
     for (OnPrimaryClipChangedListener listener : listeners) {
       listener.onPrimaryClipChanged();
     }
-  }
-
-  @Implementation(minSdk = P)
-  protected void clearPrimaryClip() {
-    setPrimaryClip(null);
-  }
-
-  @Implementation
-  protected ClipData getPrimaryClip() {
-    return clip;
   }
 
   @Implementation


### PR DESCRIPTION
…nstance

1.Converted instances fields to static fields to ensure proper state management. 2.add tests for the same in ShadowClipboardManagerTest. 3.add tests for ClipboardManager instance behaviour across application and activity contexts in ContextTest

### Overview

### Proposed Changes
