### PR TITLE
Fix warnings in `:shadows:playservices`

### DIFF
--- a/shadows/playservices/src/main/java/org/robolectric/shadows/gms/ShadowGoogleAuthUtil.java
+++ b/shadows/playservices/src/main/java/org/robolectric/shadows/gms/ShadowGoogleAuthUtil.java
@@ -207,7 +207,7 @@ public class ShadowGoogleAuthUtil {
         String authority,
         Bundle syncBundle)
         throws IOException, UserRecoverableNotifiedException, GoogleAuthException {
-      if (authority == null || authority.length() == 0) {
+      if (authority == null || authority.isEmpty()) {
         throw new IllegalArgumentException("Authority cannot be empty.");
       }
       return "token";

--- a/shadows/playservices/src/main/java/org/robolectric/shadows/gms/common/ShadowGoogleApiAvailability.java
+++ b/shadows/playservices/src/main/java/org/robolectric/shadows/gms/common/ShadowGoogleApiAvailability.java
@@ -14,7 +14,6 @@ import org.robolectric.shadow.api.Shadow;
 public class ShadowGoogleApiAvailability {
   private int availabilityCode = ConnectionResult.SERVICE_MISSING;
   private boolean isUserResolvableError = false;
-  private String openSourceSoftwareLicenseInfo = "";
   private Dialog errorDialog;
 
   @Implementation
@@ -42,7 +41,7 @@ public class ShadowGoogleApiAvailability {
 
   @Implementation
   public String getOpenSourceSoftwareLicenseInfo(Context context) {
-    return openSourceSoftwareLicenseInfo;
+    return "";
   }
 
   @Implementation


### PR DESCRIPTION
- Remove unnecessary `throws` declaration.
- Remove never-updated private field.