### PR TITLE
Fix typo in `ActivityData#isClearTaskOnLaungh()`

### DIFF
--- a/resources/src/main/java/org/robolectric/manifest/ActivityData.java
+++ b/resources/src/main/java/org/robolectric/manifest/ActivityData.java
@@ -72,7 +72,7 @@ public class ActivityData {
     return getBooleanAttr(withXMLNS(ALWAYS_RETAIN_TASK_STATE), false);
   }
 
-  public boolean isClearTaskOnLaungh() {
+  public boolean isClearTaskOnLaunch() {
     return getBooleanAttr(withXMLNS(CLEAR_TASK_ON_LAUNCH), false);
   }
 


### PR DESCRIPTION
Fix a typo in the method name `isClearTaskOnLaungh` to `isClearTaskOnLaunch`.