### PR TITLE
Remove Findbugs' `jsr305` dependency

### DIFF
--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 dependencies {
-  compileOnly(libs.findbugs.jsr305)
   compileOnly(libs.javax.annotation.api)
   compileOnly(AndroidSdk.MAX_SDK.coordinates)
   testImplementation(libs.truth)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,9 +15,6 @@ conscrypt = "2.5.2"
 # https://github.com/bcgit/bc-java/tags
 bouncycastle = "1.80"
 
-# https://github.com/findbugsproject/findbugs/tags
-findbugs-jsr305 = "3.0.2"
-
 # https://github.com/hamcrest/JavaHamcrest/releases
 hamcrest = "2.0.0.0"
 
@@ -160,7 +157,6 @@ error-prone-test-helpers = { module = "com.google.errorprone:error_prone_test_he
 
 conscrypt-openjdk-uber = { module = "org.conscrypt:conscrypt-openjdk-uber", version.ref = "conscrypt" }
 bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
-findbugs-jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "findbugs-jsr305" }
 
 guava = { module = "com.google.guava:guava", version.ref = "guava-jre" }
 guava-testlib = { module = "com.google.guava:guava-testlib", version.ref = "guava-jre" }

--- a/junit/build.gradle.kts
+++ b/junit/build.gradle.kts
@@ -7,6 +7,5 @@ dependencies {
   api(project(":sandbox"))
   api(project(":pluginapi"))
 
-  compileOnly(libs.findbugs.jsr305)
   compileOnly(libs.junit4)
 }

--- a/pluginapi/build.gradle.kts
+++ b/pluginapi/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 dependencies {
-  compileOnly(libs.findbugs.jsr305)
   api(project(":annotations"))
   api(libs.guava)
 

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -41,7 +41,6 @@ dependencies {
   api(project(":annotations"))
   api(project(":shadowapi"))
 
-  compileOnly(libs.findbugs.jsr305)
   api(libs.asm)
   api(libs.asm.util)
   api(libs.guava)

--- a/resources/build.gradle.kts
+++ b/resources/build.gradle.kts
@@ -9,7 +9,6 @@ dependencies {
 
   api(libs.auto.value.annotations)
   api(libs.guava)
-  compileOnly(libs.findbugs.jsr305)
 
   testImplementation(libs.junit4)
   testImplementation(libs.truth)

--- a/robolectric/build.gradle.kts
+++ b/robolectric/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
   implementation(libs.snakeyaml)
 
   api(libs.bcprov.jdk18on)
-  compileOnly(libs.findbugs.jsr305)
 
   compileOnly(AndroidSdk.MAX_SDK.coordinates)
   compileOnly(libs.junit4)

--- a/sandbox/build.gradle.kts
+++ b/sandbox/build.gradle.kts
@@ -18,7 +18,6 @@ dependencies {
   api(libs.asm)
   api(libs.asm.commons)
   api(libs.guava)
-  compileOnly(libs.findbugs.jsr305)
 
   testImplementation(libs.junit4)
   testImplementation(libs.truth)

--- a/shadowapi/build.gradle.kts
+++ b/shadowapi/build.gradle.kts
@@ -4,8 +4,6 @@ plugins {
 }
 
 dependencies {
-  compileOnly(libs.findbugs.jsr305)
-
   api(project(":annotations"))
   api(project(":utils"))
   testImplementation(libs.junit4)

--- a/shadows/framework/build.gradle.kts
+++ b/shadows/framework/build.gradle.kts
@@ -54,7 +54,6 @@ dependencies {
   api("androidx.test:monitor:$axtMonitorVersion@aar")
 
   implementation(libs.error.prone.annotations)
-  compileOnly(libs.findbugs.jsr305)
   api(libs.sqlite4java)
   compileOnly(AndroidSdk.MAX_SDK.coordinates)
   api(libs.icu4j)

--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -23,8 +23,6 @@ dependencies {
   api(libs.javax.inject)
   api(libs.javax.annotation.api)
 
-  compileOnly(libs.findbugs.jsr305)
-
   testCompileOnly(libs.auto.service.annotations)
   testAnnotationProcessor(libs.auto.service)
   testAnnotationProcessor(libs.error.prone.core)


### PR DESCRIPTION
Findbugs is no longer maintained and has been replaced by [SpotBugs](https://spotbugs.github.io/). It seems that the dependency on the `jsr305` module is not needed, so I've removed it.

Let me know if it should be kept.