### PR TITLE
Remove looseSignatures usage from ShadowNativeImageReader

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeImageReader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeImageReader.java
@@ -30,7 +30,6 @@ import org.robolectric.versioning.AndroidVersions.V;
 @Implements(
     value = ImageReader.class,
     minSdk = P,
-    looseSignatures = true,
     isInAndroidSdk = false,
     shadowPicker = Picker.class,
     callNativeMethodsByDefault = true)
@@ -127,10 +126,10 @@ public class ShadowNativeImageReader {
     return natives.nativeImageSetup(i);
   }
 
-  @Implementation(minSdk = U.SDK_INT, maxSdk = U.SDK_INT)
-  protected Object nativeImageSetup(Object i) {
+  @Implementation(minSdk = U.SDK_INT, maxSdk = U.SDK_INT, methodName = "nativeImageSetup")
+  protected int nativeImageSetupPostT(Image i) {
     // Note: reverted to Q-S API
-    return natives.nativeImageSetup((Image) i);
+    return natives.nativeImageSetup(i);
   }
 
   /** We use a class initializer to allow the native code to cache some field offsets. */


### PR DESCRIPTION
Use @ClassName annotation instead of looseSignatures.

### Overview
1, For function ` nativeImageSetup`

In api <= 32: 
`int nativeImageSetup(Image)`
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-29/blob/master/android/graphics/HardwareRenderer.java#L1079
In api 33:
`int nativeImageSetup(Image, boolean)`
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-33/blob/master/android/media/ImageReader.java#L1421
For api >= 34
`int nativeImageSetup(Image)`
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-34/blob/master/android/media/ImageReader.java#L1444

### Proposed Changes
