### PR TITLE
Update some method signatures after ClassName migration

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativePaint.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativePaint.java
@@ -517,13 +517,13 @@ public class ShadowNativePaint {
     return PaintNatives.nSetMaskFilter(paintPtr, maskfilter);
   }
 
-  @Implementation(minSdk = P, maxSdk = U.SDK_INT, methodName = "nSetTypeface")
-  protected static void nSetTypefaceFromPie(long paintPtr, long typeface) {
+  @Implementation(minSdk = P, maxSdk = U.SDK_INT)
+  protected static void nSetTypeface(long paintPtr, long typeface) {
     PaintNatives.nSetTypeface(paintPtr, typeface);
   }
 
-  @Implementation(minSdk = O, maxSdk = O_MR1)
-  protected static long nSetTypeface(long paintPtr, long typeface) {
+  @Implementation(minSdk = O, maxSdk = O_MR1, methodName = "nSetTypeface")
+  protected static long nSetTypefacePrePie(long paintPtr, long typeface) {
     PaintNatives.nSetTypeface(paintPtr, typeface);
     return paintPtr;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkCapabilities.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNetworkCapabilities.java
@@ -97,8 +97,8 @@ public class ShadowNetworkCapabilities {
 
   /** Sets the LinkDownstreamBandwidthKbps of the NetworkCapabilities. */
   @HiddenApi
-  @Implementation(maxSdk = O_MR1)
-  public void setLinkDownstreamBandwidthKbps(int kbps) {
+  @Implementation(maxSdk = O_MR1, methodName = "setLinkDownstreamBandwidthKbps")
+  protected void setLinkDownstreamBandwidthKbpsPrePie(int kbps) {
     reflector(NetworkCapabilitiesReflector.class, realNetworkCapabilities)
         .setLinkDownstreamBandwidthKbps(kbps);
   }
@@ -106,11 +106,11 @@ public class ShadowNetworkCapabilities {
   /**
    * Sets the LinkDownstreamBandwidthKbps of the NetworkCapabilities.
    *
-   * <p>Return type changed to {@code NetworkCapabilities} start from Pie.
+   * <p>Return type changed to {@code NetworkCapabilities} starting from Pie.
    */
   @HiddenApi
-  @Implementation(minSdk = P, methodName = "setLinkDownstreamBandwidthKbps")
-  public NetworkCapabilities setLinkDownstreamBandwidthKbpsFromPie(int kbps) {
+  @Implementation(minSdk = P)
+  public NetworkCapabilities setLinkDownstreamBandwidthKbps(int kbps) {
     return reflector(NetworkCapabilitiesReflector.class, realNetworkCapabilities)
         .setLinkDownstreamBandwidthKbps(kbps);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
@@ -869,7 +869,7 @@ public class ShadowWifiManager {
   }
 
   @Implementation(minSdk = TIRAMISU)
-  public void setExternalPnoScanRequest(
+  protected void setExternalPnoScanRequest(
       @ClassName("java.util.List") Object ssids,
       int[] frequencies,
       Executor executor,


### PR DESCRIPTION
* ShadowWifiManager.setExternalPnoScanRequest should be protected, not public
* ShadowNetworkCapabilities.setLinkDownstreamBandwidthKbps should be the P+ version
* ShadowNativeTypeface.nSetTypeface should be the P+ version
