### PR TITLE
Make-fields-of-ShadowLauncherApps-static-for-context-level-instance

### DIFF
--- a/integration_tests/ctesque/src/androidTest/java/android/app/ContextTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/ContextTest.java
@@ -18,6 +18,7 @@ import android.content.ClipboardManager;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.CrossProfileApps;
+import android.content.pm.LauncherApps;
 import android.hardware.biometrics.BiometricManager;
 import android.hardware.camera2.CameraManager;
 import android.hardware.fingerprint.FingerprintManager;
@@ -947,6 +948,59 @@ public class ContextTest {
                 activityCrossProfileApps.getTargetUserProfiles();
 
             assertThat(activityTargetUserProfiles).isEqualTo(applicationTargetUserProfiles);
+          });
+    }
+  }
+
+  @Test
+  public void launcherApps_applicationInstance_isNotSameAsActivityInstance() {
+    LauncherApps applicationLauncherApps =
+        (LauncherApps)
+            ApplicationProvider.getApplicationContext()
+                .getSystemService(Context.LAUNCHER_APPS_SERVICE);
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            LauncherApps activityLauncherApps =
+                (LauncherApps) activity.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+            assertThat(applicationLauncherApps).isNotSameInstanceAs(activityLauncherApps);
+          });
+    }
+  }
+
+  @Test
+  public void launcherApps_activityInstance_isSameAsActivityInstance() {
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            LauncherApps activityLauncherApps =
+                (LauncherApps) activity.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+            LauncherApps anotherActivityLauncherApps =
+                (LauncherApps) activity.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+            assertThat(anotherActivityLauncherApps).isSameInstanceAs(activityLauncherApps);
+          });
+    }
+  }
+
+  @Test
+  public void launcherApps_instance_retrievesSameProfiles() {
+    LauncherApps applicationLauncherApps =
+        (LauncherApps)
+            ApplicationProvider.getApplicationContext()
+                .getSystemService(Context.LAUNCHER_APPS_SERVICE);
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            LauncherApps activityLauncherApps =
+                (LauncherApps) activity.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+
+            List<UserHandle> applicationProfiles = applicationLauncherApps.getProfiles();
+            List<UserHandle> activityProfiles = activityLauncherApps.getProfiles();
+
+            assertThat(applicationProfiles).isNotEmpty();
+            assertThat(activityProfiles).isNotEmpty();
+
+            assertThat(activityProfiles).isEqualTo(applicationProfiles);
           });
     }
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLauncherApps.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLauncherApps.java
@@ -40,24 +40,41 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
 import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
 
 /** Shadow of {@link android.content.pm.LauncherApps}. */
 @Implements(value = LauncherApps.class)
 public class ShadowLauncherApps {
-  private List<ShortcutInfo> shortcuts = new ArrayList<>();
-  private final Multimap<UserHandle, String> enabledPackages = HashMultimap.create();
-  private final Multimap<UserHandle, ComponentName> enabledActivities = HashMultimap.create();
-  private final Multimap<UserHandle, LauncherActivityInfo> shortcutActivityList =
+  private static List<ShortcutInfo> shortcuts = new ArrayList<>();
+  private static final Multimap<UserHandle, String> enabledPackages = HashMultimap.create();
+  private static final Multimap<UserHandle, ComponentName> enabledActivities =
       HashMultimap.create();
-  private final Multimap<UserHandle, LauncherActivityInfo> activityList = HashMultimap.create();
-  private final Map<UserHandle, Map<String, ApplicationInfo>> applicationInfoList = new HashMap<>();
-  private final Map<UserHandle, Map<String, Bundle>> suspendedPackageLauncherExtras =
+  private static final Multimap<UserHandle, LauncherActivityInfo> shortcutActivityList =
+      HashMultimap.create();
+  private static final Multimap<UserHandle, LauncherActivityInfo> activityList =
+      HashMultimap.create();
+  private static final Map<UserHandle, Map<String, ApplicationInfo>> applicationInfoList =
+      new HashMap<>();
+  private static final Map<UserHandle, Map<String, Bundle>> suspendedPackageLauncherExtras =
       new HashMap<>();
 
-  private final List<Pair<LauncherApps.Callback, Handler>> callbacks = new ArrayList<>();
-  private boolean hasShortcutHostPermission = false;
+  private static final List<Pair<LauncherApps.Callback, Handler>> callbacks = new ArrayList<>();
+  private static boolean hasShortcutHostPermission = false;
+
+  @Resetter
+  public static void reset() {
+    shortcuts.clear();
+    enabledPackages.clear();
+    enabledActivities.clear();
+    shortcutActivityList.clear();
+    activityList.clear();
+    applicationInfoList.clear();
+    suspendedPackageLauncherExtras.clear();
+    callbacks.clear();
+    hasShortcutHostPermission = false;
+  }
 
   /**
    * Adds a dynamic shortcut to be returned by {@link #getShortcuts(ShortcutQuery, UserHandle)}.


### PR DESCRIPTION
1.Converted instance fields to static fields to ensure proper state management. 2.add tests for the same in ShadowLauncherAppsTest. 3.add tests for LauncherAppsinstance behavior across application and activity contexts in ContextTest

### Overview

### Proposed Changes
