### PR TITLE
Use max SDK version if lower than target SDK version

### DIFF
--- a/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkPicker.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkPicker.java
@@ -116,8 +116,9 @@ public class DefaultSdkPicker implements SdkPicker {
         throw new IllegalArgumentException(
             "Package targetSdkVersion=" + appTargetSdk + " < minSdkVersion=" + appMinSdk);
       } else if (appMaxSdk != 0 && appTargetSdk > appMaxSdk) {
-        throw new IllegalArgumentException(
+        System.err.println(
             "Package targetSdkVersion=" + appTargetSdk + " > maxSdkVersion=" + appMaxSdk);
+        return Collections.singleton(sdkCollection.getSdk(appMaxSdk));
       }
       return Collections.singleton(sdkCollection.getSdk(appTargetSdk));
     }

--- a/robolectric/src/test/java/org/robolectric/plugins/DefaultSdkPickerTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/DefaultSdkPickerTest.java
@@ -129,15 +129,11 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void withTargetSdkGreaterThanMaxSdk_shouldThrowError() {
+  public void withTargetSdkGreaterThanMaxSdk_shouldUseMaxSdk() {
     when(usesSdk.getMaxSdkVersion()).thenReturn(21);
     when(usesSdk.getTargetSdkVersion()).thenReturn(22);
-    try {
-      sdkPicker.selectSdks(buildConfig(new Config.Builder()), usesSdk);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().contains("Package targetSdkVersion=22 > maxSdkVersion=21");
-    }
+    assertThat(sdkPicker.selectSdks(buildConfig(new Config.Builder()), usesSdk))
+        .containsExactly(sdkCollection.getSdk(21));
   }
 
   @Test


### PR DESCRIPTION
### Overview

Every time a new version of Android is released, a new version of Robolectric is required for compatibility.
It can take several months between the Platform Stability milestone and the new version of Robolectric.
During this time, updating the target SDK version will cause tests to fail because it is greater than the max SDK version.
While it is still possible to explicitly declare tests to run on a lower SDK version, it adds complexity and requires maintenance.

See also https://github.com/robolectric/robolectric/issues/9203.

### Proposed Changes

Instead of failing tests, print a warning and use the max SDK version if it is lower than the target SDK version.