### PR TITLE
test: Add compat test for retrieving PackageInstaller

### DIFF
--- a/integration_tests/sdkcompat/src/test/java/org/robolectric/integrationtests/sdkcompat/NormalCompatibilityTest.kt
+++ b/integration_tests/sdkcompat/src/test/java/org/robolectric/integrationtests/sdkcompat/NormalCompatibilityTest.kt
@@ -101,4 +101,10 @@ class NormalCompatibilityTest {
     val activity = Robolectric.setupActivity(MainActivity::class.java)
     assertThat(activity.creationSource).isEqualTo(CreationSource.DEFAULT_CONSTRUCTOR)
   }
+
+  @Test
+  fun `Retrieve PackageInstaller succeed`() {
+    val packageInstaller = application.packageManager.packageInstaller
+    assertThat(packageInstaller).isNotNull()
+  }
 }


### PR DESCRIPTION
It is tested with targetSdk 29.