### PR TITLE
Update the main `Readme` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a name="README">[<img src="https://rawgithub.com/robolectric/robolectric/master/images/robolectric-horizontal.png"/>](http://robolectric.org)</a>
+<a name="README">[<img src="https://rawgithub.com/robolectric/robolectric/master/images/robolectric-horizontal.png"/>](https://robolectric.org)</a>
 
 [![Build Status](https://github.com/robolectric/robolectric/actions/workflows/tests.yml/badge.svg)](https://github.com/robolectric/robolectric/actions?query=workflow%3Atests)
 [![GitHub release](https://img.shields.io/github/release/robolectric/robolectric.svg?maxAge=60)](https://github.com/robolectric/robolectric/releases)
@@ -28,64 +28,42 @@ public class MyActivityTest {
 }
 ```
 
-For more information about how to install and use Robolectric on your project, extend its functionality, and join the community of contributors, please visit [http://robolectric.org](http://robolectric.org).
+For more information about how to install and use Robolectric on your project, extend its functionality, and join the community of contributors, please visit [robolectric.org](https://robolectric.org).
 
 ## Install
 
 ### Starting a New Project
 
-If you'd like to start a new project with Robolectric tests you can refer to `deckard` (for either [maven](http://github.com/robolectric/deckard-maven) or [gradle](http://github.com/robolectric/deckard-gradle)) as a guide to setting up both Android and Robolectric on your machine.
+If you'd like to start a new project with Robolectric tests, you can refer to `deckard` (for either [Maven](https://github.com/robolectric/deckard-maven) or [Gradle](https://github.com/robolectric/deckard-gradle)) as a guide to setting up both Android and Robolectric on your machine.
 
-#### build.gradle:
+### `build.gradle`
 
 ```groovy
 testImplementation "junit:junit:4.13.2"
 testImplementation "org.robolectric:robolectric:4.13"
 ```
 
-## Building And Contributing
+## Building and Contributing
 
-Robolectric is built using Gradle. Both IntelliJ and Android Studio can import the top-level `build.gradle` file and will automatically generate their project files from it.
+Robolectric is built using Gradle. Both Android Studio and IntelliJ can import the top-level `build.gradle.kts` file and will automatically generate their project files from it.
+
+To get Robolectric up and running on your machine, check out
+[this guide](https://robolectric.org/building-robolectric/).
 
 To get a high-level overview of Robolectric's architecture, check out
 [ARCHITECTURE.md](ARCHITECTURE.md).
 
-### Prerequisites
+## Using Snapshots
 
-See [Building Robolectric](http://robolectric.org/building-robolectric/) for more details about setting up a build environment for Robolectric.
+If you would like to live on the bleeding edge, you can try running against a snapshot build. Keep in mind that snapshots represent the most recent changes on the `master` and may contain bugs.
 
-### Building
-
-Robolectric supports running tests against multiple Android API levels. The work it must do to support each API level is slightly different, so its shadows are built separately for each. To build shadows for every API version, run:
-
-    ./gradlew clean assemble testClasses --parallel
-
-### Testing
-
-Run tests for all API levels:
-
-> The fully tests could consume more than 16G memory(total of physical and virtual memory).
-
-    ./gradlew test --parallel
-
-Run tests for part of supported API levels, e.g. run tests for API level 26, 27, 28:
-
-    ./gradlew test --parallel "-Drobolectric.enabledSdks=26,27,28"
-
-Run compatibility test suites on opening Emulator:
-
-    ./gradlew connectedCheck
-
-### Using Snapshots
-
-If you would like to live on the bleeding edge, you can try running against a snapshot build. Keep in mind that snapshots represent the most recent changes on master and may contain bugs.
-
-#### build.gradle:
+### `build.gradle`
 
 ```groovy
 repositories {
     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 }
+
 dependencies {
     testImplementation "org.robolectric:robolectric:4.14-SNAPSHOT"
 }


### PR DESCRIPTION
The main change here is to promote the new [`Building Robolectric`](https://robolectric.org/building-robolectric/) page on the website, instead of duplicating the instructions.

I've also updated some wording and switched links to https.