### PR TITLE
Remove unnecessary casts in the `:robolectric` module

### DIFF
--- a/robolectric/src/main/java/org/robolectric/ConfigMerger.java
+++ b/robolectric/src/main/java/org/robolectric/ConfigMerger.java
@@ -56,8 +56,8 @@ public class ConfigMerger {
       config = override(config, packageConfig);
     }
 
-    for (Class clazz : reverse(parentClassesFor(testClass))) {
-      Config classConfig = (Config) clazz.getAnnotation(Config.class);
+    for (Class<?> clazz : reverse(parentClassesFor(testClass))) {
+      Config classConfig = clazz.getAnnotation(Config.class);
       config = override(config, classConfig);
     }
 
@@ -123,8 +123,8 @@ public class ConfigMerger {
   }
 
   @Nonnull
-  private List<Class> parentClassesFor(Class testClass) {
-    List<Class> testClassHierarchy = new ArrayList<>();
+  private List<Class<?>> parentClassesFor(Class<?> testClass) {
+    List<Class<?>> testClassHierarchy = new ArrayList<>();
     while (testClass != null && !testClass.equals(Object.class)) {
       testClassHierarchy.add(testClass);
       testClass = testClass.getSuperclass();

--- a/robolectric/src/main/java/org/robolectric/ParameterizedRobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/ParameterizedRobolectricTestRunner.java
@@ -101,7 +101,7 @@ public final class ParameterizedRobolectricTestRunner extends Suite {
       this.name = name;
     }
 
-    private Object createTestInstance(Class bootstrappedClass) throws Exception {
+    private Object createTestInstance(Class<?> bootstrappedClass) throws Exception {
       Constructor<?>[] constructors = bootstrappedClass.getConstructors();
       Assert.assertEquals(1, constructors.length);
       if (!fieldsAreAnnotated()) {
@@ -177,7 +177,7 @@ public final class ParameterizedRobolectricTestRunner extends Suite {
                 Locale.US,
                 "Provided %d parameters, but only found fields for parameters: %s",
                 parameters.length,
-                parameterFieldsFound.toString()));
+                parameterFieldsFound));
       }
     }
 
@@ -241,7 +241,8 @@ public final class ParameterizedRobolectricTestRunner extends Suite {
     }
 
     @Override
-    protected SandboxTestRunner.HelperTestRunner getHelperTestRunner(Class bootstrappedTestClass) {
+    protected SandboxTestRunner.HelperTestRunner getHelperTestRunner(
+        Class<?> bootstrappedTestClass) {
       try {
         return new HelperTestRunner(bootstrappedTestClass) {
           @Override
@@ -262,7 +263,7 @@ public final class ParameterizedRobolectricTestRunner extends Suite {
 
           @Override
           public String toString() {
-            return "HelperTestRunner for " + TestClassRunnerForParameters.this.toString();
+            return "HelperTestRunner for " + TestClassRunnerForParameters.this;
           }
         };
       } catch (InitializationError initializationError) {
@@ -285,7 +286,7 @@ public final class ParameterizedRobolectricTestRunner extends Suite {
    * Only called reflectively. Do not use programmatically.
    */
   public ParameterizedRobolectricTestRunner(Class<?> klass) throws Throwable {
-    super(klass, Collections.<Runner>emptyList());
+    super(klass, Collections.emptyList());
     TestClass testClass = getTestClass();
     ClassLoader classLoader = getClass().getClassLoader();
     Parameters parameters =

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -544,7 +544,7 @@ public class RobolectricTestRunner extends SandboxTestRunner {
     private final boolean alwaysIncludeVariantMarkersInName;
 
     private boolean includeVariantMarkersInTestName = true;
-    TestLifecycle<?> testLifecycle;
+    TestLifecycle testLifecycle;
     Sandbox sandbox;
     TestEnvironment testEnvironment;
 

--- a/robolectric/src/main/java/org/robolectric/TestLifecycle.java
+++ b/robolectric/src/main/java/org/robolectric/TestLifecycle.java
@@ -2,7 +2,7 @@ package org.robolectric;
 
 import java.lang.reflect.Method;
 
-public interface TestLifecycle<T> {
+public interface TestLifecycle {
 
   /**
    * Called before each test method is run.

--- a/robolectric/src/main/java/org/robolectric/junit/rules/ExpectedLogMessagesRule.java
+++ b/robolectric/src/main/java/org/robolectric/junit/rules/ExpectedLogMessagesRule.java
@@ -362,8 +362,7 @@ public final class ExpectedLogMessagesRule implements TestRule {
 
     @Override
     public boolean matches(Object other) {
-      // Allow direct cast since we only use this matcher in a type-safe way.
-      return msg.equals((String) other);
+      return msg.equals(other);
     }
 
     // Designed to match legacy toString() behaviour - do not modify.

--- a/robolectric/src/main/java/org/robolectric/plugins/PackagePropertiesLoader.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/PackagePropertiesLoader.java
@@ -36,7 +36,7 @@ public class PackagePropertiesLoader {
       buf.append(packageName.replace('.', '/'));
       buf.append('/');
     }
-    String propsFile = buf.toString() + propFileName + ".properties";
+    String propsFile = buf + propFileName + ".properties";
     return cache.computeIfAbsent(
         propsFile,
         s -> {

--- a/robolectric/src/test/java/org/robolectric/ConfigTest.java
+++ b/robolectric/src/test/java/org/robolectric/ConfigTest.java
@@ -106,14 +106,11 @@ public class ConfigTest {
   public void withOverlay_withShadows_maintainsOrder() {
     Config.Implementation base = new Config.Builder().build();
 
-    Config withString =
-        overlay(base, new Config.Builder().setShadows(new Class[] {String.class}).build());
+    Config withString = overlay(base, new Config.Builder().setShadows(String.class).build());
     assertThat(withString.shadows()).asList().contains(String.class);
 
     Config withMore =
-        overlay(
-            withString,
-            new Config.Builder().setShadows(new Class[] {Map.class, String.class}).build());
+        overlay(withString, new Config.Builder().setShadows(Map.class, String.class).build());
     assertThat(withMore.shadows()).asList().containsAtLeast(String.class, Map.class, String.class);
   }
 

--- a/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerConfigTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerConfigTest.java
@@ -39,7 +39,7 @@ public final class ParameterizedRobolectricTestRunnerConfigTest {
   }
 
   @ParameterizedRobolectricTestRunner.Parameters(name = "ConfigTest: {0}")
-  public static Collection getTestData() {
+  public static Collection<?> getTestData() {
     Object[][] data = {{1}, {2}, {3}, {4}};
     return Arrays.asList(data);
   }

--- a/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerNormalTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerNormalTest.java
@@ -63,7 +63,7 @@ public final class ParameterizedRobolectricTestRunnerNormalTest {
   }
 
   @ParameterizedRobolectricTestRunner.Parameters(name = "Java Math Test: {0}, {1}")
-  public static Collection getTestData() {
+  public static Collection<?> getTestData() {
     Object[][] data = {
       {1, 1, 2, 0, 1, 1},
       {2, 1, 3, 1, 2, 2},

--- a/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerUriTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerUriTest.java
@@ -35,7 +35,7 @@ public final class ParameterizedRobolectricTestRunnerUriTest {
   }
 
   @ParameterizedRobolectricTestRunner.Parameters(name = "URI Test: {0} + {1}")
-  public static Collection getTestData() {
+  public static Collection<?> getTestData() {
     Object[][] data = {
       {"http://host", "resource", "http://host/resource"},
       {"http://host/", "resource", "http://host/resource"},

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerSelfTest.java
@@ -102,8 +102,7 @@ public class RobolectricTestRunnerSelfTest {
 
     @Override
     public void onTerminate() {
-      onTerminateCalledFromMain =
-          Boolean.valueOf(Looper.getMainLooper().getThread() == Thread.currentThread());
+      onTerminateCalledFromMain = Looper.getMainLooper().getThread() == Thread.currentThread();
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraCharacteristicsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraCharacteristicsTest.java
@@ -13,8 +13,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class ShadowCameraCharacteristicsTest {
 
-  private final CameraCharacteristics.Key key0 =
-      new CameraCharacteristics.Key("key0", Integer.class);
+  private final CameraCharacteristics.Key<Integer> key0 =
+      new CameraCharacteristics.Key<>("key0", Integer.class);
   private final CameraCharacteristics cameraCharacteristics =
       ShadowCameraCharacteristics.newCameraCharacteristics();
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
@@ -89,8 +89,8 @@ public class ShadowContentResolverTest {
   public void setUp() {
     contentResolver = ApplicationProvider.getApplicationContext().getContentResolver();
     shadowContentResolver = shadowOf(contentResolver);
-    uri21 = Uri.parse(EXTERNAL_CONTENT_URI.toString() + "/21");
-    uri22 = Uri.parse(EXTERNAL_CONTENT_URI.toString() + "/22");
+    uri21 = Uri.parse(EXTERNAL_CONTENT_URI + "/21");
+    uri22 = Uri.parse(EXTERNAL_CONTENT_URI + "/22");
 
     a = new Account("a", "type");
     b = new Account("b", "type");
@@ -271,8 +271,7 @@ public class ShadowContentResolverTest {
     assertThat(shadowContentResolver.query(null, null, null, null, null)).isNull();
     BaseCursor cursor = new BaseCursor();
     shadowContentResolver.setCursor(cursor);
-    assertThat((BaseCursor) shadowContentResolver.query(null, null, null, null, null))
-        .isSameInstanceAs(cursor);
+    assertThat(shadowContentResolver.query(null, null, null, null, null)).isSameInstanceAs(cursor);
   }
 
   @Test
@@ -281,9 +280,7 @@ public class ShadowContentResolverTest {
         .isNull();
     BaseCursor cursor = new BaseCursor();
     shadowContentResolver.setCursor(cursor);
-    assertThat(
-            (BaseCursor)
-                shadowContentResolver.query(null, null, null, null, null, new CancellationSignal()))
+    assertThat(shadowContentResolver.query(null, null, null, null, null, new CancellationSignal()))
         .isSameInstanceAs(cursor);
   }
 
@@ -297,9 +294,9 @@ public class ShadowContentResolverTest {
     shadowContentResolver.setCursor(uri21, cursor21);
     shadowContentResolver.setCursor(uri22, cursor22);
 
-    assertThat((BaseCursor) shadowContentResolver.query(uri21, null, null, null, null))
+    assertThat(shadowContentResolver.query(uri21, null, null, null, null))
         .isSameInstanceAs(cursor21);
-    assertThat((BaseCursor) shadowContentResolver.query(uri22, null, null, null, null))
+    assertThat(shadowContentResolver.query(uri22, null, null, null, null))
         .isSameInstanceAs(cursor22);
   }
 
@@ -315,7 +312,7 @@ public class ShadowContentResolverTest {
     shadowContentResolver.setCursor(testCursor);
     Cursor cursor =
         shadowContentResolver.query(uri21, projection, selection, selectionArgs, sortOrder);
-    assertThat((QueryParamTrackingCursor) cursor).isEqualTo(testCursor);
+    assertThat(cursor).isEqualTo(testCursor);
     assertThat(testCursor.uri).isEqualTo(uri21);
     assertThat(testCursor.projection).isEqualTo(projection);
     assertThat(testCursor.selection).isEqualTo(selection);
@@ -338,7 +335,7 @@ public class ShadowContentResolverTest {
     QueryParamTrackingCursor testCursor = new QueryParamTrackingCursor();
     shadowContentResolver.setCursor(testCursor);
     Cursor cursor = shadowContentResolver.query(uri21, projection, queryArgs, null);
-    assertThat((QueryParamTrackingCursor) cursor).isEqualTo(testCursor);
+    assertThat(cursor).isEqualTo(testCursor);
     assertThat(testCursor.uri).isEqualTo(uri21);
     assertThat(testCursor.projection).isEqualTo(projection);
     assertThat(testCursor.selection).isEqualTo(selection);
@@ -1091,7 +1088,7 @@ public class ShadowContentResolverTest {
 
     contentResolver.registerContentObserver(EXTERNAL_CONTENT_URI, true, co);
 
-    assertThat(scr.getContentObservers(EXTERNAL_CONTENT_URI)).containsExactly((ContentObserver) co);
+    assertThat(scr.getContentObservers(EXTERNAL_CONTENT_URI)).containsExactly(co);
 
     assertThat(co.changed).isFalse();
     contentResolver.notifyChange(EXTERNAL_CONTENT_URI, null);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowHandlerTest.java
@@ -466,7 +466,7 @@ public class ShadowHandlerTest {
 
     Message m2 = new Handler().obtainMessage(1, "foo");
     assertThat(m2.what).isEqualTo(1);
-    assertThat(m2.obj).isEqualTo((Object) "foo");
+    assertThat(m2.obj).isEqualTo("foo");
 
     Message m3 = new Handler().obtainMessage(1, 2, 3);
     assertThat(m3.what).isEqualTo(1);
@@ -478,7 +478,7 @@ public class ShadowHandlerTest {
     assertThat(m4.what).isEqualTo(1);
     assertThat(m4.arg1).isEqualTo(2);
     assertThat(m4.arg2).isEqualTo(3);
-    assertThat(m4.obj).isEqualTo((Object) "foo");
+    assertThat(m4.obj).isEqualTo("foo");
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLocationManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLocationManagerTest.java
@@ -111,7 +111,7 @@ public class ShadowLocationManagerTest {
   public void testGetAllProviders() {
     assertThat(locationManager.getAllProviders())
         .containsExactly(GPS_PROVIDER, NETWORK_PROVIDER, PASSIVE_PROVIDER);
-    shadowLocationManager.setProviderProperties(MY_PROVIDER, (ProviderProperties) null);
+    shadowLocationManager.setProviderProperties(MY_PROVIDER, null);
     assertThat(locationManager.getAllProviders())
         .containsExactly(MY_PROVIDER, GPS_PROVIDER, NETWORK_PROVIDER, PASSIVE_PROVIDER);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaPlayerTest.java
@@ -744,7 +744,7 @@ public class ShadowMediaPlayerTest {
     public Object[] args;
 
     public MethodSpec(String method) {
-      this(method, (Class<?>[]) null, (Object[]) null);
+      this(method, null, (Object[]) null);
     }
 
     public MethodSpec(String method, Class<?>[] argTypes, Object[] args) {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
@@ -89,8 +89,7 @@ public class ShadowNotificationManagerTest {
     notificationManager.createNotificationChannel(new NotificationChannel("id", "name", 1));
 
     assertThat(shadowOf(notificationManager).getNotificationChannels()).hasSize(1);
-    NotificationChannel channel =
-        (NotificationChannel) shadowOf(notificationManager).getNotificationChannel("id");
+    NotificationChannel channel = shadowOf(notificationManager).getNotificationChannel("id");
     assertThat(channel.getName().toString()).isEqualTo("name");
     assertThat(channel.getImportance()).isEqualTo(1);
   }
@@ -120,8 +119,7 @@ public class ShadowNotificationManagerTest {
     notificationManager.createNotificationChannel(channelUpdate);
 
     assertThat(shadowOf(notificationManager).getNotificationChannels()).hasSize(1);
-    NotificationChannel resultChannel =
-        (NotificationChannel) shadowOf(notificationManager).getNotificationChannel("id");
+    NotificationChannel resultChannel = shadowOf(notificationManager).getNotificationChannel("id");
     assertThat(resultChannel.getName().toString()).isEqualTo("newName");
     assertThat(resultChannel.getDescription()).isEqualTo("newDescription");
     // No importance upgrade.
@@ -146,8 +144,7 @@ public class ShadowNotificationManagerTest {
     notificationManager.createNotificationChannel(channelUpdate);
 
     assertThat(shadowOf(notificationManager).getNotificationChannels()).hasSize(1);
-    NotificationChannel resultChannel =
-        (NotificationChannel) shadowOf(notificationManager).getNotificationChannel("id");
+    NotificationChannel resultChannel = shadowOf(notificationManager).getNotificationChannel("id");
     assertThat(resultChannel.getName().toString()).isEqualTo("newName");
     assertThat(resultChannel.getDescription()).isEqualTo("newDescription");
     assertThat(resultChannel.getImportance()).isEqualTo(0);
@@ -161,7 +158,7 @@ public class ShadowNotificationManagerTest {
 
     assertThat(shadowOf(notificationManager).getNotificationChannelGroups()).hasSize(1);
     NotificationChannelGroup group =
-        (NotificationChannelGroup) shadowOf(notificationManager).getNotificationChannelGroup("id");
+        shadowOf(notificationManager).getNotificationChannelGroup("id");
     assertThat(group.getName().toString()).isEqualTo("name");
   }
 
@@ -174,11 +171,10 @@ public class ShadowNotificationManagerTest {
     notificationManager.createNotificationChannels(ImmutableList.of(channel1, channel2));
 
     assertThat(shadowOf(notificationManager).getNotificationChannels()).hasSize(2);
-    NotificationChannel channel =
-        (NotificationChannel) shadowOf(notificationManager).getNotificationChannel("id");
+    NotificationChannel channel = shadowOf(notificationManager).getNotificationChannel("id");
     assertThat(channel.getName().toString()).isEqualTo("name");
     assertThat(channel.getImportance()).isEqualTo(1);
-    channel = (NotificationChannel) shadowOf(notificationManager).getNotificationChannel("id2");
+    channel = shadowOf(notificationManager).getNotificationChannel("id2");
     assertThat(channel.getName().toString()).isEqualTo("name2");
     assertThat(channel.getImportance()).isEqualTo(1);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -2921,7 +2921,7 @@ public class ShadowPackageManagerTest {
   public void getPackagesForUid() {
     assertThat(packageManager.getPackagesForUid(10)).isNull();
 
-    shadowOf(packageManager).setPackagesForUid(10, new String[] {"a_name"});
+    shadowOf(packageManager).setPackagesForUid(10, "a_name");
 
     assertThat(packageManager.getPackagesForUid(10)).asList().containsExactly("a_name");
   }
@@ -2929,7 +2929,7 @@ public class ShadowPackageManagerTest {
   @Test
   @Config(minSdk = N)
   public void getPackageUid() throws NameNotFoundException {
-    shadowOf(packageManager).setPackagesForUid(10, new String[] {"a_name"});
+    shadowOf(packageManager).setPackagesForUid(10, "a_name");
     assertThat(packageManager.getPackageUid("a_name", 0)).isEqualTo(10);
   }
 
@@ -2947,7 +2947,7 @@ public class ShadowPackageManagerTest {
   @Test
   @Config(minSdk = TIRAMISU)
   public void getPackageUid_sdkT() throws NameNotFoundException {
-    shadowOf(packageManager).setPackagesForUid(10, new String[] {"a_name"});
+    shadowOf(packageManager).setPackagesForUid(10, "a_name");
     assertThat(packageManager.getPackageUid("a_name", PackageInfoFlags.of(0))).isEqualTo(10);
   }
 
@@ -2964,7 +2964,7 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void getPackagesForUid_shouldReturnSetPackageName() {
-    shadowOf(packageManager).setPackagesForUid(10, new String[] {"a_name"});
+    shadowOf(packageManager).setPackagesForUid(10, "a_name");
     assertThat(packageManager.getPackagesForUid(10)).asList().containsExactly("a_name");
   }
 
@@ -4103,7 +4103,7 @@ public class ShadowPackageManagerTest {
         /* suspended= */ true,
         /* appExtras= */ null,
         /* launcherExtras= */ null,
-        /* dialogMessage= */ (String) null);
+        /* dialogMessage= */ null);
     assertThat(packageManager.isPackageSuspended(TEST_PACKAGE_NAME)).isTrue();
   }
 
@@ -4131,13 +4131,13 @@ public class ShadowPackageManagerTest {
         /* suspended= */ true,
         /* appExtras= */ null,
         /* launcherExtras= */ null,
-        /* dialogMessage= */ (String) null);
+        /* dialogMessage= */ null);
     setPackagesSuspended(
         new String[] {TEST_PACKAGE_NAME},
         /* suspended= */ false,
         /* appExtras= */ null,
         /* launcherExtras= */ null,
-        /* dialogMessage= */ (String) null);
+        /* dialogMessage= */ null);
     assertThat(packageManager.isPackageSuspended(TEST_PACKAGE_NAME)).isFalse();
   }
 
@@ -4174,7 +4174,7 @@ public class ShadowPackageManagerTest {
           /* suspended= */ true,
           /* appExtras= */ null,
           /* launcherExtras= */ null,
-          /* dialogMessage= */ (String) null);
+          /* dialogMessage= */ null);
       fail("Should have thrown UnsupportedOperationException");
     } catch (UnsupportedOperationException expected) {
     }
@@ -4235,7 +4235,7 @@ public class ShadowPackageManagerTest {
           /* suspended= */ true,
           /* appExtras= */ null,
           /* launcherExtras= */ null,
-          /* dialogMessage= */ (String) null);
+          /* dialogMessage= */ null);
       fail("Should have thrown UnsupportedOperationException");
     } catch (UnsupportedOperationException expected) {
     }
@@ -4305,7 +4305,7 @@ public class ShadowPackageManagerTest {
                 /* suspended= */ true,
                 /* appExtras= */ null,
                 /* launcherExtras= */ null,
-                /* dialogMessage= */ (String) null))
+                /* dialogMessage= */ null))
         .asList()
         .containsExactly("com.nonexistent.package", "android", context.getPackageName());
 
@@ -4430,7 +4430,7 @@ public class ShadowPackageManagerTest {
         /* suspended= */ false,
         /* appExtras= */ null,
         /* launcherExtras= */ null,
-        /* dialogMessage= */ (String) null);
+        /* dialogMessage= */ null);
 
     assertThat(
             setPackagesSuspended(
@@ -4444,7 +4444,7 @@ public class ShadowPackageManagerTest {
                 /* suspended= */ false,
                 /* appExtras= */ null,
                 /* launcherExtras= */ null,
-                /* dialogMessage= */ (String) null))
+                /* dialogMessage= */ null))
         .asList()
         .containsExactly("com.nonexistent.package", "android", context.getPackageName());
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelTest.java
@@ -1128,7 +1128,7 @@ public class ShadowParcelTest {
     try {
       assertThat(parcel2.readString()).isEqualTo("hello world");
 
-      Intent unmarshalledIntent = (Intent) parcel2.readParcelable(Intent.class.getClassLoader());
+      Intent unmarshalledIntent = parcel2.readParcelable(Intent.class.getClassLoader());
       assertThat(unmarshalledIntent.getAction()).isEqualTo("action.foo");
       assertThat(unmarshalledIntent.getStringExtra("key1")).isEqualTo("str1");
       assertThat(unmarshalledIntent.getIntExtra("key2", -1)).isEqualTo(2);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPausedAsyncTaskTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPausedAsyncTaskTest.java
@@ -181,7 +181,7 @@ public class ShadowPausedAsyncTaskTest {
           @Override
           protected Void doInBackground(Void... params) {
             boolean isMainLooper = Looper.getMainLooper().getThread() == Thread.currentThread();
-            transcript.add("doInBackground on main looper " + Boolean.toString(isMainLooper));
+            transcript.add("doInBackground on main looper " + isMainLooper);
             return null;
           }
         };

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPowerManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPowerManagerTest.java
@@ -696,8 +696,7 @@ public class ShadowPowerManagerTest {
 
     LowPowerStandbyPortsLock lock = powerManager.newLowPowerStandbyPortsLock(ports);
 
-    ShadowLowPowerStandbyPortsLock shadowLock =
-        (ShadowLowPowerStandbyPortsLock) Shadow.extract(lock);
+    ShadowLowPowerStandbyPortsLock shadowLock = Shadow.extract(lock);
     assertThat(shadowLock.getPorts()).isEqualTo(ports);
   }
 
@@ -709,8 +708,7 @@ public class ShadowPowerManagerTest {
     ImmutableList<LowPowerStandbyPortDescription> portDescriptions = ImmutableList.of(defaultPort);
 
     LowPowerStandbyPortsLock lock = powerManager.newLowPowerStandbyPortsLock(portDescriptions);
-    ShadowLowPowerStandbyPortsLock shadowLock =
-        (ShadowLowPowerStandbyPortsLock) Shadow.extract(lock);
+    ShadowLowPowerStandbyPortsLock shadowLock = Shadow.extract(lock);
     lock.acquire();
     lock.acquire();
     assertThat(shadowLock.getAcquireCount()).isEqualTo(2);
@@ -724,8 +722,7 @@ public class ShadowPowerManagerTest {
     ImmutableList<LowPowerStandbyPortDescription> portDescriptions = ImmutableList.of(defaultPort);
 
     LowPowerStandbyPortsLock lock = powerManager.newLowPowerStandbyPortsLock(portDescriptions);
-    ShadowLowPowerStandbyPortsLock shadowLock =
-        (ShadowLowPowerStandbyPortsLock) Shadow.extract(lock);
+    ShadowLowPowerStandbyPortsLock shadowLock = Shadow.extract(lock);
     lock.acquire();
     assertThat(shadowLock.isAcquired()).isTrue();
   }
@@ -738,8 +735,7 @@ public class ShadowPowerManagerTest {
     ImmutableList<LowPowerStandbyPortDescription> portDescriptions = ImmutableList.of(defaultPort);
 
     LowPowerStandbyPortsLock lock = powerManager.newLowPowerStandbyPortsLock(portDescriptions);
-    ShadowLowPowerStandbyPortsLock shadowLock =
-        (ShadowLowPowerStandbyPortsLock) Shadow.extract(lock);
+    ShadowLowPowerStandbyPortsLock shadowLock = Shadow.extract(lock);
     lock.acquire();
     lock.release();
     assertThat(shadowLock.isAcquired()).isFalse();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSpeechRecognizerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSpeechRecognizerTest.java
@@ -273,7 +273,7 @@ public class ShadowSpeechRecognizerTest {
         new RecognitionSupport.Builder().addInstalledOnDeviceLanguage("en-US").build();
     speechRecognizer.checkRecognitionSupport(new Intent(), executor, supportCallback);
 
-    ((ShadowSpeechRecognizer) shadowOf(speechRecognizer)).triggerSupportResult(recognitionSupport);
+    shadowOf(speechRecognizer).triggerSupportResult(recognitionSupport);
     executor.runAll();
 
     assertThat(supportCallback.recognitionSupportReceived).isEqualTo(recognitionSupport);
@@ -286,7 +286,7 @@ public class ShadowSpeechRecognizerTest {
     TestRecognitionSupportCallback supportCallback = new TestRecognitionSupportCallback();
     speechRecognizer.checkRecognitionSupport(new Intent(), executor, supportCallback);
 
-    ((ShadowSpeechRecognizer) shadowOf(speechRecognizer)).triggerSupportError(1);
+    shadowOf(speechRecognizer).triggerSupportError(1);
     executor.runAll();
 
     assertThat(supportCallback.errorReceived).isEqualTo(1);
@@ -298,7 +298,7 @@ public class ShadowSpeechRecognizerTest {
     Intent modelDownloadIntent = new Intent();
     speechRecognizer.triggerModelDownload(modelDownloadIntent);
 
-    assertThat(((ShadowSpeechRecognizer) shadowOf(speechRecognizer)).getLatestModelDownloadIntent())
+    assertThat(shadowOf(speechRecognizer).getLatestModelDownloadIntent())
         .isSameInstanceAs(modelDownloadIntent);
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStateListDrawableTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStateListDrawableTest.java
@@ -30,7 +30,7 @@ public class ShadowStateListDrawableTest {
     Drawable drawableForState = shadow.getDrawableForState(states);
 
     assertNotNull(drawableForState);
-    assertThat(((ShadowBitmapDrawable) shadowOf(drawableForState)).getCreatedFromResId())
+    assertThat(shadowOf(drawableForState).getCreatedFromResId())
         .isEqualTo(android.R.drawable.ic_delete);
   }
 
@@ -47,7 +47,7 @@ public class ShadowStateListDrawableTest {
     ShadowStateListDrawable shadow = shadowOf(stateListDrawable);
     Drawable drawableForState = shadow.getDrawableForState(StateSet.WILD_CARD);
     assertNotNull(drawableForState);
-    assertThat(((ShadowBitmapDrawable) shadowOf(drawableForState)).getCreatedFromResId())
+    assertThat(shadowOf(drawableForState).getCreatedFromResId())
         .isEqualTo(android.R.drawable.ic_delete);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStatsLogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStatsLogTest.java
@@ -34,7 +34,7 @@ public final class ShadowStatsLogTest {
     final int expectedAtomId = 0;
 
     assertEquals(1, ShadowStatsLog.getStatsLogs().size());
-    assertEquals((int) expectedAtomId, (int) ShadowStatsLog.getStatsLogs().get(0).atomId());
+    assertEquals(expectedAtomId, ShadowStatsLog.getStatsLogs().get(0).atomId());
 
     final ByteBuffer buffer =
         ByteBuffer.wrap(ShadowStatsLog.getStatsLogs().get(0).bytes())
@@ -88,7 +88,7 @@ public final class ShadowStatsLogTest {
     long maxTimestamp = SystemClock.elapsedRealtimeNanos();
 
     assertEquals(1, ShadowStatsLog.getStatsLogs().size());
-    assertEquals((int) expectedAtomId, (int) ShadowStatsLog.getStatsLogs().get(0).atomId());
+    assertEquals(expectedAtomId, ShadowStatsLog.getStatsLogs().get(0).atomId());
 
     final ByteBuffer buffer =
         ByteBuffer.wrap(ShadowStatsLog.getStatsLogs().get(0).bytes())
@@ -196,7 +196,7 @@ public final class ShadowStatsLogTest {
     long maxTimestamp = SystemClock.elapsedRealtimeNanos();
 
     assertEquals(1, ShadowStatsLog.getStatsLogs().size());
-    assertEquals((int) expectedAtomId, (int) ShadowStatsLog.getStatsLogs().get(0).atomId());
+    assertEquals(expectedAtomId, ShadowStatsLog.getStatsLogs().get(0).atomId());
 
     final ByteBuffer buffer =
         ByteBuffer.wrap(ShadowStatsLog.getStatsLogs().get(0).bytes())

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTelephonyManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTelephonyManagerTest.java
@@ -821,9 +821,8 @@ public class ShadowTelephonyManagerTest {
   }
 
   private String callGetSimCountryIso(TelephonyManager telephonyManager, int subId) {
-    return (String)
-        ReflectionHelpers.callInstanceMethod(
-            telephonyManager, "getSimCountryIso", ClassParameter.from(int.class, subId));
+    return ReflectionHelpers.callInstanceMethod(
+        telephonyManager, "getSimCountryIso", ClassParameter.from(int.class, subId));
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUIModeManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUIModeManagerTest.java
@@ -33,7 +33,7 @@ public class ShadowUIModeManagerTest {
   public void setUp() {
     context = ApplicationProvider.getApplicationContext();
     uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
-    shadowUiModeManager = (ShadowUIModeManager) Shadow.extract(uiModeManager);
+    shadowUiModeManager = Shadow.extract(uiModeManager);
   }
 
   @Test


### PR DESCRIPTION
This commit:
- Removes casts that are not necessary.
- Adds missing generic where possible.
- Removes the unused generic from `TestLifecycle`.