### PR TITLE
Remove looseSignatures usage from ShadowNfcAdapter

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNfcAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNfcAdapter.java
@@ -18,6 +18,7 @@ import android.os.Bundle;
 import java.util.Map;
 import javax.annotation.concurrent.GuardedBy;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -30,7 +31,7 @@ import org.robolectric.util.reflector.ForType;
 import org.robolectric.util.reflector.Static;
 
 /** Shadow implementation of {@link NfcAdapter}. */
-@Implements(value = NfcAdapter.class, looseSignatures = true)
+@Implements(value = NfcAdapter.class)
 public class ShadowNfcAdapter {
   @RealObject NfcAdapter nfcAdapter;
 
@@ -283,7 +284,7 @@ public class ShadowNfcAdapter {
 
   // TODO: use NfcAntennaInfo when minimum supported compile SDK is >= android U
   @Implementation(minSdk = UPSIDE_DOWN_CAKE)
-  protected Object /* NfcAntennaInfo */ getNfcAntennaInfo() {
+  protected @ClassName("android.nfc.NfcAntennaInfo") Object getNfcAntennaInfo() {
     synchronized (this) {
       return nfcAntennaInfo;
     }


### PR DESCRIPTION
Use @ClassName annotation instead of looseSignatures.

### Overview

API 34 added new function with new type `android.nfc.NfcAntennaInfo`
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-34/blob/master/android/nfc/NfcAdapter.java#L1763

### Proposed Changes
