### PR TITLE
Enable native SQLite on Windows

### DIFF
--- a/robolectric/src/main/java/org/robolectric/plugins/SQLiteModeConfigurer.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/SQLiteModeConfigurer.java
@@ -2,12 +2,9 @@ package org.robolectric.plugins;
 
 import com.google.auto.service.AutoService;
 import java.util.Properties;
-import javax.annotation.Nonnull;
 import org.robolectric.annotation.SQLiteMode;
-import org.robolectric.annotation.SQLiteMode.Mode;
 import org.robolectric.pluginapi.config.Configurer;
 import org.robolectric.plugins.config.SingleValueConfigurer;
-import org.robolectric.util.OsUtil;
 
 /** Provides configuration to Robolectric for its @{@link SQLiteMode} annotation. */
 @AutoService(Configurer.class)
@@ -18,7 +15,7 @@ public class SQLiteModeConfigurer extends SingleValueConfigurer<SQLiteMode, SQLi
     super(
         SQLiteMode.class,
         SQLiteMode.Mode.class,
-        defaultValue(),
+        SQLiteMode.Mode.NATIVE,
         propertyFileLoader,
         systemProperties);
   }
@@ -26,14 +23,5 @@ public class SQLiteModeConfigurer extends SingleValueConfigurer<SQLiteMode, SQLi
   @Override
   protected String propertyName() {
     return "sqliteMode";
-  }
-
-  @Nonnull
-  private static SQLiteMode.Mode defaultValue() {
-    // NATIVE SQLite mode not supported on Windows
-    if (OsUtil.isWindows()) {
-      return Mode.LEGACY;
-    }
-    return Mode.NATIVE;
   }
 }

--- a/robolectric/src/test/java/org/robolectric/plugins/SQLiteModeConfigurerTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/SQLiteModeConfigurerTest.java
@@ -1,6 +1,5 @@
 package org.robolectric.plugins;
 
-import static com.google.common.base.StandardSystemProperty.OS_NAME;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.Properties;
@@ -28,28 +27,5 @@ public class SQLiteModeConfigurerTest {
         new SQLiteModeConfigurer(systemProperties2, new PackagePropertiesLoader());
     systemProperties2.setProperty("robolectric.sqliteMode", "NATIVE");
     assertThat(configurer2.defaultConfig()).isSameInstanceAs(Mode.NATIVE);
-  }
-
-  @Test
-  public void osArchSpecificConfig() {
-    String oldName = OS_NAME.value();
-    try {
-      System.setProperty("os.name", "Mac OS X");
-      SQLiteModeConfigurer configurer1 =
-          new SQLiteModeConfigurer(System.getProperties(), new PackagePropertiesLoader());
-      assertThat(configurer1.defaultConfig()).isSameInstanceAs(Mode.NATIVE);
-
-      System.setProperty("os.name", "Windows 7");
-      SQLiteModeConfigurer configurer2 =
-          new SQLiteModeConfigurer(System.getProperties(), new PackagePropertiesLoader());
-
-      assertThat(configurer2.defaultConfig()).isSameInstanceAs(Mode.LEGACY);
-    } finally {
-      if (oldName != null) {
-        System.setProperty("os.name", oldName);
-      } else {
-        System.clearProperty("os.name");
-      }
-    }
   }
 }


### PR DESCRIPTION
Native SQLite is supported on Windows since [Robolectric 4.12](https://github.com/robolectric/robolectric/releases/tag/robolectric-4.12).

This commit makes it the default in `SQLiteModeConfigurer`, independently of the platform.