### PR TITLE
Remove looseSignatures usage from ShadowNativeImageReaderSurfaceImage

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeImageReaderSurfaceImage.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeImageReaderSurfaceImage.java
@@ -5,6 +5,7 @@ import static android.os.Build.VERSION_CODES.R;
 import static android.os.Build.VERSION_CODES.S;
 
 import android.hardware.HardwareBuffer;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -16,7 +17,6 @@ import org.robolectric.versioning.AndroidVersions.U;
 @Implements(
     className = "android.media.ImageReader$SurfaceImage",
     minSdk = P,
-    looseSignatures = true,
     isInAndroidSdk = false,
     shadowPicker = ShadowNativeImageReaderSurfaceImage.Picker.class,
     callNativeMethodsByDefault = true)
@@ -25,17 +25,17 @@ public class ShadowNativeImageReaderSurfaceImage {
   @RealObject private Object realSurfaceImage;
 
   @Implementation(maxSdk = R)
-  protected synchronized /*SurfacePlane[]*/ Object nativeCreatePlanes(
-      /*int*/ Object numPlanes, /*int*/ Object readerFormat) {
+  protected synchronized @ClassName("android.media.ImageReader$SurfaceImage$SurfacePlane[]") Object
+      nativeCreatePlanes(int numPlanes, int readerFormat) {
     return ImageReaderSurfaceImageNatives.nativeSurfaceImageCreatePlanes(
-        realSurfaceImage, (int) numPlanes, (int) readerFormat, /* readerUsage= */ 0);
+        realSurfaceImage, numPlanes, readerFormat, /* readerUsage= */ 0);
   }
 
   @Implementation(minSdk = S, maxSdk = U.SDK_INT)
-  protected synchronized /*SurfacePlane[]*/ Object nativeCreatePlanes(
-      /*int*/ Object numPlanes, /*int*/ Object readerFormat, /*long*/ Object readerUsage) {
+  protected synchronized @ClassName("android.media.ImageReader$SurfaceImage$SurfacePlane[]") Object
+      nativeCreatePlanes(int numPlanes, int readerFormat, long readerUsage) {
     return ImageReaderSurfaceImageNatives.nativeSurfaceImageCreatePlanes(
-        realSurfaceImage, (int) numPlanes, (int) readerFormat, (long) readerUsage);
+        realSurfaceImage, numPlanes, readerFormat, readerUsage);
   }
 
   @Implementation(maxSdk = U.SDK_INT)


### PR DESCRIPTION
Use @ClassName annotation instead of looseSignatures.

### Overview

For function `nativeCreatePlanes`

<= 30
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-30/blob/master/android/media/ImageReader.java#L1040

>= 31
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-31/blob/master/android/media/ImageReader.java#L1133

### Proposed Changes
