### PR TITLE
Fix warnings in the `utils` module

### DIFF
--- a/utils/reflector/src/main/java/org/robolectric/util/reflector/Reflector.java
+++ b/utils/reflector/src/main/java/org/robolectric/util/reflector/Reflector.java
@@ -1,11 +1,11 @@
 package org.robolectric.util.reflector;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -120,7 +120,7 @@ public class Reflector {
     if (DEBUG) {
       File file = new File("/tmp", reflectorClassName + ".class");
       System.out.println("Generated reflector: " + file.getAbsolutePath());
-      try (OutputStream out = new FileOutputStream(file)) {
+      try (OutputStream out = Files.newOutputStream(file.toPath())) {
         out.write(bytecode);
       } catch (IOException e) {
         throw new RuntimeException(e);
@@ -146,7 +146,7 @@ public class Reflector {
     ClassLoader classLoader =
         new ClassLoader(iClass.getClassLoader()) {
           @Override
-          protected Class<?> findClass(String name) throws ClassNotFoundException {
+          protected Class<?> findClass(String name) {
             return defineClass(name, bytecode, 0, bytecode.length);
           }
         };

--- a/utils/reflector/src/main/java/org/robolectric/util/reflector/UnsafeAccess.java
+++ b/utils/reflector/src/main/java/org/robolectric/util/reflector/UnsafeAccess.java
@@ -49,7 +49,6 @@ public class UnsafeAccess {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T> Class<?> defineClass(Class<T> iClass, String reflectorClassName, byte[] bytecode) {
       // use reflection to call since this method does not exist on JDK11
       try {

--- a/utils/reflector/src/test/java/org/robolectric/util/reflector/ReflectorTest.java
+++ b/utils/reflector/src/test/java/org/robolectric/util/reflector/ReflectorTest.java
@@ -17,13 +17,12 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
 @RunWith(JUnit4.class)
 public class ReflectorTest {
 
-  private SomeClass someClass;
   private _SomeClass_ reflector;
   private _SomeClass_ staticReflector;
 
   @Before
-  public void setUp() throws Exception {
-    someClass = new SomeClass("c");
+  public void setUp() {
+    SomeClass someClass = new SomeClass("c");
     reflector = reflector(_SomeClass_.class, someClass);
 
     staticReflector = reflector(_SomeClass_.class, null);
@@ -144,11 +143,11 @@ public class ReflectorTest {
     _SomeClass_ accessor = reflector(_SomeClass_.class, i);
 
     time("ReflectionHelpers", 10_000_000, this::constructorByReflectionHelpers);
-    time("accessor", 10_000_000, () -> constructorByReflector());
+    time("accessor", 10_000_000, this::constructorByReflector);
     time("saved accessor", 10_000_000, () -> constructorBySavedReflector(accessor));
 
-    time("ReflectionHelpers", 10_000_000, () -> constructorByReflectionHelpers());
-    time("accessor", 10_000_000, () -> constructorByReflector());
+    time("ReflectionHelpers", 10_000_000, this::constructorByReflectionHelpers);
+    time("accessor", 10_000_000, this::constructorByReflector);
     time("saved accessor", 10_000_000, () -> constructorBySavedReflector(accessor));
   }
 
@@ -259,8 +258,8 @@ public class ReflectorTest {
     for (int i = 0; i < times; i++) {
       runnable.run();
     }
-    long elasedMs = System.currentTimeMillis() - startTime;
-    System.out.println(name + " took " + elasedMs);
+    long elapsedMs = System.currentTimeMillis() - startTime;
+    System.out.println(name + " took " + elapsedMs);
   }
 
   private String methodByReflectionHelpers(SomeClass o) {

--- a/utils/src/main/java/org/robolectric/util/Join.java
+++ b/utils/src/main/java/org/robolectric/util/Join.java
@@ -4,12 +4,12 @@ import java.util.Collection;
 
 /** Utility class used to join strings together with a delimiter. */
 public class Join {
-  public static String join(String delimiter, Collection collection) {
+  public static String join(String delimiter, Collection<?> collection) {
     String del = "";
     StringBuilder sb = new StringBuilder();
     for (Object obj : collection) {
       String asString = obj == null ? null : obj.toString();
-      if (obj != null && asString.length() > 0) {
+      if (obj != null && !asString.isEmpty()) {
         sb.append(del).append(obj);
         del = delimiter;
       }
@@ -22,7 +22,7 @@ public class Join {
     StringBuilder sb = new StringBuilder();
     for (Object obj : collection) {
       String asString = obj == null ? null : obj.toString();
-      if (asString != null && asString.length() > 0) {
+      if (asString != null && !asString.isEmpty()) {
         sb.append(del).append(asString);
         del = delimiter;
       }

--- a/utils/src/main/java/org/robolectric/util/PerfStatsCollector.java
+++ b/utils/src/main/java/org/robolectric/util/PerfStatsCollector.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.robolectric.pluginapi.perf.Metadata;
 import org.robolectric.pluginapi.perf.Metric;
 import org.robolectric.pluginapi.perf.PerfStatsReporter;
@@ -169,7 +170,7 @@ public class PerfStatsCollector {
       if (success != metricKey.success) {
         return false;
       }
-      return name != null ? name.equals(metricKey.name) : metricKey.name == null;
+      return Objects.equals(name, metricKey.name);
     }
 
     @Override

--- a/utils/src/main/java/org/robolectric/util/Scheduler.java
+++ b/utils/src/main/java/org/robolectric/util/Scheduler.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.Iterator;
 import java.util.PriorityQueue;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 
 /**
  * Class that manages a queue of Runnables that are scheduled to run now (or at some time in the
@@ -397,7 +398,7 @@ public class Scheduler {
     }
 
     @Override
-    public int compareTo(ScheduledRunnable runnable) {
+    public int compareTo(@Nonnull ScheduledRunnable runnable) {
       int timeCompare = Long.compare(scheduledTime, runnable.scheduledTime);
       if (timeCompare == 0) {
         return Long.compare(timeDisambiguator, runnable.timeDisambiguator);

--- a/utils/src/main/java/org/robolectric/util/SimplePerfStatsReporter.java
+++ b/utils/src/main/java/org/robolectric/util/SimplePerfStatsReporter.java
@@ -6,7 +6,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.TreeMap;
+import javax.annotation.Nonnull;
 import org.robolectric.AndroidMetadata;
 import org.robolectric.pluginapi.perf.Metadata;
 import org.robolectric.pluginapi.perf.Metric;
@@ -99,7 +101,7 @@ public class SimplePerfStatsReporter implements PerfStatsReporter {
       if (success != metricKey.success) {
         return false;
       }
-      if (name != null ? !name.equals(metricKey.name) : metricKey.name != null) {
+      if (!Objects.equals(name, metricKey.name)) {
         return false;
       }
       if (sdkLevel != metricKey.sdkLevel) {
@@ -117,7 +119,7 @@ public class SimplePerfStatsReporter implements PerfStatsReporter {
     }
 
     @Override
-    public int compareTo(MetricKey o) {
+    public int compareTo(@Nonnull MetricKey o) {
       int i = name.compareTo(o.name);
       if (i != 0) {
         return i;

--- a/utils/src/main/java/org/robolectric/util/TempDirectory.java
+++ b/utils/src/main/java/org/robolectric/util/TempDirectory.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import javax.annotation.Nonnull;
 
 /**
  * A helper class for working with temporary directories. All temporary directories created by this
@@ -64,7 +65,7 @@ public class TempDirectory {
 
     synchronized (tempDirectoriesToDelete) {
       // If we haven't initialised the shutdown hook we should set everything up.
-      if (tempDirectoriesToDelete.size() == 0) {
+      if (tempDirectoriesToDelete.isEmpty()) {
         // Use a manual hook that actually clears the directory
         // This is necessary because File.deleteOnExit won't delete non empty directories
         Runtime.getRuntime().addShutdownHook(new Thread(TempDirectory::clearAllDirectories));
@@ -157,8 +158,9 @@ public class TempDirectory {
     Files.walkFileTree(
         directory,
         new SimpleFileVisitor<Path>() {
+          @Nonnull
           @Override
-          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+          public FileVisitResult visitFile(Path file, @Nonnull BasicFileAttributes attrs)
               throws IOException {
             // Avoid deleting the obsolete temp directory marker
             if (!(OsUtil.isWindows()
@@ -168,6 +170,7 @@ public class TempDirectory {
             return FileVisitResult.CONTINUE;
           }
 
+          @Nonnull
           @Override
           public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
             if (!dir.equals(directory)) {

--- a/utils/src/main/java/org/robolectric/util/inject/Injector.java
+++ b/utils/src/main/java/org/robolectric/util/inject/Injector.java
@@ -244,7 +244,6 @@ public class Injector {
     return new MemoizingProvider<>(tProvider);
   }
 
-  @SuppressWarnings("unchecked")
   @Nonnull
   private <T> T inject(@Nonnull Class<? extends T> implementingClass) {
     Constructor<T> ctor;
@@ -264,6 +263,7 @@ public class Injector {
     }
   }
 
+  @SuppressWarnings("unchecked")
   private <T> Constructor<T> findConstructor(@Nonnull Class<? extends T> implementingClass) {
     List<Constructor<T>> injectCtors = new ArrayList<>();
     List<Constructor<T>> otherCtors = new ArrayList<>();
@@ -405,7 +405,7 @@ public class Injector {
       this(theInterface, null);
     }
 
-    public Key(Type theInterface, String name) {
+    public Key(@Nonnull Type theInterface, String name) {
       this.theInterface = theInterface;
       this.name = name;
     }
@@ -423,7 +423,7 @@ public class Injector {
       if (!(o instanceof Key)) {
         return false;
       }
-      Key key = (Key) o;
+      Key<?> key = (Key<?>) o;
       return theInterface.equals(key.theInterface) && Objects.equals(name, key.name);
     }
 
@@ -447,7 +447,7 @@ public class Injector {
       StringBuilder buf = new StringBuilder();
       buf.append(
           theInterface instanceof Class
-              ? ((Class) theInterface).getSimpleName()
+              ? ((Class<?>) theInterface).getSimpleName()
               : theInterface.getTypeName());
       if (name != null) {
         buf.append(" \"").append(name).append("\"");
@@ -456,7 +456,7 @@ public class Injector {
     }
 
     public boolean isArray() {
-      return (theInterface instanceof Class && ((Class) theInterface).isArray())
+      return (theInterface instanceof Class && ((Class<?>) theInterface).isArray())
           || theInterface instanceof GenericArrayType;
     }
 
@@ -471,7 +471,7 @@ public class Injector {
     Class<?> getComponentType() {
       if (isArray()) {
         if (theInterface instanceof Class) {
-          return ((Class) theInterface).getComponentType();
+          return ((Class<?>) theInterface).getComponentType();
         } else if (theInterface instanceof GenericArrayType) {
           Type genericComponentType = ((GenericArrayType) theInterface).getGenericComponentType();
           return (Class<?>) ((ParameterizedType) genericComponentType).getRawType();
@@ -479,7 +479,7 @@ public class Injector {
           throw new InjectionException(this, new IllegalArgumentException());
         }
       } else if (isCollection() && theInterface instanceof ParameterizedType) {
-        return (Class) ((ParameterizedType) theInterface).getActualTypeArguments()[0];
+        return (Class<?>) ((ParameterizedType) theInterface).getActualTypeArguments()[0];
       } else {
         throw new IllegalStateException(theInterface + "...?");
       }
@@ -487,7 +487,7 @@ public class Injector {
 
     boolean isAutoFactory() {
       return theInterface instanceof Class
-          && ((Class) theInterface).isAnnotationPresent(AutoFactory.class);
+          && ((Class<?>) theInterface).isAnnotationPresent(AutoFactory.class);
     }
   }
 

--- a/utils/src/test/java/org/robolectric/util/inject/InjectorTest.java
+++ b/utils/src/test/java/org/robolectric/util/inject/InjectorTest.java
@@ -25,20 +25,20 @@ public class InjectorTest {
   private final List<Class<?>> pluginClasses = new ArrayList<>();
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     builder = new Injector.Builder();
     injector = builder.build();
   }
 
   @Test
-  public void whenImplSpecified_shouldProvideInstance() throws Exception {
+  public void whenImplSpecified_shouldProvideInstance() {
     injector = builder.bind(Thing.class, MyThing.class).build();
 
     assertThat(injector.getInstance(Thing.class)).isInstanceOf(MyThing.class);
   }
 
   @Test
-  public void whenImplSpecified_shouldUseSameInstance() throws Exception {
+  public void whenImplSpecified_shouldUseSameInstance() {
     injector = builder.bind(Thing.class, MyThing.class).build();
 
     Thing thing = injector.getInstance(Thing.class);
@@ -46,36 +46,36 @@ public class InjectorTest {
   }
 
   @Test
-  public void whenServiceSpecified_shouldProvideInstance() throws Exception {
+  public void whenServiceSpecified_shouldProvideInstance() {
     assertThat(injector.getInstance(Thing.class)).isInstanceOf(ThingFromServiceConfig.class);
   }
 
   @Test
-  public void whenServiceSpecified_shouldUseSameInstance() throws Exception {
+  public void whenServiceSpecified_shouldUseSameInstance() {
     Thing thing = injector.getInstance(Thing.class);
     assertThat(injector.getInstance(Thing.class)).isSameInstanceAs(thing);
   }
 
   @Test
-  public void whenConcreteClassRequested_shouldProvideInstance() throws Exception {
+  public void whenConcreteClassRequested_shouldProvideInstance() {
     assertThat(injector.getInstance(MyUmm.class)).isInstanceOf(MyUmm.class);
   }
 
   @Test
-  public void whenDefaultSpecified_shouldProvideInstance() throws Exception {
+  public void whenDefaultSpecified_shouldProvideInstance() {
     injector = builder.bindDefault(Umm.class, MyUmm.class).build();
 
     assertThat(injector.getInstance(Umm.class)).isInstanceOf(MyUmm.class);
   }
 
   @Test
-  public void whenDefaultSpecified_shouldUseSameInstance() throws Exception {
+  public void whenDefaultSpecified_shouldUseSameInstance() {
     Thing thing = injector.getInstance(Thing.class);
     assertThat(injector.getInstance(Thing.class)).isSameInstanceAs(thing);
   }
 
   @Test
-  public void whenNoImplOrServiceOrDefaultSpecified_shouldThrow() throws Exception {
+  public void whenNoImplOrServiceOrDefaultSpecified_shouldThrow() {
     try {
       injector.getInstance(Umm.class);
       fail();
@@ -85,8 +85,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void registerDefaultService_providesFallbackImplOnlyIfNoServiceSpecified()
-      throws Exception {
+  public void registerDefaultService_providesFallbackImplOnlyIfNoServiceSpecified() {
     builder.bindDefault(Thing.class, MyThing.class);
 
     assertThat(injector.getInstance(Thing.class)).isInstanceOf(ThingFromServiceConfig.class);
@@ -96,7 +95,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void shouldPreferSingularPublicConstructorAnnotatedInject() throws Exception {
+  public void shouldPreferSingularPublicConstructorAnnotatedInject() {
     injector = builder.bind(Thing.class, MyThing.class).bind(Umm.class, MyUmm.class).build();
 
     Umm umm = injector.getInstance(Umm.class);
@@ -111,7 +110,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void shouldAcceptSingularPublicConstructorWithoutInjectAnnotation() throws Exception {
+  public void shouldAcceptSingularPublicConstructorWithoutInjectAnnotation() {
     injector =
         builder.bind(Thing.class, MyThing.class).bind(Umm.class, MyUmmNoInject.class).build();
 
@@ -127,7 +126,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void whenArrayRequested_mayReturnMultiplePlugins() throws Exception {
+  public void whenArrayRequested_mayReturnMultiplePlugins() {
     MultiThing[] multiThings = injector.getInstance(MultiThing[].class);
 
     // X comes first because it has a higher priority
@@ -137,7 +136,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void whenCollectionRequested_mayReturnMultiplePlugins() throws Exception {
+  public void whenCollectionRequested_mayReturnMultiplePlugins() {
     ThingRequiringMultiThings it = injector.getInstance(ThingRequiringMultiThings.class);
 
     // X comes first because it has a higher priority
@@ -147,7 +146,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void whenListRequested_itIsUnmodifiable() throws Exception {
+  public void whenListRequested_itIsUnmodifiable() {
     ThingRequiringMultiThings it = injector.getInstance(ThingRequiringMultiThings.class);
 
     try {
@@ -159,7 +158,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void autoFactory_factoryMethodsCreateNewInstances() throws Exception {
+  public void autoFactory_factoryMethodsCreateNewInstances() {
     injector = builder.bind(Umm.class, MyUmm.class).build();
     FooFactory factory = injector.getInstance(FooFactory.class);
     Foo chauncey = factory.create("Chauncey");
@@ -170,7 +169,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void autoFactory_injectedValuesComeFromSuperInjector() throws Exception {
+  public void autoFactory_injectedValuesComeFromSuperInjector() {
     injector = builder.bind(Umm.class, MyUmm.class).build();
     FooFactory factory = injector.getInstance(FooFactory.class);
     Foo chauncey = factory.create("Chauncey");
@@ -178,7 +177,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void whenFactoryRequested_createsInjectedFactory() throws Exception {
+  public void whenFactoryRequested_createsInjectedFactory() {
     injector = builder.bind(Umm.class, MyUmm.class).build();
     FooFactory factory = injector.getInstance(FooFactory.class);
     Foo chauncey = factory.create("Chauncey");
@@ -191,7 +190,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void scopedInjector_shouldCheckParentBeforeProvidingDefault() throws Exception {
+  public void scopedInjector_shouldCheckParentBeforeProvidingDefault() {
     injector = builder.build();
     Injector subInjector = new Injector.Builder(injector).build();
 
@@ -200,7 +199,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void shouldInjectByNamedKeys() throws Exception {
+  public void shouldInjectByNamedKeys() {
     injector =
         builder
             .bind(new Injector.Key<>(String.class, "namedThing"), "named value")
@@ -212,7 +211,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void shouldPreferPluginsOverConcreteClass() throws Exception {
+  public void shouldPreferPluginsOverConcreteClass() {
     PluginFinder pluginFinder = new PluginFinder(new MyServiceFinderAdapter(pluginClasses));
     Injector injector = new Injector.Builder(null, pluginFinder).build();
     pluginClasses.add(SubclassOfConcreteThing.class);
@@ -221,7 +220,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void subInjectorIsUsedForResolvingTransitiveDependencies() throws Exception {
+  public void subInjectorIsUsedForResolvingTransitiveDependencies() {
     FakeSandboxManager sandboxManager = injector.getInstance(FakeSandboxManager.class);
     FakeSdk runtimeSdk = new FakeSdk("runtime");
     FakeSdk compileSdk = new FakeSdk("compile");
@@ -232,7 +231,7 @@ public class InjectorTest {
 
   @Test
   @Ignore("todo")
-  public void objectsCreatedByFactoryShareTransitiveDependencies() throws Exception {
+  public void objectsCreatedByFactoryShareTransitiveDependencies() {
     FakeSandboxManager sandboxManager = injector.getInstance(FakeSandboxManager.class);
     FakeSdk runtimeSdk = new FakeSdk("runtime");
     FakeSdk compileASdk = new FakeSdk("compileA");
@@ -243,7 +242,7 @@ public class InjectorTest {
   }
 
   @Test
-  public void shouldProvideDecentErrorMessages() throws Exception {
+  public void shouldProvideDecentErrorMessages() {
     FakeSandboxManager sandboxManager = injector.getInstance(FakeSandboxManager.class);
     Exception actualException = null;
     try {
@@ -258,7 +257,7 @@ public class InjectorTest {
 
   @Test
   @Ignore("todo")
-  public void shouldOnlyAttemptToResolveTypesKnownToClassLoader() throws Exception {}
+  public void shouldOnlyAttemptToResolveTypesKnownToClassLoader() {}
 
   /////////////////////////////
 
@@ -295,7 +294,7 @@ public class InjectorTest {
     }
 
     @SuppressWarnings("unused")
-    public MyUmm(String thingz) {
+    public MyUmm(String thing) {
       this.thing = null;
     }
   }

--- a/utils/src/test/java/org/robolectric/util/inject/MyServiceFinderAdapter.kt
+++ b/utils/src/test/java/org/robolectric/util/inject/MyServiceFinderAdapter.kt
@@ -6,7 +6,7 @@ import org.robolectric.util.inject.PluginFinder.ServiceFinderAdapter
 internal class MyServiceFinderAdapter(private val pluginClasses: List<Class<*>>) :
   ServiceFinderAdapter(null) {
   @Nonnull
-  public override fun <T> load(pluginType: Class<T>): Iterable<Class<out T>> {
+  override fun <T> load(pluginType: Class<T>): Iterable<Class<out T>> {
     return fill()
   }
 


### PR DESCRIPTION
Specifically, it:
- Fixes generic usages.
- Adds some nullability annotations.
- Removes unnecessary `throws` declarations.
- Uses `Objects.equals()`.
- Fixes some typo.