### PR TITLE
Remove unused dependencies

### DIFF
--- a/shadows/httpclient/build.gradle.kts
+++ b/shadows/httpclient/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
   testImplementation(project(":robolectric"))
   testImplementation(libs.junit4)
   testImplementation(libs.truth)
-  testImplementation(libs.mockito)
   testImplementation("androidx.test.ext:junit:$axtJunitVersion@aar")
 
   testCompileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates)

--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -19,7 +19,6 @@ tasks.compileKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 tasks.compileTestKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
 dependencies {
-  api(project(":annotations"))
   api(project(":pluginapi"))
   api(libs.javax.inject)
   api(libs.javax.annotation.api)
@@ -29,7 +28,6 @@ dependencies {
   testCompileOnly(libs.auto.service.annotations)
   testAnnotationProcessor(libs.auto.service)
   testAnnotationProcessor(libs.error.prone.core)
-  implementation(libs.error.prone.annotations)
 
   testImplementation(libs.junit4)
   testImplementation(libs.truth)

--- a/utils/reflector/build.gradle.kts
+++ b/utils/reflector/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 dependencies {
   api(libs.asm)
   api(libs.asm.commons)
-  api(libs.asm.util)
   api(project(":utils"))
 
   testImplementation(project(":shadowapi"))


### PR DESCRIPTION
This commit removes unused dependencies on recently reviewed modules:
- `:shadows:httpclient`:
  - `libs.mockito`
- `:utils`:
  - `project(":annotations")`
  - `libs.error.prone.annotations`
- `:utils:reflector`:
  - `libs.asm.util`