### PR TITLE
Fix small warnings in the `resources` module

### DIFF
--- a/resources/build.gradle.kts
+++ b/resources/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 dependencies {
   api(project(":utils"))
-  api(project(":annotations"))
   api(project(":pluginapi"))
 
   api(libs.auto.value.annotations)
@@ -14,7 +13,6 @@ dependencies {
 
   testImplementation(libs.junit4)
   testImplementation(libs.truth)
-  testImplementation(libs.compile.testing)
   testImplementation(libs.mockito)
 
   annotationProcessor(libs.auto.value)

--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -156,7 +156,7 @@ public class AndroidManifest implements UsesSdk {
     return rClassName;
   }
 
-  public Class getRClass() {
+  public Class<?> getRClass() {
     try {
       String rClassName = getRClassName();
       return Class.forName(rClassName);
@@ -665,7 +665,7 @@ public class AndroidManifest implements UsesSdk {
   public Map<String, Object> getApplicationMetaData() {
     parseAndroidManifest();
     if (applicationMetaData == null) {
-      applicationMetaData = new MetaData(Collections.<Node>emptyList());
+      applicationMetaData = new MetaData(Collections.emptyList());
     }
     return applicationMetaData.getValueMap();
   }

--- a/resources/src/main/java/org/robolectric/manifest/BroadcastReceiverData.java
+++ b/resources/src/main/java/org/robolectric/manifest/BroadcastReceiverData.java
@@ -14,7 +14,7 @@ public class BroadcastReceiverData extends PackageItemData {
 
   private final Map<String, String> attributes;
   private final List<String> actions;
-  private List<IntentFilterData> intentFilters;
+  private final List<IntentFilterData> intentFilters;
 
   public BroadcastReceiverData(
       Map<String, String> attributes, MetaData metaData, List<IntentFilterData> intentFilters) {

--- a/resources/src/main/java/org/robolectric/manifest/IntentFilterData.java
+++ b/resources/src/main/java/org/robolectric/manifest/IntentFilterData.java
@@ -93,8 +93,8 @@ public class IntentFilterData {
   }
 
   public static class DataAuthority {
-    private String host;
-    private String port;
+    private final String host;
+    private final String port;
 
     public DataAuthority(String host, String port) {
       this.host = host;

--- a/resources/src/main/java/org/robolectric/manifest/ServiceData.java
+++ b/resources/src/main/java/org/robolectric/manifest/ServiceData.java
@@ -14,7 +14,7 @@ public class ServiceData extends PackageItemData {
 
   private final Map<String, String> attributes;
   private final List<String> actions;
-  private List<IntentFilterData> intentFilters;
+  private final List<IntentFilterData> intentFilters;
 
   public ServiceData(
       Map<String, String> attributes, MetaData metaData, List<IntentFilterData> intentFilters) {

--- a/resources/src/main/java/org/robolectric/res/ResourceIdGenerator.java
+++ b/resources/src/main/java/org/robolectric/res/ResourceIdGenerator.java
@@ -7,10 +7,10 @@ import java.util.Map;
 public class ResourceIdGenerator {
 
   private final Map<String, TypeTracker> typeInfo = new HashMap<>();
-  private int packageIdentifier;
+  private final int packageIdentifier;
 
   private static class TypeTracker {
-    private int typeIdentifier;
+    private final int typeIdentifier;
     private int currentMaxEntry;
 
     TypeTracker(int typeIdentifier) {

--- a/resources/src/main/java/org/robolectric/res/ResourceRemapper.java
+++ b/resources/src/main/java/org/robolectric/res/ResourceRemapper.java
@@ -22,8 +22,8 @@ import java.util.Map;
  */
 class ResourceRemapper {
 
-  private BiMap<String, Integer> resIds = HashBiMap.create();
-  private ResourceIdGenerator resourceIdGenerator = new ResourceIdGenerator(0x7F);
+  private final BiMap<String, Integer> resIds = HashBiMap.create();
+  private final ResourceIdGenerator resourceIdGenerator = new ResourceIdGenerator(0x7F);
 
   /**
    * @param primaryRClass - An R class (usually the applications) that can be assumed to have a

--- a/resources/src/main/java/org/robolectric/res/ResourceTableFactory.java
+++ b/resources/src/main/java/org/robolectric/res/ResourceTableFactory.java
@@ -56,7 +56,7 @@ public class ResourceTableFactory {
   }
 
   private void addRClassValues(PackageResourceTable resourceTable, Class<?> rClass) {
-    for (Class innerClass : rClass.getClasses()) {
+    for (Class<?> innerClass : rClass.getClasses()) {
       String resourceType = innerClass.getSimpleName();
       if (!resourceType.equals("styleable")) {
         for (Field field : innerClass.getDeclaredFields()) {
@@ -88,7 +88,7 @@ public class ResourceTableFactory {
    * field.
    */
   private void addMissingStyleableAttributes(PackageResourceTable resourceTable, Class<?> rClass) {
-    for (Class innerClass : rClass.getClasses()) {
+    for (Class<?> innerClass : rClass.getClasses()) {
       if (innerClass.getSimpleName().equals("styleable")) {
         String styleableName = null; // Current styleable name
         int[] styleableArray = null; // Current styleable value array or references

--- a/resources/src/main/java/org/robolectric/res/StaxStyleLoader.java
+++ b/resources/src/main/java/org/robolectric/res/StaxStyleLoader.java
@@ -17,7 +17,7 @@ public class StaxStyleLoader extends StaxLoader {
         "item",
         new NodeHandler() {
           private String attrName;
-          private StringBuilder buf = new StringBuilder();
+          private final StringBuilder buf = new StringBuilder();
 
           @Override
           public void onStart(XMLStreamReader xml, XmlContext xmlContext) {

--- a/resources/src/main/java/org/robolectric/res/ThemeStyleSet.java
+++ b/resources/src/main/java/org/robolectric/res/ThemeStyleSet.java
@@ -6,7 +6,7 @@ import java.util.List;
 /** Represents the list of styles applied to a Theme. */
 public class ThemeStyleSet implements Style {
 
-  private List<OverlayedStyle> styles = new ArrayList<>();
+  private final List<OverlayedStyle> styles = new ArrayList<>();
 
   @Override
   public AttributeResource getAttrValue(ResName attrName) {

--- a/resources/src/main/java/org/robolectric/res/ThemeStyleSet.java
+++ b/resources/src/main/java/org/robolectric/res/ThemeStyleSet.java
@@ -44,7 +44,7 @@ public class ThemeStyleSet implements Style {
     if (styles.isEmpty()) {
       return "theme with no applied styles";
     } else {
-      return "theme with applied styles: " + styles + "";
+      return "theme with applied styles: " + styles;
     }
   }
 

--- a/resources/src/main/java/org/robolectric/res/android/Asset.java
+++ b/resources/src/main/java/org/robolectric/res/android/Asset.java
@@ -80,7 +80,7 @@ public abstract class Asset {
           return enumMode;
         }
       }
-      throw new IllegalArgumentException("invalid mode " + Integer.toString(mode));
+      throw new IllegalArgumentException("invalid mode " + mode);
     }
   }
 
@@ -779,7 +779,7 @@ public abstract class Asset {
         // if (ftell(mFp) != mStart + mOffset) {
         try {
           if (mFp.getFilePointer() != mStart + mOffset) {
-            ALOGE("Hosed: %d != %d+%d\n", mFp.getFilePointer(), (long) mStart, (long) mOffset);
+            ALOGE("Hosed: %d != %d+%d\n", mFp.getFilePointer(), mStart, mOffset);
             assert false;
           }
 
@@ -892,7 +892,7 @@ public abstract class Asset {
           return null;
         }
 
-        ALOGV("Asset %s allocating buffer size %d (smaller than threshold)", this, (int) allocLen);
+        ALOGV("Asset %s allocating buffer size %d (smaller than threshold)", this, allocLen);
         if (mLength > 0) {
           try {
             // long oldPosn = ftell(mFp);
@@ -901,7 +901,7 @@ public abstract class Asset {
             mFp.seek(mStart);
             // if (fread(buf, 1, mLength, mFp) != (size_t) mLength) {
             if (mFp.read(buf, 0, toIntExact(mLength)) != (int) mLength) {
-              ALOGE("failed reading %d bytes\n", (long) mLength);
+              ALOGE("failed reading %d bytes\n", mLength);
               // delete[] buf;
               return null;
             }

--- a/resources/src/main/java/org/robolectric/res/android/AttributeResolution.java
+++ b/resources/src/main/java/org/robolectric/res/android/AttributeResolution.java
@@ -40,7 +40,7 @@ public class AttributeResolution {
 
   public static class XmlAttributeFinder {
 
-    private ResXMLParser xmlParser;
+    private final ResXMLParser xmlParser;
 
     public XmlAttributeFinder(ResXMLParser xmlParser) {
       this.xmlParser = xmlParser;

--- a/resources/src/main/java/org/robolectric/res/android/AttributeResolution10.java
+++ b/resources/src/main/java/org/robolectric/res/android/AttributeResolution10.java
@@ -38,7 +38,7 @@ public class AttributeResolution10 {
 
   public static class XmlAttributeFinder {
 
-    private ResXMLParser xmlParser;
+    private final ResXMLParser xmlParser;
 
     XmlAttributeFinder(ResXMLParser xmlParser) {
       this.xmlParser = xmlParser;

--- a/resources/src/main/java/org/robolectric/res/android/AttributeResolution9.java
+++ b/resources/src/main/java/org/robolectric/res/android/AttributeResolution9.java
@@ -35,7 +35,7 @@ public class AttributeResolution9 {
 
   public static class XmlAttributeFinder {
 
-    private ResXMLParser xmlParser;
+    private final ResXMLParser xmlParser;
 
     XmlAttributeFinder(ResXMLParser xmlParser) {
       this.xmlParser = xmlParser;

--- a/resources/src/main/java/org/robolectric/res/android/Chunk.java
+++ b/resources/src/main/java/org/robolectric/res/android/Chunk.java
@@ -71,7 +71,7 @@ class Chunk {
   }
 
   // private:
-  private ResChunk_header device_chunk_;
+  private final ResChunk_header device_chunk_;
 
   public ResTable_header asResTable_header() {
     if (header_size() >= ResTable_header.SIZEOF) {

--- a/resources/src/main/java/org/robolectric/res/android/CppApkAssets.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppApkAssets.java
@@ -284,10 +284,6 @@ public class CppApkAssets {
                 .order(ByteOrder.LITTLE_ENDIAN),
             0 /*(int) loaded_apk.resources_asset_.getLength()*/);
     loaded_apk.loaded_arsc_ = LoadedArsc.Load(data, loaded_idmap, system, load_as_shared_library);
-    if (loaded_apk.loaded_arsc_ == null) {
-      System.err.println("Failed to load '" + kResourcesArsc + "' in APK '" + path + "'.");
-      return null;
-    }
 
     // Need to force a move for mingw32.
     return loaded_apk;

--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager.java
@@ -1030,7 +1030,7 @@ public class CppAssetManager {
        *
        * We start with Zip archives, then do loose files.
        */
-      pMergedInfo = new Ref<>(new SortedVector<AssetDir.FileInfo>());
+      pMergedInfo = new Ref<>(new SortedVector<>());
 
       int i = mAssetPaths.size();
       while (i > 0) {

--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager.java
@@ -1168,7 +1168,7 @@ public class CppAssetManager {
           // printf("+++ no match on '%s'\n", (final char*) match);
         }
 
-        ALOGD("HEY: size=%d removing %d\n", (int) pContents.size(), i);
+        ALOGD("HEY: size=%d removing %d\n", pContents.size(), i);
         pContents.removeAt(i);
         i--; // adjust "for" loop
         count--; //  and loop limit

--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager2.java
@@ -1407,7 +1407,7 @@ public class CppAssetManager2 {
     private final CppAssetManager2 asset_manager_;
     private int type_spec_flags_ = 0;
     //  std.array<std.unique_ptr<Package>, kPackageCount> packages_;
-    private ThemePackage[] packages_ = new ThemePackage[kPackageCount];
+    private final ThemePackage[] packages_ = new ThemePackage[kPackageCount];
 
     public Theme(CppAssetManager2 cppAssetManager2) {
       asset_manager_ = cppAssetManager2;

--- a/resources/src/main/java/org/robolectric/res/android/DynamicRefTable.java
+++ b/resources/src/main/java/org/robolectric/res/android/DynamicRefTable.java
@@ -140,7 +140,7 @@ public class DynamicRefTable {
       return UNKNOWN_ERROR;
     }
 
-    resId.set((res & 0x00ffffff) | (((int) translatedId) << 24));
+    resId.set((res & 0x00ffffff) | (translatedId << 24));
     return NO_ERROR;
   }
 

--- a/resources/src/main/java/org/robolectric/res/android/LoadedArsc.java
+++ b/resources/src/main/java/org/robolectric/res/android/LoadedArsc.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.robolectric.res.android.Chunk.Iterator;
 import org.robolectric.res.android.Idmap.LoadedIdmap;
 import org.robolectric.res.android.ResourceTypes.IdmapEntry_header;
@@ -602,6 +603,7 @@ public class LoadedArsc {
       return 0;
     }
 
+    @Nonnull
     static LoadedPackage Load(
         Chunk chunk, LoadedIdmap loaded_idmap, boolean system, boolean load_as_shared_library) {
       // ATRACE_NAME("LoadedPackage::Load");
@@ -1054,9 +1056,6 @@ public class LoadedArsc {
 
             LoadedPackage loaded_package =
                 LoadedPackage.Load(child_chunk, loaded_idmap, system_, load_as_shared_library);
-            if (!isTruthy(loaded_package)) {
-              return false;
-            }
             packages_.add(loaded_package);
           }
           break;
@@ -1086,6 +1085,7 @@ public class LoadedArsc {
   // If `load_as_shared_library` is set to true, the application package (0x7f) is treated
   // as a shared library (0x00). When loaded into an AssetManager, the package will be assigned an
   // ID.
+  @Nonnull
   static LoadedArsc Load(
       StringPiece data,
       LoadedIdmap loaded_idmap /* = null */,

--- a/resources/src/main/java/org/robolectric/res/android/LoadedArsc.java
+++ b/resources/src/main/java/org/robolectric/res/android/LoadedArsc.java
@@ -898,7 +898,7 @@ public class LoadedArsc {
 
       // Flatten and construct the TypeSpecs.
       for (Entry<Integer, TypeSpecPtrBuilder> entry : type_builder_map.entrySet()) {
-        byte type_idx = (byte) entry.getKey().byteValue();
+        byte type_idx = entry.getKey().byteValue();
         TypeSpec type_spec_ptr = entry.getValue().Build();
         if (type_spec_ptr == null) {
           logError("Too many type configurations, overflow detected.");

--- a/resources/src/main/java/org/robolectric/res/android/LocaleData.java
+++ b/resources/src/main/java/org/robolectric/res/android/LocaleData.java
@@ -154,7 +154,7 @@ public class LocaleData {
     }
 
     int[] request_ancestors = new int[MAX_PARENT_DEPTH + 1];
-    final Ref<Long> left_right_indexRef = new Ref<Long>(null);
+    final Ref<Long> left_right_indexRef = new Ref<>(null);
     // Find the parents of the request, but stop as soon as we saw left or right
     final int[] left_and_right = {left, right};
     final int ancestor_count =

--- a/resources/src/main/java/org/robolectric/res/android/LocaleData.java
+++ b/resources/src/main/java/org/robolectric/res/android/LocaleData.java
@@ -177,7 +177,7 @@ public class LocaleData {
     final int right_distance =
         findDistance(right, requested_script, request_ancestors, ancestor_count);
     if (left_distance != right_distance) {
-      return (int) right_distance - (int) left_distance; // smaller distance is better
+      return right_distance - left_distance; // smaller distance is better
     }
     // If we are here, left and right are equidistant from the request. We will
     // try and see if any of them is a representative locale.

--- a/resources/src/main/java/org/robolectric/res/android/ResStringPool.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResStringPool.java
@@ -31,7 +31,7 @@ import org.robolectric.res.android.ResourceTypes.WithOffset;
 @SuppressWarnings("NewApi")
 public class ResStringPool {
 
-  private static boolean kDebugStringPoolNoisy = false;
+  private static final boolean kDebugStringPoolNoisy = false;
 
   private final long myNativePtr;
 

--- a/resources/src/main/java/org/robolectric/res/android/ResStringPool.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResStringPool.java
@@ -163,7 +163,7 @@ public class ResStringPool {
     if (mHeader.header.headerSize > mHeader.header.size || mHeader.header.size > size) {
       ALOGW(
           "Bad string block: header size %d or total size %d is larger than data size %d\n",
-          (int) mHeader.header.headerSize, (int) mHeader.header.size, (int) size);
+          (int) mHeader.header.headerSize, mHeader.header.size, size);
       return (mError = BAD_TYPE);
     }
     mSize = mHeader.header.size;
@@ -174,8 +174,7 @@ public class ResStringPool {
           || (mHeader.header.headerSize + (mHeader.stringCount * 4 /*sizeof(uint32_t)*/)) > size) {
         ALOGW(
             "Bad string block: entry of %d items extends past data size %d\n",
-            (int) (mHeader.header.headerSize + (mHeader.stringCount * 4 /*sizeof(uint32_t)*/)),
-            (int) size);
+            (mHeader.header.headerSize + (mHeader.stringCount * 4 /*sizeof(uint32_t)*/)), size);
         return (mError = BAD_TYPE);
       }
 
@@ -191,7 +190,7 @@ public class ResStringPool {
       if (mHeader.stringsStart >= (mSize - 2 /*sizeof(uint16_t)*/)) {
         ALOGW(
             "Bad string block: string pool starts at %d, after total size %d\n",
-            (int) mHeader.stringsStart, (int) mHeader.header.size);
+            mHeader.stringsStart, mHeader.header.size);
         return (mError = BAD_TYPE);
       }
 
@@ -204,14 +203,14 @@ public class ResStringPool {
         if (mHeader.stylesStart >= (mSize - 2 /*sizeof(uint16_t)*/)) {
           ALOGW(
               "Bad style block: style block starts at %d past data size of %d\n",
-              (int) mHeader.stylesStart, (int) mHeader.header.size);
+              mHeader.stylesStart, mHeader.header.size);
           return (mError = BAD_TYPE);
         }
         // check invariant: styles follow the strings
         if (mHeader.stylesStart <= mHeader.stringsStart) {
           ALOGW(
               "Bad style block: style block starts at %d, before strings at %d\n",
-              (int) mHeader.stylesStart, (int) mHeader.stringsStart);
+              mHeader.stylesStart, mHeader.stringsStart);
           return (mError = BAD_TYPE);
         }
         mStringPoolSize = (mHeader.stylesStart - mHeader.stringsStart) / charSize;
@@ -219,8 +218,7 @@ public class ResStringPool {
 
       // check invariant: stringCount > 0 requires a string pool to exist
       if (mStringPoolSize == 0) {
-        ALOGW(
-            "Bad string block: stringCount is %d but pool size is 0\n", (int) mHeader.stringCount);
+        ALOGW("Bad string block: stringCount is %d but pool size is 0\n", mHeader.stringCount);
         return (mError = BAD_TYPE);
       }
 
@@ -266,17 +264,17 @@ public class ResStringPool {
       }
 
       //      if (((const uint8_t*)mEntryStyles-(const uint8_t*)mHeader) > (int)size) {
-      if ((mEntryStyles.myOffset() - mHeader.myOffset()) > (int) size) {
+      if ((mEntryStyles.myOffset() - mHeader.myOffset()) > size) {
         ALOGW(
             "Bad string block: entry of %d styles extends past data size %d\n",
-            (int) mEntryStyles.myOffset(), (int) size);
+            mEntryStyles.myOffset(), size);
         return (mError = BAD_TYPE);
       }
       mStyles = mHeader.stylesStart;
       if (mHeader.stylesStart >= mHeader.header.size) {
         ALOGW(
             "Bad string block: style pool starts %d, after total size %d\n",
-            (int) mHeader.stylesStart, (int) mHeader.header.size);
+            mHeader.stylesStart, mHeader.header.size);
         return (mError = BAD_TYPE);
       }
       mStylePoolSize = (mHeader.header.size - mHeader.stylesStart) /* / sizeof(uint32_t)*/;
@@ -446,9 +444,7 @@ public class ResStringPool {
       } else {
         ALOGW(
             "Bad string block: string #%d entry is at %d, past end at %d\n",
-            (int) idx,
-            (int) (off * 2 /*sizeof(uint16_t)*/),
-            (int) (mStringPoolSize * 2 /*sizeof(uint16_t)*/));
+            idx, (off * 2 /*sizeof(uint16_t)*/), (mStringPoolSize * 2 /*sizeof(uint16_t)*/));
       }
     }
     return null;
@@ -481,7 +477,7 @@ public class ResStringPool {
       } else {
         ALOGW(
             "Bad string block: style #%d entry is at %d, past end at %d\n",
-            (int) idx, (int) (off * SIZEOF_INT), (int) (mStylePoolSize * SIZEOF_INT));
+            idx, (off * SIZEOF_INT), (mStylePoolSize * SIZEOF_INT));
       }
     }
     return null;
@@ -511,7 +507,7 @@ public class ResStringPool {
         String s = stringAt(mid);
         int c = s != null ? s.compareTo(str) : -1;
         if (kDebugStringPoolNoisy) {
-          ALOGI("Looking at %s, cmp=%d, l/mid/h=%d/%d/%d\n", s, c, (int) l, (int) mid, (int) h);
+          ALOGI("Looking at %s, cmp=%d, l/mid/h=%d/%d/%d\n", s, c, l, mid, h);
         }
         if (c == 0) {
           if (kDebugStringPoolNoisy) {

--- a/resources/src/main/java/org/robolectric/res/android/ResTable.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResTable.java
@@ -266,7 +266,7 @@ public class ResTable {
     if (dataSize < ResTable_header.SIZEOF) {
       ALOGE(
           "Invalid data. Size(%d) is smaller than a ResTable_header(%d).",
-          (int) dataSize, (int) ResTable_header.SIZEOF);
+          dataSize, ResTable_header.SIZEOF);
       return UNKNOWN_ERROR;
     }
 
@@ -316,13 +316,13 @@ public class ResTable {
     if (dtohs(header.header.header.headerSize) > header.size || header.size > dataSize) {
       ALOGW(
           "Bad resource table: header size 0x%x or total size 0x%x is larger than data size 0x%x\n",
-          (int) dtohs(header.header.header.headerSize), (int) header.size, (int) dataSize);
+          (int) dtohs(header.header.header.headerSize), header.size, dataSize);
       return (mError = BAD_TYPE);
     }
     if (((dtohs(header.header.header.headerSize) | header.size) & 0x3) != 0) {
       ALOGW(
           "Bad resource table: header size 0x%x or total size 0x%x is not on an integer boundary\n",
-          (int) dtohs(header.header.header.headerSize), (int) header.size);
+          (int) dtohs(header.header.header.headerSize), header.size);
       return (mError = BAD_TYPE);
     }
     //    header->dataEnd = ((const uint8_t*)header->header) + header->size;
@@ -348,7 +348,7 @@ public class ResTable {
             dtohs(chunk.type),
             dtohs(chunk.headerSize),
             dtohl(chunk.size),
-            (Object) (chunk.myOffset() - header.header.myOffset()));
+            chunk.myOffset() - header.header.myOffset());
       }
       final int csize = dtohl(chunk.size);
       final int ctype = dtohs(chunk.type);
@@ -394,7 +394,7 @@ public class ResTable {
     if (curPackage < dtohl(header.header.packageCount)) {
       ALOGW(
           "Fewer package chunks (%d) were found than the %d declared in the header.",
-          (int) curPackage, dtohl(header.header.packageCount));
+          curPackage, dtohl(header.header.packageCount));
       return (mError = BAD_TYPE);
     }
     mError = header.values.getError();
@@ -533,7 +533,7 @@ public class ResTable {
       if (kDebugTableTheme) {
         ALOGI(
             "Resolving reference 0x%x: newIndex=%d, type=0x%x, data=0x%x\n",
-            value.get().data, (int) newIndex, (int) value.get().dataType, value.get().data);
+            value.get().data, newIndex, (int) value.get().dataType, value.get().data);
       }
       // printf("Getting reference 0x%08x: newIndex=%d\n", value.data, newIndex);
       if (inoutTypeSpecFlags != null) {
@@ -623,12 +623,12 @@ public class ResTable {
       // Check that the entry idx is within range of the declared entry count (ResTable_typeSpec).
       // Particular types (ResTable_type) may be encoded with sparse entries, and so their
       // entryCount do not need to match.
-      if (((int) realEntryIndex) >= typeSpec.entryCount) {
+      if (realEntryIndex >= typeSpec.entryCount) {
         ALOGW(
             "For resource 0x%08x, entry index(%d) is beyond type entryCount(%d)",
             Res_MAKEID(packageGroup.id - 1, typeIndex, entryIndex),
             entryIndex,
-            ((int) typeSpec.entryCount));
+            typeSpec.entryCount);
         // We should normally abort here, but some legacy apps declare
         // resources in the 'android' package (old bug in AAPT).
         continue;
@@ -1001,7 +1001,7 @@ public class ResTable {
               if (existingType.entryCount != newEntryCount && idmapEntry == null) {
                 ALOGW(
                     "ResTable_typeSpec entry count inconsistent: given %d, previously %d",
-                    (int) newEntryCount, (int) existingType.entryCount);
+                    newEntryCount, existingType.entryCount);
                 // We should normally abort here, but some legacy apps declare
                 // resources in the 'android' package (old bug in AAPT).
               }
@@ -2465,8 +2465,8 @@ public class ResTable {
     LOG_FATAL_IF(
         idx >= mPackageGroups.size(),
         "Requested package index %d past package count %d",
-        (int) idx,
-        (int) mPackageGroups.size());
+        idx,
+        mPackageGroups.size());
     return mPackageGroups.get(keyFor(idx)).name;
   }
 
@@ -2477,8 +2477,8 @@ public class ResTable {
     LOG_FATAL_IF(
         idx >= mPackageGroups.size(),
         "Requested package index %d past package count %d",
-        (int) idx,
-        (int) mPackageGroups.size());
+        idx,
+        mPackageGroups.size());
     return mPackageGroups.get(keyFor(idx)).id;
   }
 
@@ -2489,8 +2489,8 @@ public class ResTable {
     LOG_FATAL_IF(
         idx >= mPackageGroups.size(),
         "Requested package index %d past package count %d",
-        (int) idx,
-        (int) mPackageGroups.size());
+        idx,
+        mPackageGroups.size());
     PackageGroup group = mPackageGroups.get(keyFor(idx));
     return group.largestTypeId;
   }
@@ -2859,10 +2859,10 @@ public class ResTable {
     }
 
     final int NENTRY = typeConfigs.get(0).entryCount;
-    if (e >= (int) NENTRY) {
+    if (e >= NENTRY) {
       ALOGW(
           "Entry identifier 0x%x is larger than entry count 0x%x",
-          e, (int) typeConfigs.get(0).entryCount);
+          e, typeConfigs.get(0).entryCount);
       return BAD_INDEX;
     }
 
@@ -2998,7 +2998,7 @@ public class ResTable {
       if (curOff > (dtohl(entry.type.header.size) - ResTable_map.SIZEOF)) {
         ALOGW(
             "ResTable_map at %d is beyond type chunk data %d",
-            (int) curOff, dtohl(entry.type.header.size));
+            curOff, dtohl(entry.type.header.size));
         return BAD_TYPE;
       }
       //      map = (const ResTable_map*)(((const uint8_t*)entry.type) + curOff);
@@ -3012,7 +3012,7 @@ public class ResTable {
         if (grp.dynamicRefTable.lookupResourceId(newName) != NO_ERROR) {
           ALOGE(
               "Failed resolving ResTable_map name at %d with ident 0x%08x",
-              (int) curEntry, (int) newName.get());
+              curEntry, newName.get());
           return UNKNOWN_ERROR;
         }
       }

--- a/resources/src/main/java/org/robolectric/res/android/ResTable.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResTable.java
@@ -2802,7 +2802,6 @@ public class ResTable {
 
     int typeIdOffset;
   }
-  ;
 
   public static class bag_entry {
     public int stringBlock;

--- a/resources/src/main/java/org/robolectric/res/android/ResTableTheme.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResTableTheme.java
@@ -28,7 +28,7 @@ import org.robolectric.res.android.ResourceTypes.Res_value;
 public class ResTableTheme {
 
   private final List<AppliedStyle> styles = new ArrayList<>();
-  private static boolean styleDebug = false;
+  private static final boolean styleDebug = false;
   private static final type_info EMPTY_TYPE_INFO = new type_info();
   private static final theme_entry EMPTY_THEME_ENTRY = new theme_entry();
 
@@ -58,10 +58,10 @@ public class ResTableTheme {
     }
   }
 
-  private ResTable mTable;
-  private boolean kDebugTableTheme = false;
-  private boolean kDebugTableNoisy = false;
-  private package_info[] mPackages = new package_info[Res_MAXPACKAGE];
+  private final ResTable mTable;
+  private final boolean kDebugTableTheme = false;
+  private final boolean kDebugTableNoisy = false;
+  private final package_info[] mPackages = new package_info[Res_MAXPACKAGE];
   private Ref<Integer> mTypeSpecFlags = new Ref<>(0);
 
   public ResTableTheme(ResTable resources) {

--- a/resources/src/main/java/org/robolectric/res/android/ResTableTheme.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResTableTheme.java
@@ -54,7 +54,7 @@ public class ResTableTheme {
     if (styles.isEmpty()) {
       return "theme with no applied styles";
     } else {
-      return "theme with applied styles: " + styles + "";
+      return "theme with applied styles: " + styles;
     }
   }
 
@@ -152,7 +152,7 @@ public class ResTableTheme {
       if (kDebugTableTheme) {
         ALOGI(
             "Resolving attr reference: blockIndex=%d, type=0x%x, data=0x%x\n",
-            (int) blockIndex, (int) inOutValue.get().dataType, inOutValue.get().data);
+            blockIndex, (int) inOutValue.get().dataType, inOutValue.get().data);
       }
       if (inoutTypeSpecFlags != null)
         inoutTypeSpecFlags.set(inoutTypeSpecFlags.get() | newTypeSpecFlags.get());

--- a/resources/src/main/java/org/robolectric/res/android/ResXMLParser.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResXMLParser.java
@@ -256,7 +256,7 @@ public class ResXMLParser {
 
   public int getAttributeNameResID(int idx) {
     int id = getAttributeNameID(idx);
-    if (id >= 0 && (int) id < mTree.mNumResIds) {
+    if (id >= 0 && id < mTree.mNumResIds) {
       int resId = dtohl(mTree.mResIds[id]);
       if (mTree.mDynamicRefTable != null) {
         final Ref<Integer> resIdRef = new Ref<>(resId);
@@ -557,8 +557,8 @@ public class ResXMLParser {
             "Bad XML block: header type 0x%x in node at 0x%x has size %d, need %d\n",
             (int) dtohs(next.header.type),
             (next.myOffset() - mTree.mHeader.myOffset()),
-            (int) (totalSize - headerSize),
-            (int) minExtSize);
+            (totalSize - headerSize),
+            minExtSize);
         return (mEventCode = BAD_DOCUMENT);
       }
 

--- a/resources/src/main/java/org/robolectric/res/android/ResXMLTree.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResXMLTree.java
@@ -102,7 +102,7 @@ public class ResXMLTree {
     if (dtohs(mHeader.header.headerSize) > mSize || mSize > size) {
       ALOGW(
           "Bad XML block: header size %d or total size %d is larger than data size %d\n",
-          (int) dtohs(mHeader.header.headerSize), (int) dtohl(mHeader.header.size), (int) size);
+          (int) dtohs(mHeader.header.headerSize), dtohl(mHeader.header.size), size);
       mError = BAD_TYPE;
       mParser.restart();
       return mError;
@@ -240,11 +240,9 @@ public class ResXMLTree {
         }
         ALOGW(
             "Bad XML block: node attributes use 0x%x bytes, only have 0x%x bytes\n",
-            (int) (dtohs(attrExt.attributeStart) + attrSize), (int) (size - headerSize));
+            (dtohs(attrExt.attributeStart) + attrSize), (size - headerSize));
       } else {
-        ALOGW(
-            "Bad XML start block: node header size 0x%x, size 0x%x\n",
-            (int) headerSize, (int) size);
+        ALOGW("Bad XML start block: node header size 0x%x, size 0x%x\n", (int) headerSize, size);
       }
       return BAD_TYPE;
     }

--- a/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
@@ -46,7 +46,7 @@ public class ResourceTypes {
         }
         ALOGW(
             "%s size 0x%x or headerSize 0x%x is not on an integer boundary.",
-            name, (int) size, (int) headerSize);
+            name, size, (int) headerSize);
         return BAD_TYPE;
       }
       ALOGW("%s size 0x%x is smaller than header size 0x%x.", name, size, headerSize);

--- a/resources/src/main/java/org/robolectric/res/android/SortedVector.java
+++ b/resources/src/main/java/org/robolectric/res/android/SortedVector.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class SortedVector<T extends Comparable<T>> {
 
   // internal storage for the data. Re-sorted on insertion
-  private List<T> mStorage;
+  private final List<T> mStorage;
 
   SortedVector(int itemSize) {
     mStorage = new ArrayList<>(itemSize);

--- a/resources/src/main/java/org/robolectric/res/android/String8.java
+++ b/resources/src/main/java/org/robolectric/res/android/String8.java
@@ -11,7 +11,7 @@ import org.robolectric.res.Fs;
 @SuppressWarnings("NewApi")
 public class String8 {
 
-  private StringBuilder mString;
+  private final StringBuilder mString;
 
   public String8() {
     this("");

--- a/resources/src/main/java/org/robolectric/res/android/StringPoolRef.java
+++ b/resources/src/main/java/org/robolectric/res/android/StringPoolRef.java
@@ -9,7 +9,7 @@ package org.robolectric.res.android;
 class StringPoolRef {
 
   private final ResStringPool mPool;
-  private int mIndex;
+  private final int mIndex;
 
   StringPoolRef(final ResStringPool pool, int index) {
     this.mPool = pool;

--- a/resources/src/main/java/org/robolectric/res/android/Util.java
+++ b/resources/src/main/java/org/robolectric/res/android/Util.java
@@ -12,7 +12,7 @@ public class Util {
   public static final int SIZEOF_SHORT = 2;
   public static final int SIZEOF_INT = 4;
   public static final int SIZEOF_CPTR = 4;
-  private static boolean littleEndian = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
+  private static final boolean littleEndian = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
 
   private static final boolean DEBUG = false;
 

--- a/resources/src/test/java/org/robolectric/manifest/ActivityDataTest.java
+++ b/resources/src/test/java/org/robolectric/manifest/ActivityDataTest.java
@@ -15,8 +15,7 @@ public class ActivityDataTest {
   public void test_non_android_namespace() {
     HashMap<String, String> attrs = new HashMap<>();
     attrs.put("testns:name", ".test.TestActivity");
-    ActivityData activityData =
-        new ActivityData("testns", attrs, new ArrayList<IntentFilterData>());
+    ActivityData activityData = new ActivityData("testns", attrs, new ArrayList<>());
 
     assertThat(activityData.getName()).isEqualTo(".test.TestActivity");
     assertThat(activityData.getAllAttributes().get("android:name")).isNull();
@@ -26,7 +25,7 @@ public class ActivityDataTest {
   public void test_config_changes() {
     HashMap<String, String> attrs = new HashMap<>();
     attrs.put("android:configChanges", "mcc|screenLayout|orientation");
-    ActivityData activityData = new ActivityData(attrs, new ArrayList<IntentFilterData>());
+    ActivityData activityData = new ActivityData(attrs, new ArrayList<>());
 
     assertThat(activityData.getConfigChanges()).isEqualTo("mcc|screenLayout|orientation");
   }

--- a/resources/src/test/java/org/robolectric/manifest/MetaDataTest.java
+++ b/resources/src/test/java/org/robolectric/manifest/MetaDataTest.java
@@ -15,7 +15,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.res.ResourceTable;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 
 /** Tests for {@link MetaData} */
 @RunWith(JUnit4.class)
@@ -38,7 +37,7 @@ public class MetaDataTest {
   public void testNonExistentResource_throwsResourceNotFoundException() {
     Element metaDataElement = createMetaDataNode("aName", "@xml/non_existent_resource");
 
-    MetaData metaData = new MetaData(ImmutableList.<Node>of(metaDataElement));
+    MetaData metaData = new MetaData(ImmutableList.of(metaDataElement));
 
     assertThrows(RoboNotFoundException.class, () -> metaData.init(resourceProvider, "a.package"));
   }


### PR DESCRIPTION
This PR fixes the following warnings in the `resources` module:
- Remove unused dependencies.
- Fix generics.
- Remove unnecessary semicolons.
- Add nullability annotations in `LoadedArsc`.
- Remove unnecessary casts.
- Add missing final declarations.