### PR TITLE
Globally enable Gradle's parallel execution

### DIFF
--- a/.github/workflows/copybara_build_and_test.yml
+++ b/.github/workflows/copybara_build_and_test.yml
@@ -29,14 +29,14 @@ jobs:
       - name: Build
         run: |
           SKIP_ERRORPRONE=true SKIP_JAVADOC=true \
-          ./gradlew assemble testClasses --parallel --stacktrace --no-watch-fs
+          ./gradlew assemble testClasses --stacktrace --no-watch-fs
 
       - name: Integration tests
         run: |
           # Only run integration tests on Copybara PRs
           (cd integration_tests && \
             SKIP_ERRORPRONE=true SKIP_JAVADOC=true \
-            ../gradlew test --stacktrace --continue --parallel --no-watch-fs \
+            ../gradlew test --stacktrace --continue --no-watch-fs \
             -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
             -Drobolectric.enabledSdks=34 \
             -Dorg.gradle.workers.max=2 \

--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -56,7 +56,6 @@ jobs:
           ./gradlew
           :integration_tests:nativegraphics:testDebugUnitTest
           --stacktrace --continue
-          --parallel
           --no-watch-fs
           "-Drobolectric.alwaysIncludeVariantMarkersInTestName=true"
           "-Drobolectric.enabledSdks=${{ env.ENABLED_SDKS }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build
         run: |
           SKIP_ERRORPRONE=true SKIP_JAVADOC=true \
-          ./gradlew assemble testClasses --parallel --stacktrace --no-watch-fs
+          ./gradlew assemble testClasses --stacktrace --no-watch-fs
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -64,7 +64,6 @@ jobs:
         run: |
           SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew test \
           --stacktrace --continue \
-          --parallel \
           --no-watch-fs \
           -Drobolectric.enabledSdks=${{ matrix.api-versions }} \
           -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,13 @@ kotlin.stdlib.default.dependency=false
 org.gradle.caching=true
 
 # Increase Gradle's max memory due to OutOfMemoryException during compilation
+# https://docs.gradle.org/current/userguide/performance.html#increase_the_heap_size
 org.gradle.jvmargs=-Xmx2g
 
+# Enable Gradle's parallel execution
+# https://docs.gradle.org/current/userguide/performance.html#parallel_execution
+org.gradle.parallel=true
+
 # Give Kotlin's daemon 2g of memory
+# https://kotlinlang.org/docs/gradle-compilation-and-caches.html#kotlin-daemon-jvmargs-property
 kotlin.daemon.jvmargs=-Xmx2g


### PR DESCRIPTION
This PR enables Gradle's parallel execution for the whole project.

In most CI jobs, this was already enabled by using the `--parallel` flag. So the impacts on CI should be limited.

This helps bring local and remote builds closer, without the need for additional arguments.

FYI @hoisie as I've modified the Copybara workflow.