### PR TITLE
Make-fields-of-ShadowShortcutManager-static-for-context-level-instance

### DIFF
--- a/integration_tests/ctesque/src/androidTest/java/android/app/ShortcutManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/ShortcutManagerTest.java
@@ -1,0 +1,65 @@
+package android.app;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.content.Context;
+import android.content.pm.ShortcutManager;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.testapp.TestActivity;
+
+@RunWith(AndroidJUnit4.class)
+public class ShortcutManagerTest {
+
+  @Test
+  public void shortcutManager_applicationInstance_isNotSameAsActivityInstance() {
+    ShortcutManager applicationShortcutManager =
+        (ShortcutManager)
+            ApplicationProvider.getApplicationContext().getSystemService(Context.SHORTCUT_SERVICE);
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            ShortcutManager activityShortcutManager =
+                (ShortcutManager) activity.getSystemService(Context.SHORTCUT_SERVICE);
+            assertThat(applicationShortcutManager).isNotSameInstanceAs(activityShortcutManager);
+          });
+    }
+  }
+
+  @Test
+  public void shortcutManager_activityInstance_isSameAsActivityInstance() {
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            ShortcutManager activityShortcutManager =
+                (ShortcutManager) activity.getSystemService(Context.SHORTCUT_SERVICE);
+            ShortcutManager anotherActivityShortcutManager =
+                (ShortcutManager) activity.getSystemService(Context.SHORTCUT_SERVICE);
+            assertThat(anotherActivityShortcutManager).isSameInstanceAs(activityShortcutManager);
+          });
+    }
+  }
+
+  @Test
+  public void shortcutManager_instance_checksRateLimiting() {
+    ShortcutManager applicationShortcutManager =
+        (ShortcutManager)
+            ApplicationProvider.getApplicationContext().getSystemService(Context.SHORTCUT_SERVICE);
+
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            ShortcutManager activityShortcutManager =
+                (ShortcutManager) activity.getSystemService(Context.SHORTCUT_SERVICE);
+
+            boolean applicationRateLimiting = applicationShortcutManager.isRateLimitingActive();
+            boolean activityRateLimiting = activityShortcutManager.isRateLimitingActive();
+
+            assertThat(activityRateLimiting).isEqualTo(applicationRateLimiting);
+          });
+    }
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowShortcutManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowShortcutManagerTest.java
@@ -4,12 +4,14 @@ import static android.content.pm.ShortcutManager.FLAG_MATCH_CACHED;
 import static android.content.pm.ShortcutManager.FLAG_MATCH_DYNAMIC;
 import static android.content.pm.ShortcutManager.FLAG_MATCH_MANIFEST;
 import static android.content.pm.ShortcutManager.FLAG_MATCH_PINNED;
+import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.R;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.pm.ShortcutInfo;
 import android.content.pm.ShortcutManager;
@@ -22,6 +24,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -385,5 +388,35 @@ public final class ShadowShortcutManagerTest {
     return new ShortcutInfo.Builder(ApplicationProvider.getApplicationContext(), id)
         .setLongLabel(longLabel)
         .build();
+  }
+
+  @Test
+  @Config(minSdk = O)
+  public void shortcutManager_activityContextEnabled_differentInstancesCheckRateLimiting() {
+    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
+    System.setProperty("robolectric.createActivityContexts", "true");
+    Activity activity = null;
+    try {
+      ShortcutManager applicationShortcutManager =
+          (ShortcutManager)
+              ApplicationProvider.getApplicationContext()
+                  .getSystemService(Context.SHORTCUT_SERVICE);
+
+      activity = Robolectric.setupActivity(Activity.class);
+      ShortcutManager activityShortcutManager =
+          (ShortcutManager) activity.getSystemService(Context.SHORTCUT_SERVICE);
+
+      assertThat(applicationShortcutManager).isNotSameInstanceAs(activityShortcutManager);
+
+      boolean applicationRateLimiting = applicationShortcutManager.isRateLimitingActive();
+      boolean activityRateLimiting = activityShortcutManager.isRateLimitingActive();
+
+      assertThat(activityRateLimiting).isEqualTo(applicationRateLimiting);
+    } finally {
+      if (activity != null) {
+        activity.finish();
+      }
+      System.setProperty("robolectric.createActivityContexts", originalProperty);
+    }
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowShortcutManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowShortcutManager.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
 
 /** */
 @Implements(value = ShortcutManager.class, minSdk = Build.VERSION_CODES.N_MR1)
@@ -33,16 +34,28 @@ public class ShadowShortcutManager {
 
   private static final int MAX_ICON_DIMENSION = 128;
 
-  private final Map<String, ShortcutInfo> dynamicShortcuts = new HashMap<>();
-  private final Map<String, ShortcutInfo> activePinnedShortcuts = new HashMap<>();
-  private final Map<String, ShortcutInfo> disabledPinnedShortcuts = new HashMap<>();
+  private static final Map<String, ShortcutInfo> dynamicShortcuts = new HashMap<>();
+  private static final Map<String, ShortcutInfo> activePinnedShortcuts = new HashMap<>();
+  private static final Map<String, ShortcutInfo> disabledPinnedShortcuts = new HashMap<>();
 
-  private List<ShortcutInfo> manifestShortcuts = ImmutableList.of();
+  private static List<ShortcutInfo> manifestShortcuts = ImmutableList.of();
 
-  private boolean isRequestPinShortcutSupported = true;
-  private int maxShortcutCountPerActivity = 16;
-  private int maxIconHeight = MAX_ICON_DIMENSION;
-  private int maxIconWidth = MAX_ICON_DIMENSION;
+  private static boolean isRequestPinShortcutSupported = true;
+  private static int maxShortcutCountPerActivity = 16;
+  private static int maxIconHeight = MAX_ICON_DIMENSION;
+  private static int maxIconWidth = MAX_ICON_DIMENSION;
+
+  @Resetter
+  public static void reset() {
+    dynamicShortcuts.clear();
+    activePinnedShortcuts.clear();
+    disabledPinnedShortcuts.clear();
+    manifestShortcuts = ImmutableList.of();
+    isRequestPinShortcutSupported = true;
+    maxShortcutCountPerActivity = 16;
+    maxIconHeight = MAX_ICON_DIMENSION;
+    maxIconWidth = MAX_ICON_DIMENSION;
+  }
 
   @Implementation
   protected boolean addDynamicShortcuts(List<ShortcutInfo> shortcutInfoList) {


### PR DESCRIPTION
1.Converted instance fields to static fields to ensure proper state management. 
2.add tests for the same in ShadowShortcutManagerTest. 
3.add tests for ShortcutManager instance behavior across application and activity contexts in ContextTest

### Overview

### Proposed Changes
