### PR TITLE
Fix warnings in `annotations`

### DIFF
--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -9,6 +9,5 @@ dependencies {
   compileOnly(AndroidSdk.MAX_SDK.coordinates)
   testImplementation(libs.truth)
   testImplementation(libs.junit4)
-  testImplementation(libs.javax.annotation.api)
   testCompileOnly(AndroidSdk.MAX_SDK.coordinates) // compile against latest Android SDK
 }

--- a/annotations/src/main/java/org/robolectric/annotation/Config.java
+++ b/annotations/src/main/java/org/robolectric/annotation/Config.java
@@ -186,7 +186,7 @@ public @interface Config {
     private final String[] libraries;
 
     public static Config fromProperties(Properties properties) {
-      if (properties == null || properties.size() == 0) return null;
+      if (properties == null || properties.isEmpty()) return null;
       return new Implementation(
           parseSdkArrayProperty(properties.getProperty("sdk", "")),
           parseSdkInt(properties.getProperty("minSdk", "-1")),
@@ -216,7 +216,7 @@ public @interface Config {
     private static Class<?>[] parseClasses(String input) {
       if (input.isEmpty()) return new Class[0];
       final String[] classNames = input.split("[, ]+", 0);
-      final Class[] classes = new Class[classNames.length];
+      final Class<?>[] classes = new Class[classNames.length];
       for (int i = 0; i < classNames.length; i++) {
         classes[i] = parseClass(classNames[i]);
       }
@@ -560,7 +560,7 @@ public @interface Config {
       this.fontScale = pick(this.fontScale, overlayFontScale, DEFAULT_FONT_SCALE);
 
       String qualifiersOverlayValue = overlayConfig.qualifiers();
-      if (qualifiersOverlayValue != null && !qualifiersOverlayValue.equals("")) {
+      if (qualifiersOverlayValue != null && !qualifiersOverlayValue.isEmpty()) {
         if (qualifiersOverlayValue.startsWith("+")) {
           this.qualifiers = this.qualifiers + " " + qualifiersOverlayValue;
         } else {
@@ -575,20 +575,18 @@ public @interface Config {
 
       List<Class<?>> shadows = new ArrayList<>(Arrays.asList(this.shadows));
       shadows.addAll(Arrays.asList(overlayConfig.shadows()));
-      this.shadows = shadows.toArray(new Class[shadows.size()]);
+      this.shadows = shadows.toArray(new Class[0]);
 
       Set<String> instrumentedPackages = new HashSet<>();
       instrumentedPackages.addAll(Arrays.asList(this.instrumentedPackages));
       instrumentedPackages.addAll(Arrays.asList(overlayConfig.instrumentedPackages()));
-      this.instrumentedPackages =
-          instrumentedPackages.toArray(new String[instrumentedPackages.size()]);
-
+      this.instrumentedPackages = instrumentedPackages.toArray(new String[0]);
       this.application = pick(this.application, overlayConfig.application(), DEFAULT_APPLICATION);
 
       Set<String> libraries = new HashSet<>();
       libraries.addAll(Arrays.asList(this.libraries));
       libraries.addAll(Arrays.asList(overlayConfig.libraries()));
-      this.libraries = libraries.toArray(new String[libraries.size()]);
+      this.libraries = libraries.toArray(new String[0]);
 
       return this;
     }

--- a/annotations/src/main/java/org/robolectric/annotation/Implements.java
+++ b/annotations/src/main/java/org/robolectric/annotation/Implements.java
@@ -71,10 +71,9 @@ public @interface Implements {
    * If set to true, Robolectric will invoke the native method variant instead of the no-op variant.
    * This requires the native method to be bound, or an {@link UnsatisfiedLinkError} will occur.
    *
-   * <p>{@link Implements#callNativeMethodsByDefault()} has precedence over {@link
-   * Implements#callThroughByDefault()} For instance, if both {@link
-   * Implements#callNativeMethodsByDefault()} and {@link Implements#callThroughByDefault()} are
-   * true, the native method variant will be preferred over the no-op native variant.
+   * <p>This method has precedence over {@link Implements#callThroughByDefault()}. For instance, if
+   * both this method and {@link Implements#callThroughByDefault()} are true, the native method
+   * variant will be preferred over the no-op native variant.
    */
   boolean callNativeMethodsByDefault() default false;
 

--- a/annotations/src/main/java/org/robolectric/annotation/experimental/LazyApplication.java
+++ b/annotations/src/main/java/org/robolectric/annotation/experimental/LazyApplication.java
@@ -9,10 +9,10 @@ import java.lang.annotation.Target;
  * A {@link org.robolectric.pluginapi.config.Configurer} annotation that dictates whether or not
  * Robolectric should lazily instantiate the Application under test.
  *
- * <p>In particular, any test with {@link LazyLoad.ON} that does not need the Application will not
+ * <p>In particular, any test with {@link LazyLoad#ON} that does not need the Application will not
  * load it (and recoup the associated cost)
  *
- * <p>NOTE: This feature is currently still experimental, so any users of {@link LazyLoad.ON} do so
+ * <p>NOTE: This feature is currently still experimental, so any users of {@link LazyLoad#ON} do so
  * at their own risk
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/annotations/src/main/java/org/robolectric/versioning/AndroidVersions.java
+++ b/annotations/src/main/java/org/robolectric/versioning/AndroidVersions.java
@@ -54,6 +54,7 @@ import javax.annotation.Nullable;
  */
 public final class AndroidVersions {
 
+  @SuppressWarnings("FieldMayBeFinal") // The value is changed via reflection in tests
   private static boolean warnOnly;
 
   private AndroidVersions() {}
@@ -89,17 +90,10 @@ public final class AndroidVersions {
      *
      * @param other the object to be compared.
      * @return 1 if this is greater than other, 0 if equal, -1 if less
-     * @throws IllegalStateException if other is not an instance of AndroidRelease.
+     * @throws NullPointerException if other is null.
      */
     @Override
     public int compareTo(AndroidRelease other) {
-      if (other == null) {
-        throw new IllegalStateException(
-            "Only "
-                + AndroidVersions.class.getName()
-                + " should define Releases, illegal class "
-                + other.getClass());
-      }
       return Integer.compare(this.getSdkInt(), other.getSdkInt());
     }
 
@@ -952,7 +946,7 @@ public final class AndroidVersions {
             current = shortCodeToAllReleases.get(codename);
             // else, assume the fullname is the first letter is correct.
             if (current == null) {
-              current = shortCodeToAllReleases.get(String.valueOf(foundCode));
+              current = shortCodeToAllReleases.get(foundCode);
             }
           }
           if (current == null) {
@@ -1080,7 +1074,7 @@ public final class AndroidVersions {
 
   private static final SdkInformation information;
 
-  private static final void errorMessage(String errorMessage, @Nullable Exception ex) {
+  private static void errorMessage(String errorMessage, @Nullable Exception ex) {
     if (warnOnly) {
       System.err.println(errorMessage);
     } else {

--- a/annotations/src/test/java/org/robolectric/versioning/AndroidVersionsEdgeCaseTest.java
+++ b/annotations/src/test/java/org/robolectric/versioning/AndroidVersionsEdgeCaseTest.java
@@ -1,9 +1,11 @@
 package org.robolectric.versioning;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -36,7 +38,10 @@ public final class AndroidVersionsEdgeCaseTest {
       SdkInformation information = AndroidVersions.gatherStaticSdkInformationFromThisClass();
       earliestUnrelease = information.earliestUnreleased;
       information.computeCurrentSdk(
-          earliestUnrelease.getSdkInt(), earliestUnrelease.getVersion(), "REL", Arrays.asList());
+          earliestUnrelease.getSdkInt(),
+          earliestUnrelease.getVersion(),
+          "REL",
+          Collections.emptyList());
       assertThat(this).isNull();
     } catch (RuntimeException e) {
       assertThat(e)
@@ -69,7 +74,7 @@ public final class AndroidVersionsEdgeCaseTest {
           latestRelease.getSdkInt(),
           null,
           latestRelease.getShortCode(),
-          Arrays.asList(latestRelease.getShortCode()));
+          Collections.singletonList(latestRelease.getShortCode()));
       assertThat(this).isNull();
     } catch (RuntimeException e) {
       assertThat(e)
@@ -85,7 +90,7 @@ public final class AndroidVersionsEdgeCaseTest {
 
   @Test
   public void sdkIntReleasedButStillReportsCodeName_warningMode() {
-    AndroidRelease latestRelease = null;
+    AndroidRelease latestRelease;
     try {
       forceWarningMode(true);
       SdkInformation information = AndroidVersions.gatherStaticSdkInformationFromThisClass();
@@ -95,7 +100,7 @@ public final class AndroidVersionsEdgeCaseTest {
           latestRelease.getSdkInt(),
           null,
           information.latestRelease.getShortCode(),
-          Arrays.asList(latestRelease.getShortCode()));
+          Collections.singletonList(latestRelease.getShortCode()));
     } catch (Throwable t) {
       assertThat(t).isNull();
     }
@@ -115,7 +120,7 @@ public final class AndroidVersionsEdgeCaseTest {
         latestRelease.getSdkInt(),
         null,
         information.latestRelease.getShortCode(),
-        Arrays.asList(latestRelease.getShortCode()));
+        Collections.singletonList(latestRelease.getShortCode()));
     assertThat(this).isNotNull();
   }
 
@@ -131,5 +136,11 @@ public final class AndroidVersionsEdgeCaseTest {
     } catch (Throwable t) {
       assertThat(t).isNull();
     }
+  }
+
+  @Test
+  public void compareToNull_throwsNullPointerException() {
+    //noinspection DataFlowIssue Passing null to ensure that the right exception is thrown
+    assertThrows(NullPointerException.class, () -> new AndroidVersions.T().compareTo(null));
   }
 }


### PR DESCRIPTION
This PR addresses some warnings reported by Android Studio in the `annotations` module.

The `AndroidVersions` class uses the Stream API, which is only available on API 24+. I don't know if that's an issue or not, so I left the code as it is for now.