### PR TITLE
Use Truth's `hasSize()` to check iterable size

### DIFF
--- a/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativeTextRunShaperTest.java
+++ b/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativeTextRunShaperTest.java
@@ -160,7 +160,7 @@ public class ShadowNativeTextRunShaperTest {
     for (int i = 0; i < result.glyphCount(); ++i) {
       set.add(result.getFont(i));
     }
-    assertThat(set.size()).isEqualTo(2); // Roboto + Emoji is expected
+    assertThat(set).hasSize(2); // Roboto + Emoji is expected
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
+++ b/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
@@ -345,12 +345,12 @@ public class AndroidManifestTest {
     ActivityData activityData = appManifest.getActivityData("org.robolectric.shadows.TestActivity");
     final List<IntentFilterData> ifd = activityData.getIntentFilters();
     assertThat(ifd).isNotNull();
-    assertThat(ifd.size()).isEqualTo(1);
+    assertThat(ifd).hasSize(1);
 
     final IntentFilterData data = ifd.get(0);
-    assertThat(data.getActions().size()).isEqualTo(1);
+    assertThat(data.getActions()).hasSize(1);
     assertThat(data.getActions().get(0)).isEqualTo(Intent.ACTION_MAIN);
-    assertThat(data.getCategories().size()).isEqualTo(1);
+    assertThat(data.getCategories()).hasSize(1);
     assertThat(data.getCategories().get(0)).isEqualTo(Intent.CATEGORY_LAUNCHER);
   }
 
@@ -363,21 +363,21 @@ public class AndroidManifestTest {
     ActivityData activityData = appManifest.getActivityData("org.robolectric.shadows.TestActivity");
     final List<IntentFilterData> ifd = activityData.getIntentFilters();
     assertThat(ifd).isNotNull();
-    assertThat(ifd.size()).isEqualTo(2);
+    assertThat(ifd).hasSize(2);
 
     IntentFilterData data = ifd.get(0);
-    assertThat(data.getActions().size()).isEqualTo(1);
+    assertThat(data.getActions()).hasSize(1);
     assertThat(data.getActions().get(0)).isEqualTo(Intent.ACTION_MAIN);
-    assertThat(data.getCategories().size()).isEqualTo(1);
+    assertThat(data.getCategories()).hasSize(1);
     assertThat(data.getCategories().get(0)).isEqualTo(Intent.CATEGORY_LAUNCHER);
 
     data = ifd.get(1);
-    assertThat(data.getActions().size()).isEqualTo(3);
+    assertThat(data.getActions()).hasSize(3);
     assertThat(data.getActions().get(0)).isEqualTo(Intent.ACTION_VIEW);
     assertThat(data.getActions().get(1)).isEqualTo(Intent.ACTION_EDIT);
     assertThat(data.getActions().get(2)).isEqualTo(Intent.ACTION_PICK);
 
-    assertThat(data.getCategories().size()).isEqualTo(3);
+    assertThat(data.getCategories()).hasSize(3);
     assertThat(data.getCategories().get(0)).isEqualTo(Intent.CATEGORY_DEFAULT);
     assertThat(data.getCategories().get(1)).isEqualTo(Intent.CATEGORY_ALTERNATIVE);
     assertThat(data.getCategories().get(2)).isEqualTo(Intent.CATEGORY_SELECTED_ALTERNATIVE);
@@ -431,20 +431,20 @@ public class AndroidManifestTest {
     ActivityData activityData = appManifest.getActivityData("org.robolectric.shadows.TestActivity");
     final List<IntentFilterData> ifd = activityData.getIntentFilters();
     assertThat(ifd).isNotNull();
-    assertThat(ifd.size()).isEqualTo(1);
+    assertThat(ifd).hasSize(1);
 
     final IntentFilterData intentFilterData = ifd.get(0);
-    assertThat(intentFilterData.getActions().size()).isEqualTo(1);
+    assertThat(intentFilterData.getActions()).hasSize(1);
     assertThat(intentFilterData.getActions().get(0)).isEqualTo(Intent.ACTION_VIEW);
-    assertThat(intentFilterData.getCategories().size()).isEqualTo(1);
+    assertThat(intentFilterData.getCategories()).hasSize(1);
     assertThat(intentFilterData.getCategories().get(0)).isEqualTo(Intent.CATEGORY_DEFAULT);
 
-    assertThat(intentFilterData.getSchemes().size()).isEqualTo(3);
-    assertThat(intentFilterData.getAuthorities().size()).isEqualTo(3);
-    assertThat(intentFilterData.getMimeTypes().size()).isEqualTo(3);
-    assertThat(intentFilterData.getPaths().size()).isEqualTo(1);
-    assertThat(intentFilterData.getPathPatterns().size()).isEqualTo(1);
-    assertThat(intentFilterData.getPathPrefixes().size()).isEqualTo(1);
+    assertThat(intentFilterData.getSchemes()).hasSize(3);
+    assertThat(intentFilterData.getAuthorities()).hasSize(3);
+    assertThat(intentFilterData.getMimeTypes()).hasSize(3);
+    assertThat(intentFilterData.getPaths()).hasSize(1);
+    assertThat(intentFilterData.getPathPatterns()).hasSize(1);
+    assertThat(intentFilterData.getPathPrefixes()).hasSize(1);
 
     assertThat(intentFilterData.getSchemes().get(0)).isEqualTo("content");
     assertThat(intentFilterData.getPaths().get(0)).isEqualTo("/testPath/test.jpeg");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityNodeInfoTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityNodeInfoTest.java
@@ -143,7 +143,7 @@ public class ShadowAccessibilityNodeInfoTest {
     assertThat(shadow.getPerformedActions().get(0)).isEqualTo(AccessibilityNodeInfo.ACTION_CLICK);
     boolean longClickResult = node.performAction(AccessibilityNodeInfo.ACTION_LONG_CLICK);
     assertThat(longClickResult).isFalse();
-    assertThat(shadow.getPerformedActions().size()).isEqualTo(2);
+    assertThat(shadow.getPerformedActions()).hasSize(2);
     assertThat(shadow.getPerformedActions().get(1))
         .isEqualTo(AccessibilityNodeInfo.ACTION_LONG_CLICK);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityServiceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityServiceTest.java
@@ -44,7 +44,7 @@ public class ShadowAccessibilityServiceTest {
   @Test
   public void shouldRecordPerformedAction() {
     service.performGlobalAction(AccessibilityService.GLOBAL_ACTION_BACK);
-    assertThat(shadow.getGlobalActionsPerformed().size()).isEqualTo(1);
+    assertThat(shadow.getGlobalActionsPerformed()).hasSize(1);
     assertThat(shadow.getGlobalActionsPerformed().get(0)).isEqualTo(1);
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityManagerTest.java
@@ -131,7 +131,7 @@ public class ShadowActivityManagerTest {
     final ActivityManager.RunningAppProcessInfo process2 =
         buildProcessInfo(new ComponentName("org.robolectric", "Process 2"));
 
-    assertThat(activityManager.getRunningAppProcesses().size()).isEqualTo(1);
+    assertThat(activityManager.getRunningAppProcesses()).hasSize(1);
     ActivityManager.RunningAppProcessInfo myInfo = activityManager.getRunningAppProcesses().get(0);
     assertThat(myInfo.pid).isEqualTo(android.os.Process.myPid());
     assertThat(myInfo.uid).isEqualTo(android.os.Process.myUid());

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
@@ -1630,7 +1630,7 @@ public class ShadowActivityTest {
       TestActivity testActivity = controller.setup().get();
       Consumer<List<DirectAction>> testConsumer =
           (directActions) -> {
-            assertThat(directActions.size()).isEqualTo(1);
+            assertThat(directActions).hasSize(1);
             DirectAction action = directActions.get(0);
             assertThat(action.getId()).isEqualTo(testActivity.getDirectActionForTesting().getId());
             ComponentName componentName = action.getExtras().getParcelable("componentName");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
@@ -723,7 +723,7 @@ public class ShadowApplicationTest {
     Activity activity = Robolectric.setupActivity(Activity.class);
     activity.registerReceiver(new TestBroadcastReceiver(), new IntentFilter("Foo"));
 
-    assertThat(shadowOf(context).getRegisteredReceivers().size()).isAtLeast(1);
+    assertThat(shadowOf(context).getRegisteredReceivers()).isNotEmpty();
 
     shadowOf(context).clearRegisteredReceivers();
 
@@ -806,7 +806,7 @@ public class ShadowApplicationTest {
   public void bindServiceShouldAddServiceConnectionToListOfBoundServiceConnections() {
     final ServiceConnection expectedServiceConnection = new EmptyServiceConnection();
 
-    assertThat(Shadows.shadowOf(context).getBoundServiceConnections()).hasSize(0);
+    assertThat(Shadows.shadowOf(context).getBoundServiceConnections()).isEmpty();
     assertThat(
             context.bindService(
                 new Intent("connect").setPackage("dummy.package"), expectedServiceConnection, 0))
@@ -823,7 +823,7 @@ public class ShadowApplicationTest {
     final String unboundableAction = "refuse";
     final Intent serviceIntent = new Intent(unboundableAction).setPackage("dummy.package");
     Shadows.shadowOf(context).declareActionUnbindable(unboundableAction);
-    assertThat(Shadows.shadowOf(context).getBoundServiceConnections()).hasSize(0);
+    assertThat(Shadows.shadowOf(context).getBoundServiceConnections()).isEmpty();
     assertThat(context.bindService(serviceIntent, expectedServiceConnection, 0)).isFalse();
     assertThat(Shadows.shadowOf(context).getBoundServiceConnections()).hasSize(1);
     assertThat(Shadows.shadowOf(context).getBoundServiceConnections().get(0))
@@ -839,9 +839,9 @@ public class ShadowApplicationTest {
                 new Intent("connect").setPackage("dummy.package"), expectedServiceConnection, 0))
         .isTrue();
     assertThat(Shadows.shadowOf(context).getBoundServiceConnections()).hasSize(1);
-    assertThat(Shadows.shadowOf(context).getUnboundServiceConnections()).hasSize(0);
+    assertThat(Shadows.shadowOf(context).getUnboundServiceConnections()).isEmpty();
     context.unbindService(expectedServiceConnection);
-    assertThat(Shadows.shadowOf(context).getBoundServiceConnections()).hasSize(0);
+    assertThat(Shadows.shadowOf(context).getBoundServiceConnections()).isEmpty();
     assertThat(Shadows.shadowOf(context).getUnboundServiceConnections()).hasSize(1);
     assertThat(Shadows.shadowOf(context).getUnboundServiceConnections().get(0))
         .isSameInstanceAs(expectedServiceConnection);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraParametersTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraParametersTest.java
@@ -79,7 +79,7 @@ public class ShadowCameraParametersTest {
   public void testGetSupportedPreviewFormats() {
     List<Integer> supportedFormats = parameters.getSupportedPreviewFormats();
     assertThat(supportedFormats).isNotNull();
-    assertThat(supportedFormats.size()).isNotEqualTo(0);
+    assertThat(supportedFormats).isNotEmpty();
     assertThat(supportedFormats).contains(ImageFormat.NV21);
   }
 
@@ -87,7 +87,7 @@ public class ShadowCameraParametersTest {
   public void testGetSupportedPictureFormats() {
     List<Integer> supportedFormats = parameters.getSupportedPictureFormats();
     assertThat(supportedFormats).isNotNull();
-    assertThat(supportedFormats.size()).isEqualTo(2);
+    assertThat(supportedFormats).hasSize(2);
     assertThat(supportedFormats).contains(ImageFormat.NV21);
   }
 
@@ -95,7 +95,7 @@ public class ShadowCameraParametersTest {
   public void testGetSupportedPictureSizes() {
     List<Camera.Size> supportedSizes = parameters.getSupportedPictureSizes();
     assertThat(supportedSizes).isNotNull();
-    assertThat(supportedSizes.size()).isEqualTo(3);
+    assertThat(supportedSizes).hasSize(3);
     assertThat(supportedSizes.get(0).width).isEqualTo(320);
     assertThat(supportedSizes.get(0).height).isEqualTo(240);
   }
@@ -104,7 +104,7 @@ public class ShadowCameraParametersTest {
   public void testGetSupportedPreviewSizes() {
     List<Camera.Size> supportedSizes = parameters.getSupportedPreviewSizes();
     assertThat(supportedSizes).isNotNull();
-    assertThat(supportedSizes.size()).isEqualTo(2);
+    assertThat(supportedSizes).hasSize(2);
     assertThat(supportedSizes.get(0).width).isEqualTo(320);
     assertThat(supportedSizes.get(0).height).isEqualTo(240);
   }
@@ -130,7 +130,7 @@ public class ShadowCameraParametersTest {
   public void testGetSupportedPreviewFpsRange() {
     List<int[]> supportedRanges = parameters.getSupportedPreviewFpsRange();
     assertThat(supportedRanges).isNotNull();
-    assertThat(supportedRanges.size()).isEqualTo(2);
+    assertThat(supportedRanges).hasSize(2);
     assertThat(supportedRanges.get(0)[0]).isEqualTo(15000);
     assertThat(supportedRanges.get(0)[1]).isEqualTo(15000);
     assertThat(supportedRanges.get(1)[0]).isEqualTo(10000);
@@ -141,7 +141,7 @@ public class ShadowCameraParametersTest {
   public void testGetSupportedPreviewFrameRates() {
     List<Integer> supportedRates = parameters.getSupportedPreviewFrameRates();
     assertThat(supportedRates).isNotNull();
-    assertThat(supportedRates.size()).isEqualTo(3);
+    assertThat(supportedRates).hasSize(3);
     assertThat(supportedRates.get(0)).isEqualTo(10);
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraTest.java
@@ -67,7 +67,7 @@ public class ShadowCameraTest {
     Camera.Parameters parameters = camera.getParameters();
     assertThat(parameters).isNotNull();
     assertThat(parameters.getSupportedPreviewFormats()).isNotNull();
-    assertThat(parameters.getSupportedPreviewFormats().size()).isNotEqualTo(0);
+    assertThat(parameters.getSupportedPreviewFormats()).isNotEmpty();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
@@ -300,13 +300,13 @@ public class ShadowConnectivityManagerTest {
 
     Map<Network, Boolean> reportedNetworks =
         shadowOf(connectivityManager).getReportedNetworkConnectivity();
-    assertThat(reportedNetworks.size()).isEqualTo(1);
+    assertThat(reportedNetworks).hasSize(1);
     assertThat(reportedNetworks.get(wifiNetwork)).isTrue();
 
     // Update the status.
     connectivityManager.reportNetworkConnectivity(wifiNetwork, false);
     reportedNetworks = shadowOf(connectivityManager).getReportedNetworkConnectivity();
-    assertThat(reportedNetworks.size()).isEqualTo(1);
+    assertThat(reportedNetworks).hasSize(1);
     assertThat(reportedNetworks.get(wifiNetwork)).isFalse();
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
@@ -159,7 +159,7 @@ public class ShadowContentResolverTest {
     ContentValues contentValues = new ContentValues();
     contentValues.put("foo", "bar");
     contentResolver.insert(EXTERNAL_CONTENT_URI, contentValues);
-    assertThat(shadowContentResolver.getInsertStatements().size()).isEqualTo(1);
+    assertThat(shadowContentResolver.getInsertStatements()).hasSize(1);
     assertThat(shadowContentResolver.getInsertStatements().get(0).getUri())
         .isEqualTo(EXTERNAL_CONTENT_URI);
     assertThat(
@@ -173,7 +173,7 @@ public class ShadowContentResolverTest {
     contentValues = new ContentValues();
     contentValues.put("hello", "world");
     contentResolver.insert(EXTERNAL_CONTENT_URI, contentValues);
-    assertThat(shadowContentResolver.getInsertStatements().size()).isEqualTo(2);
+    assertThat(shadowContentResolver.getInsertStatements()).hasSize(2);
     assertThat(
             shadowContentResolver
                 .getInsertStatements()
@@ -189,7 +189,7 @@ public class ShadowContentResolverTest {
     contentValues.put("foo", "bar");
     contentResolver.update(
         EXTERNAL_CONTENT_URI, contentValues, "robolectric", new String[] {"awesome"});
-    assertThat(shadowContentResolver.getUpdateStatements().size()).isEqualTo(1);
+    assertThat(shadowContentResolver.getUpdateStatements()).hasSize(1);
     assertThat(shadowContentResolver.getUpdateStatements().get(0).getUri())
         .isEqualTo(EXTERNAL_CONTENT_URI);
     assertThat(
@@ -207,7 +207,7 @@ public class ShadowContentResolverTest {
     contentValues = new ContentValues();
     contentValues.put("hello", "world");
     contentResolver.update(EXTERNAL_CONTENT_URI, contentValues, null, null);
-    assertThat(shadowContentResolver.getUpdateStatements().size()).isEqualTo(2);
+    assertThat(shadowContentResolver.getUpdateStatements()).hasSize(2);
     assertThat(shadowContentResolver.getUpdateStatements().get(1).getUri())
         .isEqualTo(EXTERNAL_CONTENT_URI);
     assertThat(
@@ -235,23 +235,23 @@ public class ShadowContentResolverTest {
 
   @Test
   public void delete_shouldTrackDeletedUris() {
-    assertThat(shadowContentResolver.getDeletedUris().size()).isEqualTo(0);
+    assertThat(shadowContentResolver.getDeletedUris()).isEmpty();
 
     assertThat(contentResolver.delete(uri21, null, null)).isEqualTo(1);
     assertThat(shadowContentResolver.getDeletedUris()).contains(uri21);
-    assertThat(shadowContentResolver.getDeletedUris().size()).isEqualTo(1);
+    assertThat(shadowContentResolver.getDeletedUris()).hasSize(1);
 
     assertThat(contentResolver.delete(uri22, null, null)).isEqualTo(1);
     assertThat(shadowContentResolver.getDeletedUris()).contains(uri22);
-    assertThat(shadowContentResolver.getDeletedUris().size()).isEqualTo(2);
+    assertThat(shadowContentResolver.getDeletedUris()).hasSize(2);
   }
 
   @Test
   public void delete_shouldTrackDeletedStatements() {
-    assertThat(shadowContentResolver.getDeleteStatements().size()).isEqualTo(0);
+    assertThat(shadowContentResolver.getDeleteStatements()).isEmpty();
 
     assertThat(contentResolver.delete(uri21, "id", new String[] {"5"})).isEqualTo(1);
-    assertThat(shadowContentResolver.getDeleteStatements().size()).isEqualTo(1);
+    assertThat(shadowContentResolver.getDeleteStatements()).hasSize(1);
     assertThat(shadowContentResolver.getDeleteStatements().get(0).getUri()).isEqualTo(uri21);
     assertThat(shadowContentResolver.getDeleteStatements().get(0).getContentProvider()).isNull();
     assertThat(shadowContentResolver.getDeleteStatements().get(0).getWhere()).isEqualTo("id");
@@ -259,7 +259,7 @@ public class ShadowContentResolverTest {
         .isEqualTo("5");
 
     assertThat(contentResolver.delete(uri21, "foo", new String[] {"bar"})).isEqualTo(1);
-    assertThat(shadowContentResolver.getDeleteStatements().size()).isEqualTo(2);
+    assertThat(shadowContentResolver.getDeleteStatements()).hasSize(2);
     assertThat(shadowContentResolver.getDeleteStatements().get(1).getUri()).isEqualTo(uri21);
     assertThat(shadowContentResolver.getDeleteStatements().get(1).getWhere()).isEqualTo("foo");
     assertThat(shadowContentResolver.getDeleteStatements().get(1).getSelectionArgs()[0])
@@ -677,7 +677,7 @@ public class ShadowContentResolverTest {
     contentResolver.notifyChange(Uri.parse("foo"), null, true);
     contentResolver.notifyChange(Uri.parse("bar"), null);
 
-    assertThat(shadowContentResolver.getNotifiedUris().size()).isEqualTo(2);
+    assertThat(shadowContentResolver.getNotifiedUris()).hasSize(2);
     ShadowContentResolver.NotifiedUri uri = shadowContentResolver.getNotifiedUris().get(0);
 
     assertThat(uri.uri.toString()).isEqualTo("foo");
@@ -697,7 +697,7 @@ public class ShadowContentResolverTest {
     contentResolver.notifyChange(Uri.parse("foo"), null, ContentResolver.NOTIFY_SYNC_TO_NETWORK);
     contentResolver.notifyChange(Uri.parse("bar"), null, ContentResolver.NOTIFY_UPDATE);
 
-    assertThat(shadowContentResolver.getNotifiedUris().size()).isEqualTo(2);
+    assertThat(shadowContentResolver.getNotifiedUris()).hasSize(2);
 
     ShadowContentResolver.NotifiedUri uri = shadowContentResolver.getNotifiedUris().get(0);
 
@@ -782,7 +782,7 @@ public class ShadowContentResolverTest {
     List<ContentProviderOperation> resultOperations =
         shadowContentResolver.getContentProviderOperations(AUTHORITY);
     assertThat(resultOperations).isNotNull();
-    assertThat(resultOperations.size()).isEqualTo(0);
+    assertThat(resultOperations).isEmpty();
 
     Uri uri = Uri.parse("content://org.robolectric");
     ArrayList<ContentProviderOperation> operations = new ArrayList<>();
@@ -830,7 +830,7 @@ public class ShadowContentResolverTest {
     ContentResolver.requestSync(b, AUTHORITY, new Bundle());
 
     List<SyncInfo> syncs = ContentResolver.getCurrentSyncs();
-    assertThat(syncs.size()).isEqualTo(2);
+    assertThat(syncs).hasSize(2);
 
     SyncInfo syncA = Iterables.find(syncs, s -> s.account.equals(a));
     assertThat(syncA.account).isEqualTo(a);
@@ -842,7 +842,7 @@ public class ShadowContentResolverTest {
 
     ContentResolver.cancelSync(a, AUTHORITY);
     List<SyncInfo> syncsAgain = ContentResolver.getCurrentSyncs();
-    assertThat(syncsAgain.size()).isEqualTo(1);
+    assertThat(syncsAgain).hasSize(1);
 
     SyncInfo firstAgain = syncsAgain.get(0);
     assertThat(firstAgain.account).isEqualTo(b);
@@ -850,7 +850,7 @@ public class ShadowContentResolverTest {
 
     ContentResolver.cancelSync(b, AUTHORITY);
     List<SyncInfo> s = ContentResolver.getCurrentSyncs();
-    assertThat(s.size()).isEqualTo(0);
+    assertThat(s).isEmpty();
   }
 
   @Test
@@ -961,11 +961,11 @@ public class ShadowContentResolverTest {
 
   @Test
   public void shouldGetPeriodSyncs() {
-    assertThat(ContentResolver.getPeriodicSyncs(a, AUTHORITY).size()).isEqualTo(0);
+    assertThat(ContentResolver.getPeriodicSyncs(a, AUTHORITY)).isEmpty();
     ContentResolver.addPeriodicSync(a, AUTHORITY, new Bundle(), 6000L);
 
     List<PeriodicSync> syncs = ContentResolver.getPeriodicSyncs(a, AUTHORITY);
-    assertThat(syncs.size()).isEqualTo(1);
+    assertThat(syncs).hasSize(1);
 
     PeriodicSync first = syncs.get(0);
     assertThat(first.account).isEqualTo(a);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowGeocoderTTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowGeocoderTTest.java
@@ -110,7 +110,7 @@ public class ShadowGeocoderTTest {
     Geocoder.GeocodeListener geocodeListener = addresses -> decodedAddresses = addresses;
     shadowGeocoder.getFromLocationName("test", 1, geocodeListener);
 
-    assertThat(decodedAddresses).hasSize(0);
+    assertThat(decodedAddresses).isEmpty();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowGeocoderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowGeocoderTest.java
@@ -42,7 +42,7 @@ public class ShadowGeocoderTest {
 
   @Test
   public void getFromLocationReturnsAnEmptyArrayByDefault() throws IOException {
-    assertThat(geocoder.getFromLocation(90.0, 90.0, 1)).hasSize(0);
+    assertThat(geocoder.getFromLocation(90.0, 90.0, 1)).isEmpty();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLogTest.java
@@ -225,7 +225,7 @@ public class ShadowLogTest {
     Log.d("throwable", "7", specificMethodName());
 
     List<LogItem> allItems = ShadowLog.getLogs();
-    assertThat(allItems.size()).isEqualTo(7);
+    assertThat(allItems).hasSize(7);
     int i = 1;
     for (LogItem item : allItems) {
       assertThat(item.msg).isEqualTo(Integer.toString(i));
@@ -240,7 +240,7 @@ public class ShadowLogTest {
 
   private static void assertUniformLogsForTag(String tag, int count) {
     List<LogItem> tag1Items = ShadowLog.getLogsForTag(tag);
-    assertThat(tag1Items.size()).isEqualTo(count);
+    assertThat(tag1Items).hasSize(count);
     int last = -1;
     for (LogItem item : tag1Items) {
       assertThat(item.tag).isEqualTo(tag);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -2525,9 +2525,9 @@ public class ShadowPackageManagerTest {
     int filterCount = packageManager.getPreferredActivities(filters, activities, null);
 
     assertThat(filterCount).isEqualTo(1);
-    assertThat(activities.size()).isEqualTo(1);
+    assertThat(activities).hasSize(1);
     assertThat(activities.get(0).getPackageName()).isEqualTo(packageName);
-    assertThat(filters.size()).isEqualTo(1);
+    assertThat(filters).hasSize(1);
 
     filterCount = packageManager.getPreferredActivities(filters, activities, "other");
 
@@ -3911,7 +3911,7 @@ public class ShadowPackageManagerTest {
 
     shadowOf(packageManager).doPendingUninstallCallbacks();
 
-    assertThat(shadowOf(packageManager).getDeletedPackages()).hasSize(0);
+    assertThat(shadowOf(packageManager).getDeletedPackages()).isEmpty();
     verify(mockObserver)
         .packageDeleted(packageInfo.packageName, PackageManager.DELETE_FAILED_INTERNAL_ERROR);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSharedPreferencesTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSharedPreferencesTest.java
@@ -39,7 +39,7 @@ public class ShadowSharedPreferencesTest {
 
     sharedPreferences = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE);
     // Ensure no shared preferences have leaked from previous tests.
-    assertThat(sharedPreferences.getAll()).hasSize(0);
+    assertThat(sharedPreferences.getAll()).isEmpty();
 
     editor = sharedPreferences.edit();
     editor.putBoolean("boolean", true);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSurfaceViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSurfaceViewTest.java
@@ -54,7 +54,7 @@ public class ShadowSurfaceViewTest {
     surfaceHolder.addCallback(callback1);
     surfaceHolder.addCallback(callback2);
 
-    assertThat(fakeSurfaceHolder.getCallbacks().size()).isEqualTo(2);
+    assertThat(fakeSurfaceHolder.getCallbacks()).hasSize(2);
 
     surfaceHolder.removeCallback(callback1);
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTelecomManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTelecomManagerTest.java
@@ -77,7 +77,7 @@ public class ShadowTelecomManagerTest {
   @Test
   public void registerAndUnRegister() {
     assertThat(shadowOf(telecomService).getAllPhoneAccountsCount()).isEqualTo(0);
-    assertThat(shadowOf(telecomService).getAllPhoneAccounts()).hasSize(0);
+    assertThat(shadowOf(telecomService).getAllPhoneAccounts()).isEmpty();
 
     PhoneAccountHandle handler = createHandle("id");
     PhoneAccount phoneAccount = PhoneAccount.builder(handler, "main_account").build();
@@ -93,8 +93,8 @@ public class ShadowTelecomManagerTest {
     telecomService.unregisterPhoneAccount(handler);
 
     assertThat(shadowOf(telecomService).getAllPhoneAccountsCount()).isEqualTo(0);
-    assertThat(shadowOf(telecomService).getAllPhoneAccounts()).hasSize(0);
-    assertThat(telecomService.getAllPhoneAccountHandles()).hasSize(0);
+    assertThat(shadowOf(telecomService).getAllPhoneAccounts()).isEmpty();
+    assertThat(telecomService.getAllPhoneAccountHandles()).isEmpty();
   }
 
   @Test
@@ -298,7 +298,7 @@ public class ShadowTelecomManagerTest {
     verifyNoMoreInteractions(connectionServiceListener);
 
     List<ConnectionRequest> values = requestCaptor.getAllValues();
-    assertThat(values.size()).isEqualTo(2);
+    assertThat(values).hasSize(2);
     ConnectionRequest request1 = values.get(0);
     ConnectionRequest request2 = values.get(1);
     assertThat(request1.getAddress()).isEqualTo(address1);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUserManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUserManagerTest.java
@@ -347,12 +347,12 @@ public class ShadowUserManagerTest {
   @Test
   @Config(minSdk = R)
   public void getUserHandles() {
-    assertThat(shadowOf(userManager).getUserHandles(/* excludeDying= */ true).size()).isEqualTo(1);
+    assertThat(shadowOf(userManager).getUserHandles(/* excludeDying= */ true)).hasSize(1);
     shadowOf(userManager).getUserHandles(/* excludeDying= */ true).get(0);
     assertThat(UserHandle.myUserId()).isEqualTo(UserHandle.USER_SYSTEM);
 
     UserHandle expectedUserHandle = shadowOf(userManager).addUser(10, "secondary_user", 0);
-    assertThat(shadowOf(userManager).getUserHandles(/* excludeDying= */ true).size()).isEqualTo(2);
+    assertThat(shadowOf(userManager).getUserHandles(/* excludeDying= */ true)).hasSize(2);
     assertThat(shadowOf(userManager).getUserHandles(/* excludeDying= */ true).get(1))
         .isEqualTo(expectedUserHandle);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowVoiceInteractorTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowVoiceInteractorTest.java
@@ -138,7 +138,7 @@ public final class ShadowVoiceInteractorTest {
   }
 
   private void assertValues(List<String> promptMessage) {
-    assertThat(shadowVoiceInteractor.getVoiceInteractions().size()).isEqualTo(promptMessage.size());
+    assertThat(shadowVoiceInteractor.getVoiceInteractions()).hasSize(promptMessage.size());
     assertThat(shadowVoiceInteractor.getVoiceInteractions()).isEqualTo(promptMessage);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiManagerTest.java
@@ -231,7 +231,7 @@ public class ShadowWifiManagerTest {
 
     assertThat(wifiManager.updateNetwork(configuration)).isEqualTo(networkId);
     List<WifiConfiguration> configuredNetworks = wifiManager.getConfiguredNetworks();
-    assertThat(configuredNetworks.size()).isEqualTo(2);
+    assertThat(configuredNetworks).hasSize(2);
     assertThat(configuration.priority).isEqualTo(44);
     assertThat(configuredNetworks.get(1).priority).isEqualTo(44);
   }
@@ -261,12 +261,12 @@ public class ShadowWifiManagerTest {
     wifiManager.addNetwork(wifiConfiguration);
 
     List<WifiConfiguration> list = wifiManager.getConfiguredNetworks();
-    assertThat(list.size()).isEqualTo(1);
+    assertThat(list).hasSize(1);
 
     wifiManager.removeNetwork(0);
 
     list = wifiManager.getConfiguredNetworks();
-    assertThat(list.size()).isEqualTo(0);
+    assertThat(list).isEmpty();
   }
 
   @Test
@@ -357,12 +357,12 @@ public class ShadowWifiManagerTest {
     wifiManager.addNetwork(wifiConfiguration);
 
     List<WifiConfiguration> list = wifiManager.getPrivilegedConfiguredNetworks();
-    assertThat(list.size()).isEqualTo(1);
+    assertThat(list).hasSize(1);
 
     wifiManager.removeNetwork(0);
 
     list = wifiManager.getPrivilegedConfiguredNetworks();
-    assertThat(list.size()).isEqualTo(0);
+    assertThat(list).isEmpty();
   }
 
   @Test

--- a/sandbox/src/test/java/org/robolectric/internal/bytecode/ClassInstrumentorTest.java
+++ b/sandbox/src/test/java/org/robolectric/internal/bytecode/ClassInstrumentorTest.java
@@ -73,7 +73,7 @@ public class ClassInstrumentorTest {
     // Side effect: original method has been made private.
     assertThat(methodNode.access & Opcodes.ACC_PRIVATE).isNotEqualTo(0);
     // Side effect: instructions have been rewritten to return 0.
-    assertThat(methodNode.instructions.size()).isEqualTo(2);
+    assertThat(methodNode.instructions).hasSize(2);
     assertThat(methodNode.instructions.get(0).getOpcode()).isEqualTo(Opcodes.ICONST_0);
     assertThat(methodNode.instructions.get(1).getOpcode()).isEqualTo(Opcodes.IRETURN);
   }

--- a/shadows/httpclient/src/test/java/org/robolectric/shadows/httpclient/ParamsParserTest.java
+++ b/shadows/httpclient/src/test/java/org/robolectric/shadows/httpclient/ParamsParserTest.java
@@ -46,7 +46,7 @@ public class ParamsParserTest {
   public void parseParams_shouldParseParamsFromGetRequests() {
     HttpGet httpGet = new HttpGet("http://example.com/path?foo=bar");
     Map<String, String> parsed = ParamsParser.parseParams(httpGet);
-    assertThat(parsed.size()).isEqualTo(1);
+    assertThat(parsed).hasSize(1);
     assertThat(parsed.get("foo")).isEqualTo("bar");
   }
 


### PR DESCRIPTION
This commit replaces Truth assertions to use the `hasSize()` and `is(Not)Empty()` methods.