### PR TITLE
Remove custom CSS from the generated Javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,6 @@ gradle.projectsEvaluated {
                 source("8")
                 header = headerHtml
                 footer = headerHtml
-                // bottom = "<link rel=\"stylesheet\" href=\"http://robolectric.org/assets/css/main.css\">"
                 version = thisVersion
             }
         }

--- a/buildSrc/src/main/java/org/robolectric/gradle/DeployedRoboJavaModulePlugin.kt
+++ b/buildSrc/src/main/java/org/robolectric/gradle/DeployedRoboJavaModulePlugin.kt
@@ -62,11 +62,6 @@ class DeployedRoboJavaModulePlugin : Plugin<Project> {
         javadocOptions.noTimestamp(true)
         javadocOptions.header = extraNavItem
         javadocOptions.footer = extraNavItem
-        javadocOptions.bottom =
-          """
-          <link rel="stylesheet" href="https://robolectric.org/assets/css/main.css">
-          """
-            .trimIndent()
       }
 
       project.extensions.configure<PublishingExtension> {


### PR DESCRIPTION
This PR removes the custom CSS linked in the generated Javadoc Jar. That CSS file is no longer available since the new website: https://github.com/robolectric/robolectric.github.io/pull/212 
This closes https://github.com/robolectric/robolectric.github.io/issues/276