### PR TITLE
Update to `google-java-format` 1.23.0

### DIFF
--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -35,8 +35,9 @@ jobs:
 
       - name: Download google-java-format
         run: |
-          curl -L -o $HOME/google-java-format.jar https://github.com/google/google-java-format/releases/download/v1.22.0/google-java-format-1.22.0-all-deps.jar
-          curl -L -o $HOME/google-java-format-diff.py https://raw.githubusercontent.com/google/google-java-format/v1.22.0/scripts/google-java-format-diff.py
+          googleJavaFormatVersion="1.23.0"
+          curl -L -o $HOME/google-java-format.jar https://github.com/google/google-java-format/releases/download/v${googleJavaFormatVersion}/google-java-format-${googleJavaFormatVersion}-all-deps.jar
+          curl -L -o $HOME/google-java-format-diff.py https://raw.githubusercontent.com/google/google-java-format/v${googleJavaFormatVersion}/scripts/google-java-format-diff.py
           chmod +x $HOME/google-java-format-diff.py
 
       - name: Check Java formatting

--- a/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativeBitmapTest.java
+++ b/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativeBitmapTest.java
@@ -986,7 +986,7 @@ public class ShadowNativeBitmapTest {
         assertFalse(bitmap.isPremultiplied());
         break;
       case ALPHA_8:
-        // ALPHA_8 behaves mostly the same as 8888, except for premultiplied. Fall through.
+      // ALPHA_8 behaves mostly the same as 8888, except for premultiplied. Fall through.
       case ARGB_8888:
         // Since 565 is necessarily opaque, we revert to hasAlpha when switching to a type
         // that can have alpha.

--- a/resources/src/main/java/org/robolectric/res/android/ConfigDescription.java
+++ b/resources/src/main/java/org/robolectric/res/android/ConfigDescription.java
@@ -117,7 +117,7 @@ public class ConfigDescription {
                 set_script(subtags[1]);
                 break;
               }
-              // fall through
+            // fall through
             case 5:
             case 6:
             case 7:

--- a/resources/src/main/java/org/robolectric/res/android/DynamicRefTable.java
+++ b/resources/src/main/java/org/robolectric/res/android/DynamicRefTable.java
@@ -159,7 +159,7 @@ public class DynamicRefTable {
     switch (dataType) {
       case ATTRIBUTE:
         resolvedType = DataType.ATTRIBUTE.code();
-        // fallthrough
+      // fallthrough
       case REFERENCE:
         if (!mAppAsLib) {
           return NO_ERROR;
@@ -170,7 +170,7 @@ public class DynamicRefTable {
         break;
       case DYNAMIC_ATTRIBUTE:
         resolvedType = DataType.ATTRIBUTE.code();
-        // fallthrough
+      // fallthrough
       case DYNAMIC_REFERENCE:
         break;
       default:

--- a/resources/src/main/java/org/robolectric/res/android/ResTable_config.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResTable_config.java
@@ -1967,7 +1967,7 @@ public class ResTable_config {
           }
           break;
         }
-        // fall through
+      // fall through
       case 5:
       case 6:
       case 7:

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassInstrumentor.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassInstrumentor.java
@@ -610,22 +610,22 @@ public class ClassInstrumentor {
           break;
 
         case Opcodes.GETFIELD:
-          /* falls through */
+        /* falls through */
         case Opcodes.PUTFIELD:
-          /* falls through */
+        /* falls through */
         case Opcodes.GETSTATIC:
-          /* falls through */
+        /* falls through */
         case Opcodes.PUTSTATIC:
           FieldInsnNode fieldInsnNode = (FieldInsnNode) node;
           fieldInsnNode.desc = mutableClass.config.mappedTypeName(fieldInsnNode.desc); // todo test
           break;
 
         case Opcodes.INVOKESTATIC:
-          /* falls through */
+        /* falls through */
         case Opcodes.INVOKEINTERFACE:
-          /* falls through */
+        /* falls through */
         case Opcodes.INVOKESPECIAL:
-          /* falls through */
+        /* falls through */
         case Opcodes.INVOKEVIRTUAL:
           MethodInsnNode targetMethod = (MethodInsnNode) node;
           targetMethod.desc = mutableClass.config.remapParams(targetMethod.desc);

--- a/shadows/framework/src/main/java/org/robolectric/android/controller/ActivityController.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/controller/ActivityController.java
@@ -585,15 +585,15 @@ public class ActivityController<T extends Activity>
     switch (originalState) {
       case INITIAL:
         create();
-        // fall through
+      // fall through
       case CREATED:
       case RESTARTED:
         start();
         postCreate(null);
-        // fall through
+      // fall through
       case STARTED:
         resume();
-        // fall through
+      // fall through
       default:
         // fall through
     }
@@ -613,10 +613,10 @@ public class ActivityController<T extends Activity>
       case STARTED:
       case RESUMED:
         pause();
-        // fall through
+      // fall through
       case PAUSED:
         stop();
-        // fall through
+      // fall through
       case STOPPED:
         break;
       default:
@@ -678,16 +678,16 @@ public class ActivityController<T extends Activity>
         return;
       case RESUMED:
         pause();
-        // fall through
+      // fall through
       case PAUSED:
-        // fall through
+      // fall through
       case RESTARTED:
-        // fall through
+      // fall through
       case STARTED:
         stop();
-        // fall through
+      // fall through
       case STOPPED:
-        // fall through
+      // fall through
       case CREATED:
         break;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextToSpeech.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextToSpeech.java
@@ -212,8 +212,8 @@ public class ShadowTextToSpeech {
         && utteranceProgressListener != null
         && !Boolean.getBoolean("robolectric.enableShadowTtsSynthesisToFileCallbackSuppression")) {
       switch (synthesizeToFileResult) {
-          // Right now this only supports success an error though there are other possible
-          // situations.
+        // Right now this only supports success an error though there are other possible
+        // situations.
         case TextToSpeech.SUCCESS:
           utteranceProgressListener.onStart(utteranceId);
           utteranceProgressListener.onDone(utteranceId);


### PR DESCRIPTION
This PR updates `google-java-format` to its latest version.
It also reformats the project to take the latest rules into consideration.
The release notes are available here: https://github.com/google/google-java-format/releases/tag/v1.23.0