### PR TITLE
Make-fields-of-ShadowWallpaperManager-static-for-context-level-instance

### DIFF
--- a/integration_tests/ctesque/src/androidTest/java/android/app/WallpaperManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/WallpaperManagerTest.java
@@ -1,0 +1,84 @@
+package android.app;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+import android.content.Context;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.testapp.TestActivity;
+
+@RunWith(AndroidJUnit4.class)
+public class WallpaperManagerTest {
+  private WallpaperManager wallpaperManager;
+  private boolean isWallpaperSupported = false;
+
+  @Before
+  public void setUp() {
+    // Test code can't access com.android.internal config value to check whether the current running
+    // Android
+    // supports WallpaperManagerService, and it uses returned WallpaperManager's flag to check it.
+    Object manager =
+        ApplicationProvider.getApplicationContext().getSystemService(Context.WALLPAPER_SERVICE);
+    if (manager != null) {
+      wallpaperManager = (WallpaperManager) manager;
+    }
+
+    isWallpaperSupported = wallpaperManager != null && wallpaperManager.isWallpaperSupported();
+  }
+
+  @Test
+  public void wallpaperManager_applicationInstance_matchesExpectedBehavior() {
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            WallpaperManager activityWallpaperManager =
+                (WallpaperManager) activity.getSystemService(Context.WALLPAPER_SERVICE);
+            // If WallpaperManagerService is not supported by the device, it returns a special
+            // WindowManager implementation called DisabledWallpaperManager, and it uses
+            // singleton for all Context instances.
+            if (isWallpaperSupported) {
+              assertThat(wallpaperManager).isNotSameInstanceAs(activityWallpaperManager);
+            } else {
+              assertThat(wallpaperManager).isSameInstanceAs(activityWallpaperManager);
+            }
+          });
+    }
+  }
+
+  @Test
+  public void wallpaperManager_activityInstance_isSameAsActivityInstance() {
+    assumeTrue(isWallpaperSupported);
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            WallpaperManager activityWallpaperManager =
+                (WallpaperManager) activity.getSystemService(Context.WALLPAPER_SERVICE);
+            WallpaperManager anotherActivityWallpaperManager =
+                (WallpaperManager) activity.getSystemService(Context.WALLPAPER_SERVICE);
+            assertThat(anotherActivityWallpaperManager).isSameInstanceAs(activityWallpaperManager);
+          });
+    }
+  }
+
+  @Test
+  public void wallpaperManager_instance_retrievesSameWallpaper() {
+    assumeTrue(isWallpaperSupported);
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            WallpaperManager activityWallpaperManager =
+                (WallpaperManager) activity.getSystemService(Context.WALLPAPER_SERVICE);
+
+            WallpaperInfo applicationWallpaper = wallpaperManager.getWallpaperInfo();
+            WallpaperInfo activityWallpaper = activityWallpaperManager.getWallpaperInfo();
+
+            assertThat(activityWallpaper).isEqualTo(applicationWallpaper);
+          });
+    }
+  }
+}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWallpaperManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWallpaperManager.java
@@ -34,24 +34,25 @@ import javax.annotation.Nullable;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
 import org.robolectric.util.Logger;
 import org.xmlpull.v1.XmlPullParserException;
 
 @Implements(WallpaperManager.class)
 public class ShadowWallpaperManager {
   private static final String TAG = "ShadowWallpaperManager";
-  private Bitmap lockScreenImage = null;
-  private Bitmap homeScreenImage = null;
-  private boolean isWallpaperAllowed = true;
-  private boolean isWallpaperSupported = true;
-  private WallpaperInfo wallpaperInfo = null;
-  private final List<WallpaperCommandRecord> wallpaperCommandRecords = new ArrayList<>();
-  private AtomicInteger wallpaperId = new AtomicInteger(0);
-  private int lockScreenId;
-  private int homeScreenId;
+  private static Bitmap lockScreenImage = null;
+  private static Bitmap homeScreenImage = null;
+  private static boolean isWallpaperAllowed = true;
+  private static boolean isWallpaperSupported = true;
+  private static WallpaperInfo wallpaperInfo = null;
+  private static final List<WallpaperCommandRecord> wallpaperCommandRecords = new ArrayList<>();
+  private static AtomicInteger wallpaperId = new AtomicInteger(0);
+  private static int lockScreenId;
+  private static int homeScreenId;
 
-  private float wallpaperDimAmount = 0.0f;
-  private final ArrayList<Float> allWallpaperDimAmounts = new ArrayList<>();
+  private static float wallpaperDimAmount = 0.0f;
+  private static final ArrayList<Float> allWallpaperDimAmounts = new ArrayList<>();
 
   @Implementation
   protected void sendWallpaperCommand(
@@ -320,5 +321,20 @@ public class ShadowWallpaperManager {
       this.z = z;
       this.extras = extras;
     }
+  }
+
+  @Resetter
+  public static void reset() {
+    lockScreenImage = null;
+    homeScreenImage = null;
+    isWallpaperAllowed = true;
+    isWallpaperSupported = true;
+    wallpaperInfo = null;
+    wallpaperCommandRecords.clear();
+    wallpaperId.set(0);
+    lockScreenId = 0;
+    homeScreenId = 0;
+    wallpaperDimAmount = 0.0f;
+    allWallpaperDimAmounts.clear();
   }
 }


### PR DESCRIPTION
1.Converted instance fields to static fields to ensure proper state management. 
2.add tests for the same in ShadowWallpaperManagerTest. 
3.add tests for WallpaperManager instance behavior across application and activity contexts in ContextTest

### Overview

### Proposed Changes
