### PR TITLE
Do not calculate determineTargetClass when the cache is available

### DIFF
--- a/utils/reflector/src/main/java/org/robolectric/util/reflector/Reflector.java
+++ b/utils/reflector/src/main/java/org/robolectric/util/reflector/Reflector.java
@@ -62,11 +62,10 @@ public class Reflector {
       return (T) staticReflectorCache.get(iClass);
     }
 
-    Class<?> targetClass = determineTargetClass(iClass);
-
     Constructor<? extends T> ctor = (Constructor<? extends T>) cache.get(iClass);
     try {
       if (ctor == null) {
+        Class<?> targetClass = determineTargetClass(iClass);
         Class<? extends T> reflectorClass =
             PerfStatsCollector.getInstance()
                 .measure(


### PR DESCRIPTION
### Overview
I noticed that calls like `Class.getAnnotation()` in determineTargetClass() can be a bottleneck in some projects,
so I avoid using it when the cache is available.

I might make some mistakes or misunderstandings, and I haven't checked the fixed version in my project.

### Proposed Changes
I added a cache for `getAnnotation` in Reflector.

<img width="1050" alt="image" src="https://github.com/user-attachments/assets/3d411319-5b52-4395-ae83-c9f82f3aaf45">
