### PR TITLE
Fix a potential NPE in ShadowAccessibilityManager resetter

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
@@ -299,4 +299,11 @@ public class ShadowAccessibilityManagerTest {
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
+
+  @Test
+  public void reset_afterSetEnabledAccessibilityServiceListNull() {
+    shadowOf(accessibilityManager).setEnabledAccessibilityServiceList(null);
+    ShadowAccessibilityManager.reset();
+    assertThat(accessibilityManager.getAccessibilityServiceList()).isEmpty();
+  }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
@@ -63,7 +63,9 @@ public class ShadowAccessibilityManager {
     sentAccessibilityEvents.clear();
     enabled = false;
     installedAccessibilityServiceList.clear();
-    enabledAccessibilityServiceList.clear();
+    // enabledAccessibilityServiceList may be null, so set it to a new list.
+    // TODO(hoisie): change this to clear when null enabledAccessibilityServiceList is not allowed.
+    enabledAccessibilityServiceList = new ArrayList<>();
     accessibilityServiceList.clear();
     onAccessibilityStateChangeListeners.clear();
     touchExplorationEnabled = false;


### PR DESCRIPTION
The 'enabledAccessibilityServiceList' may be null due to shadow APIs, so set it to an empty list instead of clearing it.
