### PR TITLE
Add missing `@Resetter` annotation in ShadowColorDisplayManager

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowColorDisplayManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowColorDisplayManagerTest.java
@@ -10,14 +10,17 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.Optional;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 
 /** Tests for ShadowColorDisplayManager. */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = Q)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING) // getAppSaturationLevel_afterReset* depends on order
 public class ShadowColorDisplayManagerTest {
 
   private static final String PACKAGE_NAME = "test_package_name";
@@ -136,8 +139,20 @@ public class ShadowColorDisplayManagerTest {
     assertThat(getShadowColorDisplayManager().getTransformCapabilities()).isEqualTo(0x0);
   }
 
+  @Test
+  public void getAppSaturationLevel_afterReset_shouldBeDefault1() {
+    instance.get().setAppSaturationLevel(PACKAGE_NAME, 50);
+    assertThat(getShadowColorDisplayManager().getAppSaturationLevel(PACKAGE_NAME)).isEqualTo(50);
+  }
+
+  @Test
+  public void getAppSaturationLevel_afterReset_shouldBeDefault2() {
+    // A reset should have occurred
+    assertThat(getShadowColorDisplayManager().getAppSaturationLevel(PACKAGE_NAME)).isEqualTo(100);
+  }
+
   private ShadowColorDisplayManager getShadowColorDisplayManager() {
-    return (ShadowColorDisplayManager) extract(instance.get());
+    return extract(instance.get());
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowColorDisplayManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowColorDisplayManager.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
 
 @Implements(
     className = "android.hardware.display.ColorDisplayManager",
@@ -27,6 +28,7 @@ public class ShadowColorDisplayManager {
   // No capabilities by default
   private int transformCapabilities = 0x0;
 
+  @Resetter
   public static void reset() {
     isNightDisplayActivated = false;
     nightDisplayTemperature = 0;


### PR DESCRIPTION
The missing `@Resetter` annotation was causing static state to not be reset.
