### PR TITLE
Migrate deprecated initMocks to openMocks

### DIFF
--- a/resources/src/test/java/org/robolectric/manifest/MetaDataTest.java
+++ b/resources/src/test/java/org/robolectric/manifest/MetaDataTest.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,10 +22,16 @@ import org.w3c.dom.Node;
 public class MetaDataTest {
 
   @Mock private ResourceTable resourceProvider;
+  private AutoCloseable mock;
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
+    mock = MockitoAnnotations.openMocks(this);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mock.close();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCaptioningManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCaptioningManagerTest.java
@@ -18,6 +18,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,6 +41,7 @@ public final class ShadowCaptioningManagerTest {
 
   private CaptioningManager captioningManager;
   private Context context;
+  private AutoCloseable mock;
 
   public class TestCaptioningChangeListener extends CaptioningChangeListener {
     public boolean isEnabled = false;
@@ -82,12 +84,17 @@ public final class ShadowCaptioningManagerTest {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
+    mock = MockitoAnnotations.openMocks(this);
     captioningManager =
         (CaptioningManager)
             ApplicationProvider.getApplicationContext()
                 .getSystemService(Context.CAPTIONING_SERVICE);
     context = RuntimeEnvironment.getApplication();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mock.close();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowJobServiceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowJobServiceTest.java
@@ -7,6 +7,7 @@ import android.app.Notification;
 import android.app.job.JobParameters;
 import android.app.job.JobService;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,9 +22,11 @@ public class ShadowJobServiceTest {
   private JobService jobService;
   @Mock private JobParameters params;
 
+  private AutoCloseable mock;
+
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
+    mock = MockitoAnnotations.openMocks(this);
     jobService =
         new JobService() {
           @Override
@@ -36,6 +39,11 @@ public class ShadowJobServiceTest {
             return false;
           }
         };
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mock.close();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbDeviceConnectionTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbDeviceConnectionTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import javax.annotation.Nullable;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,13 +34,15 @@ public class ShadowUsbDeviceConnectionTest {
 
   private UsbManager usbManager;
 
+  private AutoCloseable mock;
+
   @Mock private UsbDevice usbDevice;
   @Mock private UsbConfiguration usbConfiguration;
   @Mock private UsbInterface usbInterface;
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
+    mock = MockitoAnnotations.openMocks(this);
     usbManager =
         (UsbManager)
             ApplicationProvider.getApplicationContext().getSystemService(Context.USB_SERVICE);
@@ -49,6 +52,11 @@ public class ShadowUsbDeviceConnectionTest {
     when(usbDevice.getConfiguration(0)).thenReturn(usbConfiguration);
     when(usbConfiguration.getInterfaceCount()).thenReturn(1);
     when(usbConfiguration.getInterface(0)).thenReturn(usbInterface);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mock.close();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbManagerTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,19 +49,26 @@ public class ShadowUsbManagerTest {
 
   private UsbManager usbManager;
 
+  private AutoCloseable mock;
+
   @Mock UsbDevice usbDevice1;
   @Mock UsbDevice usbDevice2;
   @Mock UsbAccessory usbAccessory;
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
+    mock = MockitoAnnotations.openMocks(this);
     usbManager =
         (UsbManager)
             ApplicationProvider.getApplicationContext().getSystemService(Context.USB_SERVICE);
 
     when(usbDevice1.getDeviceName()).thenReturn(DEVICE_NAME_1);
     when(usbDevice2.getDeviceName()).thenReturn(DEVICE_NAME_2);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mock.close();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbRequestTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbRequestTest.java
@@ -35,13 +35,15 @@ public class ShadowUsbRequestTest {
   private UsbManager usbManager;
   private UsbRequest dataRequest;
 
+  private AutoCloseable mock;
+
   @Mock private UsbDevice usbDevice;
   @Mock private UsbConfiguration usbConfiguration;
   @Mock private UsbInterface usbInterface;
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
+    mock = MockitoAnnotations.openMocks(this);
     usbManager =
         (UsbManager)
             ApplicationProvider.getApplicationContext().getSystemService(Context.USB_SERVICE);
@@ -58,8 +60,9 @@ public class ShadowUsbRequestTest {
   }
 
   @After
-  public void tearDown() {
+  public void tearDown() throws Exception {
     dataRequest.close();
+    mock.close();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiP2pManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiP2pManagerTest.java
@@ -16,6 +16,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,15 +34,21 @@ public class ShadowWifiP2pManagerTest {
   private ShadowWifiP2pManager shadowManager;
   @Mock private WifiP2pManager.ChannelListener mockListener;
   private WifiP2pManager.Channel channel;
+  private AutoCloseable mock;
 
   @Before
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
+    mock = MockitoAnnotations.openMocks(this);
     context = ApplicationProvider.getApplicationContext();
     manager = (WifiP2pManager) context.getSystemService(Context.WIFI_P2P_SERVICE);
     shadowManager = shadowOf(manager);
     channel = manager.initialize(context, context.getMainLooper(), mockListener);
     assertThat(channel).isNotNull();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mock.close();
   }
 
   @Test

--- a/shadows/playservices/src/test/java/org/robolectric/shadows/gms/ShadowGoogleAuthUtilTest.java
+++ b/shadows/playservices/src/test/java/org/robolectric/shadows/gms/ShadowGoogleAuthUtilTest.java
@@ -11,6 +11,7 @@ import android.content.Intent;
 import com.google.android.gms.auth.AccountChangeEvent;
 import com.google.android.gms.auth.GoogleAuthUtil;
 import java.util.List;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,14 +31,21 @@ import org.robolectric.shadows.gms.ShadowGoogleAuthUtil.GoogleAuthUtilImpl;
     shadows = {ShadowGoogleAuthUtil.class})
 public class ShadowGoogleAuthUtilTest {
 
+  private AutoCloseable mock;
+
   @Mock private GoogleAuthUtilImpl mockGoogleAuthUtil;
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Before
   public void setup() {
-    MockitoAnnotations.initMocks(this);
+    mock = MockitoAnnotations.openMocks(this);
     ShadowGoogleAuthUtil.reset();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mock.close();
   }
 
   @Test

--- a/shadows/playservices/src/test/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtilTest.java
+++ b/shadows/playservices/src/test/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtilTest.java
@@ -11,6 +11,7 @@ import android.app.Activity;
 import android.content.Context;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,9 +34,16 @@ public class ShadowGooglePlayServicesUtilTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
+  private AutoCloseable mock;
+
   @Before
   public void setup() {
-    MockitoAnnotations.initMocks(this);
+    mock = MockitoAnnotations.openMocks(this);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    mock.close();
   }
 
   @Test


### PR DESCRIPTION
Use `openMocks` instead of deprecated `initMocks`. `openMocks` doesn't close result automatically, and we need to do it in tearDown method as the library recommends.