### PR TITLE
Use `org.junit.Assert` instead of `junit.framework.Assert`

### DIFF
--- a/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativeAnimatedVectorDrawableTest.java
+++ b/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativeAnimatedVectorDrawableTest.java
@@ -1,9 +1,9 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.O;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import android.content.res.Resources;
 import android.graphics.Bitmap;

--- a/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativeImageDecoderTest.java
+++ b/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativeImageDecoderTest.java
@@ -2,9 +2,9 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.Q;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertSame;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 
 import android.content.res.AssetManager;
 import android.content.res.Resources;

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWallpaperManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWallpaperManagerTest.java
@@ -5,7 +5,7 @@ import static android.os.Build.VERSION_CODES.N;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.TIRAMISU;
 import static com.google.common.truth.Truth.assertThat;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.fail;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Activity;


### PR DESCRIPTION
The `junit.framework.Assert` class is deprecated in favor of `org.junit.Assert`.