### PR TITLE
Fix warnings in some `integration_tests` module

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -180,7 +180,6 @@ libphonenumber = { module = "com.googlecode.libphonenumber:libphonenumber", vers
 okhttp = { module = "com.squareup.okhttp3:okhttp" }
 okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
 
-powermock-module-junit4 = { module = "org.powermock:powermock-module-junit4", version.ref = "powermock" }
 powermock-module-junit4-rule = { module = "org.powermock:powermock-module-junit4-rule", version.ref = "powermock" }
 powermock-api-mockito2 = { module = "org.powermock:powermock-api-mockito2", version.ref = "powermock" }
 powermock-classloading-xstream = { module = "org.powermock:powermock-classloading-xstream", version.ref = "powermock" }
@@ -246,7 +245,7 @@ spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.re
 
 [bundles]
 play-services-for-shadows = ["androidx-fragment-for-shadows", "play-services-auth-for-shadows", "play-services-base-for-shadows", "play-services-basement-for-shadows"]
-powermock = ["powermock-module-junit4", "powermock-module-junit4-rule", "powermock-api-mockito2", "powermock-classloading-xstream"]
+powermock = ["powermock-module-junit4-rule", "powermock-api-mockito2", "powermock-classloading-xstream"]
 sqlite4java-native = ["sqlite4java-osx", "sqlite4java-linux-amd64", "sqlite4java-win32-x64", "sqlite4java-linux-i386", "sqlite4java-win32-x86"]
 
 [plugins]

--- a/integration_tests/roborazzi/build.gradle.kts
+++ b/integration_tests/roborazzi/build.gradle.kts
@@ -54,7 +54,6 @@ dependencies {
   api(project(":robolectric"))
   testImplementation(libs.androidx.test.core)
   testImplementation(libs.junit4)
-  testImplementation(libs.truth)
   testImplementation(libs.roborazzi)
   testImplementation(libs.roborazzi.rule)
 }

--- a/integration_tests/room/build.gradle.kts
+++ b/integration_tests/room/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
   testImplementation(project(":testapp"))
   testImplementation(project(":robolectric"))
   testImplementation(libs.junit4)
-  testImplementation(libs.guava.testlib)
   testImplementation(libs.truth)
   implementation(libs.androidx.room.runtime)
   annotationProcessor(libs.androidx.room.compiler)

--- a/integration_tests/room/src/test/java/org/robolectric/integrationtests/room/UserDatabaseTest.java
+++ b/integration_tests/room/src/test/java/org/robolectric/integrationtests/room/UserDatabaseTest.java
@@ -12,7 +12,7 @@ import org.robolectric.annotation.SQLiteMode;
 public final class UserDatabaseTest {
 
   /**
-   * There was an issue using Room with {@link SQLiteMode.Mode.LEGACY}. The {@link
+   * There was an issue using Room with {@link SQLiteMode.Mode#LEGACY}. The {@link
    * android.database.sqlite.SQLiteException} exceptions were wrapped in a way that was not
    * compatible with Room.
    */

--- a/integration_tests/sdkcompat/src/test/java/org/robolectric/integrationtests/sdkcompat/NormalCompatibilityTest.kt
+++ b/integration_tests/sdkcompat/src/test/java/org/robolectric/integrationtests/sdkcompat/NormalCompatibilityTest.kt
@@ -13,7 +13,6 @@ import android.view.PixelCopy
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
 import org.robolectric.Robolectric.buildActivity
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
@@ -76,30 +75,36 @@ class NormalCompatibilityTest {
 
   @Test
   fun `PixelCopy request`() {
-    val testActivity = Robolectric.setupActivity(TestActivity::class.java)
-    val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
-    val listener = PixelCopy.OnPixelCopyFinishedListener {}
-    val srcRect = Rect(0, 0, 100, 100)
-    PixelCopy.request(
-      testActivity.window,
-      srcRect,
-      bitmap,
-      listener,
-      Handler(Looper.getMainLooper()),
-    )
+    buildActivity(TestActivity::class.java).use { controller ->
+      val testActivity = controller.setup().get()
+      val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
+      val listener = PixelCopy.OnPixelCopyFinishedListener {}
+      val srcRect = Rect(0, 0, 100, 100)
+      PixelCopy.request(
+        testActivity.window,
+        srcRect,
+        bitmap,
+        listener,
+        Handler(Looper.getMainLooper()),
+      )
+    }
   }
 
   @Test
   fun `MainActivity created correctly using AppComponentFactory`() {
-    val activity = Robolectric.setupActivity(MainActivity::class.java)
-    assertThat(activity.creationSource).isEqualTo(CreationSource.CUSTOM_CONSTRUCTOR)
+    buildActivity(MainActivity::class.java).use { controller ->
+      val activity = controller.setup().get()
+      assertThat(activity.creationSource).isEqualTo(CreationSource.CUSTOM_CONSTRUCTOR)
+    }
   }
 
   @Test
   @Config(minSdk = 19, maxSdk = 27)
   fun `MainActivity created correctly using default constructor on api lower than 28`() {
-    val activity = Robolectric.setupActivity(MainActivity::class.java)
-    assertThat(activity.creationSource).isEqualTo(CreationSource.DEFAULT_CONSTRUCTOR)
+    buildActivity(MainActivity::class.java).use { controller ->
+      val activity = controller.setup().get()
+      assertThat(activity.creationSource).isEqualTo(CreationSource.DEFAULT_CONSTRUCTOR)
+    }
   }
 
   @Test

--- a/integration_tests/security-providers/build.gradle.kts
+++ b/integration_tests/security-providers/build.gradle.kts
@@ -2,12 +2,11 @@ plugins { alias(libs.plugins.robolectric.java.module) }
 
 dependencies {
   api(project(":robolectric"))
-  api(libs.junit4)
   compileOnly(AndroidSdk.MAX_SDK.coordinates)
 
   testRuntimeOnly(AndroidSdk.MAX_SDK.coordinates)
-  testImplementation(libs.truth)
   testImplementation(libs.conscrypt.openjdk.uber)
+  testImplementation(libs.junit4)
   testImplementation(libs.okhttp)
   testImplementation(platform(libs.okhttp.bom))
 }

--- a/integration_tests/security-providers/src/test/java/org/robolectric/integrationtests/securityproviders/SecurityProvidersTest.java
+++ b/integration_tests/security-providers/src/test/java/org/robolectric/integrationtests/securityproviders/SecurityProvidersTest.java
@@ -1,5 +1,6 @@
 package org.robolectric.integrationtests.securityproviders;
 
+import java.net.URI;
 import java.net.URL;
 import java.security.Provider;
 import java.security.Security;
@@ -22,7 +23,7 @@ public class SecurityProvidersTest {
 
   @Test
   public void jsseProvider_isFunctioning() throws Exception {
-    URL url = new URL("https://www.google.com");
+    URL url = new URI("https://www.google.com").toURL();
     url.openConnection().getInputStream();
   }
 
@@ -33,6 +34,6 @@ public class SecurityProvidersTest {
     }
     OkHttpClient client = new OkHttpClient.Builder().build();
     Request request = new Request.Builder().url("https://www.google.com").build();
-    client.newCall(request).execute();
+    client.newCall(request).execute().close();
   }
 }

--- a/integration_tests/sparsearray/build.gradle.kts
+++ b/integration_tests/sparsearray/build.gradle.kts
@@ -27,7 +27,6 @@ android {
 
 dependencies {
   compileOnly(AndroidSdk.MAX_SDK.coordinates)
-  implementation(project(path = ":shadowapi", configuration = "default"))
 
   testCompileOnly(AndroidSdk.MAX_SDK.coordinates)
   testRuntimeOnly(AndroidSdk.MAX_SDK.coordinates)

--- a/integration_tests/testparameterinjector/src/test/java/org/robolectric/integrationtests/testparameterinjector/RobolectricTestParameterInjectorTest.java
+++ b/integration_tests/testparameterinjector/src/test/java/org/robolectric/integrationtests/testparameterinjector/RobolectricTestParameterInjectorTest.java
@@ -7,6 +7,7 @@ import static com.google.common.truth.Truth.assertThat;
 import android.os.Build.VERSION;
 import com.google.testing.junit.testparameterinjector.TestParameter;
 import java.util.ArrayList;
+import javax.annotation.Nonnull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -21,7 +22,12 @@ import org.junit.runners.JUnit4;
 import org.robolectric.RobolectricTestParameterInjector;
 import org.robolectric.annotation.Config;
 
-@SuppressWarnings({"TestMethodWithIncorrectSignature", "UnconstructableJUnitTestCase"})
+@SuppressWarnings({
+  "IgnoreWithoutReason",
+  "NewClassNamingConvention",
+  "TestMethodWithIncorrectSignature",
+  "UnconstructableJUnitTestCase"
+})
 @RunWith(JUnit4.class)
 public class RobolectricTestParameterInjectorTest {
   private String priorAlwaysInclude;
@@ -40,7 +46,7 @@ public class RobolectricTestParameterInjectorTest {
     runNotifier.addListener(
         new RunListener() {
           @Override
-          public void testFailure(Failure failure) throws Exception {
+          public void testFailure(Failure failure) {
             throw new AssertionError("Unexpected test failure: " + failure, failure.getException());
           }
         });
@@ -93,8 +99,8 @@ public class RobolectricTestParameterInjectorTest {
     assertThat(runner.testCount()).isEqualTo(2);
     ArrayList<Description> descriptions = runner.getDescription().getChildren();
     // In Gradle it's test[false], in Bazel it's test[param=false].
-    assertThat(descriptions.get(0).getMethodName()).matches("test\\[(param=)?false\\]");
-    assertThat(descriptions.get(1).getMethodName()).matches("test\\[(param=)?true\\]");
+    assertThat(descriptions.get(0).getMethodName()).matches("test\\[(param=)?false]");
+    assertThat(descriptions.get(1).getMethodName()).matches("test\\[(param=)?true]");
   }
 
   @Ignore
@@ -146,8 +152,8 @@ public class RobolectricTestParameterInjectorTest {
     assertThat(runner.testCount()).isEqualTo(2);
     ArrayList<Description> descriptions = runner.getDescription().getChildren();
     // In Gradle it's test[1], in Bazel it's test[param=1].
-    assertThat(descriptions.get(0).getMethodName()).matches("test\\[(param=)?1\\]");
-    assertThat(descriptions.get(1).getMethodName()).matches("test\\[(param=)?2\\]");
+    assertThat(descriptions.get(0).getMethodName()).matches("test\\[(param=)?1]");
+    assertThat(descriptions.get(1).getMethodName()).matches("test\\[(param=)?2]");
   }
 
   @Ignore
@@ -197,10 +203,10 @@ public class RobolectricTestParameterInjectorTest {
 
     ArrayList<Description> descriptions = runner.getDescription().getChildren();
     // In Gradle it's test[false][28], in Bazel it's test[param=false][28].
-    assertThat(descriptions.get(0).getMethodName()).matches("test\\[(param=)?false\\]\\[28\\]");
-    assertThat(descriptions.get(1).getMethodName()).matches("test\\[(param=)?true\\]\\[28\\]");
-    assertThat(descriptions.get(2).getMethodName()).matches("test\\[(param=)?false\\]");
-    assertThat(descriptions.get(3).getMethodName()).matches("test\\[(param=)?true\\]");
+    assertThat(descriptions.get(0).getMethodName()).matches("test\\[(param=)?false]\\[28]");
+    assertThat(descriptions.get(1).getMethodName()).matches("test\\[(param=)?true]\\[28]");
+    assertThat(descriptions.get(2).getMethodName()).matches("test\\[(param=)?false]");
+    assertThat(descriptions.get(3).getMethodName()).matches("test\\[(param=)?true]");
   }
 
   // Simulate the behavior of proto lite enum toString which includes the object hashcode (proto
@@ -213,6 +219,7 @@ public class RobolectricTestParameterInjectorTest {
       TWO;
 
       @Override
+      @Nonnull
       public String toString() {
         return "" + super.hashCode();
       }

--- a/integration_tests/versioning/build.gradle.kts
+++ b/integration_tests/versioning/build.gradle.kts
@@ -1,14 +1,10 @@
 plugins { alias(libs.plugins.robolectric.java.module) }
 
-val earlyRuntime by configurations.registering
-val axtJunitVersion: String by rootProject.extra
-
 dependencies {
   // compile against latest Android SDK (AndroidSdk.s.coordinates) { force = true }
   compileOnly(AndroidSdk.MAX_SDK.coordinates)
   testImplementation(project(":robolectric"))
   testImplementation(libs.truth)
-  testImplementation("androidx.test.ext:junit:$axtJunitVersion@aar")
   testCompileOnly(AndroidSdk.MAX_SDK.coordinates) // compile against latest Android SDK
   testRuntimeOnly(AndroidSdk.MAX_SDK.coordinates) // run against whatever this JDK supports
 }

--- a/integration_tests/versioning/src/test/resources/AndroidManifest.xml
+++ b/integration_tests/versioning/src/test/resources/AndroidManifest.xml
@@ -2,6 +2,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.robolectric">
     <uses-sdk android:targetSdkVersion="33" android:minSdkVersion="33"/>
-    <application android:name="android.app.Application">
-    </application>
 </manifest>


### PR DESCRIPTION
This PR addresses warnings in the following modules:
- `:integration_tests:versioning`
- `:integration_tests:testparameterinjector`
- `:integration_tests:sparsearray`
- `:integration_tests:security-providers`
- `:integration_tests:sdkcompat`
- `:integration_tests:room`
- `:integration_tests:roborazzi`
- `:integration_tests:powermock`