### PR TITLE
Fix package name in integration_tests/multidex manifest

### DIFF
--- a/integration_tests/multidex/build.gradle.kts
+++ b/integration_tests/multidex/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
   compileSdk = 34
-  namespace = "org.robolectric.integrationtests.multidex"
+  namespace = "android.support.multidex"
 
   defaultConfig {
     minSdk = 21

--- a/integration_tests/multidex/src/test/AndroidManifest.xml
+++ b/integration_tests/multidex/src/test/AndroidManifest.xml
@@ -10,6 +10,6 @@
 
   <instrumentation
       android:name="androidx.test.runner.AndroidJUnitRunner"
-      android:targetPackage="org.robolectric.integrationtests.multidex"/>
+      android:targetPackage="android.support.multidex" />
 
 </manifest>


### PR DESCRIPTION
The package of the files changed, so the manifest needs to be updated.
