### PR TITLE
Fix task name in `ShadowAlwaysOnHotwordDetector`

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAlwaysOnHotwordDetector.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAlwaysOnHotwordDetector.java
@@ -161,15 +161,8 @@ public class ShadowAlwaysOnHotwordDetector {
     }
   }
 
-  /** Shadow for AsyncTask kicked off in the constructor of AlwaysOnHotwordDetector. */
-  @Implements(
-      className = "android.service.voice.AlwaysOnHotwordDetector$RefreshAvailabiltyTask",
-      maxSdk = TIRAMISU,
-      isInAndroidSdk = false)
-  @SuppressWarnings("robolectric.mismatchedTypes")
-  public static class ShadowRefreshAvailabilityTask<Params, Progress, Result>
+  private abstract static class BaseShadowRefreshAvailabilityTask<Params, Progress, Result>
       extends ShadowPausedAsyncTask<Params, Progress, Result> {
-
     @Implementation
     protected int internalGetInitialAvailability() {
       return STATE_KEYPHRASE_ENROLLED;
@@ -185,6 +178,24 @@ public class ShadowAlwaysOnHotwordDetector {
       // No-op, we already set this field in #setEnrollmentFields()
     }
   }
+
+  /** Shadow for AsyncTask kicked off in the constructor of AlwaysOnHotwordDetector. */
+  @Implements(
+      className = "android.service.voice.AlwaysOnHotwordDetector$RefreshAvailabiltyTask",
+      maxSdk = TIRAMISU,
+      isInAndroidSdk = false)
+  @SuppressWarnings("robolectric.mismatchedTypes")
+  public static class ShadowRefreshAvailabilityTaskPreU<Params, Progress, Result>
+      extends BaseShadowRefreshAvailabilityTask<Params, Progress, Result> {}
+
+  /** Shadow for AsyncTask kicked off in the constructor of AlwaysOnHotwordDetector. */
+  @Implements(
+      className = "android.service.voice.AlwaysOnHotwordDetector$RefreshAvailabilityTask",
+      minSdk = UPSIDE_DOWN_CAKE,
+      isInAndroidSdk = false)
+  @SuppressWarnings("robolectric.mismatchedTypes")
+  public static class ShadowRefreshAvailabilityTask<Params, Progress, Result>
+      extends BaseShadowRefreshAvailabilityTask<Params, Progress, Result> {}
 
   /** Invokes the normally hidden EventPayload constructor for passing to Callback#onDetected(). */
   public static EventPayload createEventPayload(


### PR DESCRIPTION
There is a typo in the class name of the task used internally: `RefreshAvailabiltyTask` -> `RefreshAvailabilityTask`.

https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/service/voice/AlwaysOnHotwordDetector.java;l=1837