### PR TITLE
Add `ShadowArrayAdapter#getDropDownViewResourceId()`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowArrayAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowArrayAdapterTest.java
@@ -89,6 +89,20 @@ public class ShadowArrayAdapterTest {
   }
 
   @Test
+  public void setDropDownViewResource() {
+    ArrayAdapter<String> arrayAdapter = new ArrayAdapter<>(context, R.layout.main);
+    ShadowArrayAdapter<String> shadow = Shadows.shadowOf(arrayAdapter);
+
+    assertThat(shadow.getResourceId()).isEqualTo(R.layout.main);
+    assertThat(shadow.getDropDownViewResourceId()).isEqualTo(R.layout.main);
+
+    arrayAdapter.setDropDownViewResource(R.layout.activity_list_item);
+
+    assertThat(shadow.getResourceId()).isEqualTo(R.layout.main);
+    assertThat(shadow.getDropDownViewResourceId()).isEqualTo(R.layout.activity_list_item);
+  }
+
+  @Test
   public void shouldClear() {
     arrayAdapter.clear();
     assertEquals(0, arrayAdapter.getCount());

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArrayAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArrayAdapter.java
@@ -17,4 +17,8 @@ public class ShadowArrayAdapter<T> extends ShadowBaseAdapter {
   public int getResourceId() {
     return ReflectionHelpers.getField(realArrayAdapter, "mResource");
   }
+
+  public int getDropDownViewResourceId() {
+    return ReflectionHelpers.getField(realArrayAdapter, "mDropDownResource");
+  }
 }


### PR DESCRIPTION
This adds the ability to get the dropdown resource id that is set on the `ArrayAdapter`, so that it can be verified during a unit test that it was set to the expected resource id.

This is an updated version of #3290 by @kingargyle, with added tests.