### PR TITLE
Mark `AndroidVersions.V` as released

### DIFF
--- a/annotations/src/main/java/org/robolectric/versioning/AndroidVersions.java
+++ b/annotations/src/main/java/org/robolectric/versioning/AndroidVersions.java
@@ -400,9 +400,9 @@ public final class AndroidVersions {
   }
 
   /**
-   * Release: 7.1 <br>
+   * Version: 7.1 <br>
    * ShortCode: NMR1 <br>
-   * SDK Framework: 25 <br>
+   * SDK API Level: 25 <br>
    * release: true <br>
    */
   public static final class NMR1 extends AndroidReleased {
@@ -430,7 +430,7 @@ public final class AndroidVersions {
   }
 
   /**
-   * Release: 8.0 <br>
+   * Version: 8.0 <br>
    * ShortCode: O <br>
    * SDK API Level: 26 <br>
    * release: true <br>
@@ -460,7 +460,7 @@ public final class AndroidVersions {
   }
 
   /**
-   * Release: 8.1 <br>
+   * Version: 8.1 <br>
    * ShortCode: OMR1 <br>
    * SDK API Level: 27 <br>
    * release: true <br>
@@ -490,7 +490,7 @@ public final class AndroidVersions {
   }
 
   /**
-   * Release: 9.0 <br>
+   * Version: 9 <br>
    * ShortCode: P <br>
    * SDK API Level: 28 <br>
    * release: true <br>
@@ -501,7 +501,7 @@ public final class AndroidVersions {
 
     public static final String SHORT_CODE = "P";
 
-    public static final String VERSION = "9.0";
+    public static final String VERSION = "9";
 
     @Override
     public int getSdkInt() {
@@ -520,7 +520,7 @@ public final class AndroidVersions {
   }
 
   /**
-   * Release: 10.0 <br>
+   * Version: 10 <br>
    * ShortCode: Q <br>
    * SDK API Level: 29 <br>
    * release: true <br>
@@ -531,7 +531,7 @@ public final class AndroidVersions {
 
     public static final String SHORT_CODE = "Q";
 
-    public static final String VERSION = "10.0";
+    public static final String VERSION = "10";
 
     @Override
     public int getSdkInt() {
@@ -550,7 +550,7 @@ public final class AndroidVersions {
   }
 
   /**
-   * Release: 11.0 <br>
+   * Version: 11 <br>
    * ShortCode: R <br>
    * SDK API Level: 30 <br>
    * release: true <br>
@@ -561,7 +561,7 @@ public final class AndroidVersions {
 
     public static final String SHORT_CODE = "R";
 
-    public static final String VERSION = "11.0";
+    public static final String VERSION = "11";
 
     @Override
     public int getSdkInt() {
@@ -580,7 +580,7 @@ public final class AndroidVersions {
   }
 
   /**
-   * Release: 12.0 <br>
+   * Version: 12 <br>
    * ShortCode: S <br>
    * SDK API Level: 31 <br>
    * release: true <br>
@@ -591,7 +591,7 @@ public final class AndroidVersions {
 
     public static final String SHORT_CODE = "S";
 
-    public static final String VERSION = "12.0";
+    public static final String VERSION = "12";
 
     @Override
     public int getSdkInt() {
@@ -610,7 +610,7 @@ public final class AndroidVersions {
   }
 
   /**
-   * Release: 12.1 <br>
+   * Version: 12.1 <br>
    * ShortCode: Sv2 <br>
    * SDK API Level: 32 <br>
    * release: true <br>
@@ -641,7 +641,7 @@ public final class AndroidVersions {
   }
 
   /**
-   * Release: 13.0 <br>
+   * Version: 13 <br>
    * ShortCode: T <br>
    * SDK API Level: 33 <br>
    * release: true <br>
@@ -652,7 +652,7 @@ public final class AndroidVersions {
 
     public static final String SHORT_CODE = "T";
 
-    public static final String VERSION = "13.0";
+    public static final String VERSION = "13";
 
     @Override
     public int getSdkInt() {
@@ -671,7 +671,7 @@ public final class AndroidVersions {
   }
 
   /**
-   * Potential Release: 14.0 <br>
+   * Version: 14 <br>
    * ShortCode: U <br>
    * SDK API Level: 34 <br>
    * release: false <br>
@@ -682,7 +682,7 @@ public final class AndroidVersions {
 
     public static final String SHORT_CODE = "U";
 
-    public static final String VERSION = "14.0";
+    public static final String VERSION = "14";
 
     @Override
     public int getSdkInt() {
@@ -701,10 +701,10 @@ public final class AndroidVersions {
   }
 
   /**
-   * Potential Release: 15.0 <br>
+   * Version: 15 <br>
    * ShortCode: V <br>
-   * SDK API Level: 34+ <br>
-   * release: false <br>
+   * SDK API Level: 35 <br>
+   * release: true <br>
    */
   public static final class V extends AndroidReleased {
 

--- a/annotations/src/test/java/org/robolectric/versioning/AndroidVersionsTest.java
+++ b/annotations/src/test/java/org/robolectric/versioning/AndroidVersionsTest.java
@@ -56,10 +56,10 @@ public final class AndroidVersionsTest {
   public void testStandardInitializationU() {
     assertThat(AndroidVersions.U.SDK_INT).isEqualTo(34);
     assertThat(AndroidVersions.U.SHORT_CODE).isEqualTo("U");
-    assertThat(AndroidVersions.U.VERSION).isEqualTo("14.0");
+    assertThat(AndroidVersions.U.VERSION).isEqualTo("14");
     assertThat(new AndroidVersions.U().getSdkInt()).isEqualTo(34);
     assertThat(new AndroidVersions.U().getShortCode()).isEqualTo("U");
-    assertThat(new AndroidVersions.U().getVersion()).isEqualTo("14.0");
+    assertThat(new AndroidVersions.U().getVersion()).isEqualTo("14");
     assertThat(new AndroidVersions.U().isReleased()).isTrue();
   }
 
@@ -67,10 +67,10 @@ public final class AndroidVersionsTest {
   public void testStandardInitializationT() {
     assertThat(AndroidVersions.T.SDK_INT).isEqualTo(33);
     assertThat(AndroidVersions.T.SHORT_CODE).isEqualTo("T");
-    assertThat(AndroidVersions.T.VERSION).isEqualTo("13.0");
+    assertThat(AndroidVersions.T.VERSION).isEqualTo("13");
     assertThat(new AndroidVersions.T().getSdkInt()).isEqualTo(33);
     assertThat(new AndroidVersions.T().getShortCode()).isEqualTo("T");
-    assertThat(new AndroidVersions.T().getVersion()).isEqualTo("13.0");
+    assertThat(new AndroidVersions.T().getVersion()).isEqualTo("13");
     assertThat(new AndroidVersions.T().isReleased()).isTrue();
   }
 
@@ -89,10 +89,10 @@ public final class AndroidVersionsTest {
   public void testStandardInitializationS() {
     assertThat(AndroidVersions.S.SDK_INT).isEqualTo(31);
     assertThat(AndroidVersions.S.SHORT_CODE).isEqualTo("S");
-    assertThat(AndroidVersions.S.VERSION).isEqualTo("12.0");
+    assertThat(AndroidVersions.S.VERSION).isEqualTo("12");
     assertThat(new AndroidVersions.S().getSdkInt()).isEqualTo(31);
     assertThat(new AndroidVersions.S().getShortCode()).isEqualTo("S");
-    assertThat(new AndroidVersions.S().getVersion()).isEqualTo("12.0");
+    assertThat(new AndroidVersions.S().getVersion()).isEqualTo("12");
     assertThat(new AndroidVersions.S().isReleased()).isTrue();
   }
 
@@ -100,10 +100,10 @@ public final class AndroidVersionsTest {
   public void testStandardInitializationR() {
     assertThat(AndroidVersions.R.SDK_INT).isEqualTo(30);
     assertThat(AndroidVersions.R.SHORT_CODE).isEqualTo("R");
-    assertThat(AndroidVersions.R.VERSION).isEqualTo("11.0");
+    assertThat(AndroidVersions.R.VERSION).isEqualTo("11");
     assertThat(new AndroidVersions.R().getSdkInt()).isEqualTo(30);
     assertThat(new AndroidVersions.R().getShortCode()).isEqualTo("R");
-    assertThat(new AndroidVersions.R().getVersion()).isEqualTo("11.0");
+    assertThat(new AndroidVersions.R().getVersion()).isEqualTo("11");
     assertThat(new AndroidVersions.R().isReleased()).isTrue();
   }
 
@@ -111,10 +111,10 @@ public final class AndroidVersionsTest {
   public void testStandardInitializationQ() {
     assertThat(AndroidVersions.Q.SDK_INT).isEqualTo(29);
     assertThat(AndroidVersions.Q.SHORT_CODE).isEqualTo("Q");
-    assertThat(AndroidVersions.Q.VERSION).isEqualTo("10.0");
+    assertThat(AndroidVersions.Q.VERSION).isEqualTo("10");
     assertThat(new AndroidVersions.Q().getSdkInt()).isEqualTo(29);
     assertThat(new AndroidVersions.Q().getShortCode()).isEqualTo("Q");
-    assertThat(new AndroidVersions.Q().getVersion()).isEqualTo("10.0");
+    assertThat(new AndroidVersions.Q().getVersion()).isEqualTo("10");
     assertThat(new AndroidVersions.Q().isReleased()).isTrue();
   }
 
@@ -122,10 +122,10 @@ public final class AndroidVersionsTest {
   public void testStandardInitializationP() {
     assertThat(AndroidVersions.P.SDK_INT).isEqualTo(28);
     assertThat(AndroidVersions.P.SHORT_CODE).isEqualTo("P");
-    assertThat(AndroidVersions.P.VERSION).isEqualTo("9.0");
+    assertThat(AndroidVersions.P.VERSION).isEqualTo("9");
     assertThat(new AndroidVersions.P().getSdkInt()).isEqualTo(28);
     assertThat(new AndroidVersions.P().getShortCode()).isEqualTo("P");
-    assertThat(new AndroidVersions.P().getVersion()).isEqualTo("9.0");
+    assertThat(new AndroidVersions.P().getVersion()).isEqualTo("9");
     assertThat(new AndroidVersions.P().isReleased()).isTrue();
   }
 

--- a/integration_tests/versioning/src/test/java/org/robolectric/versioning/AndroidVersionsTest.java
+++ b/integration_tests/versioning/src/test/java/org/robolectric/versioning/AndroidVersionsTest.java
@@ -24,11 +24,29 @@ public final class AndroidVersionsTest {
   }
 
   @Test
+  @Config(sdk = 35)
+  public void testStandardInitializationV() {
+    assertThat(AndroidVersions.V.SDK_INT).isEqualTo(35);
+    assertThat(AndroidVersions.V.SHORT_CODE).isEqualTo("V");
+    assertThat(new AndroidVersions.V().getVersion()).isEqualTo("15");
+    assertThat(AndroidVersions.CURRENT.getShortCode()).isEqualTo("V");
+  }
+
+  @Test
+  @Config(sdk = 34)
+  public void testStandardInitializationU() {
+    assertThat(AndroidVersions.U.SDK_INT).isEqualTo(34);
+    assertThat(AndroidVersions.U.SHORT_CODE).isEqualTo("U");
+    assertThat(new AndroidVersions.U().getVersion()).isEqualTo("14");
+    assertThat(AndroidVersions.CURRENT.getShortCode()).isEqualTo("U");
+  }
+
+  @Test
   @Config(sdk = 33)
   public void testStandardInitializationT() {
     assertThat(AndroidVersions.T.SDK_INT).isEqualTo(33);
     assertThat(AndroidVersions.T.SHORT_CODE).isEqualTo("T");
-    assertThat(new AndroidVersions.T().getVersion()).isEqualTo("13.0");
+    assertThat(new AndroidVersions.T().getVersion()).isEqualTo("13");
     assertThat(AndroidVersions.CURRENT.getShortCode()).isEqualTo("T");
   }
 
@@ -46,7 +64,7 @@ public final class AndroidVersionsTest {
   public void testStandardInitializationS() {
     assertThat(AndroidVersions.S.SDK_INT).isEqualTo(31);
     assertThat(AndroidVersions.S.SHORT_CODE).isEqualTo("S");
-    assertThat(new AndroidVersions.S().getVersion()).isEqualTo("12.0");
+    assertThat(new AndroidVersions.S().getVersion()).isEqualTo("12");
     assertThat(AndroidVersions.CURRENT.getShortCode()).isEqualTo("S");
   }
 
@@ -55,7 +73,7 @@ public final class AndroidVersionsTest {
   public void testStandardInitializationR() {
     assertThat(AndroidVersions.R.SDK_INT).isEqualTo(30);
     assertThat(AndroidVersions.R.SHORT_CODE).isEqualTo("R");
-    assertThat(new AndroidVersions.R().getVersion()).isEqualTo("11.0");
+    assertThat(new AndroidVersions.R().getVersion()).isEqualTo("11");
     assertThat(AndroidVersions.CURRENT.getShortCode()).isEqualTo("R");
   }
 
@@ -64,7 +82,7 @@ public final class AndroidVersionsTest {
   public void testStandardInitializationQ() {
     assertThat(AndroidVersions.Q.SDK_INT).isEqualTo(29);
     assertThat(AndroidVersions.Q.SHORT_CODE).isEqualTo("Q");
-    assertThat(new AndroidVersions.Q().getVersion()).isEqualTo("10.0");
+    assertThat(new AndroidVersions.Q().getVersion()).isEqualTo("10");
     assertThat(AndroidVersions.CURRENT.getShortCode()).isEqualTo("Q");
   }
 
@@ -73,7 +91,7 @@ public final class AndroidVersionsTest {
   public void testStandardInitializationP() {
     assertThat(AndroidVersions.P.SDK_INT).isEqualTo(28);
     assertThat(AndroidVersions.P.SHORT_CODE).isEqualTo("P");
-    assertThat(new AndroidVersions.P().getVersion()).isEqualTo("9.0");
+    assertThat(new AndroidVersions.P().getVersion()).isEqualTo("9");
     assertThat(AndroidVersions.CURRENT.getShortCode()).isEqualTo("P");
   }
 


### PR DESCRIPTION
This PR contains the following changes:
- Document `AndroidVersions.V` as released.
- Fix the version name of Android 9+.
- Align the format of each `AndroidVersions` implementation javadoc.
- Add missing tests.

@hoisie I've aligned the version name of `AndroidVersions` 9+ to be what is publicly used (i.e. without the trailing `.0`). Since this might be a breaking change, let me know if you're fine with that or not.