### PR TITLE
Remove generics from ClassName annotation values

### DIFF
--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/SdkStore.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/SdkStore.java
@@ -56,6 +56,8 @@ import org.robolectric.versioning.AndroidVersions;
 /** Encapsulates a collection of Android framework jars. */
 public class SdkStore {
 
+  private static final String VALID_CLASS_NAME_ANNOTATION_CHARS = "^[a-zA-Z0-9_$.;\\[\\]]+$";
+
   private final Set<Sdk> sdks = new TreeSet<>();
   private boolean loaded = false;
 
@@ -595,6 +597,15 @@ public class SdkStore {
         // If parameter is annotated with @ClassName, then use the indicated type instead.
         ClassName className = variableElement.getAnnotation(ClassName.class);
         if (className != null) {
+          if (!className.value().matches(VALID_CLASS_NAME_ANNOTATION_CHARS)) {
+            throw new RuntimeException(
+                "Invalid @ClassName annotation '"
+                    + paramType
+                    + "' in "
+                    + methodElement.getEnclosingElement().getSimpleName()
+                    + "."
+                    + methodElement.getSimpleName());
+          }
           paramType = className.value().replace('$', '.');
         }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
@@ -385,8 +385,8 @@ public class ShadowActivityManager {
    * {@code packageName} is ignored.
    */
   @Implementation(minSdk = R)
-  protected @ClassName("java.util.List<android.app.ApplicationExitInfo>") Object
-      getHistoricalProcessExitReasons(String packageName, int pid, int maxNum) {
+  protected List</*android.app.ApplicationExitInfo*/ ?> getHistoricalProcessExitReasons(
+      String packageName, int pid, int maxNum) {
     return appExitInfoList.stream()
         .filter(
             appExitInfo ->

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
@@ -470,8 +470,8 @@ public class ShadowAudioManager {
    */
   @Implementation(minSdk = R)
   @NonNull
-  protected @ClassName("java.util.List<android.media.AudioDeviceAttributes>") List<Object>
-      getDevicesForAttributes(@NonNull AudioAttributes attributes) {
+  protected List</*android.media.AudioDeviceAttributes*/ ?> getDevicesForAttributes(
+      @NonNull AudioAttributes attributes) {
     ImmutableList<Object> devices = devicesForAttributes.get(attributes);
     return devices == null ? defaultDevicesForAttributes : devices;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
@@ -48,7 +48,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import javax.annotation.Nullable;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -414,7 +413,7 @@ public class ShadowBluetoothAdapter {
 
   /** Return value changed from {@code int} to {@link Duration} starting in T. */
   @Implementation(minSdk = TIRAMISU, methodName = "getDiscoverableTimeout")
-  protected @ClassName("java.time.Duration") Object getDiscoverableTimeoutT() {
+  protected Duration getDiscoverableTimeoutT() {
     return discoverableTimeout;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyTypeface.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyTypeface.java
@@ -133,7 +133,7 @@ public class ShadowLegacyTypeface extends ShadowTypeface {
       @ClassName("android.content.res.FontResourcesParser$FamilyResourceEntry") Object entry,
       AssetManager mgr,
       String path) {
-    return createUnderlyingTypeface((String) path, Typeface.NORMAL);
+    return createUnderlyingTypeface(path, Typeface.NORMAL);
   }
 
   @Implementation
@@ -194,7 +194,7 @@ public class ShadowLegacyTypeface extends ShadowTypeface {
       String fallbackName,
       int weight,
       int italic) {
-    return createUnderlyingTypeface((String) fallbackName, Typeface.NORMAL);
+    return createUnderlyingTypeface(fallbackName, Typeface.NORMAL);
   }
 
   @Implementation(minSdk = P, maxSdk = P)
@@ -214,7 +214,7 @@ public class ShadowLegacyTypeface extends ShadowTypeface {
   @Implementation(minSdk = Q, maxSdk = R)
   protected static void initSystemDefaultTypefaces(
       Map<String, Typeface> systemFontMap,
-      @ClassName("java.util.Map<String, android.graphics.FontFamily[]>") Object fallbacks,
+      Map<String, /*android.graphics.FontFamily[]*/ ?> fallbacks,
       @ClassName("android.text.FontConfig$Alias[]") Object aliases) {}
 
   @Resetter

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -180,15 +180,14 @@ public class ShadowNotificationManager {
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
   protected void createNotificationChannelGroups(
-      List<@ClassName("android.app.NotificationChannelGroup") Object> groupList) {
+      List</*android.app.NotificationChannelGroup*/ ?> groupList) {
     for (Object group : groupList) {
       createNotificationChannelGroup(group);
     }
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  protected List<@ClassName("android.app.NotificationChannelGroup") Object>
-      getNotificationChannelGroups() {
+  protected List</*android.app.NotificationChannelGroup*/ ?> getNotificationChannelGroups() {
     return ImmutableList.copyOf(notificationChannelGroups.values());
   }
 
@@ -225,14 +224,14 @@ public class ShadowNotificationManager {
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
   protected void createNotificationChannels(
-      List<@ClassName("android.app.NotificationChannel") Object> channelList) {
+      List</*android.app.NotificationChannel*/ ?> channelList) {
     for (Object channel : channelList) {
       createNotificationChannel(channel);
     }
   }
 
   @Implementation(minSdk = Build.VERSION_CODES.O)
-  public List<@ClassName("android.app.NotificationChannel") Object> getNotificationChannels() {
+  public List</*android.app.NotificationChannel*/ ?> getNotificationChannels() {
     return ImmutableList.copyOf(notificationChannels.values());
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPixelCopy.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPixelCopy.java
@@ -118,7 +118,7 @@ public class ShadowPixelCopy {
   protected static void request(
       @ClassName("android.view.PixelCopy$Request") Object requestObject,
       Executor callbackExecutor,
-      @ClassName("java.util.function.Consumer<android.view.PixelCopy$Result>") Object listener) {
+      Consumer</*android.view.PixelCopy$Result*/ ?> listener) {
     PixelCopy.Request request = (PixelCopy.Request) requestObject;
     RequestReflector requestReflector = reflector(RequestReflector.class, request);
     OnPixelCopyFinishedListener legacyListener =

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
@@ -648,8 +648,8 @@ public class ShadowTelephonyManager {
   /** Returns the UICC cards information set by {@link #setUiccCardsInfo}. */
   @Implementation(minSdk = Q)
   @HiddenApi
-  protected @ClassName("java.util.List<android.telephony.UiccCardInfo>") Object getUiccCardsInfo() {
-    return uiccCardsInfo;
+  protected List</*android.telephony.UiccCardInfo*/ ?> getUiccCardsInfo() {
+    return (List<?>) uiccCardsInfo;
   }
 
   /** Clears {@code slotIndex} to state mapping and resets to default state. */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsageStatsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsageStatsManager.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.concurrent.TimeUnit;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -589,8 +588,8 @@ public class ShadowUsageStatsManager {
 
   @SuppressWarnings("unchecked")
   @Implementation(minSdk = TIRAMISU)
-  protected @ClassName("java.util.List<android.app.usage.BroadcastResponseStats>") Object
-      queryBroadcastResponseStats(@Nullable String packageName, long id) {
+  protected List</*android.app.usage.BroadcastResponseStats*/ ?> queryBroadcastResponseStats(
+      @Nullable String packageName, long id) {
     List<BroadcastResponseStats> result = new ArrayList<>();
     for (Map.Entry<String, Map<Long, Object /*BroadcastResponseStats*/>> entry :
         appBroadcastStats.entrySet()) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsbManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsbManager.java
@@ -207,7 +207,7 @@ public class ShadowUsbManager {
 
   @Implementation(minSdk = Q, methodName = "getPorts")
   @HiddenApi
-  protected @ClassName("java.util.List<android.hardware.usb.UsbPort>") Object getPortsFromQ() {
+  protected List</*android.hardware.usb.UsbPort*/ ?> getPortsFromQ() {
     return new ArrayList<>(usbPortStatuses.keySet());
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
@@ -870,7 +870,7 @@ public class ShadowWifiManager {
 
   @Implementation(minSdk = TIRAMISU)
   protected void setExternalPnoScanRequest(
-      @ClassName("java.util.List") Object ssids,
+      List</*android.net.wifi.WifiSsid*/ ?> ssids,
       int[] frequencies,
       Executor executor,
       @ClassName("android.net.wifi.WifiManager$PnoScanResultsCallback") Object callback) {


### PR DESCRIPTION
ClassName annotation values are designed to work with Class.forName and asm's Type.getType. These are not allowed to have generics. Remove generic usage from ClassName values and add a check in the annotation processor for this.

This came up because at Google, there is some custom bytecode instrumentation that may cause shadow methods to be invoked directly from Android classes, and it fails when reading ClassName annotation values that are malformed.
