### PR TITLE
Fix an NPE in ShadowConnectivityManager

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
@@ -839,4 +839,11 @@ public class ShadowConnectivityManagerTest {
       assertThat(connectivityManager.getActiveNetwork()).isNotNull();
     }
   }
+
+  @Config(minSdk = M)
+  @Test
+  public void getActiveNetwork_afterSetActiveNetworkInfoNull() {
+    shadowOf(connectivityManager).setActiveNetworkInfo(null);
+    assertThat(connectivityManager.getActiveNetwork()).isNull();
+  }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowConnectivityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowConnectivityManager.java
@@ -239,8 +239,8 @@ public class ShadowConnectivityManager {
    */
   @Implementation(minSdk = M)
   protected Network getActiveNetwork() {
-    if (defaultNetworkActive) {
-      return netIdToNetwork.get(getActiveNetworkInfo().getType());
+    if (defaultNetworkActive && activeNetworkInfo != null) {
+      return netIdToNetwork.get(activeNetworkInfo.getType());
     }
     return null;
   }


### PR DESCRIPTION
If ConnectivityManager.getActiveNetwork() was called after calling ShadowConnectivityManager.setActiveNetworkInfo(null), an NPE would result. Fix this edge case.