### PR TITLE
Fix small warnings in the `resources` module

### DIFF
--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -151,7 +151,7 @@ public class AndroidManifest implements UsesSdk {
     return themeRef;
   }
 
-  public String getRClassName() throws Exception {
+  public String getRClassName() {
     parseAndroidManifest();
     return rClassName;
   }

--- a/resources/src/main/java/org/robolectric/res/Qualifiers.java
+++ b/resources/src/main/java/org/robolectric/res/Qualifiers.java
@@ -7,7 +7,7 @@ import org.robolectric.res.android.ConfigDescription;
 import org.robolectric.res.android.ResTable_config;
 
 /**
- * Android qualifers as defined by
+ * Android qualifiers as defined by
  * https://developer.android.com/guide/topics/resources/providing-resources.html
  */
 @SuppressWarnings("NewApi")

--- a/resources/src/main/java/org/robolectric/res/ResourceMerger.java
+++ b/resources/src/main/java/org/robolectric/res/ResourceMerger.java
@@ -19,7 +19,6 @@ public class ResourceMerger {
 
     return new ResourceTableFactory()
         .newResourceTable(
-            appManifest.getPackageName(),
-            allResourcePaths.toArray(new ResourcePath[allResourcePaths.size()]));
+            appManifest.getPackageName(), allResourcePaths.toArray(new ResourcePath[0]));
   }
 }

--- a/resources/src/main/java/org/robolectric/res/ResourceRemapper.java
+++ b/resources/src/main/java/org/robolectric/res/ResourceRemapper.java
@@ -27,9 +27,9 @@ class ResourceRemapper {
 
   /**
    * @param primaryRClass - An R class (usually the applications) that can be assumed to have a
-   *     complete set of IDs. If this is provided then use the values from this class for
-   *     re-writting all values in follow up calls to {@link #remapRClass(Class)}. If it is not
-   *     provided the ResourceRemapper will generate its own unique non-conflicting IDs.
+   *     complete set of IDs. If this is provided then use the values from this class for re-writing
+   *     all values in follow up calls to {@link #remapRClass(Class)}. If it is not provided the
+   *     ResourceRemapper will generate its own unique non-conflicting IDs.
    */
   ResourceRemapper(Class<?> primaryRClass) {
     if (primaryRClass != null) {

--- a/resources/src/main/java/org/robolectric/res/StaxArrayLoader.java
+++ b/resources/src/main/java/org/robolectric/res/StaxArrayLoader.java
@@ -21,19 +21,17 @@ public class StaxArrayLoader extends StaxLoader {
         "item",
         new NodeHandler() {
           @Override
-          public void onStart(XMLStreamReader xml, XmlContext xmlContext)
-              throws XMLStreamException {
+          public void onStart(XMLStreamReader xml, XmlContext xmlContext) {
             buf.setLength(0);
           }
 
           @Override
-          public void onCharacters(XMLStreamReader xml, XmlContext xmlContext)
-              throws XMLStreamException {
+          public void onCharacters(XMLStreamReader xml, XmlContext xmlContext) {
             buf.append(xml.getText());
           }
 
           @Override
-          public void onEnd(XMLStreamReader xml, XmlContext xmlContext) throws XMLStreamException {
+          public void onEnd(XMLStreamReader xml, XmlContext xmlContext) {
             ResType resType =
                 scalarResType == null ? ResType.inferType(buf.toString()) : scalarResType;
             items.add(new TypedResource<>(buf.toString(), resType, xmlContext));
@@ -53,7 +51,7 @@ public class StaxArrayLoader extends StaxLoader {
   }
 
   @Override
-  public void onEnd(XMLStreamReader xml, XmlContext xmlContext) throws XMLStreamException {
+  public void onEnd(XMLStreamReader xml, XmlContext xmlContext) {
     resourceTable.addResource(attrType, name, new TypedResource<>(items, resType, xmlContext));
   }
 }

--- a/resources/src/main/java/org/robolectric/res/StaxAttrLoader.java
+++ b/resources/src/main/java/org/robolectric/res/StaxAttrLoader.java
@@ -20,8 +20,7 @@ public class StaxAttrLoader extends StaxLoader {
           private String name;
 
           @Override
-          public void onStart(XMLStreamReader xml, XmlContext xmlContext)
-              throws XMLStreamException {
+          public void onStart(XMLStreamReader xml, XmlContext xmlContext) {
             String type = xml.getLocalName();
             if (pairs.isEmpty()) {
               if (format == null) {
@@ -36,11 +35,10 @@ public class StaxAttrLoader extends StaxLoader {
           }
 
           @Override
-          public void onCharacters(XMLStreamReader xml, XmlContext xmlContext)
-              throws XMLStreamException {}
+          public void onCharacters(XMLStreamReader xml, XmlContext xmlContext) {}
 
           @Override
-          public void onEnd(XMLStreamReader xml, XmlContext xmlContext) throws XMLStreamException {}
+          public void onEnd(XMLStreamReader xml, XmlContext xmlContext) {}
         });
   }
 
@@ -51,7 +49,7 @@ public class StaxAttrLoader extends StaxLoader {
   }
 
   @Override
-  public void onEnd(XMLStreamReader xml, XmlContext xmlContext) throws XMLStreamException {
+  public void onEnd(XMLStreamReader xml, XmlContext xmlContext) {
     AttrData attrData = new AttrData(name, format, new ArrayList<>(pairs));
     pairs.clear();
 

--- a/resources/src/main/java/org/robolectric/res/StaxPluralsLoader.java
+++ b/resources/src/main/java/org/robolectric/res/StaxPluralsLoader.java
@@ -20,20 +20,18 @@ public class StaxPluralsLoader extends StaxLoader {
           private final StringBuilder buf = new StringBuilder();
 
           @Override
-          public void onStart(XMLStreamReader xml, XmlContext xmlContext)
-              throws XMLStreamException {
+          public void onStart(XMLStreamReader xml, XmlContext xmlContext) {
             quantity = xml.getAttributeValue(null, "quantity");
             buf.setLength(0);
           }
 
           @Override
-          public void onCharacters(XMLStreamReader xml, XmlContext xmlContext)
-              throws XMLStreamException {
+          public void onCharacters(XMLStreamReader xml, XmlContext xmlContext) {
             buf.append(xml.getText());
           }
 
           @Override
-          public void onEnd(XMLStreamReader xml, XmlContext xmlContext) throws XMLStreamException {
+          public void onEnd(XMLStreamReader xml, XmlContext xmlContext) {
             plurals.add(new Plural(quantity, buf.toString()));
           }
 
@@ -50,7 +48,7 @@ public class StaxPluralsLoader extends StaxLoader {
   }
 
   @Override
-  public void onEnd(XMLStreamReader xml, XmlContext xmlContext) throws XMLStreamException {
+  public void onEnd(XMLStreamReader xml, XmlContext xmlContext) {
     resourceTable.addResource(
         attrType, name, new PluralRules(new ArrayList<>(plurals), resType, xmlContext));
     plurals.clear();

--- a/resources/src/main/java/org/robolectric/res/StaxStyleLoader.java
+++ b/resources/src/main/java/org/robolectric/res/StaxStyleLoader.java
@@ -20,20 +20,18 @@ public class StaxStyleLoader extends StaxLoader {
           private StringBuilder buf = new StringBuilder();
 
           @Override
-          public void onStart(XMLStreamReader xml, XmlContext xmlContext)
-              throws XMLStreamException {
+          public void onStart(XMLStreamReader xml, XmlContext xmlContext) {
             attrName = xml.getAttributeValue(null, "name");
             buf.setLength(0);
           }
 
           @Override
-          public void onCharacters(XMLStreamReader xml, XmlContext xmlContext)
-              throws XMLStreamException {
+          public void onCharacters(XMLStreamReader xml, XmlContext xmlContext) {
             buf.append(xml.getText());
           }
 
           @Override
-          public void onEnd(XMLStreamReader xml, XmlContext xmlContext) throws XMLStreamException {
+          public void onEnd(XMLStreamReader xml, XmlContext xmlContext) {
             ResName attrResName =
                 ResName.qualifyResName(attrName, xmlContext.getPackageName(), "attr");
             attributeResources.add(
@@ -50,7 +48,7 @@ public class StaxStyleLoader extends StaxLoader {
   }
 
   @Override
-  public void onEnd(XMLStreamReader xml, XmlContext xmlContext) throws XMLStreamException {
+  public void onEnd(XMLStreamReader xml, XmlContext xmlContext) {
     String styleParent = parent;
 
     if (styleParent == null) {

--- a/resources/src/main/java/org/robolectric/res/StaxValueLoader.java
+++ b/resources/src/main/java/org/robolectric/res/StaxValueLoader.java
@@ -22,12 +22,12 @@ public class StaxValueLoader extends StaxLoader {
   }
 
   @Override
-  public void onCharacters(XMLStreamReader xml, XmlContext xmlContext) throws XMLStreamException {
+  public void onCharacters(XMLStreamReader xml, XmlContext xmlContext) {
     buf.append(xml.getText());
   }
 
   @Override
-  public void onEnd(XMLStreamReader xml, XmlContext xmlContext) throws XMLStreamException {
+  public void onEnd(XMLStreamReader xml, XmlContext xmlContext) {
     String s = buf.toString();
     if (resType == ResType.CHAR_SEQUENCE) {
       s = StringResources.processStringResources(s);

--- a/resources/src/main/java/org/robolectric/res/TextCollectingNodeHandler.java
+++ b/resources/src/main/java/org/robolectric/res/TextCollectingNodeHandler.java
@@ -1,6 +1,5 @@
 package org.robolectric.res;
 
-import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
 public class TextCollectingNodeHandler extends NodeHandler {
@@ -11,7 +10,7 @@ public class TextCollectingNodeHandler extends NodeHandler {
   }
 
   @Override
-  public void onCharacters(XMLStreamReader xml, XmlContext xmlContext) throws XMLStreamException {
+  public void onCharacters(XMLStreamReader xml, XmlContext xmlContext) {
     buf.append(xml.getText());
   }
 

--- a/resources/src/main/java/org/robolectric/res/android/AssetDir.java
+++ b/resources/src/main/java/org/robolectric/res/android/AssetDir.java
@@ -128,7 +128,6 @@ public class AssetDir {
       return pVector.indexOf(tmpInfo);
     }
   }
-  ;
 
   /* AssetManager uses this to initialize us */
   void setFileList(SortedVector<FileInfo> list) {

--- a/resources/src/main/java/org/robolectric/res/android/AttributeResolution10.java
+++ b/resources/src/main/java/org/robolectric/res/android/AttributeResolution10.java
@@ -106,7 +106,7 @@ public class AttributeResolution10 {
           theme, def_style_attr, def_style_res);
     }
 
-    CppAssetManager2 assetmanager = theme.GetAssetManager();
+    CppAssetManager2 assetManager = theme.GetAssetManager();
     ResTable_config config = new ResTable_config();
     Res_value value;
 
@@ -128,7 +128,7 @@ public class AttributeResolution10 {
     // Retrieve the default style bag, if requested.
     ResolvedBag default_style_bag = null;
     if (def_style_res != 0) {
-      default_style_bag = assetmanager.GetBag(def_style_res);
+      default_style_bag = assetManager.GetBag(def_style_res);
       if (default_style_bag != null) {
         def_style_flags.set(def_style_flags.get() | default_style_bag.type_spec_flags);
       }
@@ -173,9 +173,9 @@ public class AttributeResolution10 {
         }
       }
 
-      int resid = 0;
+      int resId = 0;
       final Ref<Res_value> valueRef = new Ref<>(value);
-      final Ref<Integer> residRef = new Ref<>(resid);
+      final Ref<Integer> residRef = new Ref<>(resId);
       final Ref<Integer> type_set_flagsRef = new Ref<>(type_set_flags);
       final Ref<ResTable_config> configRef = new Ref<>(config);
       if (value.dataType != Res_value.TYPE_NULL) {
@@ -197,7 +197,7 @@ public class AttributeResolution10 {
             ALOGI("-> From theme: type=0x%x, data=0x%08x", value.dataType, value.data);
           }
           new_cookie =
-              assetmanager.ResolveReference(
+              assetManager.ResolveReference(
                   new_cookie, valueRef, configRef, type_set_flagsRef, residRef);
           if (new_cookie.intValue() != kInvalidCookie) {
             cookie = new_cookie;
@@ -208,7 +208,7 @@ public class AttributeResolution10 {
         }
       }
       value = valueRef.get();
-      resid = residRef.get();
+      resId = residRef.get();
       type_set_flags = type_set_flagsRef.get();
       config = configRef.get();
 
@@ -229,7 +229,7 @@ public class AttributeResolution10 {
       out_values[destOffset + STYLE_TYPE] = value.dataType;
       out_values[destOffset + STYLE_DATA] = value.data;
       out_values[destOffset + STYLE_ASSET_COOKIE] = ApkAssetsCookieToJavaCookie(cookie);
-      out_values[destOffset + STYLE_RESOURCE_ID] = resid;
+      out_values[destOffset + STYLE_RESOURCE_ID] = resId;
       out_values[destOffset + STYLE_CHANGING_CONFIGURATIONS] = type_set_flags;
       out_values[destOffset + STYLE_DENSITY] = config.density;
 
@@ -251,7 +251,7 @@ public class AttributeResolution10 {
       Theme theme,
       ResXMLParser xml_parser,
       int def_style_attr,
-      int def_style_resid,
+      int def_style_res_id,
       int[] attrs,
       int attrs_length,
       int[] out_values,
@@ -259,10 +259,10 @@ public class AttributeResolution10 {
     if (kDebugStyles) {
       ALOGI(
           "APPLY STYLE: theme=%s defStyleAttr=0x%x defStyleRes=0x%x xml=%s",
-          theme, def_style_attr, def_style_resid, xml_parser);
+          theme, def_style_attr, def_style_res_id, xml_parser);
     }
 
-    CppAssetManager2 assetmanager = theme.GetAssetManager();
+    CppAssetManager2 assetManager = theme.GetAssetManager();
     final Ref<ResTable_config> config = new Ref<>(new ResTable_config());
     final Ref<Res_value> value = new Ref<>(new Res_value());
 
@@ -273,13 +273,13 @@ public class AttributeResolution10 {
     if (def_style_attr != 0) {
       if (theme.GetAttribute(def_style_attr, value, def_style_flags).intValue() != kInvalidCookie) {
         if (value.get().dataType == DataType.REFERENCE.code()) {
-          def_style_resid = value.get().data;
+          def_style_res_id = value.get().data;
         }
       }
     }
 
     // Retrieve the style resource ID associated with the current XML tag's style attribute.
-    int style_resid = 0;
+    int style_res_id = 0;
     final Ref<Integer> style_flags = new Ref<>(0);
     if (xml_parser != null) {
       int idx = xml_parser.indexOfStyle();
@@ -293,15 +293,15 @@ public class AttributeResolution10 {
         }
 
         if (value.get().dataType == DataType.REFERENCE.code()) {
-          style_resid = value.get().data;
+          style_res_id = value.get().data;
         }
       }
     }
 
     // Retrieve the default style bag, if requested.
     ResolvedBag default_style_bag = null;
-    if (def_style_resid != 0) {
-      default_style_bag = assetmanager.GetBag(def_style_resid);
+    if (def_style_res_id != 0) {
+      default_style_bag = assetManager.GetBag(def_style_res_id);
       if (default_style_bag != null) {
         def_style_flags.set(def_style_flags.get() | default_style_bag.type_spec_flags);
       }
@@ -311,8 +311,8 @@ public class AttributeResolution10 {
 
     // Retrieve the style class bag, if requested.
     ResolvedBag xml_style_bag = null;
-    if (style_resid != 0) {
-      xml_style_bag = assetmanager.GetBag(style_resid);
+    if (style_res_id != 0) {
+      xml_style_bag = assetManager.GetBag(style_res_id);
       if (xml_style_bag != null) {
         style_flags.set(style_flags.get() | xml_style_bag.type_spec_flags);
       }
@@ -337,7 +337,7 @@ public class AttributeResolution10 {
 
       value.set(Res_value.NULL_VALUE);
       config.get().density = 0;
-      int source_style_resid = 0;
+      int source_style_res_id = 0;
 
       // Try to find a value for this attribute...  we prioritize values
       // coming from, first XML attributes, then XML style, then default
@@ -363,7 +363,7 @@ public class AttributeResolution10 {
           cookie = entry.cookie;
           type_set_flags.set(style_flags.get());
           value.set(entry.value);
-          source_style_resid = entry.style;
+          source_style_res_id = entry.style;
           if (kDebugStyles) {
             ALOGI(
                 "-> From style: type=0x%x, data=0x%08x, style=0x%08x",
@@ -387,15 +387,15 @@ public class AttributeResolution10 {
                 "-> From def style: type=0x%x, data=0x%08x, style=0x%08x",
                 value.get().dataType, value.get().data, entry.style);
           }
-          source_style_resid = entry.style;
+          source_style_res_id = entry.style;
         }
       }
 
-      final Ref<Integer> resid = new Ref<>(0);
+      final Ref<Integer> resId = new Ref<>(0);
       if (value.get().dataType != DataType.NULL.code()) {
         // Take care of resolving the found resource to its final value.
         ApkAssetsCookie new_cookie =
-            theme.ResolveAttributeReference(cookie, value, config, type_set_flags, resid);
+            theme.ResolveAttributeReference(cookie, value, config, type_set_flags, resId);
         if (new_cookie.intValue() != kInvalidCookie) {
           cookie = new_cookie;
         }
@@ -411,7 +411,7 @@ public class AttributeResolution10 {
             ALOGI("-> From theme: type=0x%x, data=0x%08x", value.get().dataType, value.get().data);
           }
           new_cookie =
-              assetmanager.ResolveReference(new_cookie, value, config, type_set_flags, resid);
+              assetManager.ResolveReference(new_cookie, value, config, type_set_flags, resId);
           if (new_cookie.intValue() != kInvalidCookie) {
             cookie = new_cookie;
           }
@@ -445,10 +445,10 @@ public class AttributeResolution10 {
       out_values[destIndex + STYLE_TYPE] = res_value.dataType;
       out_values[destIndex + STYLE_DATA] = res_value.data;
       out_values[destIndex + STYLE_ASSET_COOKIE] = ApkAssetsCookieToJavaCookie(cookie);
-      out_values[destIndex + STYLE_RESOURCE_ID] = resid.get();
+      out_values[destIndex + STYLE_RESOURCE_ID] = resId.get();
       out_values[destIndex + STYLE_CHANGING_CONFIGURATIONS] = type_set_flags.get();
       out_values[destIndex + STYLE_DENSITY] = config.get().density;
-      out_values[destIndex + STYLE_SOURCE_STYLE_RESOURCE_ID] = source_style_resid;
+      out_values[destIndex + STYLE_SOURCE_STYLE_RESOURCE_ID] = source_style_res_id;
 
       if (res_value.dataType != DataType.NULL.code()
           || res_value.data == Res_value.DATA_NULL_EMPTY) {
@@ -462,8 +462,8 @@ public class AttributeResolution10 {
       // if (false && res_value.dataType == DataType.ATTRIBUTE.code()) {
       //   final Ref<ResourceName> attrName = new Ref<>(null);
       //   final Ref<ResourceName> attrRefName = new Ref<>(null);
-      //   boolean gotName = assetmanager.GetResourceName(cur_ident, attrName);
-      //   boolean gotRefName = assetmanager.GetResourceName(res_value.data, attrRefName);
+      //   boolean gotName = assetManager.GetResourceName(cur_ident, attrName);
+      //   boolean gotRefName = assetManager.GetResourceName(res_value.data, attrRefName);
       //   Logger.warn(
       //       "Failed to resolve attribute lookup: %s=\"?%s\"; theme: %s",
       //       gotName ? attrName.get() : "unknown", gotRefName ? attrRefName.get() : "unknown",
@@ -478,7 +478,7 @@ public class AttributeResolution10 {
   }
 
   public static boolean RetrieveAttributes(
-      CppAssetManager2 assetmanager,
+      CppAssetManager2 assetManager,
       ResXMLParser xml_parser,
       int[] attrs,
       int attrs_length,
@@ -518,11 +518,11 @@ public class AttributeResolution10 {
         cur_xml_attr = xml_parser.getAttributeNameResID(ix);
       }
 
-      final Ref<Integer> resid = new Ref<>(0);
+      final Ref<Integer> resId = new Ref<>(0);
       if (value.get().dataType != Res_value.TYPE_NULL) {
         // Take care of resolving the found resource to its final value.
         ApkAssetsCookie new_cookie =
-            assetmanager.ResolveReference(cookie, value, config, type_set_flags, resid);
+            assetManager.ResolveReference(cookie, value, config, type_set_flags, resId);
         if (new_cookie.intValue() != kInvalidCookie) {
           cookie = new_cookie;
         }
@@ -538,7 +538,7 @@ public class AttributeResolution10 {
       out_values[baseDest + STYLE_TYPE] = value.get().dataType;
       out_values[baseDest + STYLE_DATA] = value.get().data;
       out_values[baseDest + STYLE_ASSET_COOKIE] = ApkAssetsCookieToJavaCookie(cookie);
-      out_values[baseDest + STYLE_RESOURCE_ID] = resid.get();
+      out_values[baseDest + STYLE_RESOURCE_ID] = resId.get();
       out_values[baseDest + STYLE_CHANGING_CONFIGURATIONS] = type_set_flags.get();
       out_values[baseDest + STYLE_DENSITY] = config.get().density;
 

--- a/resources/src/main/java/org/robolectric/res/android/AttributeResolution9.java
+++ b/resources/src/main/java/org/robolectric/res/android/AttributeResolution9.java
@@ -103,7 +103,7 @@ public class AttributeResolution9 {
           theme, def_style_attr, def_style_res);
     }
 
-    CppAssetManager2 assetmanager = theme.GetAssetManager();
+    CppAssetManager2 assetManager = theme.GetAssetManager();
     ResTable_config config = new ResTable_config();
     Res_value value;
 
@@ -125,7 +125,7 @@ public class AttributeResolution9 {
     // Retrieve the default style bag, if requested.
     ResolvedBag default_style_bag = null;
     if (def_style_res != 0) {
-      default_style_bag = assetmanager.GetBag(def_style_res);
+      default_style_bag = assetManager.GetBag(def_style_res);
       if (default_style_bag != null) {
         def_style_flags.set(def_style_flags.get() | default_style_bag.type_spec_flags);
       }
@@ -170,9 +170,9 @@ public class AttributeResolution9 {
         }
       }
 
-      int resid = 0;
+      int resId = 0;
       final Ref<Res_value> valueRef = new Ref<>(value);
-      final Ref<Integer> residRef = new Ref<>(resid);
+      final Ref<Integer> residRef = new Ref<>(resId);
       final Ref<Integer> type_set_flagsRef = new Ref<>(type_set_flags);
       final Ref<ResTable_config> configRef = new Ref<>(config);
       if (value.dataType != Res_value.TYPE_NULL) {
@@ -194,7 +194,7 @@ public class AttributeResolution9 {
             ALOGI("-> From theme: type=0x%x, data=0x%08x", value.dataType, value.data);
           }
           new_cookie =
-              assetmanager.ResolveReference(
+              assetManager.ResolveReference(
                   new_cookie, valueRef, configRef, type_set_flagsRef, residRef);
           if (new_cookie.intValue() != kInvalidCookie) {
             cookie = new_cookie;
@@ -205,7 +205,7 @@ public class AttributeResolution9 {
         }
       }
       value = valueRef.get();
-      resid = residRef.get();
+      resId = residRef.get();
       type_set_flags = type_set_flagsRef.get();
       config = configRef.get();
 
@@ -226,7 +226,7 @@ public class AttributeResolution9 {
       out_values[destOffset + STYLE_TYPE] = value.dataType;
       out_values[destOffset + STYLE_DATA] = value.data;
       out_values[destOffset + STYLE_ASSET_COOKIE] = ApkAssetsCookieToJavaCookie(cookie);
-      out_values[destOffset + STYLE_RESOURCE_ID] = resid;
+      out_values[destOffset + STYLE_RESOURCE_ID] = resId;
       out_values[destOffset + STYLE_CHANGING_CONFIGURATIONS] = type_set_flags;
       out_values[destOffset + STYLE_DENSITY] = config.density;
 
@@ -248,7 +248,7 @@ public class AttributeResolution9 {
       Theme theme,
       ResXMLParser xml_parser,
       int def_style_attr,
-      int def_style_resid,
+      int def_style_res_id,
       int[] attrs,
       int attrs_length,
       int[] out_values,
@@ -256,10 +256,10 @@ public class AttributeResolution9 {
     if (kDebugStyles) {
       ALOGI(
           "APPLY STYLE: theme=%s defStyleAttr=0x%x defStyleRes=0x%x xml=%s",
-          theme, def_style_attr, def_style_resid, xml_parser);
+          theme, def_style_attr, def_style_res_id, xml_parser);
     }
 
-    CppAssetManager2 assetmanager = theme.GetAssetManager();
+    CppAssetManager2 assetManager = theme.GetAssetManager();
     final Ref<ResTable_config> config = new Ref<>(new ResTable_config());
     final Ref<Res_value> value = new Ref<>(new Res_value());
 
@@ -270,13 +270,13 @@ public class AttributeResolution9 {
     if (def_style_attr != 0) {
       if (theme.GetAttribute(def_style_attr, value, def_style_flags).intValue() != kInvalidCookie) {
         if (value.get().dataType == DataType.REFERENCE.code()) {
-          def_style_resid = value.get().data;
+          def_style_res_id = value.get().data;
         }
       }
     }
 
     // Retrieve the style resource ID associated with the current XML tag's style attribute.
-    int style_resid = 0;
+    int style_res_id = 0;
     final Ref<Integer> style_flags = new Ref<>(0);
     if (xml_parser != null) {
       int idx = xml_parser.indexOfStyle();
@@ -290,15 +290,15 @@ public class AttributeResolution9 {
         }
 
         if (value.get().dataType == DataType.REFERENCE.code()) {
-          style_resid = value.get().data;
+          style_res_id = value.get().data;
         }
       }
     }
 
     // Retrieve the default style bag, if requested.
     ResolvedBag default_style_bag = null;
-    if (def_style_resid != 0) {
-      default_style_bag = assetmanager.GetBag(def_style_resid);
+    if (def_style_res_id != 0) {
+      default_style_bag = assetManager.GetBag(def_style_res_id);
       if (default_style_bag != null) {
         def_style_flags.set(def_style_flags.get() | default_style_bag.type_spec_flags);
       }
@@ -308,8 +308,8 @@ public class AttributeResolution9 {
 
     // Retrieve the style class bag, if requested.
     ResolvedBag xml_style_bag = null;
-    if (style_resid != 0) {
-      xml_style_bag = assetmanager.GetBag(style_resid);
+    if (style_res_id != 0) {
+      xml_style_bag = assetManager.GetBag(style_res_id);
       if (xml_style_bag != null) {
         style_flags.set(style_flags.get() | xml_style_bag.type_spec_flags);
       }
@@ -383,11 +383,11 @@ public class AttributeResolution9 {
         }
       }
 
-      final Ref<Integer> resid = new Ref<>(0);
+      final Ref<Integer> resId = new Ref<>(0);
       if (value.get().dataType != DataType.NULL.code()) {
         // Take care of resolving the found resource to its final value.
         ApkAssetsCookie new_cookie =
-            theme.ResolveAttributeReference(cookie, value, config, type_set_flags, resid);
+            theme.ResolveAttributeReference(cookie, value, config, type_set_flags, resId);
         if (new_cookie.intValue() != kInvalidCookie) {
           cookie = new_cookie;
         }
@@ -403,7 +403,7 @@ public class AttributeResolution9 {
             ALOGI("-> From theme: type=0x%x, data=0x%08x", value.get().dataType, value.get().data);
           }
           new_cookie =
-              assetmanager.ResolveReference(new_cookie, value, config, type_set_flags, resid);
+              assetManager.ResolveReference(new_cookie, value, config, type_set_flags, resId);
           if (new_cookie.intValue() != kInvalidCookie) {
             cookie = new_cookie;
           }
@@ -437,7 +437,7 @@ public class AttributeResolution9 {
       out_values[destIndex + STYLE_TYPE] = res_value.dataType;
       out_values[destIndex + STYLE_DATA] = res_value.data;
       out_values[destIndex + STYLE_ASSET_COOKIE] = ApkAssetsCookieToJavaCookie(cookie);
-      out_values[destIndex + STYLE_RESOURCE_ID] = resid.get();
+      out_values[destIndex + STYLE_RESOURCE_ID] = resId.get();
       out_values[destIndex + STYLE_CHANGING_CONFIGURATIONS] = type_set_flags.get();
       out_values[destIndex + STYLE_DENSITY] = config.get().density;
 
@@ -453,8 +453,8 @@ public class AttributeResolution9 {
       // if (false && res_value.dataType == DataType.ATTRIBUTE.code()) {
       //   final Ref<ResourceName> attrName = new Ref<>(null);
       //   final Ref<ResourceName> attrRefName = new Ref<>(null);
-      //   boolean gotName = assetmanager.GetResourceName(cur_ident, attrName);
-      //   boolean gotRefName = assetmanager.GetResourceName(res_value.data, attrRefName);
+      //   boolean gotName = assetManager.GetResourceName(cur_ident, attrName);
+      //   boolean gotRefName = assetManager.GetResourceName(res_value.data, attrRefName);
       //   Logger.warn(
       //       "Failed to resolve attribute lookup: %s=\"?%s\"; theme: %s",
       //       gotName ? attrName.get() : "unknown", gotRefName ? attrRefName.get() : "unknown",
@@ -469,7 +469,7 @@ public class AttributeResolution9 {
   }
 
   public static boolean RetrieveAttributes(
-      CppAssetManager2 assetmanager,
+      CppAssetManager2 assetManager,
       ResXMLParser xml_parser,
       int[] attrs,
       int attrs_length,
@@ -509,11 +509,11 @@ public class AttributeResolution9 {
         cur_xml_attr = xml_parser.getAttributeNameResID(ix);
       }
 
-      final Ref<Integer> resid = new Ref<>(0);
+      final Ref<Integer> resId = new Ref<>(0);
       if (value.get().dataType != Res_value.TYPE_NULL) {
         // Take care of resolving the found resource to its final value.
         ApkAssetsCookie new_cookie =
-            assetmanager.ResolveReference(cookie, value, config, type_set_flags, resid);
+            assetManager.ResolveReference(cookie, value, config, type_set_flags, resId);
         if (new_cookie.intValue() != kInvalidCookie) {
           cookie = new_cookie;
         }
@@ -529,7 +529,7 @@ public class AttributeResolution9 {
       out_values[baseDest + STYLE_TYPE] = value.get().dataType;
       out_values[baseDest + STYLE_DATA] = value.get().data;
       out_values[baseDest + STYLE_ASSET_COOKIE] = ApkAssetsCookieToJavaCookie(cookie);
-      out_values[baseDest + STYLE_RESOURCE_ID] = resid.get();
+      out_values[baseDest + STYLE_RESOURCE_ID] = resId.get();
       out_values[baseDest + STYLE_CHANGING_CONFIGURATIONS] = type_set_flags.get();
       out_values[baseDest + STYLE_DENSITY] = config.get().density;
 

--- a/resources/src/main/java/org/robolectric/res/android/Chunk.java
+++ b/resources/src/main/java/org/robolectric/res/android/Chunk.java
@@ -152,7 +152,6 @@ class Chunk {
     boolean HasNext() {
       return !HadError() && len_ != 0;
     }
-    ;
 
     // Returns whether there was an error and processing should stop
     boolean HadError() {

--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager.java
@@ -324,7 +324,7 @@ public class CppAssetManager {
   //        // delete idmap;
   //
   //        if (overlayPath != packagePath) {
-  //          ALOGW("idmap file %s inconcistent: expected path %s does not match actual path %s\n",
+  //          ALOGW("idmap file %s inconsistent: expected path %s does not match actual path %s\n",
   //              idmapPath.string(), packagePath.string(), overlayPath.string());
   //          return false;
   //        }

--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
@@ -104,7 +104,6 @@ public class CppAssetManager2 {
         return "Entry{" + "key=" + key + ", value=" + value + '}';
       }
     }
-    ;
 
     // Denotes the configuration axis that this bag varies with.
     // If a configuration changes with respect to one of these axis,
@@ -118,7 +117,6 @@ public class CppAssetManager2 {
     // of the Entry structs that follow this structure and avoids a bunch of casts.
     public Entry[] entries;
   }
-  ;
 
   // AssetManager2 is the main entry point for accessing assets and resources.
   // AssetManager2 provides caching of resources retrieved via the underlying ApkAssets.
@@ -136,7 +134,6 @@ public class CppAssetManager2 {
     // public String entry16 = null;
     // int entry_len = 0;
   }
-  ;
 
   public CppAssetManager2() {}
 

--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
@@ -1425,7 +1425,7 @@ public class CppAssetManager2 {
       static final int SIZEOF_WITHOUT_ENTRIES = 8;
 
       int entry_count;
-      ThemeEntry entries[];
+      ThemeEntry[] entries;
     }
 
     //  static final int kPackageCount = std.numeric_limits<byte>.max() + 1;

--- a/resources/src/main/java/org/robolectric/res/android/LoadedArsc.java
+++ b/resources/src/main/java/org/robolectric/res/android/LoadedArsc.java
@@ -225,7 +225,6 @@ public class LoadedArsc {
     IdmapEntry_header idmap_header_;
     final List<ResTable_type> types_ = new ArrayList<>();
   }
-  ;
 
   //  }  // namespace
 

--- a/resources/src/main/java/org/robolectric/res/android/LocaleData.java
+++ b/resources/src/main/java/org/robolectric/res/android/LocaleData.java
@@ -156,7 +156,7 @@ public class LocaleData {
     int[] request_ancestors = new int[MAX_PARENT_DEPTH + 1];
     final Ref<Long> left_right_indexRef = new Ref<Long>(null);
     // Find the parents of the request, but stop as soon as we saw left or right
-    final int left_and_right[] = {left, right};
+    final int[] left_and_right = {left, right};
     final int ancestor_count =
         findAncestors(
             request_ancestors, left_right_indexRef,

--- a/resources/src/main/java/org/robolectric/res/android/ResTable.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResTable.java
@@ -2741,7 +2741,6 @@ public class ResTable {
     int[] resourceIDMap;
     int resourceIDMapSize;
   }
-  ;
 
   public static class Entry {
     ResTable_config config;
@@ -3099,7 +3098,6 @@ public class ResTable {
       //      curOff += size + sizeof(*map)-sizeof(map->value);
       curOff += size + ResTable_map.SIZEOF - Res_value.SIZEOF;
     }
-    ;
 
     if (curEntry > set.numAttrs) {
       set.numAttrs = curEntry;
@@ -3148,7 +3146,6 @@ public class ResTable {
       bag_entries = newEntries;
     }
   }
-  ;
 
   /**
    * Configuration dependent cached data. This must be cleared when the configuration is changed
@@ -3165,7 +3162,6 @@ public class ResTable {
     // ResTable.
     List<List<ResTable_type>> filteredConfigs;
   }
-  ;
 
   private int Res_MAKEID(int packageId, int typeId, int entryId) {
     return (((packageId + 1) << 24) | (((typeId + 1) & 0xFF) << 16) | (entryId & 0xFFFF));

--- a/resources/src/main/java/org/robolectric/res/android/ResTableTheme.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResTableTheme.java
@@ -377,7 +377,6 @@ public class ResTableTheme {
       }
     }
   }
-  ;
 
   static class type_info {
     int numEntries;
@@ -398,7 +397,6 @@ public class ResTableTheme {
       }
     }
   }
-  ;
 
   static class package_info {
     type_info[] types = new type_info[Res_MAXTYPE + 1];
@@ -416,7 +414,6 @@ public class ResTableTheme {
       }
     }
   }
-  ;
 
   static final int Res_MAXPACKAGE = 255;
   static final int Res_MAXTYPE = 255;

--- a/resources/src/main/java/org/robolectric/res/android/ResTable_config.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResTable_config.java
@@ -1014,7 +1014,7 @@ public class ResTable_config {
     // systems should happen very infrequently (if at all.)
     // The comparison code relies on memcmp low-level optimizations that make it
     // more efficient than strncmp.
-    final byte emptyScript[] = {'\0', '\0', '\0', '\0'};
+    final byte[] emptyScript = {'\0', '\0', '\0', '\0'};
     final byte[] lScript = l.localeScriptWasComputed ? emptyScript : l.localeScript;
     final byte[] rScript = r.localeScriptWasComputed ? emptyScript : r.localeScript;
     //    int script = memcmp(lScript, rScript);

--- a/resources/src/main/java/org/robolectric/res/android/ResXMLParser.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResXMLParser.java
@@ -594,5 +594,4 @@ public class ResXMLParser {
     ResXMLTree_node curNode;
     int curExt;
   }
-  ;
 }

--- a/resources/src/main/java/org/robolectric/res/android/ResourceTable.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResourceTable.java
@@ -14,7 +14,6 @@ public class ResourceTable {
       this.description = description;
     }
   }
-  ;
 
   public static flag_entry[] gFormatFlags = {
     new flag_entry(

--- a/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
@@ -395,7 +395,6 @@ public class ResourceTypes {
       return "ResTable_ref{ident=" + ident + '}';
     }
   }
-  ;
 
   /** Reference to a string in a string pool. */
   public static class ResStringPool_ref {
@@ -624,7 +623,6 @@ public class ResourceTypes {
       return name.index == END && firstChar == END && lastChar == END;
     }
   }
-  ;
 
   /**
    * ******************************************************************** XML Tree
@@ -701,7 +699,6 @@ public class ResourceTypes {
           contents);
     }
   }
-  ;
 
   /**
    * Extended XML tree node for CDATA tags -- includes the CDATA string. Appears header.headerSize
@@ -722,7 +719,6 @@ public class ResourceTypes {
       this.typedData = new Res_value((byte) dataType, data);
     }
   }
-  ;
 
   /**
    * Extended XML tree node for namespace start/end nodes. Appears header.headerSize bytes after a
@@ -740,7 +736,6 @@ public class ResourceTypes {
       this.uri = new ResStringPool_ref(buf, offset + 4);
     }
   }
-  ;
 
   /**
    * Extended XML tree node for element start/end nodes. Appears header.headerSize bytes after a
@@ -779,7 +774,6 @@ public class ResourceTypes {
       }
     }
   }
-  ;
 
   /**
    * Extended XML tree node for start tags -- includes attribute information. Appears
@@ -916,7 +910,6 @@ public class ResourceTypes {
       }
     }
   }
-  ;
 
   static class ResXMLTree_attribute {
     public static final int SIZEOF = 12 + ResourceTypes.Res_value.SIZEOF;
@@ -948,7 +941,6 @@ public class ResourceTypes {
       ResourceTypes.Res_value.write(buf, resValueDataType, resValueData);
     }
   }
-  ;
 
   /**
    * ******************************************************************** RESOURCE TABLE
@@ -1029,7 +1021,6 @@ public class ResourceTypes {
       typeIdOffset = buf.getInt(offset + ResChunk_header.SIZEOF + 4 + 256 + 16);
     }
   }
-  ;
 
   // The most specific locale can consist of:
   //
@@ -1099,7 +1090,6 @@ public class ResourceTypes {
       return ints;
     }
   }
-  ;
 
   /**
    * A collection of resource entries for a particular resource data type.
@@ -1240,7 +1230,6 @@ public class ResourceTypes {
       return dtohl(byteBuffer.getInt(offset + entriesStart + entryOffset + STRING_POOL_REF_OFFSET));
     }
   }
-  ;
 
   // The minimum size required to read any version of ResTable_type.
   //   constexpr size_t kResTableTypeMinSize =
@@ -1275,7 +1264,6 @@ public class ResourceTypes {
       this.offset = buf.getShort(offset + 2);
     }
   }
-  ;
 
   /**
    * This is the beginning of information about an entry in the resource table. It holds the
@@ -1376,7 +1364,6 @@ public class ResourceTypes {
       count = buf.getInt(offset + ResTable_entry.SIZEOF + ResTable_ref.SIZEOF);
     }
   }
-  ;
 
   /** A single name/value mapping that is part of a complex resource entry. */
   public static class ResTable_map extends WithOffset {
@@ -1482,7 +1469,6 @@ public class ResourceTypes {
       return "ResTable_map{" + "name=" + name + ", value=" + value + '}';
     }
   }
-  ;
 
   /**
    * A package-id to package name mapping for any shared libraries used in this resource table. The
@@ -1504,7 +1490,6 @@ public class ResourceTypes {
       count = buf.getInt(offset + ResChunk_header.SIZEOF);
     }
   }
-  ;
 
   /** A shared library package-id to package name entry. */
   static class ResTable_lib_entry extends WithOffset {
@@ -1527,7 +1512,6 @@ public class ResourceTypes {
       }
     }
   }
-  ;
 
   /**
    * A map that allows rewriting staged (non-finalized) resource ids to their finalized

--- a/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
@@ -1591,7 +1591,7 @@ public class ResourceTypes {
     short overlay_type_id;
     short entry_count;
     short entry_id_offset;
-    int entries[];
+    int[] entries;
 
     IdmapEntry_header(ByteBuffer buf, int offset) {
       super(buf, offset);

--- a/resources/src/main/java/org/robolectric/res/android/ZipFileRO.java
+++ b/resources/src/main/java/org/robolectric/res/android/ZipFileRO.java
@@ -43,7 +43,6 @@ public class ZipFileRO {
     //    ZipEntryRO(final ZipEntryRO& other);
     //    ZipEntryRO& operator=(final ZipEntryRO& other);
   }
-  ;
 
   //  ~ZipFileRO() {
   @Override

--- a/resources/src/main/java/org/robolectric/res/android/ZipFileRO.java
+++ b/resources/src/main/java/org/robolectric/res/android/ZipFileRO.java
@@ -249,7 +249,7 @@ public class ZipFileRO {
    * Create a new FileMap object that spans the data in "entry".
    */
   /*FileMap*/ ZipFileRO(org.robolectric.res.android.ZipFileRO.ZipEntryRO entry) {
-    throw new UnsupportedOperationException("Implememnt me");
+    throw new UnsupportedOperationException("Implement me");
 
     //    final ZipEntryRO *zipEntry = reinterpret_cast<ZipEntryRO*>(entry);
     //    final ZipEntry& ze = zipEntry.entry;
@@ -302,7 +302,7 @@ public class ZipFileRO {
    */
   boolean uncompressEntry(
       org.robolectric.res.android.ZipFileRO.ZipEntryRO entry, Object buffer, int size) {
-    throw new UnsupportedOperationException("Implememnt me");
+    throw new UnsupportedOperationException("Implement me");
     //    ZipEntryRO *zipEntry = reinterpret_cast<ZipEntryRO*>(entry);
     //    final int error = ExtractToMemory(mHandle, &(zipEntry.entry),
     //    (uint8_t*) buffer, size);
@@ -320,7 +320,7 @@ public class ZipFileRO {
    * This doesn't verify the data's CRC, but probably should.
    */
   boolean uncompressEntry(org.robolectric.res.android.ZipFileRO.ZipEntryRO entry, int fd) {
-    throw new UnsupportedOperationException("Implememnt me");
+    throw new UnsupportedOperationException("Implement me");
     //    ZipEntryRO *zipEntry = reinterpret_cast<ZipEntryRO*>(entry);
     //    final int error = ExtractEntryToFile(mHandle, &(zipEntry.entry), fd);
     //    if (error) {

--- a/resources/src/test/java/org/robolectric/manifest/MetaDataTest.java
+++ b/resources/src/test/java/org/robolectric/manifest/MetaDataTest.java
@@ -35,8 +35,8 @@ public class MetaDataTest {
   }
 
   @Test
-  public void testNonExistantResource_throwsResourceNotFoundException() {
-    Element metaDataElement = createMetaDataNode("aName", "@xml/non_existant_resource");
+  public void testNonExistentResource_throwsResourceNotFoundException() {
+    Element metaDataElement = createMetaDataNode("aName", "@xml/non_existent_resource");
 
     MetaData metaData = new MetaData(ImmutableList.<Node>of(metaDataElement));
 

--- a/resources/src/test/java/org/robolectric/manifest/MetaDataTest.java
+++ b/resources/src/test/java/org/robolectric/manifest/MetaDataTest.java
@@ -35,7 +35,7 @@ public class MetaDataTest {
   }
 
   @Test
-  public void testNonExistantResource_throwsResourceNotFoundException() throws Exception {
+  public void testNonExistantResource_throwsResourceNotFoundException() {
     Element metaDataElement = createMetaDataNode("aName", "@xml/non_existant_resource");
 
     MetaData metaData = new MetaData(ImmutableList.<Node>of(metaDataElement));

--- a/resources/src/test/java/org/robolectric/res/QualifiersTest.java
+++ b/resources/src/test/java/org/robolectric/res/QualifiersTest.java
@@ -13,12 +13,12 @@ import org.robolectric.res.android.ResTable_config;
 @RunWith(JUnit4.class)
 public class QualifiersTest {
   @Test
-  public void testQualifiers() throws Exception {
+  public void testQualifiers() {
     assertThat(configFrom("values-land-finger")).isEqualTo("land-finger");
   }
 
   @Test
-  public void testWhenQualifiersFailToParse() throws Exception {
+  public void testWhenQualifiersFailToParse() {
     try {
       configFrom("values-unknown-v23");
       fail("Expected exception");
@@ -38,7 +38,7 @@ public class QualifiersTest {
   ///////// deprecated stuff...
 
   @Test
-  public void addSmallestScreenWidth() throws Exception {
+  public void addSmallestScreenWidth() {
     assertThat(Qualifiers.addSmallestScreenWidth("", 320)).isEqualTo("sw320dp");
     assertThat(Qualifiers.addSmallestScreenWidth("sw160dp", 320)).isEqualTo("sw160dp");
     assertThat(Qualifiers.addSmallestScreenWidth("sw480dp", 320)).isEqualTo("sw480dp");
@@ -51,7 +51,7 @@ public class QualifiersTest {
   }
 
   @Test
-  public void addScreenWidth() throws Exception {
+  public void addScreenWidth() {
     assertThat(Qualifiers.addScreenWidth("", 320)).isEqualTo("w320dp");
     assertThat(Qualifiers.addScreenWidth("w160dp", 320)).isEqualTo("w160dp");
     assertThat(Qualifiers.addScreenWidth("w480dp", 320)).isEqualTo("w480dp");

--- a/resources/src/test/java/org/robolectric/res/StaxValueLoaderTest.java
+++ b/resources/src/test/java/org/robolectric/res/StaxValueLoaderTest.java
@@ -23,7 +23,7 @@ public class StaxValueLoaderTest {
   private StaxDocumentLoader staxDocumentLoader;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     resourceTable = new PackageResourceTable("pkg");
 
     topLevelNodeHandler = new NodeHandler();

--- a/resources/src/test/java/org/robolectric/res/StyleDataTest.java
+++ b/resources/src/test/java/org/robolectric/res/StyleDataTest.java
@@ -64,7 +64,7 @@ public class StyleDataTest {
   }
 
   @Test
-  public void getAttrValue_willReturnTrimmedAttributeValues() throws Exception {
+  public void getAttrValue_willReturnTrimmedAttributeValues() {
     StyleData styleData =
         new StyleData(
             "library.resource",

--- a/resources/src/test/java/org/robolectric/res/ThemeStyleSetTest.java
+++ b/resources/src/test/java/org/robolectric/res/ThemeStyleSetTest.java
@@ -14,12 +14,12 @@ public class ThemeStyleSetTest {
   private ThemeStyleSet themeStyleSet;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     themeStyleSet = new ThemeStyleSet();
   }
 
   @Test
-  public void shouldFindAttributesFromAnAppliedStyle() throws Exception {
+  public void shouldFindAttributesFromAnAppliedStyle() {
     themeStyleSet = new ThemeStyleSet();
     themeStyleSet.apply(
         createStyle(
@@ -36,7 +36,7 @@ public class ThemeStyleSetTest {
   }
 
   @Test
-  public void shouldFindAttributesFromAnAppliedFromForcedStyle() throws Exception {
+  public void shouldFindAttributesFromAnAppliedFromForcedStyle() {
     themeStyleSet.apply(
         createStyle(
             "style1",

--- a/resources/src/test/java/org/robolectric/res/android/ResTable_configTest.java
+++ b/resources/src/test/java/org/robolectric/res/android/ResTable_configTest.java
@@ -10,7 +10,7 @@ import org.junit.runners.JUnit4;
 public class ResTable_configTest {
 
   @Test
-  public void testLocale() throws Exception {
+  public void testLocale() {
     ResTable_config resTable_config = new ResTable_config();
     resTable_config.language[0] = 'e';
     resTable_config.language[1] = 'n';


### PR DESCRIPTION
This PR fixes the following warnings in the `resources` module:
- Remove unnecessary `throws` declarations.
- Remove unnecessary semicolons.
- Correct spelling and variable names.
- Update array declarations/usages.