### PR TITLE
Remove looseSignatures usage from ShadowTimeZoneFinderS

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeZoneFinderS.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeZoneFinderS.java
@@ -8,21 +8,18 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /** Shadow for TimeZoneFinder on S or above. */
-@Implements(
-    value = TimeZoneFinder.class,
-    minSdk = S,
-    isInAndroidSdk = false,
-    looseSignatures = true)
+@Implements(value = TimeZoneFinder.class, minSdk = S, isInAndroidSdk = false)
 public class ShadowTimeZoneFinderS {
 
   private static final String TZLOOKUP_PATH = "/usr/share/zoneinfo/tzlookup.xml";
 
   @Implementation
-  protected static Object getInstance() {
+  protected static @ClassName("com.android.i18n.timezone.TimeZoneFinder") Object getInstance() {
     return TimeZoneFinder.createInstanceForTests(readTzlookup());
   }
 


### PR DESCRIPTION
Use @classname annotation instead of looseSignatures

### Overview

https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-31/blob/master/android/timezone/TimeZoneFinder.java#L41

### Proposed Changes
