### PR TITLE
Disable native graphics test on Windows in SDK 35

### DIFF
--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -44,9 +44,9 @@ jobs:
         run: uname -a
 
       - name: Disable graphics tests for Windows on Android V
-        if: matrix.os == 'windows-2022'
+        if: runner.os == 'Windows'
         run: |
-          echo "robolectric.enabledSdks=26,27,28,29,30,31,32,33,34" >> $env:GITHUB_ENV
+          echo "ENABLED_SDKS=26,27,28,29,30,31,32,33,34" >> $env:GITHUB_ENV
 
       - name: Run unit tests
         env:
@@ -59,6 +59,7 @@ jobs:
           --parallel
           --no-watch-fs
           "-Drobolectric.alwaysIncludeVariantMarkersInTestName=true"
+          "-Drobolectric.enabledSdks=${{ env.ENABLED_SDKS }}"
           "-Dorg.gradle.workers.max=2"
 
       - name: Upload Test Results


### PR DESCRIPTION
Disable native graphics test on Windows in SDK 35

This is cherry-picked from #9720. Thanks @MGaetan89.
