### PR TITLE
Fix edge case when using `@Implementation(methodName=...)`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/MethodNameTest.java
+++ b/robolectric/src/test/java/org/robolectric/MethodNameTest.java
@@ -1,0 +1,35 @@
+package org.robolectric;
+
+import static android.os.Build.VERSION_CODES.LOLLIPOP;
+import static android.os.Build.VERSION_CODES.S;
+
+import android.content.Intent;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.DirectReflectorTest.ShadowClass;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.util.reflector.Direct;
+import org.robolectric.util.reflector.Reflector;
+
+/** Tests for @{@link Direct} annotation incorporated inside {@link Reflector}. */
+@RunWith(AndroidJUnit4.class)
+@Config(shadows = ShadowClass.class)
+public class MethodNameTest {
+  @Config(sdk = S, shadows = ShadowThrowingIntent.class)
+  @Test
+  public void methodName_shouldNotInvokeOlderSdks() {
+    Intent intent = new Intent();
+    intent.setAction("test"); // should not crash
+  }
+
+  @Implements(Intent.class)
+  public static class ShadowThrowingIntent {
+    @Implementation(minSdk = LOLLIPOP, maxSdk = LOLLIPOP, methodName = "setAction")
+    protected void setActionImpl(String action) {
+      throw new RuntimeException("Should never get called");
+    }
+  }
+}

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
@@ -329,8 +329,11 @@ public class ShadowWrangler implements ClassHandler {
         continue;
       }
 
-      if (Arrays.equals(method.getParameterTypes(), paramClasses)
-          && shadowMatcher.matches(method)) {
+      if (!shadowMatcher.matches(method)) {
+        continue;
+      }
+
+      if (Arrays.equals(method.getParameterTypes(), paramClasses)) {
         // Found an exact match, we can exit early.
         foundMethod = method;
         break;
@@ -344,13 +347,13 @@ public class ShadowWrangler implements ClassHandler {
             break;
           }
         }
-        if (allParameterTypesAreObject && shadowMatcher.matches(method)) {
+        if (allParameterTypesAreObject) {
           // Found a looseSignatures match, but continue looking for an exact match.
           foundMethod = method;
         }
       } else {
         // Or maybe support @ClassName.
-        if (parameterClassNameMatch(method, paramClasses) && shadowMatcher.matches(method)) {
+        if (parameterClassNameMatch(method, paramClasses)) {
           // Found a @ClassName match, but continue looking for an exact match.
           foundMethod = method;
         }
@@ -366,6 +369,9 @@ public class ShadowWrangler implements ClassHandler {
         }
         String mappedMethodName = implementation.methodName().trim();
         if (mappedMethodName.isEmpty() || !mappedMethodName.equals(methodName)) {
+          continue;
+        }
+        if (!shadowMatcher.matches(method)) {
           continue;
         }
         if (Arrays.equals(method.getParameterTypes(), paramClasses)


### PR DESCRIPTION
Previously, it was possible for a shadow method using `methodName` to be invoked for an SDK level that it did not support.  This is because the logic that location a methodName shadow method did not check the SDK range. Add this check for methodName.
