### PR TITLE
Enable Gradle's File System Watching on CI

### DIFF
--- a/.github/workflows/copybara_build_and_test.yml
+++ b/.github/workflows/copybara_build_and_test.yml
@@ -29,14 +29,14 @@ jobs:
       - name: Build
         run: |
           SKIP_ERRORPRONE=true SKIP_JAVADOC=true \
-          ./gradlew assemble testClasses --stacktrace --no-watch-fs
+          ./gradlew assemble testClasses --stacktrace
 
       - name: Integration tests
         run: |
           # Only run integration tests on Copybara PRs
           (cd integration_tests && \
             SKIP_ERRORPRONE=true SKIP_JAVADOC=true \
-            ../gradlew test --stacktrace --continue --no-watch-fs \
+            ../gradlew test --stacktrace --continue \
             -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
             -Drobolectric.enabledSdks=34 \
             -Dorg.gradle.workers.max=2 \
@@ -49,5 +49,5 @@ jobs:
           # `SdkCompat tests` is run as a separate step because it has to run on all SDK levels, and
           # the `Integration tests` step only runs on a single SDK level.
           SKIP_ERRORPRONE=true SKIP_JAVADOC=true \
-          ./gradlew :integration_tests:sdkcompat:test --stacktrace --continue --no-watch-fs \
+          ./gradlew :integration_tests:sdkcompat:test --stacktrace --continue \
           -Drobolectric.alwaysIncludeVariantMarkersInTestName=true

--- a/.github/workflows/gradle_tasks_validation.yml
+++ b/.github/workflows/gradle_tasks_validation.yml
@@ -98,4 +98,4 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Publish to Maven local
-        run: ./gradlew publishToMavenLocal --no-watch-fs
+        run: ./gradlew publishToMavenLocal

--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -56,7 +56,6 @@ jobs:
           ./gradlew
           :integration_tests:nativegraphics:testDebugUnitTest
           --stacktrace --continue
-          --no-watch-fs
           "-Drobolectric.alwaysIncludeVariantMarkersInTestName=true"
           "-Drobolectric.enabledSdks=${{ env.ENABLED_SDKS }}"
           "-Dorg.gradle.workers.max=2"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build
         run: |
           SKIP_ERRORPRONE=true SKIP_JAVADOC=true \
-          ./gradlew assemble testClasses --stacktrace --no-watch-fs
+          ./gradlew assemble testClasses --stacktrace
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -64,7 +64,6 @@ jobs:
         run: |
           SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew test \
           --stacktrace --continue \
-          --no-watch-fs \
           -Drobolectric.enabledSdks=${{ matrix.api-versions }} \
           -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
           -Dorg.gradle.workers.max=2 \
@@ -156,7 +155,7 @@ jobs:
           profile: Nexus One
           script: |
             adb shell wm density 240
-            SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew cAT --stacktrace --no-watch-fs -Dorg.gradle.workers.max=2
+            SKIP_ERRORPRONE=true SKIP_JAVADOC=true ./gradlew cAT --stacktrace -Dorg.gradle.workers.max=2
 
       - name: Upload test results
         if: always()
@@ -186,4 +185,4 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Publish
-        run: ./gradlew publish --stacktrace --no-watch-fs
+        run: ./gradlew publish --stacktrace


### PR DESCRIPTION
This was introduced in #6849, almost three years ago. Since then, the feature has evolved and stabilized.

Locally, I don't see the log message reported in the linked PR. The feature itself is still not needed on CI,
but it helps align commands between local and remote builds.

Gradle File System Watching documentation: https://docs.gradle.org/current/userguide/file_system_watching.html