### PR TITLE
Add `jitpack.yml` file

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+before_install:
+  - sdkmanager "platforms;android-34"
+  - sdk install java 17-open
+  - sdk use java 17-open


### PR DESCRIPTION
This tells Jitpack to use Java 17 to build and publish Robolectric.

The need for this comes from #8742, in order to be able to use Robolectric at the specific commit (as opposed to a moving SNAPSHOT release).
@hoisie do we want to support this use case?

Fixes #8742