### PR TITLE
Fix warnings in the `nativeruntime` module

### DIFF
--- a/nativeruntime/build.gradle.kts
+++ b/nativeruntime/build.gradle.kts
@@ -63,7 +63,6 @@ if (System.getenv("PUBLISH_NATIVERUNTIME_DIST_COMPAT") == "true") {
 dependencies {
   api(project(":shadowapi"))
   api(project(":utils"))
-  api(project(":utils:reflector"))
   api(libs.guava)
 
   implementation(libs.robolectric.nativeruntime.dist.compat)

--- a/nativeruntime/src/main/java/org/robolectric/nativeruntime/ColorSpaceRgbNatives.java
+++ b/nativeruntime/src/main/java/org/robolectric/nativeruntime/ColorSpaceRgbNatives.java
@@ -17,7 +17,7 @@
 package org.robolectric.nativeruntime;
 
 /**
- * Native methods for BitmapFactory JNI registration.
+ * Native methods for ColorSpace JNI registration.
  *
  * <p>Native method signatures are derived from
  * https://cs.android.com/android/platform/superproject/+/android-12.0.0_r1:frameworks/base/graphics/java/android/graphics/ColorSpace.java

--- a/nativeruntime/src/main/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoader.java
+++ b/nativeruntime/src/main/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoader.java
@@ -114,7 +114,7 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
           });
 
   /**
-   * {@link #DEFERRED_STATIC_INITIALIZERS} that invoke their own native methods in static
+   * {@code DEFERRED_STATIC_INITIALIZERS} that invoke their own native methods in static
    * initializers. Unlike libcore, registering JNI on the JVM causes static initialization to be
    * performed on the class. Because of this, static initializers cannot invoke the native methods
    * of the class under registration. Executing these static initializers must be deferred until
@@ -209,7 +209,7 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
    * graphics.
    */
   private void maybeCopyFonts(TempDirectory tempDirectory) throws IOException {
-    URI fontsUri = null;
+    URI fontsUri;
     try {
       fontsUri = Resources.getResource("fonts/").toURI();
     } catch (IllegalArgumentException | URISyntaxException e) {

--- a/nativeruntime/src/main/java/org/robolectric/nativeruntime/HardwareRendererNatives.java
+++ b/nativeruntime/src/main/java/org/robolectric/nativeruntime/HardwareRendererNatives.java
@@ -26,7 +26,7 @@ import android.view.Surface;
 import java.io.FileDescriptor;
 
 /**
- * Native methods for {@link HardwareRenderer} JNI registration.
+ * Native methods for {@link android.graphics.HardwareRenderer} JNI registration.
  *
  * <p>Native method signatures are derived from
  * https://cs.android.com/android/platform/superproject/+/android-12.0.0_r1:frameworks/base/graphics/java/android/graphics/HardwareRenderer.java

--- a/nativeruntime/src/main/java/org/robolectric/nativeruntime/HardwareRendererObserverNatives.java
+++ b/nativeruntime/src/main/java/org/robolectric/nativeruntime/HardwareRendererObserverNatives.java
@@ -17,7 +17,7 @@
 package org.robolectric.nativeruntime;
 
 /**
- * Native methods for {@link ImageDecoder} JNI registration.
+ * Native methods for {@link android.graphics.HardwareRendererObserver} JNI registration.
  *
  * <p>Native method signatures are derived from
  * https://cs.android.com/android/platform/superproject/+/android-12.0.0_r1:frameworks/base/graphics/java/android/graphics/HardwareRendererObserver.java

--- a/nativeruntime/src/test/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLazyLoadTest.java
+++ b/nativeruntime/src/test/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLazyLoadTest.java
@@ -2,7 +2,6 @@ package org.robolectric.nativeruntime;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import android.app.Application;
 import android.database.CursorWindow;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,10 +21,9 @@ public final class DefaultNativeRuntimeLazyLoadTest {
    *
    * <p>Note that lazy loading is disabled for V and above.
    */
-  @SuppressWarnings("UnusedVariable")
   @Test
-  public void lazyLoad() throws Exception {
-    Application application = RuntimeEnvironment.getApplication();
+  public void lazyLoad() {
+    RuntimeEnvironment.getApplication();
     assertThat(DefaultNativeRuntimeLoader.isLoaded()).isFalse();
     CursorWindow cursorWindow = new CursorWindow("hi");
     cursorWindow.close();

--- a/nativeruntime/src/test/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoaderTest.java
+++ b/nativeruntime/src/test/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoaderTest.java
@@ -25,7 +25,8 @@ public final class DefaultNativeRuntimeLoaderTest {
   }
 
   @Test
-  public void concurrentLoad() throws Exception {
+  public void concurrentLoad() {
+    //noinspection resource
     executor.execute(() -> SQLiteDatabase.create(null));
     CursorWindow cursorWindow = new CursorWindow("sdfsdf");
     cursorWindow.close();

--- a/nativeruntime/src/test/resources/AndroidManifest.xml
+++ b/nativeruntime/src/test/resources/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
   package="org.robolectric.nativeruntime">
 
-  <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="33"/>
+  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33"/>
   <application />
 </manifest>


### PR DESCRIPTION
This PR:
- Removes an unused dependency.
- Fixes a couple of warnings.
- Fixes some copy/paste errors in the Javadoc.