### PR TITLE
Remove redundant `@TextLayoutMode` annotation

### DIFF
--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoWithMenuTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoWithMenuTest.java
@@ -11,12 +11,9 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.TextLayoutMode;
-import org.robolectric.annotation.TextLayoutMode.Mode;
 
 /** Test Espresso on Robolectric interoperability for menus. */
 @RunWith(AndroidJUnit4.class)
-@TextLayoutMode(Mode.REALISTIC)
 public class EspressoWithMenuTest {
 
   @Test

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoWithSwitchCompatTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoWithSwitchCompatTest.java
@@ -10,12 +10,10 @@ import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.TextLayoutMode;
 import org.robolectric.integration.axt.R;
 
 /** Tests Espresso on Activities with {@link androidx.appcompat.widget.SwitchCompat}. */
 @RunWith(AndroidJUnit4.class)
-@TextLayoutMode(TextLayoutMode.Mode.REALISTIC)
 public class EspressoWithSwitchCompatTest {
   @Test
   public void switchCompatTest() {

--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoWithToolbarMenuTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/EspressoWithToolbarMenuTest.java
@@ -11,13 +11,10 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.TextLayoutMode;
-import org.robolectric.annotation.TextLayoutMode.Mode;
 import org.robolectric.shadows.ShadowViewConfiguration;
 
 /** Test Espresso on Robolectric interoperability for toolbar menus. */
 @RunWith(AndroidJUnit4.class)
-@TextLayoutMode(Mode.REALISTIC)
 public class EspressoWithToolbarMenuTest {
   @Test
   public void appCompatToolbarMenuClick() {


### PR DESCRIPTION
`REALISTIC` is the default mode for `@TextLayoutMode`, so there is no need to explicitly set it.