### PR TITLE
Rearrange API levels for unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-versions: [ '21,34', '22,23,33', '24,25,32', '26,27,28', '29,30,31', ]
+        api-versions: [ '21,22,23', '24,25,26', '27,28,29', '30,31,32', '33,34' ]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This commit reorders the API levels groups used in the `unit-tests` step of the `tests.yml` workflow.
They are now grouped chronologically.