### PR TITLE
Fix warnings in the `junit` module

### DIFF
--- a/junit/build.gradle.kts
+++ b/junit/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 }
 
 dependencies {
-  api(project(":annotations"))
   api(project(":sandbox"))
   api(project(":pluginapi"))
-  api(project(":shadowapi"))
-  api(project(":utils:reflector"))
 
   compileOnly(libs.findbugs.jsr305)
   compileOnly(libs.junit4)

--- a/junit/src/main/java/org/robolectric/internal/SandboxTestRunner.java
+++ b/junit/src/main/java/org/robolectric/internal/SandboxTestRunner.java
@@ -457,7 +457,7 @@ public class SandboxTestRunner extends BlockJUnit4ClassRunner {
     List<Class<?>> shadowClasses = new ArrayList<>();
     addShadows(shadowClasses, getTestClass().getJavaClass().getAnnotation(SandboxConfig.class));
     addShadows(shadowClasses, method.getAnnotation(SandboxConfig.class));
-    return shadowClasses.toArray(new Class[shadowClasses.size()]);
+    return shadowClasses.toArray(new Class[0]);
   }
 
   private void addShadows(List<Class<?>> shadowClasses, SandboxConfig annotation) {

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestParameterInjector.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestParameterInjector.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.IntStream;
+import javax.annotation.Nonnull;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
@@ -52,6 +53,7 @@ public final class RobolectricTestParameterInjector extends RobolectricTestRunne
   }
 
   @Override
+  @Nonnull
   protected InstrumentationConfiguration createClassLoaderConfig(FrameworkMethod method) {
     return new InstrumentationConfiguration.Builder(super.createClassLoaderConfig(method))
         .doNotAcquireClass(DelegateTestRunner.class)

--- a/robolectric/src/test/java/org/robolectric/SingleSdkRobolectricTestRunner.java
+++ b/robolectric/src/test/java/org/robolectric/SingleSdkRobolectricTestRunner.java
@@ -34,6 +34,7 @@ public class SingleSdkRobolectricTestRunner extends RobolectricTestRunner {
   }
 
   @Override
+  @Nonnull
   protected AndroidSandbox getSandbox(FrameworkMethod method) {
     AndroidSandbox sandbox = super.getSandbox(method);
     latestSandbox = sandbox;


### PR DESCRIPTION
This PR removes unused dependencies and fixes a couple of warnings in the `junit` module.