### PR TITLE
Remove looseSignatures usage from ShadowSystemServiceRegistry

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemServiceRegistry.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemServiceRegistry.java
@@ -6,6 +6,7 @@ import static org.robolectric.util.reflector.Reflector.reflector;
 import android.content.Context;
 import android.os.Build;
 import java.util.Map;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
@@ -15,7 +16,6 @@ import org.robolectric.util.reflector.ForType;
 @Implements(
     className = "android.app.SystemServiceRegistry",
     isInAndroidSdk = false,
-    looseSignatures = true,
     minSdk = Build.VERSION_CODES.M)
 public class ShadowSystemServiceRegistry {
 
@@ -124,7 +124,8 @@ public class ShadowSystemServiceRegistry {
   }
 
   @Implementation(minSdk = O)
-  protected static void onServiceNotFound(/* ServiceNotFoundException */ Object e0) {
+  protected static void onServiceNotFound(
+      @ClassName("android.os.ServiceManager$ServiceNotFoundException") Object e0) {
     // otherwise the full stacktrace might be swallowed...
     Exception e = (Exception) e0;
     e.printStackTrace();


### PR DESCRIPTION
Use @ClassName annotation instead of looseSignatures.

### Overview
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-26/blob/master/android/app/SystemServiceRegistry.java#L998
### Proposed Changes
