### PR TITLE
Migrate to Java8 APIs from the `javax.lang.model` package

### DIFF
--- a/processor/src/main/java/org/robolectric/annotation/processing/Helpers.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/Helpers.java
@@ -20,14 +20,14 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
-import javax.lang.model.util.SimpleAnnotationValueVisitor6;
-import javax.lang.model.util.SimpleElementVisitor6;
+import javax.lang.model.util.SimpleAnnotationValueVisitor8;
+import javax.lang.model.util.SimpleElementVisitor8;
 import javax.lang.model.util.Types;
 
 public class Helpers {
 
   private static final AnnotationValueVisitor<TypeMirror, Void> TYPE_MIRROR_VISITOR =
-      new SimpleAnnotationValueVisitor6<TypeMirror, Void>() {
+      new SimpleAnnotationValueVisitor8<TypeMirror, Void>() {
         @Override
         public TypeMirror visitType(TypeMirror t, Void arg) {
           return t;
@@ -35,7 +35,7 @@ public class Helpers {
       };
 
   private static final ElementVisitor<TypeElement, Void> TYPE_ELEMENT_VISITOR =
-      new SimpleElementVisitor6<TypeElement, Void>() {
+      new SimpleElementVisitor8<TypeElement, Void>() {
         @Override
         public TypeElement visitType(TypeElement e, Void p) {
           return e;
@@ -43,7 +43,7 @@ public class Helpers {
       };
 
   private static final AnnotationValueVisitor<String, Void> STRING_VISITOR =
-      new SimpleAnnotationValueVisitor6<String, Void>() {
+      new SimpleAnnotationValueVisitor8<String, Void>() {
         @Override
         public String visitString(String s, Void arg) {
           return s;
@@ -51,7 +51,7 @@ public class Helpers {
       };
 
   private static final AnnotationValueVisitor<Integer, Void> INT_VISITOR =
-      new SimpleAnnotationValueVisitor6<Integer, Void>() {
+      new SimpleAnnotationValueVisitor8<Integer, Void>() {
         @Override
         public Integer visitInt(int i, Void aVoid) {
           return i;

--- a/processor/src/main/java/org/robolectric/annotation/processing/RobolectricModel.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/RobolectricModel.java
@@ -29,8 +29,8 @@ import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVisitor;
-import javax.lang.model.util.SimpleElementVisitor6;
-import javax.lang.model.util.SimpleTypeVisitor6;
+import javax.lang.model.util.SimpleElementVisitor8;
+import javax.lang.model.util.SimpleTypeVisitor8;
 import org.robolectric.annotation.Implements;
 import org.robolectric.shadow.api.ShadowPicker;
 
@@ -70,7 +70,7 @@ public class RobolectricModel {
   }
 
   private static final ElementVisitor<TypeElement, Void> TYPE_ELEMENT_VISITOR =
-      new SimpleElementVisitor6<TypeElement, Void>() {
+      new SimpleElementVisitor8<TypeElement, Void>() {
         @Override
         public TypeElement visitType(TypeElement e, Void p) {
           return e;
@@ -201,8 +201,8 @@ public class RobolectricModel {
             referentMap.put(type, referents.getKey());
           } else {
             for (TypeElement type : c) {
-              SimpleElementVisitor6<Void, TypeElement> visitor =
-                  new SimpleElementVisitor6<Void, TypeElement>() {
+              ElementVisitor<Void, TypeElement> visitor =
+                  new SimpleElementVisitor8<Void, TypeElement>() {
                     @Override
                     public Void visitType(TypeElement parent, TypeElement type) {
                       nextRound.put(parent.getSimpleName() + "." + type.getSimpleName(), type);
@@ -276,7 +276,7 @@ public class RobolectricModel {
     }
 
     private final TypeVisitor<String, Void> findReferent =
-        new SimpleTypeVisitor6<String, Void>() {
+        new SimpleTypeVisitor8<String, Void>() {
           @Override
           public String visitDeclared(DeclaredType t, Void p) {
             return referentMap.get(t.asElement());

--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/RealObjectValidator.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/RealObjectValidator.java
@@ -8,7 +8,7 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVisitor;
-import javax.lang.model.util.SimpleTypeVisitor6;
+import javax.lang.model.util.SimpleTypeVisitor8;
 import javax.tools.Diagnostic.Kind;
 import org.robolectric.annotation.processing.RobolectricModel;
 
@@ -33,7 +33,7 @@ public class RealObjectValidator extends FoundOnImplementsValidator {
   }
 
   TypeVisitor<Void, VariableElement> typeVisitor =
-      new SimpleTypeVisitor6<Void, VariableElement>() {
+      new SimpleTypeVisitor8<Void, VariableElement>() {
         @Override
         public Void visitDeclared(DeclaredType t, VariableElement v) {
           List<? extends TypeMirror> typeParams = t.getTypeArguments();

--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/Validator.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/Validator.java
@@ -11,7 +11,7 @@ import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
-import javax.lang.model.util.AbstractElementVisitor6;
+import javax.lang.model.util.AbstractElementVisitor8;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
@@ -28,7 +28,7 @@ public abstract class Validator implements ElementVisitor<Void, Element> {
   protected final Helpers helpers;
   // This is the easiest way to do it because visit() is final in AbstractEV6
   final ElementVisitor<Void, Element> visitorAdapter =
-      new AbstractElementVisitor6<Void, Element>() {
+      new AbstractElementVisitor8<Void, Element>() {
 
         @Override
         public Void visitPackage(PackageElement e, Element p) {


### PR DESCRIPTION
- `AbstractElementVisitor6` -> `AbstractElementVisitor8`.
- `SimpleAnnotationValueVisitor6` -> `SimpleAnnotationValueVisitor8`.
- `SimpleElementVisitor6` -> `SimpleElementVisitor8`.
- `SimpleTypeVisitor6` -> `SimpleTypeVisitor8`.