### PR TITLE
Extend VirtualDisplay shadow support down to SDK 28

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManagerGlobal.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManagerGlobal.java
@@ -20,6 +20,7 @@ import android.os.RemoteException;
 import android.util.SparseArray;
 import android.view.Display;
 import android.view.DisplayInfo;
+import android.view.Surface;
 import com.google.common.annotations.VisibleForTesting;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -194,9 +195,9 @@ public class ShadowDisplayManagerGlobal {
       registerCallback(iDisplayManagerCallback);
     }
 
-    // for android U
+    // for android R+ (SDK 30+)
     // Use Object here instead of VirtualDisplayConfig to avoid breaking projects that still
-    // compile against SDKs < U
+    // compile against SDKs < R
     public int createVirtualDisplay(
         @ClassName("android.hardware.display.VirtualDisplayConfig")
             Object virtualDisplayConfigObject,
@@ -216,6 +217,36 @@ public class ShadowDisplayManagerGlobal {
       displayInfo.logicalWidth = config.getWidth();
       displayInfo.appHeight = config.getHeight();
       displayInfo.logicalHeight = config.getHeight();
+      displayInfo.state = Display.STATE_ON;
+      int id = addDisplay(displayInfo);
+      virtualDisplayIds.put(callbackWrapper, id);
+      return id;
+    }
+
+    // for android Q (SDK 29) and below
+    public int createVirtualDisplay(
+        IVirtualDisplayCallback callbackWrapper,
+        IMediaProjection projectionToken,
+        String packageName,
+        String name,
+        int width,
+        int height,
+        int densityDpi,
+        Surface surface,
+        int flags,
+        String uniqueId) {
+      DisplayInfo displayInfo = new DisplayInfo();
+      displayInfo.flags = flags;
+      displayInfo.type = Display.TYPE_VIRTUAL;
+      displayInfo.name = name;
+      displayInfo.logicalDensityDpi = densityDpi;
+      displayInfo.physicalXDpi = densityDpi;
+      displayInfo.physicalYDpi = densityDpi;
+      displayInfo.ownerPackageName = packageName;
+      displayInfo.appWidth = width;
+      displayInfo.logicalWidth = width;
+      displayInfo.appHeight = height;
+      displayInfo.logicalHeight = height;
       displayInfo.state = Display.STATE_ON;
       int id = addDisplay(displayInfo);
       virtualDisplayIds.put(callbackWrapper, id);


### PR DESCRIPTION
194ac08527ae9dcb5062d2ed5d47660841931c7d introduced shadow support for virtual displays but the `IDisplayManager#createVirtualDisplay` proxy signature only works for SDK 30+. This adds a signature for pre-SDK 30.

### Overview

I found when integrating Robo 4.13 that several tests using virtual displays on SDK 28 began failing with:
```
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:209)
	at java.base/java.util.TreeMap.getEntry(TreeMap.java:345)
	at java.base/java.util.TreeMap.get(TreeMap.java:279)
	at org.robolectric.shadows.ShadowDisplayManagerGlobal$DisplayManagerProxyDelegate.resizeVirtualDisplay(ShadowDisplayManagerGlobal.java:229)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.robolectric.util.ReflectionHelpers.lambda$createDelegatingProxy$2(ReflectionHelpers.java:104)
	at jdk.proxy3/jdk.proxy3.$Proxy36.resizeVirtualDisplay(Unknown Source)
	at android.hardware.display.DisplayManagerGlobal.resizeVirtualDisplay(DisplayManagerGlobal.java:449)
	at android.hardware.display.VirtualDisplay.resize(VirtualDisplay.java:90)
... (omitted)
```

The root of the issue is that the `createVirtualDisplay` proxy was not intercepting due to signature mis-match, but the `resizeVirtualDisplay` proxy was (and `virtualDisplayIds` was never populated).

### Proposed Changes

Add a pre-SDK-30 compatible signature for `IDisplayManager#createVirtualDisplay` in the proxy. Update the tests to verify from SDK 28 onwards.