### PR TITLE
Remove looseSignatures usage from ShadowTimeZoneFinder

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeZoneFinder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeZoneFinder.java
@@ -8,6 +8,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.util.ReflectionHelpers;
@@ -18,14 +19,13 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
     className = "libcore.util.TimeZoneFinder",
     minSdk = O,
     maxSdk = P,
-    isInAndroidSdk = false,
-    looseSignatures = true)
+    isInAndroidSdk = false)
 public class ShadowTimeZoneFinder {
 
   private static final String TZLOOKUP_PATH = "/usr/share/zoneinfo/tzlookup.xml";
 
   @Implementation
-  protected static Object getInstance() {
+  protected static @ClassName("libcore.util.TimeZoneFinder") Object getInstance() {
     try {
       return ReflectionHelpers.callStaticMethod(
           Class.forName("libcore.util.TimeZoneFinder"),


### PR DESCRIPTION
Use @ClassName annotation instead of looseSignatures

### Overview
https://cs.android.com/android/platform/superproject/+/android-8.0.0_r1:libcore/luni/src/main/java/libcore/util/TimeZoneFinder.java;l=70

### Proposed Changes
