### PR TITLE
Fix ShadowAccessibilityManager tests

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
@@ -299,11 +299,4 @@ public class ShadowAccessibilityManagerTest {
       System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
-
-  @Test
-  public void reset_afterSetEnabledAccessibilityServiceListNull() {
-    shadowOf(accessibilityManager).setEnabledAccessibilityServiceList(null);
-    ShadowAccessibilityManager.reset();
-    assertThat(accessibilityManager.getAccessibilityServiceList()).isEmpty();
-  }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
@@ -64,9 +64,7 @@ public class ShadowAccessibilityManager {
     sentAccessibilityEvents.clear();
     enabled = false;
     installedAccessibilityServiceList.clear();
-    // enabledAccessibilityServiceList may be null, so set it to a new list.
-    // TODO(hoisie): change this to clear when null enabledAccessibilityServiceList is not allowed.
-    enabledAccessibilityServiceList = new ArrayList<>();
+    enabledAccessibilityServiceList.clear();
     accessibilityServiceList.clear();
     onAccessibilityStateChangeListeners.clear();
     touchExplorationEnabled = false;
@@ -159,7 +157,7 @@ public class ShadowAccessibilityManager {
 
   public void setInstalledAccessibilityServiceList(
       List<AccessibilityServiceInfo> installedAccessibilityServiceList) {
-    Preconditions.checkNotNull(accessibilityServiceList);
+    Preconditions.checkNotNull(installedAccessibilityServiceList);
     this.installedAccessibilityServiceList = new ArrayList<>(installedAccessibilityServiceList);
   }
 


### PR DESCRIPTION
With the recent changes from the `google` branch, ShadowAccessibilityManager
tests broke. Update the tests to reflect the recent changes.

Also fix a typo in
ShadowAccessibilityManager.setinstalledAccessibilityServiceList. The
Preconditions check should be for installedAccessibilityServiceList.