### PR TITLE
Add tests for  ShadowCaptioningManager static state

### DIFF
--- a/integration_tests/ctesque/src/androidTest/java/android/app/ContextTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/ContextTest.java
@@ -29,6 +29,7 @@ import android.os.Build;
 import android.os.DropBoxManager;
 import android.os.UserHandle;
 import android.telephony.euicc.EuiccManager;
+import android.view.accessibility.CaptioningManager;
 import android.view.autofill.AutofillManager;
 import android.widget.RemoteViews;
 import androidx.test.core.app.ActivityScenario;
@@ -1108,6 +1109,62 @@ public class ContextTest {
             MediaRouter.RouteInfo activityDefaultRoute = activityMediaRouter.getDefaultRoute();
 
             assertThat(activityDefaultRoute).isEqualTo(applicationDefaultRoute);
+          });
+    }
+  }
+
+  @Test
+  public void captioningManager_applicationInstance_isNotSameAsActivityInstance() {
+    CaptioningManager applicationCaptioningManager =
+        (CaptioningManager)
+            ApplicationProvider.getApplicationContext()
+                .getSystemService(Context.CAPTIONING_SERVICE);
+
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            CaptioningManager activityCaptioningManager =
+                (CaptioningManager) activity.getSystemService(Context.CAPTIONING_SERVICE);
+
+            assertThat(applicationCaptioningManager).isNotSameInstanceAs(activityCaptioningManager);
+          });
+    }
+  }
+
+  @Test
+  public void captioningManager_activityInstance_isSameAsActivityInstance() {
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            CaptioningManager activityCaptioningManager =
+                (CaptioningManager) activity.getSystemService(Context.CAPTIONING_SERVICE);
+
+            CaptioningManager anotherActivityCaptioningManager =
+                (CaptioningManager) activity.getSystemService(Context.CAPTIONING_SERVICE);
+
+            assertThat(anotherActivityCaptioningManager)
+                .isSameInstanceAs(activityCaptioningManager);
+          });
+    }
+  }
+
+  @Test
+  public void captioningManager_instance_retrievesSameValues() {
+    CaptioningManager applicationCaptioningManager =
+        (CaptioningManager)
+            ApplicationProvider.getApplicationContext()
+                .getSystemService(Context.CAPTIONING_SERVICE);
+
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            CaptioningManager activityCaptioningManager =
+                (CaptioningManager) activity.getSystemService(Context.CAPTIONING_SERVICE);
+
+            boolean applicationisEnabled = applicationCaptioningManager.isEnabled();
+            boolean activityisEnabled = activityCaptioningManager.isEnabled();
+
+            assertThat(applicationisEnabled).isEqualTo(activityisEnabled);
           });
     }
   }


### PR DESCRIPTION
1.Converted instances fields to static fields to ensure proper state management. 
2.add tests for the same in ShadowCaptioningManagerTest.

### Overview

### Proposed Changes
