### PR TITLE
Fix warnings in `integration_tests:androidx_test`

### DIFF
--- a/integration_tests/androidx_test/build.gradle.kts
+++ b/integration_tests/androidx_test/build.gradle.kts
@@ -49,7 +49,6 @@ dependencies {
 
   // Testing dependencies
   testImplementation(project(":robolectric"))
-  testImplementation(libs.androidx.test.runner)
   testImplementation(libs.junit4)
   testImplementation(libs.androidx.test.rules)
   testImplementation(libs.androidx.test.espresso.intents)
@@ -63,12 +62,9 @@ dependencies {
   testImplementation(libs.truth)
 
   androidTestImplementation(project(":annotations"))
-  androidTestImplementation(libs.androidx.test.runner)
   androidTestImplementation(libs.junit4)
   androidTestImplementation(libs.androidx.test.rules)
-  androidTestImplementation(libs.androidx.test.espresso.intents)
   androidTestImplementation(libs.androidx.test.espresso.core)
-  androidTestImplementation(libs.androidx.test.ext.truth)
   androidTestImplementation(libs.androidx.test.core)
   androidTestImplementation(libs.androidx.test.ext.junit)
   androidTestImplementation(platform(libs.kotlin.bom))

--- a/integration_tests/androidx_test/src/main/java/org/robolectric/integrationtests/axt/ActivityWithAppCompatMenu.java
+++ b/integration_tests/androidx_test/src/main/java/org/robolectric/integrationtests/axt/ActivityWithAppCompatMenu.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import org.robolectric.integration.axt.R;
 
@@ -26,7 +27,7 @@ public class ActivityWithAppCompatMenu extends AppCompatActivity {
   }
 
   @Override
-  public boolean onOptionsItemSelected(MenuItem item) {
+  public boolean onOptionsItemSelected(@NonNull MenuItem item) {
     menuClicked = true;
     return true;
   }

--- a/integration_tests/androidx_test/src/main/java/org/robolectric/integrationtests/axt/ActivityWithPlatformMenu.java
+++ b/integration_tests/androidx_test/src/main/java/org/robolectric/integrationtests/axt/ActivityWithPlatformMenu.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import androidx.annotation.NonNull;
 import org.robolectric.integration.axt.R;
 
 /** {@link EspressoWithMenuTest} fixture activity that uses Android platform menu's */
@@ -26,7 +27,7 @@ public class ActivityWithPlatformMenu extends Activity {
   }
 
   @Override
-  public boolean onOptionsItemSelected(MenuItem item) {
+  public boolean onOptionsItemSelected(@NonNull MenuItem item) {
     menuClicked = true;
     return true;
   }

--- a/integration_tests/androidx_test/src/main/res/layout/appcompat_activity_with_toolbar_menu.xml
+++ b/integration_tests/androidx_test/src/main/res/layout/appcompat_activity_with_toolbar_menu.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/layout"
     android:layout_width="match_parent"

--- a/integration_tests/androidx_test/src/main/res/layout/espresso_activity.xml
+++ b/integration_tests/androidx_test/src/main/res/layout/espresso_activity.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/layout"
     android:layout_width="wrap_content"

--- a/integration_tests/androidx_test/src/sharedTest/AndroidManifest.xml
+++ b/integration_tests/androidx_test/src/sharedTest/AndroidManifest.xml
@@ -38,6 +38,6 @@
 
   <instrumentation
       android:name="androidx.test.runner.AndroidJUnitRunner"
-      android:targetPackage="org.robolectric.integration.axt"/>
+      android:targetPackage="org.robolectric.integrationtests.axt"/>
 
 </manifest>

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/ActivityScenarioTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/ActivityScenarioTest.java
@@ -39,6 +39,9 @@ public class ActivityScenarioTest {
 
   private static final List<String> callbacks = new ArrayList<>();
 
+  /**
+   * @noinspection NewClassNamingConvention
+   */
   public static class TranscriptActivity extends Activity {
 
     @Override
@@ -96,6 +99,9 @@ public class ActivityScenarioTest {
     }
   }
 
+  /**
+   * @noinspection NewClassNamingConvention
+   */
   public static class LifecycleOwnerActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle bundle) {
@@ -109,6 +115,9 @@ public class ActivityScenarioTest {
     callbacks.clear();
   }
 
+  /**
+   * @noinspection NewClassNamingConvention
+   */
   public static class ActivityWithCustomConstructor extends Activity {
     private final int intValue;
 
@@ -121,6 +130,9 @@ public class ActivityScenarioTest {
     }
   }
 
+  /**
+   * @noinspection NewClassNamingConvention
+   */
   public static class CustomAppComponentFactory extends AppComponentFactory {
 
     @Nonnull
@@ -324,9 +336,8 @@ public class ActivityScenarioTest {
     try (ActivityScenario<TranscriptActivity> activityScenario =
         ActivityScenario.launch(TranscriptActivity.class)) {
       activityScenario.onActivity(
-          activity -> {
-            assertThat(Looper.getMainLooper().getThread()).isEqualTo(Thread.currentThread());
-          });
+          activity ->
+              assertThat(Looper.getMainLooper().getThread()).isEqualTo(Thread.currentThread()));
     }
   }
 
@@ -334,10 +345,7 @@ public class ActivityScenarioTest {
   public void getCallingActivity_empty() {
     try (ActivityScenario<TranscriptActivity> activityScenario =
         ActivityScenario.launch(TranscriptActivity.class)) {
-      activityScenario.onActivity(
-          activity -> {
-            assertThat(activity.getCallingActivity()).isNull();
-          });
+      activityScenario.onActivity(activity -> assertThat(activity.getCallingActivity()).isNull());
     }
   }
 
@@ -346,10 +354,9 @@ public class ActivityScenarioTest {
     try (ActivityScenario<TranscriptActivity> activityScenario =
         ActivityScenario.launchActivityForResult(TranscriptActivity.class)) {
       activityScenario.onActivity(
-          activity -> {
-            assertThat(activity.getCallingActivity().getPackageName())
-                .isEqualTo("org.robolectric.integrationtests.axt");
-          });
+          activity ->
+              assertThat(activity.getCallingActivity().getPackageName())
+                  .isEqualTo("org.robolectric.integrationtests.axt"));
     }
   }
 
@@ -359,10 +366,7 @@ public class ActivityScenarioTest {
     try (ActivityScenario<ActivityWithCustomConstructor> activityScenario =
         ActivityScenario.launch(ActivityWithCustomConstructor.class)) {
       assertThat(activityScenario.getState()).isEqualTo(State.RESUMED);
-      activityScenario.onActivity(
-          activity -> {
-            assertThat(activity.getIntValue()).isEqualTo(100);
-          });
+      activityScenario.onActivity(activity -> assertThat(activity.getIntValue()).isEqualTo(100));
     }
   }
 }

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/ActivityTestRuleTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/ActivityTestRuleTest.java
@@ -47,6 +47,9 @@ public class ActivityTestRuleTest {
         }
       };
 
+  /**
+   * @noinspection NewClassNamingConvention
+   */
   public static class TranscriptActivity extends Activity {
     Bundle receivedBundle;
 

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/CryptoObjectTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/CryptoObjectTest.java
@@ -7,8 +7,6 @@ import androidx.biometric.BiometricPrompt.PromptInfo;
 import androidx.fragment.app.FragmentActivity;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.security.NoSuchAlgorithmException;
-import java.util.concurrent.Executor;
-import javax.annotation.Nonnull;
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import org.junit.Before;
@@ -33,22 +31,7 @@ public class CryptoObjectTest {
       throws NoSuchPaddingException, NoSuchAlgorithmException {
     BiometricPrompt biometricPrompt =
         new BiometricPrompt(
-            fragmentActivity,
-            new Executor() {
-              @Override
-              public void execute(Runnable command) {}
-            },
-            new BiometricPrompt.AuthenticationCallback() {
-              @Override
-              public void onAuthenticationError(int errorCode, @Nonnull CharSequence errString) {}
-
-              @Override
-              public void onAuthenticationSucceeded(
-                  @Nonnull BiometricPrompt.AuthenticationResult result) {}
-
-              @Override
-              public void onAuthenticationFailed() {}
-            });
+            fragmentActivity, command -> {}, new BiometricPrompt.AuthenticationCallback() {});
 
     PromptInfo promptInfo =
         new PromptInfo.Builder()

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoIdlingResourceTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoIdlingResourceTest.java
@@ -42,7 +42,7 @@ public final class EspressoIdlingResourceTest {
   }
 
   @Test
-  public void onIdle_idlingResourceIsIdle_doesntBlock() {
+  public void onIdle_idlingResourceIsIdle_doesNotBlock() {
     AtomicBoolean didCheckIdle = new AtomicBoolean();
     idlingRegistry.register(
         new NamedIdleResource("Test", /* isIdle= */ true) {
@@ -179,6 +179,9 @@ public final class EspressoIdlingResourceTest {
     }
   }
 
+  /**
+   * @noinspection NewClassNamingConvention
+   */
   private static class NamedIdleResource implements IdlingResource {
     final String name;
     final AtomicBoolean isIdle;

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoWithPausedLooperTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoWithPausedLooperTest.java
@@ -28,7 +28,7 @@ public final class EspressoWithPausedLooperTest {
   public void launchActivity() {}
 
   @Test
-  public void onIdle_doesnt_block() {
+  public void onIdle_does_not_block() {
     Espresso.onIdle();
   }
 

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoWithSwitchCompatTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoWithSwitchCompatTest.java
@@ -19,7 +19,7 @@ import org.robolectric.integration.axt.R;
 public class EspressoWithSwitchCompatTest {
   @Test
   public void switchCompatTest() {
-    try (ActivityScenario<ActivityWithSwitchCompat> scenario =
+    try (ActivityScenario<ActivityWithSwitchCompat> ignored =
         ActivityScenario.launch(ActivityWithSwitchCompat.class)) {
       onView(withId(R.id.switch_compat_2)).check(matches(isCompletelyDisplayed())).perform(click());
     }

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/FragmentScenarioTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/FragmentScenarioTest.java
@@ -17,8 +17,10 @@ public class FragmentScenarioTest {
   @Test
   public void launchFragment() {
     final AtomicReference<Fragment> loadedFragment = new AtomicReference<>();
-    FragmentScenario.launch(Fragment.class).onFragment(loadedFragment::set);
-    assertThat(loadedFragment.get()).isNotNull();
+    try (FragmentScenario<Fragment> scenario = FragmentScenario.launch(Fragment.class)) {
+      scenario.onFragment(loadedFragment::set);
+      assertThat(loadedFragment.get()).isNotNull();
+    }
   }
 
   /**
@@ -30,7 +32,9 @@ public class FragmentScenarioTest {
   @Config(instrumentedPackages = "androidx.")
   public void launchFragmentInstrumented() {
     final AtomicReference<Fragment> loadedFragment = new AtomicReference<>();
-    FragmentScenario.launch(Fragment.class).onFragment(loadedFragment::set);
-    assertThat(loadedFragment.get()).isNotNull();
+    try (FragmentScenario<Fragment> scenario = FragmentScenario.launch(Fragment.class)) {
+      scenario.onFragment(loadedFragment::set);
+      assertThat(loadedFragment.get()).isNotNull();
+    }
   }
 }

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/IntentsTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/IntentsTest.java
@@ -128,7 +128,11 @@ public class IntentsTest {
     assertThat(getIntents()).comparingElementsUsing(all(action(), data())).contains(expectedIntent);
   }
 
-  /** Activity that captures calls to {#onActivityResult() } */
+  /**
+   * Activity that captures calls to {@link Activity#onActivityResult(int, int, Intent)}
+   *
+   * @noinspection NewClassNamingConvention
+   */
   public static class ResultCapturingActivity extends Activity {
 
     private ActivityResult activityResult;
@@ -165,7 +169,11 @@ public class IntentsTest {
     }
   }
 
-  /** Dummy activity whose calls we intent to we're stubbing out. */
+  /**
+   * Dummy activity whose calls we intent to we're stubbing out.
+   *
+   * @noinspection NewClassNamingConvention
+   */
   public static class DummyActivity extends Activity {}
 
   @Test
@@ -173,17 +181,18 @@ public class IntentsTest {
     intending(hasComponent(hasClassName(DummyActivity.class.getName())))
         .respondWith(new ActivityResult(Activity.RESULT_OK, new Intent().putExtra("key", 123)));
 
-    ActivityScenario<ResultCapturingActivity> activityScenario =
-        ActivityScenario.launch(ResultCapturingActivity.class);
+    try (ActivityScenario<ResultCapturingActivity> activityScenario =
+        ActivityScenario.launch(ResultCapturingActivity.class)) {
+      activityScenario.onActivity(
+          activity ->
+              activity.startActivityForResult(new Intent(activity, DummyActivity.class), 0));
 
-    activityScenario.onActivity(
-        activity -> activity.startActivityForResult(new Intent(activity, DummyActivity.class), 0));
-
-    activityScenario.onActivity(
-        activity -> {
-          assertThat(activity.activityResult.getResultCode()).isEqualTo(Activity.RESULT_OK);
-          assertThat(activity.activityResult.getResultData()).extras().containsKey("key");
-        });
+      activityScenario.onActivity(
+          activity -> {
+            assertThat(activity.activityResult.getResultCode()).isEqualTo(Activity.RESULT_OK);
+            assertThat(activity.activityResult.getResultData()).extras().containsKey("key");
+          });
+    }
   }
 
   @Test


### PR DESCRIPTION
This removes unused dependencies and addresses most warnings in `integration_tests:androidx_test`.