### PR TITLE
De-duplicate Javadoc config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,19 +84,19 @@ gradle.projectsEvaluated {
             " style=\"max-height: 18pt; vertical-align: sub;\"/></a></li></ul>"
     project.allprojects { p ->
         p.tasks.withType(Javadoc) {
+            failOnError = false
+
             options {
                 noTimestamp = true
                 links = [
                         "https://docs.oracle.com/javase/8/docs/api/",
                         "https://developer.android.com/reference/",
                 ]
-                // Set javadoc source to JDK 8 to avoid unnamed module problem
-                // when running aggregateJavadoc with OpenJDK 13+.
+                // Set Javadoc source to JDK 8 to avoid unnamed module problem
+                // when running 'aggregateJavadocs' with OpenJDK 13+.
                 source("8")
                 header = headerHtml
                 footer = headerHtml
-                // bottom = "<link rel=\"stylesheet\" href=\"http://robolectric.org/assets/css/main.css\">"
-                version = thisVersion
             }
         }
     }

--- a/buildSrc/src/main/java/org/robolectric/gradle/DeployedRoboJavaModulePlugin.kt
+++ b/buildSrc/src/main/java/org/robolectric/gradle/DeployedRoboJavaModulePlugin.kt
@@ -8,7 +8,6 @@ import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.javadoc.Javadoc
-import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.register
@@ -21,8 +20,7 @@ class DeployedRoboJavaModulePlugin : Plugin<Project> {
     project.pluginManager.apply("java-library")
     project.pluginManager.apply("maven-publish")
 
-    val projectVersion = project.version.toString()
-    val isSnapshotVersion = projectVersion.endsWith("-SNAPSHOT")
+    val isSnapshotVersion = project.version.toString().endsWith("-SNAPSHOT")
     val mavenArtifactName = project.path.substring(1).split(":").joinToString("-")
 
     project.extensions.configure<BasePluginExtension> {
@@ -46,28 +44,6 @@ class DeployedRoboJavaModulePlugin : Plugin<Project> {
           archiveClassifier.set("javadoc")
           from(javadocTask.map { it.destinationDir })
         }
-
-      project.tasks.withType<Javadoc> {
-        isFailOnError = false
-        source = sourceSets.getByName("main").allJava
-
-        val extraNavItem =
-          """
-          <ul class="navList">
-              <li>Robolectric $projectVersion | <a href="/">Home</a></li>
-          </ul>
-          """
-            .trimIndent()
-        val javadocOptions = options as StandardJavadocDocletOptions
-        javadocOptions.noTimestamp(true)
-        javadocOptions.header = extraNavItem
-        javadocOptions.footer = extraNavItem
-        javadocOptions.bottom =
-          """
-          <link rel="stylesheet" href="https://robolectric.org/assets/css/main.css">
-          """
-            .trimIndent()
-      }
 
       project.extensions.configure<PublishingExtension> {
         publications {


### PR DESCRIPTION
The configuration of the Javadoc tasks was done in two places: the root `build.gradle` file and the `DeployedRoboJavaModulePlugin` plugin.

However, it seems that only the configuration in the root `build.gradle` file was taken into consideration.

This PR updates the project to only keep the configuration from the root `build.gradle` file.

- This closes https://github.com/robolectric/robolectric.github.io/issues/276, since `assets/css/main.css` was actually no longer used.
- This also answers https://github.com/robolectric/robolectric/pull/9430#discussion_r1711298195: the `version` was set on the project. It has nothing to do with Javadoc, and it's still done here: https://github.com/robolectric/robolectric/blob/e24baa272f30bc21b2aab78f16e18c0ce94a7dcd/build.gradle#L28