### PR TITLE
Remove the `--info` flag from Gradle tasks

### DIFF
--- a/.github/workflows/copybara_build_and_test.yml
+++ b/.github/workflows/copybara_build_and_test.yml
@@ -36,12 +36,12 @@ jobs:
           # Only run integration tests on Copybara PRs
           (cd integration_tests && \
             SKIP_ERRORPRONE=true SKIP_JAVADOC=true \
-            ../gradlew test --info --stacktrace --continue --parallel --no-watch-fs \
+            ../gradlew test --stacktrace --continue --parallel --no-watch-fs \
             -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
             -Drobolectric.enabledSdks=34 \
             -Dorg.gradle.workers.max=2 \
             -x :integration_tests:nativegraphics:test \
-            -x :integration_tests:sdkcompat:test \
+            -x :integration_tests:sdkcompat:test
           )
 
       - name: SdkCompat tests
@@ -49,5 +49,5 @@ jobs:
           # `SdkCompat tests` is run as a separate step because it has to run on all SDK levels, and
           # the `Integration tests` step only runs on a single SDK level.
           SKIP_ERRORPRONE=true SKIP_JAVADOC=true \
-          ./gradlew :integration_tests:sdkcompat:test --info --stacktrace --continue --no-watch-fs \
-          -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
+          ./gradlew :integration_tests:sdkcompat:test --stacktrace --continue --no-watch-fs \
+          -Drobolectric.alwaysIncludeVariantMarkersInTestName=true

--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -55,7 +55,7 @@ jobs:
         run: >
           ./gradlew
           :integration_tests:nativegraphics:testDebugUnitTest
-          --info --stacktrace --continue
+          --stacktrace --continue
           --parallel
           --no-watch-fs
           "-Drobolectric.alwaysIncludeVariantMarkersInTestName=true"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run unit tests
         run: |
           SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew test \
-          --info --stacktrace --continue \
+          --stacktrace --continue \
           --parallel \
           --no-watch-fs \
           -Drobolectric.enabledSdks=${{ matrix.api-versions }} \
@@ -154,7 +154,7 @@ jobs:
           profile: Nexus One
           script: |
             adb shell wm density 240
-            SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew cAT --info --stacktrace --no-watch-fs -Dorg.gradle.workers.max=2
+            SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew cAT --stacktrace --no-watch-fs -Dorg.gradle.workers.max=2
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
This change removes the `--info` flag from Gradle tasks in the CI workflows. This is done to reduce the verbosity of the output and make it easier to identify errors.
It can easily be added back if we have investigations to do.

**Note:** I left the `--info` flag in the `deploy-snapshot.sh` script. Let me know if you think I can remove it there too.