### PR TITLE
Remove unnecessary `throws` declarations in `robolectric`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/AttributeSetBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/AttributeSetBuilderTest.java
@@ -27,7 +27,7 @@ public class AttributeSetBuilderTest {
   private static final String APP_NS = RES_AUTO_NS_URI;
 
   @Test
-  public void getAttributeResourceValue_shouldReturnTheResourceValue() throws Exception {
+  public void getAttributeResourceValue_shouldReturnTheResourceValue() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet()
             .addAttribute(android.R.attr.text, "@android:string/ok")
@@ -38,8 +38,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeResourceValueWithLeadingWhitespace_shouldReturnTheResourceValue()
-      throws Exception {
+  public void getAttributeResourceValueWithLeadingWhitespace_shouldReturnTheResourceValue() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet()
             .addAttribute(android.R.attr.text, " @android:string/ok")
@@ -50,8 +49,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getSystemAttributeResourceValue_shouldReturnDefaultValueForNullResourceId()
-      throws Exception {
+  public void getSystemAttributeResourceValue_shouldReturnDefaultValueForNullResourceId() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet()
             .addAttribute(android.R.attr.text, AttributeResource.NULL_VALUE)
@@ -64,8 +62,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getSystemAttributeResourceValue_shouldReturnDefaultValueForNonMatchingNamespaceId()
-      throws Exception {
+  public void getSystemAttributeResourceValue_shouldReturnDefaultValueForNonMatchingNamespaceId() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(android.R.attr.id, "@+id/text1").build();
 
@@ -76,7 +73,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void shouldCopeWithDefiningLocalIds() throws Exception {
+  public void shouldCopeWithDefiningLocalIds() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(android.R.attr.id, "@+id/text1").build();
 
@@ -85,8 +82,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeResourceValue_withNamespace_shouldReturnTheResourceValue()
-      throws Exception {
+  public void getAttributeResourceValue_withNamespace_shouldReturnTheResourceValue() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(R.attr.message, "@string/howdy").build();
 
@@ -95,8 +91,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeResourceValue_shouldReturnDefaultValueWhenAttributeIsNull()
-      throws Exception {
+  public void getAttributeResourceValue_shouldReturnDefaultValueWhenAttributeIsNull() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet()
             .addAttribute(android.R.attr.text, AttributeResource.NULL_VALUE)
@@ -106,15 +101,14 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeResourceValue_shouldReturnDefaultValueWhenNotInAttributeSet()
-      throws Exception {
+  public void getAttributeResourceValue_shouldReturnDefaultValueWhenNotInAttributeSet() {
     AttributeSet roboAttributeSet = Robolectric.buildAttributeSet().build();
 
     assertThat(roboAttributeSet.getAttributeResourceValue(APP_NS, "message", -1)).isEqualTo(-1);
   }
 
   @Test
-  public void getAttributeBooleanValue_shouldGetBooleanValuesFromAttributes() throws Exception {
+  public void getAttributeBooleanValue_shouldGetBooleanValuesFromAttributes() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(R.attr.isSugary, "true").build();
 
@@ -122,8 +116,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeBooleanValue_withNamespace_shouldGetBooleanValuesFromAttributes()
-      throws Exception {
+  public void getAttributeBooleanValue_withNamespace_shouldGetBooleanValuesFromAttributes() {
     // org.robolectric.lib1.R values should be reconciled to match org.robolectric.R values.
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(R.attr.isSugary, "true").build();
@@ -132,8 +125,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeBooleanValue_shouldReturnDefaultBooleanValueWhenNotInAttributeSet()
-      throws Exception {
+  public void getAttributeBooleanValue_shouldReturnDefaultBooleanValueWhenNotInAttributeSet() {
     AttributeSet roboAttributeSet = Robolectric.buildAttributeSet().build();
 
     assertThat(
@@ -143,7 +135,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeValue_byName_shouldReturnValueFromAttribute() throws Exception {
+  public void getAttributeValue_byName_shouldReturnValueFromAttribute() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(R.attr.isSugary, "oh heck yeah").build();
 
@@ -155,8 +147,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeValue_byNameWithReference_shouldReturnFullyQualifiedValueFromAttribute()
-      throws Exception {
+  public void getAttributeValue_byNameWithReference_shouldReturnFullyQualifiedValueFromAttribute() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(R.attr.isSugary, "@string/ok").build();
 
@@ -164,7 +155,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeValue_byId_shouldReturnValueFromAttribute() throws Exception {
+  public void getAttributeValue_byId_shouldReturnValueFromAttribute() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(R.attr.isSugary, "oh heck yeah").build();
 
@@ -172,8 +163,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeValue_byIdWithReference_shouldReturnValueFromAttribute()
-      throws Exception {
+  public void getAttributeValue_byIdWithReference_shouldReturnValueFromAttribute() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(R.attr.isSugary, "@string/ok").build();
 
@@ -181,7 +171,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeIntValue_shouldReturnValueFromAttribute() throws Exception {
+  public void getAttributeIntValue_shouldReturnValueFromAttribute() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(R.attr.sugarinessPercent, "100").build();
 
@@ -190,7 +180,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeIntValue_shouldReturnHexValueFromAttribute() throws Exception {
+  public void getAttributeIntValue_shouldReturnHexValueFromAttribute() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(R.attr.sugarinessPercent, "0x10").build();
 
@@ -198,8 +188,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeIntValue_whenTypeAllowsIntOrEnum_withInt_shouldReturnInt()
-      throws Exception {
+  public void getAttributeIntValue_whenTypeAllowsIntOrEnum_withInt_shouldReturnInt() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(R.attr.numColumns, "3").build();
 
@@ -207,8 +196,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeIntValue_shouldReturnValueFromAttributeWhenNotInAttributeSet()
-      throws Exception {
+  public void getAttributeIntValue_shouldReturnValueFromAttributeWhenNotInAttributeSet() {
     AttributeSet roboAttributeSet = Robolectric.buildAttributeSet().build();
 
     assertThat(roboAttributeSet.getAttributeIntValue(APP_NS, "sugarinessPercent", 42))
@@ -216,16 +204,14 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeIntValue_shouldReturnEnumValuesForEnumAttributesWhenNotInAttributeSet()
-      throws Exception {
+  public void getAttributeIntValue_shouldReturnEnumValuesForEnumAttributesWhenNotInAttributeSet() {
     AttributeSet roboAttributeSet = Robolectric.buildAttributeSet().build();
 
     assertThat(roboAttributeSet.getAttributeIntValue(APP_NS, "itemType", 24)).isEqualTo(24);
   }
 
   @Test
-  public void getAttributeIntValue_shouldReturnEnumValuesForEnumAttributesInAttributeSet()
-      throws Exception {
+  public void getAttributeIntValue_shouldReturnEnumValuesForEnumAttributesInAttributeSet() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(R.attr.itemType, "ungulate").build();
 
@@ -238,7 +224,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void shouldFailOnMissingEnumValue() throws Exception {
+  public void shouldFailOnMissingEnumValue() {
     try {
       Robolectric.buildAttributeSet().addAttribute(R.attr.itemType, "simian").build();
       fail("should fail");
@@ -249,7 +235,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void shouldFailOnMissingFlagValue() throws Exception {
+  public void shouldFailOnMissingFlagValue() {
     try {
       Robolectric.buildAttributeSet().addAttribute(R.attr.scrollBars, "temporal").build();
       fail("should fail");
@@ -260,8 +246,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeIntValue_shouldReturnFlagValuesForFlagAttributesInAttributeSet()
-      throws Exception {
+  public void getAttributeIntValue_shouldReturnFlagValuesForFlagAttributesInAttributeSet() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet()
             .addAttribute(R.attr.scrollBars, "horizontal|vertical")
@@ -272,7 +257,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeFloatValue_shouldGetFloatValuesFromAttributes() throws Exception {
+  public void getAttributeFloatValue_shouldGetFloatValuesFromAttributes() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(R.attr.aspectRatio, "1234.456").build();
 
@@ -281,8 +266,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeFloatValue_shouldReturnDefaultFloatValueWhenNotInAttributeSet()
-      throws Exception {
+  public void getAttributeFloatValue_shouldReturnDefaultFloatValueWhenNotInAttributeSet() {
     AttributeSet roboAttributeSet = Robolectric.buildAttributeSet().build();
 
     assertThat(roboAttributeSet.getAttributeFloatValue(APP_NS, "aspectRatio", 78.9f))
@@ -290,14 +274,14 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getClassAndIdAttribute_returnsZeroWhenNotSpecified() throws Exception {
+  public void getClassAndIdAttribute_returnsZeroWhenNotSpecified() {
     AttributeSet roboAttributeSet = Robolectric.buildAttributeSet().build();
     assertThat(roboAttributeSet.getClassAttribute()).isNull();
     assertThat(roboAttributeSet.getIdAttribute()).isNull();
   }
 
   @Test
-  public void getClassAndIdAttribute_returnsAttr() throws Exception {
+  public void getClassAndIdAttribute_returnsAttr() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet()
             .setIdAttribute("the id")
@@ -308,14 +292,14 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getStyleAttribute_returnsZeroWhenNoStyle() throws Exception {
+  public void getStyleAttribute_returnsZeroWhenNoStyle() {
     AttributeSet roboAttributeSet = Robolectric.buildAttributeSet().build();
 
     assertThat(roboAttributeSet.getStyleAttribute()).isEqualTo(0);
   }
 
   @Test
-  public void getStyleAttribute_returnsCorrectValue() throws Exception {
+  public void getStyleAttribute_returnsCorrectValue() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().setStyleAttribute("@style/Gastropod").build();
 
@@ -323,7 +307,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getStyleAttribute_whenStyleIsBogus() throws Exception {
+  public void getStyleAttribute_whenStyleIsBogus() {
     try {
       Robolectric.buildAttributeSet().setStyleAttribute("@style/non_existent_style").build();
       fail();
@@ -335,7 +319,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void getAttributeNameResource() throws Exception {
+  public void getAttributeNameResource() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet().addAttribute(R.attr.aspectRatio, "1").build();
 
@@ -343,7 +327,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void shouldReturnAttributesInOrderOfNameResId() throws Exception {
+  public void shouldReturnAttributesInOrderOfNameResId() {
     AttributeSet roboAttributeSet =
         Robolectric.buildAttributeSet()
             .addAttribute(android.R.attr.height, "1px")
@@ -367,7 +351,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void whenAttrSetAttrSpecifiesUnknownStyle_throwsException() throws Exception {
+  public void whenAttrSetAttrSpecifiesUnknownStyle_throwsException() {
     try {
       Robolectric.buildAttributeSet()
           .addAttribute(R.attr.string2, "?org.robolectric:attr/noSuchAttr")
@@ -380,7 +364,7 @@ public class AttributeSetBuilderTest {
   }
 
   @Test
-  public void whenAttrSetAttrSpecifiesUnknownReference_throwsException() throws Exception {
+  public void whenAttrSetAttrSpecifiesUnknownReference_throwsException() {
     try {
       Robolectric.buildAttributeSet()
           .addAttribute(R.attr.string2, "@org.robolectric:attr/noSuchRes")

--- a/robolectric/src/test/java/org/robolectric/ConfigTest.java
+++ b/robolectric/src/test/java/org/robolectric/ConfigTest.java
@@ -15,7 +15,7 @@ import org.robolectric.annotation.Config;
 @RunWith(JUnit4.class)
 public class ConfigTest {
   @Test
-  public void testDefaults() throws Exception {
+  public void testDefaults() {
     Config defaults = Config.Builder.defaults().build();
     assertThat(defaults.manifest()).isEqualTo("AndroidManifest.xml");
     assertThat(defaults.resourceDir()).isEqualTo("res");
@@ -23,7 +23,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void withOverlay_withBaseSdk() throws Exception {
+  public void withOverlay_withBaseSdk() {
     Config.Implementation base = new Config.Builder().setSdk(16, 17, 18).build();
 
     assertThat(sdksIn(overlay(base, new Config.Builder().build())))
@@ -43,7 +43,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void withOverlay_withBaseMinSdk() throws Exception {
+  public void withOverlay_withBaseMinSdk() {
     Config.Implementation base = new Config.Builder().setMinSdk(18).build();
 
     assertThat(sdksIn(overlay(base, new Config.Builder().build())))
@@ -63,7 +63,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void withOverlay_withBaseMaxSdk() throws Exception {
+  public void withOverlay_withBaseMaxSdk() {
     Config.Implementation base = new Config.Builder().setMaxSdk(18).build();
 
     assertThat(sdksIn(overlay(base, new Config.Builder().build())))
@@ -83,7 +83,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void withOverlay_withBaseMinAndMaxSdk() throws Exception {
+  public void withOverlay_withBaseMinAndMaxSdk() {
     Config.Implementation base = new Config.Builder().setMinSdk(17).setMaxSdk(18).build();
 
     assertThat(sdksIn(overlay(base, new Config.Builder().build())))
@@ -103,7 +103,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void withOverlay_withShadows_maintainsOrder() throws Exception {
+  public void withOverlay_withShadows_maintainsOrder() {
     Config.Implementation base = new Config.Builder().build();
 
     Config withString =
@@ -118,7 +118,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void shouldAppendQualifiersStartingWithPlus() throws Exception {
+  public void shouldAppendQualifiersStartingWithPlus() {
     Config config = new Config.Builder().setQualifiers("w100dp").build();
     config = overlay(config, new Config.Builder().setQualifiers("w101dp").build());
     assertThat(config.qualifiers()).isEqualTo("w101dp");
@@ -133,7 +133,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void sdksFromProperties() throws Exception {
+  public void sdksFromProperties() {
     Properties properties = new Properties();
     properties.setProperty("sdk", "1, 2, ALL_SDKS, TARGET_SDK, OLDEST_SDK, NEWEST_SDK, 666");
     Config config = Config.Implementation.fromProperties(properties);
@@ -141,7 +141,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void minMaxSdksFromProperties() throws Exception {
+  public void minMaxSdksFromProperties() {
     Properties properties = new Properties();
     properties.setProperty("minSdk", "OLDEST_SDK");
     properties.setProperty("maxSdk", "NEWEST_SDK");
@@ -150,7 +150,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testIllegalArguments_sdkMutualExclusion() throws Exception {
+  public void testIllegalArguments_sdkMutualExclusion() {
     try {
       new Config.Builder().setSdk(16, 17, 18).setMinSdk(16).setMaxSdk(18).build();
       fail();
@@ -163,7 +163,7 @@ public class ConfigTest {
   }
 
   @Test
-  public void testIllegalArguments_minMaxSdkRange() throws Exception {
+  public void testIllegalArguments_minMaxSdkRange() {
     try {
       new Config.Builder().setMinSdk(18).setMaxSdk(16).build();
       fail();

--- a/robolectric/src/test/java/org/robolectric/QualifiersTest.java
+++ b/robolectric/src/test/java/org/robolectric/QualifiersTest.java
@@ -29,7 +29,7 @@ public class QualifiersTest {
 
   @Test
   @Config(sdk = 26)
-  public void testDefaultQualifiers() throws Exception {
+  public void testDefaultQualifiers() {
     assertThat(RuntimeEnvironment.getQualifiers())
         .isEqualTo(
             "en-rUS-ldltr-sw320dp-w320dp-h470dp-normal-notlong-notround-nowidecg-lowdr-port-notnight-mdpi-finger-keyssoft-nokeys-navhidden-nonav");
@@ -37,7 +37,7 @@ public class QualifiersTest {
 
   @Test
   @Config(qualifiers = "en", sdk = 26)
-  public void testDefaultQualifiers_withoutRegion() throws Exception {
+  public void testDefaultQualifiers_withoutRegion() {
     assertThat(RuntimeEnvironment.getQualifiers())
         .isEqualTo(
             "en-ldltr-sw320dp-w320dp-h470dp-normal-notlong-notround-nowidecg-lowdr-port-notnight-mdpi-finger-keyssoft-nokeys-navhidden-nonav");
@@ -73,19 +73,19 @@ public class QualifiersTest {
 
   @Test
   @Config(qualifiers = "fr")
-  public void shouldGetFromMethod() throws Exception {
+  public void shouldGetFromMethod() {
     assertThat(RuntimeEnvironment.getQualifiers()).contains("fr");
   }
 
   @Test
   @Config(qualifiers = "de")
-  public void getQuantityString() throws Exception {
+  public void getQuantityString() {
     assertThat(resources.getQuantityString(R.plurals.minute, 2))
         .isEqualTo(resources.getString(R.string.minute_plural));
   }
 
   @Test
-  public void inflateLayout_defaultsTo_sw320dp() throws Exception {
+  public void inflateLayout_defaultsTo_sw320dp() {
     View view =
         Robolectric.setupActivity(Activity.class)
             .getLayoutInflater()
@@ -98,7 +98,7 @@ public class QualifiersTest {
 
   @Test
   @Config(qualifiers = "sw720dp")
-  public void inflateLayout_overridesTo_sw720dp() throws Exception {
+  public void inflateLayout_overridesTo_sw720dp() {
     View view =
         Robolectric.setupActivity(Activity.class)
             .getLayoutInflater()
@@ -111,7 +111,7 @@ public class QualifiersTest {
 
   @Test
   @Config(qualifiers = "b+sr+Latn")
-  public void supportsBcp47() throws Exception {
+  public void supportsBcp47() {
     assertThat(resources.getString(R.string.hello)).isEqualTo("Zdravo");
   }
 
@@ -123,7 +123,7 @@ public class QualifiersTest {
 
   @Test
   @Config(qualifiers = "land")
-  public void setQualifiers_updatesSystemAndAppResources() throws Exception {
+  public void setQualifiers_updatesSystemAndAppResources() {
     Resources systemResources = Resources.getSystem();
     Resources appResources = getApplicationContext().getResources();
 
@@ -140,12 +140,12 @@ public class QualifiersTest {
   }
 
   @Test
-  public void setQualifiers_allowsSameSdkVersion() throws Exception {
+  public void setQualifiers_allowsSameSdkVersion() {
     RuntimeEnvironment.setQualifiers("v" + RuntimeEnvironment.getApiLevel());
   }
 
   @Test
-  public void setQualifiers_disallowsOtherSdkVersions() throws Exception {
+  public void setQualifiers_disallowsOtherSdkVersions() {
     try {
       RuntimeEnvironment.setQualifiers("v13");
       fail();
@@ -157,7 +157,7 @@ public class QualifiersTest {
 
   @Test
   @Config(minSdk = O, qualifiers = "widecg-highdr-vrheadset")
-  public void testQualifiersNewIn26() throws Exception {
+  public void testQualifiersNewIn26() {
     assertThat(RuntimeEnvironment.getQualifiers()).contains("-widecg-highdr-");
     assertThat(RuntimeEnvironment.getQualifiers()).contains("-vrheadset-");
   }

--- a/robolectric/src/test/java/org/robolectric/RobolectricTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTest.java
@@ -39,7 +39,7 @@ public class RobolectricTest {
   private Application context = ApplicationProvider.getApplicationContext();
 
   @Test
-  public void clickOn_shouldThrowIfViewIsDisabled() throws Exception {
+  public void clickOn_shouldThrowIfViewIsDisabled() {
     View view = new View(context);
     view.setEnabled(false);
     assertThrows(RuntimeException.class, () -> ShadowView.clickOn(view));
@@ -47,14 +47,14 @@ public class RobolectricTest {
 
   @Test
   @LooperMode(LEGACY)
-  public void shouldResetBackgroundSchedulerBeforeTests() throws Exception {
+  public void shouldResetBackgroundSchedulerBeforeTests() {
     assertThat(Robolectric.getBackgroundThreadScheduler().isPaused()).isFalse();
     Robolectric.getBackgroundThreadScheduler().pause();
   }
 
   @Test
   @LooperMode(LEGACY)
-  public void shouldResetBackgroundSchedulerAfterTests() throws Exception {
+  public void shouldResetBackgroundSchedulerAfterTests() {
     assertThat(Robolectric.getBackgroundThreadScheduler().isPaused()).isFalse();
     Robolectric.getBackgroundThreadScheduler().pause();
   }
@@ -72,7 +72,7 @@ public class RobolectricTest {
   }
 
   @Test
-  public void clickOn_shouldCallClickListener() throws Exception {
+  public void clickOn_shouldCallClickListener() {
     View view = new View(context);
     shadowOf(view).setMyParent(ReflectionHelpers.createNullProxy(ViewParent.class));
     OnClickListener testOnClickListener = mock(OnClickListener.class);
@@ -83,7 +83,7 @@ public class RobolectricTest {
   }
 
   @Test
-  public void checkActivities_shouldSetValueOnShadowApplication() throws Exception {
+  public void checkActivities_shouldSetValueOnShadowApplication() {
     ShadowApplication.getInstance().checkActivities(true);
     assertThrows(
         ActivityNotFoundException.class,
@@ -94,7 +94,7 @@ public class RobolectricTest {
 
   @Test
   @Config(sdk = Config.NEWEST_SDK)
-  public void setupActivity_returnsAVisibleActivity() throws Exception {
+  public void setupActivity_returnsAVisibleActivity() {
     LifeCycleActivity activity = Robolectric.setupActivity(LifeCycleActivity.class);
 
     assertThat(activity.isCreated()).isTrue();

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerCleanupTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerCleanupTest.java
@@ -51,6 +51,6 @@ public class RobolectricTestRunnerCleanupTest {
   @Ignore
   public static class TestWithEmptyTest {
     @Test
-    public void emptyTest() throws Exception {}
+    public void emptyTest() {}
   }
 }

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerMultiApiTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerMultiApiTest.java
@@ -342,17 +342,17 @@ public class RobolectricTestRunnerMultiApiTest {
     private List<String> ignored = new ArrayList<>();
 
     @Override
-    public void testStarted(Description description) throws Exception {
+    public void testStarted(Description description) {
       started.add(description.getDisplayName());
     }
 
     @Override
-    public void testFinished(Description description) throws Exception {
+    public void testFinished(Description description) {
       finished.add(description.getDisplayName());
     }
 
     @Override
-    public void testIgnored(Description description) throws Exception {
+    public void testIgnored(Description description) {
       ignored.add(description.getDisplayName());
     }
   }

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
@@ -81,7 +81,7 @@ public class RobolectricTestRunnerSelfTest {
   }
 
   @Test
-  public void hamcrestMatchersDontBlowUpDuringLinking() throws Exception {
+  public void hamcrestMatchersDontBlowUpDuringLinking() {
     org.hamcrest.MatcherAssert.assertThat(true, CoreMatchers.is(true));
   }
 

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -380,14 +380,14 @@ public class RobolectricTestRunnerTest {
   public static class TestWithOldSdk {
     @Config(sdk = Build.VERSION_CODES.HONEYCOMB)
     @Test
-    public void oldSdkMethod() throws Exception {
+    public void oldSdkMethod() {
       fail("I should not be run!");
     }
 
     @Ignore("This test shouldn't run, and shouldn't cause the test runner to fail")
     @Config(sdk = Build.VERSION_CODES.HONEYCOMB)
     @Test
-    public void ignoredOldSdkMethod() throws Exception {
+    public void ignoredOldSdkMethod() {
       fail("I should not be run!");
     }
   }

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerThreadTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerThreadTest.java
@@ -16,7 +16,7 @@ public class RobolectricTestRunnerThreadTest {
   private static ClassLoader sClassLoader;
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     sThread = Thread.currentThread();
     sClassLoader = Thread.currentThread().getContextClassLoader();
   }
@@ -46,7 +46,7 @@ public class RobolectricTestRunnerThreadTest {
   }
 
   @AfterClass
-  public static void afterClass() throws Exception {
+  public static void afterClass() {
     assertThat(Thread.currentThread() == sThread).isTrue();
     assertThat(Thread.currentThread().getContextClassLoader() == sClassLoader).isTrue();
   }

--- a/robolectric/src/test/java/org/robolectric/RuntimeEnvironmentTest.java
+++ b/robolectric/src/test/java/org/robolectric/RuntimeEnvironmentTest.java
@@ -83,7 +83,7 @@ public class RuntimeEnvironmentTest {
 
   @Test
   @LooperMode(LEGACY)
-  public void isMainThread_withArg_forNewThread_withSwitch() throws InterruptedException {
+  public void isMainThread_withArg_forNewThread_withSwitch() {
     Thread t = new Thread();
     RuntimeEnvironment.setMainThread(t);
     assertThat(RuntimeEnvironment.isMainThread(t)).isTrue();

--- a/robolectric/src/test/java/org/robolectric/TemporaryBindingsTest.java
+++ b/robolectric/src/test/java/org/robolectric/TemporaryBindingsTest.java
@@ -20,7 +20,7 @@ public class TemporaryBindingsTest {
 
   @Test
   @Config(shadows = TemporaryShadowView.class)
-  public void overridingShadowBindingsShouldNotAffectBindingsInLaterTests() throws Exception {
+  public void overridingShadowBindingsShouldNotAffectBindingsInLaterTests() {
     TemporaryShadowView shadowView =
         Shadow.extract(new View(ApplicationProvider.getApplicationContext()));
     assertThat(shadowView.getClass().getSimpleName())
@@ -28,7 +28,7 @@ public class TemporaryBindingsTest {
   }
 
   @Test
-  public void overridingShadowBindingsShouldNotAffectBindingsInLaterTestsAgain() throws Exception {
+  public void overridingShadowBindingsShouldNotAffectBindingsInLaterTestsAgain() {
     assertThat(
             shadowOf(new View(ApplicationProvider.getApplicationContext()))
                 .getClass()

--- a/robolectric/src/test/java/org/robolectric/TestRunnerSequenceTest.java
+++ b/robolectric/src/test/java/org/robolectric/TestRunnerSequenceTest.java
@@ -74,12 +74,12 @@ public class TestRunnerSequenceTest {
   @Config(application = TestRunnerSequenceTest.MyApplication.class)
   public static class SimpleTest {
     @Test
-    public void shouldDoNothingMuch() throws Exception {
+    public void shouldDoNothingMuch() {
       StateHolder.transcript.add("TEST!");
     }
   }
 
-  private Result run(Runner runner) throws InitializationError {
+  private Result run(Runner runner) {
     RunNotifier notifier = new RunNotifier();
     Result result = new Result();
     notifier.addListener(result.createListener());

--- a/robolectric/src/test/java/org/robolectric/android/AndroidTranslatorClassInstrumentedTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/AndroidTranslatorClassInstrumentedTest.java
@@ -18,7 +18,7 @@ public class AndroidTranslatorClassInstrumentedTest {
 
   @Test
   @Config(shadows = ShadowPaintForTests.class)
-  public void testNativeMethodsAreDelegated() throws Exception {
+  public void testNativeMethodsAreDelegated() {
     Paint paint = new Paint();
     paint.setColor(1234);
 
@@ -45,7 +45,7 @@ public class AndroidTranslatorClassInstrumentedTest {
    */
   @Test
   @Config(shadows = {ShadowCustomPaint.class, ShadowPaintForTests.class})
-  public void testCustomMethodShadowed() throws Exception {
+  public void testCustomMethodShadowed() {
     CustomPaint customPaint = new CustomPaint();
     assertThat(customPaint.getColor()).isEqualTo(10);
     assertThat(customPaint.getColorName()).isEqualTo("rainbow");

--- a/robolectric/src/test/java/org/robolectric/android/BootstrapTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/BootstrapTest.java
@@ -75,7 +75,7 @@ public class BootstrapTest {
 
   @Test
   @Config(qualifiers = "w480dp-h640dp")
-  public void shouldSetUpRealisticDisplay() throws Exception {
+  public void shouldSetUpRealisticDisplay() {
     DisplayManager displayManager =
         (DisplayManager)
             ApplicationProvider.getApplicationContext().getSystemService(Context.DISPLAY_SERVICE);
@@ -106,7 +106,7 @@ public class BootstrapTest {
 
   @Test
   @Config(qualifiers = "w480dp-h640dp-land-hdpi")
-  public void shouldSetUpRealisticDisplay_landscapeHighDensity() throws Exception {
+  public void shouldSetUpRealisticDisplay_landscapeHighDensity() {
     DisplayManager displayManager =
         (DisplayManager)
             ApplicationProvider.getApplicationContext().getSystemService(Context.DISPLAY_SERVICE);
@@ -228,7 +228,7 @@ public class BootstrapTest {
   }
 
   @Test
-  public void applyQualifiers_longShouldMakeScreenTaller() throws Exception {
+  public void applyQualifiers_longShouldMakeScreenTaller() {
     Bootstrap.applyQualifiers(
         "long", RuntimeEnvironment.getApiLevel(), configuration, displayMetrics);
     assertThat(configuration.smallestScreenWidthDp).isEqualTo(320);
@@ -239,8 +239,7 @@ public class BootstrapTest {
   }
 
   @Test
-  public void whenScreenRationGreatherThan175Percent_applyQualifiers_ShouldSetLong()
-      throws Exception {
+  public void whenScreenRationGreaterThan175Percent_applyQualifiers_ShouldSetLong() {
     Bootstrap.applyQualifiers(
         "w400dp-h200dp", RuntimeEnvironment.getApiLevel(), configuration, displayMetrics);
     assertThat(configuration.screenWidthDp).isEqualTo(400);
@@ -301,7 +300,7 @@ public class BootstrapTest {
   }
 
   @Test
-  public void applyQualifiers_shouldSetLocaleScript() throws Exception {
+  public void applyQualifiers_shouldSetLocaleScript() {
     Bootstrap.applyQualifiers(
         "b+sr+Latn", RuntimeEnvironment.getApiLevel(), configuration, displayMetrics);
     String outQualifiers = ConfigurationV25.resourceQualifierString(configuration, displayMetrics);
@@ -319,7 +318,7 @@ public class BootstrapTest {
   }
 
   @Test
-  public void spaceSeparated_applyQualifiers_shouldReplaceQualifiers() throws Exception {
+  public void spaceSeparated_applyQualifiers_shouldReplaceQualifiers() {
     Bootstrap.applyQualifiers(
         "ru-rRU-h123dp-large fr-w321dp",
         RuntimeEnvironment.getApiLevel(),
@@ -331,7 +330,7 @@ public class BootstrapTest {
   }
 
   @Test
-  public void whenPrefixedWithPlus_applyQualifiers_shouldOverlayQualifiers() throws Exception {
+  public void whenPrefixedWithPlus_applyQualifiers_shouldOverlayQualifiers() {
     Bootstrap.applyQualifiers(
         "+en ru-rRU-h123dp-large +fr-w321dp-small",
         RuntimeEnvironment.getApiLevel(),
@@ -343,7 +342,7 @@ public class BootstrapTest {
   }
 
   @Test
-  public void whenAllPrefixedWithPlus_applyQualifiers_shouldOverlayQualifiers() throws Exception {
+  public void whenAllPrefixedWithPlus_applyQualifiers_shouldOverlayQualifiers() {
     Bootstrap.applyQualifiers(
         "+xxhdpi +ru-rRU-h123dp-large +fr-w321dp-small",
         RuntimeEnvironment.getApiLevel(),

--- a/robolectric/src/test/java/org/robolectric/android/DeviceConfigTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/DeviceConfigTest.java
@@ -120,7 +120,7 @@ public class DeviceConfigTest {
   }
 
   @Test
-  public void applyRules_heightWidthOrientation() throws Exception {
+  public void applyRules_heightWidthOrientation() {
     applyQualifiers("w800dp-h400dp-port");
     DeviceConfig.applyRules(configuration, displayMetrics, apiLevel);
 

--- a/robolectric/src/test/java/org/robolectric/android/PreferenceIntegrationTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/PreferenceIntegrationTest.java
@@ -24,7 +24,7 @@ import org.robolectric.Robolectric;
 public class PreferenceIntegrationTest {
 
   @Test
-  public void inflate_shouldCreateCorrectClasses() throws Exception {
+  public void inflate_shouldCreateCorrectClasses() {
     final PreferenceScreen screen = inflatePreferenceActivity();
     assertThat(screen.getPreference(0)).isInstanceOf(PreferenceCategory.class);
 
@@ -47,7 +47,7 @@ public class PreferenceIntegrationTest {
   }
 
   @Test
-  public void inflate_shouldParseIntentContainedInPreference() throws Exception {
+  public void inflate_shouldParseIntentContainedInPreference() {
     final PreferenceScreen screen = inflatePreferenceActivity();
     final Preference intentPreference = screen.findPreference("intent");
 
@@ -61,14 +61,14 @@ public class PreferenceIntegrationTest {
   }
 
   @Test
-  public void inflate_shouldBindPreferencesToPreferenceManager() throws Exception {
+  public void inflate_shouldBindPreferencesToPreferenceManager() {
     final PreferenceScreen screen = inflatePreferenceActivity();
     final Preference preference = screen.findPreference("preference");
     assertThat(preference.getPreferenceManager().findPreference("preference")).isNotNull();
   }
 
   @Test
-  public void setPersistent_shouldMarkThePreferenceAsPersistent() throws Exception {
+  public void setPersistent_shouldMarkThePreferenceAsPersistent() {
     final PreferenceScreen screen = inflatePreferenceActivity();
     final Preference preference = screen.findPreference("preference");
 
@@ -80,7 +80,7 @@ public class PreferenceIntegrationTest {
   }
 
   @Test
-  public void setEnabled_shouldEnableThePreference() throws Exception {
+  public void setEnabled_shouldEnableThePreference() {
     final PreferenceScreen screen = inflatePreferenceActivity();
     final Preference preference = screen.findPreference("preference");
 
@@ -92,7 +92,7 @@ public class PreferenceIntegrationTest {
   }
 
   @Test
-  public void setOrder_shouldSetOrderOnPreference() throws Exception {
+  public void setOrder_shouldSetOrderOnPreference() {
     final PreferenceScreen screen = inflatePreferenceActivity();
     final Preference preference = screen.findPreference("preference");
 
@@ -104,7 +104,7 @@ public class PreferenceIntegrationTest {
   }
 
   @Test
-  public void setDependency_shouldSetDependencyBetweenPreferences() throws Exception {
+  public void setDependency_shouldSetDependencyBetweenPreferences() {
     final PreferenceScreen screen = inflatePreferenceActivity();
     final Preference dependant = screen.findPreference("dependant");
     assertThat(dependant.getDependency()).isEqualTo("preference");
@@ -114,7 +114,7 @@ public class PreferenceIntegrationTest {
   }
 
   @Test
-  public void click_shouldCallPreferenceClickListener() throws Exception {
+  public void click_shouldCallPreferenceClickListener() {
     final PreferenceScreen screen = inflatePreferenceActivity();
     final Preference preference = screen.findPreference("preference");
 

--- a/robolectric/src/test/java/org/robolectric/android/ShadowingTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/ShadowingTest.java
@@ -16,23 +16,23 @@ import org.junit.runner.RunWith;
 public class ShadowingTest {
 
   @Test
-  public void testPrintlnWorks() throws Exception {
+  public void testPrintlnWorks() {
     Log.println(1, "tag", "msg");
   }
 
   @Test
-  public void shouldDelegateToObjectToStringIfShadowHasNone() throws Exception {
+  public void shouldDelegateToObjectToStringIfShadowHasNone() {
     assertThat(new Toast(ApplicationProvider.getApplicationContext()).toString())
         .startsWith("android.widget.Toast@");
   }
 
   @Test
-  public void shouldDelegateToObjectHashCodeIfShadowHasNone() throws Exception {
+  public void shouldDelegateToObjectHashCodeIfShadowHasNone() {
     assertFalse(new View(ApplicationProvider.getApplicationContext()).hashCode() == 0);
   }
 
   @Test
-  public void shouldDelegateToObjectEqualsIfShadowHasNone() throws Exception {
+  public void shouldDelegateToObjectEqualsIfShadowHasNone() {
     View view = new View(ApplicationProvider.getApplicationContext());
     new EqualsTester().addEqualityGroup(view).testEquals();
   }

--- a/robolectric/src/test/java/org/robolectric/android/controller/ActivityControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/ActivityControllerTest.java
@@ -101,14 +101,14 @@ public class ActivityControllerTest {
   }
 
   @Test
-  public void shouldSetIntent() throws Exception {
+  public void shouldSetIntent() {
     MyActivity myActivity = controller.create().get();
     assertThat(myActivity.getIntent()).isNotNull();
     assertThat(myActivity.getIntent().getComponent()).isEqualTo(componentName);
   }
 
   @Test
-  public void shouldSetIntentComponentWithCustomIntentWithoutComponentSet() throws Exception {
+  public void shouldSetIntentComponentWithCustomIntentWithoutComponentSet() {
     MyActivity myActivity =
         Robolectric.buildActivity(MyActivity.class, new Intent(Intent.ACTION_VIEW)).create().get();
     assertThat(myActivity.getIntent().getAction()).isEqualTo(Intent.ACTION_VIEW);
@@ -116,7 +116,7 @@ public class ActivityControllerTest {
   }
 
   @Test
-  public void shouldSetIntentForGivenActivityInstance() throws Exception {
+  public void shouldSetIntentForGivenActivityInstance() {
     ActivityController<MyActivity> activityController =
         ActivityController.of(new MyActivity()).create();
     assertThat(activityController.get().getIntent()).isNotNull();
@@ -124,7 +124,7 @@ public class ActivityControllerTest {
 
   @Test
   @LooperMode(LEGACY)
-  public void whenLooperIsNotPaused_shouldCreateWithMainLooperPaused() throws Exception {
+  public void whenLooperIsNotPaused_shouldCreateWithMainLooperPaused() {
     ShadowLooper.unPauseMainLooper();
     controller.create();
     assertThat(shadowOf(Looper.getMainLooper()).isPaused()).isFalse();
@@ -132,7 +132,7 @@ public class ActivityControllerTest {
   }
 
   @Test
-  public void whenLooperIsAlreadyPaused_shouldCreateWithMainLooperPaused() throws Exception {
+  public void whenLooperIsAlreadyPaused_shouldCreateWithMainLooperPaused() {
     shadowMainLooper().pause();
     controller.create();
     assertThat(transcript).contains("finishedOnCreate");

--- a/robolectric/src/test/java/org/robolectric/android/controller/BackupAgentControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/BackupAgentControllerTest.java
@@ -20,7 +20,7 @@ public class BackupAgentControllerTest {
       Robolectric.buildBackupAgent(MyBackupAgent.class);
 
   @Test
-  public void shouldSetBaseContext() throws Exception {
+  public void shouldSetBaseContext() {
     MyBackupAgent myBackupAgent = backupAgentController.get();
     assertThat(myBackupAgent.getBaseContext())
         .isEqualTo(((Application) ApplicationProvider.getApplicationContext()).getBaseContext());

--- a/robolectric/src/test/java/org/robolectric/android/controller/ContentProviderControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/ContentProviderControllerTest.java
@@ -33,14 +33,14 @@ public class ContentProviderControllerTest {
   }
 
   @Test
-  public void shouldSetBaseContext() throws Exception {
+  public void shouldSetBaseContext() {
     TestContentProvider1 myContentProvider = controller.create().get();
     assertThat(myContentProvider.getContext())
         .isEqualTo(((Application) ApplicationProvider.getApplicationContext()).getBaseContext());
   }
 
   @Test
-  public void shouldInitializeFromManifestProviderInfo() throws Exception {
+  public void shouldInitializeFromManifestProviderInfo() {
     TestContentProvider1 myContentProvider = controller.create().get();
     assertThat(myContentProvider.getReadPermission()).isEqualTo("READ_PERMISSION");
     assertThat(myContentProvider.getWritePermission()).isEqualTo("WRITE_PERMISSION");
@@ -77,7 +77,7 @@ public class ContentProviderControllerTest {
   }
 
   @Test
-  public void whenNoProviderManifestEntryFound_shouldStillInitialize() throws Exception {
+  public void whenNoProviderManifestEntryFound_shouldStillInitialize() {
     TestContentProvider1 myContentProvider =
         Robolectric.buildContentProvider(NotInManifestContentProvider.class).create().get();
     assertThat(myContentProvider.getReadPermission()).isNull();
@@ -86,13 +86,13 @@ public class ContentProviderControllerTest {
   }
 
   @Test
-  public void create_shouldCallOnCreate() throws Exception {
+  public void create_shouldCallOnCreate() {
     TestContentProvider1 myContentProvider = controller.create().get();
     assertThat(myContentProvider.transcript).containsExactly("onCreate");
   }
 
   @Test
-  public void shutdown_shouldCallShutdown() throws Exception {
+  public void shutdown_shouldCallShutdown() {
     TestContentProvider1 myContentProvider = controller.shutdown().get();
     assertThat(myContentProvider.transcript).containsExactly("shutdown");
   }
@@ -111,7 +111,7 @@ public class ContentProviderControllerTest {
   }
 
   @Test
-  public void contentProviderShouldBeCreatedBeforeBeingRegistered() throws Exception {
+  public void contentProviderShouldBeCreatedBeforeBeingRegistered() {
     XContentProvider xContentProvider =
         Robolectric.setupContentProvider(XContentProvider.class, "x-authority");
     assertThat(xContentProvider.transcript).containsExactly("x-authority not registered yet");
@@ -122,7 +122,7 @@ public class ContentProviderControllerTest {
   }
 
   @Test
-  public void createContentProvider_nullAuthority() throws Exception {
+  public void createContentProvider_nullAuthority() {
     assertThrows(
         IllegalArgumentException.class,
         () ->

--- a/robolectric/src/test/java/org/robolectric/android/controller/IntentServiceControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/IntentServiceControllerTest.java
@@ -35,21 +35,21 @@ public class IntentServiceControllerTest {
   }
 
   @Test
-  public void onBindShouldSetIntent() throws Exception {
+  public void onBindShouldSetIntent() {
     MyService myService = controller.create().bind().get();
     assertThat(myService.boundIntent).isNotNull();
     assertThat(myService.boundIntent.getComponent()).isEqualTo(componentName);
   }
 
   @Test
-  public void onStartCommandShouldSetIntent() throws Exception {
+  public void onStartCommandShouldSetIntent() {
     MyService myService = controller.create().startCommand(3, 4).get();
     assertThat(myService.startIntent).isNotNull();
     assertThat(myService.startIntent.getComponent()).isEqualTo(componentName);
   }
 
   @Test
-  public void onBindShouldSetIntentComponentWithCustomIntentWithoutComponentSet() throws Exception {
+  public void onBindShouldSetIntentComponentWithCustomIntentWithoutComponentSet() {
     MyService myService =
         Robolectric.buildIntentService(MyService.class, new Intent(Intent.ACTION_VIEW))
             .bind()
@@ -59,7 +59,7 @@ public class IntentServiceControllerTest {
   }
 
   @Test
-  public void shouldSetIntentForGivenServiceInstance() throws Exception {
+  public void shouldSetIntentForGivenServiceInstance() {
     IntentServiceController<MyService> intentServiceController =
         IntentServiceController.of(new MyService(), null).bind();
     assertThat(intentServiceController.get().boundIntent).isNotNull();
@@ -67,7 +67,7 @@ public class IntentServiceControllerTest {
 
   @Test
   @LooperMode(LEGACY)
-  public void whenLooperIsNotPaused_shouldCreateWithMainLooperPaused() throws Exception {
+  public void whenLooperIsNotPaused_shouldCreateWithMainLooperPaused() {
     ShadowLooper.unPauseMainLooper();
     controller.create();
     assertThat(shadowOf(Looper.getMainLooper()).isPaused()).isFalse();
@@ -75,7 +75,7 @@ public class IntentServiceControllerTest {
   }
 
   @Test
-  public void whenLooperIsAlreadyPaused_shouldCreateWithMainLooperPaused() throws Exception {
+  public void whenLooperIsAlreadyPaused_shouldCreateWithMainLooperPaused() {
     shadowMainLooper().pause();
     controller.create();
     assertThat(transcript).contains("finishedOnCreate");

--- a/robolectric/src/test/java/org/robolectric/android/controller/ServiceControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/ServiceControllerTest.java
@@ -34,14 +34,14 @@ public class ServiceControllerTest {
   }
 
   @Test
-  public void onBindShouldSetIntent() throws Exception {
+  public void onBindShouldSetIntent() {
     MyService myService = controller.create().bind().get();
     assertThat(myService.boundIntent).isNotNull();
     assertThat(myService.boundIntent.getComponent()).isEqualTo(componentName);
   }
 
   @Test
-  public void onStartCommandShouldSetIntentAndFlags() throws Exception {
+  public void onStartCommandShouldSetIntentAndFlags() {
     MyService myService = controller.create().startCommand(3, 4).get();
     assertThat(myService.startIntent).isNotNull();
     assertThat(myService.startIntent.getComponent()).isEqualTo(componentName);
@@ -50,7 +50,7 @@ public class ServiceControllerTest {
   }
 
   @Test
-  public void onBindShouldSetIntentComponentWithCustomIntentWithoutComponentSet() throws Exception {
+  public void onBindShouldSetIntentComponentWithCustomIntentWithoutComponentSet() {
     MyService myService =
         Robolectric.buildService(MyService.class, new Intent(Intent.ACTION_VIEW)).bind().get();
     assertThat(myService.boundIntent.getAction()).isEqualTo(Intent.ACTION_VIEW);
@@ -58,7 +58,7 @@ public class ServiceControllerTest {
   }
 
   @Test
-  public void shouldSetIntentForGivenServiceInstance() throws Exception {
+  public void shouldSetIntentForGivenServiceInstance() {
     ServiceController<MyService> serviceController =
         ServiceController.of(new MyService(), null).bind();
     assertThat(serviceController.get().boundIntent).isNotNull();
@@ -66,7 +66,7 @@ public class ServiceControllerTest {
 
   @Test
   @LooperMode(LEGACY)
-  public void whenLooperIsNotPaused_shouldCreateWithMainLooperPaused() throws Exception {
+  public void whenLooperIsNotPaused_shouldCreateWithMainLooperPaused() {
     ShadowLooper.unPauseMainLooper();
     controller.create();
     assertThat(shadowOf(Looper.getMainLooper()).isPaused()).isFalse();
@@ -74,7 +74,7 @@ public class ServiceControllerTest {
   }
 
   @Test
-  public void whenLooperIsAlreadyPaused_shouldCreateWithMainLooperPaused() throws Exception {
+  public void whenLooperIsAlreadyPaused_shouldCreateWithMainLooperPaused() {
     shadowMainLooper().pause();
     controller.create();
     assertThat(transcript).contains("finishedOnCreate");

--- a/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentCreateApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentCreateApplicationTest.java
@@ -34,7 +34,7 @@ public class AndroidTestEnvironmentCreateApplicationTest {
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
-  public void shouldThrowWhenManifestContainsBadApplicationClassName() throws Exception {
+  public void shouldThrowWhenManifestContainsBadApplicationClassName() {
     assertThrows(
         RuntimeException.class,
         () ->

--- a/robolectric/src/test/java/org/robolectric/android/internal/ClassNameResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/ClassNameResolverTest.java
@@ -41,8 +41,7 @@ public class ClassNameResolverTest {
   }
 
   @Test
-  public void shouldNotResolveClassesByUndottedPartiallyQualifiedNameBecauseAndroidDoesnt()
-      throws Exception {
+  public void shouldNotResolveClassesByUndottedPartiallyQualifiedNameBecauseAndroidDoesnt() {
     assertThrows(
         ClassNotFoundException.class,
         () -> ClassNameResolver.resolve("org", "robolectric.shadows.testing.TestApplication"));

--- a/robolectric/src/test/java/org/robolectric/android/util/concurrent/InlineExecutorServiceTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/util/concurrent/InlineExecutorServiceTest.java
@@ -100,7 +100,7 @@ public class InlineExecutorServiceTest {
   }
 
   @Test
-  public void postingTasks() throws Exception {
+  public void postingTasks() {
     Runnable postingRunnable =
         new Runnable() {
           @Override

--- a/robolectric/src/test/java/org/robolectric/android/util/concurrent/PausedExecutorServiceTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/util/concurrent/PausedExecutorServiceTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -27,7 +26,7 @@ public class PausedExecutorServiceTest {
   }
 
   @Test
-  public void executionRunsInBackgroundThread() throws ExecutionException, InterruptedException {
+  public void executionRunsInBackgroundThread() {
     final Thread testThread = Thread.currentThread();
     executorService.execute(
         () -> {
@@ -39,7 +38,7 @@ public class PausedExecutorServiceTest {
   }
 
   @Test
-  public void runAll() throws Exception {
+  public void runAll() {
     executorService.execute(() -> executedTasksRecord.add("background event ran"));
 
     assertThat(executedTasksRecord).isEmpty();
@@ -49,7 +48,7 @@ public class PausedExecutorServiceTest {
   }
 
   @Test
-  public void runAll_inOrder() throws Exception {
+  public void runAll_inOrder() {
     executorService.execute(() -> executedTasksRecord.add("first"));
     executorService.execute(() -> executedTasksRecord.add("second"));
     assertThat(executedTasksRecord).isEmpty();
@@ -59,7 +58,7 @@ public class PausedExecutorServiceTest {
   }
 
   @Test
-  public void runNext() throws Exception {
+  public void runNext() {
     executorService.execute(() -> executedTasksRecord.add("first"));
     executorService.execute(() -> executedTasksRecord.add("second"));
     assertThat(executedTasksRecord).isEmpty();
@@ -72,7 +71,7 @@ public class PausedExecutorServiceTest {
   }
 
   @Test
-  public void runAll_clearsQueuedTasks() throws Exception {
+  public void runAll_clearsQueuedTasks() {
     executorService.execute(() -> executedTasksRecord.add("background event ran"));
 
     assertThat(executedTasksRecord).isEmpty();
@@ -124,8 +123,7 @@ public class PausedExecutorServiceTest {
   }
 
   @Test
-  public void whenShutdownBeforeSubmittedTasksAreExecuted_TaskIsNotInTranscript()
-      throws ExecutionException, InterruptedException {
+  public void whenShutdownBeforeSubmittedTasksAreExecuted_TaskIsNotInTranscript() {
     executorService.execute(() -> executedTasksRecord.add("background event ran"));
 
     executorService.shutdown();
@@ -135,8 +133,7 @@ public class PausedExecutorServiceTest {
   }
 
   @Test
-  public void whenShutdownNow_ReturnedListContainsOneRunnable()
-      throws ExecutionException, InterruptedException {
+  public void whenShutdownNow_ReturnedListContainsOneRunnable() {
     executorService.execute(() -> executedTasksRecord.add("background event ran"));
 
     List<Runnable> notExecutedRunnables = executorService.shutdownNow();
@@ -163,7 +160,7 @@ public class PausedExecutorServiceTest {
 
   @Test
   @SuppressWarnings("FutureReturnValueIgnored")
-  public void exceptionsPropagated() throws ExecutionException, InterruptedException {
+  public void exceptionsPropagated() {
     Callable<Void> throwingCallable =
         () -> {
           throw new IllegalStateException("I failed");
@@ -178,7 +175,7 @@ public class PausedExecutorServiceTest {
   }
 
   @Test
-  public void postingTasks() throws Exception {
+  public void postingTasks() {
     Runnable postingRunnable =
         new Runnable() {
           @Override

--- a/robolectric/src/test/java/org/robolectric/android/util/concurrent/RoboExecutorServiceTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/util/concurrent/RoboExecutorServiceTest.java
@@ -36,7 +36,7 @@ public class RoboExecutorServiceTest {
   }
 
   @Test
-  public void execute_shouldRunStuffOnBackgroundThread() throws Exception {
+  public void execute_shouldRunStuffOnBackgroundThread() {
     executorService.execute(runnable);
 
     assertThat(transcript).isEmpty();

--- a/robolectric/src/test/java/org/robolectric/fakes/RoboCursorTest.java
+++ b/robolectric/src/test/java/org/robolectric/fakes/RoboCursorTest.java
@@ -48,7 +48,7 @@ public class RoboCursorTest {
   }
 
   @Test
-  public void query_shouldMakeQueryParamsAvailable() throws Exception {
+  public void query_shouldMakeQueryParamsAvailable() {
     contentResolver.query(
         uri, new String[] {"projection"}, "selection", new String[] {"selection"}, "sortOrder");
     assertThat(cursor.uri).isEqualTo(uri);
@@ -59,8 +59,7 @@ public class RoboCursorTest {
   }
 
   @Test
-  public void getColumnCount_whenSetColumnNamesHasntBeenCalled_shouldReturnCountFromData()
-      throws Exception {
+  public void getColumnCount_whenSetColumnNamesHasntBeenCalled_shouldReturnCountFromData() {
     RoboCursor cursor = new RoboCursor();
     cursor.setResults(
         new Object[][] {
@@ -74,14 +73,14 @@ public class RoboCursorTest {
   }
 
   @Test
-  public void getColumnName_shouldReturnColumnName() throws Exception {
+  public void getColumnName_shouldReturnColumnName() {
     assertThat(cursor.getColumnCount()).isEqualTo(8);
     assertThat(cursor.getColumnName(0)).isEqualTo(STRING_COLUMN);
     assertThat(cursor.getColumnName(1)).isEqualTo(LONG_COLUMN);
   }
 
   @Test
-  public void getType_shouldReturnColumnType() throws Exception {
+  public void getType_shouldReturnColumnType() {
     cursor.setResults(
         new Object[][] {
           new Object[] {"aString", 1234L, 42, new byte[] {1, 2, 3}, 255, 1.25f, 2.5d, null}
@@ -98,7 +97,7 @@ public class RoboCursorTest {
   }
 
   @Test
-  public void get_shouldReturnColumnValue() throws Exception {
+  public void get_shouldReturnColumnValue() {
     cursor.setResults(
         new Object[][] {
           new Object[] {"aString", 1234L, 42, new byte[] {1, 2, 3}, 255, 1.25f, 2.5d, null}
@@ -118,7 +117,7 @@ public class RoboCursorTest {
   }
 
   @Test
-  public void get_shouldConvert() throws Exception {
+  public void get_shouldConvert() {
     cursor.setResults(
         new Object[][] {
           new Object[] {"aString", "1234", "42", new byte[] {1, 2, 3}, 255, "1.25", 2.5d, null}
@@ -133,7 +132,7 @@ public class RoboCursorTest {
   }
 
   @Test
-  public void moveToNext_advancesToNextRow() throws Exception {
+  public void moveToNext_advancesToNextRow() {
     cursor.setResults(
         new Object[][] {
           new Object[] {"aString", 1234L, 41}, new Object[] {"anotherString", 5678L, 42}
@@ -152,7 +151,7 @@ public class RoboCursorTest {
   }
 
   @Test
-  public void moveToPosition_movesToAppropriateRow() throws Exception {
+  public void moveToPosition_movesToAppropriateRow() {
     cursor.setResults(
         new Object[][] {
           new Object[] {"aString", 1234L, 41}, new Object[] {"anotherString", 5678L, 42}
@@ -189,7 +188,7 @@ public class RoboCursorTest {
   }
 
   @Test
-  public void close_isRemembered() throws Exception {
+  public void close_isRemembered() {
     cursor.close();
     assertThat(cursor.getCloseWasCalled()).isTrue();
   }

--- a/robolectric/src/test/java/org/robolectric/fakes/RoboWebSettingsTest.java
+++ b/robolectric/src/test/java/org/robolectric/fakes/RoboWebSettingsTest.java
@@ -139,7 +139,7 @@ public class RoboWebSettingsTest {
   }
 
   @Test
-  public void testMediaPlaybackRequiresUserGesture() throws Exception {
+  public void testMediaPlaybackRequiresUserGesture() {
     for (boolean value : TRUE_AND_FALSE) {
       webSettings.setMediaPlaybackRequiresUserGesture(value);
       assertThat(webSettings.getMediaPlaybackRequiresUserGesture()).isEqualTo(value);
@@ -188,13 +188,13 @@ public class RoboWebSettingsTest {
   }
 
   @Test
-  public void testSetCacheMode() throws Exception {
+  public void testSetCacheMode() {
     webSettings.setCacheMode(7);
     assertThat(webSettings.getCacheMode()).isEqualTo(7);
   }
 
   @Test
-  public void testSetUseWideViewPort() throws Exception {
+  public void testSetUseWideViewPort() {
     for (boolean value : TRUE_AND_FALSE) {
       webSettings.setUseWideViewPort(value);
       assertThat(webSettings.getUseWideViewPort()).isEqualTo(value);
@@ -202,7 +202,7 @@ public class RoboWebSettingsTest {
   }
 
   @Test
-  public void testSetAppCacheEnabled() throws Exception {
+  public void testSetAppCacheEnabled() {
     for (boolean value : TRUE_AND_FALSE) {
       webSettings.setAppCacheEnabled(value);
       assertThat(webSettings.getAppCacheEnabled()).isEqualTo(value);
@@ -210,7 +210,7 @@ public class RoboWebSettingsTest {
   }
 
   @Test
-  public void testSetGeolocationEnabled() throws Exception {
+  public void testSetGeolocationEnabled() {
     for (boolean value : TRUE_AND_FALSE) {
       webSettings.setGeolocationEnabled(value);
       assertThat(webSettings.getGeolocationEnabled()).isEqualTo(value);
@@ -218,7 +218,7 @@ public class RoboWebSettingsTest {
   }
 
   @Test
-  public void testSetSaveFormData() throws Exception {
+  public void testSetSaveFormData() {
     for (boolean value : TRUE_AND_FALSE) {
       webSettings.setSaveFormData(value);
       assertThat(webSettings.getSaveFormData()).isEqualTo(value);
@@ -226,49 +226,49 @@ public class RoboWebSettingsTest {
   }
 
   @Test
-  public void testSetDatabasePath() throws Exception {
+  public void testSetDatabasePath() {
     webSettings.setDatabasePath("new_path");
     assertThat(webSettings.getDatabasePath()).isEqualTo("new_path");
   }
 
   @Test
-  public void testSetRenderPriority() throws Exception {
+  public void testSetRenderPriority() {
     webSettings.setRenderPriority(WebSettings.RenderPriority.HIGH);
     assertThat(webSettings.getRenderPriority()).isEqualTo(WebSettings.RenderPriority.HIGH);
   }
 
   @Test
-  public void testSetAppCachePath() throws Exception {
+  public void testSetAppCachePath() {
     webSettings.setAppCachePath("new_path");
     assertThat(webSettings.getAppCachePath()).isEqualTo("new_path");
   }
 
   @Test
-  public void testSetAppCacheMaxSize() throws Exception {
+  public void testSetAppCacheMaxSize() {
     webSettings.setAppCacheMaxSize(100);
     assertThat(webSettings.getAppCacheMaxSize()).isEqualTo(100);
   }
 
   @Test
-  public void testSetGeolocationDatabasePath() throws Exception {
+  public void testSetGeolocationDatabasePath() {
     webSettings.setGeolocationDatabasePath("new_path");
     assertThat(webSettings.getGeolocationDatabasePath()).isEqualTo("new_path");
   }
 
   @Test
-  public void testSetJavascriptCanOpenWindowsAutomaticallyIsTrue() throws Exception {
+  public void testSetJavascriptCanOpenWindowsAutomaticallyIsTrue() {
     webSettings.setJavaScriptCanOpenWindowsAutomatically(true);
     assertThat(webSettings.getJavaScriptCanOpenWindowsAutomatically()).isTrue();
   }
 
   @Test
-  public void testSetJavascriptCanOpenWindowsAutomaticallyIsFalse() throws Exception {
+  public void testSetJavascriptCanOpenWindowsAutomaticallyIsFalse() {
     webSettings.setJavaScriptCanOpenWindowsAutomatically(false);
     assertThat(webSettings.getJavaScriptCanOpenWindowsAutomatically()).isFalse();
   }
 
   @Test
-  public void testSetTextZoom() throws Exception {
+  public void testSetTextZoom() {
     webSettings.setTextZoom(50);
     assertThat(webSettings.getTextZoom()).isEqualTo(50);
   }

--- a/robolectric/src/test/java/org/robolectric/interceptors/AndroidInterceptorsTest.java
+++ b/robolectric/src/test/java/org/robolectric/interceptors/AndroidInterceptorsTest.java
@@ -11,7 +11,7 @@ import org.robolectric.internal.bytecode.MethodRef;
 @RunWith(JUnit4.class)
 public class AndroidInterceptorsTest {
   @Test
-  public void allMethodRefs() throws Exception {
+  public void allMethodRefs() {
     assertThat(new Interceptors(AndroidInterceptors.all()).getAllMethodRefs())
         .containsAtLeast(
             new MethodRef("java.util.LinkedHashMap", "eldest"),
@@ -31,7 +31,7 @@ public class AndroidInterceptorsTest {
   }
 
   @Test
-  public void localeAdjustCodeInterceptor() throws Exception {
+  public void localeAdjustCodeInterceptor() {
     assertThat(adjust("EN")).isEqualTo("en");
     assertThat(adjust("he")).isEqualTo("iw");
     assertThat(adjust("yi")).isEqualTo("ji");

--- a/robolectric/src/test/java/org/robolectric/internal/DefaultManifestFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/DefaultManifestFactoryTest.java
@@ -66,7 +66,7 @@ public class DefaultManifestFactoryTest {
   }
 
   @Test
-  public void identify_configNoneShouldBeIgnored() throws Exception {
+  public void identify_configNoneShouldBeIgnored() {
     Properties properties = new Properties();
     properties.put("android_merged_manifest", "gradle/AndroidManifest.xml");
     properties.put("android_merged_resources", "gradle/res");
@@ -85,7 +85,7 @@ public class DefaultManifestFactoryTest {
   }
 
   @Test
-  public void identify_packageCanBeOverridenFromConfig() throws Exception {
+  public void identify_packageCanBeOverriddenFromConfig() {
     Properties properties = new Properties();
     properties.put("android_merged_manifest", "gradle/AndroidManifest.xml");
     properties.put("android_merged_resources", "gradle/res");

--- a/robolectric/src/test/java/org/robolectric/internal/MavenManifestFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/MavenManifestFactoryTest.java
@@ -23,7 +23,7 @@ public class MavenManifestFactoryTest {
   }
 
   @Test
-  public void identify() throws Exception {
+  public void identify() {
     ManifestIdentifier manifestIdentifier = myMavenManifestFactory.identify(configBuilder.build());
     assertThat(manifestIdentifier.getManifestFile())
         .isEqualTo(Paths.get("_fakefs_path").resolve("to").resolve("DifferentManifest.xml"));
@@ -31,7 +31,7 @@ public class MavenManifestFactoryTest {
   }
 
   @Test
-  public void withDotSlashManifest_identify() throws Exception {
+  public void withDotSlashManifest_identify() {
     configBuilder.setManifest("./DifferentManifest.xml");
 
     ManifestIdentifier manifestIdentifier = myMavenManifestFactory.identify(configBuilder.build());
@@ -42,7 +42,7 @@ public class MavenManifestFactoryTest {
   }
 
   @Test
-  public void withDotDotSlashManifest_identify() throws Exception {
+  public void withDotDotSlashManifest_identify() {
     configBuilder.setManifest("../DifferentManifest.xml");
 
     ManifestIdentifier manifestIdentifier = myMavenManifestFactory.identify(configBuilder.build());

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/InstrumentationConfigurationTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/InstrumentationConfigurationTest.java
@@ -25,7 +25,7 @@ public class InstrumentationConfigurationTest {
   }
 
   @Test
-  public void shouldNotInstrumentAndroidAppClasses() throws Exception {
+  public void shouldNotInstrumentAndroidAppClasses() {
     assertThat(config.shouldInstrument(wrap("com.google.android.apps.Foo"))).isFalse();
   }
 
@@ -35,13 +35,13 @@ public class InstrumentationConfigurationTest {
   }
 
   @Test
-  public void shouldNotInstrumentCoreJdkClasses() throws Exception {
+  public void shouldNotInstrumentCoreJdkClasses() {
     assertThat(config.shouldInstrument(wrap("java.lang.Object"))).isFalse();
     assertThat(config.shouldInstrument(wrap("java.lang.String"))).isFalse();
   }
 
   @Test
-  public void shouldInstrumentAndroidCoreClasses() throws Exception {
+  public void shouldInstrumentAndroidCoreClasses() {
     assertThat(config.shouldInstrument(wrap("android.content.Intent"))).isTrue();
     assertThat(config.shouldInstrument(wrap("android.and.now.for.something.completely.different")))
         .isTrue();
@@ -58,7 +58,7 @@ public class InstrumentationConfigurationTest {
   }
 
   @Test
-  public void shouldAcquireAndroidRClasses() throws Exception {
+  public void shouldAcquireAndroidRClasses() {
     assertThat(config.shouldAcquire("android.Rfoo")).isTrue();
     assertThat(config.shouldAcquire("android.fooR")).isTrue();
     assertThat(config.shouldAcquire("android.R")).isTrue();
@@ -67,7 +67,7 @@ public class InstrumentationConfigurationTest {
   }
 
   @Test
-  public void shouldAcquireRClasses() throws Exception {
+  public void shouldAcquireRClasses() {
     assertThat(config.shouldAcquire("com.whatever.Rfoo")).isTrue();
     assertThat(config.shouldAcquire("com.whatever.fooR")).isTrue();
     assertThat(config.shouldAcquire("com.whatever.R")).isTrue();
@@ -76,7 +76,7 @@ public class InstrumentationConfigurationTest {
   }
 
   @Test
-  public void shouldNotAcquireExcludedPackages() throws Exception {
+  public void shouldNotAcquireExcludedPackages() {
     assertThat(config.shouldAcquire("scala.Test")).isFalse();
     assertThat(config.shouldAcquire("scala.util.Test")).isFalse();
     assertThat(config.shouldAcquire("org.specs2.whatever.foo")).isFalse();
@@ -85,22 +85,22 @@ public class InstrumentationConfigurationTest {
   }
 
   @Test
-  public void shouldNotAcquireShadowClass() throws Exception {
+  public void shouldNotAcquireShadowClass() {
     assertThat(config.shouldAcquire("org.robolectric.shadow.api.Shadow")).isTrue();
   }
 
   @Test
-  public void shouldAcquireDistinguishedNameParser_Issue1864() throws Exception {
+  public void shouldAcquireDistinguishedNameParser_Issue1864() {
     assertThat(config.shouldAcquire("javax.net.ssl.DistinguishedNameParser")).isTrue();
   }
 
   @Test
-  public void shouldAcquireOpenglesGL_Issue2960() throws Exception {
+  public void shouldAcquireOpenglesGL_Issue2960() {
     assertThat(config.shouldAcquire("javax.microedition.khronos.opengles.GL")).isTrue();
   }
 
   @Test
-  public void shouldInstrumentCustomClasses() throws Exception {
+  public void shouldInstrumentCustomClasses() {
     String instrumentName = "com.whatever.SomeClassNameToInstrument";
     String notInstrumentName = "com.whatever.DoNotInstrumentMe";
     InstrumentationConfiguration customConfig =
@@ -110,7 +110,7 @@ public class InstrumentationConfigurationTest {
   }
 
   @Test
-  public void equals_ShouldCheckClassNames() throws Exception {
+  public void equals_ShouldCheckClassNames() {
     String instrumentName = "com.whatever.SomeClassNameToInstrument";
     InstrumentationConfiguration baseConfig = InstrumentationConfiguration.newBuilder().build();
     InstrumentationConfiguration customConfig =
@@ -120,7 +120,7 @@ public class InstrumentationConfigurationTest {
   }
 
   @Test
-  public void shouldNotInstrumentListedClasses() throws Exception {
+  public void shouldNotInstrumentListedClasses() {
     String instrumentName = "android.foo.bar";
     InstrumentationConfiguration customConfig =
         InstrumentationConfiguration.newBuilder().doNotInstrumentClass(instrumentName).build();
@@ -129,7 +129,7 @@ public class InstrumentationConfigurationTest {
   }
 
   @Test
-  public void shouldNotInstrumentPackages() throws Exception {
+  public void shouldNotInstrumentPackages() {
     String includedClass = "android.foo.Bar";
     String excludedClass = "androidx.test.foo.Bar";
     InstrumentationConfiguration customConfig =
@@ -143,7 +143,7 @@ public class InstrumentationConfigurationTest {
   }
 
   @Test
-  public void shouldNotInstrumentClassNamesWithNullRegex() throws Exception {
+  public void shouldNotInstrumentClassNamesWithNullRegex() {
     InstrumentationConfiguration customConfig =
         InstrumentationConfiguration.newBuilder()
             .addInstrumentedPackage("com.random")
@@ -155,7 +155,7 @@ public class InstrumentationConfigurationTest {
   }
 
   @Test
-  public void shouldNotInstrumentClassNamesWithRegex() throws Exception {
+  public void shouldNotInstrumentClassNamesWithRegex() {
     InstrumentationConfiguration customConfig =
         InstrumentationConfiguration.newBuilder()
             .addInstrumentedPackage("com.random")
@@ -167,7 +167,7 @@ public class InstrumentationConfigurationTest {
   }
 
   @Test
-  public void shouldNotInstrumentClassNamesWithMultiRegex() throws Exception {
+  public void shouldNotInstrumentClassNamesWithMultiRegex() {
     InstrumentationConfiguration customConfig =
         InstrumentationConfiguration.newBuilder()
             .addInstrumentedPackage("com.random")
@@ -183,7 +183,7 @@ public class InstrumentationConfigurationTest {
   }
 
   @Test
-  public void removesRedundantPackageAndClassConfig() throws Exception {
+  public void removesRedundantPackageAndClassConfig() {
     InstrumentationConfiguration config1 =
         InstrumentationConfiguration.newBuilder()
             .addInstrumentedPackage("a.b")

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowMapTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowMapTest.java
@@ -59,13 +59,13 @@ public class ShadowMapTest {
   }
 
   @Test
-  public void shouldLookUpShadowClassesByNamingConvention() throws Exception {
+  public void shouldLookUpShadowClassesByNamingConvention() {
     ShadowMap map = baseShadowMap.newBuilder().build();
     assertThat(map.getShadowInfo(Activity.class, ShadowMatcher.MATCH_ALL)).isNull();
   }
 
   @Test
-  public void shouldNotReturnMismatchedClassesJustBecauseTheSimpleNameMatches() throws Exception {
+  public void shouldNotReturnMismatchedClassesJustBecauseTheSimpleNameMatches() {
     ShadowMap map = baseShadowMap.newBuilder().addShadowClasses(ShadowActivity.class).build();
     assertThat(
             map.getShadowInfo(android.app.Activity.class, ShadowMatcher.MATCH_ALL).shadowClassName)
@@ -101,7 +101,7 @@ public class ShadowMapTest {
   }
 
   @Test
-  public void equalsHashCode() throws Exception {
+  public void equalsHashCode() {
     ShadowMap a = baseShadowMap.newBuilder().addShadowClass(A, B, true, false, false).build();
     ShadowMap b = baseShadowMap.newBuilder().addShadowClass(A, B, true, false, false).build();
     assertThat(a).isEqualTo(b);

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowWranglerUnitTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowWranglerUnitTest.java
@@ -27,8 +27,7 @@ public class ShadowWranglerUnitTest {
   }
 
   @Test
-  public void getInterceptionHandler_whenCallIsNotRecognized_shouldReturnDoNothingHandler()
-      throws Exception {
+  public void getInterceptionHandler_whenCallIsNotRecognized_shouldReturnDoNothingHandler() {
     MethodSignature methodSignature = MethodSignature.parse("java/lang/Object/unknownMethod()V");
     Function<Object, Object> handler = interceptors.getInterceptionHandler(methodSignature);
 
@@ -37,8 +36,7 @@ public class ShadowWranglerUnitTest {
 
   @Test
   public void
-      getInterceptionHandler_whenInterceptingElderOnLinkedHashMap_shouldReturnNonDoNothingHandler()
-          throws Exception {
+      getInterceptionHandler_whenInterceptingElderOnLinkedHashMap_shouldReturnNonDoNothingHandler() {
     MethodSignature methodSignature =
         MethodSignature.parse("java/util/LinkedHashMap/eldest()Ljava/lang/Object;");
     Function<Object, Object> handler = interceptors.getInterceptionHandler(methodSignature);

--- a/robolectric/src/test/java/org/robolectric/junit/rules/BackgroundTestRuleTest.java
+++ b/robolectric/src/test/java/org/robolectric/junit/rules/BackgroundTestRuleTest.java
@@ -22,12 +22,12 @@ public final class BackgroundTestRuleTest {
 
   @Test
   @BackgroundTestRule.BackgroundTest
-  public void testRunsInBackground() throws Exception {
+  public void testRunsInBackground() {
     assertThat(Looper.myLooper()).isNotEqualTo(Looper.getMainLooper());
   }
 
   @Test
-  public void testNoAnnotation_runsOnMainThread() throws Exception {
+  public void testNoAnnotation_runsOnMainThread() {
     assertThat(Looper.myLooper()).isEqualTo(Looper.getMainLooper());
   }
 

--- a/robolectric/src/test/java/org/robolectric/plugins/CustomConfigurerTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/CustomConfigurerTest.java
@@ -48,7 +48,7 @@ public class CustomConfigurerTest {
 
     @Test
     @SomeConfig(value = "the value")
-    public void shouldHaveValue() throws Exception {
+    public void shouldHaveValue() {
       SomeConfig someConfig = ConfigurationRegistry.get(SomeConfig.class);
       fail("someConfig value is " + someConfig.value());
     }

--- a/robolectric/src/test/java/org/robolectric/plugins/DefaultSdkPickerTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/DefaultSdkPickerTest.java
@@ -37,14 +37,14 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void withDefaultSdk_shouldUseTargetSdkFromAndroidManifest() throws Exception {
+  public void withDefaultSdk_shouldUseTargetSdkFromAndroidManifest() {
     when(usesSdk.getTargetSdkVersion()).thenReturn(22);
     assertThat(sdkPicker.selectSdks(buildConfig(new Config.Builder()), usesSdk))
         .containsExactly(sdkCollection.getSdk(22));
   }
 
   @Test
-  public void withAllSdksConfig_shouldUseFullSdkRangeFromAndroidManifest() throws Exception {
+  public void withAllSdksConfig_shouldUseFullSdkRangeFromAndroidManifest() {
     when(usesSdk.getTargetSdkVersion()).thenReturn(22);
     when(usesSdk.getMinSdkVersion()).thenReturn(19);
     when(usesSdk.getMaxSdkVersion()).thenReturn(23);
@@ -59,8 +59,7 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void withAllSdksConfigAndNoMinSdkVersion_shouldUseFullSdkRangeFromAndroidManifest()
-      throws Exception {
+  public void withAllSdksConfigAndNoMinSdkVersion_shouldUseFullSdkRangeFromAndroidManifest() {
     when(usesSdk.getTargetSdkVersion()).thenReturn(22);
     when(usesSdk.getMinSdkVersion()).thenReturn(1);
     when(usesSdk.getMaxSdkVersion()).thenReturn(22);
@@ -77,8 +76,7 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void withAllSdksConfigAndNoMaxSdkVersion_shouldUseFullSdkRangeFromAndroidManifest()
-      throws Exception {
+  public void withAllSdksConfigAndNoMaxSdkVersion_shouldUseFullSdkRangeFromAndroidManifest() {
     when(usesSdk.getTargetSdkVersion()).thenReturn(22);
     when(usesSdk.getMinSdkVersion()).thenReturn(19);
     when(usesSdk.getMaxSdkVersion()).thenReturn(null);
@@ -93,7 +91,7 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void withMinSdkHigherThanSupportedRange_shouldReturnNone() throws Exception {
+  public void withMinSdkHigherThanSupportedRange_shouldReturnNone() {
     when(usesSdk.getTargetSdkVersion()).thenReturn(23);
     when(usesSdk.getMinSdkVersion()).thenReturn(1);
     when(usesSdk.getMaxSdkVersion()).thenReturn(null);
@@ -102,7 +100,7 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void withMinSdkHigherThanMaxSdk_shouldThrowError() throws Exception {
+  public void withMinSdkHigherThanMaxSdk_shouldThrowError() {
     when(usesSdk.getTargetSdkVersion()).thenReturn(23);
     when(usesSdk.getMinSdkVersion()).thenReturn(1);
     when(usesSdk.getMaxSdkVersion()).thenReturn(null);
@@ -118,7 +116,7 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void withTargetSdkLessThanMinSdk_shouldThrowError() throws Exception {
+  public void withTargetSdkLessThanMinSdk_shouldThrowError() {
     when(usesSdk.getMinSdkVersion()).thenReturn(23);
     when(usesSdk.getTargetSdkVersion()).thenReturn(22);
 
@@ -131,7 +129,7 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void withTargetSdkGreaterThanMaxSdk_shouldThrowError() throws Exception {
+  public void withTargetSdkGreaterThanMaxSdk_shouldThrowError() {
     when(usesSdk.getMaxSdkVersion()).thenReturn(21);
     when(usesSdk.getTargetSdkVersion()).thenReturn(22);
     try {
@@ -143,7 +141,7 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void shouldClipSdkRangeFromAndroidManifest() throws Exception {
+  public void shouldClipSdkRangeFromAndroidManifest() {
     when(usesSdk.getTargetSdkVersion()).thenReturn(1);
     when(usesSdk.getMinSdkVersion()).thenReturn(1);
     when(usesSdk.getMaxSdkVersion()).thenReturn(null);
@@ -152,7 +150,7 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void withMinSdk_shouldClipSdkRangeFromAndroidManifest() throws Exception {
+  public void withMinSdk_shouldClipSdkRangeFromAndroidManifest() {
     when(usesSdk.getTargetSdkVersion()).thenReturn(22);
     when(usesSdk.getMinSdkVersion()).thenReturn(19);
     when(usesSdk.getMaxSdkVersion()).thenReturn(23);
@@ -162,7 +160,7 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void withMaxSdk_shouldUseSdkRangeFromAndroidManifest() throws Exception {
+  public void withMaxSdk_shouldUseSdkRangeFromAndroidManifest() {
     when(usesSdk.getTargetSdkVersion()).thenReturn(22);
     when(usesSdk.getMinSdkVersion()).thenReturn(19);
     when(usesSdk.getMaxSdkVersion()).thenReturn(23);
@@ -171,7 +169,7 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void withExplicitSdk_selectSdks() throws Exception {
+  public void withExplicitSdk_selectSdks() {
     when(usesSdk.getTargetSdkVersion()).thenReturn(21);
     when(usesSdk.getMinSdkVersion()).thenReturn(19);
     when(usesSdk.getMaxSdkVersion()).thenReturn(22);
@@ -198,7 +196,7 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void withEnabledSdks_shouldRestrictAsSpecified() throws Exception {
+  public void withEnabledSdks_shouldRestrictAsSpecified() {
     when(usesSdk.getMinSdkVersion()).thenReturn(16);
     when(usesSdk.getMaxSdkVersion()).thenReturn(23);
     sdkPicker = new DefaultSdkPicker(sdkCollection, "17,18");
@@ -209,7 +207,7 @@ public class DefaultSdkPickerTest {
   }
 
   @Test
-  public void shouldParseSdkSpecs() throws Exception {
+  public void shouldParseSdkSpecs() {
     assertThat(ConfigUtils.parseSdkArrayProperty("17,18"))
         .asList()
         .containsExactly(VERSION_CODES.JELLY_BEAN_MR1, VERSION_CODES.JELLY_BEAN_MR2);

--- a/robolectric/src/test/java/org/robolectric/plugins/HierarchicalConfigurationStrategyTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/HierarchicalConfigurationStrategyTest.java
@@ -31,13 +31,13 @@ import org.robolectric.shadows.testing.TestApplication;
 public class HierarchicalConfigurationStrategyTest {
 
   @Test
-  public void defaultValuesAreMerged() throws Exception {
+  public void defaultValuesAreMerged() {
     assertThat(configFor(Test2.class, "withoutAnnotation").manifest())
         .isEqualTo("AndroidManifest.xml");
   }
 
   @Test
-  public void globalValuesAreMerged() throws Exception {
+  public void globalValuesAreMerged() {
     assertThat(
             configFor(
                     Test2.class,
@@ -48,8 +48,7 @@ public class HierarchicalConfigurationStrategyTest {
   }
 
   @Test
-  public void whenClassHasConfigAnnotation_getConfig_shouldMergeClassAndMethodConfig()
-      throws Exception {
+  public void whenClassHasConfigAnnotation_getConfig_shouldMergeClassAndMethodConfig() {
     assertConfig(
         configFor(Test1.class, "withoutAnnotation"),
         new int[] {1},
@@ -91,8 +90,7 @@ public class HierarchicalConfigurationStrategyTest {
   }
 
   @Test
-  public void whenClassDoesntHaveConfigAnnotation_getConfig_shouldUseMethodConfig()
-      throws Exception {
+  public void whenClassDoesntHaveConfigAnnotation_getConfig_shouldUseMethodConfig() {
     assertConfig(
         configFor(Test2.class, "withoutAnnotation"),
         new int[0],
@@ -134,8 +132,8 @@ public class HierarchicalConfigurationStrategyTest {
   }
 
   @Test
-  public void whenClassDoesntHaveConfigAnnotation_getConfig_shouldMergeParentClassAndMethodConfig()
-      throws Exception {
+  public void
+      whenClassDoesntHaveConfigAnnotation_getConfig_shouldMergeParentClassAndMethodConfig() {
     assertConfig(
         configFor(Test1B.class, "withoutAnnotation"),
         new int[] {1},
@@ -178,8 +176,7 @@ public class HierarchicalConfigurationStrategyTest {
 
   @Test
   public void
-      whenClassAndParentClassHaveConfigAnnotation_getConfig_shouldMergeParentClassAndMethodConfig()
-          throws Exception {
+      whenClassAndParentClassHaveConfigAnnotation_getConfig_shouldMergeParentClassAndMethodConfig() {
     assertConfig(
         configFor(Test1C.class, "withoutAnnotation"),
         new int[] {1},
@@ -222,8 +219,7 @@ public class HierarchicalConfigurationStrategyTest {
 
   @Test
   public void
-      whenClassAndSubclassHaveConfigAnnotation_getConfig_shouldMergeClassSubclassAndMethodConfig()
-          throws Exception {
+      whenClassAndSubclassHaveConfigAnnotation_getConfig_shouldMergeClassSubclassAndMethodConfig() {
     assertConfig(
         configFor(Test1A.class, "withoutAnnotation"),
         new int[] {1},
@@ -266,8 +262,7 @@ public class HierarchicalConfigurationStrategyTest {
 
   @Test
   public void
-      whenClassDoesntHaveConfigAnnotationButSubclassDoes_getConfig_shouldMergeSubclassAndMethodConfig()
-          throws Exception {
+      whenClassDoesntHaveConfigAnnotationButSubclassDoes_getConfig_shouldMergeSubclassAndMethodConfig() {
     assertConfig(
         configFor(Test2A.class, "withoutAnnotation"),
         new int[0],
@@ -309,7 +304,7 @@ public class HierarchicalConfigurationStrategyTest {
   }
 
   @Test
-  public void shouldLoadDefaultsFromGlobalPropertiesFile() throws Exception {
+  public void shouldLoadDefaultsFromGlobalPropertiesFile() {
     String properties =
         "sdk: 432\n"
             + "manifest: --none\n"
@@ -341,7 +336,7 @@ public class HierarchicalConfigurationStrategyTest {
   }
 
   @Test
-  public void shouldMergeConfigFromTestClassPackageProperties() throws Exception {
+  public void shouldMergeConfigFromTestClassPackageProperties() {
     assertConfig(
         configFor(
             Test2.class,
@@ -360,7 +355,7 @@ public class HierarchicalConfigurationStrategyTest {
   }
 
   @Test
-  public void shouldMergeConfigUpPackageHierarchy() throws Exception {
+  public void shouldMergeConfigUpPackageHierarchy() {
     assertConfig(
         configFor(
             Test2.class,
@@ -385,7 +380,7 @@ public class HierarchicalConfigurationStrategyTest {
   }
 
   @Test
-  public void withEmptyShadowList_shouldLoadDefaultsFromGlobalPropertiesFile() throws Exception {
+  public void withEmptyShadowList_shouldLoadDefaultsFromGlobalPropertiesFile() {
     assertConfig(
         configFor(
             Test2.class,
@@ -572,11 +567,11 @@ public class HierarchicalConfigurationStrategyTest {
       assetDir = "test/assets")
   public static class Test1 {
     @Test
-    public void withoutAnnotation() throws Exception {}
+    public void withoutAnnotation() {}
 
     @Test
     @Config
-    public void withDefaultsAnnotation() throws Exception {}
+    public void withDefaultsAnnotation() {}
 
     @Test
     @Config(
@@ -590,17 +585,17 @@ public class HierarchicalConfigurationStrategyTest {
         qualifiers = "from-method",
         resourceDir = "method/res",
         assetDir = "method/assets")
-    public void withOverrideAnnotation() throws Exception {}
+    public void withOverrideAnnotation() {}
   }
 
   @Ignore
   public static class Test2 {
     @Test
-    public void withoutAnnotation() throws Exception {}
+    public void withoutAnnotation() {}
 
     @Test
     @Config
-    public void withDefaultsAnnotation() throws Exception {}
+    public void withDefaultsAnnotation() {}
 
     @Test
     @Config(
@@ -614,7 +609,7 @@ public class HierarchicalConfigurationStrategyTest {
         qualifiers = "from-method",
         resourceDir = "method/res",
         assetDir = "method/assets")
-    public void withOverrideAnnotation() throws Exception {}
+    public void withOverrideAnnotation() {}
   }
 
   @Ignore
@@ -629,12 +624,12 @@ public class HierarchicalConfigurationStrategyTest {
   public static class Test1B extends Test1 {
     @Override
     @Test
-    public void withoutAnnotation() throws Exception {}
+    public void withoutAnnotation() {}
 
     @Override
     @Test
     @Config
-    public void withDefaultsAnnotation() throws Exception {}
+    public void withDefaultsAnnotation() {}
 
     @Override
     @Test
@@ -645,7 +640,7 @@ public class HierarchicalConfigurationStrategyTest {
         packageName = "com.example.test",
         qualifiers = "from-method5",
         assetDir = "method5/assets")
-    public void withOverrideAnnotation() throws Exception {}
+    public void withOverrideAnnotation() {}
   }
 
   @Ignore

--- a/robolectric/src/test/java/org/robolectric/plugins/LegacyDependencyResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/LegacyDependencyResolverTest.java
@@ -44,7 +44,7 @@ public class LegacyDependencyResolverTest {
   }
 
   @Test
-  public void whenRobolectricDepsPropertiesProperty() throws Exception {
+  public void whenRobolectricDepsPropertiesProperty() {
     Path depsPath =
         tempDirectory.createFile(
             "deps.properties", "org.robolectric\\:android-all\\:" + VERSION + ": file-123.jar");
@@ -59,7 +59,7 @@ public class LegacyDependencyResolverTest {
   }
 
   @Test
-  public void whenRobolectricDepsPropertiesPropertyAndOfflineProperty() throws Exception {
+  public void whenRobolectricDepsPropertiesPropertyAndOfflineProperty() {
     Path depsPath =
         tempDirectory.createFile(
             "deps.properties", "org.robolectric\\:android-all\\:" + VERSION + ": file-123.jar");
@@ -75,7 +75,7 @@ public class LegacyDependencyResolverTest {
   }
 
   @Test
-  public void whenRobolectricDepsPropertiesResource() throws Exception {
+  public void whenRobolectricDepsPropertiesResource() {
     Path depsPath =
         tempDirectory.createFile(
             "deps.properties", "org.robolectric\\:android-all\\:" + VERSION + ": file-123.jar");
@@ -88,7 +88,7 @@ public class LegacyDependencyResolverTest {
   }
 
   @Test
-  public void whenRobolectricDependencyDirProperty() throws Exception {
+  public void whenRobolectricDependencyDirProperty() {
     Path jarsPath = tempDirectory.create("jars");
     Path sdkJarPath = tempDirectory.createFile("jars/android-all-" + VERSION + ".jar", "...");
 

--- a/robolectric/src/test/java/org/robolectric/plugins/SdkCollectionTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/SdkCollectionTest.java
@@ -40,7 +40,7 @@ public class SdkCollectionTest {
   }
 
   @Test
-  public void shouldComplainAboutDupes() throws Exception {
+  public void shouldComplainAboutDupes() {
     try {
       new SdkCollection(() -> Arrays.asList(fakeSdk1234, fakeSdk1234));
       fail();
@@ -50,7 +50,7 @@ public class SdkCollectionTest {
   }
 
   @Test
-  public void shouldCacheSdks() throws Exception {
+  public void shouldCacheSdks() {
     assertThat(sdkCollection.getSdk(1234)).isSameInstanceAs(fakeSdk1234);
     assertThat(sdkCollection.getSdk(1234)).isSameInstanceAs(fakeSdk1234);
 
@@ -58,25 +58,25 @@ public class SdkCollectionTest {
   }
 
   @Test
-  public void getMaxSupportedSdk() throws Exception {
+  public void getMaxSupportedSdk() {
     assertThat(sdkCollection.getMaxSupportedSdk()).isSameInstanceAs(fakeSdk1236);
   }
 
   @Test
-  public void getSdk_shouldReturnNullObjectForUnknownSdks() throws Exception {
+  public void getSdk_shouldReturnNullObjectForUnknownSdks() {
     assertThat(sdkCollection.getSdk(4321)).isNotNull();
     assertThat(sdkCollection.getSdk(4321).isKnown()).isFalse();
   }
 
   @Test
-  public void getKnownSdks_shouldReturnAll() throws Exception {
+  public void getKnownSdks_shouldReturnAll() {
     assertThat(sdkCollection.getKnownSdks())
         .containsExactly(fakeSdk1234, fakeSdk1235, fakeSdk1236, fakeUnsupportedSdk1237)
         .inOrder();
   }
 
   @Test
-  public void getSupportedSdks_shouldReturnOnlySupported() throws Exception {
+  public void getSupportedSdks_shouldReturnOnlySupported() {
     assertThat(sdkCollection.getSupportedSdks())
         .containsExactly(fakeSdk1234, fakeSdk1235, fakeSdk1236)
         .inOrder();

--- a/robolectric/src/test/java/org/robolectric/res/RawResourceLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/RawResourceLoaderTest.java
@@ -24,7 +24,7 @@ public class RawResourceLoaderTest {
   }
 
   @Test
-  public void shouldReturnRawResourcesWithExtensions() throws Exception {
+  public void shouldReturnRawResourcesWithExtensions() {
     String f = (String) resourceTable.getValue(R.raw.raw_resource, new ResTable_config()).getData();
     assertThat(f)
         .isEqualTo(
@@ -36,7 +36,7 @@ public class RawResourceLoaderTest {
   }
 
   @Test
-  public void shouldReturnRawResourcesWithoutExtensions() throws Exception {
+  public void shouldReturnRawResourcesWithoutExtensions() {
     String f = (String) resourceTable.getValue(R.raw.raw_no_ext, new ResTable_config()).getData();
     assertThat(f)
         .isEqualTo(

--- a/robolectric/src/test/java/org/robolectric/res/ResBundleTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/ResBundleTest.java
@@ -129,7 +129,7 @@ public class ResBundleTest {
   }
 
   @Test
-  public void shouldMatchQualifiersPerAndroidSpec() throws Exception {
+  public void shouldMatchQualifiersPerAndroidSpec() {
     assertEquals(
         "en-port",
         asResMap(
@@ -145,7 +145,7 @@ public class ResBundleTest {
   }
 
   @Test
-  public void shouldMatchQualifiersInSizeRange() throws Exception {
+  public void shouldMatchQualifiersInSizeRange() {
     assertEquals(
         "sw300dp-port",
         asResMap("", "sw200dp", "sw350dp-port", "sw300dp-port", "sw300dp")
@@ -154,7 +154,7 @@ public class ResBundleTest {
   }
 
   @Test
-  public void shouldPreferWidthOverHeight() throws Exception {
+  public void shouldPreferWidthOverHeight() {
     assertEquals(
         "sw300dp-w200dp",
         asResMap("", "sw200dp", "sw200dp-w300dp", "sw300dp-w200dp", "w300dp")

--- a/robolectric/src/test/java/org/robolectric/res/ResNameTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/ResNameTest.java
@@ -9,7 +9,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ResNameTest {
   @Test
-  public void shouldQualify() throws Exception {
+  public void shouldQualify() {
     assertThat(ResName.qualifyResourceName("some.package:type/name", null, null))
         .isEqualTo("some.package:type/name");
     assertThat(ResName.qualifyResourceName("some.package:type/name", "default.package", "deftype"))
@@ -26,7 +26,7 @@ public class ResNameTest {
   }
 
   @Test
-  public void shouldQualifyResNameFromString() throws Exception {
+  public void shouldQualifyResNameFromString() {
     assertThat(ResName.qualifyResName("some.package:type/name", "default_package", "default_type"))
         .isEqualTo(new ResName("some.package", "type", "name"));
     assertThat(ResName.qualifyResName("some.package:name", "default_package", "default_type"))

--- a/robolectric/src/test/java/org/robolectric/res/ResourceTableFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/ResourceTableFactoryTest.java
@@ -31,7 +31,7 @@ public class ResourceTableFactoryTest {
   }
 
   @Test
-  public void shouldHandleStyleable() throws Exception {
+  public void shouldHandleStyleable() {
     assertThat(appResourceTable.getResourceId(new ResName("org.robolectric:id/burritos")))
         .isEqualTo(R.id.burritos);
     assertThat(
@@ -41,13 +41,13 @@ public class ResourceTableFactoryTest {
   }
 
   @Test
-  public void shouldPrefixAllSystemResourcesWithAndroid() throws Exception {
+  public void shouldPrefixAllSystemResourcesWithAndroid() {
     assertThat(systemResourceTable.getResourceId(new ResName("android:id/text1")))
         .isEqualTo(android.R.id.text1);
   }
 
   @Test
-  public void shouldRetainPackageNameForFullyQualifiedQueries() throws Exception {
+  public void shouldRetainPackageNameForFullyQualifiedQueries() {
     assertThat(systemResourceTable.getResName(android.R.id.text1).getFullyQualifiedName())
         .isEqualTo("android:id/text1");
     assertThat(appResourceTable.getResName(R.id.burritos).getFullyQualifiedName())

--- a/robolectric/src/test/java/org/robolectric/shadows/AdapterViewBehavior.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/AdapterViewBehavior.java
@@ -49,7 +49,7 @@ public abstract class AdapterViewBehavior {
   }
 
   @Test
-  public void testSetAdapter_shouldCauseViewsToBeRenderedAsynchronously() throws Exception {
+  public void testSetAdapter_shouldCauseViewsToBeRenderedAsynchronously() {
     adapterView.setAdapter(new ShadowCountingAdapter(2));
 
     assertThat(adapterView.getCount()).isEqualTo(2);
@@ -62,7 +62,7 @@ public abstract class AdapterViewBehavior {
   }
 
   @Test
-  public void testSetEmptyView_shouldHideAdapterViewIfAdapterIsNull() throws Exception {
+  public void testSetEmptyView_shouldHideAdapterViewIfAdapterIsNull() {
     adapterView.setAdapter(null);
 
     View emptyView = new View(adapterView.getContext());
@@ -73,7 +73,7 @@ public abstract class AdapterViewBehavior {
   }
 
   @Test
-  public void testSetEmptyView_shouldHideAdapterViewIfAdapterViewIsEmpty() throws Exception {
+  public void testSetEmptyView_shouldHideAdapterViewIfAdapterViewIsEmpty() {
     adapterView.setAdapter(new ShadowCountingAdapter(0));
 
     View emptyView = new View(adapterView.getContext());
@@ -84,7 +84,7 @@ public abstract class AdapterViewBehavior {
   }
 
   @Test
-  public void testSetEmptyView_shouldHideEmptyViewIfAdapterViewIsNotEmpty() throws Exception {
+  public void testSetEmptyView_shouldHideEmptyViewIfAdapterViewIsNotEmpty() {
     adapterView.setAdapter(new ShadowCountingAdapter(1));
 
     View emptyView = new View(adapterView.getContext());
@@ -95,7 +95,7 @@ public abstract class AdapterViewBehavior {
   }
 
   @Test
-  public void testSetEmptyView_shouldHideEmptyViewWhenAdapterGetsNewItem() throws Exception {
+  public void testSetEmptyView_shouldHideEmptyViewWhenAdapterGetsNewItem() {
     ShadowCountingAdapter adapter = new ShadowCountingAdapter(0);
     adapterView.setAdapter(adapter);
 
@@ -114,7 +114,7 @@ public abstract class AdapterViewBehavior {
   }
 
   @Test
-  public void testSetEmptyView_shouldHideAdapterViewWhenAdapterBecomesEmpty() throws Exception {
+  public void testSetEmptyView_shouldHideAdapterViewWhenAdapterBecomesEmpty() {
     ShadowCountingAdapter adapter = new ShadowCountingAdapter(1);
     adapterView.setAdapter(adapter);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/BarringInfoBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/BarringInfoBuilderTest.java
@@ -64,7 +64,7 @@ public final class BarringInfoBuilderTest {
   }
 
   @Test
-  public void buildBarringInfo_fromSdkR() throws Exception {
+  public void buildBarringInfo_fromSdkR() {
     BarringServiceInfo barringServiceInfo =
         BarringServiceInfoBuilder.newBuilder()
             .setBarringType(BARRING_TYPE_CONDITIONAL)

--- a/robolectric/src/test/java/org/robolectric/shadows/SQLiteCursorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SQLiteCursorTest.java
@@ -51,7 +51,7 @@ public class SQLiteCursorTest {
   }
 
   @Test
-  public void testGetColumnNamesEmpty() throws Exception {
+  public void testGetColumnNamesEmpty() {
     setupEmptyResult();
     String[] columnNames = cursor.getColumnNames();
 
@@ -72,7 +72,7 @@ public class SQLiteCursorTest {
   }
 
   @Test
-  public void testGetColumnIndexEmpty() throws Exception {
+  public void testGetColumnIndexEmpty() {
     setupEmptyResult();
 
     assertThat(cursor.getColumnIndex("id")).isEqualTo(0);
@@ -91,14 +91,14 @@ public class SQLiteCursorTest {
   }
 
   @Test
-  public void testGetColumnIndexOrThrowEmpty() throws Exception {
+  public void testGetColumnIndexOrThrowEmpty() {
     setupEmptyResult();
 
     assertThat(cursor.getColumnIndexOrThrow("name")).isEqualTo(1);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testGetColumnIndexOrThrowNotFoundEmpty() throws Exception {
+  public void testGetColumnIndexOrThrowNotFoundEmpty() {
     setupEmptyResult();
 
     cursor.getColumnIndexOrThrow("Fred");
@@ -112,7 +112,7 @@ public class SQLiteCursorTest {
   }
 
   @Test
-  public void testMoveToFirstEmpty() throws Exception {
+  public void testMoveToFirstEmpty() {
     setupEmptyResult();
 
     assertThat(cursor.moveToFirst()).isFalse();
@@ -159,7 +159,7 @@ public class SQLiteCursorTest {
   }
 
   @Test
-  public void testMoveToNextEmpty() throws Exception {
+  public void testMoveToNextEmpty() {
     setupEmptyResult();
 
     assertThat(cursor.moveToFirst()).isFalse();
@@ -185,7 +185,7 @@ public class SQLiteCursorTest {
   }
 
   @Test
-  public void testMoveToPreviousEmpty() throws Exception {
+  public void testMoveToPreviousEmpty() {
     setupEmptyResult();
     assertThat(cursor.moveToFirst()).isFalse();
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAbsoluteLayoutTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAbsoluteLayoutTest.java
@@ -13,7 +13,7 @@ import org.junit.runner.RunWith;
 public class ShadowAbsoluteLayoutTest {
 
   @Test
-  public void getLayoutParams_shouldReturnAbsoluteLayoutParams() throws Exception {
+  public void getLayoutParams_shouldReturnAbsoluteLayoutParams() {
     ViewGroup.LayoutParams layoutParams =
         new AbsoluteLayout(ApplicationProvider.getApplicationContext()) {
           @Override

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
@@ -794,7 +794,7 @@ public class ShadowAccountManagerTest {
   }
 
   @Test
-  public void addAccount_withOptionsShouldSupportGetNextAddAccountOptions() throws Exception {
+  public void addAccount_withOptionsShouldSupportGetNextAddAccountOptions() {
     assertThat(shadowOf(am).getNextAddAccountOptions()).isNull();
 
     shadowOf(am).addAuthenticator("google.com");
@@ -811,7 +811,7 @@ public class ShadowAccountManagerTest {
   }
 
   @Test
-  public void addAccount_withOptionsShouldSupportPeekNextAddAccountOptions() throws Exception {
+  public void addAccount_withOptionsShouldSupportPeekNextAddAccountOptions() {
     assertThat(shadowOf(am).peekNextAddAccountOptions()).isNull();
 
     shadowOf(am).addAuthenticator("google.com");
@@ -847,7 +847,7 @@ public class ShadowAccountManagerTest {
   }
 
   @Test
-  public void testGetAsSystemService() throws Exception {
+  public void testGetAsSystemService() {
     AccountManager systemService =
         (AccountManager)
             ApplicationProvider.getApplicationContext().getSystemService(Context.ACCOUNT_SERVICE);
@@ -1090,7 +1090,7 @@ public class ShadowAccountManagerTest {
   }
 
   @Test
-  public void removeAllAccounts() throws Exception {
+  public void removeAllAccounts() {
 
     Account account = new Account("name@gmail.com", "gmail.com");
     shadowOf(am).addAccount(account);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
@@ -93,14 +93,14 @@ public class ShadowActivityTest {
   private Activity activity;
 
   @Test
-  public void shouldUseApplicationLabelFromManifestAsTitleForActivity() throws Exception {
+  public void shouldUseApplicationLabelFromManifestAsTitleForActivity() {
     activity = Robolectric.setupActivity(LabelTestActivity1.class);
     assertThat(activity.getTitle()).isNotNull();
     assertThat(activity.getTitle().toString()).isEqualTo(activity.getString(R.string.app_name));
   }
 
   @Test
-  public void shouldUseActivityLabelFromManifestAsTitleForActivity() throws Exception {
+  public void shouldUseActivityLabelFromManifestAsTitleForActivity() {
     activity = Robolectric.setupActivity(LabelTestActivity2.class);
     assertThat(activity.getTitle()).isNotNull();
     assertThat(activity.getTitle().toString())
@@ -108,7 +108,7 @@ public class ShadowActivityTest {
   }
 
   @Test
-  public void shouldUseActivityLabelFromManifestAsTitleForActivityWithShortName() throws Exception {
+  public void shouldUseActivityLabelFromManifestAsTitleForActivityWithShortName() {
     activity = Robolectric.setupActivity(LabelTestActivity3.class);
     assertThat(activity.getTitle()).isNotNull();
     assertThat(activity.getTitle().toString())
@@ -223,8 +223,7 @@ public class ShadowActivityTest {
 
   @Test
   public void
-      shouldNotComplainIfActivityIsDestroyedWhileAnotherActivityHasRegisteredBroadcastReceivers()
-          throws Exception {
+      shouldNotComplainIfActivityIsDestroyedWhileAnotherActivityHasRegisteredBroadcastReceivers() {
     try (ActivityController<DialogCreatingActivity> controller =
         Robolectric.buildActivity(DialogCreatingActivity.class)) {
       activity = controller.get();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAmbientContextManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAmbientContextManagerTest.java
@@ -43,7 +43,7 @@ public class ShadowAmbientContextManagerTest {
   }
 
   @Test
-  public void default_shouldNotStoreAnyRequest() throws Exception {
+  public void default_shouldNotStoreAnyRequest() {
     assertThat(
             ((ShadowAmbientContextManager)
                     Shadow.extract(context.getSystemService(AmbientContextManager.class)))
@@ -52,7 +52,7 @@ public class ShadowAmbientContextManagerTest {
   }
 
   @Test
-  public void registerObserver_shouldStoreLastRequest() throws Exception {
+  public void registerObserver_shouldStoreLastRequest() {
     AmbientContextManager ambientContextManager =
         context.getSystemService(AmbientContextManager.class);
     AmbientContextEventRequest request =
@@ -79,7 +79,7 @@ public class ShadowAmbientContextManagerTest {
   }
 
   @Test
-  public void registerObserver_thenUnregister_shouldClearLastRequest() throws Exception {
+  public void registerObserver_thenUnregister_shouldClearLastRequest() {
     AmbientContextManager ambientContextManager =
         context.getSystemService(AmbientContextManager.class);
     AmbientContextEventRequest request =
@@ -165,8 +165,7 @@ public class ShadowAmbientContextManagerTest {
 
   @Test
   public void
-      getLastRequestedEventCodesForConsentActivity_consentActivityNeverStarted_shouldReturnNull()
-          throws Exception {
+      getLastRequestedEventCodesForConsentActivity_consentActivityNeverStarted_shouldReturnNull() {
     Set<Integer> lastRequestedEventCodes =
         ((ShadowAmbientContextManager)
                 Shadow.extract(context.getSystemService(AmbientContextManager.class)))
@@ -177,8 +176,7 @@ public class ShadowAmbientContextManagerTest {
 
   @Test
   public void
-      getLastRequestedEventCodesForConsentActivity_consentActivityStarted_shouldReturnRequestedEventCodes()
-          throws Exception {
+      getLastRequestedEventCodesForConsentActivity_consentActivityStarted_shouldReturnRequestedEventCodes() {
     AmbientContextManager ambientContextManager =
         context.getSystemService(AmbientContextManager.class);
     ImmutableSet<Integer> requestedEventCodes =

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAmbientDisplayConfigurationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAmbientDisplayConfigurationTest.java
@@ -29,7 +29,7 @@ public final class ShadowAmbientDisplayConfigurationTest {
   }
 
   @Test
-  public void ambientDisplayComponent_shouldReturnNullByDefault() throws Exception {
+  public void ambientDisplayComponent_shouldReturnNullByDefault() {
     String component =
         ReflectionHelpers.callInstanceMethod(
             instanceAmbientDisplayConfiguration, "ambientDisplayComponent");
@@ -37,8 +37,7 @@ public final class ShadowAmbientDisplayConfigurationTest {
   }
 
   @Test
-  public void ambientDisplayComponent_whenValidDozeComponentIsSet_shouldReturnDozeComponent()
-      throws Exception {
+  public void ambientDisplayComponent_whenValidDozeComponentIsSet_shouldReturnDozeComponent() {
     ShadowAmbientDisplayConfiguration.setDozeComponent(
         "com.google.android.aod/.TestDozeAlwaysOnDisplay");
 
@@ -49,8 +48,7 @@ public final class ShadowAmbientDisplayConfigurationTest {
   }
 
   @Test
-  public void ambientDisplayAvailable_whenValidDozeComponentIsSet_shouldReturnTrue()
-      throws Exception {
+  public void ambientDisplayAvailable_whenValidDozeComponentIsSet_shouldReturnTrue() {
     ShadowAmbientDisplayConfiguration.setDozeComponent(
         "com.google.android.aod/.TestDozeAlwaysOnDisplay");
 
@@ -62,8 +60,7 @@ public final class ShadowAmbientDisplayConfigurationTest {
   }
 
   @Test
-  public void ambientDisplayAvailable_whenInvalidDozeComponentIsSet_shouldReturnFalse()
-      throws Exception {
+  public void ambientDisplayAvailable_whenInvalidDozeComponentIsSet_shouldReturnFalse() {
     ShadowAmbientDisplayConfiguration.setDozeComponent("");
 
     assertThat(
@@ -75,8 +72,7 @@ public final class ShadowAmbientDisplayConfigurationTest {
 
   @Test
   public void
-      alwaysOnDisplayAvailable_whenOverrideDozeAlwaysOnDisplayAvailableStateToTrue_shouldReturnTrue()
-          throws Exception {
+      alwaysOnDisplayAvailable_whenOverrideDozeAlwaysOnDisplayAvailableStateToTrue_shouldReturnTrue() {
     ShadowAmbientDisplayConfiguration.setDozeAlwaysOnDisplayAvailable(
         /* dozeAlwaysOnDisplayAvailable= */ true);
 
@@ -89,8 +85,7 @@ public final class ShadowAmbientDisplayConfigurationTest {
 
   @Test
   public void
-      alwaysOnDisplayAvailable_whenOverrideDozeAlwaysOnDisplayAvailableStateToFalse_shouldReturnFalse()
-          throws Exception {
+      alwaysOnDisplayAvailable_whenOverrideDozeAlwaysOnDisplayAvailableStateToFalse_shouldReturnFalse() {
     ShadowAmbientDisplayConfiguration.setDozeAlwaysOnDisplayAvailable(
         /* dozeAlwaysOnDisplayAvailable= */ false);
 
@@ -103,8 +98,7 @@ public final class ShadowAmbientDisplayConfigurationTest {
 
   @Test
   public void
-      alwaysOnDisplayDebuggingEnabled_whenBothDebuggableAndAodSystemPropertyAreSet_shouldReturnTrue()
-          throws Exception {
+      alwaysOnDisplayDebuggingEnabled_whenBothDebuggableAndAodSystemPropertyAreSet_shouldReturnTrue() {
     ShadowSystemProperties.override("ro.debuggable", "1");
     ShadowSystemProperties.override("debug.doze.aod", "true");
 
@@ -117,8 +111,7 @@ public final class ShadowAmbientDisplayConfigurationTest {
 
   @Test
   public void
-      alwaysOnDisplayDebuggingEnabled_whenOnlyDebuggableSystemPropertyIsSet_shouldReturnFalse()
-          throws Exception {
+      alwaysOnDisplayDebuggingEnabled_whenOnlyDebuggableSystemPropertyIsSet_shouldReturnFalse() {
     ShadowSystemProperties.override("ro.debuggable", "1");
 
     assertThat(
@@ -129,8 +122,7 @@ public final class ShadowAmbientDisplayConfigurationTest {
   }
 
   @Test
-  public void alwaysOnDisplayDebuggingEnabled_whenOnlyAodSystemPropertyIsSet_shouldReturnFalse()
-      throws Exception {
+  public void alwaysOnDisplayDebuggingEnabled_whenOnlyAodSystemPropertyIsSet_shouldReturnFalse() {
     ShadowSystemProperties.override("debug.doze.aod", "true");
 
     assertThat(
@@ -142,8 +134,7 @@ public final class ShadowAmbientDisplayConfigurationTest {
 
   @Test
   public void
-      alwaysOnAvailable_whenValidSystemPropertiesAndValidDozeComponentAreSet_shouldReturnTrue()
-          throws Exception {
+      alwaysOnAvailable_whenValidSystemPropertiesAndValidDozeComponentAreSet_shouldReturnTrue() {
     ShadowSystemProperties.override("ro.debuggable", "1");
     ShadowSystemProperties.override("debug.doze.aod", "true");
 
@@ -161,8 +152,7 @@ public final class ShadowAmbientDisplayConfigurationTest {
 
   @Test
   public void
-      alwaysOnAvailable_whenOverrideDozeAlwaysOnDisplayAvailableStateAndValidDozeComponentAreSet_shouldReturnTrue()
-          throws Exception {
+      alwaysOnAvailable_whenOverrideDozeAlwaysOnDisplayAvailableStateAndValidDozeComponentAreSet_shouldReturnTrue() {
     ShadowSystemProperties.override("ro.debuggable", "0");
     ShadowSystemProperties.override("debug.doze.aod", "false");
 
@@ -179,7 +169,7 @@ public final class ShadowAmbientDisplayConfigurationTest {
   }
 
   @Test
-  public void alwaysOnAvailable_whenInvalidDozeComponentIsSet_shouldReturnFalse() throws Exception {
+  public void alwaysOnAvailable_whenInvalidDozeComponentIsSet_shouldReturnFalse() {
     ShadowSystemProperties.override("ro.debuggable", "1");
     ShadowSystemProperties.override("debug.doze.aod", "true");
 
@@ -196,8 +186,7 @@ public final class ShadowAmbientDisplayConfigurationTest {
 
   @Test
   public void
-      alwaysOnAvailable_whenInvalidSystemPropertiesAreSetAndOverrideDozeAlwaysOnDisplayAvailableStateToFalse_shouldReturnFalse()
-          throws Exception {
+      alwaysOnAvailable_whenInvalidSystemPropertiesAreSetAndOverrideDozeAlwaysOnDisplayAvailableStateToFalse_shouldReturnFalse() {
     ShadowSystemProperties.override("ro.debuggable", "0");
     ShadowSystemProperties.override("debug.doze.aod", "false");
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
@@ -71,7 +71,7 @@ public class ShadowApplicationTest {
   }
 
   @Test
-  public void shouldBeAContext() throws Exception {
+  public void shouldBeAContext() {
     assertThat(Robolectric.setupActivity(Activity.class).getApplication())
         .isSameInstanceAs(ApplicationProvider.getApplicationContext());
     assertThat(Robolectric.setupActivity(Activity.class).getApplication().getApplicationContext())
@@ -79,7 +79,7 @@ public class ShadowApplicationTest {
   }
 
   @Test
-  public void shouldProvideServices() throws Exception {
+  public void shouldProvideServices() {
     assertThat(context.getSystemService(Context.ACTIVITY_SERVICE))
         .isInstanceOf(android.app.ActivityManager.class);
     assertThat(context.getSystemService(Context.POWER_SERVICE))
@@ -125,7 +125,7 @@ public class ShadowApplicationTest {
   }
 
   @Test
-  public void shouldProvideServicesAvailableInAllSdKs() throws Exception {
+  public void shouldProvideServicesAvailableInAllSdKs() {
     assertThat(context.getSystemService(Context.DISPLAY_SERVICE))
         .isInstanceOf(android.hardware.display.DisplayManager.class);
     assertThat(context.getSystemService(Context.USER_SERVICE)).isInstanceOf(UserManager.class);
@@ -142,21 +142,21 @@ public class ShadowApplicationTest {
 
   @Test
   @Config(minSdk = LOLLIPOP_MR1)
-  public void shouldProvideServicesIntroducedInLollipopMr1() throws Exception {
+  public void shouldProvideServicesIntroducedInLollipopMr1() {
     assertThat(context.getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE))
         .isInstanceOf(SubscriptionManager.class);
   }
 
   @Test
   @Config(minSdk = M)
-  public void shouldProvideServicesIntroducedMarshmallow() throws Exception {
+  public void shouldProvideServicesIntroducedMarshmallow() {
     assertThat(context.getSystemService(Context.FINGERPRINT_SERVICE))
         .isInstanceOf(FingerprintManager.class);
   }
 
   @Test
   @Config(minSdk = O)
-  public void shouldProvideServicesIntroducedOreo() throws Exception {
+  public void shouldProvideServicesIntroducedOreo() {
     // Context.AUTOFILL_MANAGER_SERVICE is marked @hide and this is the documented way to obtain
     // this service.
     AutofillManager autofillManager = context.getSystemService(AutofillManager.class);
@@ -167,13 +167,13 @@ public class ShadowApplicationTest {
   }
 
   @Test
-  public void shouldProvideLayoutInflater() throws Exception {
+  public void shouldProvideLayoutInflater() {
     Object systemService = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
     assertThat(systemService).isInstanceOf(LayoutInflater.class);
   }
 
   @Test
-  public void shouldCorrectlyInstantiatedAccessibilityService() throws Exception {
+  public void shouldCorrectlyInstantiatedAccessibilityService() {
     AccessibilityManager accessibilityManager =
         (AccessibilityManager) context.getSystemService(Context.ACCESSIBILITY_SERVICE);
 
@@ -699,7 +699,7 @@ public class ShadowApplicationTest {
   }
 
   @Test
-  public void canFindAllReceiversForAnIntent() throws Exception {
+  public void canFindAllReceiversForAnIntent() {
     BroadcastReceiver expectedReceiver = new TestBroadcastReceiver();
     assertFalse(shadowOf(context).hasReceiverForIntent(new Intent("Foo")));
     context.registerReceiver(expectedReceiver, new IntentFilter("Foo"));
@@ -771,12 +771,12 @@ public class ShadowApplicationTest {
   }
 
   @Test
-  public void shouldRememberResourcesAfterLazilyLoading() throws Exception {
+  public void shouldRememberResourcesAfterLazilyLoading() {
     assertSame(context.getResources(), context.getResources());
   }
 
   @Test
-  public void startActivity_whenActivityCheckingEnabled_doesntFindResolveInfo() throws Exception {
+  public void startActivity_whenActivityCheckingEnabled_doesntFindResolveInfo() {
     shadowOf(context).checkActivities(true);
 
     String action = "com.does.not.exist.android.app.v2.mobile";
@@ -791,7 +791,7 @@ public class ShadowApplicationTest {
   }
 
   @Test
-  public void startActivity_whenActivityCheckingEnabled_findsResolveInfo() throws Exception {
+  public void startActivity_whenActivityCheckingEnabled_findsResolveInfo() {
     shadowOf(context).checkActivities(true);
 
     context.startActivity(

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAudioManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAudioManagerTest.java
@@ -1661,8 +1661,7 @@ public class ShadowAudioManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void onCommunicationDeviceChangedListener_callWithNullAudioDeviceInfo_receiveNull()
-      throws Exception {
+  public void onCommunicationDeviceChangedListener_callWithNullAudioDeviceInfo_receiveNull() {
     AudioManager.OnCommunicationDeviceChangedListener mockListener =
         mock(AudioManager.OnCommunicationDeviceChangedListener.class);
 
@@ -1674,8 +1673,7 @@ public class ShadowAudioManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void onCommunicationDeviceChangedListener_removeBeforeAddingListener_throwsException()
-      throws Exception {
+  public void onCommunicationDeviceChangedListener_removeBeforeAddingListener_throwsException() {
     AudioManager.OnCommunicationDeviceChangedListener mockListener =
         mock(AudioManager.OnCommunicationDeviceChangedListener.class);
 
@@ -1686,7 +1684,7 @@ public class ShadowAudioManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void onCommunicationDeviceChangedListener_addSameTwice_throwsException() throws Exception {
+  public void onCommunicationDeviceChangedListener_addSameTwice_throwsException() {
     AudioManager.OnCommunicationDeviceChangedListener mockListener =
         mock(AudioManager.OnCommunicationDeviceChangedListener.class);
 
@@ -1698,8 +1696,7 @@ public class ShadowAudioManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void onCommunicationDeviceChangedListener_addNullListener_throwsException()
-      throws Exception {
+  public void onCommunicationDeviceChangedListener_addNullListener_throwsException() {
     Assert.assertThrows(
         NullPointerException.class,
         () -> audioManager.addOnCommunicationDeviceChangedListener(directExecutor(), null));
@@ -1707,8 +1704,7 @@ public class ShadowAudioManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void onCommunicationDeviceChangedListener_addNullExecutor_throwsException()
-      throws Exception {
+  public void onCommunicationDeviceChangedListener_addNullExecutor_throwsException() {
     AudioManager.OnCommunicationDeviceChangedListener mockListener =
         mock(AudioManager.OnCommunicationDeviceChangedListener.class);
 
@@ -1719,7 +1715,7 @@ public class ShadowAudioManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void onCommunicationDeviceChangedListener_removeNull_throwsException() throws Exception {
+  public void onCommunicationDeviceChangedListener_removeNull_throwsException() {
     Assert.assertThrows(
         NullPointerException.class,
         () -> audioManager.removeOnCommunicationDeviceChangedListener(null));

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBinderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBinderTest.java
@@ -47,7 +47,7 @@ public class ShadowBinderTest {
   }
 
   @Test
-  public void testLinkToDeath() throws Exception {
+  public void testLinkToDeath() {
     Binder binder = new Binder();
     DeathRecipient recipient = () -> {};
     binder.linkToDeath(recipient, 0);
@@ -55,7 +55,7 @@ public class ShadowBinderTest {
   }
 
   @Test
-  public void testLinkToDeath_unlink() throws Exception {
+  public void testLinkToDeath_unlink() {
     Binder binder = new Binder();
     DeathRecipient recipient = () -> {};
     // recipient doesn't exist, returns false.
@@ -68,7 +68,7 @@ public class ShadowBinderTest {
   }
 
   @Test
-  public void testLinkToDeath_twice() throws Exception {
+  public void testLinkToDeath_twice() {
     Binder binder = new Binder();
     DeathRecipient recipient = () -> {};
     binder.linkToDeath(recipient, 0);
@@ -80,7 +80,7 @@ public class ShadowBinderTest {
   }
 
   @Test
-  public void testLinkToDeath_weakReference() throws Exception {
+  public void testLinkToDeath_weakReference() {
     Binder binder = new Binder();
     binder.linkToDeath(
         new DeathRecipient() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothAdapterTest.java
@@ -125,7 +125,7 @@ public class ShadowBluetoothAdapterTest {
   }
 
   @Test
-  public void canGetAndSetAddress() throws Exception {
+  public void canGetAndSetAddress() {
     BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
     shadowOf(adapter).setAddress("expected");
     assertThat(adapter.getAddress()).isEqualTo("expected");
@@ -163,7 +163,7 @@ public class ShadowBluetoothAdapterTest {
   }
 
   @Test
-  public void canGetBluetoothLeAdvertiser() throws Exception {
+  public void canGetBluetoothLeAdvertiser() {
     // bluetooth needs to be ON in APIS 21 and 22 for getBluetoothLeAdvertiser to return a
     // non null value
     bluetoothAdapter.enable();
@@ -172,7 +172,7 @@ public class ShadowBluetoothAdapterTest {
 
   @Test
   @Config(minSdk = M)
-  public void canGetAndSetBleScanAlwaysAvailable() throws Exception {
+  public void canGetAndSetBleScanAlwaysAvailable() {
     BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
 
     // By default, scanning with BT is not supported.
@@ -184,7 +184,7 @@ public class ShadowBluetoothAdapterTest {
   }
 
   @Test
-  public void canGetAndSetMultipleAdvertisementSupport() throws Exception {
+  public void canGetAndSetMultipleAdvertisementSupport() {
     BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
 
     // By default, multiple advertising is supported.
@@ -196,7 +196,7 @@ public class ShadowBluetoothAdapterTest {
   }
 
   @Test
-  public void canEnable_withAndroidApi() throws Exception {
+  public void canEnable_withAndroidApi() {
     bluetoothAdapter.enable();
     assertThat(bluetoothAdapter.isEnabled()).isTrue();
   }
@@ -219,14 +219,14 @@ public class ShadowBluetoothAdapterTest {
   }
 
   @Test
-  public void canDisable_withAndroidApi() throws Exception {
+  public void canDisable_withAndroidApi() {
     shadowOf(bluetoothAdapter).setEnabled(true);
     bluetoothAdapter.disable();
     assertThat(bluetoothAdapter.isEnabled()).isFalse();
   }
 
   @Test
-  public void name_getAndSet() throws Exception {
+  public void name_getAndSet() {
     // The name shouldn't be null, even before we set anything.
     assertThat(bluetoothAdapter.getName()).isNotNull();
 
@@ -261,7 +261,7 @@ public class ShadowBluetoothAdapterTest {
 
   @Test
   @Config(maxSdk = S_V2)
-  public void scanMode_getAndSet_none() throws Exception {
+  public void scanMode_getAndSet_none() {
     boolean result =
         ReflectionHelpers.callInstanceMethod(
             bluetoothAdapter,
@@ -273,7 +273,7 @@ public class ShadowBluetoothAdapterTest {
 
   @Test
   @Config(maxSdk = S_V2)
-  public void scanMode_getAndSet_invalid() throws Exception {
+  public void scanMode_getAndSet_invalid() {
     boolean result =
         ReflectionHelpers.callInstanceMethod(
             bluetoothAdapter, "setScanMode", ClassParameter.from(int.class, 9999));
@@ -329,7 +329,7 @@ public class ShadowBluetoothAdapterTest {
 
   @Config(minSdk = TIRAMISU)
   @Test
-  public void scanMode_getAndSet_connectable_T() throws Exception {
+  public void scanMode_getAndSet_connectable_T() {
     assertThat(bluetoothAdapter.setScanMode(BluetoothAdapter.SCAN_MODE_CONNECTABLE))
         .isEqualTo(BluetoothStatusCodes.SUCCESS);
     assertThat(bluetoothAdapter.getScanMode()).isEqualTo(BluetoothAdapter.SCAN_MODE_CONNECTABLE);
@@ -337,7 +337,7 @@ public class ShadowBluetoothAdapterTest {
 
   @Config(minSdk = TIRAMISU)
   @Test
-  public void scanMode_getAndSet_discoverable_T() throws Exception {
+  public void scanMode_getAndSet_discoverable_T() {
     assertThat(bluetoothAdapter.setScanMode(BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE))
         .isEqualTo(BluetoothStatusCodes.SUCCESS);
     assertThat(bluetoothAdapter.getScanMode())
@@ -346,7 +346,7 @@ public class ShadowBluetoothAdapterTest {
 
   @Config(minSdk = TIRAMISU)
   @Test
-  public void scanMode_getAndSet_none_T() throws Exception {
+  public void scanMode_getAndSet_none_T() {
     assertThat(bluetoothAdapter.setScanMode(BluetoothAdapter.SCAN_MODE_NONE))
         .isEqualTo(BluetoothStatusCodes.SUCCESS);
     assertThat(bluetoothAdapter.getScanMode()).isEqualTo(BluetoothAdapter.SCAN_MODE_NONE);
@@ -354,13 +354,13 @@ public class ShadowBluetoothAdapterTest {
 
   @Config(minSdk = TIRAMISU)
   @Test
-  public void scanMode_getAndSet_invalid_T() throws Exception {
+  public void scanMode_getAndSet_invalid_T() {
     assertThat(bluetoothAdapter.setScanMode(9999)).isEqualTo(BluetoothStatusCodes.ERROR_UNKNOWN);
   }
 
   @Test
   @Config(minSdk = M)
-  public void isLeEnabled() throws Exception {
+  public void isLeEnabled() {
     // Le is enabled when either BT or BLE is enabled. Check all states.
     BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
 
@@ -461,7 +461,7 @@ public class ShadowBluetoothAdapterTest {
   }
 
   @Test
-  public void canGetProfileConnectionState() throws Exception {
+  public void canGetProfileConnectionState() {
     BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
     assertThat(adapter.getProfileConnectionState(BluetoothProfile.HEADSET))
         .isEqualTo(BluetoothProfile.STATE_DISCONNECTED);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothDeviceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothDeviceTest.java
@@ -43,7 +43,7 @@ public class ShadowBluetoothDeviceTest {
   private final Application application = ApplicationProvider.getApplicationContext();
 
   @Test
-  public void canCreateBluetoothDeviceViaNewInstance() throws Exception {
+  public void canCreateBluetoothDeviceViaNewInstance() {
     // This test passes as long as no Exception is thrown. It tests if the constructor can be
     // executed without throwing an Exception when getService() is called inside.
     BluetoothDevice bluetoothDevice = ShadowBluetoothDevice.newInstance(MOCK_MAC_ADDRESS);
@@ -51,7 +51,7 @@ public class ShadowBluetoothDeviceTest {
   }
 
   @Test
-  public void canSetAndGetUuids() throws Exception {
+  public void canSetAndGetUuids() {
     shadowOf(application).grantPermissions(BLUETOOTH_CONNECT);
     BluetoothDevice device = BluetoothAdapter.getDefaultAdapter().getRemoteDevice(MOCK_MAC_ADDRESS);
     ParcelUuid[] uuids =

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBugreportManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBugreportManagerTest.java
@@ -93,7 +93,7 @@ public final class ShadowBugreportManagerTest {
   }
 
   @Test
-  public void startBugreport_noPermission() throws Exception {
+  public void startBugreport_noPermission() {
     BugreportCallback callback = mock(BugreportCallback.class);
     shadowBugreportManager.setHasPermission(false);
 
@@ -167,7 +167,7 @@ public final class ShadowBugreportManagerTest {
 
   @Test
   @Config(minSdk = UPSIDE_DOWN_CAKE)
-  public void retrieveBugreport_noPermission() throws Exception {
+  public void retrieveBugreport_noPermission() {
     BugreportCallback callback = mock(BugreportCallback.class);
     shadowBugreportManager.setHasPermission(false);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraDeviceImplTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraDeviceImplTest.java
@@ -78,8 +78,7 @@ public final class ShadowCameraDeviceImplTest {
 
   @Test
   @Config(sdk = VERSION_CODES.P)
-  public void createCaptureRequest_throwsIllegalStateExceptionAfterClose()
-      throws CameraAccessException {
+  public void createCaptureRequest_throwsIllegalStateExceptionAfterClose() {
     cameraDevice.close();
 
     IllegalStateException thrown =
@@ -114,8 +113,7 @@ public final class ShadowCameraDeviceImplTest {
 
   @Test
   @Config(sdk = VERSION_CODES.P)
-  public void createCaptureSession_throwsIllegalStateExceptionAfterClose()
-      throws CameraAccessException {
+  public void createCaptureSession_throwsIllegalStateExceptionAfterClose() {
     cameraDevice.close();
 
     IllegalStateException thrown =
@@ -131,8 +129,7 @@ public final class ShadowCameraDeviceImplTest {
 
   @Test
   @Config(sdk = VERSION_CODES.P)
-  public void createCaptureSession_configuration_throwsIllegalStateExceptionAfterClose()
-      throws CameraAccessException {
+  public void createCaptureSession_configuration_throwsIllegalStateExceptionAfterClose() {
     cameraDevice.close();
 
     SessionConfiguration configuration =

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraManagerTest.java
@@ -202,7 +202,7 @@ public class ShadowCameraManagerTest {
   }
 
   @Test
-  public void triggerDisconnect_noCameraOpen() throws CameraAccessException {
+  public void triggerDisconnect_noCameraOpen() {
     shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
     shadowOf(cameraManager).triggerDisconnect();
     // Nothing should happen - just make sure we don't crash.
@@ -263,7 +263,7 @@ public class ShadowCameraManagerTest {
   }
 
   @Test
-  public void registerCallbackAvailable() throws CameraAccessException {
+  public void registerCallbackAvailable() {
     CameraManager.AvailabilityCallback mockCallback =
         mock(CameraManager.AvailabilityCallback.class);
     // Verify adding the camera triggers the callback
@@ -274,7 +274,7 @@ public class ShadowCameraManagerTest {
   }
 
   @Test
-  public void unregisterCallbackAvailable() throws CameraAccessException {
+  public void unregisterCallbackAvailable() {
     CameraManager.AvailabilityCallback mockCallback =
         mock(CameraManager.AvailabilityCallback.class);
 
@@ -289,7 +289,7 @@ public class ShadowCameraManagerTest {
   }
 
   @Test
-  public void registerCallbackUnavailable() throws CameraAccessException {
+  public void registerCallbackUnavailable() {
     CameraManager.AvailabilityCallback mockCallback =
         mock(CameraManager.AvailabilityCallback.class);
 
@@ -302,7 +302,7 @@ public class ShadowCameraManagerTest {
   }
 
   @Test
-  public void unregisterCallbackUnavailable() throws CameraAccessException {
+  public void unregisterCallbackUnavailable() {
     CameraManager.AvailabilityCallback mockCallback =
         mock(CameraManager.AvailabilityCallback.class);
 
@@ -316,7 +316,7 @@ public class ShadowCameraManagerTest {
   }
 
   @Test
-  public void registerCallbackUnavailableInvalidCameraId() throws CameraAccessException {
+  public void registerCallbackUnavailableInvalidCameraId() {
     CameraManager.AvailabilityCallback mockCallback =
         mock(CameraManager.AvailabilityCallback.class);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCanvasTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCanvasTest.java
@@ -37,7 +37,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void shouldDescribeBitmapDrawing() throws Exception {
+  public void shouldDescribeBitmapDrawing() {
     Canvas canvas = new Canvas(targetBitmap);
     canvas.drawBitmap(imageBitmap, 1, 2, new Paint());
     canvas.drawBitmap(imageBitmap, 100, 200, new Paint());
@@ -52,7 +52,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void shouldDescribeBitmapDrawing_withDestinationRect() throws Exception {
+  public void shouldDescribeBitmapDrawing_withDestinationRect() {
     Canvas canvas = new Canvas(targetBitmap);
     canvas.drawBitmap(imageBitmap, new Rect(1, 2, 3, 4), new Rect(5, 6, 7, 8), new Paint());
 
@@ -63,7 +63,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void shouldDescribeBitmapDrawing_withDestinationRectF() throws Exception {
+  public void shouldDescribeBitmapDrawing_withDestinationRectF() {
     Canvas canvas = new Canvas(targetBitmap);
     canvas.drawBitmap(
         imageBitmap, new Rect(1, 2, 3, 4), new RectF(5.0f, 6.0f, 7.5f, 8.5f), new Paint());
@@ -75,7 +75,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void shouldDescribeBitmapDrawing_WithMatrix() throws Exception {
+  public void shouldDescribeBitmapDrawing_WithMatrix() {
     Canvas canvas = new Canvas(targetBitmap);
     canvas.drawBitmap(imageBitmap, new Matrix(), new Paint());
     canvas.drawBitmap(imageBitmap, new Matrix(), new Paint());
@@ -94,7 +94,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void visualize_shouldReturnDescription() throws Exception {
+  public void visualize_shouldReturnDescription() {
     Canvas canvas = new Canvas(targetBitmap);
     canvas.drawBitmap(imageBitmap, new Matrix(), new Paint());
     canvas.drawBitmap(imageBitmap, new Matrix(), new Paint());
@@ -107,7 +107,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void drawColor_shouldReturnDescription() throws Exception {
+  public void drawColor_shouldReturnDescription() {
     Canvas canvas = new Canvas(targetBitmap);
     canvas.drawColor(Color.WHITE);
     canvas.drawColor(Color.GREEN);
@@ -117,7 +117,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void drawPath_shouldRecordThePathAndThePaint() throws Exception {
+  public void drawPath_shouldRecordThePathAndThePaint() {
     Canvas canvas = new Canvas(targetBitmap);
     Path path = new Path();
     path.lineTo(10, 10);
@@ -141,8 +141,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void drawPath_shouldRecordThePointsOfEachPathEvenWhenItIsTheSameInstance()
-      throws Exception {
+  public void drawPath_shouldRecordThePointsOfEachPathEvenWhenItIsTheSameInstance() {
     Canvas canvas = new Canvas(targetBitmap);
     Paint paint = new Paint();
     Path path = new Path();
@@ -163,7 +162,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void drawPath_shouldAppendDescriptionToBitmap() throws Exception {
+  public void drawPath_shouldAppendDescriptionToBitmap() {
     Canvas canvas = new Canvas(targetBitmap);
     Path path1 = new Path();
     path1.lineTo(10, 10);
@@ -194,7 +193,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void resetCanvasHistory_shouldClearTheHistoryAndDescription() throws Exception {
+  public void resetCanvasHistory_shouldClearTheHistoryAndDescription() {
     Canvas canvas = new Canvas();
     canvas.drawPath(new Path(), new Paint());
     canvas.drawText("hi", 1, 2, new Paint());
@@ -208,7 +207,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void shouldGetAndSetHeightAndWidth() throws Exception {
+  public void shouldGetAndSetHeightAndWidth() {
     Canvas canvas = new Canvas();
     shadowOf(canvas).setWidth(99);
     shadowOf(canvas).setHeight(42);
@@ -218,7 +217,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void shouldRecordText() throws Exception {
+  public void shouldRecordText() {
     Canvas canvas = new Canvas();
     Paint paint = new Paint();
     Paint paint2 = new Paint();
@@ -243,7 +242,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void shouldRecordText_charArrayOverload() throws Exception {
+  public void shouldRecordText_charArrayOverload() {
     Canvas canvas = new Canvas();
     Paint paint = new Paint();
     paint.setColor(1);
@@ -261,7 +260,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void shouldRecordText_stringWithRangeOverload() throws Exception {
+  public void shouldRecordText_stringWithRangeOverload() {
     Canvas canvas = new Canvas();
     Paint paint = new Paint();
     paint.setColor(1);
@@ -279,7 +278,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void shouldRecordText_charSequenceOverload() throws Exception {
+  public void shouldRecordText_charSequenceOverload() {
     Canvas canvas = new Canvas();
     Paint paint = new Paint();
     paint.setColor(1);
@@ -298,7 +297,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void drawCircle_shouldRecordCirclePaintHistoryEvents() throws Exception {
+  public void drawCircle_shouldRecordCirclePaintHistoryEvents() {
     Canvas canvas = new Canvas();
     Paint paint0 = new Paint();
     Paint paint1 = new Paint();
@@ -318,7 +317,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void drawArc_shouldRecordArcHistoryEvents() throws Exception {
+  public void drawArc_shouldRecordArcHistoryEvents() {
     Canvas canvas = new Canvas();
     RectF oval0 = new RectF();
     RectF oval1 = new RectF();
@@ -342,7 +341,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void getArcHistoryCount_shouldReturnTotalNumberOfDrawArcEvents() throws Exception {
+  public void getArcHistoryCount_shouldReturnTotalNumberOfDrawArcEvents() {
     Canvas canvas = new Canvas();
     canvas.drawArc(new RectF(), 0f, 0f, true, new Paint());
     canvas.drawArc(new RectF(), 0f, 0f, true, new Paint());
@@ -351,7 +350,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void getRectHistoryCount_shouldReturnTotalNumberOfDrawRectEvents() throws Exception {
+  public void getRectHistoryCount_shouldReturnTotalNumberOfDrawRectEvents() {
     Canvas canvas = new Canvas();
     canvas.drawRect(1f, 2f, 3f, 4f, new Paint());
     canvas.drawRect(1f, 2f, 3f, 4f, new Paint());
@@ -369,7 +368,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void getOvalHistoryCount_shouldReturnTotalNumberOfDrawOvalEvents() throws Exception {
+  public void getOvalHistoryCount_shouldReturnTotalNumberOfDrawOvalEvents() {
     Canvas canvas = new Canvas();
     canvas.drawOval(new RectF(), new Paint());
     canvas.drawOval(new RectF(), new Paint());
@@ -378,7 +377,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void getLineHistoryCount_shouldReturnTotalNumberOfDrawLineEvents() throws Exception {
+  public void getLineHistoryCount_shouldReturnTotalNumberOfDrawLineEvents() {
     Canvas canvas = new Canvas();
     canvas.drawLine(0f, 1f, 2f, 3f, new Paint());
     canvas.drawLine(0f, 1f, 2f, 3f, new Paint());
@@ -387,7 +386,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void drawLine_shouldRecordLineHistoryEvents() throws Exception {
+  public void drawLine_shouldRecordLineHistoryEvents() {
     Canvas canvas = new Canvas();
     Paint paint0 = new Paint();
     paint0.setColor(Color.RED);
@@ -416,7 +415,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void drawOval_shouldRecordOvalHistoryEvents() throws Exception {
+  public void drawOval_shouldRecordOvalHistoryEvents() {
     Canvas canvas = new Canvas();
     RectF oval0 = new RectF();
     RectF oval1 = new RectF();
@@ -437,7 +436,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void drawRect_shouldRecordRectHistoryEvents() throws Exception {
+  public void drawRect_shouldRecordRectHistoryEvents() {
     Canvas canvas = new Canvas();
     Paint paint0 = new Paint();
     paint0.setColor(Color.WHITE);
@@ -570,7 +569,7 @@ public class ShadowCanvasTest {
   }
 
   @Test
-  public void drawRect_withRectF() throws Exception {
+  public void drawRect_withRectF() {
     Canvas canvas = new Canvas();
     Paint paint = new Paint();
     paint.setColor(Color.WHITE);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
@@ -496,7 +496,7 @@ public class ShadowContentResolverTest {
 
   @Test
   public void openOutputStream_withRealContentProvider_canReadBytesWrittenToOutputStream()
-      throws IOException, RemoteException {
+      throws IOException {
     Robolectric.setupContentProvider(MyContentProvider.class, AUTHORITY);
     Uri uri = Uri.parse("content://" + AUTHORITY + "/test/1");
 
@@ -590,7 +590,7 @@ public class ShadowContentResolverTest {
 
   @Test
   public void openOutputStream_withModeWithRealContentProvider_canReadBytesWrittenToOutputStream()
-      throws IOException, RemoteException {
+      throws IOException {
     Robolectric.setupContentProvider(MyContentProvider.class, AUTHORITY);
     Uri uri = Uri.parse("content://" + AUTHORITY + "/test/1");
 
@@ -1116,7 +1116,7 @@ public class ShadowContentResolverTest {
   }
 
   @Test
-  public void shouldNotifyChildContentObservers() throws Exception {
+  public void shouldNotifyChildContentObservers() {
     TestContentObserver co1 = new TestContentObserver(null);
     TestContentObserver co2 = new TestContentObserver(null);
 
@@ -1183,8 +1183,7 @@ public class ShadowContentResolverTest {
   }
 
   @Test
-  public void openTypedAssetFileDescriptor_shouldOpenDescriptor()
-      throws IOException, RemoteException {
+  public void openTypedAssetFileDescriptor_shouldOpenDescriptor() throws IOException {
     Robolectric.setupContentProvider(MyContentProvider.class, AUTHORITY);
 
     try (AssetFileDescriptor afd =

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
@@ -75,7 +75,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void sendBroadcast_shouldSendToManifestReceiver() throws Exception {
+  public void sendBroadcast_shouldSendToManifestReceiver() {
     ConfigTestReceiver receiver = getReceiverOfClass(ConfigTestReceiver.class);
 
     contextWrapper.sendBroadcast(new Intent(context, ConfigTestReceiver.class));
@@ -85,7 +85,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void sendBroadcastWithData_shouldSendToManifestReceiver() throws Exception {
+  public void sendBroadcastWithData_shouldSendToManifestReceiver() {
     ConfigTestReceiver receiver = getReceiverOfClass(ConfigTestReceiver.class);
 
     contextWrapper.sendBroadcast(
@@ -110,7 +110,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void registerReceiver_shouldRegisterForAllIntentFilterActions() throws Exception {
+  public void registerReceiver_shouldRegisterForAllIntentFilterActions() {
     BroadcastReceiver receiver = broadcastReceiver("Larry");
     contextWrapper.registerReceiver(receiver, intentFilter("foo", "baz"));
 
@@ -126,7 +126,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void sendBroadcast_shouldSendIntentToEveryInterestedReceiver() throws Exception {
+  public void sendBroadcast_shouldSendIntentToEveryInterestedReceiver() {
     BroadcastReceiver larryReceiver = broadcastReceiver("Larry");
     contextWrapper.registerReceiver(larryReceiver, intentFilter("foo", "baz"));
 
@@ -241,8 +241,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void sendBroadcast_shouldSendIntentUsingHandlerIfOneIsProvided()
-      throws InterruptedException {
+  public void sendBroadcast_shouldSendIntentUsingHandlerIfOneIsProvided() {
     HandlerThread handlerThread = new HandlerThread("test");
     handlerThread.start();
 
@@ -273,7 +272,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void sendBroadcast_withClassSet_shouldSendIntentToSpecifiedReceiver() throws Exception {
+  public void sendBroadcast_withClassSet_shouldSendIntentToSpecifiedReceiver() {
     BroadcastReceiver larryReceiver =
         new BroadcastReceiver() {
           @Override
@@ -293,7 +292,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void sendOrderedBroadcast_shouldReturnValues() throws Exception {
+  public void sendOrderedBroadcast_shouldReturnValues() {
     String action = "test";
 
     IntentFilter lowFilter = new IntentFilter(action);
@@ -314,7 +313,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void sendOrderedBroadcastAsUser_shouldReturnValues() throws Exception {
+  public void sendOrderedBroadcastAsUser_shouldReturnValues() {
     String action = "test";
 
     IntentFilter lowFilter = new IntentFilter(action);
@@ -336,7 +335,7 @@ public class ShadowContextWrapperTest {
 
   @Test
   @Config(minSdk = M)
-  public void sendOrderedBroadcastAsUser_withAppOp_shouldReturnValues() throws Exception {
+  public void sendOrderedBroadcastAsUser_withAppOp_shouldReturnValues() {
     String action = "test";
 
     IntentFilter lowFilter = new IntentFilter(action);
@@ -370,7 +369,7 @@ public class ShadowContextWrapperTest {
 
   @Test
   @Config(minSdk = M)
-  public void sendOrderedBroadcastAsUser_withAppOpAndOptions_shouldReturnValues() throws Exception {
+  public void sendOrderedBroadcastAsUser_withAppOpAndOptions_shouldReturnValues() {
     String action = "test";
 
     IntentFilter lowFilter = new IntentFilter(action);
@@ -458,7 +457,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void sendOrderedBroadcast_shouldSendByPriority() throws Exception {
+  public void sendOrderedBroadcast_shouldSendByPriority() {
     String action = "test";
 
     IntentFilter lowFilter = new IntentFilter(action);
@@ -477,7 +476,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void orderedBroadcasts_shouldAbort() throws Exception {
+  public void orderedBroadcasts_shouldAbort() {
     String action = "test";
 
     IntentFilter lowFilter = new IntentFilter(action);
@@ -502,7 +501,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void unregisterReceiver_shouldUnregisterReceiver() throws Exception {
+  public void unregisterReceiver_shouldUnregisterReceiver() {
     BroadcastReceiver receiver = broadcastReceiver("Larry");
 
     contextWrapper.registerReceiver(receiver, intentFilter("foo", "baz"));
@@ -513,14 +512,12 @@ public class ShadowContextWrapperTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void unregisterReceiver_shouldThrowExceptionWhenReceiverIsNotRegistered()
-      throws Exception {
+  public void unregisterReceiver_shouldThrowExceptionWhenReceiverIsNotRegistered() {
     contextWrapper.unregisterReceiver(new AppWidgetProvider());
   }
 
   @Test
-  public void broadcastReceivers_shouldBeSharedAcrossContextsPerApplicationContext()
-      throws Exception {
+  public void broadcastReceivers_shouldBeSharedAcrossContextsPerApplicationContext() {
     BroadcastReceiver receiver = broadcastReceiver("Larry");
 
     Application application = ApplicationProvider.getApplicationContext();
@@ -605,7 +602,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void shouldReturnSameApplicationEveryTime() throws Exception {
+  public void shouldReturnSameApplicationEveryTime() {
     Activity activity = new Activity();
     assertThat(activity.getApplication()).isSameInstanceAs(activity.getApplication());
 
@@ -613,7 +610,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void shouldReturnSameApplicationContextEveryTime() throws Exception {
+  public void shouldReturnSameApplicationContextEveryTime() {
     Activity activity = Robolectric.setupActivity(Activity.class);
     assertThat(activity.getApplicationContext()).isSameInstanceAs(activity.getApplicationContext());
 
@@ -622,8 +619,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void shouldReturnApplicationContext_forViewContextInflatedWithApplicationContext()
-      throws Exception {
+  public void shouldReturnApplicationContext_forViewContextInflatedWithApplicationContext() {
     View view =
         LayoutInflater.from(ApplicationProvider.getApplicationContext())
             .inflate(R.layout.custom_layout, null);
@@ -633,7 +629,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void shouldReturnSameContentResolverEveryTime() throws Exception {
+  public void shouldReturnSameContentResolverEveryTime() {
     Activity activity = Robolectric.setupActivity(Activity.class);
     assertThat(activity.getContentResolver()).isSameInstanceAs(activity.getContentResolver());
 
@@ -642,17 +638,17 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void shouldReturnSameLocationManagerEveryTime() throws Exception {
+  public void shouldReturnSameLocationManagerEveryTime() {
     assertSameInstanceEveryTime(Context.LOCATION_SERVICE);
   }
 
   @Test
-  public void shouldReturnSameWifiManagerEveryTime() throws Exception {
+  public void shouldReturnSameWifiManagerEveryTime() {
     assertSameInstanceEveryTime(Context.WIFI_SERVICE);
   }
 
   @Test
-  public void shouldReturnSameAlarmServiceEveryTime() throws Exception {
+  public void shouldReturnSameAlarmServiceEveryTime() {
     assertSameInstanceEveryTime(Context.ALARM_SERVICE);
   }
 
@@ -849,8 +845,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void checkCallingPermissionsShouldReturnPermissionGrantedToAddedPermissions()
-      throws Exception {
+  public void checkCallingPermissionsShouldReturnPermissionGrantedToAddedPermissions() {
     shadowOf(contextWrapper).grantPermissions("foo", "bar");
     assertThat(contextWrapper.checkCallingPermission("foo")).isEqualTo(PERMISSION_GRANTED);
     assertThat(contextWrapper.checkCallingPermission("bar")).isEqualTo(PERMISSION_GRANTED);
@@ -858,8 +853,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void checkCallingOrSelfPermissionsShouldReturnPermissionGrantedToAddedPermissions()
-      throws Exception {
+  public void checkCallingOrSelfPermissionsShouldReturnPermissionGrantedToAddedPermissions() {
     shadowOf(contextWrapper).grantPermissions("foo", "bar");
     assertThat(contextWrapper.checkCallingOrSelfPermission("foo")).isEqualTo(PERMISSION_GRANTED);
     assertThat(contextWrapper.checkCallingOrSelfPermission("bar")).isEqualTo(PERMISSION_GRANTED);
@@ -867,8 +861,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void checkCallingPermission_shouldReturnPermissionDeniedForRemovedPermissions()
-      throws Exception {
+  public void checkCallingPermission_shouldReturnPermissionDeniedForRemovedPermissions() {
     shadowOf(contextWrapper).grantPermissions("foo", "bar");
     shadowOf(contextWrapper).denyPermissions("foo", "qux");
     assertThat(contextWrapper.checkCallingPermission("foo")).isEqualTo(PERMISSION_DENIED);
@@ -878,8 +871,7 @@ public class ShadowContextWrapperTest {
   }
 
   @Test
-  public void checkCallingOrSelfPermission_shouldReturnPermissionDeniedForRemovedPermissions()
-      throws Exception {
+  public void checkCallingOrSelfPermission_shouldReturnPermissionDeniedForRemovedPermissions() {
     shadowOf(contextWrapper).grantPermissions("foo", "bar");
     shadowOf(contextWrapper).denyPermissions("foo", "qux");
     assertThat(contextWrapper.checkCallingOrSelfPermission("foo")).isEqualTo(PERMISSION_DENIED);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCursorAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCursorAdapterTest.java
@@ -88,7 +88,7 @@ public class ShadowCursorAdapterTest {
   }
 
   @Test
-  public void shouldNotErrorOnCursorChangeWhenNoFlagsAreSet() throws Exception {
+  public void shouldNotErrorOnCursorChangeWhenNoFlagsAreSet() {
     try (Cursor newCursor = database.rawQuery("SELECT * FROM table_name;", null)) {
       adapter = new TestAdapterWithFlags(curs, 0);
       adapter.changeCursor(newCursor);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDevicePolicyManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDevicePolicyManagerTest.java
@@ -1810,7 +1810,7 @@ public final class ShadowDevicePolicyManagerTest {
 
   @Test
   @Config(minSdk = N)
-  public void setPackagesSuspended_suspendsPossible() throws Exception {
+  public void setPackagesSuspended_suspendsPossible() {
     shadowOf(devicePolicyManager).setProfileOwner(testComponent);
     shadowOf(packageManager).addPackage("installed");
     String[] packages = new String[] {"installed", "not.installed"};
@@ -1969,7 +1969,7 @@ public final class ShadowDevicePolicyManagerTest {
 
   @Test
   @Config(minSdk = N)
-  public void isPackagesSuspended_notInstalledPackage() throws Exception {
+  public void isPackagesSuspended_notInstalledPackage() {
     shadowOf(devicePolicyManager).setProfileOwner(testComponent);
 
     try {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowKeyguardManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowKeyguardManagerTest.java
@@ -52,7 +52,7 @@ public class ShadowKeyguardManagerTest {
   }
 
   @Test
-  public void testShouldBeAbleToDisableTheKeyguardLock() throws Exception {
+  public void testShouldBeAbleToDisableTheKeyguardLock() {
     KeyguardManager.KeyguardLock lock = manager.newKeyguardLock(KEYGUARD_SERVICE);
     assertThat(shadowOf(lock).isEnabled()).isTrue();
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLauncherAppsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLauncherAppsTest.java
@@ -218,7 +218,7 @@ public class ShadowLauncherAppsTest {
 
   @Test
   @Config(minSdk = O)
-  public void testGetApplicationInfo_packageNotFound() throws Exception {
+  public void testGetApplicationInfo_packageNotFound() {
     Throwable throwable =
         assertThrows(
             NameNotFoundException.class,
@@ -231,7 +231,7 @@ public class ShadowLauncherAppsTest {
   }
 
   @Test
-  public void testGetApplicationInfo_incorrectPackage() throws Exception {
+  public void testGetApplicationInfo_incorrectPackage() {
     ApplicationInfo applicationInfo = new ApplicationInfo();
     applicationInfo.name = "Test app";
     shadowOf(launcherApps).addApplicationInfo(USER_HANDLE, TEST_PACKAGE_NAME_2, applicationInfo);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLegacyAsyncTaskTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLegacyAsyncTaskTest.java
@@ -54,7 +54,7 @@ public class ShadowLegacyAsyncTaskTest {
   }
 
   @Test
-  public void testCancelBeforeBackground() throws Exception {
+  public void testCancelBeforeBackground() {
     AsyncTask<String, String, String> asyncTask = new MyAsyncTask();
 
     asyncTask.execute("a", "b");
@@ -133,7 +133,7 @@ public class ShadowLegacyAsyncTaskTest {
   }
 
   @Test
-  public void shouldGetStatusForAsyncTask() throws Exception {
+  public void shouldGetStatusForAsyncTask() {
     AsyncTask<String, String, String> asyncTask = new MyAsyncTask();
     assertThat(asyncTask.getStatus()).isEqualTo(AsyncTask.Status.PENDING);
     asyncTask.execute("a");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLocaleDataTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLocaleDataTest.java
@@ -23,7 +23,7 @@ import org.robolectric.util.reflector.ForType;
 public class ShadowLocaleDataTest {
 
   @Test
-  public void shouldSupportLocaleEn_US() throws NoSuchFieldException, IllegalAccessException {
+  public void shouldSupportLocaleEn_US() {
     LocaleData localeData = LocaleData.get(Locale.US);
     LocaleDataReflector localeDataReflector = reflector(LocaleDataReflector.class, localeData);
     assertThat(localeData.amPm).isEqualTo(new String[] {"AM", "PM"});
@@ -125,7 +125,7 @@ public class ShadowLocaleDataTest {
   }
 
   @Test
-  public void shouldSupportLocaleEn_US_since() throws NoSuchFieldException, IllegalAccessException {
+  public void shouldSupportLocaleEn_US_since() {
     LocaleData localeData = LocaleData.get(Locale.US);
     LocaleDataReflector localeDataReflector = reflector(LocaleDataReflector.class, localeData);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
@@ -193,7 +193,7 @@ public class ShadowLogTest {
   }
 
   @Test
-  public void shouldLogToProvidedStream() throws Exception {
+  public void shouldLogToProvidedStream() {
     final ByteArrayOutputStream bos = new ByteArrayOutputStream();
     PrintStream old = ShadowLog.stream;
     try {
@@ -214,7 +214,7 @@ public class ShadowLogTest {
   }
 
   @Test
-  public void shouldLogAccordingToTag() throws Exception {
+  public void shouldLogAccordingToTag() {
     ShadowLog.reset();
     Log.d("tag1", "1");
     Log.i("tag2", "2");
@@ -251,7 +251,7 @@ public class ShadowLogTest {
   }
 
   @Test
-  public void infoIsDefaultLoggableLevel() throws Exception {
+  public void infoIsDefaultLoggableLevel() {
     PrintStream old = ShadowLog.stream;
     ShadowLog.stream = null;
     assertFalse(Log.isLoggable("FOO", Log.VERBOSE));

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMergeCursorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMergeCursorTest.java
@@ -158,7 +158,7 @@ public class ShadowMergeCursorTest {
   }
 
   @Test
-  public void testGetDataSingleCursor() throws Exception {
+  public void testGetDataSingleCursor() {
     Cursor[] cursors = new Cursor[1];
     cursors[0] = dbCursor1;
     cursor = new MergeCursor(cursors);
@@ -168,7 +168,7 @@ public class ShadowMergeCursorTest {
   }
 
   @Test
-  public void testGetDataMultipleCursor() throws Exception {
+  public void testGetDataMultipleCursor() {
     Cursor[] cursors = new Cursor[2];
     cursors[0] = dbCursor1;
     cursors[1] = dbCursor2;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTestBase.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationBuilderTestBase.java
@@ -211,7 +211,7 @@ public abstract class ShadowNotificationBuilderTestBase {
   }
 
   @Test
-  public void build_addsActionToNotification() throws Exception {
+  public void build_addsActionToNotification() {
     PendingIntent action =
         PendingIntent.getBroadcast(ApplicationProvider.getApplicationContext(), 0, null, 0);
     Notification notification = builder.addAction(0, "Action", action).build();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageInstallerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageInstallerTest.java
@@ -320,7 +320,7 @@ public class ShadowPackageInstallerTest {
   }
 
   @Test
-  public void uninstallMaxVersion() throws Exception {
+  public void uninstallMaxVersion() {
     packageInstaller.uninstall("packageName", /* statusReceiver */ null);
 
     assertThat(shadowOf(packageInstaller).getLastUninstalledVersion("packageName"))
@@ -329,7 +329,7 @@ public class ShadowPackageInstallerTest {
   }
 
   @Test
-  public void uninstallMaxVersionWithStatusReceiver() throws Exception {
+  public void uninstallMaxVersionWithStatusReceiver() {
     IntentSender intentSender = createStatusReceiver();
     packageInstaller.uninstall("packageName", intentSender);
 
@@ -341,7 +341,7 @@ public class ShadowPackageInstallerTest {
 
   @Config(sdk = O)
   @Test
-  public void uninstallVersion() throws Exception {
+  public void uninstallVersion() {
     packageInstaller.uninstall(new VersionedPackage("packageName", 1), /* statusReceiver */ null);
 
     assertThat(shadowOf(packageInstaller).getLastUninstalledVersion("packageName")).isEqualTo(1);
@@ -350,7 +350,7 @@ public class ShadowPackageInstallerTest {
 
   @Config(sdk = UPSIDE_DOWN_CAKE)
   @Test
-  public void uninstallVersionWithFlags() throws Exception {
+  public void uninstallVersionWithFlags() {
     packageInstaller.uninstall(
         new VersionedPackage("packageName", 1), /* flags= */ 0, /* statusReceiver= */ null);
 
@@ -360,7 +360,7 @@ public class ShadowPackageInstallerTest {
 
   @Config(sdk = S)
   @Test
-  public void uninstallExtistingPackage() throws Exception {
+  public void uninstallExistingPackage() {
     packageInstaller.uninstallExistingPackage("packageName", /* IntentSender */ null);
 
     assertThat(shadowOf(packageInstaller).getLastUninstalledVersion("packageName"))
@@ -369,7 +369,7 @@ public class ShadowPackageInstallerTest {
   }
 
   @Test
-  public void nothingUninstalled() throws Exception {
+  public void nothingUninstalled() {
     assertThat(shadowOf(packageInstaller).getLastUninstalledVersion("packageName")).isNull();
     assertThat(shadowOf(packageInstaller).getLastUninstalledStatusReceiver("packageName")).isNull();
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -871,7 +871,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void getGroupOfPlatformPermission_fromManifest() throws Exception {
+  public void getGroupOfPlatformPermission_fromManifest() {
     String[] permissionGroupArg = new String[1];
 
     packageManager.getGroupOfPlatformPermission(
@@ -887,7 +887,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void getGroupOfPlatformPermission_fromExtraPermissions() throws Exception {
+  public void getGroupOfPlatformPermission_fromExtraPermissions() {
     String permissionName = "some_other_permission";
     String permissionGroupName = "some_other_permission_group";
     PermissionInfo permissionInfo = new PermissionInfo();
@@ -909,7 +909,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void getGroupOfPlatformPermission_fromExtraPermissionsPlatformPrefix() throws Exception {
+  public void getGroupOfPlatformPermission_fromExtraPermissionsPlatformPrefix() {
     String permissionName = "android.permission.some_other_permission";
     String permissionGroupName = "some_other_permission_group";
     PermissionInfo permissionInfo = new PermissionInfo();
@@ -931,7 +931,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void getGroupOfPlatformPermission_unknown() throws Exception {
+  public void getGroupOfPlatformPermission_unknown() {
     String[] permissionGroupArg = new String[1];
 
     packageManager.getGroupOfPlatformPermission(
@@ -947,7 +947,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void getGroupOfPlatformPermission_fromPlatform() throws Exception {
+  public void getGroupOfPlatformPermission_fromPlatform() {
     String[] permissionGroupArg = new String[1];
 
     packageManager.getGroupOfPlatformPermission(
@@ -963,7 +963,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void getGroupOfPlatformPermission_overriddenPlatformPermission() throws Exception {
+  public void getGroupOfPlatformPermission_overriddenPlatformPermission() {
     PermissionInfo permissionInfo = new PermissionInfo();
     permissionInfo.name = READ_CONTACTS;
     permissionInfo.group = permission_group.CALENDAR;
@@ -983,7 +983,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void getPlatformPermissionsForGroup_fromManifest() throws Exception {
+  public void getPlatformPermissionsForGroup_fromManifest() {
     List<List<String>> permissionsArg = new ArrayList<>();
 
     packageManager.getPlatformPermissionsForGroup(
@@ -1000,7 +1000,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void getPlatformPermissionsForGroup_fromExtraPermissions() throws Exception {
+  public void getPlatformPermissionsForGroup_fromExtraPermissions() {
     String permissionName1 = "some_other_permission";
     String permissionName2 = "android.permission.my_calendar_permission";
     String permissionGroupName = permission_group.CALENDAR;
@@ -1029,7 +1029,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void getPlatformPermissionsForGroup_unknown() throws Exception {
+  public void getPlatformPermissionsForGroup_unknown() {
     List<List<String>> permissionsArg = new ArrayList<>();
 
     packageManager.getPlatformPermissionsForGroup(
@@ -1046,7 +1046,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void getPlatformPermissionsForGroup_fromPlatform() throws Exception {
+  public void getPlatformPermissionsForGroup_fromPlatform() {
     List<List<String>> permissionsArg = new ArrayList<>();
 
     packageManager.getPlatformPermissionsForGroup(
@@ -1063,7 +1063,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void getPlatformPermissionsForGroup_overriddenPlatformPermission() throws Exception {
+  public void getPlatformPermissionsForGroup_overriddenPlatformPermission() {
     PermissionInfo permissionInfo = new PermissionInfo();
     permissionInfo.name = READ_CONTACTS;
     permissionInfo.group = permission_group.CALENDAR;
@@ -1702,7 +1702,7 @@ public class ShadowPackageManagerTest {
   }
 
   @Test
-  public void addIntentFilterForComponent() throws Exception {
+  public void addIntentFilterForComponent() {
     ComponentName testComponent = new ComponentName("package", "name");
     IntentFilter intentFilter = new IntentFilter("ACTION");
     intentFilter.addCategory(Intent.CATEGORY_DEFAULT);
@@ -1778,7 +1778,7 @@ public class ShadowPackageManagerTest {
   }
 
   @Test
-  public void resolveExplicitIntent_sameApp() throws Exception {
+  public void resolveExplicitIntent_sameApp() {
     ComponentName testComponent = new ComponentName(RuntimeEnvironment.getApplication(), "name");
     IntentFilter intentFilter = new IntentFilter("ACTION");
 
@@ -1792,7 +1792,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = TIRAMISU)
-  public void resolveExplicitIntent_filterMatch() throws Exception {
+  public void resolveExplicitIntent_filterMatch() {
     ComponentName testComponent = new ComponentName("some.other.package", "name");
     IntentFilter intentFilter = new IntentFilter("ACTION");
 
@@ -1807,7 +1807,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = TIRAMISU)
-  public void resolveExplicitIntent_noFilterMatch() throws Exception {
+  public void resolveExplicitIntent_noFilterMatch() {
     ComponentName testComponent = new ComponentName("some.other.package", "name");
     IntentFilter intentFilter = new IntentFilter("ACTION");
 
@@ -1819,7 +1819,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(maxSdk = S)
-  public void resolveExplicitIntent_noFilterMatch_belowT() throws Exception {
+  public void resolveExplicitIntent_noFilterMatch_belowT() {
     ComponentName testComponent = new ComponentName("some.other.package", "name");
     IntentFilter intentFilter = new IntentFilter("ACTION");
 
@@ -1831,7 +1831,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = TIRAMISU)
-  public void resolveExplicitIntent_noFilterMatch_targetBelowT() throws Exception {
+  public void resolveExplicitIntent_noFilterMatch_targetBelowT() {
     PackageInfo testPackage =
         PackageInfoBuilder.newBuilder().setPackageName("some.other.package").build();
     testPackage.applicationInfo.targetSdkVersion = S;
@@ -1847,7 +1847,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = TIRAMISU)
-  public void resolveExplicitIntent_noAction() throws Exception {
+  public void resolveExplicitIntent_noAction() {
     ComponentName testComponent = new ComponentName("some.other.package", "name");
     IntentFilter intentFilter = new IntentFilter("ACTION");
 
@@ -3607,7 +3607,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = VERSION_CODES.R)
-  public void getInstallerSourceInfo_notExists_throwsException() throws Exception {
+  public void getInstallerSourceInfo_notExists_throwsException() {
     assertThrows(
         NameNotFoundException.class,
         () -> packageManager.getInstallSourceInfo("nonExistTarget.package"));
@@ -3961,7 +3961,7 @@ public class ShadowPackageManagerTest {
   private static class ActivityWithFilters extends Activity {}
 
   @Test
-  public void getIntentFiltersForComponent() throws Exception {
+  public void getIntentFiltersForComponent() {
     List<IntentFilter> intentFilters =
         shadowOf(packageManager)
             .getIntentFiltersForActivity(new ComponentName(context, ActivityWithFilters.class));
@@ -4982,7 +4982,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   @Config(minSdk = S)
-  public void getProperty_component() throws NameNotFoundException {
+  public void getProperty_component() {
     final ComponentName componentName =
         new ComponentName(RuntimeEnvironment.getApplication().getPackageName(), "mycomponentname");
     assertThrows(

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelFileDescriptorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelFileDescriptorTest.java
@@ -89,7 +89,7 @@ public class ShadowParcelFileDescriptorTest {
   }
 
   @Test
-  public void testOpenWithOnCloseListener_nullHandler() throws Exception {
+  public void testOpenWithOnCloseListener_nullHandler() {
     final AtomicBoolean onCloseCalled = new AtomicBoolean(false);
     ParcelFileDescriptor.OnCloseListener onCloseListener =
         new ParcelFileDescriptor.OnCloseListener() {
@@ -106,7 +106,7 @@ public class ShadowParcelFileDescriptorTest {
   }
 
   @Test
-  public void testOpenWithOnCloseListener_nullOnCloseListener() throws Exception {
+  public void testOpenWithOnCloseListener_nullOnCloseListener() {
     HandlerThread handlerThread = new HandlerThread("test");
     handlerThread.start();
     Handler handler = new Handler(handlerThread.getLooper());

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelTest.java
@@ -395,7 +395,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testReadWriteIntArray() throws Exception {
+  public void testReadWriteIntArray() {
     final int[] ints = {1, 2};
     parcel.writeIntArray(ints);
     // Make sure a copy was stored.
@@ -408,14 +408,14 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testWriteAndCreateNullIntArray() throws Exception {
+  public void testWriteAndCreateNullIntArray() {
     parcel.writeIntArray(null);
     parcel.setDataPosition(0);
     assertThat(parcel.createIntArray()).isNull();
   }
 
   @Test
-  public void testReadWriteLongArray() throws Exception {
+  public void testReadWriteLongArray() {
     final long[] longs = {1, 2};
     parcel.writeLongArray(longs);
     parcel.setDataPosition(0);
@@ -425,7 +425,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testWriteAndCreateNullLongArray() throws Exception {
+  public void testWriteAndCreateNullLongArray() {
     parcel.writeLongArray(null);
     parcel.setDataPosition(0);
     assertThat(parcel.createLongArray()).isNull();
@@ -440,7 +440,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testReadWriteFloatArray() throws Exception {
+  public void testReadWriteFloatArray() {
     final float[] floats = {1.1f, 2.0f};
     parcel.writeFloatArray(floats);
     parcel.setDataPosition(0);
@@ -450,14 +450,14 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testWriteAndCreateNullFloatArray() throws Exception {
+  public void testWriteAndCreateNullFloatArray() {
     parcel.writeFloatArray(null);
     parcel.setDataPosition(0);
     assertThat(parcel.createFloatArray()).isNull();
   }
 
   @Test
-  public void testReadWriteDoubleArray() throws Exception {
+  public void testReadWriteDoubleArray() {
     final double[] doubles = {1.1f, 2.0f};
     parcel.writeDoubleArray(doubles);
     parcel.setDataPosition(0);
@@ -467,14 +467,14 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testWriteAndCreateNullDoubleArray() throws Exception {
+  public void testWriteAndCreateNullDoubleArray() {
     parcel.writeDoubleArray(null);
     parcel.setDataPosition(0);
     assertThat(parcel.createDoubleArray()).isNull();
   }
 
   @Test
-  public void testReadWriteStringArray() throws Exception {
+  public void testReadWriteStringArray() {
     final String[] strings = {"foo", "bar"};
     parcel.writeStringArray(strings);
     parcel.setDataPosition(0);
@@ -484,7 +484,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testWriteAndCreateNullStringArray() throws Exception {
+  public void testWriteAndCreateNullStringArray() {
     parcel.writeStringArray(null);
     parcel.setDataPosition(0);
     assertThat(parcel.createStringArray()).isNull();
@@ -575,7 +575,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testWriteAndCreateNullByteArray() throws Exception {
+  public void testWriteAndCreateNullByteArray() {
     parcel.writeByteArray(null);
     assertThat(parcel.dataSize()).isEqualTo(4);
     parcel.setDataPosition(0);
@@ -828,7 +828,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testCreateStringArrayList() throws Exception {
+  public void testCreateStringArrayList() {
     parcel.writeStringList(Arrays.asList("str1", "str2"));
     parcel.setDataPosition(0);
 
@@ -839,7 +839,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testWriteTypedListAndCreateTypedArrayList() throws Exception {
+  public void testWriteTypedListAndCreateTypedArrayList() {
     TestParcelable normal = new TestParcelable(23);
     ArrayList<TestParcelable> normals = new ArrayList<>();
     normals.add(normal);
@@ -854,7 +854,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testParcelableWithPackageProtected() throws Exception {
+  public void testParcelableWithPackageProtected() {
     TestParcelablePackage normal = new TestParcelablePackage(23);
 
     parcel.writeParcelable(normal, 0);
@@ -867,7 +867,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testParcelableWithBase() throws Exception {
+  public void testParcelableWithBase() {
     TestParcelableImpl normal = new TestParcelableImpl(23);
 
     parcel.writeParcelable(normal, 0);
@@ -880,7 +880,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testParcelableWithPublicClass() throws Exception {
+  public void testParcelableWithPublicClass() {
     TestParcelable normal = new TestParcelable(23);
 
     parcel.writeParcelable(normal, 0);
@@ -892,7 +892,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testReadAndWriteStringList() throws Exception {
+  public void testReadAndWriteStringList() {
     ArrayList<String> original = new ArrayList<>();
     List<String> rehydrated = new ArrayList<>();
     original.add("str1");
@@ -906,7 +906,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testReadWriteMap() throws Exception {
+  public void testReadWriteMap() {
     HashMap<String, String> original = new HashMap<>();
     original.put("key", "value");
     parcel.writeMap(original);
@@ -1189,7 +1189,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testUnmarshallZeroes() throws IOException {
+  public void testUnmarshallZeroes() {
     // This tests special-case handling of zeroes in marshalling.  A few tests rely on the rather
     // well-defined behavior that Parcel will interpret a byte array of all zeroes as zero
     // primitives and empty arrays.  When unmarshalling, this can be easily disambiguated from an
@@ -1232,7 +1232,7 @@ public class ShadowParcelTest {
   }
 
   @Test
-  public void testUnmarshallEmpty() throws IOException {
+  public void testUnmarshallEmpty() {
     // Unmarshall an zero-length byte string, although, pass a non-empty array to make sure the
     // length/offset are respected.
     parcel.unmarshall(new byte[] {1, 2, 3}, 1, 0);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPausedLooperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPausedLooperTest.java
@@ -105,7 +105,7 @@ public class ShadowPausedLooperTest {
   }
 
   @Test
-  public void postedBackgroundLooperTasksAreExecuted() throws InterruptedException {
+  public void postedBackgroundLooperTasksAreExecuted() {
     Runnable mockRunnable = mock(Runnable.class);
     Handler handler = new Handler(handlerThread.getLooper());
     handler.post(mockRunnable);
@@ -115,7 +115,7 @@ public class ShadowPausedLooperTest {
   }
 
   @Test
-  public void postedBackgroundLooperTasksWhenPaused() throws InterruptedException {
+  public void postedBackgroundLooperTasksWhenPaused() {
     Runnable mockRunnable = mock(Runnable.class);
     shadowOf(handlerThread.getLooper()).pause();
     new Handler(handlerThread.getLooper()).post(mockRunnable);
@@ -155,8 +155,7 @@ public class ShadowPausedLooperTest {
   }
 
   @Test
-  public void postedDelayedBackgroundLooperTasksAreExecutedOnlyWhenSystemClockAdvanced()
-      throws InterruptedException {
+  public void postedDelayedBackgroundLooperTasksAreExecutedOnlyWhenSystemClockAdvanced() {
     Runnable mockRunnable = mock(Runnable.class);
     new Handler(handlerThread.getLooper()).postDelayed(mockRunnable, 10);
     ShadowPausedLooper shadowLooper = Shadow.extract(handlerThread.getLooper());
@@ -467,7 +466,7 @@ public class ShadowPausedLooperTest {
   }
 
   @Test
-  public void isIdle_paused() throws InterruptedException {
+  public void isIdle_paused() {
     ShadowLooper shadowLooper = shadowOf(handlerThread.getLooper());
     shadowLooper.pause();
     assertThat(shadowLooper.isIdle()).isTrue();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowQueuedWorkResetterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowQueuedWorkResetterTest.java
@@ -44,7 +44,7 @@ public class ShadowQueuedWorkResetterTest {
 
     private static final AtomicInteger initialLooperCount = new AtomicInteger(-1);
 
-    private void doPostToQueuedWorkTest() throws InterruptedException {
+    private void doPostToQueuedWorkTest() {
       AtomicBoolean wasRun = new AtomicBoolean(false);
       if (RuntimeEnvironment.getApiLevel() < O) {
         reflector(QueuedWorkReflector.class).add(() -> wasRun.set(true));
@@ -59,12 +59,12 @@ public class ShadowQueuedWorkResetterTest {
     }
 
     @Test
-    public void postToQueuedTest() throws InterruptedException {
+    public void postToQueuedTest() {
       doPostToQueuedWorkTest();
     }
 
     @Test
-    public void anotherPostToQueuedWorkTest() throws InterruptedException {
+    public void anotherPostToQueuedWorkTest() {
       doPostToQueuedWorkTest();
     }
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResourcesTest.java
@@ -301,7 +301,7 @@ public class ShadowResourcesTest {
 
   @Test
   @Config(minSdk = S)
-  public void getColor_shouldReturnCorrectMaterialYouColor() throws Exception {
+  public void getColor_shouldReturnCorrectMaterialYouColor() {
     SparseIntArray sparseArray =
         new SparseIntArray(LAST_RESOURCE_COLOR_ID - FIRST_RESOURCE_COLOR_ID + 1);
     IntStream.range(0, greenBlueColorBase.length)

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSmsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSmsManagerTest.java
@@ -304,8 +304,7 @@ public class ShadowSmsManagerTest {
 
   @Test
   @Config(minSdk = R)
-  public void getSmscAddress_shouldThrowSecurityExceptionWhenReadPhoneStatePermissionNotGranted()
-      throws Exception {
+  public void getSmscAddress_shouldThrowSecurityExceptionWhenReadPhoneStatePermissionNotGranted() {
     shadowOf(smsManager).setSmscAddressPermission(false);
     assertThrows(SecurityException.class, () -> smsManager.getSmscAddress());
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSoundTriggerManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSoundTriggerManagerTest.java
@@ -29,14 +29,14 @@ public final class ShadowSoundTriggerManagerTest {
 
   @Config(sdk = VERSION_CODES.S)
   @Test
-  public void getModuleProperties_nullModuleProperties() throws Exception {
+  public void getModuleProperties_nullModuleProperties() {
     SoundTrigger.ModuleProperties moduleProperties = instance.getModuleProperties();
     assertThat(moduleProperties).isNull();
   }
 
   @Config(sdk = VERSION_CODES.R)
   @Test
-  public void getModuleProperties_nullPointExceptionAtAndroidR() throws Exception {
+  public void getModuleProperties_nullPointExceptionAtAndroidR() {
     try {
       SoundTrigger.ModuleProperties unused = instance.getModuleProperties();
       fail("Expect NullPointException");
@@ -47,7 +47,7 @@ public final class ShadowSoundTriggerManagerTest {
 
   @Config(sdk = VERSION_CODES.R)
   @Test
-  public void getModuleProperties_nonNullProperties() throws Exception {
+  public void getModuleProperties_nonNullProperties() {
     instance.setModuleProperties(
         (SoundTrigger.ModuleProperties) getModuleProperties("supportedModelArch", 1234));
     SoundTrigger.ModuleProperties moduleProperties = instance.getModuleProperties();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStatsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStatsManagerTest.java
@@ -16,7 +16,7 @@ import org.robolectric.annotation.Config;
 public final class ShadowStatsManagerTest {
 
   @Test
-  public void testGetMetadata() throws Exception {
+  public void testGetMetadata() {
     StatsManager statsManager =
         ApplicationProvider.getApplicationContext().getSystemService(StatsManager.class);
     byte[] metadataBytes = new byte[] {1, 2, 3, 4, 5};
@@ -107,7 +107,7 @@ public final class ShadowStatsManagerTest {
   }
 
   @Test
-  public void testReset_clearsMetadata() throws Exception {
+  public void testReset_clearsMetadata() {
     StatsManager statsManager =
         ApplicationProvider.getApplicationContext().getSystemService(StatsManager.class);
     byte[] metadataBytes = new byte[] {1, 2, 3, 4, 5};

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemHealthManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemHealthManagerTest.java
@@ -51,14 +51,14 @@ public final class ShadowSystemHealthManagerTest {
   }
 
   @Test
-  public void snapshotForMyUid_expectedResult() throws Exception {
+  public void snapshotForMyUid_expectedResult() {
     HealthStats stats = systemHealthManager.takeMyUidSnapshot();
 
     assertThat(stats).isEqualTo(MY_UID_HEALTH_STATS);
   }
 
   @Test
-  public void snapshotForOtherUids_expectedResult() throws Exception {
+  public void snapshotForOtherUids_expectedResult() {
     HealthStats stats1 = systemHealthManager.takeUidSnapshot(OTHER_UID_1);
     HealthStats stats2 = systemHealthManager.takeUidSnapshot(OTHER_UID_2);
 
@@ -67,7 +67,7 @@ public final class ShadowSystemHealthManagerTest {
   }
 
   @Test
-  public void snapshotForAllUids_expectedResult() throws Exception {
+  public void snapshotForAllUids_expectedResult() {
     int[] uids = {OTHER_UID_1, MY_UID, OTHER_UID_2};
 
     HealthStats[] stats = systemHealthManager.takeUidSnapshots(uids);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTelecomManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTelecomManagerTest.java
@@ -20,7 +20,6 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -590,8 +589,7 @@ public class ShadowTelecomManagerTest {
 
   @Config(minSdk = R)
   @Test
-  public void createLaunchEmergencyDialerIntent_whenPackageAvailable_shouldContainPackage()
-      throws NameNotFoundException {
+  public void createLaunchEmergencyDialerIntent_whenPackageAvailable_shouldContainPackage() {
     ComponentName componentName = new ComponentName("com.android.phone", "EmergencyDialer");
     shadowOf(context.getPackageManager()).addActivityIfNotPresent(componentName);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTelephonyManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTelephonyManagerTest.java
@@ -264,8 +264,7 @@ public class ShadowTelephonyManagerTest {
 
   @Test(expected = SecurityException.class)
   public void
-      getSimSerialNumber_shouldThrowSecurityExceptionWhenReadPhoneStatePermissionNotGranted()
-          throws Exception {
+      getSimSerialNumber_shouldThrowSecurityExceptionWhenReadPhoneStatePermissionNotGranted() {
     shadowOf(telephonyManager).setReadPhoneStatePermission(false);
     telephonyManager.getSimSerialNumber();
   }
@@ -387,8 +386,7 @@ public class ShadowTelephonyManagerTest {
   }
 
   @Test(expected = SecurityException.class)
-  public void getDeviceId_shouldThrowSecurityExceptionWhenReadPhoneStatePermissionNotGranted()
-      throws Exception {
+  public void getDeviceId_shouldThrowSecurityExceptionWhenReadPhoneStatePermissionNotGranted() {
     shadowOf(telephonyManager).setReadPhoneStatePermission(false);
     telephonyManager.getDeviceId();
   }
@@ -396,16 +394,14 @@ public class ShadowTelephonyManagerTest {
   @Test
   @Config(minSdk = M)
   public void
-      getDeviceIdForSlot_shouldThrowSecurityExceptionWhenReadPhoneStatePermissionNotGranted()
-          throws Exception {
+      getDeviceIdForSlot_shouldThrowSecurityExceptionWhenReadPhoneStatePermissionNotGranted() {
     shadowOf(telephonyManager).setReadPhoneStatePermission(false);
     assertThrows(SecurityException.class, () -> telephonyManager.getDeviceId(1));
   }
 
   @Test
   public void
-      getDeviceSoftwareVersion_shouldThrowSecurityExceptionWhenReadPhoneStatePermissionNotGranted()
-          throws Exception {
+      getDeviceSoftwareVersion_shouldThrowSecurityExceptionWhenReadPhoneStatePermissionNotGranted() {
     shadowOf(telephonyManager).setReadPhoneStatePermission(false);
     assertThrows(SecurityException.class, () -> telephonyManager.getDeviceSoftwareVersion());
   }
@@ -1154,8 +1150,7 @@ public class ShadowTelephonyManagerTest {
   @Test
   @Config(minSdk = M)
   public void
-      isTtyModeSupported_shouldThrowSecurityExceptionWhenReadPhoneStatePermissionNotGranted()
-          throws Exception {
+      isTtyModeSupported_shouldThrowSecurityExceptionWhenReadPhoneStatePermissionNotGranted() {
     shadowOf(telephonyManager).setReadPhoneStatePermission(false);
     assertThrows(SecurityException.class, () -> telephonyManager.isTtyModeSupported());
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTraceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTraceTest.java
@@ -263,7 +263,7 @@ public class ShadowTraceTest {
   }
 
   @Test
-  public void reset_resetsInternalState() throws Exception {
+  public void reset_resetsInternalState() {
     Trace.beginSection(/* sectionName= */ "section1");
     Trace.endSection();
     Trace.beginSection(/* sectionName= */ "section2");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUsageStatsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUsageStatsManagerTest.java
@@ -70,7 +70,7 @@ public class ShadowUsageStatsManagerTest {
   }
 
   @Test
-  public void testQueryEvents_emptyEvents() throws Exception {
+  public void testQueryEvents_emptyEvents() {
     UsageEvents events = usageStatsManager.queryEvents(1000L, 2000L);
     Event event = new Event();
 
@@ -79,7 +79,7 @@ public class ShadowUsageStatsManagerTest {
   }
 
   @Test
-  public void testQueryEvents_overlappingEvents() throws Exception {
+  public void testQueryEvents_overlappingEvents() {
     shadowOf(usageStatsManager).addEvent(TEST_PACKAGE_NAME1, 1000L, Event.MOVE_TO_BACKGROUND);
     shadowOf(usageStatsManager)
         .addEvent(
@@ -112,7 +112,7 @@ public class ShadowUsageStatsManagerTest {
   }
 
   @Test
-  public void testQueryEvents_appendEventData_shouldCombineWithPreviousData() throws Exception {
+  public void testQueryEvents_appendEventData_shouldCombineWithPreviousData() {
     shadowOf(usageStatsManager).addEvent(TEST_PACKAGE_NAME1, 500L, Event.MOVE_TO_FOREGROUND);
     shadowOf(usageStatsManager).addEvent(TEST_PACKAGE_NAME1, 1000L, Event.MOVE_TO_BACKGROUND);
     shadowOf(usageStatsManager)
@@ -154,8 +154,7 @@ public class ShadowUsageStatsManagerTest {
   }
 
   @Test
-  public void testQueryEvents_appendEventData_simulateTimeChange_shouldAddOffsetToPreviousData()
-      throws Exception {
+  public void testQueryEvents_appendEventData_simulateTimeChange_shouldAddOffsetToPreviousData() {
     shadowOf(usageStatsManager).addEvent(TEST_PACKAGE_NAME1, 500L, Event.MOVE_TO_FOREGROUND);
     shadowOf(usageStatsManager).addEvent(TEST_PACKAGE_NAME1, 1000L, Event.MOVE_TO_BACKGROUND);
     shadowOf(usageStatsManager)
@@ -1071,7 +1070,7 @@ public class ShadowUsageStatsManagerTest {
 
   @Test
   @Config(minSdk = V.SDK_INT)
-  public void testQueryEvents_newApiV_shouldReturn() throws Exception {
+  public void testQueryEvents_newApiV_shouldReturn() {
     // These events should be returned.
     shadowOf(usageStatsManager)
         .addEvent(

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbDeviceConnectionTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbDeviceConnectionTest.java
@@ -134,7 +134,7 @@ public class ShadowUsbDeviceConnectionTest {
   }
 
   @Test
-  public void releaseInterface_closesOutgoingDataStream() throws Exception {
+  public void releaseInterface_closesOutgoingDataStream() {
     UsbDeviceConnection usbDeviceConnection = usbManager.openDevice(usbDevice);
     UsbInterface usbInterface = selectInterface(usbDevice);
     UsbEndpoint usbEndpointOut = getEndpoint(usbInterface, UsbConstants.USB_DIR_OUT);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbManagerTest.java
@@ -221,7 +221,7 @@ public class ShadowUsbManagerTest {
   }
 
   @Test
-  public void openDevice() throws Exception {
+  public void openDevice() {
     shadowOf(usbManager).addOrUpdateUsbDevice(usbDevice1, true);
     UsbDeviceConnection connection = usbManager.openDevice(usbDevice1);
     assertThat(connection).isNotNull();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
@@ -106,14 +106,14 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void layout_shouldAffectWidthAndHeight() throws Exception {
+  public void layout_shouldAffectWidthAndHeight() {
     view.layout(100, 200, 303, 404);
     assertThat(view.getWidth()).isEqualTo(303 - 100);
     assertThat(view.getHeight()).isEqualTo(404 - 200);
   }
 
   @Test
-  public void measuredDimensions() throws Exception {
+  public void measuredDimensions() {
     View view1 =
         new View(context) {
           {
@@ -125,7 +125,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void layout_shouldCallOnLayoutOnlyIfChanged() throws Exception {
+  public void layout_shouldCallOnLayoutOnlyIfChanged() {
     View view1 =
         new View(context) {
           @Override
@@ -144,7 +144,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldFocus() throws Exception {
+  public void shouldFocus() {
     final List<String> transcript = new ArrayList<>();
 
     view.setOnFocusChangeListener(
@@ -181,7 +181,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldNotBeFocusableByDefault() throws Exception {
+  public void shouldNotBeFocusableByDefault() {
     assertFalse(view.isFocusable());
 
     view.setFocusable(true);
@@ -189,7 +189,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldKnowIfThisOrAncestorsAreVisible() throws Exception {
+  public void shouldKnowIfThisOrAncestorsAreVisible() {
     assertThat(view.isShown()).isTrue();
     shadowOf(view).setMyParent(null);
 
@@ -205,7 +205,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldInflateMergeRootedLayoutAndNotCreateReferentialLoops() throws Exception {
+  public void shouldInflateMergeRootedLayoutAndNotCreateReferentialLoops() {
     LinearLayout root = new LinearLayout(context);
     LinearLayout.inflate(context, R.layout.inner_merge, root);
     for (int i = 0; i < root.getChildCount(); i++) {
@@ -215,7 +215,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void performLongClick_shouldClickOnView() throws Exception {
+  public void performLongClick_shouldClickOnView() {
     OnLongClickListener clickListener = mock(OnLongClickListener.class);
     view.setOnLongClickListener(clickListener);
     view.performLongClick();
@@ -224,7 +224,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void checkedClick_shouldClickOnView() throws Exception {
+  public void checkedClick_shouldClickOnView() {
     OnClickListener clickListener = mock(OnClickListener.class);
     view.setOnClickListener(clickListener);
     shadowOf(view).checkedPerformClick();
@@ -233,7 +233,7 @@ public class ShadowViewTest {
   }
 
   @Test(expected = RuntimeException.class)
-  public void checkedClick_shouldThrowIfViewIsNotVisible() throws Exception {
+  public void checkedClick_shouldThrowIfViewIsNotVisible() {
     ViewGroup grandParent = new LinearLayout(context);
     ViewGroup parent = new LinearLayout(context);
     grandParent.addView(parent);
@@ -244,13 +244,13 @@ public class ShadowViewTest {
   }
 
   @Test(expected = RuntimeException.class)
-  public void checkedClick_shouldThrowIfViewIsDisabled() throws Exception {
+  public void checkedClick_shouldThrowIfViewIsDisabled() {
     view.setEnabled(false);
     shadowOf(view).checkedPerformClick();
   }
 
   @Test
-  public void getBackground_shouldReturnNullIfNoBackgroundHasBeenSet() throws Exception {
+  public void getBackground_shouldReturnNullIfNoBackgroundHasBeenSet() {
     assertThat(view.getBackground()).isNull();
   }
 
@@ -263,14 +263,14 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldSetBackgroundResource() throws Exception {
+  public void shouldSetBackgroundResource() {
     view.setBackgroundResource(R.drawable.an_image);
     assertThat(shadowOf((BitmapDrawable) view.getBackground()).getCreatedFromResId())
         .isEqualTo(R.drawable.an_image);
   }
 
   @Test
-  public void shouldClearBackgroundResource() throws Exception {
+  public void shouldClearBackgroundResource() {
     view.setBackgroundResource(R.drawable.an_image);
     view.setBackgroundResource(0);
     assertThat(view.getBackground()).isEqualTo(null);
@@ -296,7 +296,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldPostActionsToTheMessageQueue() throws Exception {
+  public void shouldPostActionsToTheMessageQueue() {
     shadowMainLooper().pause();
 
     TestRunnable runnable = new TestRunnable();
@@ -308,7 +308,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldPostInvalidateDelayed() throws Exception {
+  public void shouldPostInvalidateDelayed() {
     shadowMainLooper().pause();
     ShadowView shadowView = shadowOf(view);
     shadowView.clearWasInvalidated();
@@ -322,7 +322,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldPostActionsToTheMessageQueueWithDelay() throws Exception {
+  public void shouldPostActionsToTheMessageQueueWithDelay() {
     shadowMainLooper().pause();
 
     TestRunnable runnable = new TestRunnable();
@@ -334,7 +334,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldRemovePostedCallbacksFromMessageQueue() throws Exception {
+  public void shouldRemovePostedCallbacksFromMessageQueue() {
     TestRunnable runnable = new TestRunnable();
     assertThat(view.postDelayed(runnable, 1)).isTrue();
 
@@ -345,7 +345,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldSupportAllConstructors() throws Exception {
+  public void shouldSupportAllConstructors() {
     new View(context);
     new View(context, null);
     new View(context, null, 0);
@@ -361,7 +361,7 @@ public class ShadowViewTest {
 
   @Test
   @ResourcesMode(ResourcesMode.Mode.BINARY)
-  public void shouldAddOnClickListenerFromAttribute() throws Exception {
+  public void shouldAddOnClickListenerFromAttribute() {
     AttributeSet attrs =
         Robolectric.buildAttributeSet().addAttribute(android.R.attr.onClick, "clickMe").build();
 
@@ -371,7 +371,7 @@ public class ShadowViewTest {
 
   @Test
   @ResourcesMode(ResourcesMode.Mode.BINARY)
-  public void shouldCallOnClickWithAttribute() throws Exception {
+  public void shouldCallOnClickWithAttribute() {
     MyActivity myActivity = buildActivity(MyActivity.class).create().get();
 
     AttributeSet attrs =
@@ -383,7 +383,7 @@ public class ShadowViewTest {
   }
 
   @Test(expected = RuntimeException.class)
-  public void shouldThrowExceptionWithBadMethodName() throws Exception {
+  public void shouldThrowExceptionWithBadMethodName() {
     MyActivity myActivity = buildActivity(MyActivity.class).create().get();
 
     AttributeSet attrs =
@@ -394,14 +394,14 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldSetAnimation() throws Exception {
+  public void shouldSetAnimation() {
     Animation anim = new TestAnimation();
     view.setAnimation(anim);
     assertThat(view.getAnimation()).isSameInstanceAs(anim);
   }
 
   @Test
-  public void clearAnimation_cancelsAnimation() throws Exception {
+  public void clearAnimation_cancelsAnimation() {
     AtomicInteger numTicks = new AtomicInteger();
     final Animation anim =
         new Animation() {
@@ -425,7 +425,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void scrollTo_shouldStoreTheScrolledCoordinates() throws Exception {
+  public void scrollTo_shouldStoreTheScrolledCoordinates() {
     // This test depends on broken scrolling behavior.
     System.setProperty("robolectric.useRealScrolling", "false");
     try {
@@ -437,7 +437,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldScrollTo() throws Exception {
+  public void shouldScrollTo() {
     view.scrollTo(7, 6);
 
     assertEquals(7, view.getScrollX());
@@ -445,7 +445,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void scrollBy_shouldStoreTheScrolledCoordinates() throws Exception {
+  public void scrollBy_shouldStoreTheScrolledCoordinates() {
     // This test depends on broken scrolling behavior.
     System.setProperty("robolectric.useRealScrolling", "false");
     try {
@@ -467,14 +467,14 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void getViewTreeObserver_shouldReturnTheSameObserverFromMultipleCalls() throws Exception {
+  public void getViewTreeObserver_shouldReturnTheSameObserverFromMultipleCalls() {
     ViewTreeObserver observer = view.getViewTreeObserver();
     assertThat(observer).isInstanceOf(ViewTreeObserver.class);
     assertThat(view.getViewTreeObserver()).isSameInstanceAs(observer);
   }
 
   @Test
-  public void dispatchTouchEvent_sendsMotionEventToOnTouchEvent() throws Exception {
+  public void dispatchTouchEvent_sendsMotionEventToOnTouchEvent() {
     TouchableView touchableView = new TouchableView(context);
     MotionEvent event = MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_DOWN, 12f, 34f, 0);
     touchableView.dispatchTouchEvent(event);
@@ -484,7 +484,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void dispatchTouchEvent_listensToFalseFromListener() throws Exception {
+  public void dispatchTouchEvent_listensToFalseFromListener() {
     final AtomicBoolean called = new AtomicBoolean(false);
     view.setOnTouchListener(
         new View.OnTouchListener() {
@@ -501,7 +501,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void test_nextFocusDownId() throws Exception {
+  public void test_nextFocusDownId() {
     assertEquals(View.NO_ID, view.getNextFocusDownId());
 
     view.setNextFocusDownId(R.id.icon);
@@ -590,7 +590,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldGetAndSetTranslations() throws Exception {
+  public void shouldGetAndSetTranslations() {
     view = new TestView(buildActivity(Activity.class).create().get());
     view.setTranslationX(8.9f);
     view.setTranslationY(4.6f);
@@ -600,7 +600,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldGetAndSetAlpha() throws Exception {
+  public void shouldGetAndSetAlpha() {
     view = new TestView(buildActivity(Activity.class).create().get());
     view.setAlpha(9.1f);
 
@@ -623,7 +623,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldTrackRequestLayoutCalls() throws Exception {
+  public void shouldTrackRequestLayoutCalls() {
     shadowOf(view).setDidRequestLayout(false);
     assertThat(shadowOf(view).didRequestLayout()).isFalse();
     view.requestLayout();
@@ -633,7 +633,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldClickAndNotClick() throws Exception {
+  public void shouldClickAndNotClick() {
     assertThat(view.isClickable()).isFalse();
     view.setClickable(true);
     assertThat(view.isClickable()).isTrue();
@@ -650,7 +650,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldLongClickAndNotLongClick() throws Exception {
+  public void shouldLongClickAndNotLongClick() {
     assertThat(view.isLongClickable()).isFalse();
     view.setLongClickable(true);
     assertThat(view.isLongClickable()).isTrue();
@@ -747,7 +747,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void performHapticFeedback_shouldSetLastPerformedHapticFeedback() throws Exception {
+  public void performHapticFeedback_shouldSetLastPerformedHapticFeedback() {
     assertThat(shadowOf(view).lastHapticFeedbackPerformed()).isEqualTo(-1);
     view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
     assertThat(shadowOf(view).lastHapticFeedbackPerformed())
@@ -755,7 +755,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void canAssertThatSuperDotOnLayoutWasCalledFromViewSubclasses() throws Exception {
+  public void canAssertThatSuperDotOnLayoutWasCalledFromViewSubclasses() {
     TestView2 view = new TestView2(setupActivity(Activity.class), 1111, 1112);
     assertThat(shadowOf(view).onLayoutWasCalled()).isFalse();
     view.onLayout(true, 1, 2, 3, 4);
@@ -763,7 +763,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void setScrolls_canBeAskedFor() throws Exception {
+  public void setScrolls_canBeAskedFor() {
     view.setScrollX(234);
     view.setScrollY(544);
     assertThat(view.getScrollX()).isEqualTo(234);
@@ -771,7 +771,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void setScrolls_firesOnScrollChanged() throws Exception {
+  public void setScrolls_firesOnScrollChanged() {
     TestView testView = new TestView(buildActivity(Activity.class).create().get());
     testView.setScrollX(122);
     testView.setScrollY(150);
@@ -784,7 +784,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void layerType() throws Exception {
+  public void layerType() {
     assertThat(view.getLayerType()).isEqualTo(View.LAYER_TYPE_NONE);
     view.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
     assertThat(view.getLayerType()).isEqualTo(View.LAYER_TYPE_SOFTWARE);
@@ -855,7 +855,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void shouldCallOnAttachedToAndDetachedFromWindow() throws Exception {
+  public void shouldCallOnAttachedToAndDetachedFromWindow() {
     MyView parent = new MyView("parent", transcript);
     parent.addView(new MyView("child", transcript));
     assertThat(transcript).isEmpty();
@@ -882,7 +882,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void getWindowId_shouldReturnValidObjectWhenAttached() throws Exception {
+  public void getWindowId_shouldReturnValidObjectWhenAttached() {
     MyView parent = new MyView("parent", transcript);
     MyView child = new MyView("child", transcript);
     parent.addView(child);
@@ -909,7 +909,7 @@ public class ShadowViewTest {
 
   // todo looks like this is flaky...
   @Test
-  public void removeAllViews_shouldCallOnAttachedToAndDetachedFromWindow() throws Exception {
+  public void removeAllViews_shouldCallOnAttachedToAndDetachedFromWindow() {
     MyView parent = new MyView("parent", transcript);
     Activity activity = Robolectric.buildActivity(ContentViewActivity.class).create().get();
     activity.getWindowManager().addView(parent, new WindowManager.LayoutParams(100, 100));
@@ -924,7 +924,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void capturesOnSystemUiVisibilityChangeListener() throws Exception {
+  public void capturesOnSystemUiVisibilityChangeListener() {
     TestView testView = new TestView(buildActivity(Activity.class).create().get());
     View.OnSystemUiVisibilityChangeListener changeListener =
         new View.OnSystemUiVisibilityChangeListener() {
@@ -938,7 +938,7 @@ public class ShadowViewTest {
   }
 
   @Test
-  public void capturesOnCreateContextMenuListener() throws Exception {
+  public void capturesOnCreateContextMenuListener() {
     TestView testView = new TestView(buildActivity(Activity.class).create().get());
     assertThat(shadowOf(testView).getOnCreateContextMenuListener()).isNull();
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWallpaperManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWallpaperManagerTest.java
@@ -284,7 +284,7 @@ public class ShadowWallpaperManagerTest {
 
   @Test
   @Config(minSdk = N)
-  public void getWallpaperFile_flagSystem_nothingCached_shouldReturnNull() throws Exception {
+  public void getWallpaperFile_flagSystem_nothingCached_shouldReturnNull() {
     assertThat(manager.getWallpaperFile(WallpaperManager.FLAG_SYSTEM)).isNull();
   }
 
@@ -307,7 +307,7 @@ public class ShadowWallpaperManagerTest {
 
   @Test
   @Config(minSdk = N)
-  public void getWallpaperFile_flagLock_nothingCached_shouldReturnNull() throws Exception {
+  public void getWallpaperFile_flagLock_nothingCached_shouldReturnNull() {
     assertThat(manager.getWallpaperFile(WallpaperManager.FLAG_LOCK)).isNull();
   }
 
@@ -330,7 +330,7 @@ public class ShadowWallpaperManagerTest {
 
   @Test
   @Config(minSdk = N)
-  public void getWallpaperFile_unsupportedFlag_shouldReturnNull() throws Exception {
+  public void getWallpaperFile_unsupportedFlag_shouldReturnNull() {
     assertThat(manager.getWallpaperFile(UNSUPPORTED_FLAG)).isNull();
   }
 
@@ -439,8 +439,7 @@ public class ShadowWallpaperManagerTest {
   @Test
   @Config(minSdk = M)
   public void
-      setWallpaperComponent_liveWallpaperSet_shouldReturnLiveWallpaperComponentAndUnsetStaticWallpapers()
-          throws Exception {
+      setWallpaperComponent_liveWallpaperSet_shouldReturnLiveWallpaperComponentAndUnsetStaticWallpapers() {
     manager.setWallpaperComponent(TEST_WALLPAPER_SERVICE);
 
     assertThat(manager.getWallpaperInfo().getComponent()).isEqualTo(TEST_WALLPAPER_SERVICE);
@@ -450,7 +449,7 @@ public class ShadowWallpaperManagerTest {
 
   @Test
   @Config(minSdk = M)
-  public void getWallpaperInfo_noLiveWallpaperSet_shouldReturnNull() throws Exception {
+  public void getWallpaperInfo_noLiveWallpaperSet_shouldReturnNull() {
     assertThat(manager.getWallpaperInfo()).isNull();
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWearableSensingManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWearableSensingManagerTest.java
@@ -87,7 +87,7 @@ public class ShadowWearableSensingManagerTest {
   }
 
   @Test
-  public void getLastDataBundle_noDataProvided_doesNotThrow() throws Exception {
+  public void getLastDataBundle_noDataProvided_doesNotThrow() {
     WearableSensingManager wearableSensingManager =
         (WearableSensingManager)
             getApplicationContext().getSystemService(Context.WEARABLE_SENSING_SERVICE);
@@ -98,7 +98,7 @@ public class ShadowWearableSensingManagerTest {
   }
 
   @Test
-  public void getLastSharedMemory_noDataProvided_doesNotThrow() throws Exception {
+  public void getLastSharedMemory_noDataProvided_doesNotThrow() {
     WearableSensingManager wearableSensingManager =
         (WearableSensingManager)
             getApplicationContext().getSystemService(Context.WEARABLE_SENSING_SERVICE);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiAwareManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiAwareManagerTest.java
@@ -73,8 +73,7 @@ public final class ShadowWifiAwareManagerTest {
   }
 
   @Test
-  public void attach_shouldNotAttachSessionIfSessionDetachedAndWifiAwareUnavailable()
-      throws Exception {
+  public void attach_shouldNotAttachSessionIfSessionDetachedAndWifiAwareUnavailable() {
     shadowOf(wifiAwareManager).setAvailable(false);
     shadowOf(wifiAwareManager).setSessionDetached(true);
     TestAttachCallback testAttachCallback = new TestAttachCallback();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowTest.java
@@ -58,7 +58,7 @@ public class ShadowWindowTest {
 
   @Test
   @Config(minSdk = Q)
-  public void getSystemFlag_shouldReturnFlagsSetViaAddSystemFlags() throws Exception {
+  public void getSystemFlag_shouldReturnFlagsSetViaAddSystemFlags() {
     Activity activity = Robolectric.buildActivity(Activity.class).create().get();
     Window window = activity.getWindow();
     int fakeSystemFlag1 = 0b1;
@@ -70,7 +70,7 @@ public class ShadowWindowTest {
 
   @Test
   @Config(minSdk = Q)
-  public void getSystemFlag_callingAddSystemFlagsShouldNotOverrideExistingFlags() throws Exception {
+  public void getSystemFlag_callingAddSystemFlagsShouldNotOverrideExistingFlags() {
     Activity activity = Robolectric.buildActivity(Activity.class).create().get();
     Window window = activity.getWindow();
     int fakeSystemFlag1 = 0b1;
@@ -84,7 +84,7 @@ public class ShadowWindowTest {
 
   @Test
   @Config(maxSdk = VERSION_CODES.R)
-  public void getSystemFlag_shouldReturnFlagsSetViaAddPrivateFlags() throws Exception {
+  public void getSystemFlag_shouldReturnFlagsSetViaAddPrivateFlags() {
     Activity activity = Robolectric.buildActivity(Activity.class).create().get();
     Window window = activity.getWindow();
     int fakeSystemFlag1 = 0b1;
@@ -96,8 +96,7 @@ public class ShadowWindowTest {
 
   @Test
   @Config(maxSdk = VERSION_CODES.R)
-  public void getSystemFlag_callingAddPrivateFlagsShouldNotOverrideExistingFlags()
-      throws Exception {
+  public void getSystemFlag_callingAddPrivateFlagsShouldNotOverrideExistingFlags() {
     Activity activity = Robolectric.buildActivity(Activity.class).create().get();
     Window window = activity.getWindow();
     int fakeSystemFlag1 = 0b1;


### PR DESCRIPTION
This commit removes unnecessary `throws` declarations in the `robolectric` module.