### PR TITLE
Update naming for ShadowPausedMessageQueue.nativePollOnce

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedMessageQueue.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedMessageQueue.java
@@ -76,13 +76,13 @@ public class ShadowPausedMessageQueue extends ShadowMessageQueue {
     ShadowPausedSystemClock.removeListener(q.clockListener);
   }
 
-  @Implementation(maxSdk = LOLLIPOP_MR1)
-  protected static void nativePollOnce(long ptr, int timeoutMillis) {
-    nativeQueueRegistry.getNativeObject(ptr).nativePollOnceFromM(ptr, timeoutMillis);
+  @Implementation(maxSdk = LOLLIPOP_MR1, methodName = "nativePollOnce")
+  protected static void nativePollOncePreM(long ptr, int timeoutMillis) {
+    nativeQueueRegistry.getNativeObject(ptr).nativePollOnce(ptr, timeoutMillis);
   }
 
-  @Implementation(minSdk = M, methodName = "nativePollOnce")
-  protected void nativePollOnceFromM(long ptr, int timeoutMillis) {
+  @Implementation(minSdk = M)
+  protected void nativePollOnce(long ptr, int timeoutMillis) {
     if (timeoutMillis == 0) {
       return;
     }


### PR DESCRIPTION
Use the name 'nativePollOnce' for the current (M+) method, and use a custom name for the method on older SDKs. This will enable the faster path for modern and more widely used SDK levels.
