### PR TITLE
Update the Android V SDK to build 12650502

### DIFF
--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -44,11 +44,6 @@ jobs:
       - name: Show runner info
         run: uname -a
 
-      - name: Disable graphics tests for Windows on Android V
-        if: runner.os == 'Windows'
-        run: |
-          echo "ENABLED_SDKS=26,27,28,29,30,31,32,33,34" >> $env:GITHUB_ENV
-
       - name: Run unit tests
         env:
           SKIP_ERRORPRONE: true
@@ -60,7 +55,6 @@ jobs:
           --parallel
           --no-watch-fs
           "-Drobolectric.alwaysIncludeVariantMarkersInTestName=true"
-          "-Drobolectric.enabledSdks=${{ env.ENABLED_SDKS }}"
           "-Dorg.gradle.workers.max=2"
 
       - name: Upload Test Results

--- a/buildSrc/src/main/java/AndroidSdk.kt
+++ b/buildSrc/src/main/java/AndroidSdk.kt
@@ -64,7 +64,7 @@ class AndroidSdk(
     val S_V2 = AndroidSdk(32, "12.1", "8229987")
     val TIRAMISU = AndroidSdk(33, "13", "9030017")
     val U = AndroidSdk(34, "14", "10818077")
-    val V = AndroidSdk(35, "15", "12543294")
+    val V = AndroidSdk(35, "15", "12650502")
 
     val ALL_SDKS =
       listOf(LOLLIPOP, LOLLIPOP_MR1, M, N, N_MR1, O, O_MR1, P, Q, R, S, S_V2, TIRAMISU, U, V)

--- a/nativeruntime/src/main/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoader.java
+++ b/nativeruntime/src/main/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoader.java
@@ -249,10 +249,7 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
   }
 
   private void loadLibrary(TempDirectory tempDirectory) throws IOException {
-    String libraryName =
-        System.mapLibraryName(
-            isAndroidVOrGreater() ? "android_runtime" : "robolectric-nativeruntime");
-    Path libraryPath = tempDirectory.getBasePath().resolve(libraryName);
+    Path libraryPath = tempDirectory.getBasePath().resolve(libraryName());
     URL libraryResource = Resources.getResource(nativeLibraryPath());
     Resources.asByteSource(libraryResource).copyTo(Files.asByteSink(libraryPath.toFile()));
     System.load(libraryPath.toAbsolutePath().toString());
@@ -266,14 +263,17 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
   }
 
   private static String nativeLibraryPath() {
-    String os = osName();
-    String arch = arch();
-    return String.format(
-        "native/%s/%s/%s",
-        os,
-        arch,
-        System.mapLibraryName(
-            isAndroidVOrGreater() ? "android_runtime" : "robolectric-nativeruntime"));
+    return String.format("native/%s/%s/%s", osName(), arch(), libraryName());
+  }
+
+  private static String libraryName() {
+    if (isAndroidVOrGreater()) {
+      // For V and above, hwui's android_graphics_HardwareRenderer.cpp has shared library symbol
+      // lookup logic that assumes that Windows library name is "libandroid_runtime.dll".
+      return System.mapLibraryName(OsUtil.isWindows() ? "libandroid_runtime" : "android_runtime");
+    } else {
+      return System.mapLibraryName("robolectric-nativeruntime");
+    }
   }
 
   private static String osName() {

--- a/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
@@ -76,7 +76,7 @@ public class DefaultSdkProvider implements SdkProvider {
     knownSdks.put(Sv2.SDK_INT, new DefaultSdk(Sv2.SDK_INT, "12.1", "8229987", "REL", 9));
     knownSdks.put(T.SDK_INT, new DefaultSdk(T.SDK_INT, "13", "9030017", "Tiramisu", 9));
     knownSdks.put(U.SDK_INT, new DefaultSdk(U.SDK_INT, "14", "10818077", "REL", 17));
-    knownSdks.put(V.SDK_INT, new DefaultSdk(V.SDK_INT, "15", "12543294", "REL", 17));
+    knownSdks.put(V.SDK_INT, new DefaultSdk(V.SDK_INT, "15", "12650502", "REL", 17));
   }
 
   @Override


### PR DESCRIPTION
Update the Android V SDK to build 12650502

This build contains some fixes for BitmapFactory on Windows. With this build,
the Windows native graphics tests can be re-enabled.

Also, there is logic in hwui that requires the shared library to be named
"libandroid_runtime.dll". So the Android V library naming logic had to be
updated to reflect this.
