### PR TITLE
Add shadow support for SDK 33 PackageManager#queryIntentServices

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -1891,6 +1891,22 @@ public class ShadowPackageManagerTest {
   }
 
   @Test
+  @Config(minSdk = TIRAMISU)
+  public void queryIntentServices_Match_withResolveInfoFlags() {
+    Intent i = new Intent(Intent.ACTION_MAIN, null);
+
+    ResolveInfo info = new ResolveInfo();
+    info.serviceInfo = new ServiceInfo();
+    info.nonLocalizedLabel = TEST_PACKAGE_LABEL;
+
+    shadowOf(packageManager).addResolveInfoForIntent(i, info);
+
+    List<ResolveInfo> services = packageManager.queryIntentServices(i, ResolveInfoFlags.of(0));
+    assertThat(services).hasSize(1);
+    assertThat(services.get(0).nonLocalizedLabel.toString()).isEqualTo(TEST_PACKAGE_LABEL);
+  }
+
+  @Test
   public void queryIntentServices_fromManifest() {
     Intent i = new Intent("org.robolectric.ACTION_DIFFERENT_PACKAGE");
     i.addCategory(Intent.CATEGORY_LAUNCHER);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -584,6 +584,13 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
         ServiceInfo::new);
   }
 
+  @Implementation(minSdk = TIRAMISU)
+  protected List<ResolveInfo> queryIntentServices(
+      Intent intent,
+      @ClassName("android.content.pm.PackageManager$ResolveInfoFlags") Object flagsObject) {
+    return queryIntentServices(intent, (int) ((ResolveInfoFlags) flagsObject).getValue());
+  }
+
   private boolean hasSomeComponentInfo(ResolveInfo resolveInfo) {
 
     return resolveInfo.activityInfo != null


### PR DESCRIPTION
Similar to the other SDK 33 methods with the new flag objects, add support for `queryIntentServices()` as well.

See:
https://developer.android.com/reference/android/content/pm/PackageManager#queryIntentServices(android.content.Intent,%20android.content.pm.PackageManager.ResolveInfoFlags)

### Overview

Seems like this was missing.

### Proposed Changes

Add the missing shadow support.