### PR TITLE
Add necessary minSdk = O for some createActivityContexts tests

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
@@ -666,6 +666,7 @@ public class ShadowAlarmManagerTest {
   }
 
   @Test
+  @Config(minSdk = VERSION_CODES.O)
   public void alarmManager_instance_retrievesSameAlarmClockInfo() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowClipboardManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowClipboardManagerTest.java
@@ -157,7 +157,7 @@ public class ShadowClipboardManagerTest {
   }
 
   @Test
-  @Config(minSdk = android.os.Build.VERSION_CODES.O)
+  @Config(minSdk = O)
   public void clipboardManager_instance_retrievesSamePrimaryClip() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDevicePolicyManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDevicePolicyManagerTest.java
@@ -2715,6 +2715,7 @@ public final class ShadowDevicePolicyManagerTest {
   }
 
   @Test
+  @Config(minSdk = O)
   public void devicePolicyManager_instance_retrievesSameAdminStatus() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDropBoxManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDropBoxManagerTest.java
@@ -1,5 +1,6 @@
 package org.robolectric.shadows;
 
+import static android.os.Build.VERSION_CODES.O;
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.robolectric.Shadows.shadowOf;
@@ -17,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
 
 /** Unit tests for {@see ShadowDropboxManager}. */
 @RunWith(AndroidJUnit4.class)
@@ -88,7 +90,7 @@ public class ShadowDropBoxManagerTest {
     assertThat(entry.getTimeMillis()).isEqualTo(3);
   }
 
-  @Test()
+  @Test
   public void resetClearsData() {
     shadowDropBoxManager.addData(TAG, 1, DATA);
 
@@ -119,6 +121,7 @@ public class ShadowDropBoxManagerTest {
   }
 
   @Test
+  @Config(minSdk = O)
   public void dropBoxManager_activityContextEnabled_differentInstancesVerifyTagEnabled() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowFingerprintManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowFingerprintManagerTest.java
@@ -125,6 +125,7 @@ public class ShadowFingerprintManagerTest {
   }
 
   @Test
+  @Config(minSdk = VERSION_CODES.O)
   public void fingerprintManager_activityContextEnabled_differentInstancesHaveConsistentState() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLauncherAppsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLauncherAppsTest.java
@@ -430,6 +430,7 @@ public class ShadowLauncherAppsTest {
   }
 
   @Test
+  @Config(minSdk = O)
   public void launcherApps_activityContextEnabled_differentInstancesRetrieveProfiles() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");


### PR DESCRIPTION
Some createActivityContexts tests miss the minSdk = O, but it looks like work as expected.