### PR TITLE
Use `ApplicationProvider.getApplicationContext()` instead of `buildActivity()`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowListPreferenceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowListPreferenceTest.java
@@ -1,10 +1,9 @@
 package org.robolectric.shadows;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.robolectric.Robolectric.buildActivity;
 
-import android.app.Activity;
 import android.preference.ListPreference;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,7 +17,7 @@ public class ShadowListPreferenceTest {
 
   @Before
   public void setUp() throws Exception {
-    listPreference = new ListPreference(buildActivity(Activity.class).create().get());
+    listPreference = new ListPreference(ApplicationProvider.getApplicationContext());
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
@@ -78,7 +78,7 @@ public class ShadowViewTest {
     InstrumentationRegistry.getInstrumentation().setInTouchMode(false);
     transcript = new ArrayList<>();
     context = ApplicationProvider.getApplicationContext();
-    view = Robolectric.setupActivity(ContainerActivity.class).getView();
+    view = setupActivity(ContainerActivity.class).getView();
   }
 
   public static class ContainerActivity extends Activity {
@@ -861,7 +861,7 @@ public class ShadowViewTest {
     parent.addView(new MyView("child", transcript));
     assertThat(transcript).isEmpty();
 
-    Activity activity = Robolectric.buildActivity(ContentViewActivity.class).setup().get();
+    Activity activity = buildActivity(ContentViewActivity.class).setup().get();
     activity.getWindowManager().addView(parent, new WindowManager.LayoutParams(100, 100));
     shadowMainLooper().idle();
     assertThat(transcript).containsExactly("parent attached", "child attached");
@@ -891,7 +891,7 @@ public class ShadowViewTest {
     assertThat(parent.getWindowId()).isNull();
     assertThat(child.getWindowId()).isNull();
 
-    Activity activity = Robolectric.buildActivity(ContentViewActivity.class).create().get();
+    Activity activity = buildActivity(ContentViewActivity.class).create().get();
     activity.getWindowManager().addView(parent, new WindowManager.LayoutParams(100, 100));
     shadowMainLooper().idle();
 
@@ -912,7 +912,7 @@ public class ShadowViewTest {
   @Test
   public void removeAllViews_shouldCallOnAttachedToAndDetachedFromWindow() {
     MyView parent = new MyView("parent", transcript);
-    Activity activity = Robolectric.buildActivity(ContentViewActivity.class).create().get();
+    Activity activity = buildActivity(ContentViewActivity.class).create().get();
     activity.getWindowManager().addView(parent, new WindowManager.LayoutParams(100, 100));
 
     parent.addView(new MyView("child", transcript));
@@ -1015,8 +1015,7 @@ public class ShadowViewTest {
   @Test
   public void usesDefaultGlobalVisibleRect() {
 
-    final ActivityController<Activity> activityController =
-        Robolectric.buildActivity(Activity.class);
+    final ActivityController<Activity> activityController = buildActivity(Activity.class);
     final Activity activity = activityController.get();
     TextView fooView = new TextView(activity);
     activity.setContentView(


### PR DESCRIPTION
This commit replaces usages of `Robolectric.buildActivity()` with `ApplicationProvider.getApplicationContext()` where the former does not make sense.