### PR TITLE
Cleanup `integration_tests/androidx` module

### DIFF
--- a/integration_tests/androidx/build.gradle.kts
+++ b/integration_tests/androidx/build.gradle.kts
@@ -22,7 +22,6 @@ android {
 
 dependencies {
   implementation(libs.kotlinx.coroutines.android)
-  implementation(libs.androidx.appcompat)
   implementation(libs.androidx.window)
 
   // Testing dependencies
@@ -31,10 +30,6 @@ dependencies {
   testImplementation(libs.junit4)
   testImplementation(libs.androidx.test.core)
   testImplementation(libs.androidx.core)
-  testImplementation(libs.androidx.test.runner)
-  testImplementation(libs.androidx.test.rules)
-  testImplementation(libs.androidx.test.espresso.intents)
-  testImplementation(libs.androidx.test.ext.truth)
   testImplementation(libs.androidx.test.ext.junit)
   testImplementation(libs.truth)
 }

--- a/integration_tests/androidx/src/main/AndroidManifest.xml
+++ b/integration_tests/androidx/src/main/AndroidManifest.xml
@@ -2,9 +2,7 @@
 <!--
   Manifest for androidx integration test module
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest>
 
-    <application>
-    </application>
+    <application />
 </manifest>
-

--- a/integration_tests/androidx/src/test/java/org/robolectric/integrationtests/androidx/WindowMetricsCalculatorTest.java
+++ b/integration_tests/androidx/src/test/java/org/robolectric/integrationtests/androidx/WindowMetricsCalculatorTest.java
@@ -2,12 +2,13 @@ package org.robolectric.integrationtests.androidx;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import android.graphics.Rect;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.window.layout.WindowMetrics;
 import androidx.window.layout.WindowMetricsCalculator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.testapp.TestActivity;
 
@@ -17,11 +18,14 @@ public class WindowMetricsCalculatorTest {
   @Test
   @Config(qualifiers = "w400dp-h600dp")
   public void computeCurrentWindowMetrics() {
-    TestActivity activity = Robolectric.buildActivity(TestActivity.class).setup().get();
-    WindowMetrics windowMetrics =
-        WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(activity);
+    try (ActivityController<TestActivity> activityController =
+        Robolectric.buildActivity(TestActivity.class)) {
+      TestActivity activity = activityController.setup().get();
+      Rect bounds =
+          WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(activity).getBounds();
 
-    assertThat(windowMetrics.getBounds().width()).isEqualTo(400);
-    assertThat(windowMetrics.getBounds().height()).isEqualTo(600);
+      assertThat(bounds.width()).isEqualTo(400);
+      assertThat(bounds.height()).isEqualTo(600);
+    }
   }
 }


### PR DESCRIPTION
This change includes:
- Remove unused dependencies from `integration_tests/androidx`.
- Fix warning in `integration_tests/androidx/src/main/AndroidManifest.xml`.
- Fix warning in `WindowMetricsCalculatorTest`.