### PR TITLE
Remove unused dependency and TODO in `errorprone`

### DIFF
--- a/errorprone/build.gradle.kts
+++ b/errorprone/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
 
   // Testing dependencies
   testImplementation(libs.junit4)
-  testImplementation(libs.truth)
   testImplementation(libs.error.prone.test.helpers)
   testCompileOnly(AndroidSdk.MAX_SDK.coordinates)
 }

--- a/errorprone/src/main/java/org/robolectric/errorprone/bugpatterns/Helpers.java
+++ b/errorprone/src/main/java/org/robolectric/errorprone/bugpatterns/Helpers.java
@@ -48,10 +48,6 @@ public class Helpers {
     @Override
     public boolean apply(Type type, VisitorState state) {
       Type bound = expected.get(state);
-      if (bound == null || type == null) {
-        // TODO(cushon): type suppliers are allowed to return null :(
-        return false;
-      }
       return ASTHelpers.isCastable(type, bound, state);
     }
   }


### PR DESCRIPTION
Truth is not used in the `errorprone` module, so that dependency is not necessary.

Also, `ASTHelpers.isCastable()` already checks if its arguments are `null`. So the TODO/check are not necessary anymore.
https://github.com/google/error-prone/blob/0e06cc234b45625ca136ce1e47d096280df3ddd1/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java#L1328-L1335