### PR TITLE
Fix typo in `ResourceIds`

### DIFF
--- a/resources/src/main/java/org/robolectric/res/ResourceIdGenerator.java
+++ b/resources/src/main/java/org/robolectric/res/ResourceIdGenerator.java
@@ -49,7 +49,7 @@ public class ResourceIdGenerator {
       typeTracker = new TypeTracker(getNextFreeTypeIdentifier());
       typeInfo.put(type, typeTracker);
     }
-    return ResourceIds.makeIdentifer(
+    return ResourceIds.makeIdentifier(
         packageIdentifier, typeTracker.getTypeIdentifier(), typeTracker.getFreeIdentifier());
   }
 

--- a/resources/src/main/java/org/robolectric/res/ResourceIds.java
+++ b/resources/src/main/java/org/robolectric/res/ResourceIds.java
@@ -20,7 +20,7 @@ public class ResourceIds {
     return resId & 0x0000FFFF;
   }
 
-  public static int makeIdentifer(int packageIdentifier, int typeIdentifier, int entryIdenifier) {
-    return packageIdentifier << 24 | typeIdentifier << 16 | entryIdenifier;
+  public static int makeIdentifier(int packageIdentifier, int typeIdentifier, int entryIdentifier) {
+    return packageIdentifier << 24 | typeIdentifier << 16 | entryIdentifier;
   }
 }

--- a/resources/src/test/java/org/robolectric/res/ResourceIdsTest.java
+++ b/resources/src/test/java/org/robolectric/res/ResourceIdsTest.java
@@ -35,7 +35,7 @@ public class ResourceIdsTest {
 
   @Test
   public void testMakeIdentifier() {
-    assertThat(ResourceIds.makeIdentifer(0x01, 0x01, 0x9876)).isEqualTo(0x01019876);
-    assertThat(ResourceIds.makeIdentifer(0x7F, 0x78, 0x1234)).isEqualTo(0x7F781234);
+    assertThat(ResourceIds.makeIdentifier(0x01, 0x01, 0x9876)).isEqualTo(0x01019876);
+    assertThat(ResourceIds.makeIdentifier(0x7F, 0x78, 0x1234)).isEqualTo(0x7F781234);
   }
 }


### PR DESCRIPTION
This commit fixes a typo in the `ResourceIds` class, changing `makeIdentifer` to `makeIdentifier`.