### PR TITLE
Make-fields-of-ShadowTimeManager-static-for-context-level-instance

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTimeManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTimeManagerTest.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import android.app.Activity;
 import android.app.time.TimeManager;
 import android.app.time.TimeZoneCapabilitiesAndConfig;
 import android.app.time.TimeZoneConfiguration;
@@ -10,6 +11,7 @@ import androidx.test.core.app.ApplicationProvider;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -55,5 +57,36 @@ public final class ShadowTimeManagerTest {
     capabilitiesAndConfig = timeManager.getTimeZoneCapabilitiesAndConfig();
 
     assertThat(capabilitiesAndConfig.getConfiguration()).isEqualTo(updatedConfiguration);
+  }
+
+  @Test
+  @Config(minSdk = Build.VERSION_CODES.S)
+  public void timeManager_activityContextEnabled_differentInstancesRetrieveTimeZoneCapabilities() {
+    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
+    System.setProperty("robolectric.createActivityContexts", "true");
+    Activity activity = null;
+    try {
+      TimeManager applicationTimeManager =
+          ApplicationProvider.getApplicationContext().getSystemService(TimeManager.class);
+      activity = Robolectric.setupActivity(Activity.class);
+      TimeManager activityTimeManager = activity.getSystemService(TimeManager.class);
+
+      TimeZoneConfiguration timeZoneConfiguration = new TimeZoneConfiguration.Builder().build();
+      applicationTimeManager.updateTimeZoneConfiguration(timeZoneConfiguration);
+
+      assertThat(applicationTimeManager).isNotSameInstanceAs(activityTimeManager);
+
+      TimeZoneCapabilitiesAndConfig applicationCapabilities =
+          applicationTimeManager.getTimeZoneCapabilitiesAndConfig();
+      TimeZoneCapabilitiesAndConfig activityCapabilities =
+          activityTimeManager.getTimeZoneCapabilitiesAndConfig();
+
+      assertThat(activityCapabilities).isEqualTo(applicationCapabilities);
+    } finally {
+      if (activity != null) {
+        activity.finish();
+      }
+      System.setProperty("robolectric.createActivityContexts", originalProperty);
+    }
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeManager.java
@@ -15,6 +15,7 @@ import java.util.concurrent.Executor;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 import org.robolectric.versioning.AndroidVersions.U;
@@ -26,9 +27,9 @@ public class ShadowTimeManager {
   public static final String CONFIGURE_GEO_DETECTION_CAPABILITY =
       "configure_geo_detection_capability";
 
-  private TimeZoneCapabilities timeZoneCapabilities = getTimeZoneCapabilities();
+  private static TimeZoneCapabilities timeZoneCapabilities = getTimeZoneCapabilities();
 
-  private TimeZoneConfiguration timeZoneConfiguration;
+  private static TimeZoneConfiguration timeZoneConfiguration;
 
   /**
    * Capabilites are predefined and not controlled by user, so they can't be changed via TimeManager
@@ -115,7 +116,7 @@ public class ShadowTimeManager {
   @Implementation
   protected void suggestExternalTime(ExternalTimeSuggestion timeSuggestion) {}
 
-  private TimeZoneCapabilities getTimeZoneCapabilities() {
+  private static TimeZoneCapabilities getTimeZoneCapabilities() {
     TimeZoneCapabilities.Builder timeZoneCapabilitiesBuilder =
         new TimeZoneCapabilities.Builder(UserHandle.CURRENT)
             .setConfigureAutoDetectionEnabledCapability(Capabilities.CAPABILITY_POSSESSED)
@@ -138,5 +139,11 @@ public class ShadowTimeManager {
           ClassParameter.from(int.class, Capabilities.CAPABILITY_POSSESSED));
       return timeZoneCapabilitiesBuilder.build();
     }
+  }
+
+  @Resetter
+  public static void reset() {
+    timeZoneCapabilities = getTimeZoneCapabilities();
+    timeZoneConfiguration = null;
   }
 }


### PR DESCRIPTION
1.Converted instance fields to static fields to ensure proper state management. 
2.add tests for the same in ShadowTimeManagerTest.

### Overview

### Proposed Changes
