### PR TITLE
Only checking getWindowId for Robolectric's AccessibilityNodeInfoTest

### DIFF
--- a/integration_tests/ctesque/src/sharedTest/java/android/view/accessibility/AccessibilityNodeInfoTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/view/accessibility/AccessibilityNodeInfoTest.java
@@ -110,8 +110,21 @@ public class AccessibilityNodeInfoTest {
             node.setQueryFromAppProcessEnabled(rootView, true);
             assertThat(node.getChildCount()).isEqualTo(1);
             assertThat(node.getChild(0)).isNotNull();
-            assertThat(node.getWindowId()).isEqualTo(-1);
+            // Only expect getWindowId() is -1 in Robolectric environment.
+            // TODO remove isRobolectric checking after fixing Robolectric's implementation.
+            if (isRobolectric()) {
+              assertThat(node.getWindowId()).isEqualTo(-1);
+            }
           });
+    }
+  }
+
+  private static boolean isRobolectric() {
+    try {
+      Class.forName("org.robolectric.RobolectricTestRunner");
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
     }
   }
 }


### PR DESCRIPTION
This assertion is used to track Robolectric's incorrect implementation, and I think it will be removed after Robolectric AccessibilityNodeInfo's implementation is changed to real code, and we can remove this CL adding's workaround to restrict the running environment.
