### PR TITLE
gradle: Bump Spotless to 7.0.0.BETA3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ kotlin = "2.0.21"
 kotlinx-coroutines = '1.9.0'
 
 # https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md
-spotless-gradle = "6.25.0"
+spotless-gradle = "7.0.0.BETA3"
 
 # https://detekt.dev/changelog
 detekt-gradle = "1.23.7"


### PR DESCRIPTION
It works with Gradle + JDK21 that Robolectric uses now.