### PR TITLE
Add support for Android V

### DIFF
--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Show runner info
         run: uname -a
 
+      - name: Disable graphics tests for Windows on Android V
+        if: matrix.os == 'windows-2022'
+        run: |
+          echo "robolectric.enabledSdks=26,27,28,29,30,31,32,33,34" >> $env:GITHUB_ENV
+
       - name: Run unit tests
         env:
           SKIP_ERRORPRONE: true

--- a/buildSrc/src/main/java/AndroidSdk.kt
+++ b/buildSrc/src/main/java/AndroidSdk.kt
@@ -64,9 +64,10 @@ class AndroidSdk(
     val S_V2 = AndroidSdk(32, "12.1", "8229987")
     val TIRAMISU = AndroidSdk(33, "13", "9030017")
     val U = AndroidSdk(34, "14", "10818077")
+    val V = AndroidSdk(35, "15", "12543294")
 
     val ALL_SDKS =
-      listOf(LOLLIPOP, LOLLIPOP_MR1, M, N, N_MR1, O, O_MR1, P, Q, R, S, S_V2, TIRAMISU, U)
+      listOf(LOLLIPOP, LOLLIPOP_MR1, M, N, N_MR1, O, O_MR1, P, Q, R, S, S_V2, TIRAMISU, U, V)
 
     val MAX_SDK = ALL_SDKS.maxBy { it.apiLevel }
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-robolectric-nativeruntime-dist-compat = "1.0.15"
+robolectric-nativeruntime-dist-compat = "1.0.16"
 
 # https://developer.android.com/studio/releases
 android-gradle = "8.6.0"

--- a/integration_tests/kotlin/src/test/kotlin/org/robolectric/integrationtests/kotlin/CustomShadowImageViewTest.kt
+++ b/integration_tests/kotlin/src/test/kotlin/org/robolectric/integrationtests/kotlin/CustomShadowImageViewTest.kt
@@ -18,7 +18,8 @@ class CustomShadowImageViewTest {
   fun `use custom ShadowImageView`() {
     val activity = Robolectric.setupActivity(Activity::class.java)
     val imageView = ImageView(activity)
-    (activity.findViewById(android.R.id.content) as ViewGroup).addView(imageView)
+    val viewGroup: ViewGroup = activity.findViewById(android.R.id.content)!!
+    viewGroup.addView(imageView)
     val shadowImageView = Shadow.extract<CustomShadowImageView>(imageView)
     assertThat(shadowImageView).isNotNull()
     assertThat(shadowImageView.realImageView).isSameInstanceAs(imageView)

--- a/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativeHardwareRendererTest.java
+++ b/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativeHardwareRendererTest.java
@@ -23,9 +23,11 @@ import java.nio.IntBuffer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.OsUtil;
 import org.robolectric.util.reflector.ForType;
+import org.robolectric.versioning.AndroidVersions.V;
 
 @Config(minSdk = Q)
 @RunWith(RobolectricTestRunner.class)
@@ -109,12 +111,12 @@ public class ShadowNativeHardwareRendererTest {
 
       // Check that the pixel at (0, 0) is white.
       assertThat(Integer.toHexString(dstImageData[0])).isEqualTo("ffffffff");
-      if (OsUtil.isMac()) {
-        // Check for red pixels in ABGR format on Mac.
+      if (OsUtil.isMac() && RuntimeEnvironment.getApiLevel() < V.SDK_INT) {
+        // Check for red pixels in ABGR format on Mac for U and below.
         assertThat(Integer.toHexString(dstImageData[1])).isEqualTo("ff0000ff");
         assertThat(Integer.toHexString(dstImageData[2])).isEqualTo("ff0000ff");
       } else {
-        // Check for red pixels in ARGB format on Linux/Windows.
+        // Check for red pixels in ARGB format on Linux/Windows, and for Mac for V and above.
         assertThat(Integer.toHexString(dstImageData[1])).isEqualTo("ffff0000");
         assertThat(Integer.toHexString(dstImageData[2])).isEqualTo("ffff0000");
       }

--- a/nativeruntime/build.gradle.kts
+++ b/nativeruntime/build.gradle.kts
@@ -61,6 +61,7 @@ if (System.getenv("PUBLISH_NATIVERUNTIME_DIST_COMPAT") == "true") {
 }
 
 dependencies {
+  api(project(":shadowapi"))
   api(project(":utils"))
   api(project(":utils:reflector"))
   api(libs.guava)

--- a/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
@@ -31,6 +31,7 @@ import org.robolectric.versioning.AndroidVersions.S;
 import org.robolectric.versioning.AndroidVersions.Sv2;
 import org.robolectric.versioning.AndroidVersions.T;
 import org.robolectric.versioning.AndroidVersions.U;
+import org.robolectric.versioning.AndroidVersions.V;
 
 /**
  * Robolectric's default {@link SdkProvider}.
@@ -75,6 +76,7 @@ public class DefaultSdkProvider implements SdkProvider {
     knownSdks.put(Sv2.SDK_INT, new DefaultSdk(Sv2.SDK_INT, "12.1", "8229987", "REL", 9));
     knownSdks.put(T.SDK_INT, new DefaultSdk(T.SDK_INT, "13", "9030017", "Tiramisu", 9));
     knownSdks.put(U.SDK_INT, new DefaultSdk(U.SDK_INT, "14", "10818077", "REL", 17));
+    knownSdks.put(V.SDK_INT, new DefaultSdk(V.SDK_INT, "15", "12543294", "REL", 17));
   }
 
   @Override

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
@@ -158,6 +158,12 @@ public class InstrumentationConfiguration {
    * @return True if the resource should be loaded.
    */
   public boolean shouldAcquireResource(String name) {
+    if (name.contains("android_runtime")) {
+      return true;
+    }
+    if (name.contains("icudt75l.dat")) {
+      return true;
+    }
     return RESOURCES_TO_ALWAYS_ACQUIRE.contains(name);
   }
 

--- a/scripts/install-android-prebuilt.sh
+++ b/scripts/install-android-prebuilt.sh
@@ -34,6 +34,13 @@ ANDROID_ALL_SRC=android-all-${ROBOLECTRIC_VERSION}-sources.jar
 ANDROID_ALL_DOC=android-all-${ROBOLECTRIC_VERSION}-javadoc.jar
 ANDROID_BUNDLE=android-all-${ROBOLECTRIC_VERSION}-bundle.jar
 
+generate_empty_sources() {
+    TMP=`mktemp --directory`
+    cd ${TMP}
+    jar cf ${JAR_DIR}/${ANDROID_ALL_SRC} .
+    cd ${JAR_DIR}; rm -rf ${TMP}
+}
+
 generate_empty_javadoc() {
     TMP=`mktemp --directory`
     cd ${TMP}
@@ -81,6 +88,7 @@ mavenize() {
 }
 
 generate_empty_javadoc
+generate_empty_sources
 build_signed_packages
 mavenize
 


### PR DESCRIPTION
Add support for Android V

This adds support for Android V (SDK 35) from build id 12543294. It requires
updating DefaultNativeRuntimeLoader since libandroid_runtime from Android V is
now embedded in the android-all jar. The ICU version is different (75 vs 68).
Currently some Windows native code tests don't pass, but they will be resolved
shortly.
