### PR TITLE
Migrate Robolectric.setupActivity to Robolectric.buildActivity

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.ReflectionHelpers;
 
@@ -274,13 +275,13 @@ public class ShadowAccessibilityManagerTest {
   public void accessibilityManager_activityContextEnabled_differentInstancesHaveSameServices() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       AccessibilityManager applicationAccessibilityManager =
           (AccessibilityManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.ACCESSIBILITY_SERVICE);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       AccessibilityManager activityAccessibilityManager =
           (AccessibilityManager) activity.getSystemService(Context.ACCESSIBILITY_SERVICE);
 
@@ -293,9 +294,6 @@ public class ShadowAccessibilityManagerTest {
 
       assertThat(activityServices).isEqualTo(applicationServices);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @RunWith(AndroidJUnit4.class)
@@ -1139,10 +1140,10 @@ public class ShadowAccountManagerTest {
   public void accountManager_activityContextEnabled_differentInstancesRetrieveAccounts() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       AccountManager applicationAccountManager = appContext.getSystemService(AccountManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       AccountManager activityAccountManager = activity.getSystemService(AccountManager.class);
 
       assertThat(applicationAccountManager).isNotSameInstanceAs(activityAccountManager);
@@ -1154,9 +1155,6 @@ public class ShadowAccountManagerTest {
 
       assertThat(activityAccounts).isEqualTo(applicationAccounts);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityManagerTest.java
@@ -36,9 +36,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
-import org.robolectric.shadows.testing.TestActivity;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowActivityManagerTest {
@@ -488,14 +488,14 @@ public class ShadowActivityManagerTest {
   public void activityManager_activityContextEnabled_retrievesConsistentLowRamDeviceStatus() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       ActivityManager applicationActivityManager =
           (ActivityManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.ACTIVITY_SERVICE);
 
-      activity = Robolectric.setupActivity(TestActivity.class);
+      Activity activity = controller.get();
       ActivityManager activityActivityManager =
           (ActivityManager) activity.getSystemService(Context.ACTIVITY_SERVICE);
 
@@ -504,9 +504,6 @@ public class ShadowActivityManagerTest {
 
       assertThat(activityLowRamStatus).isEqualTo(applicationLowRamStatus);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowAlarmManager.ScheduledAlarm;
 
@@ -670,14 +671,14 @@ public class ShadowAlarmManagerTest {
   public void alarmManager_instance_retrievesSameAlarmClockInfo() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
 
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       AlarmManager applicationAlarmManager =
           (AlarmManager)
               ApplicationProvider.getApplicationContext().getSystemService(Context.ALARM_SERVICE);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       AlarmManager activityAlarmManager =
           (AlarmManager) activity.getSystemService(Context.ALARM_SERVICE);
 
@@ -687,9 +688,6 @@ public class ShadowAlarmManagerTest {
 
       assertThat(activityAlarmClock).isEqualTo(applicationAlarmClock);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAmbientContextManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAmbientContextManagerTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -195,11 +196,11 @@ public class ShadowAmbientContextManagerTest {
   public void ambientContextManager_activityContextEnabled_differentInstancesQueryStatus() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       AmbientContextManager applicationAmbientContextManager =
           RuntimeEnvironment.getApplication().getSystemService(AmbientContextManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       AmbientContextManager activityAmbientContextManager =
           activity.getSystemService(AmbientContextManager.class);
 
@@ -238,9 +239,6 @@ public class ShadowAmbientContextManagerTest {
     } catch (Exception e) {
       fail("Test failed due to exception: " + e.getMessage());
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAppOpsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAppOpsManagerTest.java
@@ -49,6 +49,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowAppOpsManager.ModeAndException;
 import org.robolectric.util.ReflectionHelpers;
@@ -774,15 +775,15 @@ public class ShadowAppOpsManagerTest {
   public void appOpsManager_activityContextEnabled_differentInstancesRetrieveOps() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       // Get the AppOpsManager instances
       AppOpsManager applicationAppOpsManager =
           ApplicationProvider.getApplicationContext().getSystemService(AppOpsManager.class);
       ShadowAppOpsManager shadowApplicationAppOpsManager =
           Shadows.shadowOf(applicationAppOpsManager);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       AppOpsManager activityAppOpsManager = activity.getSystemService(AppOpsManager.class);
       ShadowAppOpsManager shadowActivityAppOpsManager = Shadows.shadowOf(activityAppOpsManager);
 
@@ -796,9 +797,6 @@ public class ShadowAppOpsManagerTest {
 
       assertThat(activityPackageOpsList).isEqualTo(applicationPackageOpsList);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetManagerTest.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @RunWith(AndroidJUnit4.class)
@@ -553,11 +554,11 @@ public class ShadowAppWidgetManagerTest {
   public void appWidgetManager_activityContextEnabled_sharedState() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       AppWidgetManager applicationAppWidgetManager =
           context.getSystemService(AppWidgetManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       AppWidgetManager activityAppWidgetManager = activity.getSystemService(AppWidgetManager.class);
 
       assertThat(applicationAppWidgetManager).isNotSameInstanceAs(activityAppWidgetManager);
@@ -566,9 +567,6 @@ public class ShadowAppWidgetManagerTest {
 
       assertThat(activityAppWidgetManager.getAppWidgetOptions(1)).isNotNull();
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAutofillManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAutofillManagerTest.java
@@ -16,6 +16,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Unit test for {@link ShadowAutofillManager}. */
@@ -65,11 +66,11 @@ public class ShadowAutofillManagerTest {
   public void autofillManager_activityContextEnabled_differentInstancesRetrieveSameInfo() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       AutofillManager applicationAutofillManager = context.getSystemService(AutofillManager.class);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       AutofillManager activityAutofillManager = activity.getSystemService(AutofillManager.class);
 
       assertNotSame(applicationAutofillManager, activityAutofillManager);
@@ -80,9 +81,6 @@ public class ShadowAutofillManagerTest {
       assertEquals(applicationAutofillManager.isEnabled(), activityAutofillManager.isEnabled());
 
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBatteryManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBatteryManagerTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @RunWith(AndroidJUnit4.class)
@@ -100,11 +101,11 @@ public class ShadowBatteryManagerTest {
   public void batteryManager_activityContextEnabled_sharedState() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       Context context = ApplicationProvider.getApplicationContext();
       BatteryManager applicationBatteryManager = context.getSystemService(BatteryManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       BatteryManager activityBatteryManager = activity.getSystemService(BatteryManager.class);
 
       assertThat(applicationBatteryManager).isNotSameInstanceAs(activityBatteryManager);
@@ -114,9 +115,6 @@ public class ShadowBatteryManagerTest {
 
       assertThat(activityBatteryManager.isCharging()).isTrue();
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBiometricManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBiometricManagerTest.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -108,12 +109,12 @@ public class ShadowBiometricManagerTest {
   public void biometricManager_activityContextEnabled_differentInstancesRetrieveSameResult() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       BiometricManager applicationBiometricManager =
           ApplicationProvider.getApplicationContext().getSystemService(BiometricManager.class);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       BiometricManager activityBiometricManager = activity.getSystemService(BiometricManager.class);
 
       assertThat(applicationBiometricManager).isNotSameInstanceAs(activityBiometricManager);
@@ -123,9 +124,6 @@ public class ShadowBiometricManagerTest {
 
       assertThat(activityCanAuthenticate).isEqualTo(applicationCanAuthenticate);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothManagerTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @RunWith(AndroidJUnit4.class)
@@ -165,25 +166,22 @@ public class ShadowBluetoothManagerTest {
   public void bluetoothManager_activityContextEnabled_retrievesSameAdapter() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
 
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       BluetoothManager applicationBluetoothManager =
           (BluetoothManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.BLUETOOTH_SERVICE);
 
       BluetoothAdapter applicationAdapter = applicationBluetoothManager.getAdapter();
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       BluetoothManager activityBluetoothManager = activity.getSystemService(BluetoothManager.class);
 
       BluetoothAdapter activityAdapter = activityBluetoothManager.getAdapter();
 
       assertThat(applicationAdapter).isEqualTo(activityAdapter);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraManagerTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Tests for {@link ShadowCameraManager}. */
@@ -415,12 +416,12 @@ public class ShadowCameraManagerTest {
       throws Exception {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       CameraManager applicationCameraManager =
           (CameraManager)
               ApplicationProvider.getApplicationContext().getSystemService(Context.CAMERA_SERVICE);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       CameraManager activityCameraManager =
           (CameraManager) activity.getSystemService(Context.CAMERA_SERVICE);
 
@@ -440,9 +441,6 @@ public class ShadowCameraManagerTest {
 
       assertThat(activityCameraIdList).isEqualTo(applicationCameraIdList);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCaptioningManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCaptioningManagerTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Tests for the ShadowCaptioningManager. */
@@ -194,13 +195,13 @@ public final class ShadowCaptioningManagerTest {
   public void captioningManager_activityContextEnabled_differentInstancesRetrieveValues() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       CaptioningManager applicationCaptioningManager =
           (CaptioningManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.CAPTIONING_SERVICE);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       CaptioningManager activityCaptioningManager =
           (CaptioningManager) activity.getSystemService(Context.CAPTIONING_SERVICE);
 
@@ -217,9 +218,6 @@ public final class ShadowCaptioningManagerTest {
       assertThat(applicationCaptioningEnabled).isEqualTo(activityCaptioningEnabled);
       assertThat(applicationCaptioningUiEnabled).isEqualTo(activityCaptioningUiEnabled);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCarrierConfigManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCarrierConfigManagerTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Junit test for {@link ShadowCarrierConfigManager}. */
@@ -164,14 +165,14 @@ public class ShadowCarrierConfigManagerTest {
   public void carrierConfigManager_activityContextEnabled_retrievesSameConfigs() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       CarrierConfigManager applicationCarrierConfigManager =
           (CarrierConfigManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.CARRIER_CONFIG_SERVICE);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       CarrierConfigManager activityCarrierConfigManager =
           (CarrierConfigManager) activity.getSystemService(Context.CARRIER_CONFIG_SERVICE);
 
@@ -197,9 +198,6 @@ public class ShadowCarrierConfigManagerTest {
       applicationParcel.recycle();
       activityParcel.recycle();
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowClipboardManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowClipboardManagerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import android.app.Activity;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
@@ -19,8 +20,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.testing.TestActivity;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowClipboardManagerTest {
@@ -161,8 +162,8 @@ public class ShadowClipboardManagerTest {
   public void clipboardManager_instance_retrievesSamePrimaryClip() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    TestActivity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       ClipboardManager applicationClipboardManager =
           (ClipboardManager)
               ApplicationProvider.getApplicationContext()
@@ -170,7 +171,7 @@ public class ShadowClipboardManagerTest {
       ClipData clipData = ClipData.newPlainText("label", "text");
       applicationClipboardManager.setPrimaryClip(clipData);
 
-      activity = Robolectric.setupActivity(TestActivity.class);
+      Activity activity = controller.get();
       ClipboardManager activityClipboardManager =
           (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
 
@@ -179,9 +180,6 @@ public class ShadowClipboardManagerTest {
 
       assertThat(activityClipData.toString()).isEqualTo(applicationClipData.toString());
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowColorDisplayManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowColorDisplayManagerTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Tests for ShadowColorDisplayManager. */
@@ -159,11 +160,11 @@ public class ShadowColorDisplayManagerTest {
   public void colorDisplayManager_activityContextEnabled_differentInstancesRetrieveSettings() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       ColorDisplayManager appColorDisplayManager =
           ApplicationProvider.getApplicationContext().getSystemService(ColorDisplayManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       ColorDisplayManager activityColorDisplayManager =
           activity.getSystemService(ColorDisplayManager.class);
 
@@ -178,9 +179,6 @@ public class ShadowColorDisplayManagerTest {
       assertThat(activityNightDisplayActivated).isEqualTo(appNightDisplayActivated);
 
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
@@ -40,8 +40,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.testing.TestActivity;
 import org.robolectric.util.ReflectionHelpers;
 
 @RunWith(AndroidJUnit4.class)
@@ -736,9 +736,9 @@ public class ShadowConnectivityManagerTest {
   public void connectivityManager_instanceBasedOnSdkVersion() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
-      activity = Robolectric.setupActivity(TestActivity.class);
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
+      Activity activity = controller.get();
       ConnectivityManager activityConnectivityManager =
           (ConnectivityManager) activity.getSystemService(Context.CONNECTIVITY_SERVICE);
 
@@ -752,9 +752,6 @@ public class ShadowConnectivityManagerTest {
 
       assertThat(activityActiveNetwork).isEqualTo(applicationActiveNetwork);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextHubManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextHubManagerTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -172,13 +173,13 @@ public class ShadowContextHubManagerTest {
   public void contextHubManager_instance_retrievesSameContextHubInfo() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
 
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       ContextHubManager applicationContextHubManager =
           context.getSystemService(ContextHubManager.class);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       ContextHubManager activityContextHubManager =
           activity.getSystemService(ContextHubManager.class);
 
@@ -192,9 +193,6 @@ public class ShadowContextHubManagerTest {
 
       assertThat(activityContextHubs).isEqualTo(applicationContextHubs);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCrossProfileAppsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCrossProfileAppsTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowCrossProfileApps.StartedActivity;
@@ -693,13 +694,13 @@ public class ShadowCrossProfileAppsTest {
       crossProfileApps_activityContextEnabled_differentInstancesRetrieveTargetUserProfiles() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       CrossProfileApps applicationCrossProfileApps =
           (CrossProfileApps)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.CROSS_PROFILE_APPS_SERVICE);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       CrossProfileApps activityCrossProfileApps =
           (CrossProfileApps) activity.getSystemService(Context.CROSS_PROFILE_APPS_SERVICE);
 
@@ -712,9 +713,6 @@ public class ShadowCrossProfileAppsTest {
 
       assertThat(activityTargetUserProfiles).isEqualTo(applicationTargetUserProfiles);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDevicePolicyManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDevicePolicyManagerTest.java
@@ -68,6 +68,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -2738,14 +2739,14 @@ public final class ShadowDevicePolicyManagerTest {
   public void devicePolicyManager_instance_retrievesSameAdminStatus() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       DevicePolicyManager applicationDpm =
           (DevicePolicyManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.DEVICE_POLICY_SERVICE);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
 
       DevicePolicyManager activityDpm =
           (DevicePolicyManager) activity.getSystemService(Context.DEVICE_POLICY_SERVICE);
@@ -2758,9 +2759,6 @@ public final class ShadowDevicePolicyManagerTest {
 
       assertThat(activityAdminActive).isEqualTo(applicationAdminActive);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDownloadManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDownloadManagerTest.java
@@ -20,10 +20,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowDownloadManager.CompletedDownload;
 import org.robolectric.shadows.ShadowDownloadManager.ShadowRequest;
-import org.robolectric.shadows.testing.TestActivity;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowDownloadManagerTest {
@@ -424,13 +424,13 @@ public class ShadowDownloadManagerTest {
   public void downloadManager_activityContextEnabled_retrievesSameMimeTypeForDownloadedFile() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       DownloadManager applicationDownloadManager =
           (DownloadManager)
               RuntimeEnvironment.getApplication().getSystemService(Context.DOWNLOAD_SERVICE);
 
-      activity = Robolectric.setupActivity(TestActivity.class);
+      Activity activity = controller.get();
       DownloadManager activityDownloadManager =
           (DownloadManager) activity.getSystemService(Context.DOWNLOAD_SERVICE);
 
@@ -442,9 +442,6 @@ public class ShadowDownloadManagerTest {
 
       assertThat(activityMimeType).isEqualTo(applicationMimeType);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDropBoxManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDropBoxManagerTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Unit tests for {@see ShadowDropboxManager}. */
@@ -125,8 +126,8 @@ public class ShadowDropBoxManagerTest {
   public void dropBoxManager_activityContextEnabled_differentInstancesVerifyTagEnabled() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       DropBoxManager applicationDropBoxManager =
           (DropBoxManager)
               ApplicationProvider.getApplicationContext().getSystemService(Context.DROPBOX_SERVICE);
@@ -135,7 +136,7 @@ public class ShadowDropBoxManagerTest {
       String data = "testData";
       applicationDropBoxManager.addText(tag, data);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       DropBoxManager activityDropBoxManager =
           (DropBoxManager) activity.getSystemService(Context.DROPBOX_SERVICE);
 
@@ -144,9 +145,6 @@ public class ShadowDropBoxManagerTest {
 
       assertThat(activityTagEnabled).isEqualTo(applicationTagEnabled);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowEuiccManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowEuiccManagerTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Junit test for {@link ShadowEuiccManager}. */
@@ -65,12 +66,12 @@ public class ShadowEuiccManagerTest {
   public void euiccManager_activityContextEnabled_differentInstancesRetrieveEids() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       EuiccManager applicationEuiccManager =
           (EuiccManager)
               ApplicationProvider.getApplicationContext().getSystemService(Context.EUICC_SERVICE);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       EuiccManager activityEuiccManager =
           (EuiccManager) activity.getSystemService(Context.EUICC_SERVICE);
 
@@ -81,9 +82,6 @@ public class ShadowEuiccManagerTest {
 
       assertThat(activityEid).isEqualTo(applicationEid);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowFileIntegrityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowFileIntegrityManagerTest.java
@@ -12,9 +12,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
-import org.robolectric.shadows.testing.TestActivity;
 
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = R)
@@ -45,14 +45,14 @@ public final class ShadowFileIntegrityManagerTest {
   public void fileIntegrityManager_activityContextEnabled_retrievesSameValues() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       FileIntegrityManager applicationFileIntegrityManager =
           (FileIntegrityManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.FILE_INTEGRITY_SERVICE);
 
-      activity = Robolectric.setupActivity(TestActivity.class);
+      Activity activity = controller.get();
       FileIntegrityManager activityFileIntegrityManager =
           (FileIntegrityManager) activity.getSystemService(Context.FILE_INTEGRITY_SERVICE);
 
@@ -64,9 +64,6 @@ public final class ShadowFileIntegrityManagerTest {
 
       assertThat(activityApkVeritySupported).isEqualTo(applicationApkVeritySupported);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowFingerprintManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowFingerprintManagerTest.java
@@ -21,8 +21,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.testing.TestActivity;
 
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = M)
@@ -130,14 +130,14 @@ public class ShadowFingerprintManagerTest {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
 
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       FingerprintManager applicationFingerprintManager =
           (FingerprintManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.FINGERPRINT_SERVICE);
 
-      activity = Robolectric.setupActivity(TestActivity.class);
+      Activity activity = controller.get();
       FingerprintManager activityFingerprintManager =
           (FingerprintManager) activity.getSystemService(Context.FINGERPRINT_SERVICE);
 
@@ -153,9 +153,6 @@ public class ShadowFingerprintManagerTest {
       assertThat(hasActivityEnrolledFingerprints).isEqualTo(hasApplicationEnrolledFingerprints);
 
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowInputMethodManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowInputMethodManagerTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @RunWith(AndroidJUnit4.class)
@@ -161,13 +162,13 @@ public class ShadowInputMethodManagerTest {
       inputMethodManager_activityContextEnabled_differentInstancesRetrieveInputMethodList() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       InputMethodManager applicationInputMethodManager =
           (InputMethodManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.INPUT_METHOD_SERVICE);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       InputMethodManager activityInputMethodManager =
           (InputMethodManager) activity.getSystemService(Context.INPUT_METHOD_SERVICE);
 
@@ -179,9 +180,6 @@ public class ShadowInputMethodManagerTest {
       assertThat(activityIsAcceptingText).isEqualTo(applicationIsAcceptingText);
 
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowKeyguardManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowKeyguardManagerTest.java
@@ -21,8 +21,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.testing.TestActivity;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowKeyguardManagerTest {
@@ -198,13 +198,13 @@ public class ShadowKeyguardManagerTest {
   public void keyguardManager_activityContextEnabled_retrievesSameState() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       KeyguardManager applicationKeyguardManager =
           (KeyguardManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.KEYGUARD_SERVICE);
-      activity = Robolectric.setupActivity(TestActivity.class);
+      Activity activity = controller.get();
       KeyguardManager activityKeyguardManager =
           (KeyguardManager) activity.getSystemService(Context.KEYGUARD_SERVICE);
 
@@ -213,9 +213,6 @@ public class ShadowKeyguardManagerTest {
 
       assertThat(activityIsKeyguardLocked).isEqualTo(applicationIsKeyguardLocked);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLauncherAppsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLauncherAppsTest.java
@@ -47,6 +47,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.ReflectionHelpers;
@@ -456,12 +457,12 @@ public class ShadowLauncherAppsTest {
   public void launcherApps_activityContextEnabled_differentInstancesRetrieveProfiles() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
 
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       LauncherApps applicationLauncherApps =
           ApplicationProvider.getApplicationContext().getSystemService(LauncherApps.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       LauncherApps activityLauncherApps = activity.getSystemService(LauncherApps.class);
 
       assertThat(applicationLauncherApps).isNotSameInstanceAs(activityLauncherApps);
@@ -474,9 +475,6 @@ public class ShadowLauncherAppsTest {
 
       assertThat(activityProfiles).isEqualTo(applicationProfiles);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLocaleManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLocaleManagerTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -98,12 +99,12 @@ public final class ShadowLocaleManagerTest {
   public void localeManager_activityContextEnabled_differentInstancesRetrieveLocales() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       LocaleManager applicationLocaleManager =
           (LocaleManager)
               ApplicationProvider.getApplicationContext().getSystemService(Context.LOCALE_SERVICE);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       LocaleManager activityLocaleManager =
           (LocaleManager) activity.getSystemService(Context.LOCALE_SERVICE);
 
@@ -114,9 +115,6 @@ public final class ShadowLocaleManagerTest {
 
       assertThat(activityLocales).isEqualTo(applicationLocales);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaRouterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaRouterTest.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Tests for {@link ShadowMediaRouter}. */
@@ -135,14 +136,14 @@ public final class ShadowMediaRouterTest {
   public void mediaRouter_activityContextEnabled_differentInstancesRetrieveDefaultRoute() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       MediaRouter applicationMediaRouter =
           (MediaRouter)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.MEDIA_ROUTER_SERVICE);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       MediaRouter activityMediaRouter =
           (MediaRouter) activity.getSystemService(Context.MEDIA_ROUTER_SERVICE);
 
@@ -153,9 +154,6 @@ public final class ShadowMediaRouterTest {
 
       assertThat(activityDefaultRoute).isEqualTo(applicationDefaultRoute);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaSessionManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaSessionManagerTest.java
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Tests for {@link ShadowMediaSessionManager} */
@@ -69,11 +70,11 @@ public class ShadowMediaSessionManagerTest {
   public void mediaSessionManager_activityContextEnabled_differentInstancesRetrieveSessions() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       MediaSessionManager applicationMediaSessionManager =
           RuntimeEnvironment.getApplication().getSystemService(MediaSessionManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       MediaSessionManager activityMediaSessionManager =
           activity.getSystemService(MediaSessionManager.class);
 
@@ -86,9 +87,6 @@ public class ShadowMediaSessionManagerTest {
 
       assertThat(activityControllers).isEqualTo(applicationControllers);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNetworkScoreManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNetworkScoreManagerTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -46,11 +47,11 @@ public final class ShadowNetworkScoreManagerTest {
       networkScoreManager_activityContextEnabled_differentInstancesRetrieveActiveScorerPackage() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       NetworkScoreManager applicationNetworkScoreManager =
           RuntimeEnvironment.getApplication().getSystemService(NetworkScoreManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       NetworkScoreManager activityNetworkScoreManager =
           activity.getSystemService(NetworkScoreManager.class);
 
@@ -61,9 +62,6 @@ public final class ShadowNetworkScoreManagerTest {
 
       assertThat(activityScorerPackage).isEqualTo(applicationScorerPackage);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
@@ -35,6 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.LooperMode;
 
@@ -831,8 +832,8 @@ public class ShadowNotificationManagerTest {
   public void notificationManager_activityContext_enabled_differentInstancesRetrieveChannels() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       NotificationManager applicationNotificationManager =
           (NotificationManager)
               ApplicationProvider.getApplicationContext()
@@ -843,7 +844,7 @@ public class ShadowNotificationManagerTest {
               "test_channel_id", "Test Channel", NotificationManager.IMPORTANCE_DEFAULT);
       applicationNotificationManager.createNotificationChannel(testChannel);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       NotificationManager activityNotificationManager =
           (NotificationManager) activity.getSystemService(Context.NOTIFICATION_SERVICE);
 
@@ -854,9 +855,6 @@ public class ShadowNotificationManagerTest {
 
       assertThat(activityChannel).isEqualTo(applicationChannel);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPowerManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPowerManagerTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowPowerManager.ShadowLowPowerStandbyPortsLock;
@@ -739,12 +740,12 @@ public class ShadowPowerManagerTest {
   public void powerManager_activityContextEnabled_checkIsInteractive() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       PowerManager applicationPowerManager =
           (PowerManager)
               ApplicationProvider.getApplicationContext().getSystemService(Context.POWER_SERVICE);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       PowerManager activityPowerManager =
           (PowerManager) activity.getSystemService(Context.POWER_SERVICE);
 
@@ -755,9 +756,6 @@ public class ShadowPowerManagerTest {
 
       assertThat(activityIsInteractive).isEqualTo(applicationIsInteractive);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRestrictionsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRestrictionsManagerTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @RunWith(AndroidJUnit4.class)
@@ -58,11 +59,11 @@ public final class ShadowRestrictionsManagerTest {
   public void restrictionsManager_activityContextEnabled_hasConsistentRestrictionsProvider() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       RestrictionsManager applicationRestrictionsManager =
           ApplicationProvider.getApplicationContext().getSystemService(RestrictionsManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       RestrictionsManager activityRestrictionsManager =
           activity.getSystemService(RestrictionsManager.class);
 
@@ -73,9 +74,6 @@ public final class ShadowRestrictionsManagerTest {
 
       assertThat(activityHasProvider).isEqualTo(applicationHasProvider);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRoleManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRoleManagerTest.java
@@ -17,8 +17,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.testing.TestActivity;
 
 /** Unit tests for {@link org.robolectric.shadows.ShadowRoleManager}. */
 @RunWith(AndroidJUnit4.class)
@@ -135,11 +135,11 @@ public final class ShadowRoleManagerTest {
   public void roleManager_activityContextEnabled_differentInstancesRetrieveRoles() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       RoleManager applicationRoleManager = roleManager;
 
-      activity = Robolectric.setupActivity(TestActivity.class);
+      Activity activity = controller.get();
       RoleManager activityRoleManager =
           (RoleManager) activity.getSystemService(Context.ROLE_SERVICE);
 
@@ -150,9 +150,6 @@ public final class ShadowRoleManagerTest {
 
       assertThat(activityRoleHeld).isEqualTo(applicationRoleHeld);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRollbackManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRollbackManagerTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Test for {@link ShadowRollbackManager}. */
@@ -78,12 +79,12 @@ public final class ShadowRollbackManagerTest {
   public void rollbackManager_reloadPersistedData_differentInstancesRetrieveRollbacks() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       RollbackManager applicationRollbackManager =
           (RollbackManager)
               RuntimeEnvironment.getApplication().getSystemService(Context.ROLLBACK_SERVICE);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       RollbackManager activityRollbackManager =
           (RollbackManager) activity.getSystemService(Context.ROLLBACK_SERVICE);
 
@@ -99,9 +100,6 @@ public final class ShadowRollbackManagerTest {
 
       assertThat(activityAvailableRollbacks).isEqualTo(applicationAvailableRollbacks);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSafetyCenterManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSafetyCenterManagerTest.java
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -499,12 +500,12 @@ public final class ShadowSafetyCenterManagerTest {
   public void safetyCenterManager_activityContextEnabled_differentInstancesCheckEnabled() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       SafetyCenterManager applicationSafetyCenterManager =
           (SafetyCenterManager)
               RuntimeEnvironment.getApplication().getSystemService(Context.SAFETY_CENTER_SERVICE);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       SafetyCenterManager activitySafetyCenterManager =
           (SafetyCenterManager) activity.getSystemService(Context.SAFETY_CENTER_SERVICE);
 
@@ -515,9 +516,6 @@ public final class ShadowSafetyCenterManagerTest {
 
       assertThat(activityEnabled).isEqualTo(applicationEnabled);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSearchManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSearchManagerTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @RunWith(AndroidJUnit4.class)
@@ -22,11 +23,11 @@ public class ShadowSearchManagerTest {
       searchManager_activityContextEnabled_differentInstancesRetrieveGlobalSearchActivity() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       SearchManager applicationSearchManager =
           RuntimeEnvironment.getApplication().getSystemService(SearchManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       SearchManager activitySearchManager = activity.getSystemService(SearchManager.class);
 
       assertThat(applicationSearchManager).isNotSameInstanceAs(activitySearchManager);
@@ -37,9 +38,6 @@ public class ShadowSearchManagerTest {
 
       assertThat(activityGlobalSearchActivity).isEqualTo(applicationGlobalSearchActivity);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSensorManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSensorManagerTest.java
@@ -29,8 +29,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.testing.TestActivity;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowSensorManagerTest {
@@ -340,12 +340,12 @@ public class ShadowSensorManagerTest {
   public void sensorManager_activityContextEnabled_retrievesSameSensors() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       SensorManager applicationSensorManager =
           (SensorManager)
               ApplicationProvider.getApplicationContext().getSystemService(Context.SENSOR_SERVICE);
-      activity = Robolectric.setupActivity(TestActivity.class);
+      Activity activity = controller.get();
       SensorManager activitySensorManager =
           (SensorManager) activity.getSystemService(Context.SENSOR_SERVICE);
 
@@ -368,9 +368,6 @@ public class ShadowSensorManagerTest {
         assertThat(appSensor.getMinDelay()).isEqualTo(actSensor.getMinDelay());
       }
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowShortcutManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowShortcutManagerTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -395,14 +396,14 @@ public final class ShadowShortcutManagerTest {
   public void shortcutManager_activityContextEnabled_differentInstancesCheckRateLimiting() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       ShortcutManager applicationShortcutManager =
           (ShortcutManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.SHORTCUT_SERVICE);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       ShortcutManager activityShortcutManager =
           (ShortcutManager) activity.getSystemService(Context.SHORTCUT_SERVICE);
 
@@ -413,9 +414,6 @@ public final class ShadowShortcutManagerTest {
 
       assertThat(activityRateLimiting).isEqualTo(applicationRateLimiting);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSliceManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSliceManagerTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Tests for {@link ShadowSliceManager}. */
@@ -102,11 +103,11 @@ public final class ShadowSliceManagerTest {
   public void sliceManager_activityContextEnabled_differentInstancesRetrieveSlices() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       SliceManager applicationSliceManager =
           ApplicationProvider.getApplicationContext().getSystemService(SliceManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       SliceManager activitySliceManager = activity.getSystemService(SliceManager.class);
 
       assertThat(applicationSliceManager).isNotSameInstanceAs(activitySliceManager);
@@ -128,9 +129,6 @@ public final class ShadowSliceManagerTest {
       assertThat(applicationPinnedSlices).isEqualTo(activityPinnedSlices);
 
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStatusBarManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStatusBarManagerTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -95,11 +96,11 @@ public final class ShadowStatusBarManagerTest {
   public void statusBarManager_activityContextEnabled_performOperations() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       StatusBarManager applicationStatusBarManager =
           RuntimeEnvironment.getApplication().getSystemService(StatusBarManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       StatusBarManager activityStatusBarManager = activity.getSystemService(StatusBarManager.class);
 
       assertThat(applicationStatusBarManager).isNotSameInstanceAs(activityStatusBarManager);
@@ -121,9 +122,6 @@ public final class ShadowStatusBarManagerTest {
       assertThat(activityShadowStatusBarManager.getDisable2Flags())
           .isEqualTo(StatusBarManager.DISABLE2_GLOBAL_ACTIONS);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStorageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStorageManagerTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.ReflectionHelpers;
 
@@ -143,12 +144,12 @@ public class ShadowStorageManagerTest {
   public void storageManager_activityContextEnabled_differentInstancesRetrieveVolumes() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       StorageManager applicationStorageManager =
           RuntimeEnvironment.getApplication().getSystemService(StorageManager.class);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       StorageManager activityStorageManager = activity.getSystemService(StorageManager.class);
 
       assertThat(applicationStorageManager).isNotSameInstanceAs(activityStorageManager);
@@ -158,9 +159,6 @@ public class ShadowStorageManagerTest {
 
       assertThat(activityVolumes).isEqualTo(applicationVolumes);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSubscriptionManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSubscriptionManagerTest.java
@@ -25,9 +25,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowSubscriptionManager.SubscriptionInfoBuilder;
-import org.robolectric.shadows.testing.TestActivity;
 
 /** Test for {@link ShadowSubscriptionManager}. */
 @RunWith(AndroidJUnit4.class)
@@ -531,13 +531,13 @@ public class ShadowSubscriptionManagerTest {
       subscriptionManager_activityContextEnabled_differentInstancesRetrieveDefaultSubscriptionInfo() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       SubscriptionManager applicationSubscriptionManager =
           (SubscriptionManager)
               RuntimeEnvironment.getApplication()
                   .getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE);
-      activity = Robolectric.setupActivity(TestActivity.class);
+      Activity activity = controller.get();
       SubscriptionManager activitySubscriptionManager =
           (SubscriptionManager) activity.getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE);
 
@@ -551,9 +551,6 @@ public class ShadowSubscriptionManagerTest {
 
       assertThat(applicationDefaultSubscriptionInfo).isEqualTo(activityDefaultSubscriptionInfo);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemHealthManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemHealthManagerTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -82,11 +83,11 @@ public final class ShadowSystemHealthManagerTest {
       systemHealthManager_activityContextEnabled_differentInstancesRetrieveSameUidSnapshot() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       SystemHealthManager applicationSystemHealthManager =
           ApplicationProvider.getApplicationContext().getSystemService(SystemHealthManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       SystemHealthManager activitySystemHealthManager =
           activity.getSystemService(SystemHealthManager.class);
 
@@ -97,9 +98,6 @@ public final class ShadowSystemHealthManagerTest {
 
       assertThat(activityHealthStats).isEqualTo(applicationHealthStats);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTelecomManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTelecomManagerTest.java
@@ -41,10 +41,10 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.android.controller.ServiceController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowTelecomManager.CallRequestMode;
-import org.robolectric.shadows.testing.TestActivity;
 import org.robolectric.shadows.testing.TestConnectionService;
 
 @RunWith(AndroidJUnit4.class)
@@ -758,13 +758,13 @@ public class ShadowTelecomManagerTest {
   public void telecomManager_activityContextEnabled_differentInstancesRetrieveDefaultDialer() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       TelecomManager applicationTelecomManager =
           (TelecomManager)
               ApplicationProvider.getApplicationContext().getSystemService(Context.TELECOM_SERVICE);
 
-      activity = Robolectric.setupActivity(TestActivity.class);
+      Activity activity = controller.get();
       TelecomManager activityTelecomManager =
           (TelecomManager) activity.getSystemService(Context.TELECOM_SERVICE);
 
@@ -773,9 +773,6 @@ public class ShadowTelecomManagerTest {
 
       assertThat(activityDefaultDialer).isEqualTo(applicationDefaultDialer);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTelephonyManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTelephonyManagerTest.java
@@ -91,6 +91,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.ReflectionHelpers;
@@ -1547,13 +1548,13 @@ public class ShadowTelephonyManagerTest {
   public void telephonyManager_activityContextEnabled_differentInstancesRetrievePhoneCount() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       TelephonyManager applicationTelephonyManager =
           (TelephonyManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.TELEPHONY_SERVICE);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       TelephonyManager activityTelephonyManager =
           (TelephonyManager) activity.getSystemService(Context.TELEPHONY_SERVICE);
 
@@ -1564,9 +1565,6 @@ public class ShadowTelephonyManagerTest {
 
       assertThat(activityPhoneCount).isEqualTo(applicationPhoneCount);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTimeManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTimeManagerTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Tests for {@link ShadowTimeManager} */
@@ -64,11 +65,11 @@ public final class ShadowTimeManagerTest {
   public void timeManager_activityContextEnabled_differentInstancesRetrieveTimeZoneCapabilities() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       TimeManager applicationTimeManager =
           ApplicationProvider.getApplicationContext().getSystemService(TimeManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       TimeManager activityTimeManager = activity.getSystemService(TimeManager.class);
 
       TimeZoneConfiguration timeZoneConfiguration = new TimeZoneConfiguration.Builder().build();
@@ -83,9 +84,6 @@ public final class ShadowTimeManagerTest {
 
       assertThat(activityCapabilities).isEqualTo(applicationCapabilities);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTranslationManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTranslationManagerTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -63,12 +64,12 @@ public class ShadowTranslationManagerTest {
   public void translationManager_activityContextEnabled_differentInstancesRetrieveCapabilities() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       TranslationManager applicationTranslationManager =
           ApplicationProvider.getApplicationContext().getSystemService(TranslationManager.class);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       TranslationManager activityTranslationManager =
           activity.getSystemService(TranslationManager.class);
 
@@ -81,9 +82,6 @@ public class ShadowTranslationManagerTest {
 
       assertThat(activityCapabilities).isEqualTo(applicationCapabilities);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUsageStatsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUsageStatsManagerTest.java
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowUsageStatsManager.AppUsageLimitObserver;
 import org.robolectric.shadows.ShadowUsageStatsManager.AppUsageObserver;
@@ -1039,14 +1040,14 @@ public class ShadowUsageStatsManagerTest {
   public void usageStatsManager_activityContextEnabled_differentInstancesRetrieveBuckets() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       UsageStatsManager applicationUsageStatsManager =
           (UsageStatsManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.USAGE_STATS_SERVICE);
 
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       UsageStatsManager activityUsageStatsManager =
           (UsageStatsManager) activity.getSystemService(Context.USAGE_STATS_SERVICE);
 
@@ -1057,9 +1058,6 @@ public class ShadowUsageStatsManagerTest {
 
       assertThat(applicationBucket).isEqualTo(activityBucket);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbManagerTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowUsbManager._UsbManagerQ_;
 import org.robolectric.shadows.ShadowUsbManager._UsbManager_;
@@ -252,11 +253,11 @@ public class ShadowUsbManagerTest {
   public void usbManager_activityContextEnabled_differentInstancesRetrieveSameUsbDevices() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       UsbManager applicationUsbManager =
           ApplicationProvider.getApplicationContext().getSystemService(UsbManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       UsbManager activityUsbManager = activity.getSystemService(UsbManager.class);
 
       assertThat(applicationUsbManager).isNotSameInstanceAs(activityUsbManager);
@@ -266,9 +267,6 @@ public class ShadowUsbManagerTest {
 
       assertThat(activityDevices).isEqualTo(applicationDevices);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUserManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUserManagerTest.java
@@ -39,6 +39,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowUserManager.UserState;
@@ -1187,12 +1188,12 @@ public class ShadowUserManagerTest {
   public void userManager_activityContextEnabled_consistentAcrossContexts() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       UserManager applicationUserManager =
           (UserManager)
               ApplicationProvider.getApplicationContext().getSystemService(Context.USER_SERVICE);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       UserManager activityUserManager =
           (UserManager) activity.getSystemService(Context.USER_SERVICE);
 
@@ -1203,9 +1204,6 @@ public class ShadowUserManagerTest {
 
       assertThat(isAdminActivity).isEqualTo(isAdminApplication);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUwbManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUwbManagerTest.java
@@ -27,9 +27,9 @@ import org.mockito.ArgumentMatcher;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
-import org.robolectric.shadows.testing.TestActivity;
 
 /** Unit tests for {@link ShadowUwbManager}. */
 @RunWith(RobolectricTestRunner.class)
@@ -226,11 +226,11 @@ public class ShadowUwbManagerTest {
   public void uwbManager_activityContextEnabled_differentInstancesRetrieveSpecificationInfo() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       UwbManager applicationUwbManager =
           RuntimeEnvironment.getApplication().getSystemService(UwbManager.class);
-      activity = Robolectric.setupActivity(TestActivity.class);
+      Activity activity = controller.get();
       UwbManager activityUwbManager = activity.getSystemService(UwbManager.class);
 
       assertThat(applicationUwbManager).isNotSameInstanceAs(activityUwbManager);
@@ -240,9 +240,6 @@ public class ShadowUwbManagerTest {
 
       assertThat(activitySpecificationInfo).isEqualTo(applicationSpecificationInfo);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowVcnManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowVcnManagerTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Test for {@link ShadowVcnManager}. */
@@ -97,11 +98,11 @@ public final class ShadowVcnManagerTest {
   public void vcnManager_activityContextEnabled_differentInstancesRetrieveSubscriptionGroups() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       VcnManager applicationVcnManager =
           ApplicationProvider.getApplicationContext().getSystemService(VcnManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       VcnManager activityVcnManager = activity.getSystemService(VcnManager.class);
 
       assertThat(applicationVcnManager).isNotSameInstanceAs(activityVcnManager);
@@ -116,9 +117,6 @@ public final class ShadowVcnManagerTest {
       assertThat(activityConfiguredSubscriptionGroups)
           .isEqualTo(applicationConfiguredSubscriptionGroups);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowVirtualDeviceManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowVirtualDeviceManagerTest.java
@@ -53,10 +53,10 @@ import org.mockito.junit.MockitoRule;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowVirtualDeviceManager.ShadowVirtualDevice;
-import org.robolectric.shadows.testing.TestActivity;
 
 /** Unit test for ShadowVirtualDeviceManager and ShadowVirtualDevice. */
 @Config(minSdk = UPSIDE_DOWN_CAKE)
@@ -365,12 +365,12 @@ public class ShadowVirtualDeviceManagerTest {
   public void virtualDeviceManager_activityContextEnabled_retrievesSameVirtualDevices() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       VirtualDeviceManager applicationVirtualDeviceManager =
           (VirtualDeviceManager)
               RuntimeEnvironment.getApplication().getSystemService(Context.VIRTUAL_DEVICE_SERVICE);
-      activity = Robolectric.setupActivity(TestActivity.class);
+      Activity activity = controller.get();
       VirtualDeviceManager activityVirtualDeviceManager =
           (VirtualDeviceManager) activity.getSystemService(Context.VIRTUAL_DEVICE_SERVICE);
 
@@ -383,9 +383,6 @@ public class ShadowVirtualDeviceManagerTest {
       assertThat(activityVirtualDevices).isNotNull();
       assertThat(activityVirtualDevices).isEqualTo(applicationVirtualDevices);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowVpnManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowVpnManagerTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -100,11 +101,11 @@ public class ShadowVpnManagerTest {
   public void vpnManager_activityContextEnabled_differentInstancesInteract() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       VpnManager applicationVpnManager =
           RuntimeEnvironment.getApplication().getSystemService(VpnManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       VpnManager activityVpnManager = activity.getSystemService(VpnManager.class);
 
       assertThat(applicationVpnManager).isNotSameInstanceAs(activityVpnManager);
@@ -115,9 +116,6 @@ public class ShadowVpnManagerTest {
 
       assertThat(activityProfileState).isEqualTo(applicationProfileState);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWallpaperManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWallpaperManagerTest.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowWallpaperManager.WallpaperCommandRecord;
 
@@ -587,9 +588,9 @@ public class ShadowWallpaperManagerTest {
   public void wallpaperManager_activityContextEnabled_retrievesSameWallpaper() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
-      activity = Robolectric.setupActivity(Activity.class);
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
+      Activity activity = controller.get();
       WallpaperManager applicationWallpaperManager =
           (WallpaperManager) application.getSystemService(Context.WALLPAPER_SERVICE);
       WallpaperManager activityWallpaperManager =
@@ -603,9 +604,6 @@ public class ShadowWallpaperManagerTest {
 
       assertThat(activityWallpaper).isEqualTo(applicationWallpaper);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWearableSensingManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWearableSensingManagerTest.java
@@ -24,6 +24,7 @@ import org.mockito.junit.MockitoRule;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadow.api.Shadow;
 
@@ -111,11 +112,11 @@ public class ShadowWearableSensingManagerTest {
   public void wearableSensingManager_activityContextEnabled_differentInstancesProvideDataStream() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       WearableSensingManager applicationWearableSensingManager =
           RuntimeEnvironment.getApplication().getSystemService(WearableSensingManager.class);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       WearableSensingManager activityWearableSensingManager =
           activity.getSystemService(WearableSensingManager.class);
 
@@ -139,11 +140,7 @@ public class ShadowWearableSensingManagerTest {
           activityPfd, executor, activityStatusConsumer);
 
       assertThat(activityStatus[0]).isEqualTo(applicationStatus[0]);
-
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiAwareManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiAwareManagerTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 /** Test for {@link ShadowWifiAwareManager} */
@@ -201,13 +202,13 @@ public final class ShadowWifiAwareManagerTest {
   public void wifiAwareManager_activityContextEnabled_differentInstancesIsAvailable() {
     String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
     System.setProperty("robolectric.createActivityContexts", "true");
-    Activity activity = null;
-    try {
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
       WifiAwareManager applicationWifiAwareManager =
           (WifiAwareManager)
               ApplicationProvider.getApplicationContext()
                   .getSystemService(Context.WIFI_AWARE_SERVICE);
-      activity = Robolectric.setupActivity(Activity.class);
+      Activity activity = controller.get();
       WifiAwareManager activityWifiAwareManager =
           (WifiAwareManager) activity.getSystemService(Context.WIFI_AWARE_SERVICE);
 
@@ -218,9 +219,6 @@ public final class ShadowWifiAwareManagerTest {
 
       assertThat(activityIsAvailable).isEqualTo(applicationIsAvailable);
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiP2pManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiP2pManagerTest.java
@@ -22,8 +22,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.testing.TestActivity;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowWifiP2pManagerTest {
@@ -191,9 +191,9 @@ public class ShadowWifiP2pManagerTest {
           latch.countDown();
         });
 
-    Activity activity = null;
-    try {
-      activity = Robolectric.setupActivity(TestActivity.class);
+    try (ActivityController<Activity> controller =
+        Robolectric.buildActivity(Activity.class).setup()) {
+      Activity activity = controller.get();
       WifiP2pManager activityWifiP2pManager =
           (WifiP2pManager) activity.getSystemService(Context.WIFI_P2P_SERVICE);
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -220,9 +220,6 @@ public class ShadowWifiP2pManagerTest {
     } catch (InterruptedException e) {
       fail("Failed because of latch interrupt");
     } finally {
-      if (activity != null) {
-        activity.finish();
-      }
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }


### PR DESCRIPTION
1. Replace deprecated Robolectric.setupActivity with buildActivity.
2. Use try-with-resource for returned ActivityController to close it automatically without Activity finish().
