### PR TITLE
Fix `NullPointerException` in `RoboMenuItem`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/fakes/RoboMenuItemTest.java
+++ b/robolectric/src/test/java/org/robolectric/fakes/RoboMenuItemTest.java
@@ -8,24 +8,29 @@ import android.graphics.drawable.Drawable;
 import android.view.MenuItem;
 import android.view.View;
 import androidx.test.core.app.ApplicationProvider;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.util.Arrays;
 import javax.annotation.Nonnull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.R;
+import org.robolectric.RuntimeEnvironment;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(ParameterizedRobolectricTestRunner.class)
 public class RoboMenuItemTest {
   private Context context;
-  private MenuItem item;
+  @Nonnull private MenuItem item;
   private TestOnActionExpandListener listener;
+
+  public RoboMenuItemTest(@Nonnull RoboMenuItem roboMenuItem) {
+    item = roboMenuItem;
+  }
 
   @Before
   public void setUp() throws Exception {
     context = ApplicationProvider.getApplicationContext();
     listener = new TestOnActionExpandListener();
-    item = new RoboMenuItem(context);
     item.setOnActionExpandListener(listener);
   }
 
@@ -201,5 +206,13 @@ public class RoboMenuItemTest {
       expanded = false;
       return true;
     }
+  }
+
+  @ParameterizedRobolectricTestRunner.Parameters
+  public static Iterable<?> data() {
+    return Arrays.asList(
+        new RoboMenuItem(),
+        new RoboMenuItem(R.id.text1),
+        new RoboMenuItem(RuntimeEnvironment.getApplication()));
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/fakes/RoboMenuItem.java
+++ b/shadows/framework/src/main/java/org/robolectric/fakes/RoboMenuItem.java
@@ -34,7 +34,7 @@ public class RoboMenuItem implements MenuItem {
   @Nullable private View actionView;
   @Nullable private OnActionExpandListener actionExpandListener;
   private int order;
-  private Context context;
+  @Nonnull private final Context context;
   private char numericChar;
   private char alphaChar;
   @Nullable private ActionProvider actionProvider;
@@ -43,11 +43,12 @@ public class RoboMenuItem implements MenuItem {
     this(RuntimeEnvironment.getApplication());
   }
 
-  public RoboMenuItem(Context context) {
+  public RoboMenuItem(@Nonnull Context context) {
     this.context = context;
   }
 
   public RoboMenuItem(int itemId) {
+    this();
     this.itemId = itemId;
   }
 


### PR DESCRIPTION
When using the constructor that takes a menu id, the `Context` was not set. So calling methods like `RoboMenuItem.setTitle(int)` would cause a `NullPointerException`. This is now fixed by always setting the `Context`.

Fixes #9836
