### PR TITLE
Fix warnings in the `shadowapi` module

### DIFF
--- a/shadowapi/build.gradle.kts
+++ b/shadowapi/build.gradle.kts
@@ -10,5 +10,4 @@ dependencies {
   api(project(":utils"))
   testImplementation(libs.junit4)
   testImplementation(libs.truth)
-  testImplementation(libs.mockito)
 }

--- a/shadowapi/src/main/java/org/robolectric/shadow/api/Shadow.java
+++ b/shadowapi/src/main/java/org/robolectric/shadow/api/Shadow.java
@@ -4,7 +4,7 @@ import org.robolectric.internal.IShadow;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 public class Shadow {
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "FieldMayBeFinal"})
   private static IShadow SHADOW_IMPL;
 
   static {
@@ -42,7 +42,7 @@ public class Shadow {
     }
   }
 
-  public static <T> T newInstance(Class<T> clazz, Class[] parameterTypes, Object[] params) {
+  public static <T> T newInstance(Class<T> clazz, Class<?>[] parameterTypes, Object[] params) {
     return SHADOW_IMPL.newInstance(clazz, parameterTypes, params);
   }
 
@@ -60,26 +60,29 @@ public class Shadow {
     return SHADOW_IMPL.directlyOn(shadowedObject, clazz);
   }
 
-  @SuppressWarnings(value = {"unchecked", "TypeParameterUnusedInFormals"})
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   public static <R> R directlyOn(
-      Object shadowedObject, String clazzName, String methodName, ClassParameter... paramValues) {
+      Object shadowedObject,
+      String clazzName,
+      String methodName,
+      ClassParameter<?>... paramValues) {
     return SHADOW_IMPL.directlyOn(shadowedObject, clazzName, methodName, paramValues);
   }
 
   @SuppressWarnings("TypeParameterUnusedInFormals")
   public static <R, T> R directlyOn(
-      T shadowedObject, Class<T> clazz, String methodName, ClassParameter... paramValues) {
+      T shadowedObject, Class<T> clazz, String methodName, ClassParameter<?>... paramValues) {
     return SHADOW_IMPL.directlyOn(shadowedObject, clazz, methodName, paramValues);
   }
 
   @SuppressWarnings("TypeParameterUnusedInFormals")
   public static <R, T> R directlyOn(
-      Class<T> clazz, String methodName, ClassParameter... paramValues) {
+      Class<T> clazz, String methodName, ClassParameter<?>... paramValues) {
     return SHADOW_IMPL.directlyOn(clazz, methodName, paramValues);
   }
 
   public static <R> R invokeConstructor(
-      Class<? extends R> clazz, R instance, ClassParameter... paramValues) {
+      Class<? extends R> clazz, R instance, ClassParameter<?>... paramValues) {
     return SHADOW_IMPL.invokeConstructor(clazz, instance, paramValues);
   }
 

--- a/shadowapi/src/main/java/org/robolectric/util/ReflectionHelpers.java
+++ b/shadowapi/src/main/java/org/robolectric/util/ReflectionHelpers.java
@@ -86,12 +86,12 @@ public class ReflectionHelpers {
    *
    * @param clazz the class to provide a proxy instance of.
    * @param delegate the object to delegate matching method calls to. A 'matching method' must have
-   *     exactlu the same method name and parameter class names as the desired method.
+   *     exactly the same method name and parameter class names as the desired method.
    *     The @ClassName annotation can be applied to provide a custom class name.
    * @return a new "Delegating Proxy" instance of the given class.
    */
   public static <T> T createDelegatingProxy(Class<T> clazz, final Object delegate) {
-    final Class delegateClass = delegate.getClass();
+    final Class<?> delegateClass = delegate.getClass();
     return (T)
         Proxy.newProxyInstance(
             clazz.getClassLoader(),
@@ -241,7 +241,8 @@ public class ReflectionHelpers {
   public static boolean hasField(Class<?> clazz, String fieldName) {
     try {
       Field field = clazz.getDeclaredField(fieldName);
-      return (field != null);
+      //noinspection ConstantValue
+      return field != null;
     } catch (NoSuchFieldException e) {
       return false;
     }

--- a/shadowapi/src/test/java/org/robolectric/util/ReflectionHelpersTest.java
+++ b/shadowapi/src/test/java/org/robolectric/util/ReflectionHelpersTest.java
@@ -105,7 +105,7 @@ public class ReflectionHelpersTest {
   }
 
   @Test
-  public void getFinalStaticFieldReflectively_withFieldName_getsStaticField() throws Exception {
+  public void getFinalStaticFieldReflectively_withFieldName_getsStaticField() {
     assertThat((int) ReflectionHelpers.getStaticField(ExampleBase.class, "BASE")).isEqualTo(8);
   }
 
@@ -116,7 +116,7 @@ public class ReflectionHelpersTest {
 
     ReflectionHelpers.setStaticField(field, 7);
     assertWithMessage("startingValue").that(startingValue).isEqualTo(6);
-    assertWithMessage("DESCENDENT").that(ExampleDescendant.DESCENDANT).isEqualTo(7);
+    assertWithMessage("DESCENDANT").that(ExampleDescendant.DESCENDANT).isEqualTo(7);
 
     /// Reset the value to avoid test pollution
     ReflectionHelpers.setStaticField(field, startingValue);
@@ -128,7 +128,7 @@ public class ReflectionHelpersTest {
 
     ReflectionHelpers.setStaticField(ExampleDescendant.class, "DESCENDANT", 7);
     assertWithMessage("startingValue").that(startingValue).isEqualTo(6);
-    assertWithMessage("DESCENDENT").that(ExampleDescendant.DESCENDANT).isEqualTo(7);
+    assertWithMessage("DESCENDANT").that(ExampleDescendant.DESCENDANT).isEqualTo(7);
 
     // Reset the value to avoid test pollution
     ReflectionHelpers.setStaticField(ExampleDescendant.class, "DESCENDANT", startingValue);
@@ -304,14 +304,14 @@ public class ReflectionHelpersTest {
   }
 
   @Test
-  public void callHasField_withstaticandregularmember() {
+  public void callHasField_withStaticAndRegularMember() {
     assertWithMessage("has field failed for member: unusedName")
         .that(ReflectionHelpers.hasField(FieldTestClass.class, "unusedName"))
         .isTrue();
     assertWithMessage("has field failed for member: unusedStaticName")
         .that(ReflectionHelpers.hasField(FieldTestClass.class, "unusedStaticName"))
         .isTrue();
-    assertWithMessage("has field failed for non existant member: noname")
+    assertWithMessage("has field failed for non existent member: noname")
         .that(ReflectionHelpers.hasField(FieldTestClass.class, "noname"))
         .isFalse();
   }
@@ -367,13 +367,10 @@ public class ReflectionHelpersTest {
     assertThat(fixture.delegateMethod("value", "value2")).isEqualTo("called valuevalue2");
   }
 
-  @SuppressWarnings("serial")
   private static class TestError extends Error {}
 
-  @SuppressWarnings("serial")
   private static class TestException extends Exception {}
 
-  @SuppressWarnings("serial")
   private static class TestRuntimeException extends RuntimeException {}
 
   @SuppressWarnings("unused")


### PR DESCRIPTION
This commit fixes warnings in the `shadowapi` module:
- Fix generic `Class` type.
- Fix typo.
- Remove unnecessary `throws` clause.
- Remove unused dependency.