### PR TITLE
Remove looseSignatures usage from ShadowNetworkCapabilities

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkCapabilities.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkCapabilities.java
@@ -3,6 +3,8 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.N;
 import static android.os.Build.VERSION_CODES.N_MR1;
 import static android.os.Build.VERSION_CODES.O;
+import static android.os.Build.VERSION_CODES.O_MR1;
+import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.Q;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
@@ -18,7 +20,7 @@ import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 
 /** Robolectic provides overrides for fetching and updating transport. */
-@Implements(value = NetworkCapabilities.class, looseSignatures = true)
+@Implements(value = NetworkCapabilities.class)
 public class ShadowNetworkCapabilities {
 
   @RealObject protected NetworkCapabilities realNetworkCapabilities;
@@ -89,12 +91,22 @@ public class ShadowNetworkCapabilities {
 
   /** Sets the LinkDownstreamBandwidthKbps of the NetworkCapabilities. */
   @HiddenApi
-  @Implementation
-  public Object setLinkDownstreamBandwidthKbps(Object kbps) {
-    // Loose signatures is necessary because the return type of setLinkDownstreamBandwidthKbps
-    // changed from void to NetworkCapabilities starting from API 28 (Pie)
+  @Implementation(maxSdk = O_MR1)
+  public void setLinkDownstreamBandwidthKbps(int kbps) {
+    reflector(NetworkCapabilitiesReflector.class, realNetworkCapabilities)
+        .setLinkDownstreamBandwidthKbps(kbps);
+  }
+
+  /**
+   * Sets the LinkDownstreamBandwidthKbps of the NetworkCapabilities.
+   *
+   * <p>Return type changed to {@code NetworkCapabilities} start from Pie.
+   */
+  @HiddenApi
+  @Implementation(minSdk = P, methodName = "setLinkDownstreamBandwidthKbps")
+  public NetworkCapabilities setLinkDownstreamBandwidthKbpsFromPie(int kbps) {
     return reflector(NetworkCapabilitiesReflector.class, realNetworkCapabilities)
-        .setLinkDownstreamBandwidthKbps((int) kbps);
+        .setLinkDownstreamBandwidthKbps(kbps);
   }
 
   @ForType(NetworkCapabilities.class)


### PR DESCRIPTION
Use @ClassName annotation instead of looseSignatures.

### Overview

API <= 27, `public void setLinkDownstreamBandwidthKbps(int downKbps)`
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-27/blob/master/android/net/NetworkCapabilities.java#L564

API >= 28, `public NetworkCapabilities setLinkDownstreamBandwidthKbps(int downKbps)`
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-28/blob/master/android/net/NetworkCapabilities.java#L824C5-L824C77

Actually, start from API 31, this `NetworkCapabilities ` class seems been deleted?
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-31/blob/master/android/net/NetworkCapabilities.java

### Proposed Changes
