### PR TITLE
Fix various warnings in the `:robolectric` module

### DIFF
--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -398,7 +398,7 @@ public class Robolectric {
           Service instance =
               factory.instantiateService(
                   loadedApk.getClassLoader(), serviceClass.getName(), intent);
-          if (instance != null && serviceClass.isAssignableFrom(instance.getClass())) {
+          if (serviceClass.isAssignableFrom(instance.getClass())) {
             return (T) instance;
           }
         } catch (ReflectiveOperationException e) {
@@ -418,7 +418,7 @@ public class Robolectric {
         try {
           ContentProvider instance =
               factory.instantiateProvider(loadedApk.getClassLoader(), providerClass.getName());
-          if (instance != null && providerClass.isAssignableFrom(instance.getClass())) {
+          if (providerClass.isAssignableFrom(instance.getClass())) {
             return (T) instance;
           }
         } catch (ReflectiveOperationException e) {
@@ -439,7 +439,7 @@ public class Robolectric {
           Activity instance =
               factory.instantiateActivity(
                   loadedApk.getClassLoader(), activityClass.getName(), intent);
-          if (instance != null && activityClass.isAssignableFrom(instance.getClass())) {
+          if (activityClass.isAssignableFrom(instance.getClass())) {
             return (T) instance;
           }
         } catch (ReflectiveOperationException e) {

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -26,7 +26,6 @@ import org.robolectric.android.AndroidSdkShadowMatcher;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.GraphicsMode;
 import org.robolectric.annotation.LooperMode;
-import org.robolectric.annotation.LooperMode.Mode;
 import org.robolectric.annotation.ResourcesMode;
 import org.robolectric.annotation.SQLiteMode;
 import org.robolectric.config.AndroidConfigurer;
@@ -247,26 +246,10 @@ public class RobolectricTestRunner extends SandboxTestRunner {
     Sdk sdk = roboMethod.getSdk();
 
     InstrumentationConfiguration classLoaderConfig = createClassLoaderConfig(method);
-    ResourcesMode.Mode resourcesMode =
-        roboMethod.configuration == null
-            ? ResourcesMode.Mode.BINARY
-            : roboMethod.configuration.get(ResourcesMode.Mode.class);
-    ;
-
-    LooperMode.Mode looperMode =
-        roboMethod.configuration == null
-            ? Mode.LEGACY
-            : roboMethod.configuration.get(LooperMode.Mode.class);
-
-    SQLiteMode.Mode sqliteMode =
-        roboMethod.configuration == null
-            ? SQLiteMode.Mode.LEGACY
-            : roboMethod.configuration.get(SQLiteMode.Mode.class);
-
-    GraphicsMode.Mode graphicsMode =
-        roboMethod.configuration == null
-            ? GraphicsMode.Mode.LEGACY
-            : roboMethod.configuration.get(GraphicsMode.Mode.class);
+    ResourcesMode.Mode resourcesMode = roboMethod.configuration.get(ResourcesMode.Mode.class);
+    LooperMode.Mode looperMode = roboMethod.configuration.get(LooperMode.Mode.class);
+    SQLiteMode.Mode sqliteMode = roboMethod.configuration.get(SQLiteMode.Mode.class);
+    GraphicsMode.Mode graphicsMode = roboMethod.configuration.get(GraphicsMode.Mode.class);
 
     sdk.verifySupportedSdk(method.getDeclaringClass().getName());
     return sandboxManager.getAndroidSandbox(
@@ -488,9 +471,6 @@ public class RobolectricTestRunner extends SandboxTestRunner {
     Collections.addAll(extraShadows, config.shadows());
     return extraShadows.toArray(new Class<?>[] {});
   }
-
-  @Override
-  protected void afterClass() {}
 
   @Override
   public Object createTest() throws Exception {

--- a/robolectric/src/main/java/org/robolectric/internal/ManifestIdentifier.java
+++ b/robolectric/src/main/java/org/robolectric/internal/ManifestIdentifier.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import org.robolectric.annotation.Config;
 
@@ -103,24 +104,22 @@ public class ManifestIdentifier {
 
     ManifestIdentifier that = (ManifestIdentifier) o;
 
-    if (manifestFile != null
-        ? !manifestFile.equals(that.manifestFile)
-        : that.manifestFile != null) {
+    if (!Objects.equals(manifestFile, that.manifestFile)) {
       return false;
     }
-    if (resDir != null ? !resDir.equals(that.resDir) : that.resDir != null) {
+    if (!Objects.equals(resDir, that.resDir)) {
       return false;
     }
-    if (assetDir != null ? !assetDir.equals(that.assetDir) : that.assetDir != null) {
+    if (!Objects.equals(assetDir, that.assetDir)) {
       return false;
     }
-    if (packageName != null ? !packageName.equals(that.packageName) : that.packageName != null) {
+    if (!Objects.equals(packageName, that.packageName)) {
       return false;
     }
-    if (libraries != null ? !libraries.equals(that.libraries) : that.libraries != null) {
+    if (!Objects.equals(libraries, that.libraries)) {
       return false;
     }
-    return apkFile != null ? apkFile.equals(that.apkFile) : that.apkFile == null;
+    return Objects.equals(apkFile, that.apkFile);
   }
 
   @Override

--- a/robolectric/src/main/java/org/robolectric/internal/MavenManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/MavenManifestFactory.java
@@ -119,7 +119,7 @@ public class MavenManifestFactory implements ManifestFactory {
         if (Files.isDirectory(libraryDir)) {
           // Ignore directories without any files
           Path[] libraryBaseDirFiles = Fs.listFiles(libraryDir);
-          if (libraryBaseDirFiles != null && libraryBaseDirFiles.length > 0) {
+          if (libraryBaseDirFiles.length > 0) {
             List<ManifestIdentifier> libraries =
                 findLibraries(libraryDir.resolve(Config.DEFAULT_RES_FOLDER));
             libraryBaseDirs.add(

--- a/robolectric/src/main/java/org/robolectric/junit/rules/ExpectedLogMessagesRule.java
+++ b/robolectric/src/main/java/org/robolectric/junit/rules/ExpectedLogMessagesRule.java
@@ -328,7 +328,7 @@ public final class ExpectedLogMessagesRule implements TestRule {
 
       ExpectedLogItem log = (ExpectedLogItem) o;
       return type == log.type
-          && !(tag != null ? !tag.equals(log.tag) : log.tag != null)
+          && Objects.equals(tag, log.tag)
           && Objects.equals(msgMatcher, log.msgMatcher)
           && Objects.equals(throwableMatcher, log.throwableMatcher);
     }
@@ -410,7 +410,7 @@ public final class ExpectedLogMessagesRule implements TestRule {
     // This matches legacy behaviour to allow ExpectedLogItem to de-duplicate regex expectations.
     @Override
     public boolean equals(Object other) {
-      return other instanceof MsgRegex ? isEqual(pattern, ((MsgRegex) other).pattern) : false;
+      return other instanceof MsgRegex && isEqual(pattern, ((MsgRegex) other).pattern);
     }
 
     @Override

--- a/robolectric/src/main/java/org/robolectric/plugins/PackagePropertiesLoader.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/PackagePropertiesLoader.java
@@ -40,8 +40,7 @@ public class PackagePropertiesLoader {
     return cache.computeIfAbsent(
         propsFile,
         s -> {
-          final String resourceName = propsFile;
-          try (InputStream resourceAsStream = getResourceAsStream(resourceName)) {
+          try (InputStream resourceAsStream = getResourceAsStream(propsFile)) {
             if (resourceAsStream == null) {
               return null;
             }

--- a/robolectric/src/test/java/org/robolectric/BootstrapWrapper.java
+++ b/robolectric/src/test/java/org/robolectric/BootstrapWrapper.java
@@ -12,7 +12,6 @@ import org.robolectric.pluginapi.config.ConfigurationStrategy.Configuration;
 /** Wrapper for testing use of AndroidTestEnvironment. */
 public class BootstrapWrapper extends AndroidTestEnvironment implements BootstrapWrapperI {
   public AndroidTestEnvironment wrappedTestEnvironment;
-  public boolean legacyResources;
   public String tmpDirName;
   public Configuration config;
   public AndroidManifest appManifest;

--- a/robolectric/src/test/java/org/robolectric/ReflectorObjectTest.java
+++ b/robolectric/src/test/java/org/robolectric/ReflectorObjectTest.java
@@ -25,12 +25,11 @@ public class ReflectorObjectTest {
 
   static final String TEST_STRING = "A test string.";
 
-  private SomeClass someClass;
   private ShadowClass shadowClass;
 
   @Before
   public void setUp() throws Exception {
-    someClass = new SomeClass();
+    SomeClass someClass = new SomeClass();
     shadowClass = Shadow.extract(someClass);
   }
 

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerMultiApiTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerMultiApiTest.java
@@ -51,10 +51,7 @@ public class RobolectricTestRunnerMultiApiTest {
   private MyRunListener runListener;
 
   private int numSupportedApis;
-  private String priorResourcesMode;
   private String priorAlwaysInclude;
-
-  private SdkCollection sdkCollection;
 
   @Before
   public void setUp() {
@@ -63,10 +60,8 @@ public class RobolectricTestRunnerMultiApiTest {
     runListener = new MyRunListener();
     runNotifier = new RunNotifier();
     runNotifier.addListener(runListener);
-    sdkCollection = new SdkCollection(() -> map(APIS_FOR_TEST));
+    SdkCollection sdkCollection = new SdkCollection(() -> map(APIS_FOR_TEST));
     delegateSdkPicker = new DefaultSdkPicker(sdkCollection, null);
-
-    priorResourcesMode = System.getProperty("robolectric.resourcesMode");
 
     priorAlwaysInclude = System.getProperty("robolectric.alwaysIncludeVariantMarkersInTestName");
     System.clearProperty("robolectric.alwaysIncludeVariantMarkersInTestName");

--- a/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTestRunnerTest.java
@@ -12,9 +12,9 @@ import android.app.Application;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
-import java.io.FileOutputStream;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.spi.FileSystemProvider;
@@ -466,7 +466,7 @@ public class RobolectricTestRunnerTest {
 
       try {
         Path jarPath = tempDirectory.create("some-jar").resolve("some.jar");
-        try (JarOutputStream out = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jarPath))) {
           out.putNextEntry(new JarEntry("README.txt"));
           out.write("hi!".getBytes(StandardCharsets.UTF_8));
         }
@@ -562,12 +562,14 @@ public class RobolectricTestRunnerTest {
     @Override
     public void testFailure(Failure failure) {
       Throwable exception = failure.getException();
-      String message = exception.getMessage();
-      if (message == null) {
-        message = exception.toString();
+      StringBuilder message = new StringBuilder();
+      if (exception.getMessage() == null) {
+        message.append(exception);
+      } else {
+        message.append(exception.getMessage());
       }
       for (Throwable suppressed : exception.getSuppressed()) {
-        message += "\nSuppressed: " + suppressed.getMessage();
+        message.append("\nSuppressed: ").append(suppressed.getMessage());
       }
       events.add("failure: " + message);
     }

--- a/robolectric/src/test/java/org/robolectric/TestRunnerSequenceTest.java
+++ b/robolectric/src/test/java/org/robolectric/TestRunnerSequenceTest.java
@@ -28,8 +28,6 @@ public class TestRunnerSequenceTest {
     public static List<String> transcript;
   }
 
-  private String priorResourcesMode;
-
   @Before
   public void setUp() throws Exception {
     StateHolder.transcript = new ArrayList<>();

--- a/robolectric/src/test/java/org/robolectric/android/XmlResourceParserImplTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/XmlResourceParserImplTest.java
@@ -240,12 +240,8 @@ public class XmlResourceParserImplTest {
     List<Integer> actualDepths = new ArrayList<>();
     int evt;
     while ((evt = parser.next()) != XmlResourceParser.END_DOCUMENT) {
-      switch (evt) {
-        case (XmlResourceParser.START_TAG):
-          {
-            actualDepths.add(parser.getDepth());
-            break;
-          }
+      if (evt == XmlResourceParser.START_TAG) {
+        actualDepths.add(parser.getDepth());
       }
     }
     assertThat(actualDepths).isEqualTo(expectedDepths);
@@ -388,7 +384,7 @@ public class XmlResourceParserImplTest {
   @Test
   public void testGetAttributeEscapedValue() {
     forgeAndOpenDocument("<foo bar=\"\\'\"/>");
-    assertThat(parser.getAttributeValue(0)).isEqualTo("\'");
+    assertThat(parser.getAttributeValue(0)).isEqualTo("'");
   }
 
   @Test
@@ -399,8 +395,8 @@ public class XmlResourceParserImplTest {
 
   @Test
   public void testGetNodeTextEscapedValue() {
-    forgeAndOpenDocument("<foo>\'</foo>");
-    assertThat(parser.getText()).isEqualTo("\'");
+    forgeAndOpenDocument("<foo>'</foo>");
+    assertThat(parser.getText()).isEqualTo("'");
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/android/controller/ActivityControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/controller/ActivityControllerTest.java
@@ -449,7 +449,6 @@ public class ActivityControllerTest {
   public void close_transitionsActivityStateToDestroyed() {
     Robolectric.buildActivity(MyActivity.class).close();
     assertThat(transcript).isEmpty();
-    transcript.clear();
 
     Robolectric.buildActivity(MyActivity.class).create().close();
     assertThat(transcript)

--- a/robolectric/src/test/java/org/robolectric/android/util/concurrent/RoboExecutorServiceTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/util/concurrent/RoboExecutorServiceTest.java
@@ -21,7 +21,6 @@ import org.robolectric.util.Scheduler;
 public class RoboExecutorServiceTest {
   private List<String> transcript;
   private RoboExecutorService executorService;
-  private Scheduler backgroundScheduler;
   private Runnable runnable;
 
   @Before
@@ -29,9 +28,9 @@ public class RoboExecutorServiceTest {
     transcript = new ArrayList<>();
     executorService = new RoboExecutorService();
 
-    backgroundScheduler = Robolectric.getBackgroundThreadScheduler();
-
+    Scheduler backgroundScheduler = Robolectric.getBackgroundThreadScheduler();
     backgroundScheduler.pause();
+
     runnable = () -> transcript.add("background event ran");
   }
 

--- a/robolectric/src/test/java/org/robolectric/plugins/SQLiteModeConfigurerTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/SQLiteModeConfigurerTest.java
@@ -45,7 +45,11 @@ public class SQLiteModeConfigurerTest {
 
       assertThat(configurer2.defaultConfig()).isSameInstanceAs(Mode.LEGACY);
     } finally {
-      System.setProperty("os.name", oldName);
+      if (oldName != null) {
+        System.setProperty("os.name", oldName);
+      } else {
+        System.clearProperty("os.name");
+      }
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/plugins/config/SingleValueConfigurerTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/config/SingleValueConfigurerTest.java
@@ -15,11 +15,11 @@ public final class SingleValueConfigurerTest {
 
   public enum Value {
     ON,
-    OFF;
+    OFF,
   }
 
   public @interface ValueConfig {
-    public Value value() default Value.ON;
+    Value value() default Value.ON;
   }
 
   public static class ValueConfigReader extends SingleValueConfigurer<ValueConfig, Value> {

--- a/robolectric/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
@@ -785,7 +785,7 @@ public class SQLiteDatabaseTest {
   }
 
   @Test
-  public void testCreateAndDropTable() throws Exception {
+  public void testCreateAndDropTable() {
     SQLiteDatabase db = openOrCreateDatabase("db1");
     db.execSQL("CREATE TABLE foo(id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT);");
     Cursor c = db.query("FOO", null, null, null, null, null, null);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapFactoryTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBitmapFactoryTest.java
@@ -135,8 +135,8 @@ public class ShadowBitmapFactoryTest {
   }
 
   @Test
-  public void decodeBytes_shouldSetDescriptionAndCreatedFrom() throws Exception {
-    byte[] yummyBites = "Hi!".getBytes("UTF-8");
+  public void decodeBytes_shouldSetDescriptionAndCreatedFrom() {
+    byte[] yummyBites = "Hi!".getBytes(UTF_8);
     Bitmap bitmap = BitmapFactory.decodeByteArray(yummyBites, 100, 100);
     ShadowBitmap shadowBitmap = shadowOf(bitmap);
     assertEquals("Bitmap for 3 bytes 100..100", shadowBitmap.getDescription());
@@ -146,8 +146,8 @@ public class ShadowBitmapFactoryTest {
   }
 
   @Test
-  public void decodeBytes_shouldSetDescriptionAndCreatedFromWithOptions() throws Exception {
-    byte[] yummyBites = "Hi!".getBytes("UTF-8");
+  public void decodeBytes_shouldSetDescriptionAndCreatedFromWithOptions() {
+    byte[] yummyBites = "Hi!".getBytes(UTF_8);
     BitmapFactory.Options options = new BitmapFactory.Options();
     Bitmap bitmap = BitmapFactory.decodeByteArray(yummyBites, 100, 100, options);
     ShadowBitmap shadowBitmap = shadowOf(bitmap);
@@ -529,7 +529,7 @@ public class ShadowBitmapFactoryTest {
     InputStream inputStream = com.google.common.io.Resources.getResource(imagePath).openStream();
     File tempFile = Files.createTempFile("ShadowBitmapFactoryTest", null).toFile();
     tempFile.deleteOnExit();
-    ByteStreams.copy(inputStream, new FileOutputStream(tempFile));
+    ByteStreams.copy(inputStream, Files.newOutputStream(tempFile.toPath()));
     return tempFile;
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothGattServerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothGattServerTest.java
@@ -58,8 +58,6 @@ public class ShadowBluetoothGattServerTest {
           UUID.fromString("00000000-0000-0000-0001-0000000000A1"),
           BluetoothGattService.SERVICE_TYPE_PRIMARY);
 
-  private BluetoothManager manager;
-  private Context context;
   private BluetoothGattServer server;
   private BluetoothDevice device;
 
@@ -97,8 +95,9 @@ public class ShadowBluetoothGattServerTest {
   @Before
   @Config()
   public void setUp() {
-    context = ApplicationProvider.getApplicationContext();
-    manager = (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
+    Context context = ApplicationProvider.getApplicationContext();
+    BluetoothManager manager =
+        (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
     server = manager.openGattServer(context, new BluetoothGattServerCallback() {}, 0);
     device = ShadowBluetoothDevice.newInstance(MOCK_MAC_ADDRESS);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothLeScannerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothLeScannerTest.java
@@ -17,7 +17,6 @@ import android.content.Intent;
 import android.os.ParcelUuid;
 import androidx.test.core.app.ApplicationProvider;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -237,7 +236,8 @@ public class ShadowBluetoothLeScannerTest {
     shadowBluetoothLeScanner.addScanResult(scanResultTwo);
 
     ScanFilter filter = new ScanFilter.Builder().setDeviceAddress(addressOne).build();
-    bluetoothLeScanner.startScan(Arrays.asList(filter), /* settings= */ null, scanCallback);
+    bluetoothLeScanner.startScan(
+        Collections.singletonList(filter), /* settings= */ null, scanCallback);
 
     assertThat(scanCallback.scanResults).containsExactly(scanResultOne);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowColorDisplayManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowColorDisplayManagerTest.java
@@ -27,7 +27,7 @@ public class ShadowColorDisplayManagerTest {
   private static final String PACKAGE_NAME = "test_package_name";
 
   // Must be optional to avoid ClassNotFoundException
-  Optional<ColorDisplayManager> instance;
+  private Optional<ColorDisplayManager> instance;
 
   @Before
   public void setUp() throws Exception {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCompanionDeviceManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCompanionDeviceManagerTest.java
@@ -167,7 +167,7 @@ public class ShadowCompanionDeviceManagerTest {
             .setNotifyOnDeviceNearby(false)
             .setApprovedMs(0)
             .setLastTimeConnectedMs(0);
-    Object associatedDeviceValue = null;
+    Object associatedDeviceValue;
     if (ReflectionHelpers.hasField(AssociationInfo.class, "mAssociatedDevice")) {
       try {
         Class<?> associatedDeviceClazz = Class.forName("android.companion.AssociatedDevice");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
@@ -714,7 +714,6 @@ public class ShadowContentResolverTest {
     assertThat(uri.flags).isEqualTo(ContentResolver.NOTIFY_UPDATE);
   }
 
-  @SuppressWarnings("serial")
   @Test
   public void applyBatchForRegisteredProvider()
       throws RemoteException, OperationApplicationException {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextHubClientTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextHubClientTest.java
@@ -101,8 +101,6 @@ public final class ShadowContextHubClientTest {
     ContextHubManager contextHubManager = context.getSystemService(ContextHubManager.class);
     ContextHubInfo contextHubInfo = contextHubManager.getContextHubs().get(0);
     ContextHubClientCallback contextHubClientCallback = new ContextHubClientCallback();
-    ContextHubClient contextHubClient =
-        contextHubManager.createClient(contextHubInfo, contextHubClientCallback);
-    return contextHubClient;
+    return contextHubManager.createClient(contextHubInfo, contextHubClientCallback);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDevicePolicyManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDevicePolicyManagerTest.java
@@ -505,7 +505,7 @@ public final class ShadowDevicePolicyManagerTest {
 
     // Delegate DELEGATION_PACKAGE_ACCESS scope to an app but not caller
     String delegatedApp = "com.example.not.caller";
-    List<String> scopes = Arrays.asList(DevicePolicyManager.DELEGATION_PACKAGE_ACCESS);
+    List<String> scopes = Collections.singletonList(DevicePolicyManager.DELEGATION_PACKAGE_ACCESS);
     devicePolicyManager.setDelegatedScopes(testComponent, delegatedApp, scopes);
 
     // Then DevicePolicyManager#setApplicationHidden should fail with SecurityException
@@ -534,7 +534,7 @@ public final class ShadowDevicePolicyManagerTest {
     // Delegate DELEGATION_PACKAGE_ACCESS scope to another app such that the delegated app
     // has the access to call setApplicationHidden
     String delegatedApp = context.getPackageName();
-    List<String> scopes = Arrays.asList(DevicePolicyManager.DELEGATION_PACKAGE_ACCESS);
+    List<String> scopes = Collections.singletonList(DevicePolicyManager.DELEGATION_PACKAGE_ACCESS);
     devicePolicyManager.setDelegatedScopes(testComponent, delegatedApp, scopes);
 
     // Then DevicePolicyManager#setApplicationHidden is called to hide the app,
@@ -790,7 +790,8 @@ public final class ShadowDevicePolicyManagerTest {
 
     // Delegate DELEGATION_APP_RESTRICTIONS scope to an app but not caller
     String delegatedApp = "com.example.not.caller";
-    List<String> scopes = Arrays.asList(DevicePolicyManager.DELEGATION_APP_RESTRICTIONS);
+    List<String> scopes =
+        Collections.singletonList(DevicePolicyManager.DELEGATION_APP_RESTRICTIONS);
     devicePolicyManager.setDelegatedScopes(testComponent, delegatedApp, scopes);
 
     // Then DevicePolicyManager#setApplicationRestrictions should fail with SecurityException
@@ -817,7 +818,8 @@ public final class ShadowDevicePolicyManagerTest {
     // Delegate DELEGATION_APP_RESTRICTIONS scope to another app such that the delegated app
     // has the access to call setApplicationRestriction
     String delegatedApp = context.getPackageName();
-    List<String> scopes = Arrays.asList(DevicePolicyManager.DELEGATION_APP_RESTRICTIONS);
+    List<String> scopes =
+        Collections.singletonList(DevicePolicyManager.DELEGATION_APP_RESTRICTIONS);
     devicePolicyManager.setDelegatedScopes(testComponent, delegatedApp, scopes);
 
     // WHEN DevicePolicyManager#setApplicationRestrictions is called to set the restrictions
@@ -851,11 +853,13 @@ public final class ShadowDevicePolicyManagerTest {
     shadowOf(devicePolicyManager).setDeviceOwner(testComponent);
 
     // GIVEN the caller has delegated scopes
-    List<String> initialScopes = Arrays.asList(DevicePolicyManager.DELEGATION_APP_RESTRICTIONS);
+    List<String> initialScopes =
+        Collections.singletonList(DevicePolicyManager.DELEGATION_APP_RESTRICTIONS);
     devicePolicyManager.setDelegatedScopes(testComponent, "com.example.app", initialScopes);
 
     // WHEN setDelegatedScopes is called again
-    List<String> newScopes = Arrays.asList(DevicePolicyManager.DELEGATION_ENABLE_SYSTEM_APP);
+    List<String> newScopes =
+        Collections.singletonList(DevicePolicyManager.DELEGATION_ENABLE_SYSTEM_APP);
     devicePolicyManager.setDelegatedScopes(testComponent, "com.example.app", newScopes);
 
     // THEN the new scopes should be set
@@ -1910,7 +1914,7 @@ public final class ShadowDevicePolicyManagerTest {
 
     // Delegate DELEGATION_PACKAGE_ACCESS scope to an app but not caller
     String delegatedApp = "com.example.not.caller";
-    List<String> scopes = Arrays.asList(DevicePolicyManager.DELEGATION_PACKAGE_ACCESS);
+    List<String> scopes = Collections.singletonList(DevicePolicyManager.DELEGATION_PACKAGE_ACCESS);
     devicePolicyManager.setDelegatedScopes(testComponent, delegatedApp, scopes);
 
     // Then DevicePolicyManager#setPackagesSuspended should fail with SecurityException
@@ -1939,7 +1943,7 @@ public final class ShadowDevicePolicyManagerTest {
     // Delegate DELEGATION_PACKAGE_ACCESS scope to another app such that the delegated app
     // has the access to call setPackageSuspended
     String delegatedApp = context.getPackageName();
-    List<String> scopes = Arrays.asList(DevicePolicyManager.DELEGATION_PACKAGE_ACCESS);
+    List<String> scopes = Collections.singletonList(DevicePolicyManager.DELEGATION_PACKAGE_ACCESS);
     devicePolicyManager.setDelegatedScopes(testComponent, delegatedApp, scopes);
 
     // Then DevicePolicyManager#setPackageSuspended is called to suspend the package
@@ -2678,7 +2682,7 @@ public final class ShadowDevicePolicyManagerTest {
   @Config(minSdk = TIRAMISU)
   @Test
   public void getPolicyManagedProfiles_shouldReturnSetVal() {
-    List<UserHandle> policyManagedProfiles = Arrays.asList(UserHandle.SYSTEM);
+    List<UserHandle> policyManagedProfiles = Collections.singletonList(UserHandle.SYSTEM);
     shadowDevicePolicyManager.setPolicyManagedProfiles(policyManagedProfiles);
     assertThat(devicePolicyManager.getPolicyManagedProfiles(UserHandle.SYSTEM))
         .isEqualTo(policyManagedProfiles);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowListViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowListViewTest.java
@@ -346,11 +346,10 @@ public class ShadowListViewTest {
     return new ListAdapterBuilder();
   }
 
-  private ListAdapter prepareWithListAdapter() {
+  private void prepareWithListAdapter() {
     ListAdapter adapter = new ListAdapter("a", "b", "c");
     listView.setAdapter(adapter);
     shadowOf(listView).populateItems();
-    return adapter;
   }
 
   private ShadowListView prepareListWithThreeItems() {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLocaleManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLocaleManagerTest.java
@@ -24,13 +24,12 @@ public final class ShadowLocaleManagerTest {
   private static final String DEFAULT_PACKAGE_NAME = "my.app";
   private static final LocaleList DEFAULT_LOCALES = LocaleList.forLanguageTags("en-XC,ar-XB");
 
-  private Context context;
   private LocaleManager localeManager;
   private ShadowLocaleManager shadowLocaleManager;
 
   @Before
   public void setUp() {
-    context = ApplicationProvider.getApplicationContext();
+    Context context = ApplicationProvider.getApplicationContext();
     localeManager = context.getSystemService(LocaleManager.class);
     shadowLocaleManager = Shadow.extract(localeManager);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
@@ -200,7 +200,7 @@ public class ShadowLogTest {
       ShadowLog.stream = new PrintStream(bos);
       Log.d("tag", "msg");
       assertThat(new String(bos.toByteArray(), UTF_8))
-          .isEqualTo("D/tag: msg" + System.getProperty("line.separator"));
+          .isEqualTo("D/tag: msg" + System.lineSeparator());
 
       Log.w("tag", new RuntimeException());
       assertTrue(new String(bos.toByteArray(), UTF_8).contains("RuntimeException"));

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaControllerTest.java
@@ -41,14 +41,13 @@ public final class ShadowMediaControllerTest {
 
   private MediaController mediaController;
   private ShadowMediaController shadowMediaController;
-  private final String testPackageName = "FOO";
 
   @Before
   public void setUp() {
     Context context = ApplicationProvider.getApplicationContext();
     ISessionController binder = mock(ISessionController.class);
 
-    MediaSession.Token token = null;
+    MediaSession.Token token;
     if (RuntimeEnvironment.getApiLevel() <= Q) {
       token =
           ReflectionHelpers.callConstructor(
@@ -66,6 +65,7 @@ public final class ShadowMediaControllerTest {
 
   @Test
   public void setPackageName() {
+    String testPackageName = "FOO";
     shadowMediaController.setPackageName(testPackageName);
     assertEquals(testPackageName, mediaController.getPackageName());
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelFileDescriptorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowParcelFileDescriptorTest.java
@@ -497,7 +497,7 @@ public class ShadowParcelFileDescriptorTest {
 
   @Test
   public void testClose_afterDup_doesNotCloseOriginalFd() throws Exception {
-    ParcelFileDescriptor pfd = null;
+    ParcelFileDescriptor pfd;
     File tempFile = File.createTempFile("testFile", ".txt");
     String content = "abc123";
     Files.asCharSink(tempFile, UTF_8).write(content);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRadioGroupTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRadioGroupTest.java
@@ -3,7 +3,7 @@ package org.robolectric.shadows;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 
-import android.app.Application;
+import android.content.Context;
 import android.widget.RadioGroup;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -16,12 +16,11 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class ShadowRadioGroupTest {
   private static final int BUTTON_ID = 3245;
-  private Application context;
   private RadioGroup radioGroup;
 
   @Before
   public void setUp() throws Exception {
-    context = ApplicationProvider.getApplicationContext();
+    Context context = ApplicationProvider.getApplicationContext();
     radioGroup = new RadioGroup(context);
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRingtoneManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRingtoneManagerTest.java
@@ -30,17 +30,15 @@ public final class ShadowRingtoneManagerTest {
   @Test
   public void getRingtone_noUriSet_returnNull() {
     Context appContext = ApplicationProvider.getApplicationContext();
-    int type = TYPE_RINGTONE;
 
-    assertThat(RingtoneManager.getActualDefaultRingtoneUri(appContext, type)).isNull();
+    assertThat(RingtoneManager.getActualDefaultRingtoneUri(appContext, TYPE_RINGTONE)).isNull();
   }
 
   @Test
   public void getRingtone_uriSetForDifferentType() {
     Context appContext = ApplicationProvider.getApplicationContext();
-    int type = TYPE_RINGTONE;
     Uri uri = Uri.parse("content://media/external/330");
-    RingtoneManager.setActualDefaultRingtoneUri(appContext, type, uri);
+    RingtoneManager.setActualDefaultRingtoneUri(appContext, TYPE_RINGTONE, uri);
 
     assertThat(RingtoneManager.getActualDefaultRingtoneUri(appContext, TYPE_ALARM)).isNull();
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSoftKeyboardControllerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSoftKeyboardControllerTest.java
@@ -21,12 +21,11 @@ import org.robolectric.annotation.Config;
 @Config(minSdk = N)
 public final class ShadowSoftKeyboardControllerTest {
 
-  private MyService myService;
   private SoftKeyboardController softKeyboardController;
 
   @Before
   public void setUp() {
-    myService = Robolectric.setupService(MyService.class);
+    MyService myService = Robolectric.setupService(MyService.class);
     softKeyboardController = myService.getSoftKeyboardController();
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStorageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStorageManagerTest.java
@@ -115,7 +115,7 @@ public class ShadowStorageManagerTest {
   public void getStorageVolumeFromAnUserContext() {
     File file1 = new File(internalStorage);
     shadowOf(storageManager).addStorageVolume(buildAndGetStorageVolume(file1, "internal"));
-    Context userContext = getApplication();
+    Context userContext;
 
     try {
       userContext =

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemHealthManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemHealthManagerTest.java
@@ -35,7 +35,6 @@ public final class ShadowSystemHealthManagerTest {
       HealthStatsBuilder.newBuilder().setDataType("other_uid_2_stats").build();
 
   private SystemHealthManager systemHealthManager;
-  private ShadowSystemHealthManager shadowSystemHealthManager;
 
   @Before
   public void setUp() {
@@ -43,8 +42,8 @@ public final class ShadowSystemHealthManagerTest {
         (SystemHealthManager)
             ApplicationProvider.getApplicationContext()
                 .getSystemService(Context.SYSTEM_HEALTH_SERVICE);
-    shadowSystemHealthManager = Shadow.extract(systemHealthManager);
 
+    ShadowSystemHealthManager shadowSystemHealthManager = Shadow.extract(systemHealthManager);
     shadowSystemHealthManager.addHealthStats(MY_UID_HEALTH_STATS);
     shadowSystemHealthManager.addHealthStatsForUid(OTHER_UID_1, OTHER_UID_1_HEALTH_STATS);
     shadowSystemHealthManager.addHealthStatsForUid(OTHER_UID_2, OTHER_UID_2_HEALTH_STATS);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUsageStatsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUsageStatsManagerTest.java
@@ -198,7 +198,7 @@ public class ShadowUsageStatsManagerTest {
 
   @Test
   @Config(minSdk = Build.VERSION_CODES.P)
-  public void testGetAppStandbyBucket_withPackageName() throws Exception {
+  public void testGetAppStandbyBucket_withPackageName() {
     assertThat(shadowOf(usageStatsManager).getAppStandbyBuckets()).isEmpty();
 
     shadowOf(usageStatsManager).setAppStandbyBucket("app1", UsageStatsManager.STANDBY_BUCKET_RARE);
@@ -214,7 +214,7 @@ public class ShadowUsageStatsManagerTest {
 
   @Test
   @Config(minSdk = Build.VERSION_CODES.P)
-  public void testSetAppStandbyBuckets() throws Exception {
+  public void testSetAppStandbyBuckets() {
     assertThat(shadowOf(usageStatsManager).getAppStandbyBuckets()).isEmpty();
     assertThat(shadowOf(usageStatsManager).getAppStandbyBucket("app1"))
         .isEqualTo(UsageStatsManager.STANDBY_BUCKET_ACTIVE);
@@ -230,7 +230,7 @@ public class ShadowUsageStatsManagerTest {
 
   @Test
   @Config(minSdk = Build.VERSION_CODES.P)
-  public void testGetAppStandbyBucket_currentApp() throws Exception {
+  public void testGetAppStandbyBucket_currentApp() {
     shadowOf(usageStatsManager).setCurrentAppStandbyBucket(UsageStatsManager.STANDBY_BUCKET_RARE);
     assertThat(shadowOf(usageStatsManager).getAppStandbyBucket())
         .isEqualTo(UsageStatsManager.STANDBY_BUCKET_RARE);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowVibratorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowVibratorTest.java
@@ -249,9 +249,10 @@ public class ShadowVibratorTest {
 
     vibrator.vibrate(/* delay= */ 200, audioAttributes);
 
-    AudioAttributes actualAudioAttriubes = shadowOf(vibrator).getAudioAttributesFromLastVibration();
-    assertThat(actualAudioAttriubes.getAllFlags()).isEqualTo(audioAttributes.getAllFlags());
-    assertThat(actualAudioAttriubes.getUsage()).isEqualTo(audioAttributes.getUsage());
+    AudioAttributes actualAudioAttributes =
+        shadowOf(vibrator).getAudioAttributesFromLastVibration();
+    assertThat(actualAudioAttributes.getAllFlags()).isEqualTo(audioAttributes.getAllFlags());
+    assertThat(actualAudioAttributes.getUsage()).isEqualTo(audioAttributes.getUsage());
   }
 
   @Config(minSdk = S)

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewConfigurationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewConfigurationTest.java
@@ -4,7 +4,6 @@ import static android.os.Build.VERSION_CODES.O_MR1;
 import static android.os.Build.VERSION_CODES.Q;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Application;
 import android.view.ViewConfiguration;
@@ -98,8 +97,7 @@ public class ShadowViewConfigurationTest {
   public void testHasPermanentMenuKey() {
     assertThat(viewConfiguration.hasPermanentMenuKey()).isTrue();
 
-    ShadowViewConfiguration shadowViewConfiguration = shadowOf(viewConfiguration);
-    shadowViewConfiguration.setHasPermanentMenuKey(false);
+    ShadowViewConfiguration.setHasPermanentMenuKey(false);
     assertThat(viewConfiguration.hasPermanentMenuKey()).isFalse();
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewGroupTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewGroupTest.java
@@ -71,7 +71,7 @@ public class ShadowViewGroupTest {
     child3.addView(child3a);
     child3.addView(child3b);
 
-    defaultLineSeparator = System.getProperty("line.separator");
+    defaultLineSeparator = System.lineSeparator();
     System.setProperty("line.separator", "\n");
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWallpaperManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWallpaperManagerTest.java
@@ -111,11 +111,11 @@ public class ShadowWallpaperManagerTest {
 
   @Test
   public void hasResourceWallpaper_wallpaperResourceSet_returnsTrue() throws IOException {
-    int resid = 5;
-    manager.setResource(resid);
+    int resId = 5;
+    manager.setResource(resId);
 
     assertThat(manager.hasResourceWallpaper(1)).isFalse();
-    assertThat(manager.hasResourceWallpaper(resid)).isTrue();
+    assertThat(manager.hasResourceWallpaper(resId)).isTrue();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiManagerTest.java
@@ -491,7 +491,6 @@ public class ShadowWifiManagerTest {
       fail("Expected exception");
     } catch (RuntimeException expected) {
     }
-    ;
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiScannerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiScannerTest.java
@@ -105,7 +105,7 @@ public class ShadowWifiScannerTest {
   }
 
   private static ImmutableList<ScanResult> createFakeScanResults() {
-    ScanResult scanResult = null;
+    ScanResult scanResult;
 
     if (Build.VERSION.SDK_INT >= VERSION_CODES.R) {
       // informationElements added in R

--- a/robolectric/src/test/java/org/robolectric/util/TestUtil.java
+++ b/robolectric/src/test/java/org/robolectric/util/TestUtil.java
@@ -1,10 +1,6 @@
 package org.robolectric.util;
 
-import com.google.common.io.CharStreams;
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.util.Properties;
 import org.robolectric.R;
@@ -57,18 +53,9 @@ public abstract class TestUtil {
     return SYSTEM_RESOURCE_PATH;
   }
 
-  public static ResourcePath sdkResources(int apiLevel) {
-    Path path = getSdkCollection().getSdk(apiLevel).getJarPath();
-    return new ResourcePath(null, path.resolve("raw-res/res"), null, null);
-  }
-
-  public static String readString(InputStream is) throws IOException {
-    return CharStreams.toString(new InputStreamReader(is, "UTF-8"));
-  }
-
   public static synchronized SdkCollection getSdkCollection() {
     if (sdkCollection == null) {
-      sdkCollection = getInjectedInstance(SdkCollection.class);
+      sdkCollection = injector.getInstance(SdkCollection.class);
     }
     return sdkCollection;
   }
@@ -79,9 +66,5 @@ public abstract class TestUtil {
     } else {
       System.setProperty(name, value);
     }
-  }
-
-  private static <T> T getInjectedInstance(Class<T> clazz) {
-    return injector.getInstance(clazz);
   }
 }


### PR DESCRIPTION
- Use `Objects.equals()` where possible.
- Use the `Files` API where possible.
- Use `StringBuilder` instead of concatenating `String`s in a loop.
- Use `Collections.singletonList()` instead of `Arrays.asList()` with a single item.
- Use `System.lineSeparator()` instead of reading the `line.separator` property.
- Remove unnecessary `null` checks.
- Remove unused variables/fields/methods.
- Remove unnecessary `throws` declarations.
- Fix typos.