### PR TITLE
Upgrade to Guava 33.3.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,10 +18,6 @@ updates:
         patterns:
           - "androidx.*"
     ignore:
-      # don't auto update guava since it requires updating gradle
-      - dependency-name: "*guava*"
-      # don't auto update errorprone since it requires updating guava
-      - dependency-name: "*errorprone*"
       # don't auto update nativeruntime-dist-compat since it needs
       # to be updated with code changes together
       - dependency-name: "org.robolectric:nativeruntime-dist-compat"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,7 @@ auto-value = "1.11.0"
 compile-testing = "0.21.0"
 
 # https://github.com/google/guava/releases
-guava-jre = "31.1-jre"
+guava-jre = "33.3.1-jre"
 
 # https://github.com/google/gson/releases
 gson = "2.11.0"


### PR DESCRIPTION
This PR updates to Guava 33.3.1.
The changelogs for each version are below:
- [32.0.0](https://github.com/google/guava/releases/tag/v32.0.0)
- [32.0.1](https://github.com/google/guava/releases/tag/v32.0.1)
- [32.1.0](https://github.com/google/guava/releases/tag/v32.1.0)
- [32.1.1](https://github.com/google/guava/releases/tag/v32.1.1)
- [32.1.2](https://github.com/google/guava/releases/tag/v32.1.2)
- [32.1.3](https://github.com/google/guava/releases/tag/v32.1.3)
- [33.0.0](https://github.com/google/guava/releases/tag/v33.0.0)
- [33.1.0](https://github.com/google/guava/releases/tag/v33.1.0)
- [33.2.0](https://github.com/google/guava/releases/tag/v33.2.0)
- [33.2.1](https://github.com/google/guava/releases/tag/v33.2.1)
- [33.3.0](https://github.com/google/guava/releases/tag/v33.3.0)
- [33.3.1](https://github.com/google/guava/releases/tag/v33.3.1)

I'm aware of https://github.com/robolectric/robolectric/pull/8812, so I've tested upgrading to Guava 33.3.1 on a small local project, which uses Gradle 7.6.4 and AGP 7.4.2.
The latest version of Guava doesn't seem to force updating Gradle anymore.

I've also updated Dependabot to support updating Guava and Errorprone again.

@utzcoz do you know any open source project I could check to make sure that this works? Or do you have projects you can try yourself?

Fixes https://github.com/robolectric/robolectric/issues/8811