### PR TITLE
Remove redundant casts in `:shadows:framework`

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/MediaCodecInfoBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/MediaCodecInfoBuilder.java
@@ -411,8 +411,8 @@ public class MediaCodecInfoBuilder {
       int flagsSupported = 0;
       Object[] validFeatures = ReflectionHelpers.callInstanceMethod(parent, "getValidFeatures");
       for (Object validFeature : validFeatures) {
-        String featureName = (String) ReflectionHelpers.getField(validFeature, "mName");
-        int featureValue = (int) ReflectionHelpers.getField(validFeature, "mValue");
+        String featureName = ReflectionHelpers.getField(validFeature, "mName");
+        int featureValue = ReflectionHelpers.getField(validFeature, "mValue");
         if (mediaFormat.containsFeature(featureName)
             && mediaFormat.getFeatureEnabled(featureName)) {
           flagsSupported |= featureValue;
@@ -430,8 +430,8 @@ public class MediaCodecInfoBuilder {
       Object[] validFeatures = ReflectionHelpers.callInstanceMethod(parent, "getValidFeatures");
       HashSet<String> requiredFeaturesSet = new HashSet<>(asList(requiredFeatures));
       for (Object validFeature : validFeatures) {
-        String featureName = (String) ReflectionHelpers.getField(validFeature, "mName");
-        int featureValue = (int) ReflectionHelpers.getField(validFeature, "mValue");
+        String featureName = ReflectionHelpers.getField(validFeature, "mName");
+        int featureValue = ReflectionHelpers.getField(validFeature, "mValue");
         if (requiredFeaturesSet.contains(featureName)) {
           flagsRequired |= featureValue;
         }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
@@ -302,7 +302,7 @@ public class ShadowActivityManager {
   protected void addOnUidImportanceListener(
       @ClassName("android.app.ActivityManager$OnUidImportanceListener") Object listener,
       int importanceCutpoint) {
-    importanceListeners.add(new ImportanceListener(listener, (Integer) importanceCutpoint));
+    importanceListeners.add(new ImportanceListener(listener, importanceCutpoint));
   }
 
   @Implementation(minSdk = O)
@@ -388,10 +388,8 @@ public class ShadowActivityManager {
   protected List</*android.app.ApplicationExitInfo*/ ?> getHistoricalProcessExitReasons(
       String packageName, int pid, int maxNum) {
     return appExitInfoList.stream()
-        .filter(
-            appExitInfo ->
-                (int) pid == 0 || ((ApplicationExitInfo) appExitInfo).getPid() == (int) pid)
-        .limit((int) maxNum == 0 ? appExitInfoList.size() : (int) maxNum)
+        .filter(appExitInfo -> pid == 0 || ((ApplicationExitInfo) appExitInfo).getPid() == pid)
+        .limit(maxNum == 0 ? appExitInfoList.size() : maxNum)
         .collect(toCollection(ArrayList::new));
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAlertDialog.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAlertDialog.java
@@ -117,7 +117,7 @@ public class ShadowAlertDialog extends ShadowDialog {
 
   private ShadowAlertController getShadowAlertController() {
     AlertController alertController = ReflectionHelpers.getField(realAlertDialog, "mAlert");
-    return (ShadowAlertController) Shadow.extract(alertController);
+    return Shadow.extract(alertController);
   }
 
   @Implements(AlertDialog.Builder.class)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -1223,7 +1223,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
       String pkgName,
       int uid,
       final @ClassName("android.content.pm.IPackageStatsObserver") Object observer) {
-    final PackageStats packageStats = packageStatsMap.get((String) pkgName);
+    final PackageStats packageStats = packageStatsMap.get(pkgName);
     new Handler(Looper.getMainLooper())
         .post(
             () -> {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscApkAssets9.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscApkAssets9.java
@@ -219,7 +219,7 @@ public class ShadowArscApkAssets9 extends ShadowApkAssets {
       int propertyFlags,
       @ClassName("android.content.res.loader.AssetsProvider") Object assetsProvider)
       throws IOException {
-    CppApkAssets apkAssets = CppApkAssets.loadArscFromFd((FileDescriptor) fileDescriptor);
+    CppApkAssets apkAssets = CppApkAssets.loadArscFromFd(fileDescriptor);
     if (apkAssets == null) {
       String errorMessage =
           String.format("Failed to load from the file descriptor %s", fileDescriptor);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager.java
@@ -1139,7 +1139,7 @@ public class ShadowArscAssetManager extends ShadowAssetManager.ArscBase {
     final Ref<Res_value> valueRef = new Ref<>(null);
     final bag_entry[] bag = startOfBag.get();
     int strLen = 0;
-    for (int i = 0; ((int) i) < N; i++) {
+    for (int i = 0; i < N; i++) {
       valueRef.set(bag[i].map.value);
       String str = null;
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager10.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager10.java
@@ -349,7 +349,7 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
     if (config != null) {
       out_typed_value.density = config.density;
     }
-    return (int) (ApkAssetsCookieToJavaCookie(cookie));
+    return ApkAssetsCookieToJavaCookie(cookie);
   }
 
   //  @Override
@@ -874,12 +874,7 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
               final Ref<Integer> flags = new Ref<>(0);
               ApkAssetsCookie cookie =
                   assetmanager.GetResource(
-                      resid,
-                      false /*may_be_bag*/,
-                      (short) (density),
-                      value,
-                      selected_config,
-                      flags);
+                      resid, false /*may_be_bag*/, density, value, selected_config, flags);
               if (cookie.intValue() == kInvalidCookie) {
                 return ApkAssetsCookieToJavaCookie(K_INVALID_COOKIE);
               }
@@ -911,7 +906,7 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
     ApkAssetsCookie cookie = K_INVALID_COOKIE;
     Res_value bag_value = null;
     for (ResolvedBag.Entry entry : bag.entries) {
-      if (entry.key == (int) (bag_entry_id)) {
+      if (entry.key == bag_entry_id) {
         cookie = entry.cookie;
         bag_value = entry.value;
 
@@ -1050,7 +1045,7 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
 
       int string_index = -1;
       if (value.get().dataType == Res_value.TYPE_STRING) {
-        string_index = (int) (value.get().data);
+        string_index = value.get().data;
       }
 
       buffer[i * 2] = ApkAssetsCookieToJavaCookie(cookie);
@@ -1095,7 +1090,7 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
 
       if (value.get().dataType >= Res_value.TYPE_FIRST_INT
           && value.get().dataType <= Res_value.TYPE_LAST_INT) {
-        buffer[i] = (int) (value.get().data);
+        buffer[i] = value.get().data;
       }
     }
     // env.ReleasePrimitiveArrayCritical(array, buffer, 0);
@@ -1111,7 +1106,7 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
     if (bag == null) {
       return -1;
     }
-    return (int) (bag.entry_count);
+    return bag.entry_count;
   }
 
   // static jint NativeGetResourceArray(JNIEnv* env, jclass /*clazz*/, jlong ptr, jint resid,
@@ -1130,7 +1125,7 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
     //   return -1;
     // }
 
-    if ((int) (bag.entry_count) > out_data_length * STYLE_NUM_ENTRIES) {
+    if (bag.entry_count > out_data_length * STYLE_NUM_ENTRIES) {
       throw new IllegalArgumentException("Input array is not large enough");
     }
 
@@ -1161,16 +1156,16 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
       }
 
       int offset = i * STYLE_NUM_ENTRIES;
-      cursor[offset + STYLE_TYPE] = (int) (value.get().dataType);
-      cursor[offset + STYLE_DATA] = (int) (value.get().data);
+      cursor[offset + STYLE_TYPE] = value.get().dataType;
+      cursor[offset + STYLE_DATA] = value.get().data;
       cursor[offset + STYLE_ASSET_COOKIE] = ApkAssetsCookieToJavaCookie(cookie);
-      cursor[offset + STYLE_RESOURCE_ID] = (int) (ref.get());
-      cursor[offset + STYLE_CHANGING_CONFIGURATIONS] = (int) (flags.get());
-      cursor[offset + STYLE_DENSITY] = (int) (selected_config.get().density);
+      cursor[offset + STYLE_RESOURCE_ID] = ref.get();
+      cursor[offset + STYLE_CHANGING_CONFIGURATIONS] = flags.get();
+      cursor[offset + STYLE_DENSITY] = selected_config.get().density;
       // cursor += STYLE_NUM_ENTRIES;
     }
     // env.ReleasePrimitiveArrayCritical(out_data, buffer, 0);
-    return (int) (bag.entry_count);
+    return bag.entry_count;
   }
 
   // static jint NativeGetResourceIdentifier(JNIEnv* env, jclass /*clazz*/, jlong ptr, jstring name,
@@ -1198,7 +1193,7 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
       package_ = package_utf8;
     }
     CppAssetManager2 assetmanager = AssetManagerFromLong(ptr);
-    return (int) (assetmanager.GetResourceId(name_utf8, type, package_));
+    return assetmanager.GetResourceId(name_utf8, type, package_);
   }
 
   // static jstring NativeGetResourceName(JNIEnv* env, jclass /*clazz*/, jlong ptr, jint resid) {
@@ -1424,8 +1419,8 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
     ApplyStyle(
         theme,
         xml_parser,
-        (int) (def_style_attr),
-        (int) (def_style_resid),
+        def_style_attr,
+        def_style_resid,
         attrs,
         attrs_len,
         out_values,
@@ -1507,8 +1502,8 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
     boolean result =
         ResolveAttrs(
             theme,
-            (int) (def_style_attr),
-            (int) (def_style_resid),
+            def_style_attr,
+            def_style_resid,
             values,
             values_len,
             attrs,
@@ -1718,7 +1713,7 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
   @Implementation(minSdk = P)
   protected static @NativeConfig int nativeThemeGetChangingConfigurations(long theme_ptr) {
     Theme theme = Registries.NATIVE_THEME9_REGISTRY.getNativeObject(theme_ptr);
-    return (int) (theme.GetChangingConfigurations());
+    return theme.GetChangingConfigurations();
   }
 
   // static void NativeAssetDestroy(JNIEnv* /*env*/, jclass /*clazz*/, jlong asset_ptr) {
@@ -1766,7 +1761,7 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
     if (res < 0) {
       throw new IOException();
     }
-    return res > 0 ? (int) (res) : -1;
+    return res > 0 ? res : -1;
   }
 
   // static jlong NativeAssetSeek(JNIEnv* env, jclass /*clazz*/, jlong asset_ptr, jlong offset,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager9.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager9.java
@@ -343,7 +343,7 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
     if (config != null) {
       out_typed_value.density = config.density;
     }
-    return (int) (ApkAssetsCookieToJavaCookie(cookie));
+    return ApkAssetsCookieToJavaCookie(cookie);
   }
 
   //  @Override
@@ -859,7 +859,7 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
     final Ref<Integer> flags = new Ref<>(0);
     ApkAssetsCookie cookie =
         assetmanager.GetResource(
-            resid, false /*may_be_bag*/, (short) (density), value, selected_config, flags);
+            resid, false /*may_be_bag*/, density, value, selected_config, flags);
     if (cookie.intValue() == kInvalidCookie) {
       return ApkAssetsCookieToJavaCookie(K_INVALID_COOKIE);
     }
@@ -890,7 +890,7 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
     ApkAssetsCookie cookie = K_INVALID_COOKIE;
     Res_value bag_value = null;
     for (ResolvedBag.Entry entry : bag.entries) {
-      if (entry.key == (int) (bag_entry_id)) {
+      if (entry.key == bag_entry_id) {
         cookie = entry.cookie;
         bag_value = entry.value;
 
@@ -1030,7 +1030,7 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
 
       int string_index = -1;
       if (value.get().dataType == Res_value.TYPE_STRING) {
-        string_index = (int) (value.get().data);
+        string_index = value.get().data;
       }
 
       buffer[i * 2] = ApkAssetsCookieToJavaCookie(cookie);
@@ -1075,7 +1075,7 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
 
       if (value.get().dataType >= Res_value.TYPE_FIRST_INT
           && value.get().dataType <= Res_value.TYPE_LAST_INT) {
-        buffer[i] = (int) (value.get().data);
+        buffer[i] = value.get().data;
       }
     }
     // env.ReleasePrimitiveArrayCritical(array, buffer, 0);
@@ -1091,7 +1091,7 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
     if (bag == null) {
       return -1;
     }
-    return (int) (bag.entry_count);
+    return bag.entry_count;
   }
 
   // static jint NativeGetResourceArray(JNIEnv* env, jclass /*clazz*/, jlong ptr, jint resid,
@@ -1110,7 +1110,7 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
     //   return -1;
     // }
 
-    if ((int) (bag.entry_count) > out_data_length * STYLE_NUM_ENTRIES) {
+    if (bag.entry_count > out_data_length * STYLE_NUM_ENTRIES) {
       throw new IllegalArgumentException("Input array is not large enough");
     }
 
@@ -1141,16 +1141,16 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
       }
 
       int offset = i * STYLE_NUM_ENTRIES;
-      cursor[offset + STYLE_TYPE] = (int) (value.get().dataType);
-      cursor[offset + STYLE_DATA] = (int) (value.get().data);
+      cursor[offset + STYLE_TYPE] = value.get().dataType;
+      cursor[offset + STYLE_DATA] = value.get().data;
       cursor[offset + STYLE_ASSET_COOKIE] = ApkAssetsCookieToJavaCookie(cookie);
-      cursor[offset + STYLE_RESOURCE_ID] = (int) (ref.get());
-      cursor[offset + STYLE_CHANGING_CONFIGURATIONS] = (int) (flags.get());
-      cursor[offset + STYLE_DENSITY] = (int) (selected_config.get().density);
+      cursor[offset + STYLE_RESOURCE_ID] = ref.get();
+      cursor[offset + STYLE_CHANGING_CONFIGURATIONS] = flags.get();
+      cursor[offset + STYLE_DENSITY] = selected_config.get().density;
       // cursor += STYLE_NUM_ENTRIES;
     }
     // env.ReleasePrimitiveArrayCritical(out_data, buffer, 0);
-    return (int) (bag.entry_count);
+    return bag.entry_count;
   }
 
   // static jint NativeGetResourceIdentifier(JNIEnv* env, jclass /*clazz*/, jlong ptr, jstring name,
@@ -1178,7 +1178,7 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
       package_ = package_utf8;
     }
     CppAssetManager2 assetmanager = AssetManagerFromLong(ptr);
-    return (int) (assetmanager.GetResourceId(name_utf8, type, package_));
+    return assetmanager.GetResourceId(name_utf8, type, package_);
   }
 
   // static jstring NativeGetResourceName(JNIEnv* env, jclass /*clazz*/, jlong ptr, jint resid) {
@@ -1404,8 +1404,8 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
     ApplyStyle(
         theme,
         xml_parser,
-        (int) (def_style_attr),
-        (int) (def_style_resid),
+        def_style_attr,
+        def_style_resid,
         attrs,
         attrs_len,
         out_values,
@@ -1487,8 +1487,8 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
     boolean result =
         ResolveAttrs(
             theme,
-            (int) (def_style_attr),
-            (int) (def_style_resid),
+            def_style_attr,
+            def_style_resid,
             values,
             values_len,
             attrs,
@@ -1691,7 +1691,7 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
   @Implementation(minSdk = P)
   protected static @NativeConfig int nativeThemeGetChangingConfigurations(long theme_ptr) {
     Theme theme = Registries.NATIVE_THEME9_REGISTRY.getNativeObject(theme_ptr);
-    return (int) (theme.GetChangingConfigurations());
+    return theme.GetChangingConfigurations();
   }
 
   // static void NativeAssetDestroy(JNIEnv* /*env*/, jclass /*clazz*/, jlong asset_ptr) {
@@ -1739,7 +1739,7 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
     if (res < 0) {
       throw new IOException();
     }
-    return res > 0 ? (int) (res) : -1;
+    return res > 0 ? res : -1;
   }
 
   // static jlong NativeAssetSeek(JNIEnv* env, jclass /*clazz*/, jlong asset_ptr, jlong offset,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
@@ -391,14 +391,14 @@ public class ShadowBluetoothAdapter {
   @Implementation(maxSdk = Q)
   protected boolean setScanMode(int scanMode, int discoverableTimeout) {
     setDiscoverableTimeout(discoverableTimeout);
-    return (boolean) setScanMode(scanMode);
+    return setScanMode(scanMode);
   }
 
   @Implementation(minSdk = R, maxSdk = S_V2)
   protected boolean setScanMode(int scanMode, long durationMillis) {
     int durationSeconds = Math.toIntExact(durationMillis / 1000);
     setDiscoverableTimeout(durationSeconds);
-    return (boolean) setScanMode(scanMode);
+    return setScanMode(scanMode);
   }
 
   @Implementation

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCompanionDeviceManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCompanionDeviceManager.java
@@ -283,7 +283,7 @@ public class ShadowCompanionDeviceManager {
         revoked,
         info.getTimeApprovedMs(),
         // return value of getLastTimeConnectedMs changed from a long to a Long
-        (long) ReflectionHelpers.callInstanceMethod(info, "getLastTimeConnectedMs"),
+        ReflectionHelpers.callInstanceMethod(info, "getLastTimeConnectedMs"),
         systemDataSyncFlags);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextHubManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextHubManager.java
@@ -175,8 +175,8 @@ public class ShadowContextHubManager {
     ContextHubClient client =
         reflector(ContextHubClientReflector.class)
             .newContextHubClient((ContextHubInfo) contextHubInfo, false);
-    if (context != null && ((Context) context).getAttributionTag() != null) {
-      attributionTagToClientMap.put(((Context) context).getAttributionTag(), client);
+    if (context != null && context.getAttributionTag() != null) {
+      attributionTagToClientMap.put(context.getAttributionTag(), client);
     }
 
     if (callback != null) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManagerGlobal.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManagerGlobal.java
@@ -365,7 +365,7 @@ public class ShadowDisplayManagerGlobal {
       int userId,
       String packageName) {
     BrightnessConfiguration config = (BrightnessConfiguration) configObject;
-    brightnessConfiguration.put((int) userId, config);
+    brightnessConfiguration.put(userId, config);
   }
 
   @Implementation(minSdk = P)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyMessageQueue.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyMessageQueue.java
@@ -155,7 +155,7 @@ public class ShadowLegacyMessageQueue extends ShadowMessageQueue {
   }
 
   private static ShadowLegacyMessage shadowOf(Message actual) {
-    return (ShadowLegacyMessage) Shadow.extract(actual);
+    return Shadow.extract(actual);
   }
 
   /** Reflector interface for {@link MessageQueue}'s internals. */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaCodec.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaCodec.java
@@ -463,7 +463,7 @@ public class ShadowMediaCodec {
   protected void validateOutputByteBuffer(
       @Nullable ByteBuffer[] buffers, int index, @Nonnull BufferInfo info) {
     if (buffers != null && index >= 0 && index < buffers.length) {
-      Buffer buffer = (Buffer) buffers[index];
+      Buffer buffer = buffers[index];
       if (buffer != null) {
         buffer.limit(info.offset + info.size).position(info.offset);
       }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMemoryMappedFile.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMemoryMappedFile.java
@@ -29,8 +29,7 @@ public class ShadowMemoryMappedFile {
     if (path.endsWith(TZ_DATA_1) || path.endsWith(TZ_DATA_2) || path.endsWith(TZ_DATA_3)) {
       InputStream is = MemoryMappedFile.class.getResourceAsStream(TZ_DATA_2);
       if (is == null) {
-        throw (Throwable)
-            ErrnoException.class.getConstructor(String.class, int.class).newInstance("open", -1);
+        throw ErrnoException.class.getConstructor(String.class, int.class).newInstance("open", -1);
       }
       try {
         MemoryMappedFile memoryMappedFile = new MemoryMappedFile(0L, 0L);
@@ -38,10 +37,9 @@ public class ShadowMemoryMappedFile {
         shadowMemoryMappedFile.bytes = Streams.readFully(is);
         return memoryMappedFile;
       } catch (IOException e) {
-        throw (Throwable)
-            ErrnoException.class
-                .getConstructor(String.class, int.class, Throwable.class)
-                .newInstance("mmap", -1, e);
+        throw ErrnoException.class
+            .getConstructor(String.class, int.class, Throwable.class)
+            .newInstance("mmap", -1, e);
       }
     } else {
       throw new IllegalArgumentException("Unknown file for mmap: '" + path);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeThreadedRenderer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeThreadedRenderer.java
@@ -196,7 +196,7 @@ public class ShadowNativeThreadedRenderer {
       surface.unlockCanvasAndPost(canvas);
       Image nativeImage = imageReader.acquireNextImage();
       Plane[] planes = nativeImage.getPlanes();
-      Bitmap destBitmap = Bitmap.createBitmap((int) width, (int) height, Config.ARGB_8888);
+      Bitmap destBitmap = Bitmap.createBitmap(width, height, Config.ARGB_8888);
       destBitmap.copyPixelsFromBuffer(planes[0].getBuffer());
       surface.release();
       // Return an immutable copy of the Bitmap, which is what this API expects.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
@@ -92,7 +92,7 @@ public class ShadowNotification {
       return realNotification.extras.getParcelable(Notification.EXTRA_PICTURE);
     } else {
       ImageView imageView =
-          (ImageView) applyBigContentView().findViewById(getInternalResourceId("big_picture"));
+          applyBigContentView().findViewById(getInternalResourceId("big_picture"));
       return imageView != null && imageView.getDrawable() != null
           ? ((BitmapDrawable) imageView.getDrawable()).getBitmap()
           : null;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -199,20 +199,19 @@ public class ShadowNotificationManager {
     if (deletedNotificationChannels.containsKey(id)) {
       notificationChannels.put(id, deletedNotificationChannels.remove(id));
     }
-    NotificationChannel existingChannel = (NotificationChannel) notificationChannels.get(id);
+    NotificationChannel existingChannel = notificationChannels.get(id);
     // Per documentation, recreating a channel can change name and description, lower importance or
     // set a group if no group set. Other settings remain unchanged. See
     // https://developer.android.com/reference/android/app/NotificationManager#createNotificationChannel%28android.app.NotificationChannel@29
     // for more info.
     if (existingChannel != null) {
-      NotificationChannel newChannel = (NotificationChannel) channel;
-      existingChannel.setName(newChannel.getName());
-      existingChannel.setDescription(newChannel.getDescription());
-      if (newChannel.getImportance() < existingChannel.getImportance()) {
-        existingChannel.setImportance(newChannel.getImportance());
+      existingChannel.setName(channel.getName());
+      existingChannel.setDescription(channel.getDescription());
+      if (channel.getImportance() < existingChannel.getImportance()) {
+        existingChannel.setImportance(channel.getImportance());
       }
       if (Strings.isNullOrEmpty(existingChannel.getGroup())) {
-        existingChannel.setGroup(newChannel.getGroup());
+        existingChannel.setGroup(channel.getGroup());
       }
       return;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcel.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcel.java
@@ -1140,7 +1140,7 @@ public class ShadowParcel {
     // Java version of FileDescriptor instead of the Android version.
     int fd = ReflectionHelpers.getField(val, "fd");
     NATIVE_BYTE_BUFFER_REGISTRY.getNativeObject(nativePtr).writeInt(fd);
-    return (long) nativeDataPosition(nativePtr);
+    return nativeDataPosition(nativePtr);
   }
 
   @Implementation(minSdk = M)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
@@ -24,7 +24,6 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.os.Bundle;
 import android.os.Handler;
-import android.os.IBinder;
 import android.os.Parcel;
 import android.os.Parcelable.Creator;
 import java.util.ArrayList;
@@ -243,13 +242,7 @@ public class ShadowPendingIntent {
     if (isActivity()) {
       for (Intent intentToSend : intentsToSend) {
         shadowInstrumentation.execStartActivity(
-            context,
-            (IBinder) null,
-            (IBinder) null,
-            (Activity) null,
-            intentToSend,
-            requestCode,
-            options);
+            context, null, null, (Activity) null, intentToSend, requestCode, options);
       }
     } else if (isBroadcast()) {
       for (Intent intentToSend : intentsToSend) {
@@ -503,7 +496,7 @@ public class ShadowPendingIntent {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || realPendingIntent.getClass() != o.getClass()) return false;
-    ShadowPendingIntent that = Shadow.extract((PendingIntent) o);
+    ShadowPendingIntent that = Shadow.extract(o);
 
     String packageName = savedContext == null ? null : savedContext.getPackageName();
     String thatPackageName = that.savedContext == null ? null : that.savedContext.getPackageName();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSpeechRecognizer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSpeechRecognizer.java
@@ -194,7 +194,7 @@ public class ShadowSpeechRecognizer {
     Preconditions.checkArgument(supportListener instanceof RecognitionSupportCallback);
 
     ShadowSpeechRecognizerState shadowState = getState();
-    shadowState.recognitionSupportExecutor = (Executor) executor;
+    shadowState.recognitionSupportExecutor = executor;
     shadowState.recognitionSupportCallback = supportListener;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStaticLayout.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStaticLayout.java
@@ -76,7 +76,7 @@ public class ShadowStaticLayout {
       float[] recycleDescents,
       int[] recycleFlags,
       float[] charWidths) {
-    reflector(LineBreaksReflector.class, recycle).setBreaks(new int[] {((char[]) text).length});
+    reflector(LineBreaksReflector.class, recycle).setBreaks(new int[] {text.length});
     return 1;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTabHost.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTabHost.java
@@ -107,7 +107,7 @@ public class ShadowTabHost extends ShadowViewGroup {
   protected TabWidget getTabWidget() {
     Context context = realView.getContext();
     if (context instanceof Activity) {
-      return (TabWidget) ((Activity) context).findViewById(R.id.tabs);
+      return ((Activity) context).findViewById(R.id.tabs);
     } else {
       return null;
     }


### PR DESCRIPTION
This commit removes unnecessary casts in the `:shadows:framework` module.