### PR TITLE
Disable commit body check for Dependabot

### DIFF
--- a/.github/workflows/validate_commit_message.yml
+++ b/.github/workflows/validate_commit_message.yml
@@ -37,6 +37,7 @@ jobs:
           fi
 
       - name: Validate commit body
+        if: github.actor != "dependabot[bot]"
         run: |
           # Check that the commit has a body
           commit_body="$(git log -1 --pretty=format:'%b' | grep -v 'PiperOrigin-RevId')"


### PR DESCRIPTION
Dependabot commit message may contain long lines. For example: https://github.com/robolectric/robolectric/pull/9699

This PR disables the commit message check, when the build is triggered by Dependabot.

Note: the commit title is not affected by this change.