### PR TITLE
Add migration info to `ShadowContentResolver` deprecated methods

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentResolver.java
@@ -802,7 +802,9 @@ public class ShadowContentResolver {
 
   /**
    * @deprecated This method affects all calls, and does not work with {@link
-   *     android.content.ContentResolver#acquireContentProviderClient}
+   *     android.content.ContentResolver#acquireContentProviderClient}. Instead, use {@link
+   *     org.robolectric.Robolectric#setupContentProvider(Class, String)} to install a test-specific
+   *     ContentProvider that can return any Cursor.
    */
   @Deprecated
   public void setCursor(BaseCursor cursor) {
@@ -811,7 +813,9 @@ public class ShadowContentResolver {
 
   /**
    * @deprecated This method does not work with {@link
-   *     android.content.ContentResolver#acquireContentProviderClient}
+   *     android.content.ContentResolver#acquireContentProviderClient}. Instead, use {@link
+   *     org.robolectric.Robolectric#setupContentProvider(Class, String)} to install a test-specific
+   *     ContentProvider that can return any Cursor.
    */
   @Deprecated
   public void setCursor(Uri uri, BaseCursor cursorForUri) {
@@ -820,7 +824,9 @@ public class ShadowContentResolver {
 
   /**
    * @deprecated This method affects all calls, and does not work with {@link
-   *     android.content.ContentResolver#acquireContentProviderClient}
+   *     android.content.ContentResolver#acquireContentProviderClient}. Instead, use {@link
+   *     org.robolectric.Robolectric#setupContentProvider(Class, String)} to install a test-specific
+   *     ContentProvider that can return any Cursor.
    */
   @Deprecated
   @SuppressWarnings({"unused", "WeakerAccess"})
@@ -834,7 +840,9 @@ public class ShadowContentResolver {
    *
    * @return a list of statements
    * @deprecated This method does not work with {@link
-   *     android.content.ContentResolver#acquireContentProviderClient}
+   *     android.content.ContentResolver#acquireContentProviderClient}. Instead, use {@link
+   *     org.robolectric.Robolectric#setupContentProvider(Class, String)} to install a test-specific
+   *     ContentProvider that can return any Cursor.
    */
   @Deprecated
   @SuppressWarnings({"unused", "WeakerAccess"})
@@ -849,7 +857,9 @@ public class ShadowContentResolver {
    *
    * @return a list of insert statements
    * @deprecated This method does not work with {@link
-   *     android.content.ContentResolver#acquireContentProviderClient}
+   *     android.content.ContentResolver#acquireContentProviderClient}. Instead, use {@link
+   *     org.robolectric.Robolectric#setupContentProvider(Class, String)} to install a test-specific
+   *     ContentProvider that can return any Cursor.
    */
   @Deprecated
   @SuppressWarnings({"unused", "WeakerAccess"})
@@ -863,7 +873,9 @@ public class ShadowContentResolver {
    *
    * @return a list of update statements
    * @deprecated This method does not work with {@link
-   *     android.content.ContentResolver#acquireContentProviderClient}
+   *     android.content.ContentResolver#acquireContentProviderClient}. Instead, use {@link
+   *     org.robolectric.Robolectric#setupContentProvider(Class, String)} to install a test-specific
+   *     ContentProvider that can return any Cursor.
    */
   @Deprecated
   @SuppressWarnings({"unused", "WeakerAccess"})
@@ -871,6 +883,10 @@ public class ShadowContentResolver {
     return updateStatements;
   }
 
+  /**
+   * @deprecated Use {@link org.robolectric.Robolectric#setupContentProvider(Class, String)} to
+   *     install a test-specific ContentProvider that can return any Cursor instead.
+   */
   @Deprecated
   @SuppressWarnings({"unused", "WeakerAccess"})
   public List<Uri> getDeletedUris() {
@@ -886,6 +902,8 @@ public class ShadowContentResolver {
    * ContentResolver#delete(Uri, String, String[])}.
    *
    * @return a list of delete statements
+   * @deprecated Use {@link org.robolectric.Robolectric#setupContentProvider(Class, String)} to
+   *     install a test-specific ContentProvider that can return any Cursor instead.
    */
   @Deprecated
   @SuppressWarnings({"unused", "WeakerAccess"})
@@ -893,12 +911,20 @@ public class ShadowContentResolver {
     return deleteStatements;
   }
 
+  /**
+   * @deprecated Use {@link org.robolectric.Robolectric#setupContentProvider(Class, String)} to
+   *     install a test-specific ContentProvider that can return any Cursor instead.
+   */
   @Deprecated
   @SuppressWarnings({"unused", "WeakerAccess"})
   public List<NotifiedUri> getNotifiedUris() {
     return notifiedUris;
   }
 
+  /**
+   * @deprecated Use {@link org.robolectric.Robolectric#setupContentProvider(Class, String)} to
+   *     install a test-specific ContentProvider that can return any Cursor instead.
+   */
   @Deprecated
   public List<ContentProviderOperation> getContentProviderOperations(String authority) {
     List<ContentProviderOperation> operations = contentProviderOperations.get(authority);


### PR DESCRIPTION
Some methods in `ShadowContentResolver` are deprecated, but don't provide information about the recommended approach. This fixes #8874 by adding the necessary migration guide.

This replaces #8879 and #8901 by @shashankiitbhu.