### PR TITLE
Remove looseSignatures usage from ShadowPausedMessageQueue

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedMessageQueue.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedMessageQueue.java
@@ -38,7 +38,7 @@ import org.robolectric.versioning.AndroidVersions.V;
  * <p>This class should not be referenced directly. Use {@link ShadowMessageQueue} instead.
  */
 @SuppressWarnings("SynchronizeOnNonFinalField")
-@Implements(value = MessageQueue.class, isInAndroidSdk = false, looseSignatures = true)
+@Implements(value = MessageQueue.class, isInAndroidSdk = false)
 public class ShadowPausedMessageQueue extends ShadowMessageQueue {
 
   @RealObject private MessageQueue realQueue;
@@ -76,16 +76,13 @@ public class ShadowPausedMessageQueue extends ShadowMessageQueue {
     ShadowPausedSystemClock.removeListener(q.clockListener);
   }
 
-  // use the generic Object parameter types here, to avoid conflicts with the non-static
-  // nativePollOnce
   @Implementation(maxSdk = LOLLIPOP_MR1)
-  protected static void nativePollOnce(Object ptr, Object timeoutMillis) {
-    long ptrLong = getLong(ptr);
-    nativeQueueRegistry.getNativeObject(ptrLong).nativePollOnce(ptrLong, (int) timeoutMillis);
+  protected static void nativePollOnce(long ptr, int timeoutMillis) {
+    nativeQueueRegistry.getNativeObject(ptr).nativePollOnceFromM(ptr, timeoutMillis);
   }
 
-  @Implementation(minSdk = M)
-  protected void nativePollOnce(long ptr, int timeoutMillis) {
+  @Implementation(minSdk = M, methodName = "nativePollOnce")
+  protected void nativePollOnceFromM(long ptr, int timeoutMillis) {
     if (timeoutMillis == 0) {
       return;
     }


### PR DESCRIPTION
Use methodName to coexist methods with function-signature / function-return-type changed.

### Overview

<= API 22, static function
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-22/blob/master/android/os/MessageQueue.java#L53

>= 23, member function
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-23/blob/master/android/os/MessageQueue.java#L63

### Proposed Changes
