### PR TITLE
Remove Groovy-specific config

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins { `kotlin-dsl` }
 
@@ -52,6 +51,4 @@ java {
   targetCompatibility = JavaVersion.VERSION_11
 }
 
-tasks.withType<KotlinCompile>().configureEach {
-  kotlinOptions { options.jvmTarget = JvmTarget.JVM_11 }
-}
+kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_11 } }

--- a/buildSrc/src/main/java/AndroidSdk.kt
+++ b/buildSrc/src/main/java/AndroidSdk.kt
@@ -50,38 +50,24 @@ class AndroidSdk(
   companion object {
     private const val PREINSTRUMENTED_VERSION = 6
 
-    @JvmField val LOLLIPOP = AndroidSdk(21, "5.0.2_r3", "r0")
+    val LOLLIPOP = AndroidSdk(21, "5.0.2_r3", "r0")
+    val LOLLIPOP_MR1 = AndroidSdk(22, "5.1.1_r9", "r2")
+    val M = AndroidSdk(23, "6.0.1_r3", "r1")
+    val N = AndroidSdk(24, "7.0.0_r1", "r1")
+    val N_MR1 = AndroidSdk(25, "7.1.0_r7", "r1")
+    val O = AndroidSdk(26, "8.0.0_r4", "r1")
+    val O_MR1 = AndroidSdk(27, "8.1.0", "4611349")
+    val P = AndroidSdk(28, "9", "4913185-2")
+    val Q = AndroidSdk(29, "10", "5803371")
+    val R = AndroidSdk(30, "11", "6757853")
+    val S = AndroidSdk(31, "12", "7732740")
+    val S_V2 = AndroidSdk(32, "12.1", "8229987")
+    val TIRAMISU = AndroidSdk(33, "13", "9030017")
+    val U = AndroidSdk(34, "14", "10818077")
 
-    @JvmField val LOLLIPOP_MR1 = AndroidSdk(22, "5.1.1_r9", "r2")
-
-    @JvmField val M = AndroidSdk(23, "6.0.1_r3", "r1")
-
-    @JvmField val N = AndroidSdk(24, "7.0.0_r1", "r1")
-
-    @JvmField val N_MR1 = AndroidSdk(25, "7.1.0_r7", "r1")
-
-    @JvmField val O = AndroidSdk(26, "8.0.0_r4", "r1")
-
-    @JvmField val O_MR1 = AndroidSdk(27, "8.1.0", "4611349")
-
-    @JvmField val P = AndroidSdk(28, "9", "4913185-2")
-
-    @JvmField val Q = AndroidSdk(29, "10", "5803371")
-
-    @JvmField val R = AndroidSdk(30, "11", "6757853")
-
-    @JvmField val S = AndroidSdk(31, "12", "7732740")
-
-    @JvmField val S_V2 = AndroidSdk(32, "12.1", "8229987")
-
-    @JvmField val TIRAMISU = AndroidSdk(33, "13", "9030017")
-
-    @JvmField val U = AndroidSdk(34, "14", "10818077")
-
-    @JvmField
     val ALL_SDKS =
       listOf(LOLLIPOP, LOLLIPOP_MR1, M, N, N_MR1, O, O_MR1, P, Q, R, S, S_V2, TIRAMISU, U)
 
-    @JvmField val MAX_SDK = ALL_SDKS.maxBy { it.apiLevel }
+    val MAX_SDK = ALL_SDKS.maxBy { it.apiLevel }
   }
 }

--- a/buildSrc/src/main/java/org/robolectric/gradle/AggregateJavadocPlugin.kt
+++ b/buildSrc/src/main/java/org/robolectric/gradle/AggregateJavadocPlugin.kt
@@ -30,9 +30,9 @@ class AggregateJavadocPlugin : Plugin<Project> {
           dependsOn(javadocTasks)
           source(javadocTasks.map { it.source })
 
-          val buildDirectory = rootProject.layout.buildDirectory.get().asFile.path
+          val javadocDirectory = rootProject.layout.buildDirectory.dir("docs/javadoc").get().asFile
 
-          setDestinationDir(rootProject.file("$buildDirectory/docs/javadoc"))
+          setDestinationDir(javadocDirectory)
           classpath = rootProject.files(javadocTasks.map { it.classpath })
         }
       }

--- a/buildSrc/src/main/java/org/robolectric/gradle/SpotlessPlugin.kt
+++ b/buildSrc/src/main/java/org/robolectric/gradle/SpotlessPlugin.kt
@@ -22,9 +22,6 @@ class SpotlessPlugin : Plugin<Project> {
         ktfmt("0.49").googleStyle()
       }
 
-      // Add configurations for Groovy Gradle files
-      groovyGradle { target("*.gradle", "**/*.gradle") }
-
       // Only apply yaml and json formatting for root project
       // to avoid some files are added into multiple project's spotless targets.
       if (project.rootProject == project) {

--- a/errorprone/build.gradle.kts
+++ b/errorprone/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 }
 
 // Disable annotation processor for tests
-tasks.named<JavaCompile>("compileTestJava").configure { options.compilerArgs.add("-proc:none") }
+tasks.compileTestJava.configure { options.compilerArgs.add("-proc:none") }
 
-tasks.named<Test>("test").configure { enabled = false }
+tasks.test.configure { enabled = false }
 
 dependencies {
   // Project dependencies

--- a/integration_tests/jacoco-offline/build.gradle.kts
+++ b/integration_tests/jacoco-offline/build.gradle.kts
@@ -26,7 +26,7 @@ val jacocoInstrumentedClassesOutputDir =
 
 // Make sure it's evaluated after the AGP evaluation.
 afterEvaluate {
-  tasks.named<Task>("classes").configure {
+  tasks.classes.configure {
     doLast {
       logger.debug("[JaCoCo] Generating JaCoCo instrumented classes for the build.")
 

--- a/integration_tests/kotlin/build.gradle.kts
+++ b/integration_tests/kotlin/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.detekt)
@@ -8,13 +7,9 @@ plugins {
   alias(libs.plugins.robolectric.spotless)
 }
 
-tasks.named<KotlinCompile>("compileKotlin").configure {
-  compilerOptions.jvmTarget = JvmTarget.JVM_1_8
-}
+tasks.compileKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
-tasks.named<KotlinCompile>("compileTestKotlin").configure {
-  compilerOptions.jvmTarget = JvmTarget.JVM_1_8
-}
+tasks.compileTestKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
 val axtCoreVersion: String by rootProject.extra
 

--- a/integration_tests/mockito-kotlin/build.gradle.kts
+++ b/integration_tests/mockito-kotlin/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.detekt)
@@ -8,13 +7,9 @@ plugins {
   alias(libs.plugins.robolectric.spotless)
 }
 
-tasks.named<KotlinCompile>("compileKotlin").configure {
-  compilerOptions.jvmTarget = JvmTarget.JVM_1_8
-}
+tasks.compileKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
-tasks.named<KotlinCompile>("compileTestKotlin").configure {
-  compilerOptions.jvmTarget = JvmTarget.JVM_1_8
-}
+tasks.compileTestKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
 val axtJunitVersion: String by rootProject.extra
 

--- a/integration_tests/mockk/build.gradle.kts
+++ b/integration_tests/mockk/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.detekt)
@@ -8,13 +7,9 @@ plugins {
   alias(libs.plugins.robolectric.spotless)
 }
 
-tasks.named<KotlinCompile>("compileKotlin").configure {
-  compilerOptions.jvmTarget = JvmTarget.JVM_1_8
-}
+tasks.compileKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
-tasks.named<KotlinCompile>("compileTestKotlin").configure {
-  compilerOptions.jvmTarget = JvmTarget.JVM_1_8
-}
+tasks.compileTestKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
 dependencies {
   api(project(":robolectric"))

--- a/plugins/maven-dependency-resolver/build.gradle.kts
+++ b/plugins/maven-dependency-resolver/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.detekt)
@@ -15,9 +14,9 @@ tasks.withType<GenerateModuleMetadata>().configureEach {
   enabled = false
 }
 
-tasks.named<KotlinCompile>("compileKotlin") { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
+tasks.compileKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
-tasks.named<KotlinCompile>("compileTestKotlin") { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
+tasks.compileTestKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
 dependencies {
   api(project(":pluginapi"))

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -35,7 +35,7 @@ val generateSdksFile by
     outFile = project.rootProject.layout.buildDirectory.file("sdks.txt").get().asFile
   }
 
-tasks.named("classes").configure { dependsOn(generateSdksFile) }
+tasks.classes.configure { dependsOn(generateSdksFile) }
 
 dependencies {
   api(project(":annotations"))

--- a/shadows/framework/build.gradle.kts
+++ b/shadows/framework/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.jvm.tasks.Jar
-
 plugins {
   alias(libs.plugins.robolectric.deployed.java.module)
   alias(libs.plugins.robolectric.java.module)
@@ -37,9 +35,9 @@ val copySqliteNatives by
     into(project.file(layout.buildDirectory.dir("resources/main/sqlite4java")))
   }
 
-tasks.named<Jar>("jar") { dependsOn(copySqliteNatives) }
+tasks.jar.configure { dependsOn(copySqliteNatives) }
 
-tasks.named<Javadoc>("javadoc") { dependsOn(copySqliteNatives) }
+tasks.javadoc.configure { dependsOn(copySqliteNatives) }
 
 val axtMonitorVersion: String by rootProject.extra
 

--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.detekt)
@@ -15,9 +14,9 @@ tasks.withType<GenerateModuleMetadata>().configureEach {
   enabled = false
 }
 
-tasks.named<KotlinCompile>("compileKotlin") { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
+tasks.compileKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
-tasks.named<KotlinCompile>("compileTestKotlin") { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
+tasks.compileTestKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
 dependencies {
   api(project(":annotations"))


### PR DESCRIPTION
These are no longer necessary now that every Gradle file is in Kotlin.

This PR also simplifies access to some tasks.