### PR TITLE
Fix resetting the AppOpsManager OnOpNotedCallback

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAppOpsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAppOpsManagerTest.java
@@ -761,6 +761,15 @@ public class ShadowAppOpsManagerTest {
   }
 
   @Test
+  @Config(minSdk = R)
+  public void reset_clearsOnOpNotedCallback() {
+    AppOpsManager.OnOpNotedCallback callback = mock(AppOpsManager.OnOpNotedCallback.class);
+    appOps.setOnOpNotedCallback(directExecutor(), callback);
+    ShadowAppOpsManager.reset();
+    appOps.setOnOpNotedCallback(directExecutor(), callback); // should not throw an exception
+  }
+
+  @Test
   @Config(minSdk = O)
   public void appOpsManager_activityContextEnabled_differentInstancesRetrieveOps() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppOpsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppOpsManager.java
@@ -76,7 +76,7 @@ public class ShadowAppOpsManager {
 
   @RealObject private AppOpsManager realObject;
 
-  private static boolean staticallyInitialized = false;
+  private static boolean staticallyInitialized;
 
   // Recorded operations, keyed by (uid, packageName)
   private static final Multimap<Key, Integer> storedOps = HashMultimap.create();
@@ -695,7 +695,6 @@ public class ShadowAppOpsManager {
     if (RuntimeEnvironment.getApiLevel() >= R && staticallyInitialized) {
       ReflectionHelpers.setStaticField(AppOpsManager.class, "sOnOpNotedCallback", null);
     }
-    staticallyInitialized = false;
     storedOps.clear();
     appModeMap.clear();
     longRunningOp.clear();


### PR DESCRIPTION
After the first call to the resetter, it wasn't being reset any more. Update the resetter to avoid clearing staticallyInitialized.
