### PR TITLE
Fix SelfAssertion ErrorProne error in ShadowingTest

### DIFF
--- a/robolectric/build.gradle.kts
+++ b/robolectric/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
   testImplementation("androidx.test.ext:truth:$axtTruthVersion@aar")
   testImplementation("androidx.test:runner:$axtRunnerVersion@aar")
   testImplementation(libs.guava)
+  testImplementation(libs.guava.testlib)
   testCompileOnly(AndroidSdk.MAX_SDK.coordinates) // compile against latest Android SDK
   testRuntimeOnly(androidStubsJar())
 }

--- a/robolectric/src/test/java/org/robolectric/android/ShadowingTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/ShadowingTest.java
@@ -1,7 +1,6 @@
 package org.robolectric.android;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import android.util.Log;
@@ -9,6 +8,7 @@ import android.view.View;
 import android.widget.Toast;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.common.testing.EqualsTester;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,6 +34,6 @@ public class ShadowingTest {
   @Test
   public void shouldDelegateToObjectEqualsIfShadowHasNone() throws Exception {
     View view = new View(ApplicationProvider.getApplicationContext());
-    assertEquals(view, view);
+    new EqualsTester().addEqualityGroup(view).testEquals();
   }
 }


### PR DESCRIPTION
Use Guava Testlib's EqualsTester to test that the view is equal to itself.