### PR TITLE
Fix default value regression of ShadowNotificationManager.importance

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
@@ -99,6 +99,14 @@ public class ShadowNotificationManagerTest {
 
   @Test
   @Config(minSdk = Build.VERSION_CODES.O)
+  public void getImportance_afterReset() {
+    assertThat(notificationManager.getImportance()).isEqualTo(NotificationManager.IMPORTANCE_NONE);
+    ShadowNotificationManager.reset();
+    assertThat(notificationManager.getImportance()).isEqualTo(NotificationManager.IMPORTANCE_NONE);
+  }
+
+  @Test
+  @Config(minSdk = Build.VERSION_CODES.O)
   public void createNotificationChannel_updateChannel() {
     NotificationChannel channel = new NotificationChannel("id", "name", 1);
     channel.setDescription("description");

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -60,7 +60,7 @@ public class ShadowNotificationManager {
   private static Policy notificationPolicy;
   private static Policy consolidatedNotificationPolicy;
   private static String notificationDelegate;
-  private static int importance;
+  private static int importance = NotificationManager.IMPORTANCE_NONE;
 
   @Resetter
   public static void reset() {
@@ -78,7 +78,7 @@ public class ShadowNotificationManager {
     notificationPolicy = null;
     notificationDelegate = null;
     consolidatedNotificationPolicy = null;
-    importance = NotificationManager.IMPORTANCE_DEFAULT;
+    importance = NotificationManager.IMPORTANCE_NONE;
   }
 
   @Implementation


### PR DESCRIPTION
Previously, the initial value after the static initializer is zero (IMPORTANCE_NONE), but after the first resetter invocation, it becomes IMPORTANCE_DEFAULT. Use IMPORTANCE_NONE for consistency.
