### PR TITLE
Update Ubuntu runners to use `ubuntu-latest`

### DIFF
--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   check_code_style:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/copybara_build_and_test.yml
+++ b/.github/workflows/copybara_build_and_test.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   copybara-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gradle_tasks_validation.yml
+++ b/.github/workflows/gradle_tasks_validation.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   run_aggregateDocs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
           path: build/docs
 
   run_javadocJar:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
 
 
   run_instrumentAll:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -84,7 +84,7 @@ jobs:
         run: PREINSTRUMENTED_SDK_VERSIONS=33 PUBLISH_PREINSTRUMENTED_JARS=true ./gradlew :preinstrumented:publishToMavenLocal
 
   run_publishToMavenLocal:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -24,7 +24,7 @@ jobs:
         device: [
           macos-13, # Tests Mac x86_64
           macos-14, # Tests Mac arm64
-          ubuntu-22.04, # Tests Linux x86_64
+          ubuntu-latest, # Tests Linux x86_64
           windows-2022, # Tests Windows x86_64
         ]
     runs-on: ${{ matrix.device }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
           ./gradlew assemble testClasses --parallel --stacktrace --no-watch-fs
 
   unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build
     strategy:
       fail-fast: false
@@ -80,7 +80,7 @@ jobs:
           path: '**/build/test-results/**/TEST-*.xml'
 
   instrumentation-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: build
 
@@ -169,7 +169,7 @@ jobs:
             **/build/outputs/*/connected/*
 
   publish-to-snapshots:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       SONATYPE_LOGIN: ${{ secrets.SONATYPE_LOGIN }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/validate_commit_message.yml
+++ b/.github/workflows/validate_commit_message.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   validate_commit_message:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR changes the version of the Ubuntu runners used in GitHub Actions. Currently, `ubuntu-22.04` is used for most workflows. Now `ubuntu-latest` (which points to `ubuntu-24.04`) is used everywhere.