### PR TITLE
Make-fields-of-ShadowNetworkScoreManager-static-for-context-level-instance

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkScoreManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkScoreManager.java
@@ -3,12 +3,19 @@ package org.robolectric.shadows;
 import android.net.NetworkScoreManager;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
 
 /** Provides testing APIs for {@link NetworkScoreManager}. */
 @Implements(value = NetworkScoreManager.class, isInAndroidSdk = false)
 public class ShadowNetworkScoreManager {
-  private String activeScorerPackage;
-  private boolean isScoringEnabled = true;
+  private static String activeScorerPackage;
+  private static boolean isScoringEnabled = true;
+
+  @Resetter
+  public static void reset() {
+    activeScorerPackage = null;
+    isScoringEnabled = true;
+  }
 
   @Implementation
   public String getActiveScorerPackage() {


### PR DESCRIPTION
1.Converted instance fields to static fields to ensure proper state management. 
2.add tests for the same in ShadowNetworkScoreManager. 
3.add tests for NetworkScoreManager instance behavior across application and activity contexts in ContextTest

### Overview

### Proposed Changes
