### PR TITLE
Bump Truth to 1.4.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,7 @@ guava-jre = "33.4.0-jre"
 gson = "2.11.0"
 
 # https://github.com/google/truth/releases
-truth = "1.4.2"
+truth = "1.4.4"
 
 # https://github.com/unicode-org/icu/releases
 icu4j = "76.1"


### PR DESCRIPTION
This commit updates Truth from 1.4.2 to 1.4.4.

Release notes:
- [1.4.3](https://github.com/google/truth/releases/tag/v1.4.3).
- [1.4.4](https://github.com/google/truth/releases/tag/v1.4.4).

Not sure why these were not suggested by Dependabot 🤷🏻‍♂️