### PR TITLE
Remove looseSignatures usage from ShadowRotationWatcherFor22

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRotationWatcherFor22.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRotationWatcherFor22.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
 
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
@@ -9,12 +10,12 @@ import org.robolectric.annotation.Implements;
 @Implements(
     className = "com.android.internal.policy.impl.PhoneWindow$RotationWatcher",
     isInAndroidSdk = false,
-    maxSdk = LOLLIPOP_MR1,
-    looseSignatures = true)
+    maxSdk = LOLLIPOP_MR1)
 public class ShadowRotationWatcherFor22 {
 
   @Implementation
-  protected void addWindow(Object phoneWindow) {
+  protected void addWindow(
+      @ClassName("com.android.internal.policy.impl.PhoneWindow") Object phoneWindow) {
     // ignore
   }
 }


### PR DESCRIPTION
Use @ClassName annotation instead of looseSignatures.

### Overview
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-22/blob/master/com/android/internal/policy/impl/PhoneWindow.java#L4608

### Proposed Changes
