### PR TITLE
Make-fields-of-ShadowWifiP2pManager-static-for-context-level-instance

### DIFF
--- a/integration_tests/ctesque/src/androidTest/java/android/app/WifiP2pManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/WifiP2pManagerTest.java
@@ -1,0 +1,108 @@
+package android.app;
+
+import static android.os.Looper.getMainLooper;
+import static com.google.common.truth.Truth.assertThat;
+
+import android.Manifest;
+import android.content.Context;
+import android.net.wifi.p2p.WifiP2pManager;
+import android.os.Build;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.GrantPermissionRule;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.testapp.TestActivity;
+
+@RunWith(AndroidJUnit4.class)
+public class WifiP2pManagerTest {
+
+  @Rule
+  public GrantPermissionRule mRuntimePermissionRule =
+      GrantPermissionRule.grant(
+          Manifest.permission.ACCESS_WIFI_STATE, Manifest.permission.CHANGE_WIFI_STATE);
+
+  @Test
+  public void wifiP2pManager_applicationInstance_isSameOrDifferentAsActivityInstance() {
+    WifiP2pManager applicationWifiP2pManager =
+        (WifiP2pManager)
+            ApplicationProvider.getApplicationContext().getSystemService(Context.WIFI_P2P_SERVICE);
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            WifiP2pManager activityWifiP2pManager =
+                (WifiP2pManager) activity.getSystemService(Context.WIFI_P2P_SERVICE);
+
+            if (Build.VERSION.SDK_INT >= 31) {
+              assertThat(applicationWifiP2pManager).isNotSameInstanceAs(activityWifiP2pManager);
+            } else {
+              assertThat(applicationWifiP2pManager).isSameInstanceAs(activityWifiP2pManager);
+            }
+          });
+    }
+  }
+
+  @Test
+  public void wifiP2pManager_activityInstance_isSameAsActivityInstance() {
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            WifiP2pManager activityWifiP2pManager =
+                (WifiP2pManager) activity.getSystemService(Context.WIFI_P2P_SERVICE);
+            WifiP2pManager anotherActivityWifiP2pManager =
+                (WifiP2pManager) activity.getSystemService(Context.WIFI_P2P_SERVICE);
+            assertThat(anotherActivityWifiP2pManager).isSameInstanceAs(activityWifiP2pManager);
+          });
+    }
+  }
+
+  @Test
+  public void wifiP2pManager_instance_retrievesSameGroupInfo() throws InterruptedException {
+    WifiP2pManager applicationWifiP2pManager =
+        (WifiP2pManager)
+            ApplicationProvider.getApplicationContext().getSystemService(Context.WIFI_P2P_SERVICE);
+    WifiP2pManager.Channel applicationChannel =
+        applicationWifiP2pManager.initialize(
+            ApplicationProvider.getApplicationContext(), getMainLooper(), null);
+
+    CountDownLatch latch = new CountDownLatch(2);
+    final String[] applicationGroupNameHolder = new String[1];
+    final String[] activityGroupNameHolder = new String[1];
+
+    applicationWifiP2pManager.requestGroupInfo(
+        applicationChannel,
+        group -> {
+          if (group != null) {
+            applicationGroupNameHolder[0] = group.getNetworkName();
+          }
+          latch.countDown();
+        });
+
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            WifiP2pManager activityWifiP2pManager =
+                (WifiP2pManager) activity.getSystemService(Context.WIFI_P2P_SERVICE);
+            WifiP2pManager.Channel activityChannel =
+                activityWifiP2pManager.initialize(activity, activity.getMainLooper(), null);
+
+            activityWifiP2pManager.requestGroupInfo(
+                activityChannel,
+                group -> {
+                  if (group != null) {
+                    activityGroupNameHolder[0] = group.getNetworkName();
+                  }
+                  latch.countDown();
+                });
+          });
+    }
+
+    latch.await(5, TimeUnit.SECONDS);
+
+    assertThat(applicationGroupNameHolder[0]).isEqualTo(activityGroupNameHolder[0]);
+  }
+}

--- a/integration_tests/ctesque/src/main/AndroidManifest.xml
+++ b/integration_tests/ctesque/src/main/AndroidManifest.xml
@@ -13,5 +13,8 @@
   <uses-permission android:name="android.permission.USE_BIOMETRIC" />
   <uses-permission android:name="android.permission.USE_BIOMETRIC" />
   <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+  <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+
   <application />
 </manifest>

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiP2pManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiP2pManager.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
 import org.robolectric.util.ReflectionHelpers;
 
 @Implements(WifiP2pManager.class)
@@ -19,12 +20,12 @@ public class ShadowWifiP2pManager {
 
   private static final int NO_FAILURE = -1;
 
-  private int listeningChannel;
-  private int operatingChannel;
-  private WifiP2pManager.GroupInfoListener groupInfoListener;
-  private Handler handler;
-  private int nextActionFailure = NO_FAILURE;
-  private Map<Channel, WifiP2pGroup> p2pGroupmap = new HashMap<>();
+  private static int listeningChannel;
+  private static int operatingChannel;
+  private static WifiP2pManager.GroupInfoListener groupInfoListener;
+  private static Handler handler;
+  private static int nextActionFailure = NO_FAILURE;
+  private static final Map<Channel, WifiP2pGroup> p2pGroupmap = new HashMap<>();
 
   public int getListeningChannel() {
     return listeningChannel;
@@ -104,5 +105,15 @@ public class ShadowWifiP2pManager {
 
   public void setGroupInfo(Channel channel, WifiP2pGroup wifiP2pGroup) {
     p2pGroupmap.put(channel, wifiP2pGroup);
+  }
+
+  @Resetter
+  public static void reset() {
+    listeningChannel = 0;
+    operatingChannel = 0;
+    groupInfoListener = null;
+    handler = null;
+    nextActionFailure = NO_FAILURE;
+    p2pGroupmap.clear();
   }
 }


### PR DESCRIPTION
1.Converted instance fields to static fields to ensure proper state management. 
2.add tests for the same in ShadowWifiP2pManagerManagerTest. 
3.add tests for WifiP2pManager instance behavior across application and activity contexts in ContextTest

### Overview

### Proposed Changes
