### PR TITLE
Fix warnings in the `sandbox` module

### DIFF
--- a/sandbox/src/main/java/org/robolectric/interceptors/AndroidInterceptors.java
+++ b/sandbox/src/main/java/org/robolectric/interceptors/AndroidInterceptors.java
@@ -135,16 +135,13 @@ public class AndroidInterceptors {
 
     @Override
     public Function<Object, Object> handle(MethodSignature methodSignature) {
-      return new Function<Object, Object>() {
-        @Override
-        public Object call(Class<?> theClass, Object value, Object[] params) {
-          if ("release$".equals(methodSignature.methodName)) {
-            return release((FileDescriptor) value);
-          } else if ("getInt$".equals(methodSignature.methodName)) {
-            return getInt((FileDescriptor) value);
-          } else {
-            return setInt((FileDescriptor) value, (int) params[0]);
-          }
+      return (theClass, value, params) -> {
+        if ("release$".equals(methodSignature.methodName)) {
+          return release((FileDescriptor) value);
+        } else if ("getInt$".equals(methodSignature.methodName)) {
+          return getInt((FileDescriptor) value);
+        } else {
+          return setInt((FileDescriptor) value, (int) params[0]);
         }
       };
     }
@@ -171,18 +168,13 @@ public class AndroidInterceptors {
     }
 
     @Nullable
-    static Object eldest(LinkedHashMap map) {
+    static Object eldest(LinkedHashMap<?, ?> map) {
       return map.isEmpty() ? null : map.entrySet().iterator().next();
     }
 
     @Override
     public Function<Object, Object> handle(MethodSignature methodSignature) {
-      return new Function<Object, Object>() {
-        @Override
-        public Object call(Class<?> theClass, Object value, Object[] params) {
-          return eldest((LinkedHashMap) value);
-        }
-      };
+      return (theClass, value, params) -> eldest((LinkedHashMap<?, ?>) value);
     }
 
     @Override
@@ -201,16 +193,13 @@ public class AndroidInterceptors {
 
     @Override
     public Function<Object, Object> handle(final MethodSignature methodSignature) {
-      return new Function<Object, Object>() {
-        @Override
-        public Object call(Class<?> theClass, Object value, Object[] params) {
-          ClassLoader cl = theClass.getClassLoader();
-          try {
-            Class<?> shadowSystemClass = cl.loadClass("org.robolectric.shadows.ShadowSystem");
-            return callStaticMethod(shadowSystemClass, methodSignature.methodName);
-          } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-          }
+      return (theClass, value, params) -> {
+        ClassLoader cl = theClass.getClassLoader();
+        try {
+          Class<?> shadowSystemClass = cl.loadClass("org.robolectric.shadows.ShadowSystem");
+          return callStaticMethod(shadowSystemClass, methodSignature.methodName);
+        } catch (ClassNotFoundException e) {
+          throw new RuntimeException(e);
         }
       };
     }
@@ -242,14 +231,11 @@ public class AndroidInterceptors {
 
     @Override
     public Function<Object, Object> handle(MethodSignature methodSignature) {
-      return new Function<Object, Object>() {
-        @Override
-        public Object call(Class<?> theClass, Object value, Object[] params) {
-          //noinspection SuspiciousSystemArraycopy
-          System.arraycopy(
-              params[0], (Integer) params[1], params[2], (Integer) params[3], (Integer) params[4]);
-          return null;
-        }
+      return (theClass, value, params) -> {
+        //noinspection SuspiciousSystemArraycopy
+        System.arraycopy(
+            params[0], (Integer) params[1], params[2], (Integer) params[3], (Integer) params[4]);
+        return null;
       };
     }
 
@@ -285,12 +271,7 @@ public class AndroidInterceptors {
 
     @Override
     public Function<Object, Object> handle(MethodSignature methodSignature) {
-      return new Function<Object, Object>() {
-        @Override
-        public Object call(Class<?> theClass, Object value, Object[] params) {
-          return adjustLanguageCode((String) params[0]);
-        }
-      };
+      return (theClass, value, params) -> adjustLanguageCode((String) params[0]);
     }
 
     @Override
@@ -428,8 +409,7 @@ public class AndroidInterceptors {
     }
 
     @Override
-    public MethodHandle getMethodHandle(String methodName, MethodType type)
-        throws NoSuchMethodException, IllegalAccessException {
+    public MethodHandle getMethodHandle(String methodName, MethodType type) {
       MethodHandle nothing = constant(Void.class, null).asType(methodType(void.class));
 
       if (type.parameterCount() != 0) {
@@ -453,12 +433,7 @@ public class AndroidInterceptors {
 
     @Override
     public Function<Object, Object> handle(MethodSignature methodSignature) {
-      return new Function<Object, Object>() {
-        @Override
-        public Object call(Class<?> theClass, Object value, Object[] params) {
-          return getFileDescriptor((Socket) value);
-        }
-      };
+      return (theClass, value, params) -> getFileDescriptor((Socket) value);
     }
 
     @Override
@@ -480,13 +455,13 @@ public class AndroidInterceptors {
           new MethodRef(PhantomReference.class.getName(), METHOD));
     }
 
-    static boolean refersTo(Reference ref, Object obj) {
+    static boolean refersTo(Reference<?> ref, Object obj) {
       return ref.get() == obj;
     }
 
     @Override
     public Function<Object, Object> handle(MethodSignature methodSignature) {
-      return (theClass, value, params) -> refersTo((Reference) value, params[0]);
+      return (theClass, value, params) -> refersTo((Reference<?>) value, params[0]);
     }
 
     @Override

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassHandler.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassHandler.java
@@ -18,7 +18,7 @@ public interface ClassHandler {
    *
    * @param clazz the class being loaded
    */
-  void classInitializing(Class clazz);
+  void classInitializing(Class<?> clazz);
 
   /**
    * Called by Robolectric to determine how to create and initialize a shadow object when a new

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassInstrumentor.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassInstrumentor.java
@@ -275,7 +275,7 @@ public class ClassInstrumentor {
 
   /**
    * Adds a call $$robo$init, which instantiates a shadow object if required. This is to support
-   * custom shadows for Jacoco-instrumented classes (except cnstructor shadows).
+   * custom shadows for Jacoco-instrumented classes (except constructor shadows).
    */
   protected void addCallToRoboInit(MutableClass mutableClass, MethodNode ctor) {
     AbstractInsnNode returnNode =
@@ -618,7 +618,7 @@ public class ClassInstrumentor {
 
   protected String[] exceptionArray(MethodNode method) {
     List<String> exceptions = method.exceptions;
-    return exceptions.toArray(new String[exceptions.size()]);
+    return exceptions.toArray(new String[0]);
   }
 
   /** Filters methods that might need special treatment because of various reasons */

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
@@ -68,7 +68,7 @@ public class InstrumentationConfiguration {
       Collection<String> instrumentedPackages,
       Collection<String> instrumentedClasses,
       Collection<String> classesToNotAcquire,
-      Collection<String> packagesToNotAquire,
+      Collection<String> packagesToNotAcquire,
       Collection<String> classesToNotInstrument,
       Collection<String> packagesToNotInstrument,
       String classesToNotInstrumentRegex) {
@@ -77,7 +77,7 @@ public class InstrumentationConfiguration {
     this.instrumentedPackages = ImmutableList.copyOf(instrumentedPackages);
     this.instrumentedClasses = ImmutableSet.copyOf(instrumentedClasses);
     this.classesToNotAcquire = ImmutableSet.copyOf(classesToNotAcquire);
-    this.packagesToNotAcquire = ImmutableSet.copyOf(packagesToNotAquire);
+    this.packagesToNotAcquire = ImmutableSet.copyOf(packagesToNotAcquire);
     this.classesToNotInstrument = ImmutableSet.copyOf(classesToNotInstrument);
     this.packagesToNotInstrument = ImmutableSet.copyOf(packagesToNotInstrument);
     this.classesToNotInstrumentRegex = classesToNotInstrumentRegex;

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/Interceptor.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/Interceptor.java
@@ -7,7 +7,7 @@ import org.robolectric.util.Function;
 import org.robolectric.util.ReflectionHelpers;
 
 public abstract class Interceptor {
-  private MethodRef[] methodRefs;
+  private final MethodRef[] methodRefs;
 
   public Interceptor(MethodRef... methodRefs) {
     this.methodRefs = methodRefs;
@@ -25,11 +25,7 @@ public abstract class Interceptor {
   @Nonnull
   protected static Function<Object, Object> returnDefaultValue(
       final MethodSignature methodSignature) {
-    return new Function<Object, Object>() {
-      @Override
-      public Object call(Class<?> theClass, Object value, Object[] params) {
-        return ReflectionHelpers.defaultValueForType(methodSignature.returnType);
-      }
-    };
+    return (theClass, value, params) ->
+        ReflectionHelpers.defaultValueForType(methodSignature.returnType);
   }
 }

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/InvokeDynamicSupport.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/InvokeDynamicSupport.java
@@ -133,8 +133,7 @@ public class InvokeDynamicSupport {
 
   @SuppressWarnings("UnusedDeclaration")
   public static CallSite bootstrapIntrinsic(
-      MethodHandles.Lookup caller, String name, MethodType type, String callee)
-      throws IllegalAccessException {
+      MethodHandles.Lookup caller, String name, MethodType type, String callee) {
     return PerfStatsCollector.getInstance()
         .measure(
             "invokedynamic bootstrap intrinsic",

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ProxyMaker.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ProxyMaker.java
@@ -8,13 +8,13 @@ import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
 import static org.objectweb.asm.Opcodes.V1_7;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.nio.file.Files;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
@@ -34,8 +34,8 @@ import sun.misc.Unsafe;
 @Deprecated
 public class ProxyMaker {
   private static final String TARGET_FIELD = "__proxy__";
-  private static final Class UNSAFE_CLASS = Unsafe.class;
-  private static final Class LOOKUP_CLASS = MethodHandles.Lookup.class;
+  private static final Class<Unsafe> UNSAFE_CLASS = Unsafe.class;
+  private static final Class<MethodHandles.Lookup> LOOKUP_CLASS = MethodHandles.Lookup.class;
   private static final Unsafe UNSAFE;
   private static final java.lang.reflect.Method DEFINE_ANONYMOUS_CLASS;
 
@@ -163,7 +163,7 @@ public class ProxyMaker {
     if (DEBUG) {
       File file = new File("/tmp", targetClass.getCanonicalName() + "-DirectProxy.class");
       System.out.println("Generated Direct Proxy: " + file.getAbsolutePath());
-      try (OutputStream out = new FileOutputStream(file)) {
+      try (OutputStream out = Files.newOutputStream(file.toPath())) {
         out.write(bytecode);
       } catch (IOException e) {
         throw new RuntimeException(e);
@@ -197,7 +197,7 @@ public class ProxyMaker {
     if (DEFINE_ANONYMOUS_CLASS != null) {
       return (Class<?>) DEFINE_ANONYMOUS_CLASS.invoke(UNSAFE, targetClass, bytes, (Object[]) null);
     } else {
-      MethodHandles.Lookup lookup = (MethodHandles.Lookup) LOOKUP.in(targetClass);
+      MethodHandles.Lookup lookup = LOOKUP.in(targetClass);
       MethodHandles.Lookup definedLookup =
           (MethodHandles.Lookup)
               HIDDEN_DEFINE_METHOD.invoke(lookup, bytes, false, HIDDEN_CLASS_OPTIONS);

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/RoboType.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/RoboType.java
@@ -12,13 +12,13 @@ enum RoboType {
   DOUBLE(Double.TYPE),
   OBJECT(null);
 
-  RoboType(Class type) {
+  RoboType(Class<?> type) {
     this.type = type;
   }
 
-  private final Class type;
+  private final Class<?> type;
 
-  public static Class findPrimitiveClass(String name) {
+  public static Class<?> findPrimitiveClass(String name) {
     for (RoboType type : RoboType.values()) {
       if (type.type != null && type.type.getName().equals(name)) {
         return type.type;

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/RobolectricInternals.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/RobolectricInternals.java
@@ -17,7 +17,7 @@ public class RobolectricInternals {
   private static ClassLoader classLoader;
 
   @SuppressWarnings("UnusedDeclaration")
-  public static void classInitializing(Class clazz) throws Exception {
+  public static void classInitializing(Class<?> clazz) {
     classHandler.classInitializing(clazz);
   }
 
@@ -36,8 +36,8 @@ public class RobolectricInternals {
     return classHandler.stripStackTrace(exception);
   }
 
-  public static Object intercept(String signature, Object instance, Object[] params, Class theClass)
-      throws Throwable {
+  public static Object intercept(
+      String signature, Object instance, Object[] params, Class<?> theClass) throws Throwable {
     try {
       return classHandler.intercept(signature, instance, params, theClass);
     } catch (java.lang.LinkageError e) {

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/SandboxClassLoader.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/SandboxClassLoader.java
@@ -10,6 +10,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
@@ -91,9 +93,9 @@ public class SandboxClassLoader extends URLClassLoader {
         try {
           urls.add(new File(entry).toURI().toURL());
         } catch (SecurityException e) { // File.toURI checks to see if the file is a directory
-          urls.add(new URL("file", null, new File(entry).getAbsolutePath()));
+          urls.add(new URI("file", null, new File(entry).getAbsolutePath()).toURL());
         }
-      } catch (MalformedURLException e) {
+      } catch (MalformedURLException | URISyntaxException e) {
         Logger.strict("malformed classpath entry: " + entry, e);
       }
     }

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowImpl.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowImpl.java
@@ -56,23 +56,23 @@ public class ShadowImpl implements IShadow {
   }
 
   @Override
-  @SuppressWarnings(value = {"unchecked", "TypeParameterUnusedInFormals"})
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   public <R, T> R directlyOn(
       T shadowedObject,
       Class<T> clazz,
       String methodName,
       ReflectionHelpers.ClassParameter<?>... paramValues) {
     String directMethodName = directMethodName(clazz.getName(), methodName);
-    return (R)
-        ReflectionHelpers.callInstanceMethod(clazz, shadowedObject, directMethodName, paramValues);
+    return ReflectionHelpers.callInstanceMethod(
+        clazz, shadowedObject, directMethodName, paramValues);
   }
 
   @Override
-  @SuppressWarnings(value = {"unchecked", "TypeParameterUnusedInFormals"})
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   public <R, T> R directlyOn(
       Class<T> clazz, String methodName, ReflectionHelpers.ClassParameter<?>... paramValues) {
     String directMethodName = directMethodName(clazz.getName(), methodName);
-    return (R) ReflectionHelpers.callStaticMethod(clazz, directMethodName, paramValues);
+    return ReflectionHelpers.callStaticMethod(clazz, directMethodName, paramValues);
   }
 
   private <T> T createProxy(T shadowedObject, Class<T> clazz) {
@@ -80,12 +80,12 @@ public class ShadowImpl implements IShadow {
   }
 
   @Override
-  @SuppressWarnings(value = {"unchecked", "TypeParameterUnusedInFormals"})
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   public <R> R invokeConstructor(
       Class<? extends R> clazz, R instance, ReflectionHelpers.ClassParameter<?>... paramValues) {
     String directMethodName =
         directMethodName(clazz.getName(), ShadowConstants.CONSTRUCTOR_METHOD_NAME);
-    return (R) ReflectionHelpers.callInstanceMethod(clazz, instance, directMethodName, paramValues);
+    return ReflectionHelpers.callInstanceMethod(clazz, instance, directMethodName, paramValues);
   }
 
   @Override

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowInvalidator.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowInvalidator.java
@@ -12,7 +12,7 @@ public class ShadowInvalidator {
     SwitchPoint.invalidateAll(new SwitchPoint[] {DUMMY});
   }
 
-  private Map<String, SwitchPoint> switchPoints;
+  private final Map<String, SwitchPoint> switchPoints;
 
   public ShadowInvalidator() {
     this.switchPoints = new HashMap<>();

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowMap.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowMap.java
@@ -205,9 +205,7 @@ public class ShadowMap {
 
     ShadowMap shadowMap = (ShadowMap) o;
 
-    if (!overriddenShadows.equals(shadowMap.overriddenShadows)) return false;
-
-    return true;
+    return overriddenShadows.equals(shadowMap.overriddenShadows);
   }
 
   @Override

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowWrangler.java
@@ -49,12 +49,7 @@ import org.robolectric.util.PerfStatsCollector;
 @Priority(Integer.MIN_VALUE)
 public class ShadowWrangler implements ClassHandler {
   public static final Function<Object, Object> DO_NOTHING_HANDLER =
-      new Function<Object, Object>() {
-        @Override
-        public Object call(Class<?> theClass, Object value, Object[] params) {
-          return null;
-        }
-      };
+      (theClass, value, params) -> null;
   public static final Method CALL_REAL_CODE = null;
   public static final MethodHandle DO_NOTHING =
       constant(Void.class, null).asType(methodType(void.class));
@@ -119,7 +114,7 @@ public class ShadowWrangler implements ClassHandler {
 
   @SuppressWarnings("ReferenceEquality")
   @Override
-  public void classInitializing(Class clazz) {
+  public void classInitializing(Class<?> clazz) {
     try {
       Method method =
           pickShadowMethod(clazz, ShadowConstants.STATIC_INITIALIZER_METHOD_NAME, NO_ARGS);
@@ -385,7 +380,7 @@ public class ShadowWrangler implements ClassHandler {
   }
 
   @Override
-  public Object intercept(String signature, Object instance, Object[] params, Class theClass)
+  public Object intercept(String signature, Object instance, Object[] params, Class<?> theClass)
       throws Throwable {
     final MethodSignature methodSignature = MethodSignature.parse(signature);
     return interceptors.getInterceptionHandler(methodSignature).call(theClass, instance, params);
@@ -436,7 +431,7 @@ public class ShadowWrangler implements ClassHandler {
         previousMethodName = methodName;
         previousFileName = fileName;
       }
-      throwable.setStackTrace(stackTrace.toArray(new StackTraceElement[stackTrace.size()]));
+      throwable.setStackTrace(stackTrace.toArray(new StackTraceElement[0]));
     }
     return throwable;
   }

--- a/sandbox/src/main/java/org/robolectric/util/JavaVersion.java
+++ b/sandbox/src/main/java/org/robolectric/util/JavaVersion.java
@@ -9,7 +9,7 @@ public class JavaVersion implements Comparable<JavaVersion> {
 
   public JavaVersion(String version) {
     versions = new ArrayList<>();
-    Scanner s = new Scanner(version).useDelimiter("[^\\d]+");
+    Scanner s = new Scanner(version).useDelimiter("\\D+");
     while (s.hasNext()) {
       versions.add(s.nextInt());
     }

--- a/sandbox/src/test/java/org/robolectric/ClassicSuperHandlingTest.java
+++ b/sandbox/src/test/java/org/robolectric/ClassicSuperHandlingTest.java
@@ -13,13 +13,13 @@ import org.robolectric.internal.bytecode.SandboxConfig;
 public class ClassicSuperHandlingTest {
   @Test
   @SandboxConfig(shadows = {ChildShadow.class, ParentShadow.class, GrandparentShadow.class})
-  public void uninstrumentedSubclassesShouldBeAbleToCallSuperWithoutLooping() throws Exception {
+  public void uninstrumentedSubclassesShouldBeAbleToCallSuperWithoutLooping() {
     assertEquals("4-3s-2s-1s-boof", new BabiesHavingBabies().method("boof"));
   }
 
   @Test
   @SandboxConfig(shadows = {ChildShadow.class, ParentShadow.class, GrandparentShadow.class})
-  public void shadowInvocationWhenAllAreShadowed() throws Exception {
+  public void shadowInvocationWhenAllAreShadowed() {
     assertEquals("3s-2s-1s-boof", new Child().method("boof"));
     assertEquals("2s-1s-boof", new Parent().method("boof"));
     assertEquals("1s-boof", new Grandparent().method("boof"));

--- a/sandbox/src/test/java/org/robolectric/RealApisTest.java
+++ b/sandbox/src/test/java/org/robolectric/RealApisTest.java
@@ -14,8 +14,7 @@ import org.robolectric.testing.Pony;
 public class RealApisTest {
   @Test
   @SandboxConfig(shadows = {ShimmeryShadowPony.class})
-  public void whenShadowHandlerIsInRealityBasedMode_shouldNotCallRealForUnshadowedMethod()
-      throws Exception {
+  public void whenShadowHandlerIsInRealityBasedMode_shouldNotCallRealForUnshadowedMethod() {
     assertEquals("Off I saunter to the salon!", new Pony().saunter("the salon"));
   }
 
@@ -24,7 +23,7 @@ public class RealApisTest {
 
   @Test
   @SandboxConfig(shadows = {ShadowOfClassWithSomeConstructors.class})
-  public void shouldCallOriginalConstructorBodySomehow() throws Exception {
+  public void shouldCallOriginalConstructorBodySomehow() {
     ClassWithSomeConstructors o = new ClassWithSomeConstructors("my name");
     assertEquals("my name", o.name);
   }

--- a/sandbox/src/test/java/org/robolectric/RobolectricInternalsTest.java
+++ b/sandbox/src/test/java/org/robolectric/RobolectricInternalsTest.java
@@ -172,7 +172,7 @@ public class RobolectricInternalsTest {
 
   @Instrument
   static class Outer {
-    public String outerParam = null;
+    public String outerParam;
 
     public Outer(String param) {
       this.outerParam = param;

--- a/sandbox/src/test/java/org/robolectric/ShadowWranglerIntegrationTest.java
+++ b/sandbox/src/test/java/org/robolectric/ShadowWranglerIntegrationTest.java
@@ -139,7 +139,7 @@ public class ShadowWranglerIntegrationTest {
 
   @Instrument
   public static class ThrowInShadowMethod {
-    public void method() throws IOException {}
+    public void method() {}
   }
 
   @Implements(ThrowInShadowMethod.class)
@@ -278,11 +278,11 @@ public class ShadowWranglerIntegrationTest {
   }
 
   private ShadowFoo shadowOf(Foo foo) {
-    return (ShadowFoo) Shadow.extract(foo);
+    return Shadow.extract(foo);
   }
 
   private ShadowTextFoo shadowOf(TextFoo foo) {
-    return (ShadowTextFoo) Shadow.extract(foo);
+    return Shadow.extract(foo);
   }
 
   @Implements(Foo.class)
@@ -357,11 +357,11 @@ public class ShadowWranglerIntegrationTest {
   @Instrument
   public static class AClassWithGenericFunctionParam {
     public CharSequence aMethod(List<CharSequence> strs) {
-      String ret = "";
+      StringBuilder ret = new StringBuilder();
       for (CharSequence s : strs) {
-        ret = ret + s;
+        ret.append(s);
       }
-      return ret;
+      return ret.toString();
     }
   }
 

--- a/sandbox/src/test/java/org/robolectric/ShadowingTest.java
+++ b/sandbox/src/test/java/org/robolectric/ShadowingTest.java
@@ -26,7 +26,7 @@ public class ShadowingTest {
 
   @Test
   @SandboxConfig(shadows = {ShadowAccountManagerForTests.class})
-  public void testStaticMethodsAreDelegated() throws Exception {
+  public void testStaticMethodsAreDelegated() {
     Object arg = mock(Object.class);
     AccountManager.get(arg);
     assertThat(ShadowAccountManagerForTests.wasCalled).isTrue();
@@ -55,7 +55,7 @@ public class ShadowingTest {
 
   @Test
   @SandboxConfig(shadows = {ShadowClassWithProtectedMethod.class})
-  public void testProtectedMethodsAreDelegated() throws Exception {
+  public void testProtectedMethodsAreDelegated() {
     ClassWithProtectedMethod overlay = new ClassWithProtectedMethod();
     assertEquals("shadow name", overlay.getName());
   }
@@ -77,7 +77,7 @@ public class ShadowingTest {
 
   @Test
   @SandboxConfig(shadows = {ShadowPaintForTests.class})
-  public void testNativeMethodsAreDelegated() throws Exception {
+  public void testNativeMethodsAreDelegated() {
     Paint paint = new Paint();
     paint.setColor(1234);
 
@@ -129,7 +129,7 @@ public class ShadowingTest {
 
   @Test
   @SandboxConfig(shadows = {Pony.ShadowPony.class})
-  public void directlyOn_shouldCallThroughToOriginalMethodBody() throws Exception {
+  public void directlyOn_shouldCallThroughToOriginalMethodBody() {
     Pony pony = new Pony();
 
     assertEquals("Fake whinny! You're on my neck!", pony.ride("neck"));
@@ -140,7 +140,7 @@ public class ShadowingTest {
 
   @Test
   @SandboxConfig(shadows = {Pony.ShadowPony.class})
-  public void shouldCallRealForUnshadowedMethod() throws Exception {
+  public void shouldCallRealForUnshadowedMethod() {
     assertEquals("Off I saunter to the salon!", new Pony().saunter("the salon"));
   }
 
@@ -189,7 +189,7 @@ public class ShadowingTest {
 
   @Test
   @SandboxConfig(shadows = {ShadowApiImplementedClass.class})
-  public void withNonApiSubclassesWhichExtendApi_shouldStillBeInvoked() throws Exception {
+  public void withNonApiSubclassesWhichExtendApi_shouldStillBeInvoked() {
     assertEquals("did foo", new NonApiSubclass().doSomething("foo"));
   }
 

--- a/sandbox/src/test/java/org/robolectric/StaticInitializerTest.java
+++ b/sandbox/src/test/java/org/robolectric/StaticInitializerTest.java
@@ -2,6 +2,7 @@ package org.robolectric;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -16,7 +17,7 @@ import org.robolectric.internal.bytecode.SandboxConfig;
 @RunWith(SandboxTestRunner.class)
 public class StaticInitializerTest {
   @Test
-  public void whenClassIsUnshadowed_shouldPerformStaticInitialization() throws Exception {
+  public void whenClassIsUnshadowed_shouldPerformStaticInitialization() {
     assertEquals("Floyd", ClassWithStaticInitializerA.name);
   }
 
@@ -48,7 +49,7 @@ public class StaticInitializerTest {
   public void whenClassHasShadowWithOverrideMethod_shouldDeferStaticInitialization()
       throws Exception {
     assertFalse(ShadowClassWithStaticInitializerOverride.initialized);
-    assertEquals(null, ClassWithStaticInitializerC.name);
+    assertNull(ClassWithStaticInitializerC.name);
     assertTrue(ShadowClassWithStaticInitializerOverride.initialized);
 
     RobolectricInternals.performStaticInitialization(ClassWithStaticInitializerC.class);

--- a/sandbox/src/test/java/org/robolectric/internal/bytecode/ProxyMakerTest.java
+++ b/sandbox/src/test/java/org/robolectric/internal/bytecode/ProxyMakerTest.java
@@ -12,12 +12,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ProxyMakerTest {
   private static final ProxyMaker.MethodMapper IDENTITY_NAME =
-      new ProxyMaker.MethodMapper() {
-        @Override
-        public String getName(String className, String methodName) {
-          return methodName;
-        }
-      };
+      (className, methodName) -> methodName;
 
   @Test
   public void proxyCall() {


### PR DESCRIPTION
- Replace `Function` construction with lambdas.
- Fix generic class usages.
- Remove unnecessary `throws` declarations.
- Use `try-with-resource` where necessary.
- Use `assertNull()` instead of `assertEquals()` with a `null` argument.
- Fix typo.