### PR TITLE
Fix native Bitmap.recycle in Android V

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeBitmap.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeBitmap.java
@@ -121,14 +121,14 @@ public class ShadowNativeBitmap extends ShadowBitmap {
     return BitmapNatives.nativeGetNativeFinalizer();
   }
 
-  @Implementation(maxSdk = P)
-  protected static boolean nativeRecycle(long nativeBitmap) {
+  @Implementation(maxSdk = P, methodName = "nativeRecycle")
+  protected static boolean nativeRecyclePreQ(long nativeBitmap) {
     BitmapNatives.nativeRecycle(nativeBitmap);
     return true;
   }
 
-  @Implementation(minSdk = Q, methodName = "nativeRecycle")
-  protected static void nativeRecyclePostPie(long nativeBitmap) {
+  @Implementation(minSdk = Q, maxSdk = U.SDK_INT)
+  protected static void nativeRecycle(long nativeBitmap) {
     BitmapNatives.nativeRecycle(nativeBitmap);
   }
 


### PR DESCRIPTION
It is necessary to use `maxSdk = U.SDK_INT` on Bitmap.nativeRecycle. This is because starting in Android V, `callNativeMethodsByDefault` is enabled, so native methods are bound directly to the Bitmap class, not BitmapNatives.
