### PR TITLE
dev: Add basic devcontainer for GitHub Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,58 @@
+# Modified from https://github.com/iwahjoedi/android-devcontainer/blob/main/Image/Dockerfile
+ARG VARIENT="ubuntu-22.04"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIENT}
+
+ENV DEVCONTAINER="true"
+
+RUN apt clean && apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y upgrade \
+    && apt-get -y install git \
+    && apt-get -y install clang cmake ninja-build pkg-config \
+    && apt-get -y install wget unzip \
+    && apt-get -y install openjdk-17-jdk \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG USERNAME=vscode
+
+USER $USERNAME
+
+RUN export HOME="/home/$USERNAME"
+ARG HOME="/home/$USERNAME"
+ENV ANDROID_HOME=/home/$USERNAME/Android/Sdk
+ENV ANDROID_SDK_ROOT=/home/$USERNAME/Android/Sdk
+ENV CMDLINE_HOME="${HOME}/Android/Sdk/cmdline-tools"
+ENV CMDLINE="${HOME}/Android/Sdk/cmdline-tools/cmdline-tools/bin"
+ENV ANDROID_SDK_ZIP_FILE_VERSION=11076708
+
+# setup flutter sdk
+ENV PATH=${PATH}:${ANDROID_HOME}/platform-tools
+ENV PATH=${PATH}:${ANDROID_HOME}/platforms
+ENV PATH=${PATH}:${ANDROID_HOME}/emulators
+ENV PATH=${PATH}:${CMDLINE_HOME}:${CMDLINE}
+
+RUN ls -la ~ && whoami && mkdir -pv ${CMDLINE_HOME} && cd ${CMDLINE_HOME} \
+    && wget https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_ZIP_FILE_VERSION}_latest.zip \
+    && unzip commandlinetools-linux-${ANDROID_SDK_ZIP_FILE_VERSION}_latest.zip \
+    && rm commandlinetools-linux-${ANDROID_SDK_ZIP_FILE_VERSION}_latest.zip
+
+RUN ls -la ${HOME}/ && ls -la ${CMDLINE_HOME} && echo ${CMDLINE_HOME} && chown -Rv $USERNAME:$USERNAME ${HOME}/Android/Sdk
+RUN chmod +r+w+x -Rv ${HOME}/Android/Sdk
+
+RUN yes | sdkmanager --licenses
+RUN yes | sdkmanager --install "build-tools;34.0.0"
+RUN yes | sdkmanager --install "platforms;android-21"
+RUN yes | sdkmanager --install "platforms;android-22"
+RUN yes | sdkmanager --install "platforms;android-23"
+RUN yes | sdkmanager --install "platforms;android-24"
+RUN yes | sdkmanager --install "platforms;android-25"
+RUN yes | sdkmanager --install "platforms;android-26"
+RUN yes | sdkmanager --install "platforms;android-27"
+RUN yes | sdkmanager --install "platforms;android-28"
+RUN yes | sdkmanager --install "platforms;android-29"
+RUN yes | sdkmanager --install "platforms;android-30"
+RUN yes | sdkmanager --install "platforms;android-31"
+RUN yes | sdkmanager --install "platforms;android-32"
+RUN yes | sdkmanager --install "platforms;android-33"
+RUN yes | sdkmanager --install "platforms;android-34"
+RUN yes | sdkmanager --install "platform-tools" "cmdline-tools;latest"

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,33 @@
+# GitHub's Codespaces Configuration
+
+GitHub Codespaces is the vscode-based cloud development environment for GitHub
+projects. We can use [devcontainer][devcontainer-introduction] to configure
+containers for GitHub Codespaces when opening Robolectric project from it.
+
+As Robolectric there are special requirements for Android SDK and `ANDROID_SDK_HOME`
+environment variable for building, Robolectric selects
+[`Dockerfile`][devcontainer-introduction-docker] to configure necessary Android
+environment for itself.
+
+Any contributor can update it based on the demand. When we update `Dockerfile`, we can run
+the following command to build and test it locally:
+
+```shell
+cd .devcontainer
+docker buildx build .
+```
+
+> See [Docker's buildx repository][docker-buildx] to install buildx.
+
+When local testing is passed, we can push it to remote custom branch, and checkout it
+with latest change in GitHub's Codespaces page and then trigger "Rebuild Container" to
+test its configuration in GitHub's Codespaces environment.
+
+If everything goes well, sending the PR and wait the merging.
+
+Because devcontainer is brought by VSCode, this configuration can also be used
+for VSCode.
+
+[devcontainer-introduction]: https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers
+[devcontainer-introduction-docker]: https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers#dockerfile
+[docker-buildx]: https://github.com/docker/buildx

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "build": {
+    "args": {
+      "VARIENT": "ubuntu-22.04"
+    },
+    "dockerfile": "Dockerfile"
+  },
+  "name": "robolectric-dev",
+  "remoteUser": "vscode"
+}

--- a/buildSrc/src/main/java/org/robolectric/gradle/SpotlessPlugin.kt
+++ b/buildSrc/src/main/java/org/robolectric/gradle/SpotlessPlugin.kt
@@ -24,6 +24,19 @@ class SpotlessPlugin : Plugin<Project> {
 
       // Add configurations for Groovy Gradle files
       groovyGradle { target("*.gradle", "**/*.gradle") }
+
+      // Only apply yaml and json formatting for root project
+      // to avoid some files are added into multiple project's spotless targets.
+      if (project.rootProject == project) {
+        // Add configurations for JSON files
+        json {
+          target("**/*.json")
+          gson()
+            .indentWithSpaces(2) // Follow code's indent.
+            .sortByKeys()
+            .escapeHtml()
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
I am trying to test coding with Android on large screen. And the first choice is to leverage GitHub's Codespaces. To build and run tests of Robolectric, we need to configure special environment of devcontainer for GitHub's Codespaces. Hope it can be helpful for other contributors who are interested in GitHub's Codespaces.