### PR TITLE
Fix WakeLock.toString throws NPE

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPowerManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPowerManagerTest.java
@@ -54,6 +54,16 @@ public class ShadowPowerManagerTest {
   }
 
   @Test
+  public void toString_shouldWork() {
+    PowerManager.WakeLock lock = powerManager.newWakeLock(0, "TAG");
+    assertThat(lock.toString()).contains("held=false");
+    lock.acquire();
+    assertThat(lock.toString()).contains("held=true");
+    lock.release();
+    assertThat(lock.toString()).contains("held=false");
+  }
+
+  @Test
   public void acquire_shouldAcquireAndReleaseReferenceCountedLock() {
     PowerManager.WakeLock lock = powerManager.newWakeLock(0, "TAG");
     assertThat(lock.isHeld()).isFalse();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
@@ -537,6 +537,16 @@ public class ShadowPowerManager {
       return !timeoutTimestampList.isEmpty();
     }
 
+    @Override
+    @Implementation
+    public String toString() {
+      return "WakeLock{"
+          + Integer.toHexString(System.identityHashCode(this))
+          + " held="
+          + isHeld()
+          + "}";
+    }
+
     /**
      * Retrieves if the wake lock is reference counted or not
      *


### PR DESCRIPTION
### Overview
Fixes #9566 

### Proposed Changes
Android SDK has the following WakeLock.toString implementation:
```
public String toString() {
    synchronized(this.mToken) {
        return "WakeLock{" + Integer.toHexString(System.identityHashCode(this)) + " held=" + this.mHeld + ", refCount=" + this.mInternalCount + "}";
     }
}
```

Current proposal is to add similar implementation where at least `hash` and `held` properties are included.
To add `refCount` is more complex solution so I decided to not include it.

As a result here is the example WakeLock.toString() output:
```
WakeLock{257510f9 held=false}
```
