### PR TITLE
Remove looseSignatures usage from ShadowMediaCodec

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaCodec.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaCodec.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.N_MR1;
 import static android.os.Build.VERSION_CODES.O;
+import static android.os.Build.VERSION_CODES.O_MR1;
 import static android.os.Build.VERSION_CODES.TIRAMISU;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
@@ -17,6 +18,7 @@ import android.media.MediaCodecInfo;
 import android.media.MediaCodecList;
 import android.media.MediaCrypto;
 import android.media.MediaFormat;
+import android.os.IBinder;
 import android.view.Surface;
 import com.google.common.annotations.VisibleForTesting;
 import java.nio.Buffer;
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -52,7 +55,7 @@ import org.robolectric.versioning.AndroidVersions.U;
  * implementation will present an input buffer, which will be copied to an output buffer once
  * queued, which will be subsequently presented to the callback handler.
  */
-@Implements(value = MediaCodec.class, looseSignatures = true)
+@Implements(value = MediaCodec.class)
 public class ShadowMediaCodec {
   private static final int DEFAULT_BUFFER_SIZE = 512;
   @VisibleForTesting static final int BUFFER_COUNT = 10;
@@ -163,16 +166,26 @@ public class ShadowMediaCodec {
     innerConfigure(keys, values, surface, crypto, flags);
   }
 
-  @Implementation(minSdk = O)
+  @Implementation(minSdk = O, maxSdk = O)
   protected void native_configure(
-      Object keys,
-      Object values,
-      Object surface,
-      Object crypto,
-      Object descramblerBinder,
-      Object flags) {
-    innerConfigure(
-        (String[]) keys, (Object[]) values, (Surface) surface, (MediaCrypto) crypto, (int) flags);
+      String[] keys,
+      Object[] values,
+      Surface surface,
+      MediaCrypto crypto,
+      IBinder descramblerBinder,
+      int flags) {
+    innerConfigure(keys, values, surface, crypto, flags);
+  }
+
+  @Implementation(minSdk = O_MR1)
+  protected void native_configure(
+      String[] keys,
+      Object[] values,
+      Surface surface,
+      MediaCrypto crypto,
+      @ClassName("android.os.IHwBinder") Object descramblerBinder,
+      int flags) {
+    innerConfigure(keys, values, surface, crypto, flags);
   }
 
   private void innerConfigure(


### PR DESCRIPTION
Use @classname annotation instead of looseSignatures.

### Overview
MediaCodec for API <= 25
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-25/blob/master/android/media/MediaCodec.java
void MediaCodec#native_configure(String[] keys, Object[] values,Surface surface, MediaCrypto crypto, int flags)

MediaCodec for API == 26
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-26/blob/master/android/media/MediaCodec.java
void MediaCodec#native_configure(String[] keys, Object[] values, Surface surface, MediaCrypto crypto, IBinder descramblerBinder, int flags)

MediaCodec for API >= 27
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-27/blob/master/android/media/MediaCodec.java
void MediaCodec#native_configure(String[] keys, Object[] values, Surface surface, MediaCrypto crypto, IHwBinder descramblerBinder, int flags)

### Proposed Changes
