### PR TITLE
Update to `google-java-format` 1.24.0

### DIFF
--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Download google-java-format
         run: |
-          googleJavaFormatVersion="1.23.0"
+          googleJavaFormatVersion="1.24.0"
           curl -L -o $HOME/google-java-format.jar https://github.com/google/google-java-format/releases/download/v${googleJavaFormatVersion}/google-java-format-${googleJavaFormatVersion}-all-deps.jar
           curl -L -o $HOME/google-java-format-diff.py https://raw.githubusercontent.com/google/google-java-format/v${googleJavaFormatVersion}/scripts/google-java-format-diff.py
           chmod +x $HOME/google-java-format-diff.py

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextHubManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextHubManager.java
@@ -418,4 +418,3 @@ public class ShadowContextHubManager {
     void setContents(List<NanoAppState> contents);
   }
 }
-

--- a/utils/src/main/java/org/robolectric/AndroidMetadata.java
+++ b/utils/src/main/java/org/robolectric/AndroidMetadata.java
@@ -14,5 +14,4 @@ public class AndroidMetadata {
   public Map<String, String> getDeviceBootProperties() {
     return deviceBootProperties;
   }
-
 }


### PR DESCRIPTION
This PR updates `google-java-format` to the latest version. The release notes are available here: https://github.com/google/google-java-format/releases/tag/v1.24.0