### PR TITLE
Remove some `isInAndroidSdk = false` from `Implements` annotation

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGainmap.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowGainmap.java
@@ -11,11 +11,7 @@ import org.robolectric.res.android.NativeObjRegistry;
 import org.robolectric.versioning.AndroidVersions.U;
 
 /** Fake implementation for Gainmap class. */
-@Implements(
-    value = Gainmap.class,
-    minSdk = U.SDK_INT,
-    // TODO: remove when minimum supported compileSdk is >= 34
-    isInAndroidSdk = false)
+@Implements(value = Gainmap.class, minSdk = U.SDK_INT)
 public class ShadowGainmap {
 
   @RealObject Gainmap realGainmap;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSurfaceSyncGroup.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSurfaceSyncGroup.java
@@ -15,11 +15,7 @@ import org.robolectric.util.reflector.Static;
 import org.robolectric.versioning.AndroidVersions.U;
 
 /** Shadow for new SurfaceSyncGroup introduced in android U. */
-@Implements(
-    value = SurfaceSyncGroup.class,
-    minSdk = U.SDK_INT,
-    // TODO: remove when minimum supported compileSdk is >= 34
-    isInAndroidSdk = false)
+@Implements(value = SurfaceSyncGroup.class, minSdk = U.SDK_INT)
 public class ShadowSurfaceSyncGroup {
 
   @Resetter

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVirtualSensor.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVirtualSensor.java
@@ -9,11 +9,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.versioning.AndroidVersions.U;
 
 /** Shadow for VirtualSensor. */
-@Implements(
-    value = VirtualSensor.class,
-    minSdk = U.SDK_INT,
-    // TODO: remove when minimum supported compileSdk is >= 34
-    isInAndroidSdk = false)
+@Implements(value = VirtualSensor.class, minSdk = U.SDK_INT)
 public class ShadowVirtualSensor {
 
   private int deviceId = 0;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWearableSensingManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWearableSensingManager.java
@@ -16,11 +16,7 @@ import org.robolectric.annotation.Resetter;
 import org.robolectric.versioning.AndroidVersions.U;
 
 /** Shadow for VirtualDeviceManager. */
-@Implements(
-    value = WearableSensingManager.class,
-    minSdk = U.SDK_INT,
-    // TODO: remove when minimum supported compileSdk is >= 34
-    isInAndroidSdk = false)
+@Implements(value = WearableSensingManager.class, minSdk = U.SDK_INT)
 public class ShadowWearableSensingManager {
 
   private static @StatusCode Integer provideDataStreamResult =


### PR DESCRIPTION
The `compileSdk` is now 35, so we can remove these `isInAndroidSdk = false` flag from the `Implements` annotation.