### PR TITLE
Make ContextTest euicc tests work on device that doesn't support it

### DIFF
--- a/integration_tests/ctesque/src/androidTest/java/android/app/ContextTest.java
+++ b/integration_tests/ctesque/src/androidTest/java/android/app/ContextTest.java
@@ -1,6 +1,7 @@
 package android.app;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import android.Manifest;
 import android.accounts.Account;
@@ -883,6 +884,7 @@ public class ContextTest {
     EuiccManager applicationEuiccManager =
         (EuiccManager)
             ApplicationProvider.getApplicationContext().getSystemService(Context.EUICC_SERVICE);
+    assumeTrue(applicationEuiccManager != null);
     try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
       scenario.onActivity(
           activity -> {
@@ -912,6 +914,7 @@ public class ContextTest {
     EuiccManager applicationEuiccManager =
         (EuiccManager)
             ApplicationProvider.getApplicationContext().getSystemService(Context.EUICC_SERVICE);
+    assumeTrue(applicationEuiccManager != null);
     try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
       scenario.onActivity(
           activity -> {


### PR DESCRIPTION
They can work fine on some API 35 emulator images.