### PR TITLE
Properly disable API 35 on Windows in `graphics_tests.yml`

### DIFF
--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -44,9 +44,9 @@ jobs:
         run: uname -a
 
       - name: Disable graphics tests for Windows on Android V
-        if: matrix.os == 'windows-2022'
+        if: runner.os == 'Windows'
         run: |
-          echo "robolectric.enabledSdks=26,27,28,29,30,31,32,33,34" >> $env:GITHUB_ENV
+          echo "ENABLED_SDKS=26,27,28,29,30,31,32,33,34" >> $env:GITHUB_ENV
 
       - name: Run unit tests
         env:
@@ -59,6 +59,7 @@ jobs:
           --parallel
           --no-watch-fs
           "-Drobolectric.alwaysIncludeVariantMarkersInTestName=true"
+          "-Drobolectric.enabledSdks=${{ env.ENABLED_SDKS }}"
           "-Dorg.gradle.workers.max=2"
 
       - name: Upload Test Results


### PR DESCRIPTION
Currently, `graphics_tests.yml` was using `matrix.os` to disable API 35 on Windows. However, that field doesn't exist.
Instead, we should use `matrix.device`, or the GitHub Actions provided `runner.os` for a more generic solution.