### PR TITLE
Add Javadoc for files that have been recently modified

### DIFF
--- a/integration_tests/ctesque/src/androidTest/java/android/app/CarrierConfigManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/CarrierConfigManagerTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link CarrierConfigManager}. */
 @RunWith(AndroidJUnit4.class)
 public class CarrierConfigManagerTest {
 

--- a/integration_tests/ctesque/src/androidTest/java/android/app/ConnectivityManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/ConnectivityManagerTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link ConnectivityManager}. */
 @RunWith(AndroidJUnit4.class)
 public class ConnectivityManagerTest {
 

--- a/integration_tests/ctesque/src/androidTest/java/android/app/ContextTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/ContextTest.java
@@ -66,6 +66,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 import org.robolectric.util.ReflectionHelpers;
 
+/** Compatibility test for {@link Context}. */
 @RunWith(AndroidJUnit4.class)
 public class ContextTest {
   private static final int APP_WIDGET_HOST_ID = 1;

--- a/integration_tests/ctesque/src/androidTest/java/android/app/FileIntegrityManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/FileIntegrityManagerTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link FileIntegrityManager}. */
 @RunWith(AndroidJUnit4.class)
 @SdkSuppress(minSdkVersion = Build.VERSION_CODES.TIRAMISU)
 public class FileIntegrityManagerTest {

--- a/integration_tests/ctesque/src/androidTest/java/android/app/InputMethodManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/InputMethodManagerTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link InputMethodManager}. */
 @RunWith(AndroidJUnit4.class)
 public class InputMethodManagerTest {
   @Test

--- a/integration_tests/ctesque/src/androidTest/java/android/app/LocaleManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/LocaleManagerTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link LocaleManager}. */
 @RunWith(AndroidJUnit4.class)
 @SdkSuppress(minSdkVersion = Build.VERSION_CODES.TIRAMISU)
 public class LocaleManagerTest {

--- a/integration_tests/ctesque/src/androidTest/java/android/app/MediaSessionManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/MediaSessionManagerTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link MediaSessionManager}. */
 @RunWith(AndroidJUnit4.class)
 public class MediaSessionManagerTest {
 

--- a/integration_tests/ctesque/src/androidTest/java/android/app/NotificationManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/NotificationManagerTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link NotificationManager}. */
 @RunWith(AndroidJUnit4.class)
 public class NotificationManagerTest {
 

--- a/integration_tests/ctesque/src/androidTest/java/android/app/PowerManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/PowerManagerTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link PowerManager}. */
 @RunWith(AndroidJUnit4.class)
 public class PowerManagerTest {
 

--- a/integration_tests/ctesque/src/androidTest/java/android/app/RestrictionsManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/RestrictionsManagerTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link RestrictionsManager}. */
 @RunWith(AndroidJUnit4.class)
 public class RestrictionsManagerTest {
 

--- a/integration_tests/ctesque/src/androidTest/java/android/app/SearchManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/SearchManagerTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link SearchManager}. */
 @RunWith(AndroidJUnit4.class)
 public class SearchManagerTest {
 

--- a/integration_tests/ctesque/src/androidTest/java/android/app/ShortcutManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/ShortcutManagerTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link ShortcutManager}. */
 @RunWith(AndroidJUnit4.class)
 public class ShortcutManagerTest {
 

--- a/integration_tests/ctesque/src/androidTest/java/android/app/TelecomManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/TelecomManagerTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link TelecomManager}. */
 @RunWith(AndroidJUnit4.class)
 public class TelecomManagerTest {
 

--- a/integration_tests/ctesque/src/androidTest/java/android/app/TranslationManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/TranslationManagerTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link TranslationManager}. */
 @RunWith(AndroidJUnit4.class)
 @SdkSuppress(minSdkVersion = Build.VERSION_CODES.S)
 public class TranslationManagerTest {

--- a/integration_tests/ctesque/src/androidTest/java/android/app/VcnManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/VcnManagerTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link VcnManager}. */
 @SdkSuppress(minSdkVersion = Build.VERSION_CODES.S)
 @RunWith(AndroidJUnit4.class)
 public class VcnManagerTest {

--- a/integration_tests/ctesque/src/androidTest/java/android/app/VirtualDeviceManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/VirtualDeviceManagerTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link VirtualDeviceManager}. */
 @RunWith(AndroidJUnit4.class)
 @SdkSuppress(minSdkVersion = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 public class VirtualDeviceManagerTest {

--- a/integration_tests/ctesque/src/androidTest/java/android/app/VpnManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/VpnManagerTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link VpnManager}. */
 @RunWith(AndroidJUnit4.class)
 @SdkSuppress(minSdkVersion = R)
 public class VpnManagerTest {

--- a/integration_tests/ctesque/src/androidTest/java/android/app/WallpaperManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/WallpaperManagerTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link WallpaperManager}. */
 @RunWith(AndroidJUnit4.class)
 public class WallpaperManagerTest {
   private WallpaperManager wallpaperManager;

--- a/integration_tests/ctesque/src/androidTest/java/android/app/WifiAwareManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/WifiAwareManagerTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link WifiAwareManager}. */
 @RunWith(AndroidJUnit4.class)
 public class WifiAwareManagerTest {
   private final Context application = ApplicationProvider.getApplicationContext();

--- a/integration_tests/ctesque/src/androidTest/java/android/app/WifiP2pManagerTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/WifiP2pManagerTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.testapp.TestActivity;
 
+/** Compatibility test for {@link WifiP2pManager}. */
 @RunWith(AndroidJUnit4.class)
 public class WifiP2pManagerTest {
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
@@ -43,6 +43,7 @@ import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
 import org.robolectric.util.reflector.Reflector;
 
+/** Shadow for {@link ActivityThread}. */
 @Implements(value = ActivityThread.class, isInAndroidSdk = false)
 public class ShadowActivityThread {
   private static ApplicationInfo applicationInfo;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -127,6 +127,7 @@ import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 
+/** Shadow for {@link ApplicationPackageManager}. */
 @Implements(value = ApplicationPackageManager.class, isInAndroidSdk = false)
 public class ShadowApplicationPackageManager extends ShadowPackageManager {
   /** Package name of the Android platform. */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
@@ -72,7 +72,8 @@ import org.robolectric.annotation.Resetter;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.versioning.AndroidVersions.U;
 
-@Implements(value = DevicePolicyManager.class)
+/** Shadow for {@link DevicePolicyManager}. */
+@Implements(DevicePolicyManager.class)
 @SuppressLint("NewApi")
 public class ShadowDevicePolicyManager {
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowHardwareRenderer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowHardwareRenderer.java
@@ -14,6 +14,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
 import org.robolectric.shadow.api.Shadow;
 
+/** No-op shadow for {@link HardwareRenderer}. */
 @Implements(value = HardwareRenderer.class, isInAndroidSdk = false, minSdk = Q)
 public class ShadowHardwareRenderer {
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
@@ -29,6 +29,7 @@ import org.robolectric.annotation.Resetter;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
+/** Shadow for {@link SensorManager}. */
 @Implements(value = SensorManager.class)
 public class ShadowSensorManager {
   public static boolean forceListenersToFail = false;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
@@ -81,6 +81,7 @@ import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.versioning.AndroidVersions.U;
 import org.robolectric.versioning.AndroidVersions.V;
 
+/** Shadow for {@link TelephonyManager}. */
 @Implements(value = TelephonyManager.class)
 public class ShadowTelephonyManager {
 


### PR DESCRIPTION
The Google Linter is strict about Javadoc for recently added or edited files. Add some Javadoc for files that have been modified during the ClassName migration or Activity Context project.
