### PR TITLE
Revert "ci: Bump latest API level to 35 for Emulator testing"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 29, 35 ]
+        api-level: [ 29, 34 ]
 
     steps:
       - name: Free disk space
@@ -116,6 +116,9 @@ jobs:
         id: determine-target
         run: |
           TARGET="google_apis"
+          if [[ ${{ matrix.api-level }} -ge 34 ]]; then
+            TARGET="aosp_atd"
+          fi
           echo "TARGET=$TARGET" >> $GITHUB_OUTPUT
 
       - name: AVD cache


### PR DESCRIPTION
This reverts commit 70f9585b2e3d0201f06a9ac03228f20e70bce1f0.