### PR TITLE
Create a Dependabot group for AGP

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      android-gradle-plugin:
+        patterns:
+          - "com.android.tools:common:*"
+          - "com.android.tools.build:gradle*"
       androidx-test:
         patterns:
           - "androidx.test*"


### PR DESCRIPTION
This PR creates a Dependabot dependency group for AGP and Android Tools common.