### PR TITLE
Add missing implementation in `RoboMenuItem`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/fakes/RoboMenuItemTest.java
+++ b/robolectric/src/test/java/org/robolectric/fakes/RoboMenuItemTest.java
@@ -3,11 +3,13 @@ package org.robolectric.fakes;
 import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
+import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.view.MenuItem;
 import android.view.View;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import javax.annotation.Nonnull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,13 +17,15 @@ import org.robolectric.R;
 
 @RunWith(AndroidJUnit4.class)
 public class RoboMenuItemTest {
+  private Context context;
   private MenuItem item;
   private TestOnActionExpandListener listener;
 
   @Before
   public void setUp() throws Exception {
-    item = new RoboMenuItem(ApplicationProvider.getApplicationContext());
+    context = ApplicationProvider.getApplicationContext();
     listener = new TestOnActionExpandListener();
+    item = new RoboMenuItem(context);
     item.setOnActionExpandListener(listener);
   }
 
@@ -54,15 +58,19 @@ public class RoboMenuItemTest {
 
   @Test
   public void expandActionView_shouldSetExpandedTrue() {
-    item.setActionView(new View(ApplicationProvider.getApplicationContext()));
+    View actionView = new View(context);
+    item.setActionView(actionView);
+    assertThat(item.getActionView()).isEqualTo(actionView);
     assertThat(item.expandActionView()).isTrue();
     assertThat(item.isActionViewExpanded()).isTrue();
   }
 
   @Test
   public void expandActionView_shouldInvokeListener() {
-    item.setActionView(new View(ApplicationProvider.getApplicationContext()));
-    item.expandActionView();
+    View actionView = new View(context);
+    item.setActionView(actionView);
+    assertThat(item.getActionView()).isEqualTo(actionView);
+    assertThat(item.expandActionView()).isTrue();
     assertThat(listener.expanded).isTrue();
   }
 
@@ -74,7 +82,9 @@ public class RoboMenuItemTest {
 
   @Test
   public void collapseActionView_shouldSetExpandedFalse() {
-    item.setActionView(new View(ApplicationProvider.getApplicationContext()));
+    View actionView = new View(context);
+    item.setActionView(actionView);
+    assertThat(item.getActionView()).isEqualTo(actionView);
     item.expandActionView();
     assertThat(item.collapseActionView()).isTrue();
     assertThat(item.isActionViewExpanded()).isFalse();
@@ -82,9 +92,11 @@ public class RoboMenuItemTest {
 
   @Test
   public void collapseActionView_shouldInvokeListener() {
-    item.setActionView(new View(ApplicationProvider.getApplicationContext()));
+    View actionView = new View(context);
+    item.setActionView(actionView);
+    assertThat(item.getActionView()).isEqualTo(actionView);
     listener.expanded = true;
-    item.collapseActionView();
+    assertThat(item.collapseActionView()).isTrue();
     assertThat(listener.expanded).isFalse();
   }
 
@@ -141,8 +153,7 @@ public class RoboMenuItemTest {
 
   @Test
   public void getIcon_shouldReturnDrawableFromSetIconDrawable() {
-    Drawable testDrawable =
-        ApplicationProvider.getApplicationContext().getResources().getDrawable(R.drawable.an_image);
+    Drawable testDrawable = context.getDrawable(R.drawable.an_image);
     assertThat(testDrawable).isNotNull();
     assertThat(item.getIcon()).isNull();
     item.setIcon(testDrawable);
@@ -161,17 +172,32 @@ public class RoboMenuItemTest {
     assertThat(item.setOnActionExpandListener(listener)).isSameInstanceAs(item);
   }
 
+  @Test
+  public void setTitle_shouldNullifyOnZero() {
+    item.setTitle("title");
+    assertThat(item.getTitle()).isNotNull();
+    item.setTitle(0);
+    assertThat(item.getTitle()).isNull();
+  }
+
+  @Test
+  public void setTitle_shouldSetTitleFromResourceId() {
+    assertThat(item.getTitle()).isNull();
+    item.setTitle(R.string.app_name);
+    assertThat(item.getTitle()).isEqualTo(context.getString(R.string.app_name));
+  }
+
   static class TestOnActionExpandListener implements MenuItem.OnActionExpandListener {
     private boolean expanded = false;
 
     @Override
-    public boolean onMenuItemActionExpand(MenuItem menuItem) {
+    public boolean onMenuItemActionExpand(@Nonnull MenuItem menuItem) {
       expanded = true;
       return true;
     }
 
     @Override
-    public boolean onMenuItemActionCollapse(MenuItem menuItem) {
+    public boolean onMenuItemActionCollapse(@Nonnull MenuItem menuItem) {
       expanded = false;
       return true;
     }

--- a/shadows/framework/src/main/java/org/robolectric/fakes/RoboMenuItem.java
+++ b/shadows/framework/src/main/java/org/robolectric/fakes/RoboMenuItem.java
@@ -1,5 +1,8 @@
 package org.robolectric.fakes;
 
+import android.annotation.DrawableRes;
+import android.annotation.LayoutRes;
+import android.annotation.StringRes;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
@@ -9,26 +12,32 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.SubMenu;
 import android.view.View;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.robolectric.RuntimeEnvironment;
 
-/** Robolectric implementation of {@link android.view.MenuItem}. */
+/** Robolectric implementation of {@link MenuItem}. */
 public class RoboMenuItem implements MenuItem {
   private int itemId;
   private int groupId;
-  private CharSequence title;
+  @Nullable private CharSequence title;
+  @Nullable private CharSequence titleCondensed;
   private boolean enabled = true;
   private boolean checked = false;
   private boolean checkable = false;
   private boolean visible = true;
   private boolean expanded = false;
-  private OnMenuItemClickListener menuItemClickListener;
-  public Drawable icon;
-  private Intent intent;
-  private SubMenu subMenu;
-  private View actionView;
-  private OnActionExpandListener actionExpandListener;
+  @Nullable private OnMenuItemClickListener menuItemClickListener;
+  @Nullable public Drawable icon;
+  @Nullable private Intent intent;
+  @Nullable private SubMenu subMenu;
+  @Nullable private View actionView;
+  @Nullable private OnActionExpandListener actionExpandListener;
   private int order;
   private Context context;
+  private char numericChar;
+  private char alphaChar;
+  @Nullable private ActionProvider actionProvider;
 
   public RoboMenuItem() {
     this(RuntimeEnvironment.getApplication());
@@ -70,85 +79,103 @@ public class RoboMenuItem implements MenuItem {
   }
 
   @Override
-  public MenuItem setTitle(CharSequence title) {
+  @Nonnull
+  public MenuItem setTitle(@Nullable CharSequence title) {
     this.title = title;
     return this;
   }
 
   @Override
-  public MenuItem setTitle(int title) {
+  @Nonnull
+  public MenuItem setTitle(@StringRes int title) {
+    this.title = title == 0 ? null : context.getString(title);
     return this;
   }
 
   @Override
+  @Nullable
   public CharSequence getTitle() {
     return title;
   }
 
   @Override
-  public MenuItem setTitleCondensed(CharSequence title) {
+  @Nonnull
+  public MenuItem setTitleCondensed(@Nullable CharSequence title) {
+    this.titleCondensed = title;
     return this;
   }
 
   @Override
+  @Nullable
   public CharSequence getTitleCondensed() {
-    return null;
+    return titleCondensed;
   }
 
   @Override
-  public MenuItem setIcon(Drawable icon) {
+  @Nonnull
+  public MenuItem setIcon(@Nullable Drawable icon) {
     this.icon = icon;
     return this;
   }
 
   @Override
-  public MenuItem setIcon(int iconRes) {
-    this.icon = iconRes == 0 ? null : context.getResources().getDrawable(iconRes);
+  @Nonnull
+  public MenuItem setIcon(@DrawableRes int iconRes) {
+    this.icon = iconRes == 0 ? null : context.getDrawable(iconRes);
     return this;
   }
 
   @Override
+  @Nullable
   public Drawable getIcon() {
     return this.icon;
   }
 
   @Override
-  public MenuItem setIntent(Intent intent) {
+  @Nonnull
+  public MenuItem setIntent(@Nullable Intent intent) {
     this.intent = intent;
     return this;
   }
 
   @Override
+  @Nullable
   public Intent getIntent() {
     return this.intent;
   }
 
   @Override
+  @Nonnull
   public MenuItem setShortcut(char numericChar, char alphaChar) {
     return this;
   }
 
   @Override
+  @Nonnull
   public MenuItem setNumericShortcut(char numericChar) {
+    this.numericChar = numericChar;
     return this;
   }
 
   @Override
   public char getNumericShortcut() {
-    return 0;
+    return numericChar;
   }
 
   @Override
+  @Nonnull
   public MenuItem setAlphabeticShortcut(char alphaChar) {
+    this.alphaChar = alphaChar;
     return this;
   }
 
   @Override
   public char getAlphabeticShortcut() {
-    return 0;
+    return alphaChar;
   }
 
   @Override
+  @Nonnull
   public MenuItem setCheckable(boolean checkable) {
     this.checkable = checkable;
     return this;
@@ -160,6 +187,7 @@ public class RoboMenuItem implements MenuItem {
   }
 
   @Override
+  @Nonnull
   public MenuItem setChecked(boolean checked) {
     this.checked = checked;
     return this;
@@ -171,6 +199,7 @@ public class RoboMenuItem implements MenuItem {
   }
 
   @Override
+  @Nonnull
   public MenuItem setVisible(boolean visible) {
     this.visible = visible;
     return this;
@@ -182,6 +211,7 @@ public class RoboMenuItem implements MenuItem {
   }
 
   @Override
+  @Nonnull
   public MenuItem setEnabled(boolean enabled) {
     this.enabled = enabled;
     return this;
@@ -198,21 +228,25 @@ public class RoboMenuItem implements MenuItem {
   }
 
   @Override
+  @Nullable
   public SubMenu getSubMenu() {
     return subMenu;
   }
 
-  public void setSubMenu(SubMenu subMenu) {
+  public void setSubMenu(@Nullable SubMenu subMenu) {
     this.subMenu = subMenu;
   }
 
   @Override
-  public MenuItem setOnMenuItemClickListener(OnMenuItemClickListener menuItemClickListener) {
+  @Nonnull
+  public MenuItem setOnMenuItemClickListener(
+      @Nullable OnMenuItemClickListener menuItemClickListener) {
     this.menuItemClickListener = menuItemClickListener;
     return this;
   }
 
   @Override
+  @Nullable
   public ContextMenu.ContextMenuInfo getMenuInfo() {
     return null;
   }
@@ -229,35 +263,42 @@ public class RoboMenuItem implements MenuItem {
   public void setShowAsAction(int actionEnum) {}
 
   @Override
+  @Nonnull
   public MenuItem setShowAsActionFlags(int actionEnum) {
     return this;
   }
 
   @Override
-  public MenuItem setActionView(View view) {
+  @Nonnull
+  public MenuItem setActionView(@Nullable View view) {
     actionView = view;
     return this;
   }
 
   @Override
-  public MenuItem setActionView(int resId) {
+  @Nonnull
+  public MenuItem setActionView(@LayoutRes int resId) {
     actionView = LayoutInflater.from(context).inflate(resId, null);
     return this;
   }
 
   @Override
+  @Nullable
   public View getActionView() {
     return actionView;
   }
 
   @Override
-  public MenuItem setActionProvider(ActionProvider actionProvider) {
+  @Nonnull
+  public MenuItem setActionProvider(@Nullable ActionProvider actionProvider) {
+    this.actionProvider = actionProvider;
     return this;
   }
 
   @Override
+  @Nullable
   public ActionProvider getActionProvider() {
-    return null;
+    return actionProvider;
   }
 
   @Override
@@ -294,7 +335,8 @@ public class RoboMenuItem implements MenuItem {
   }
 
   @Override
-  public MenuItem setOnActionExpandListener(OnActionExpandListener listener) {
+  @Nonnull
+  public MenuItem setOnActionExpandListener(@Nullable OnActionExpandListener listener) {
     actionExpandListener = listener;
     return this;
   }


### PR DESCRIPTION
This PR revives #3289 submitted by @jorgegil96 in order to fix #3085.

In addition to the initial fix, this commit also adds:
- Missing implementations on some getters.
- Nullability annotation to match AOSP.
- A couple of tests.