### PR TITLE
Remove redundant variable initialization in `:shadows:framework`

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
@@ -203,7 +203,7 @@ public class ShadowAccessibilityManager {
 
   public void setTouchExplorationEnabled(boolean touchExplorationEnabled) {
     this.touchExplorationEnabled = touchExplorationEnabled;
-    List<TouchExplorationStateChangeListener> listeners = new ArrayList<>();
+    List<TouchExplorationStateChangeListener> listeners;
     if (getApiLevel() >= O) {
       listeners =
           new ArrayList<>(

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
@@ -223,8 +223,6 @@ public class ShadowActivityThread {
           configController,
           "setCompatConfiguration",
           from(Configuration.class, androidConfiguration));
-      androidConfiguration =
-          ReflectionHelpers.callInstanceMethod(configController, "getCompatConfiguration");
       ReflectionHelpers.setField(realActivityThread, "mConfigurationController", configController);
     } else {
       reflector(_ActivityThread_.class, realActivityThread)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppOpsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppOpsManager.java
@@ -228,7 +228,7 @@ public class ShadowAppOpsManager {
   @SystemApi
   @Nonnull
   protected List<PackageOps> getPackagesForOps(@Nullable String[] ops) {
-    List<PackageOps> result = null;
+    List<PackageOps> result;
 
     if (ops == null) {
       int[] intOps = null;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -161,7 +161,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   private List<PackageInfo> getInstalledPackages(long flags) {
     List<PackageInfo> result = new ArrayList<>();
     synchronized (lock) {
-      Set<String> packageNames = null;
+      Set<String> packageNames;
       if ((flags & MATCH_UNINSTALLED_PACKAGES) == 0) {
         packageNames = packageInfos.keySet();
       } else {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager.java
@@ -1141,7 +1141,7 @@ public class ShadowArscAssetManager extends ShadowAssetManager.ArscBase {
     int strLen = 0;
     for (int i = 0; i < N; i++) {
       valueRef.set(bag[i].map.value);
-      String str = null;
+      String str;
 
       // Take care of resolving the found resource to its final value.
       int block = res.resolveReference(valueRef, bag[i].stringBlock, null);
@@ -1206,11 +1206,10 @@ public class ShadowArscAssetManager extends ShadowAssetManager.ArscBase {
     bag_entry[] bag = startOfBag.get();
     for (int i = 0, j = 0; i < N; i++) {
       int stringIndex = -1;
-      int stringBlock = 0;
       value.set(bag[i].map.value);
 
       // Take care of resolving the found resource to its final value.
-      stringBlock = res.resolveReference(value, bag[i].stringBlock, null);
+      int stringBlock = res.resolveReference(value, bag[i].stringBlock, null);
       if (value.get().dataType == DataType.STRING.code()) {
         stringIndex = value.get().data;
       }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager10.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager10.java
@@ -985,7 +985,7 @@ public class ShadowArscAssetManager10 extends ShadowAssetManager.ArscBase {
         CppApkAssets apk_assets = assetmanager.GetApkAssets().get(cookie.intValue());
         ResStringPool pool = apk_assets.GetLoadedArsc().GetStringPool();
 
-        String java_string = null;
+        String java_string;
         String str_utf8 = pool.stringAt(value.get().data);
         if (str_utf8 != null) {
           java_string = str_utf8;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager9.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager9.java
@@ -969,7 +969,7 @@ public class ShadowArscAssetManager9 extends ShadowAssetManager.ArscBase {
         CppApkAssets apk_assets = assetmanager.GetApkAssets().get(cookie.intValue());
         ResStringPool pool = apk_assets.GetLoadedArsc().GetStringPool();
 
-        String java_string = null;
+        String java_string;
         int str_len;
         String str_utf8 = pool.stringAt(value.get().data);
         if (str_utf8 != null) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyMatrix.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyMatrix.java
@@ -571,9 +571,7 @@ public class ShadowLegacyMatrix extends ShadowMatrix {
                 mValues[2] = mValues[3] = mValues[4] = mValues[5] = mValues[6] = mValues[7] = 0;
         mValues[8] = 1;
       } else {
-        float tx = dst.width() / src.width();
         float sx = dst.width() / src.width();
-        float ty = dst.height() / src.height();
         float sy = dst.height() / src.height();
         boolean xLarger = false;
 
@@ -586,8 +584,8 @@ public class ShadowLegacyMatrix extends ShadowMatrix {
           }
         }
 
-        tx = dst.left - src.left * sx;
-        ty = dst.top - src.top * sy;
+        float tx = dst.left - src.left * sx;
+        float ty = dst.top - src.top * sy;
         if (stf == ScaleToFit.CENTER || stf == ScaleToFit.END) {
           float diff;
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocaleData.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocaleData.java
@@ -23,9 +23,6 @@ public class ShadowLocaleData {
   @Implementation
   public static LocaleData get(Locale locale) {
     LocaleData localeData = (LocaleData) Shadow.newInstanceOf(REAL_CLASS_NAME);
-    if (locale == null) {
-      locale = Locale.getDefault();
-    }
     setEnUsLocaleData(localeData);
     return localeData;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
@@ -933,7 +933,6 @@ public class ShadowPackageManager {
       for (ComponentInfo componentInfo : componentInfos) {
         if (componentInfo.name == null) {
           componentInfo.name = appInfo.packageName + ".DefaultName" + uniqueNameCounter++;
-          componentInfo.packageName = packageInfo.packageName;
         }
         componentInfo.applicationInfo = appInfo;
         componentInfo.packageName = appInfo.packageName;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPathParser.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPathParser.java
@@ -95,7 +95,7 @@ public class ShadowPathParser {
       float[] results = new float[s.length()];
       int count = 0;
       int startPosition = 1;
-      int endPosition = 0;
+      int endPosition;
 
       ExtractFloatResult result = new ExtractFloatResult();
       int totalLength = s.length();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiScanner.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiScanner.java
@@ -56,7 +56,7 @@ public class ShadowWifiScanner {
     Map<WifiScanner.ActionListener, IWifiScannerListener.Stub> listenerMap =
         reflector(WifiScannerReflector.class, realWifiScanner).getListenerMap();
 
-    List<IWifiScannerListener.Stub> listeners = null;
+    List<IWifiScannerListener.Stub> listeners;
     synchronized (listenerMapLock) {
       listeners = new ArrayList<>(listenerMap.values());
     }
@@ -73,7 +73,7 @@ public class ShadowWifiScanner {
   private void notifyScanListeners() {
     Object listenerMapLock =
         reflector(WifiScannerReflector.class, realWifiScanner).getListenerMapLock();
-    SparseArray<Object> listenerMap = null;
+    SparseArray<Object> listenerMap;
     SparseArray<Executor> executorMap = null;
 
     synchronized (listenerMapLock) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/WifiScannerDelegate.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/WifiScannerDelegate.java
@@ -24,7 +24,7 @@ class WifiScannerDelegate {
     Bundle bundle = new Bundle();
 
     // Mock available WiFi channels. See https://en.wikipedia.org/wiki/List_of_WLAN_channels
-    List<Integer> availableChannels = new ArrayList<>();
+    List<Integer> availableChannels;
 
     switch (band) {
       case WifiScanner.WIFI_BAND_24_GHZ:


### PR DESCRIPTION
This commit removed redundant variable initialization in the `:shadows:framework` module.