### PR TITLE
Fix warnings in some `integration_tests` modules

### DIFF
--- a/integration_tests/composeui/build.gradle.kts
+++ b/integration_tests/composeui/build.gradle.kts
@@ -45,6 +45,5 @@ dependencies {
 
   testImplementation(project(":robolectric"))
   testImplementation(libs.junit4)
-  testImplementation(libs.truth)
   testImplementation(libs.androidx.compose.ui.test.junit4)
 }

--- a/integration_tests/dependency-on-stubs/build.gradle.kts
+++ b/integration_tests/dependency-on-stubs/build.gradle.kts
@@ -25,5 +25,4 @@ android {
 dependencies {
   testImplementation(project(":robolectric"))
   testImplementation(libs.junit4)
-  testImplementation(libs.truth)
 }

--- a/integration_tests/kotlin/build.gradle.kts
+++ b/integration_tests/kotlin/build.gradle.kts
@@ -11,12 +11,9 @@ tasks.compileKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
 tasks.compileTestKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
-val axtCoreVersion: String by rootProject.extra
-
 dependencies {
   api(project(":robolectric"))
   compileOnly(AndroidSdk.MAX_SDK.coordinates)
-  implementation(libs.androidx.annotation)
 
   testCompileOnly(AndroidSdk.MAX_SDK.coordinates)
   testRuntimeOnly(AndroidSdk.MAX_SDK.coordinates)
@@ -24,5 +21,4 @@ dependencies {
   testImplementation(libs.kotlinx.coroutines.android)
   testImplementation(libs.junit4)
   testImplementation(libs.truth)
-  testImplementation("androidx.test:core:$axtCoreVersion@aar")
 }

--- a/integration_tests/kotlin/src/test/kotlin/org/robolectric/integrationtests/kotlin/flow/BluetoothProvisioner.kt
+++ b/integration_tests/kotlin/src/test/kotlin/org/robolectric/integrationtests/kotlin/flow/BluetoothProvisioner.kt
@@ -19,11 +19,7 @@ import kotlinx.coroutines.flow.flow
 /** A class that invokes Android Bluetooth LE APIs. */
 class BluetoothProvisioner(applicationContext: Context) {
 
-  val context: Context
-
-  init {
-    context = applicationContext
-  }
+  val context = applicationContext
 
   fun startScan(): Flow<BluetoothDevice> = callbackFlow {
     val scanCallback =

--- a/integration_tests/kotlin/src/test/kotlin/org/robolectric/integrationtests/kotlin/flow/BluetoothProvisionerTest.kt
+++ b/integration_tests/kotlin/src/test/kotlin/org/robolectric/integrationtests/kotlin/flow/BluetoothProvisionerTest.kt
@@ -1,5 +1,6 @@
 package org.robolectric.integrationtests.kotlin.flow
 
+import android.app.Application
 import android.bluetooth.BluetoothGattService
 import android.bluetooth.BluetoothManager
 import android.bluetooth.le.ScanResult
@@ -30,7 +31,7 @@ import org.robolectric.shadows.ShadowBluetoothLeScanner
 @Config(sdk = [S])
 class BluetoothProvisionerTest {
 
-  val context = RuntimeEnvironment.getApplication()
+  val context: Application = RuntimeEnvironment.getApplication()
 
   val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
 

--- a/integration_tests/libphonenumber/src/test/java/org/robolectric/integrationtests/libphonenumber/ClassloadingTest.java
+++ b/integration_tests/libphonenumber/src/test/java/org/robolectric/integrationtests/libphonenumber/ClassloadingTest.java
@@ -15,7 +15,7 @@ public class ClassloadingTest {
 
   /** <a href="https://github.com/robolectric/robolectric/issues/2773">Issue</a> */
   @Test
-  public void getResourceAsStream() throws Exception {
+  public void getResourceAsStream() {
     Phonenumber.PhoneNumber phoneNumber = new Phonenumber.PhoneNumber();
     phoneNumber.setCountryCode(7);
     phoneNumber.setNationalNumber(4956360636L);

--- a/integration_tests/memoryleaks/src/test/java/org/robolectric/integrationtests/memoryleaks/BaseMemoryLeaksTest.java
+++ b/integration_tests/memoryleaks/src/test/java/org/robolectric/integrationtests/memoryleaks/BaseMemoryLeaksTest.java
@@ -72,8 +72,10 @@ public abstract class BaseMemoryLeaksTest {
   // that run.
   public void aaa_activityCanBeGcdBetweenTest_1() {
     assertThat(awr).isNull();
-    ActivityController<Activity> ac = Robolectric.buildActivity(Activity.class).setup();
-    awr = new WeakReference<>(ac.get());
+    try (ActivityController<Activity> ac = Robolectric.buildActivity(Activity.class)) {
+      ac.setup();
+      awr = new WeakReference<>(ac.get());
+    }
   }
 
   @Test

--- a/integration_tests/mockito-experimental/src/test/java/org/robolectric/integrationtests/mockito/experimental/MockitoMockFinalsTest.java
+++ b/integration_tests/mockito-experimental/src/test/java/org/robolectric/integrationtests/mockito/experimental/MockitoMockFinalsTest.java
@@ -36,7 +36,7 @@ public class MockitoMockFinalsTest {
   }
 
   static final class User {
-    final int getId() {
+    int getId() {
       return -1;
     }
   }

--- a/integration_tests/mockito-experimental/src/test/java/org/robolectric/integrationtests/mockito/experimental/MockitoMockJavaFrameworkTest.java
+++ b/integration_tests/mockito-experimental/src/test/java/org/robolectric/integrationtests/mockito/experimental/MockitoMockJavaFrameworkTest.java
@@ -15,7 +15,7 @@ import org.robolectric.RobolectricTestRunner;
 @RunWith(RobolectricTestRunner.class)
 public class MockitoMockJavaFrameworkTest {
   @Test
-  public void file_getAbsolutePath_isMockable() throws Exception {
+  public void file_getAbsolutePath_isMockable() {
     File file = mock(File.class);
     doReturn("absolute/path").when(file).getAbsolutePath();
     assertThat(file.getAbsolutePath()).isEqualTo("absolute/path");

--- a/integration_tests/mockk/src/test/java/org/robolectric/integrationtests/mockk/MockkInitTestCase.kt
+++ b/integration_tests/mockk/src/test/java/org/robolectric/integrationtests/mockk/MockkInitTestCase.kt
@@ -24,7 +24,7 @@ class MockkInitTestCase {
   @Before fun setUp() = MockKAnnotations.init(this)
 
   @Test
-  fun `Mockk1`() {
+  fun mockk1() {
     every { returner.returnNumber() } returns 1
     assert(returner.returnNumber() == 1)
   }


### PR DESCRIPTION
This fixes warnings in the following `integration_tests` modules:
- `composeui`.
- `dependency-on-stubs`.
- `kotlin`.
- `libphonenumber`.
- `memoryleaks`.
- `mockito-experimental`.
- `mockk`.