### PR TITLE
Upgrade Hamcrest to 3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ bouncycastle = "1.80"
 findbugs-jsr305 = "3.0.2"
 
 # https://github.com/hamcrest/JavaHamcrest/releases
-hamcrest = "2.0.0.0"
+hamcrest = "3.0"
 
 # https://github.com/google/error-prone/releases
 error-prone = "2.36.0"
@@ -165,7 +165,7 @@ findbugs-jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "f
 guava = { module = "com.google.guava:guava", version.ref = "guava-jre" }
 guava-testlib = { module = "com.google.guava:guava-testlib", version.ref = "guava-jre" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
-hamcrest-junit = { module = "org.hamcrest:hamcrest-junit", version.ref = "hamcrest" }
+hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 
 icu4j = { module = "com.ibm.icu:icu4j", version.ref = "icu4j" }
 

--- a/robolectric/build.gradle.kts
+++ b/robolectric/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
   testImplementation(libs.junit4)
   testImplementation(libs.truth)
   testImplementation(libs.mockito)
-  testImplementation(libs.hamcrest.junit)
+  testImplementation(libs.hamcrest)
   testImplementation("androidx.test:core:$axtCoreVersion@aar")
   testImplementation("androidx.test.ext:junit:$axtJunitVersion@aar")
   testImplementation("androidx.test.ext:truth:$axtTruthVersion@aar")


### PR DESCRIPTION
The [`hamcrest-junit`](https://github.com/hamcrest/hamcrest-junit) module hasn't been updated in 10 years. Since we don't use any of its features, I've switched to the latest version of the regular [`hamcrest`](https://github.com/hamcrest/JavaHamcrest) module.