### PR TITLE
ctesque: Wait display rotation with timeout before checking rotation

### DIFF
--- a/integration_tests/ctesque/src/sharedTest/java/android/app/UiAutomationTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/app/UiAutomationTest.java
@@ -3,11 +3,13 @@ package android.app;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.content.res.Configuration;
+import android.os.SystemClock;
 import android.view.Display;
 import android.view.Surface;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.internal.DoNotInstrument;
@@ -17,17 +19,26 @@ import org.robolectric.testapp.TestActivity;
 @DoNotInstrument
 @RunWith(AndroidJUnit4.class)
 public class UiAutomationTest {
+  private static final long WAIT_TIMEOUT_MS = 20000;
+  private UiAutomation uiAutomation;
+
+  @Before
+  public void setUp() {
+    Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+    uiAutomation = instrumentation.getUiAutomation();
+    // Unfreeze rotation before any test.
+    uiAutomation.setRotation(UiAutomation.ROTATION_UNFREEZE);
+  }
+
   @Test
   public void setRotation_freeze90_isLandscape() {
-    UiAutomation uiAutomation = InstrumentationRegistry.getInstrumentation().getUiAutomation();
-
     uiAutomation.setRotation(UiAutomation.ROTATION_FREEZE_90);
-
     try (ActivityScenario<? extends TestActivity> scenario =
         ActivityScenario.launch(TestActivity.class)) {
 
       scenario.onActivity(
           activity -> {
+            waitDisplayRotation(activity, Surface.ROTATION_90);
             Display display = activity.getWindowManager().getDefaultDisplay();
             Configuration configuration = activity.getResources().getConfiguration();
             assertThat(display.getRotation()).isEqualTo(Surface.ROTATION_90);
@@ -40,12 +51,12 @@ public class UiAutomationTest {
 
   @Test
   public void setRotation_freeze180_isPortrait() {
-    UiAutomation uiAutomation = InstrumentationRegistry.getInstrumentation().getUiAutomation();
     uiAutomation.setRotation(UiAutomation.ROTATION_FREEZE_180);
     try (ActivityScenario<? extends TestActivity> scenario =
         ActivityScenario.launch(TestActivity.class)) {
       scenario.onActivity(
           activity -> {
+            waitDisplayRotation(activity, Surface.ROTATION_180);
             Display display = activity.getWindowManager().getDefaultDisplay();
             Configuration configuration = activity.getResources().getConfiguration();
             assertThat(display.getRotation()).isEqualTo(Surface.ROTATION_180);
@@ -54,5 +65,21 @@ public class UiAutomationTest {
             assertThat(configuration.screenWidthDp).isLessThan(configuration.screenHeightDp);
           });
     }
+  }
+
+  private static void waitDisplayRotation(Activity activity, int expectedRotation) {
+    long startMs = SystemClock.uptimeMillis();
+    Display display = activity.getWindowManager().getDefaultDisplay();
+    do {
+      if (display.getRotation() == expectedRotation) {
+        break;
+      }
+      try {
+        // Sleep 100ms to avoid unnecessary checking.
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        // Do nothing
+      }
+    } while (SystemClock.uptimeMillis() - startMs <= UiAutomationTest.WAIT_TIMEOUT_MS);
   }
 }


### PR DESCRIPTION
Hope it can reduce the flaky of ctesque's Emulator testing.