### PR TITLE
Make-fields-of-ShadowLocaleManager-static-for-context-level-instance

### DIFF
--- a/integration_tests/ctesque/src/androidTest/java/android/app/ContextTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/ContextTest.java
@@ -23,6 +23,7 @@ import android.hardware.fingerprint.FingerprintManager;
 import android.media.AudioManager;
 import android.os.BatteryManager;
 import android.os.Build;
+import android.os.LocaleList;
 import android.telephony.euicc.EuiccManager;
 import android.view.autofill.AutofillManager;
 import android.widget.RemoteViews;
@@ -892,6 +893,56 @@ public class ContextTest {
             String activityEid = activityEuiccManager.getEid();
 
             assertThat(activityEid).isEqualTo(applicationEid);
+          });
+    }
+  }
+
+  @Test
+  public void localeManager_applicationInstance_isNotSameAsActivityInstance() {
+    LocaleManager applicationLocaleManager =
+        (LocaleManager)
+            ApplicationProvider.getApplicationContext().getSystemService(Context.LOCALE_SERVICE);
+
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            LocaleManager activityLocaleManager =
+                (LocaleManager) activity.getSystemService(Context.LOCALE_SERVICE);
+            assertThat(applicationLocaleManager).isNotSameInstanceAs(activityLocaleManager);
+          });
+    }
+  }
+
+  @Test
+  public void localeManager_activityInstance_isSameAsActivityInstance() {
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            LocaleManager activityLocaleManager =
+                (LocaleManager) activity.getSystemService(Context.LOCALE_SERVICE);
+            LocaleManager anotherActivityLocaleManager =
+                (LocaleManager) activity.getSystemService(Context.LOCALE_SERVICE);
+            assertThat(anotherActivityLocaleManager).isSameInstanceAs(activityLocaleManager);
+          });
+    }
+  }
+
+  @Test
+  public void localeManager_instance_retrievesSameApplicationLocales() {
+    LocaleManager applicationLocaleManager =
+        (LocaleManager)
+            ApplicationProvider.getApplicationContext().getSystemService(Context.LOCALE_SERVICE);
+
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            LocaleManager activityLocaleManager =
+                (LocaleManager) activity.getSystemService(Context.LOCALE_SERVICE);
+
+            LocaleList applicationLocales = applicationLocaleManager.getApplicationLocales();
+            LocaleList activityLocales = activityLocaleManager.getApplicationLocales();
+
+            assertThat(activityLocales).isEqualTo(applicationLocales);
           });
     }
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocaleManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocaleManager.java
@@ -12,15 +12,23 @@ import java.util.Map;
 import java.util.Set;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
 import org.robolectric.versioning.AndroidVersions.U;
 
 /** Shadow of {@link LocaleManager} */
 @Implements(value = LocaleManager.class, minSdk = VERSION_CODES.TIRAMISU, isInAndroidSdk = false)
 public class ShadowLocaleManager {
 
-  private final Map<String, LocaleList> appLocales = new HashMap<>();
-  private final Set<String> packagesInstalledByCaller = new HashSet<>();
-  private boolean enforceInstallerCheck;
+  private static final Map<String, LocaleList> appLocales = new HashMap<>();
+  private static final Set<String> packagesInstalledByCaller = new HashSet<>();
+  private static boolean enforceInstallerCheck;
+
+  @Resetter
+  public static void reset() {
+    appLocales.clear();
+    packagesInstalledByCaller.clear();
+    enforceInstallerCheck = false;
+  }
 
   /**
    * Returns the stored locales from in-memory map for the given package when {@link


### PR DESCRIPTION
1.Converted instance fields to static fields to ensure proper state management. 2.add tests for the same in ShadowLocaleManager.
3.add tests for LocaleManager instance behavior across application and activity contexts in ContextTest

### Overview

### Proposed Changes
