### PR TITLE
Fix typos in the `:robolectric` module

### DIFF
--- a/robolectric/src/main/java/org/robolectric/android/AttributeSetBuilder.java
+++ b/robolectric/src/main/java/org/robolectric/android/AttributeSetBuilder.java
@@ -8,7 +8,7 @@ import org.robolectric.Robolectric;
  * Builder of {@link AttributeSet}s.
  *
  * @deprecated use Xml.asAttributeSet instead. Not supported in {@link
- *     org.robolectric.annotation.ResourcesMode.Mode.NATIVE}
+ *     org.robolectric.annotation.ResourcesMode.Mode#NATIVE}
  */
 @Deprecated
 public interface AttributeSetBuilder extends Robolectric.AttributeSetBuilder {

--- a/robolectric/src/main/java/org/robolectric/android/internal/RoboMonitoringInstrumentation.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/RoboMonitoringInstrumentation.java
@@ -157,7 +157,7 @@ public class RoboMonitoringInstrumentation extends Instrumentation {
   /**
    * Executes a runnable on the main thread, blocking until it is complete.
    *
-   * <p>When in INSTUMENTATION_TEST Looper mode, the runnable is posted to the main handler and the
+   * <p>When in INSTRUMENTATION_TEST Looper mode, the runnable is posted to the main handler and the
    * caller's thread blocks until that runnable has finished. When a Throwable is thrown in the
    * runnable, the exception is propagated back to the caller's thread. If it is an unchecked
    * throwable, it will be rethrown as is. If it is a checked exception, it will be rethrown as a

--- a/robolectric/src/main/java/org/robolectric/android/internal/RobolectricThreadChecker.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/RobolectricThreadChecker.java
@@ -8,7 +8,7 @@ import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
 /**
- * Performs thread checking when in INSTRUMENTAION_TEST Looper Mode where the test thread is
+ * Performs thread checking when in INSTRUMENTATION_TEST Looper Mode where the test thread is
  * distinct from the main thread. No-op for other modes because everything is executed on the main
  * thread (except for manually created worker threads).
  */

--- a/robolectric/src/main/java/org/robolectric/junit/rules/ExpectedLogMessagesRule.java
+++ b/robolectric/src/main/java/org/robolectric/junit/rules/ExpectedLogMessagesRule.java
@@ -159,8 +159,7 @@ public final class ExpectedLogMessagesRule implements TestRule {
    * will fail.
    *
    * <p>This will also match any log statement which contains a throwable as well. For verifying the
-   * throwable, please see {@link #expectLogMessageWithThrowable(int, String, Matcher<String>,
-   * Matcher<Throwable>)}.
+   * throwable, please see {@link #expectLogMessageWithThrowable(int, String, Matcher, Matcher)}}.
    *
    * <p>Do not use this to suppress failures. Use this to test that expected error cases in your
    * code cause log messages to be printed.
@@ -187,7 +186,7 @@ public final class ExpectedLogMessagesRule implements TestRule {
 
   /**
    * Adds an expected log statement using a regular expression. If this log is not printed during
-   * test execution, the test case will fail. When possible, log output should be made determinstic
+   * test execution, the test case will fail. When possible, log output should be made deterministic
    * and {@link #expectLogMessage(int, String, String)} used instead.
    *
    * <p>This will also match any log statement which contain a throwable as well. For verifying the

--- a/robolectric/src/test/java/org/robolectric/android/DefaultPackageManagerIntentComparatorTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/DefaultPackageManagerIntentComparatorTest.java
@@ -29,8 +29,8 @@ public class DefaultPackageManagerIntentComparatorTest {
   public void canSustainConcurrentModification() {
     final IntentComparator intentComparator = new IntentComparator();
 
-    Intent intent1 = new Intent("actionstring0");
-    Intent intent2 = new Intent("actionstring1");
+    Intent intent1 = new Intent("actionString0");
+    Intent intent2 = new Intent("actionString1");
     assertThat(intentComparator.compare(intent1, intent2)).isEqualTo(-1);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/android/util/concurrent/BackgroundExecutorTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/util/concurrent/BackgroundExecutorTest.java
@@ -26,7 +26,7 @@ public class BackgroundExecutorTest {
   }
 
   @Test
-  public void forRunnable_exceptionsPropogated() {
+  public void forRunnable_exceptionsPropagated() {
     try {
       runInBackground(
           (Runnable)
@@ -53,7 +53,7 @@ public class BackgroundExecutorTest {
   }
 
   @Test
-  public void forCallable_runtimeExceptionsPropogated() {
+  public void forCallable_runtimeExceptionsPropagated() {
     try {
       runInBackground(
           (Callable<?>)

--- a/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowMapTest.java
+++ b/robolectric/src/test/java/org/robolectric/internal/bytecode/ShadowMapTest.java
@@ -73,7 +73,7 @@ public class ShadowMapTest {
   }
 
   @Test
-  public void getInvalidatedClasses_disjoin() {
+  public void getInvalidatedClasses_disjoint() {
     ShadowMap current =
         baseShadowMap.newBuilder().addShadowClass(A1, A2, true, false, false).build();
     ShadowMap previous =

--- a/robolectric/src/test/java/org/robolectric/junit/rules/ExpectedLogMessagesRuleTest.java
+++ b/robolectric/src/test/java/org/robolectric/junit/rules/ExpectedLogMessagesRuleTest.java
@@ -25,64 +25,64 @@ public final class ExpectedLogMessagesRuleTest {
 
   @Test
   public void testExpectErrorLogDoesNotFail() {
-    Log.e("Mytag", "What's up");
-    rule.expectLogMessage(Log.ERROR, "Mytag", "What's up");
+    Log.e("MyTag", "What's up");
+    rule.expectLogMessage(Log.ERROR, "MyTag", "What's up");
   }
 
   @Test
   public void testExpectWarnLogDoesNotFail() {
-    Log.w("Mytag", "What's up");
-    rule.expectLogMessage(Log.WARN, "Mytag", "What's up");
+    Log.w("MyTag", "What's up");
+    rule.expectLogMessage(Log.WARN, "MyTag", "What's up");
   }
 
   @Test
   public void testAndroidExpectedLogMessagesFailsWithMessage() {
     expectedException.expect(AssertionError.class);
-    Log.e("Mytag", "What's up");
+    Log.e("MyTag", "What's up");
   }
 
   @Test
   public void testAndroidExpectedLogMessagesDoesNotFailWithExpected() {
-    rule.expectErrorsForTag("Mytag");
-    Log.e("Mytag", "What's up");
+    rule.expectErrorsForTag("MyTag");
+    Log.e("MyTag", "What's up");
   }
 
   @Test
   public void testNoExpectedMessageFailsTest() {
     expectedException.expect(AssertionError.class);
-    rule.expectLogMessage(Log.ERROR, "Mytag", "What's up");
+    rule.expectLogMessage(Log.ERROR, "MyTag", "What's up");
   }
 
   @Test
   public void testNoExpectedTagFailsTest() {
     expectedException.expect(AssertionError.class);
-    rule.expectErrorsForTag("Mytag");
+    rule.expectErrorsForTag("MyTag");
   }
 
   @Test
   public void testExpectLogMessageWithThrowable() {
     final Throwable throwable = new Throwable("lorem ipsum");
-    Log.e("Mytag", "What's up", throwable);
-    rule.expectLogMessageWithThrowable(Log.ERROR, "Mytag", "What's up", throwable);
+    Log.e("MyTag", "What's up", throwable);
+    rule.expectLogMessageWithThrowable(Log.ERROR, "MyTag", "What's up", throwable);
   }
 
   @Test
   public void testExpectLogMessageWithThrowableMatcher() {
     final IllegalArgumentException exception = new IllegalArgumentException("lorem ipsum");
-    Log.e("Mytag", "What's up", exception);
+    Log.e("MyTag", "What's up", exception);
     rule.expectLogMessageWithThrowableMatcher(
-        Log.ERROR, "Mytag", "What's up", instanceOf(IllegalArgumentException.class));
+        Log.ERROR, "MyTag", "What's up", instanceOf(IllegalArgumentException.class));
   }
 
   @Test
   public void testMultipleExpectLogMessagee() {
     final Throwable throwable = new Throwable("lorem ipsum");
-    Log.e("Mytag", "What's up", throwable);
-    Log.e("Mytag", "Message 2");
-    Log.e("Mytag", "Message 3", throwable);
-    rule.expectLogMessageWithThrowable(Log.ERROR, "Mytag", "What's up", throwable);
-    rule.expectLogMessage(Log.ERROR, "Mytag", "Message 2");
-    rule.expectLogMessage(Log.ERROR, "Mytag", "Message 3");
+    Log.e("MyTag", "What's up", throwable);
+    Log.e("MyTag", "Message 2");
+    Log.e("MyTag", "Message 3", throwable);
+    rule.expectLogMessageWithThrowable(Log.ERROR, "MyTag", "What's up", throwable);
+    rule.expectLogMessage(Log.ERROR, "MyTag", "Message 2");
+    rule.expectLogMessage(Log.ERROR, "MyTag", "Message 3");
   }
 
   @Test
@@ -108,10 +108,10 @@ public final class ExpectedLogMessagesRuleTest {
 
   @Test
   public void testExpectedLogMessageFailureOutput() {
-    Log.e("Mytag", "message1");
-    Log.e("Mytag", "message2"); // Not expected
-    rule.expectLogMessage(Log.ERROR, "Mytag", "message1");
-    rule.expectLogMessage(Log.ERROR, "Mytag", "message3"); // Not logged
+    Log.e("MyTag", "message1");
+    Log.e("MyTag", "message2"); // Not expected
+    rule.expectLogMessage(Log.ERROR, "MyTag", "message1");
+    rule.expectLogMessage(Log.ERROR, "MyTag", "message3"); // Not logged
 
     expectedException.expect(
         new TypeSafeMatcher<AssertionError>() {
@@ -123,7 +123,7 @@ public final class ExpectedLogMessagesRuleTest {
                         "[\\s\\S]*Expected, and observed:\\s+\\[LogItem\\{"
                             + "\\s+timeString='.+'"
                             + "\\s+type=6"
-                            + "\\s+tag='Mytag'"
+                            + "\\s+tag='MyTag'"
                             + "\\s+msg='message1'"
                             + "\\s+throwable=null"
                             + "\\s+}]"
@@ -134,7 +134,7 @@ public final class ExpectedLogMessagesRuleTest {
                         "[\\s\\S]*Observed, but not expected:\\s+\\[LogItem\\{"
                             + "\\s+timeString='.+'"
                             + "\\s+type=6"
-                            + "\\s+tag='Mytag'"
+                            + "\\s+tag='MyTag'"
                             + "\\s+msg='message2'"
                             + "\\s+throwable=null"
                             + "\\s+}][\\s\\S]*")
@@ -142,7 +142,7 @@ public final class ExpectedLogMessagesRuleTest {
                     .getMessage()
                     .matches(
                         "[\\s\\S]*Expected, but not observed: \\[ExpectedLogItem\\{timeString='.+',"
-                            + " type=6, tag='Mytag', msg='message3'}]"
+                            + " type=6, tag='MyTag', msg='message3'}]"
                             + "[\\s\\S]*");
           }
 
@@ -155,12 +155,12 @@ public final class ExpectedLogMessagesRuleTest {
 
   @Test
   public void testExpectedLogMessageWithMatcherFailureOutput() {
-    Log.e("Mytag", "message1");
-    Log.e("Mytag", "message2", new IllegalArgumentException()); // Not expected
-    rule.expectLogMessage(Log.ERROR, "Mytag", "message1");
+    Log.e("MyTag", "message1");
+    Log.e("MyTag", "message2", new IllegalArgumentException()); // Not expected
+    rule.expectLogMessage(Log.ERROR, "MyTag", "message1");
     rule.expectLogMessageWithThrowableMatcher(
         Log.ERROR,
-        "Mytag",
+        "MyTag",
         "message2",
         instanceOf(UnsupportedOperationException.class)); // Not logged
 
@@ -168,7 +168,7 @@ public final class ExpectedLogMessagesRuleTest {
         "[\\s\\S]*Expected, and observed:\\s+\\[LogItem\\{"
             + "\\s+timeString='.+'"
             + "\\s+type=6"
-            + "\\s+tag='Mytag'"
+            + "\\s+tag='MyTag'"
             + "\\s+msg='message1'"
             + "\\s+throwable=null"
             + "\\s+}]"
@@ -177,7 +177,7 @@ public final class ExpectedLogMessagesRuleTest {
         "[\\s\\S]*Observed, but not expected:\\s+\\[LogItem\\{"
             + "\\s+timeString='.+'"
             + "\\s+type=6"
-            + "\\s+tag='Mytag'"
+            + "\\s+tag='MyTag'"
             + "\\s+msg='message2'"
             + "\\s+throwable=java.lang.IllegalArgumentException"
             + "(\\s+at .*\\)\\R)+"
@@ -185,7 +185,7 @@ public final class ExpectedLogMessagesRuleTest {
     String expectedNotObservedPattern =
         "[\\s\\S]*Expected, but not observed:"
             + " \\[ExpectedLogItem\\{timeString='.+',"
-            + " type=6, tag='Mytag', msg='message2', throwable="
+            + " type=6, tag='MyTag', msg='message2', throwable="
             + ".*UnsupportedOperationException.*}][\\s\\S]*";
     expectedException.expect(
         new TypeSafeMatcher<AssertionError>() {
@@ -210,24 +210,24 @@ public final class ExpectedLogMessagesRuleTest {
   }
 
   @Test
-  public void expectLogMessage_duplicateExpectatedValues_areDeduplicated() {
-    Log.e("Mytag", "message1");
-    rule.expectLogMessage(Log.ERROR, "Mytag", "message1");
-    rule.expectLogMessage(Log.ERROR, "Mytag", "message1");
+  public void expectLogMessage_duplicateExpectedValues_areDeduplicated() {
+    Log.e("MyTag", "message1");
+    rule.expectLogMessage(Log.ERROR, "MyTag", "message1");
+    rule.expectLogMessage(Log.ERROR, "MyTag", "message1");
   }
 
   @Test
-  public void expectLogMessageWithPattern_duplicateExpectatedValues_areDeduplicated() {
-    Log.e("Mytag", "message1");
-    rule.expectLogMessagePattern(Log.ERROR, "Mytag", Pattern.compile("message1"));
-    rule.expectLogMessagePattern(Log.ERROR, "Mytag", Pattern.compile("message1"));
+  public void expectLogMessageWithPattern_duplicateExpectedValues_areDeduplicated() {
+    Log.e("MyTag", "message1");
+    rule.expectLogMessagePattern(Log.ERROR, "MyTag", Pattern.compile("message1"));
+    rule.expectLogMessagePattern(Log.ERROR, "MyTag", Pattern.compile("message1"));
   }
 
   @Test
   public void expectLogMessage_duplicateMatchers_areNotDeduplicated() {
-    Log.e("Mytag", "message1");
-    rule.expectLogMessage(Log.ERROR, "Mytag", Matchers.equalTo("message1"));
-    rule.expectLogMessage(Log.ERROR, "Mytag", Matchers.equalTo("message1"));
+    Log.e("MyTag", "message1");
+    rule.expectLogMessage(Log.ERROR, "MyTag", Matchers.equalTo("message1"));
+    rule.expectLogMessage(Log.ERROR, "MyTag", Matchers.equalTo("message1"));
     expectedException.expect(Matchers.isA(AssertionError.class));
   }
 }

--- a/robolectric/src/test/java/org/robolectric/res/ResourceTableTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/ResourceTableTest.java
@@ -26,7 +26,7 @@ public class ResourceTableTest {
   }
 
   @Test
-  public void getPackageIdentifier_shouldReturnPackageIdentiferOfItsResources() {
+  public void getPackageIdentifier_shouldReturnPackageIdentifierOfItsResources() {
     resourceTable.addResource(0x02999999, "type", "name");
 
     assertThat(resourceTable.getPackageIdentifier()).isEqualTo(0x02);

--- a/robolectric/src/test/java/org/robolectric/res/StringResourcesTest.java
+++ b/robolectric/src/test/java/org/robolectric/res/StringResourcesTest.java
@@ -47,10 +47,10 @@ public class StringResourcesTest {
   @Test
   public void shouldTrimWhitespace() {
     assertThat(StringResources.processStringResources("    ")).isEmpty();
-    assertThat(StringResources.processStringResources("Trailingwhitespace    "))
-        .isEqualTo("Trailingwhitespace");
-    assertThat(StringResources.processStringResources("Leadingwhitespace    "))
-        .isEqualTo("Leadingwhitespace");
+    assertThat(StringResources.processStringResources("TrailingWhitespace    "))
+        .isEqualTo("TrailingWhitespace");
+    assertThat(StringResources.processStringResources("    LeadingWhitespace"))
+        .isEqualTo("LeadingWhitespace");
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/AssociationInfoBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/AssociationInfoBuilderTest.java
@@ -25,7 +25,7 @@ public final class AssociationInfoBuilderTest {
   private static final long APPROVED_MS = 1234L;
   private static final boolean REVOKED = true;
   private static final long LAST_TIME_CONNECTED_MS = 5678L;
-  private static final int SYSTEM_DATA_SYNC_FALGS = 7;
+  private static final int SYSTEM_DATA_SYNC_FLAGS = 7;
 
   @Test
   @Config(minSdk = VERSION_CODES.TIRAMISU)
@@ -54,7 +54,7 @@ public final class AssociationInfoBuilderTest {
             .setApprovedMs(APPROVED_MS)
             .setRevoked(REVOKED)
             .setLastTimeConnectedMs(LAST_TIME_CONNECTED_MS)
-            .setSystemDataSyncFlags(SYSTEM_DATA_SYNC_FALGS)
+            .setSystemDataSyncFlags(SYSTEM_DATA_SYNC_FLAGS)
             .build();
 
     assertThat(info.getId()).isEqualTo(ID);
@@ -74,7 +74,7 @@ public final class AssociationInfoBuilderTest {
       assertThat(associatedDevice).isEqualTo(associatedDeviceValue);
       int systemDataSyncFlags =
           ReflectionHelpers.callInstanceMethod(info, "getSystemDataSyncFlags");
-      assertThat(systemDataSyncFlags).isEqualTo(SYSTEM_DATA_SYNC_FALGS);
+      assertThat(systemDataSyncFlags).isEqualTo(SYSTEM_DATA_SYNC_FLAGS);
     }
 
     if (ReflectionHelpers.hasField(AssociationInfo.class, "mTag")) {

--- a/robolectric/src/test/java/org/robolectric/shadows/BluetoothConnectionManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/BluetoothConnectionManagerTest.java
@@ -79,28 +79,28 @@ public final class BluetoothConnectionManagerTest {
   }
 
   @Test
-  public void test_isConnected_gattClientandServerConnection() {
+  public void test_isConnected_gattClientAndServerConnection() {
     this.manager.registerGattClientConnection(REMOTE_ADDRESS1);
     this.manager.registerGattServerConnection(REMOTE_ADDRESS1);
     assertThat(this.manager.isConnected(REMOTE_ADDRESS1)).isTrue();
   }
 
   @Test
-  public void test_isNotConnected_unregistedGattClientConnection() {
+  public void test_isNotConnected_unregisteredGattClientConnection() {
     this.manager.registerGattClientConnection(REMOTE_ADDRESS1);
     this.manager.unregisterGattClientConnection(REMOTE_ADDRESS1);
     assertThat(this.manager.isConnected(REMOTE_ADDRESS1)).isFalse();
   }
 
   @Test
-  public void test_isNotConnected_unregistedGattServerConnection() {
+  public void test_isNotConnected_unregisteredGattServerConnection() {
     this.manager.registerGattServerConnection(REMOTE_ADDRESS1);
     this.manager.unregisterGattServerConnection(REMOTE_ADDRESS1);
     assertThat(this.manager.isConnected(REMOTE_ADDRESS1)).isFalse();
   }
 
   @Test
-  public void test_isConnected_gattClientConnection_unregistedGattServerConnection() {
+  public void test_isConnected_gattClientConnection_unregisteredGattServerConnection() {
     this.manager.registerGattClientConnection(REMOTE_ADDRESS1);
     this.manager.registerGattServerConnection(REMOTE_ADDRESS1);
     this.manager.unregisterGattServerConnection(REMOTE_ADDRESS1);
@@ -108,7 +108,7 @@ public final class BluetoothConnectionManagerTest {
   }
 
   @Test
-  public void test_isConnected_gattServerConnection_unregistedGattClientConnection() {
+  public void test_isConnected_gattServerConnection_unregisteredGattClientConnection() {
     this.manager.registerGattServerConnection(REMOTE_ADDRESS1);
     this.manager.registerGattClientConnection(REMOTE_ADDRESS1);
     this.manager.unregisterGattClientConnection(REMOTE_ADDRESS1);

--- a/robolectric/src/test/java/org/robolectric/shadows/CompatibilityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/CompatibilityTest.java
@@ -40,7 +40,7 @@ public class CompatibilityTest {
   }
 
   @Test
-  public void edgeToEdgeEncorcement_minSdk() {
+  public void edgeToEdgeEnforcement_minSdk() {
     assertThat(ShadowCompatibility.isEnabled(ENFORCE_EDGE_TO_EDGE, U.SDK_INT)).isFalse();
     assertThat(ShadowCompatibility.isEnabled(ENFORCE_EDGE_TO_EDGE, V.SDK_INT)).isTrue();
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ServiceStateBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ServiceStateBuilderTest.java
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 import org.robolectric.util.ReflectionHelpers;
 
-/** Test for {@link ShadowServiceState}. */
+/** Test for {@link ServiceState}. */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = P)
 public class ServiceStateBuilderTest {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityServiceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityServiceTest.java
@@ -225,13 +225,13 @@ public class ShadowAccessibilityServiceTest {
 
   @Test
   @Config(minSdk = R)
-  public void getWindowsforDefaultDisplay_returnEmptyList() {
+  public void getWindowsForDefaultDisplay_returnEmptyList() {
     assertThat(service.getWindowsOnAllDisplays().get(Display.DEFAULT_DISPLAY)).isEmpty();
   }
 
   @Test
   @Config(minSdk = R)
-  public void getWindowsforNonDefaultDisplay_returnNullList() {
+  public void getWindowsForNonDefaultDisplay_returnNullList() {
     assertThat(service.getWindowsOnAllDisplays().get(Display.DEFAULT_DISPLAY + 1)).isNull();
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
@@ -408,7 +408,7 @@ public class ShadowAccountManagerTest {
   }
 
   @Test
-  public void removeAccount_doesNotNotifyIfUnuccessful() {
+  public void removeAccount_doesNotNotifyIfUnsuccessful() {
     Account account = new Account("name", "type");
 
     TestOnAccountsUpdateListener listener = new TestOnAccountsUpdateListener();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityManagerTest.java
@@ -323,7 +323,7 @@ public class ShadowActivityManagerTest {
 
   @Config(minSdk = R)
   @Test
-  public void getHistoricalProcessExitReasons_recordsRetunredInCorrectOrder() {
+  public void getHistoricalProcessExitReasons_recordsReturnedInCorrectOrder() {
     addApplicationExitInfo(/* pid= */ 1);
     addApplicationExitInfo(/* pid= */ 2);
     addApplicationExitInfo(/* pid= */ 3);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAppOpsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAppOpsManagerTest.java
@@ -137,7 +137,7 @@ public class ShadowAppOpsManagerTest {
 
   @Test
   @Config(sdk = VERSION_CODES.Q)
-  public void noModeSet_q_noteProxyOpNoThrow_withproxiedUid_shouldReturnModeAllowed() {
+  public void noModeSet_q_noteProxyOpNoThrow_withProxiedUid_shouldReturnModeAllowed() {
     int result = appOps.noteProxyOpNoThrow(OPSTR_GPS, PACKAGE_NAME1, Binder.getCallingUid());
     assertThat(result).isEqualTo(MODE_ALLOWED);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetManagerTest.java
@@ -331,7 +331,7 @@ public class ShadowAppWidgetManagerTest {
   }
 
   @Test
-  public void updateAppWidget_landscapeAndPortrait_doesntReapplyDifferntViews() {
+  public void updateAppWidget_landscapeAndPortrait_doesntReapplyDifferentViews() {
     ComponentName provider = new ComponentName(context, SpanishTestAppWidgetProvider.class);
     appWidgetManager.bindAppWidgetIdIfAllowed(789, provider);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAudioManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAudioManagerTest.java
@@ -1642,7 +1642,7 @@ public class ShadowAudioManagerTest {
   @Test
   @Config(minSdk = S)
   public void
-      onCommunicationDeviceChangedListener_oneOfSeveralListenerRemoved_onlyRegisterdGetCalls()
+      onCommunicationDeviceChangedListener_oneOfSeveralListenerRemoved_onlyRegisteredGetCalls()
           throws Exception {
     AudioManager.OnCommunicationDeviceChangedListener mockListener1 =
         mock(AudioManager.OnCommunicationDeviceChangedListener.class);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBiometricManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBiometricManagerTest.java
@@ -83,7 +83,7 @@ public class ShadowBiometricManagerTest {
   @Test
   @Config(minSdk = R)
   public void
-      testCanAuthenticateBiometricWeak_serviceConnected_noWeakButHaveStrongEntrolled_canAuthenticate() {
+      testCanAuthenticateBiometricWeak_serviceConnected_noWeakButHaveStrongEnrolled_canAuthenticate() {
     ShadowBiometricManager shadowBiometricManager = Shadow.extract(biometricManager);
     shadowBiometricManager.setCanAuthenticate(true);
     shadowBiometricManager.setAuthenticatorType(BiometricManager.Authenticators.BIOMETRIC_STRONG);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothAdapterTest.java
@@ -772,7 +772,7 @@ public class ShadowBluetoothAdapterTest {
   @Config(minSdk = TIRAMISU)
   @Test
   @SuppressWarnings("JdkImmutableCollections")
-  public void getResgisteredUuids_returnsRegisteredServers() {
+  public void getRegisteredUuids_returnsRegisteredServers() {
     PendingIntent rfcommServerIntent = createTestPendingIntent(testIntent);
 
     Set<UUID> serverUuids = Set.of(UUID1, UUID2, UUID3, UUID4, UUID5);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothGattServerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothGattServerTest.java
@@ -387,7 +387,7 @@ public class ShadowBluetoothGattServerTest {
   }
 
   @Test
-  public void test_isConnectionCancelled_afterCancelConnection_aftereNotifyConnection() {
+  public void test_isConnectionCancelled_afterCancelConnection_afterNotifyConnection() {
     shadowOf(server).setGattServerCallback(callback);
     shadowOf(server).notifyConnection(device);
     server.cancelConnection(device);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothGattTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothGattTest.java
@@ -195,12 +195,12 @@ public class ShadowBluetoothGattTest {
   }
 
   @Test
-  public void isNotClosedbeforeClose() {
+  public void isNotClosedBeforeClose() {
     assertThat(shadowOf(bluetoothGatt).isClosed()).isFalse();
   }
 
   @Test
-  public void isClosedafterClose() {
+  public void isClosedAfterClose() {
     bluetoothGatt.close();
     assertThat(shadowOf(bluetoothGatt).isClosed()).isTrue();
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothHeadsetTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothHeadsetTest.java
@@ -188,7 +188,7 @@ public class ShadowBluetoothHeadsetTest {
   }
 
   @Test
-  public void startVoiceRecogntion_shouldEmitBroadcast() {
+  public void startVoiceRecognition_shouldEmitBroadcast() {
     shadowOf(bluetoothHeadset).addConnectedDevice(device1);
     IntentFilter intentFilter = new IntentFilter(BluetoothHeadset.ACTION_AUDIO_STATE_CHANGED);
     List<Integer> extraStateList = new ArrayList<>();
@@ -210,7 +210,7 @@ public class ShadowBluetoothHeadsetTest {
   }
 
   @Test
-  public void startVoiceRecogniton_returnsFalseIfAlreadyStarted() {
+  public void startVoiceRecognition_returnsFalseIfAlreadyStarted() {
     shadowOf(bluetoothHeadset).addConnectedDevice(device1);
     shadowOf(bluetoothHeadset).addConnectedDevice(device2);
 
@@ -220,7 +220,7 @@ public class ShadowBluetoothHeadsetTest {
   }
 
   @Test
-  public void startVoiceRecogntion_stopsAlreadyStartedRecognition() {
+  public void startVoiceRecognition_stopsAlreadyStartedRecognition() {
     shadowOf(bluetoothHeadset).addConnectedDevice(device1);
     shadowOf(bluetoothHeadset).addConnectedDevice(device2);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBugreportManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBugreportManagerTest.java
@@ -70,7 +70,7 @@ public final class ShadowBugreportManagerTest {
     shadowBugreportManager.requestBugreport(
         new BugreportParams(BugreportParams.BUGREPORT_MODE_INTERACTIVE), title, description);
 
-    // executeOnFInished() will call resetParams(), which should not crash from referencing any null
+    // executeOnFinished() will call resetParams(), which should not crash from referencing any null
     // values.
     shadowBugreportManager.executeOnFinished();
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCaptureResultTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCaptureResultTest.java
@@ -28,7 +28,7 @@ public class ShadowCaptureResultTest {
   }
 
   @Test
-  public void testGetUnrecongizedKey() {
+  public void testGetUnrecognizedKey() {
     assertThat(captureResult.get(timestampKey)).isNull();
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowChoreographerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowChoreographerTest.java
@@ -36,7 +36,7 @@ public class ShadowChoreographerTest {
   }
 
   @Test
-  public void setPaused_isPaused_doesntRunWhenClockAdancedLessThanFrameDelay() {
+  public void setPaused_isPaused_doesntRunWhenClockAdvancedLessThanFrameDelay() {
     ShadowChoreographer.setPaused(true);
     ShadowChoreographer.setFrameDelay(Duration.ofMillis(15));
     AtomicBoolean didRun = new AtomicBoolean();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
@@ -500,7 +500,7 @@ public class ShadowContentResolverTest {
     Robolectric.setupContentProvider(MyContentProvider.class, AUTHORITY);
     Uri uri = Uri.parse("content://" + AUTHORITY + "/test/1");
 
-    // Write content through given outputstream
+    // Write content through given outputStream
     try (OutputStream outputStream = contentResolver.openOutputStream(uri)) {
       outputStream.write("foo".getBytes(UTF_8));
     }
@@ -525,7 +525,7 @@ public class ShadowContentResolverTest {
 
           @Override
           public String toString() {
-            return "outputstream for " + uri;
+            return "outputStream for " + uri;
           }
         };
 
@@ -594,7 +594,7 @@ public class ShadowContentResolverTest {
     Robolectric.setupContentProvider(MyContentProvider.class, AUTHORITY);
     Uri uri = Uri.parse("content://" + AUTHORITY + "/test/1");
 
-    // Write content through given outputstream
+    // Write content through given outputStream
     try (OutputStream outputStream = contentResolver.openOutputStream(uri, "wt")) {
       outputStream.write("foo".getBytes(UTF_8));
     }
@@ -619,7 +619,7 @@ public class ShadowContentResolverTest {
 
           @Override
           public String toString() {
-            return "outputstream for " + uri;
+            return "outputStream for " + uri;
           }
         };
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextWrapperTest.java
@@ -655,76 +655,76 @@ public class ShadowContextWrapperTest {
   @Test
   @Config(minSdk = 23)
   public void checkSelfPermission() {
-    assertThat(contextWrapper.checkSelfPermission("MY_PERMISSON"))
+    assertThat(contextWrapper.checkSelfPermission("MY_PERMISSION"))
         .isEqualTo(PackageManager.PERMISSION_DENIED);
 
-    shadowContextWrapper.grantPermissions("MY_PERMISSON");
+    shadowContextWrapper.grantPermissions("MY_PERMISSION");
 
-    assertThat(contextWrapper.checkSelfPermission("MY_PERMISSON"))
+    assertThat(contextWrapper.checkSelfPermission("MY_PERMISSION"))
         .isEqualTo(PackageManager.PERMISSION_GRANTED);
-    assertThat(contextWrapper.checkSelfPermission("UNKNOWN_PERMISSON"))
+    assertThat(contextWrapper.checkSelfPermission("UNKNOWN_PERMISSION"))
         .isEqualTo(PackageManager.PERMISSION_DENIED);
   }
 
   @Test
   public void checkPermission_denied() {
-    assertThat(contextWrapper.checkPermission("MY_PERMISSON", /* pid= */ 1, /* uid= */ 1))
+    assertThat(contextWrapper.checkPermission("MY_PERMISSION", /* pid= */ 1, /* uid= */ 1))
         .isEqualTo(PackageManager.PERMISSION_DENIED);
 
-    assertThat(contextWrapper.checkPermission("MY_PERMISSON", /* pid= */ -1, /* uid= */ 1))
+    assertThat(contextWrapper.checkPermission("MY_PERMISSION", /* pid= */ -1, /* uid= */ 1))
         .isEqualTo(PackageManager.PERMISSION_DENIED);
   }
 
   @Test
   public void checkPermission_granted() {
-    shadowContextWrapper.grantPermissions(1, 1, "MY_PERMISSON");
+    shadowContextWrapper.grantPermissions(1, 1, "MY_PERMISSION");
 
-    assertThat(contextWrapper.checkPermission("MY_PERMISSON", /* pid= */ 1, /* uid= */ 1))
+    assertThat(contextWrapper.checkPermission("MY_PERMISSION", /* pid= */ 1, /* uid= */ 1))
         .isEqualTo(PackageManager.PERMISSION_GRANTED);
 
-    assertThat(contextWrapper.checkPermission("MY_PERMISSON", /* pid= */ 2, /* uid= */ 1))
+    assertThat(contextWrapper.checkPermission("MY_PERMISSION", /* pid= */ 2, /* uid= */ 1))
         .isEqualTo(PackageManager.PERMISSION_DENIED);
 
-    assertThat(contextWrapper.checkPermission("MY_PERMISSON", /* pid= */ -1, /* uid= */ 1))
+    assertThat(contextWrapper.checkPermission("MY_PERMISSION", /* pid= */ -1, /* uid= */ 1))
         .isEqualTo(PackageManager.PERMISSION_GRANTED);
   }
 
   @Test
   @Config(minSdk = 23)
   public void checkAdditionalSelfPermission() {
-    shadowContextWrapper.grantPermissions("MY_PERMISSON");
-    assertThat(contextWrapper.checkSelfPermission("MY_PERMISSON"))
+    shadowContextWrapper.grantPermissions("MY_PERMISSION");
+    assertThat(contextWrapper.checkSelfPermission("MY_PERMISSION"))
         .isEqualTo(PackageManager.PERMISSION_GRANTED);
-    assertThat(contextWrapper.checkSelfPermission("ANOTHER_PERMISSON"))
+    assertThat(contextWrapper.checkSelfPermission("ANOTHER_PERMISSION"))
         .isEqualTo(PackageManager.PERMISSION_DENIED);
 
-    shadowContextWrapper.grantPermissions("ANOTHER_PERMISSON");
-    assertThat(contextWrapper.checkSelfPermission("ANOTHER_PERMISSON"))
+    shadowContextWrapper.grantPermissions("ANOTHER_PERMISSION");
+    assertThat(contextWrapper.checkSelfPermission("ANOTHER_PERMISSION"))
         .isEqualTo(PackageManager.PERMISSION_GRANTED);
   }
 
   @Test
   @Config(minSdk = 23)
   public void revokeSelfPermission() {
-    shadowContextWrapper.grantPermissions("MY_PERMISSON");
+    shadowContextWrapper.grantPermissions("MY_PERMISSION");
 
-    assertThat(contextWrapper.checkSelfPermission("MY_PERMISSON"))
+    assertThat(contextWrapper.checkSelfPermission("MY_PERMISSION"))
         .isEqualTo(PackageManager.PERMISSION_GRANTED);
-    shadowContextWrapper.denyPermissions("MY_PERMISSON");
+    shadowContextWrapper.denyPermissions("MY_PERMISSION");
 
-    assertThat(contextWrapper.checkSelfPermission("MY_PERMISSON"))
+    assertThat(contextWrapper.checkSelfPermission("MY_PERMISSION"))
         .isEqualTo(PackageManager.PERMISSION_DENIED);
   }
 
   @Test
   public void revokePermissionUidPid() {
-    shadowContextWrapper.grantPermissions(1, 1, "MY_PERMISSON");
+    shadowContextWrapper.grantPermissions(1, 1, "MY_PERMISSION");
 
-    assertThat(contextWrapper.checkPermission("MY_PERMISSON", 1, 1))
+    assertThat(contextWrapper.checkPermission("MY_PERMISSION", 1, 1))
         .isEqualTo(PackageManager.PERMISSION_GRANTED);
-    shadowContextWrapper.denyPermissions(1, 1, "MY_PERMISSON");
+    shadowContextWrapper.denyPermissions(1, 1, "MY_PERMISSION");
 
-    assertThat(contextWrapper.checkPermission("MY_PERMISSON", 1, 1))
+    assertThat(contextWrapper.checkPermission("MY_PERMISSION", 1, 1))
         .isEqualTo(PackageManager.PERMISSION_DENIED);
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCookieManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCookieManagerTest.java
@@ -169,7 +169,7 @@ public class ShadowCookieManagerTest {
   }
 
   @Test
-  public void shouldSetCookieWithInvalidExpiesValue() {
+  public void shouldSetCookieWithInvalidExpiresValue() {
     cookieManager.setCookie(httpUrl, "name=value; Expires=3234asdfasdf10:18:14 GMT");
     assertThat(cookieManager.getCookie(url)).isEqualTo("name=value");
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCountDownTimerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCountDownTimerTest.java
@@ -43,7 +43,7 @@ public class ShadowCountDownTimerTest {
           }
 
           @Override
-          public void onTick(long millisUnitilFinished) {
+          public void onTick(long millisUntilFinished) {
             message = MESSAGE_TICK;
           }
         };

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDevicePolicyManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDevicePolicyManagerTest.java
@@ -954,7 +954,7 @@ public final class ShadowDevicePolicyManagerTest {
   }
 
   @Test
-  public void getAccountTypesWithManagementDisabledShouldReturnNothingWhenNoAccountIsDislabed() {
+  public void getAccountTypesWithManagementDisabledShouldReturnNothingWhenNoAccountIsDisabled() {
     // GIVEN no account type has ever been disabled
 
     // WHEN get disabled account types using

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayManagerTest.java
@@ -346,7 +346,7 @@ public class ShadowDisplayManagerTest {
 
   @Test
   @Config(minSdk = P)
-  public void setSaturationLevel_setToNegativevalueViaShadow_shouldThrow() {
+  public void setSaturationLevel_setToNegativeValueViaShadow_shouldThrow() {
     try {
       shadowOf(instance).setSaturationLevel(-0.1f);
       fail("Expected IllegalArgumentException thrown");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowInputMethodManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowInputMethodManagerTest.java
@@ -64,7 +64,7 @@ public class ShadowInputMethodManagerTest {
   }
 
   @Test
-  public void hideSoftInputFromWindow_shouldNotifiyResult_alreadyHidden() {
+  public void hideSoftInputFromWindow_shouldNotifyResult_alreadyHidden() {
     CapturingResultReceiver resultReceiver =
         new CapturingResultReceiver(new Handler(Looper.getMainLooper()));
     manager.hideSoftInputFromWindow(null, 0, resultReceiver);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowListViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowListViewTest.java
@@ -191,7 +191,7 @@ public class ShadowListViewTest {
   @Test(expected = IllegalArgumentException.class)
   public void clickItemContainingText_shouldThrowExceptionIfNotFound() {
     ShadowListView shadowListView = prepareListWithThreeItems();
-    shadowListView.clickFirstItemContainingText("Non-existant item");
+    shadowListView.clickFirstItemContainingText("Non-existent item");
   }
 
   @Test(expected = UnsupportedOperationException.class)
@@ -228,7 +228,7 @@ public class ShadowListViewTest {
   }
 
   @Test
-  public void shouldRecordLatestCallToSmoothScrollToPostion() {
+  public void shouldRecordLatestCallToSmoothScrollToPosition() {
     listView.smoothScrollToPosition(10);
     assertThat(shadowOf(listView).getSmoothScrolledPosition()).isEqualTo(10);
   }
@@ -255,7 +255,7 @@ public class ShadowListViewTest {
   }
 
   @Test
-  public void givenNoItemsChecked_whenGettingCheckedItemOisition_thenReturnInvalidPosition() {
+  public void givenNoItemsChecked_whenGettingCheckedItemPosition_thenReturnInvalidPosition() {
     prepareListAdapter().withChoiceMode(ListView.CHOICE_MODE_SINGLE);
 
     assertThat(listView.getCheckedItemPosition()).isEqualTo(ListView.INVALID_POSITION);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperResetterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperResetterTest.java
@@ -325,7 +325,7 @@ public class ShadowLooperResetterTest {
     }
   }
 
-  /** Tests for potentially race conditions where Looper is quit asynchrounously at end of test */
+  /** Tests for potentially race conditions where Looper is quit asynchronously at end of test */
   @Test
   public void choreographerQuitPost() throws InitializationError {
     Runner runner = new RobolectricTestRunner(ChoreographerResetQuitTest.class);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaActionSoundTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaActionSoundTest.java
@@ -82,7 +82,7 @@ public final class ShadowMediaActionSoundTest {
 
   @Test
   @Config(minSdk = VERSION_CODES.TIRAMISU)
-  public void mustPlayShutterSound_overrident_correctValue() {
+  public void mustPlayShutterSound_overridden_correctValue() {
     ShadowMediaActionSound.setMustPlayShutterSound(true);
 
     assertThat(MediaActionSound.mustPlayShutterSound()).isTrue();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaCodecTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaCodecTest.java
@@ -154,8 +154,8 @@ public final class ShadowMediaCodecTest {
 
     codec.releaseOutputBuffer(bufferIndex, /* render= */ false);
     // We should be able to dequeue the corresponding input buffer.
-    int dequeuedInputbufferIndex = codec.dequeueInputBuffer(/* timeoutUs= */ 0);
-    assertThat(dequeuedInputbufferIndex).isEqualTo(bufferIndex);
+    int dequeuedInputBufferIndex = codec.dequeueInputBuffer(/* timeoutUs= */ 0);
+    assertThat(dequeuedInputBufferIndex).isEqualTo(bufferIndex);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
@@ -1135,7 +1135,7 @@ public class ShadowMediaPlayerTest {
   }
 
   @Test
-  public void testSimulatenousEventsAllRun() {
+  public void testSimultaneousEventsAllRun() {
     // Simultaneous events should all run even if
     // one of them stops playback.
     MediaEvent e1 = (mp, smp) -> smp.doStop();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNfcAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNfcAdapterTest.java
@@ -40,7 +40,7 @@ public class ShadowNfcAdapterTest {
   }
 
   @Test
-  public void setNdefPushMesageCallback_shouldUseCallback() {
+  public void setNdefPushMessageCallback_shouldUseCallback() {
     final NfcAdapter.CreateNdefMessageCallback callback =
         mock(NfcAdapter.CreateNdefMessageCallback.class);
     final Activity activity = Robolectric.setupActivity(Activity.class);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageInstallerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageInstallerTest.java
@@ -145,7 +145,7 @@ public class ShadowPackageInstallerTest {
   }
 
   @Test(expected = SecurityException.class)
-  public void packageInstallerOpenSession_nonExistantSessionThrowsException() throws Exception {
+  public void packageInstallerOpenSession_nonExistentSessionThrowsException() throws Exception {
     packageInstaller.openSession(-99);
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -3389,7 +3389,7 @@ public class ShadowPackageManagerTest {
   @Test
   public void getPermissionInfo_notFound() {
     try {
-      packageManager.getPermissionInfo("non_existant_permission", 0);
+      packageManager.getPermissionInfo("non_existent_permission", 0);
       fail("should have thrown NameNotFoundException");
     } catch (NameNotFoundException e) {
       // expected

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPausedAsyncTaskTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPausedAsyncTaskTest.java
@@ -33,7 +33,7 @@ public class ShadowPausedAsyncTaskTest {
     transcript = new ArrayList<>();
   }
 
-  /** Test uses AsyncTask without overridding executor. */
+  /** Test uses AsyncTask without overriding executor. */
   @Test
   public void testNormalFlow() throws Exception {
     AsyncTask<String, String, String> asyncTask = new RecordingAsyncTask();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowResultReceiverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowResultReceiverTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class ShadowResultReceiverTest {
   @Test
-  public void callingSend_shouldCallOverridenOnReceiveResultWithTheSameArguments() {
+  public void callingSend_shouldCallOverriddenOnReceiveResultWithTheSameArguments() {
     TestResultReceiver testResultReceiver = new TestResultReceiver(null);
     Bundle bundle = new Bundle();
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSoundTriggerManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSoundTriggerManagerTest.java
@@ -56,7 +56,7 @@ public final class ShadowSoundTriggerManagerTest {
     assertThat(moduleProperties.getVersion()).isEqualTo(1234);
   }
 
-  // Construct a dummuy {@code SoundTrigger.ModuleProperties}. Return Object because {@code
+  // Construct a dummy {@code SoundTrigger.ModuleProperties}. Return Object because {@code
   // SoundTrigger.ModuleProperties} is not exist in public Android SDK.
   private Object getModuleProperties(String supportedModelArch, int version) {
     return new SoundTrigger.ModuleProperties(

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSpeechRecognizerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSpeechRecognizerTest.java
@@ -148,7 +148,7 @@ public class ShadowSpeechRecognizerTest {
     speechRecognizer =
         SpeechRecognizer.createSpeechRecognizer(
             ApplicationProvider.getApplicationContext(),
-            new ComponentName("org.robolectrc", "FakeComponent"));
+            new ComponentName("org.robolectric", "FakeComponent"));
     speechRecognizer.setRecognitionListener(listener);
     speechRecognizer.startListening(new Intent());
     shadowOf(getMainLooper()).idle();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStorageStatsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStorageStatsManagerTest.java
@@ -75,7 +75,7 @@ public final class ShadowStorageStatsManagerTest {
 
   @Test
   public void getFreeBytes_afterRemoveStorageDevice_throwsException() {
-    // Arange
+    // Arrange
     shadowOf(storageStatsManager).removeStorageDevice(StorageManager.UUID_DEFAULT);
 
     // Act & Assert
@@ -124,7 +124,7 @@ public final class ShadowStorageStatsManagerTest {
 
   @Test
   public void getTotalBytes_afterRemoveStorageDevice_throwsException() {
-    // Arange
+    // Arrange
     shadowOf(storageStatsManager).removeStorageDevice(StorageManager.UUID_DEFAULT);
 
     // Act & Assert

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSurfaceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSurfaceTest.java
@@ -150,7 +150,7 @@ public class ShadowSurfaceTest {
    */
   @Config(minSdk = Q)
   @Test
-  public void copyFrom_surfaceControl_lockHardwareCavnvas() {
+  public void copyFrom_surfaceControl_lockHardwareCanvas() {
     SurfaceSession session = new SurfaceSession();
     SurfaceControl surfaceControl =
         new SurfaceControl.Builder(session).setBufferSize(100, 100).setName("").build();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTelecomManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTelecomManagerTest.java
@@ -99,7 +99,7 @@ public class ShadowTelecomManagerTest {
 
   @Test
   @Config(minSdk = UPSIDE_DOWN_CAKE)
-  public void registerWithTransactionalCapabilites_addsSelfManagedCapability() {
+  public void registerWithTransactionalCapabilities_addsSelfManagedCapability() {
     PhoneAccountHandle handle = createHandle("id");
     PhoneAccount phoneAccount =
         PhoneAccount.builder(handle, "main_account")

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTextViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTextViewTest.java
@@ -369,7 +369,7 @@ public class ShadowTextViewTest {
 
   @Test
   public void
-      testSetCompountDrawablesWithIntrinsicBounds_int_shouldCreateDrawablesWithResourceIds() {
+      testSetCompoundDrawablesWithIntrinsicBounds_int_shouldCreateDrawablesWithResourceIds() {
     textView.setCompoundDrawablesWithIntrinsicBounds(
         R.drawable.an_image,
         R.drawable.an_other_image,
@@ -389,7 +389,7 @@ public class ShadowTextViewTest {
   }
 
   @Test
-  public void testSetCompountDrawablesWithIntrinsicBounds_int_shouldNotCreateDrawablesForZero() {
+  public void testSetCompoundDrawablesWithIntrinsicBounds_int_shouldNotCreateDrawablesForZero() {
     textView.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
 
     assertNull(textView.getCompoundDrawables()[0]);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowVibratorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowVibratorTest.java
@@ -201,7 +201,7 @@ public class ShadowVibratorTest {
 
   @Config(minSdk = R)
   @Test
-  public void areAllPrimitivesSupported_oneUnsupportedPrimitivie_shouldReturnFalse() {
+  public void areAllPrimitivesSupported_oneUnsupportedPrimitive_shouldReturnFalse() {
     shadowOf(vibrator)
         .setSupportedPrimitives(ImmutableList.of(EFFECT_CLICK, EFFECT_TICK, EFFECT_HEAVY_CLICK));
 
@@ -240,7 +240,7 @@ public class ShadowVibratorTest {
 
   @Config(minSdk = O, maxSdk = R)
   @Test
-  public void getAudioAttribues_vibrateWithAudioAttributes_shouldReturnAudioAttributes() {
+  public void getAudioAttributes_vibrateWithAudioAttributes_shouldReturnAudioAttributes() {
     AudioAttributes audioAttributes =
         new AudioAttributes.Builder()
             .setUsage(AudioAttributes.USAGE_NOTIFICATION_COMMUNICATION_REQUEST)
@@ -278,7 +278,7 @@ public class ShadowVibratorTest {
 
   @Config(minSdk = S)
   @Test
-  public void getPrimitiveDurations_mulitpleNonDefaultsSupplied_returnsNonDefaultValues() {
+  public void getPrimitiveDurations_multipleNonDefaultsSupplied_returnsNonDefaultValues() {
     shadowOf(vibrator).setPrimitiveDurations(EFFECT_CLICK, 10);
     shadowOf(vibrator).setPrimitiveDurations(EFFECT_TICK, 20);
 
@@ -290,7 +290,7 @@ public class ShadowVibratorTest {
 
   @Config(minSdk = S)
   @Test
-  public void getPrimitiveDurations_mulitpleNonDefaultsSupplied_returnsOnlyRequestedValues() {
+  public void getPrimitiveDurations_multipleNonDefaultsSupplied_returnsOnlyRequestedValues() {
     shadowOf(vibrator).setPrimitiveDurations(EFFECT_CLICK, 10);
     shadowOf(vibrator).setPrimitiveDurations(EFFECT_TICK, 20);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewGroupTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewGroupTest.java
@@ -162,7 +162,7 @@ public class ShadowViewGroupTest {
   }
 
   @Test
-  public void shouldfindViewWithTagFromCorrectViewGroup() {
+  public void shouldFindViewWithTagFromCorrectViewGroup() {
     root.removeAllViews();
     child1.setTag("tag1");
     child2.setTag("tag2");


### PR DESCRIPTION
This commit fixes some typos in method names, variable names, comments, Javadoc, ...