### PR TITLE
Fix broken references in Javadoc in `:shadows:framework`

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/android/XmlResourceParserImpl.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/XmlResourceParserImpl.java
@@ -21,6 +21,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
+import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 /**
@@ -529,9 +530,9 @@ public class XmlResourceParserImpl implements XmlResourceParser {
    * parent.
    *
    * @param node the node which was just explored.
-   * @return {@link XmlPullParserException#START_TAG} if the given node has siblings, {@link
-   *     XmlPullParserException#END_TAG} if the node has no unexplored siblings or {@link
-   *     XmlPullParserException#END_DOCUMENT} if the explored was the root document.
+   * @return {@link XmlPullParser#START_TAG} if the given node has siblings, {@link
+   *     XmlPullParser#END_TAG} if the node has no unexplored siblings or {@link
+   *     XmlPullParser#END_DOCUMENT} if the explored was the root document.
    * @throws XmlPullParserException if the parser fails to parse the next node.
    */
   int navigateToNextNode(Node node) throws XmlPullParserException {

--- a/shadows/framework/src/main/java/org/robolectric/android/util/concurrent/PausedExecutorService.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/util/concurrent/PausedExecutorService.java
@@ -21,7 +21,7 @@ import org.robolectric.util.Logger;
 /**
  * Executor service that queues any posted tasks.
  *
- * <p>Users must explicitly call {@link runAll()} to execute all pending tasks.
+ * <p>Users must explicitly call {@link #runAll()} to execute all pending tasks.
  *
  * <p>Intended to be a replacement for {@link RoboExecutorService} when using {@link
  * LooperMode.Mode#PAUSED}. Unlike {@link RoboExecutorService}, will execute tasks on a background

--- a/shadows/framework/src/main/java/org/robolectric/android/util/concurrent/RoboExecutorService.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/util/concurrent/RoboExecutorService.java
@@ -1,5 +1,6 @@
 package org.robolectric.android.util.concurrent;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -11,16 +12,16 @@ import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.util.Scheduler;
 
 /**
  * Executor service that runs all operations on the background scheduler.
  *
- * @deprecated only works when used in conjunction with the deprecated {@link LooperMode.LEGACY}
- *     mode. Consider using guava's {@link MoreExecutors#directExecutor()} or {@link
- *     org.robolectric.android.util.concurrent.PausedExecutorService} or {@link
- *     org.robolectric.android.util.concurrent.InlineExecutorService}.
+ * @deprecated only works when used in conjunction with the deprecated {@link
+ *     LooperMode.Mode#LEGACY} mode. Consider using guava's {@link MoreExecutors#directExecutor()}
+ *     or {@link PausedExecutorService} or {@link InlineExecutorService}.
  */
 @Deprecated
 public class RoboExecutorService implements ExecutorService {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/LauncherAppsDelegate.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/LauncherAppsDelegate.java
@@ -1,5 +1,6 @@
 package org.robolectric.shadows;
 
+import android.content.pm.ILauncherApps;
 import android.os.UserHandle;
 import android.os.UserManager;
 import java.util.List;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/MediaCodecInfoBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/MediaCodecInfoBuilder.java
@@ -190,15 +190,14 @@ public class MediaCodecInfoBuilder {
      * Sets media format.
      *
      * @param mediaFormat a {@link MediaFormat} supported by the codec. It is a requirement for
-     *     mediaFormat to have {@link MediaFormat.KEY_MIME} set. Other keys are optional. Setting
-     *     {@link MediaFormat.KEY_WIDTH}, {@link MediaFormat.KEY_MAX_WIDTH} and {@link
-     *     MediaFormat.KEY_HEIGHT}, {@link MediaFormat.KEY_MAX_HEIGHT} will set the minimum and
+     *     mediaFormat to have {@link MediaFormat#KEY_MIME} set. Other keys are optional. Setting
+     *     {@link MediaFormat#KEY_WIDTH}, {@link MediaFormat#KEY_MAX_WIDTH} and {@link
+     *     MediaFormat#KEY_HEIGHT}, {@link MediaFormat#KEY_MAX_HEIGHT} will set the minimum and
      *     maximum width, height respectively. For backwards compatibility, setting only {@link
-     *     MediaFormat.KEY_WIDTH}, {@link MediaFormat.KEY_HEIGHT} will only set the maximum width,
+     *     MediaFormat#KEY_WIDTH}, {@link MediaFormat#KEY_HEIGHT} will only set the maximum width,
      *     height respectively.
-     * @throws {@link NullPointerException} if mediaFormat is null.
-     * @throws {@link IllegalArgumentException} if mediaFormat does not have {@link
-     *     MediaFormat.KEY_MIME}.
+     * @throws NullPointerException if mediaFormat is null.
+     * @throws IllegalArgumentException if mediaFormat does not have {@link MediaFormat#KEY_MIME}.
      */
     public CodecCapabilitiesBuilder setMediaFormat(MediaFormat mediaFormat) {
       Preconditions.checkNotNull(mediaFormat);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/NativeAndroidInput.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/NativeAndroidInput.java
@@ -332,7 +332,7 @@ public class NativeAndroidInput {
    * relation to the maximum detectable size for the device. The value is normalized to a range from
    * 0 (smallest detectable size) to 1 (largest detectable size); although it is not a linear scale.
    * This value is of limited use. To obtain calibrated size information; see {@link
-   * AMOTION_EVENT_AXIS_TOUCH_MAJOR} or {@link AMOTION_EVENT_AXIS_TOOL_MAJOR}.
+   * #AMOTION_EVENT_AXIS_TOUCH_MAJOR} or {@link #AMOTION_EVENT_AXIS_TOOL_MAJOR}.
    */
   static final int AMOTION_EVENT_AXIS_SIZE = 3;
 
@@ -400,7 +400,7 @@ public class NativeAndroidInput {
    * a stylus; the orientation indicates the direction in which the stylus is pointing in relation
    * to the vertical axis of the current orientation of the screen. The range is from -PI radians to
    * PI radians; where 0 is pointing up; -PI/2 radians is pointing left; -PI or PI radians is
-   * pointing down; and PI/2 radians is pointing right. See also {@link AMOTION_EVENT_AXIS_TILT}.
+   * pointing down; and PI/2 radians is pointing right. See also {@link #AMOTION_EVENT_AXIS_TILT}.
    */
   static final int AMOTION_EVENT_AXIS_ORIENTATION = 8;
 
@@ -568,7 +568,7 @@ public class NativeAndroidInput {
   /**
    * Axis constant: The movement of y position of a motion event.
    *
-   * <p>Same as {@link RELATIVE_X}; but for y position.
+   * <p>Same as {@link #AMOTION_EVENT_AXIS_RELATIVE_X}; but for y position.
    */
   static final int AMOTION_EVENT_AXIS_RELATIVE_Y = 28;
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ServiceStateBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ServiceStateBuilder.java
@@ -78,7 +78,7 @@ public class ServiceStateBuilder {
 
   /**
    * Use this method to control return value of {@link ServiceState#isUsingCarrierAggregation()} (up
-   * to P). On APIs > P, use {@link ServiceStateBuilder#setNetworkRegistrationInfoList()}.
+   * to P). On APIs > P, use {@link #setNetworkRegistrationInfoList(List)}.
    */
   public ServiceStateBuilder setIsUsingCarrierAggregation(boolean value) {
     assertIsAtLeast(P);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
@@ -368,8 +368,8 @@ public class ShadowAccountManager {
   /**
    * Returns a bundle that contains the account session bundle under {@link
    * AccountManager#KEY_ACCOUNT_SESSION_BUNDLE} to later be passed on to {@link
-   * AccountManager#finishSession(Bundle,Activity,AccountManagerCallback<Bundle>,Handler)}. The
-   * session bundle simply propagates the given {@code accountType} so as not to be empty and is not
+   * AccountManager#finishSession(Bundle, Activity, AccountManagerCallback, Handler)}. The session
+   * bundle simply propagates the given {@code accountType} so as not to be empty and is not
    * encrypted as it would be in the real implementation. If an activity isn't provided, resulting
    * bundle will only have a dummy {@link Intent} under {@link AccountManager#KEY_INTENT}.
    *

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -400,8 +400,8 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   }
 
   /**
-   * Constructs a new Window (a {@link com.android.internal.policy.impl.PhoneWindow}) if no window
-   * has previously been set.
+   * Constructs a new Window (a {@link com.android.internal.policy.PhoneWindow}) if no window has
+   * previously been set.
    *
    * @return the window associated with this Activity
    */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
@@ -233,9 +233,9 @@ public class ShadowActivityManager {
   }
 
   /**
-   * Sets the values to be returned by {@link #getRecentTasks()}.
+   * Sets the values to be returned by {@link #getRecentTasks(int, int)}.
    *
-   * @see #getRecentTasks()
+   * @see #getRecentTasks(int, int)
    * @param recentTasks List of recent tasks.
    */
   public void setRecentTasks(List<ActivityManager.RecentTaskInfo> recentTasks) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityThread.java
@@ -248,7 +248,7 @@ public class ShadowActivityThread {
     @Accessor("mInitialApplication")
     void setInitialApplication(Application application);
 
-    /** internal use only. Tests should use {@link ActivityThread.getApplication} */
+    /** internal use only. Tests should use {@link ActivityThread#getApplication()} */
     @Accessor("mInitialApplication")
     Application getInitialApplication();
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppWidgetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppWidgetManager.java
@@ -259,7 +259,7 @@ public class ShadowAppWidgetManager {
     }
   }
 
-  /** Returns true if {@link setSupportedToRequestPinAppWidget} is called with {@code true} */
+  /** Returns true if {@link #setRequestPinAppWidgetSupported} is called with {@code true} */
   @Implementation(minSdk = O)
   protected boolean isRequestPinAppWidgetSupported() {
     return requestPinAppWidgetSupported;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -48,7 +48,7 @@ public class ShadowApplication extends ShadowContextWrapper {
   private ListPopupWindow latestListPopupWindow;
 
   /**
-   * @deprecated Use {@code shadowOf({@link ApplicationProvider#getApplicationContext()})} instead.
+   * @deprecated Use {@code shadowOf(ApplicationProvider#getApplicationContext())} instead.
    */
   @Deprecated
   public static ShadowApplication getInstance() {
@@ -197,7 +197,8 @@ public class ShadowApplication extends ShadowContextWrapper {
   }
 
   /**
-   * @deprecated Please use {@link Context#getSystemService(Context.APPWIDGET_SERVICE)} intstead.
+   * @deprecated Please use {@link Context#getSystemService(String)} with {@link
+   *     Context#APPWIDGET_SERVICE} instead.
    */
   @Deprecated
   public AppWidgetManager getAppWidgetManager() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAsyncTaskLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAsyncTaskLoader.java
@@ -2,6 +2,7 @@ package org.robolectric.shadows;
 
 import android.content.AsyncTaskLoader;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.LooperMode;
 
 /**
  * The shadow API for {@link AsyncTaskLoader}.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioEffect.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioEffect.java
@@ -171,8 +171,8 @@ public class ShadowAudioEffect {
   /**
    * Sets the error code to override setter methods in this class.
    *
-   * <p>When the error code is set to anything other than {@link SUCCESS} setters in the AudioEffect
-   * will early-out and return that error code.
+   * <p>When the error code is set to anything other than {@link AudioEffect#SUCCESS} setters in the
+   * AudioEffect will early-out and return that error code.
    */
   public void setErrorCode(int errorCode) {
     this.errorCode = errorCode;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
@@ -225,7 +225,7 @@ public class ShadowAudioManager {
             <= (int) ReflectionHelpers.getStaticField(AudioManager.class, "RINGER_MODE_MAX");
   }
 
-  /** Note that this method can silently fail. See {@link lockMode}. */
+  /** Note that this method can silently fail. See {@link #lockMode}. */
   @Implementation
   protected void setMode(int mode) {
     if (lockMode) {
@@ -262,7 +262,7 @@ public class ShadowAudioManager {
         .dispatchAudioModeChanged(newMode);
   }
 
-  /** Sets whether subsequent calls to {@link setMode} will succeed or not. */
+  /** Sets whether subsequent calls to {@link #setMode} will succeed or not. */
   public void lockMode(boolean lockMode) {
     this.lockMode = lockMode;
   }
@@ -448,7 +448,7 @@ public class ShadowAudioManager {
 
   /**
    * Registers callback that will receive changes made to the list of active playback configurations
-   * by {@link setActivePlaybackConfigurationsFor}.
+   * by {@link #setActivePlaybackConfigurationsFor)}.
    */
   @Implementation(minSdk = O)
   protected void registerAudioPlaybackCallback(
@@ -740,7 +740,7 @@ public class ShadowAudioManager {
     return outputDevices;
   }
 
-  /** Note that this method can silently fail. See {@link lockCommunicationDevice}. */
+  /** Note that this method can silently fail. See {@link #lockCommunicationDevice}. */
   @Implementation(minSdk = S)
   protected boolean setCommunicationDevice(AudioDeviceInfo communicationDevice) {
     if (!lockCommunicationDevice) {
@@ -749,7 +749,7 @@ public class ShadowAudioManager {
     return !lockCommunicationDevice;
   }
 
-  /** Sets whether subsequent calls to {@link setCommunicationDevice} will succeed. */
+  /** Sets whether subsequent calls to {@link #setCommunicationDevice} will succeed. */
   public void lockCommunicationDevice(boolean lockCommunicationDevice) {
     this.lockCommunicationDevice = lockCommunicationDevice;
   }
@@ -905,7 +905,7 @@ public class ShadowAudioManager {
 
   /**
    * Registers callback that will receive changes made to the list of active recording
-   * configurations by {@link setActiveRecordingConfigurations}.
+   * configurations by {@link #setActiveRecordingConfigurations}.
    */
   @Implementation(minSdk = N)
   protected void registerAudioRecordingCallback(
@@ -966,8 +966,8 @@ public class ShadowAudioManager {
    * <p>Note: this implementation does NOT ensure that we have the permissions necessary to register
    * the given {@link AudioPolicy}.
    *
-   * @return {@link AudioManager.ERROR} if the given policy has already been registered, and {@link
-   *     AudioManager.SUCCESS} otherwise.
+   * @return {@link AudioManager#ERROR} if the given policy has already been registered, and {@link
+   *     AudioManager#SUCCESS} otherwise.
    */
   @HiddenApi
   @Implementation(minSdk = P)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAutofillManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAutofillManager.java
@@ -11,7 +11,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
 
-/** Robolectric implementation of {@link android.os.AutofillManager}. */
+/** Robolectric implementation of {@link AutofillManager}. */
 @Implements(value = AutofillManager.class, minSdk = O)
 public class ShadowAutofillManager {
   @Nullable private static ComponentName autofillServiceComponentName = null;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBiometricManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBiometricManager.java
@@ -97,8 +97,8 @@ public class ShadowBiometricManager {
 
   /**
    * Sets the value {@code true} to allow {@link #canAuthenticate()} return {@link
-   * BIOMETRIC_SUCCESS} If sets the value to {@code false}, result will depend on {@link
-   * BiometricManager#hasBiometrics(Context context)}
+   * BiometricManager#BIOMETRIC_SUCCESS} If sets the value to {@code false}, result will depend on
+   * {@link BiometricManager#hasBiometrics(Context)}
    *
    * @param flag to set can authenticate or not
    */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -9,6 +9,7 @@ import android.content.res.AssetManager.AssetInputStream;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.BitmapFactory.Options;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.net.Uri;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothAdapter.java
@@ -474,7 +474,7 @@ public class ShadowBluetoothAdapter {
 
   /**
    * Returns the connection state for the given Bluetooth {@code profile}, defaulting to {@link
-   * BluetoothProfile.STATE_DISCONNECTED} if the profile's connection state was never set.
+   * BluetoothProfile#STATE_DISCONNECTED} if the profile's connection state was never set.
    *
    * <p>Set a Bluetooth profile's connection state via {@link #setProfileConnectionState(int, int)}.
    */
@@ -508,14 +508,14 @@ public class ShadowBluetoothAdapter {
   }
 
   /**
-   * Sets the value for {@link isBleScanAlwaysAvailable}. If true, {@link getLeState} will always
+   * Sets the value for {@link #isBleScanAlwaysAvailable}. If true, {@link #getLeState} will always
    * return true.
    */
   public void setBleScanAlwaysAvailable(boolean alwaysAvailable) {
     isBleScanAlwaysAvailable = alwaysAvailable;
   }
 
-  /** Sets the value for {@link isMultipleAdvertisementSupported}. */
+  /** Sets the value for {@link #isMultipleAdvertisementSupported}. */
   public void setIsMultipleAdvertisementSupported(boolean supported) {
     isMultipleAdvertisementSupported = supported;
   }
@@ -553,14 +553,14 @@ public class ShadowBluetoothAdapter {
   }
 
   /**
-   * Overrides behavior of {@link getProfileProxy} if {@link ShadowBluetoothAdapter#setProfileProxy}
-   * has been previously called.
+   * Overrides behavior of {@link #getProfileProxy} if {@link
+   * ShadowBluetoothAdapter#setProfileProxy} has been previously called.
    *
-   * <p>If active (non-null) proxy has been set by {@link setProfileProxy} for the given {@code
-   * profile}, {@link getProfileProxy} will immediately call {@code onServiceConnected} of the given
-   * BluetoothProfile.ServiceListener {@code listener}.
+   * <p>If active (non-null) proxy has been set by {@link #setProfileProxy} for the given {@code
+   * profile}, {@link #getProfileProxy} will immediately call {@code onServiceConnected} of the
+   * given BluetoothProfile.ServiceListener {@code listener}.
    *
-   * @return 'true' if a proxy object has been set by {@link setProfileProxy} for the given
+   * @return 'true' if a proxy object has been set by {@link #setProfileProxy} for the given
    *     BluetoothProfile {@code profile}
    */
   @Implementation
@@ -588,7 +588,7 @@ public class ShadowBluetoothAdapter {
   }
 
   /**
-   * Overrides behavior of {@link closeProfileProxy} if {@link
+   * Overrides behavior of {@link #closeProfileProxy} if {@link
    * ShadowBluetoothAdapter#setProfileProxy} has been previously called.
    *
    * <p>If the given non-null BluetoothProfile {@code proxy} was previously set for the given {@code

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothDevice.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothDevice.java
@@ -49,7 +49,7 @@ public class ShadowBluetoothDevice {
   /**
    * Interceptor interface for {@link BluetoothGatt} objects. Tests that require configuration of
    * their ShadowBluetoothGatt's may inject an interceptor, which will be called with the newly
-   * constructed BluetoothGatt before {@link ShadowBluetoothGatt#connectGatt} returns.
+   * constructed BluetoothGatt before {@link ShadowBluetoothDevice#connectGatt} returns.
    */
   public static interface BluetoothGattConnectionInterceptor {
     public void onNewGattConnection(BluetoothGatt gatt);
@@ -502,7 +502,7 @@ public class ShadowBluetoothDevice {
   }
 
   /**
-   * Allows tests to intercept the {@link BluetoothDevice.connectGatt} method and set state on both
+   * Allows tests to intercept the {@link BluetoothDevice#connectGatt} method and set state on both
    * BluetoothDevice and BluetoothGatt objects. This is useful for e2e testing situations where the
    * fine-grained execution of Bluetooth connection logic is onerous.
    */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothGatt.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothGatt.java
@@ -177,7 +177,7 @@ public class ShadowBluetoothGatt {
 
   /**
    * Overrides {@link BluetoothGatt#requestMtu} to always fail before {@link
-   * ShadowBlueoothGatt.setGattCallback} is called, and always succeed after.
+   * ShadowBluetoothGatt#setGattCallback} is called, and always succeed after.
    */
   @Implementation(minSdk = O)
   protected boolean requestMtu(int mtu) {
@@ -225,7 +225,7 @@ public class ShadowBluetoothGatt {
   }
 
   /**
-   * Overrides {@link BluetoothGatt#getService} to return a service with given UUID.
+   * Overrides {@link BluetoothGatt#getService(UUID)} to return a service with given UUID.
    *
    * @return a service with given UUID that have been discovered through {@link
    *     ShadowBluetoothGatt#discoverServices}.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothGattServer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothGattServer.java
@@ -5,6 +5,7 @@ import static android.os.Build.VERSION_CODES.O;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCallback;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattServer;
 import android.bluetooth.BluetoothGattServerCallback;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothHeadset.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothHeadset.java
@@ -34,8 +34,8 @@ public class ShadowBluetoothHeadset {
   private boolean isVoiceRecognitionSupported = true;
 
   /**
-   * Overrides behavior of {@link getConnectedDevices}. Returns list of devices that is set up by
-   * call(s) to {@link ShadowBluetoothHeadset#addConnectedDevice} or {@link connect}. Returns an
+   * Overrides behavior of {@link #getConnectedDevices}. Returns list of devices that is set up by
+   * call(s) to {@link ShadowBluetoothHeadset#addConnectedDevice} or {@link #connect}. Returns an
    * empty list by default.
    */
   @Implementation
@@ -66,10 +66,10 @@ public class ShadowBluetoothHeadset {
   }
 
   /**
-   * Overrides behavior of {@link getConnectionState}.
+   * Overrides behavior of {@link #getConnectionState}.
    *
    * @return {@code BluetoothProfile.STATE_CONNECTED} if the given device has been previously added
-   *     by a call to {@link ShadowBluetoothHeadset#addConnectedDevice} or {@link connect}, and
+   *     by a call to {@link ShadowBluetoothHeadset#addConnectedDevice} or {@link #connect}, and
    *     {@code BluetoothProfile.STATE_DISCONNECTED} otherwise.
    */
   @Implementation
@@ -90,7 +90,7 @@ public class ShadowBluetoothHeadset {
   }
 
   /**
-   * Overrides behavior of {@link connect}. Returns {@code true} and adds {@code device} to the
+   * Overrides behavior of {@link #connect}. Returns {@code true} and adds {@code device} to the
    * shadow profile's connected device list if {@code device} is currently disconnected, and returns
    * {@code false} otherwise.
    */
@@ -104,7 +104,7 @@ public class ShadowBluetoothHeadset {
   }
 
   /**
-   * Overrides behavior of {@link disconnect}. Returns {@code true} and removes {@code device} from
+   * Overrides behavior of {@link #disconnect}. Returns {@code true} and removes {@code device} from
    * the shadow profile's connected device list if {@code device} is currently connected, and
    * returns {@code false} otherwise.
    */
@@ -118,11 +118,12 @@ public class ShadowBluetoothHeadset {
   }
 
   /**
-   * Overrides behavior of {@link startVoiceRecognition}. Returns false if 'bluetoothDevice' is null
-   * or voice recognition is already started. Users can listen to {@link
-   * ACTION_AUDIO_STATE_CHANGED}. If this function returns true, this intent will be broadcasted
-   * once with {@link BluetoothProfile.EXTRA_STATE} set to {@link STATE_AUDIO_CONNECTING} and once
-   * set to {@link STATE_AUDIO_CONNECTED}.
+   * Overrides behavior of {@link #startVoiceRecognition}. Returns false if 'bluetoothDevice' is
+   * null or voice recognition is already started. Users can listen to {@link
+   * BluetoothHeadset#ACTION_AUDIO_STATE_CHANGED}. If this function returns true, this intent will
+   * be broadcasted once with {@link BluetoothProfile#EXTRA_STATE} set to {@link
+   * BluetoothHeadset#STATE_AUDIO_CONNECTING} and once set to {@link
+   * BluetoothHeadset#STATE_AUDIO_CONNECTED}.
    */
   @Implementation
   protected boolean startVoiceRecognition(BluetoothDevice bluetoothDevice) {
@@ -141,10 +142,10 @@ public class ShadowBluetoothHeadset {
   }
 
   /**
-   * Overrides the behavior of {@link stopVoiceRecognition}. Returns false if voice recognition was
+   * Overrides the behavior of {@link #stopVoiceRecognition}. Returns false if voice recognition was
    * not started or voice recognition has already ended on this headset. If this function returns
-   * true, {@link ACTION_AUDIO_STATE_CHANGED} intent is broadcasted with {@link
-   * BluetoothProfile.EXTRA_STATE} set to {@link STATE_DISCONNECTED}.
+   * true, {@link BluetoothHeadset#ACTION_AUDIO_STATE_CHANGED} intent is broadcasted with {@link
+   * BluetoothProfile#EXTRA_STATE} set to {@link BluetoothHeadset#STATE_DISCONNECTED}.
    */
   @Implementation
   protected boolean stopVoiceRecognition(BluetoothDevice bluetoothDevice) {
@@ -162,10 +163,10 @@ public class ShadowBluetoothHeadset {
   }
 
   /**
-   * Overrides behavior of {@link sendVendorSpecificResultCode}.
+   * Overrides behavior of {@link #sendVendorSpecificResultCode}.
    *
    * @return 'true' only if the given device has been previously added by a call to {@link
-   *     ShadowBluetoothHeadset#addConnectedDevice} or {@link connect}, and {@link
+   *     ShadowBluetoothHeadset#addConnectedDevice} or {@link #connect}, and {@link
    *     ShadowBluetoothHeadset#setAllowsSendVendorSpecificResultCode} has not been called with
    *     'false' argument.
    * @throws IllegalArgumentException if 'command' argument is null, per Android API

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothManager.java
@@ -133,7 +133,7 @@ public class ShadowBluetoothManager {
   }
 
   /**
-   * Overrides behavior of {@link openGattServer} and returns {@link ShadowBluetoothGattServer}
+   * Overrides behavior of {@link #openGattServer} and returns {@link ShadowBluetoothGattServer}
    * after creating and using a nullProxy for {@link IBluetoothGatt}.
    */
   @Implementation(minSdk = S)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCarrierConfigManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCarrierConfigManager.java
@@ -100,7 +100,7 @@ public class ShadowCarrierConfigManager {
 
   /**
    * Sets that the {@code config} PersistableBundle for a particular {@code subId}; controls the
-   * return value of {@link CarrierConfigManager#getConfigForSubId()}.
+   * return value of {@link CarrierConfigManager#getConfigForSubId(int, String...)}.
    */
   public void setConfigForSubId(int subId, PersistableBundle config) {
     bundles.put(subId, config);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowChoreographer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowChoreographer.java
@@ -112,10 +112,11 @@ public abstract class ShadowChoreographer {
   }
 
   /**
-   * Allows application to specify a fixed amount of delay when {@link #postCallback(int, Runnable,
-   * Object)} is invoked. The default delay value is 0. This can be used to avoid infinite animation
-   * tasks to be spawned when the Robolectric {@link org.robolectric.util.Scheduler} is in {@link
-   * org.robolectric.util.Scheduler.IdleState#PAUSED} mode.
+   * Allows application to specify a fixed amount of delay when {@link
+   * Choreographer#postCallback(int, Runnable, Object)} is invoked. The default delay value is 0.
+   * This can be used to avoid infinite animation tasks to be spawned when the Robolectric {@link
+   * org.robolectric.util.Scheduler} is in {@link org.robolectric.util.Scheduler.IdleState#PAUSED}
+   * mode.
    *
    * <p>Only supported in {@link LooperMode.Mode#LEGACY}
    *
@@ -129,8 +130,8 @@ public abstract class ShadowChoreographer {
 
   /**
    * Allows application to specify a fixed amount of delay when {@link
-   * #postFrameCallback(FrameCallback)} is invoked. The default delay value is 0. This can be used
-   * to avoid infinite animation tasks to be spawned when in LooperMode PAUSED or {@link
+   * Choreographer#postFrameCallback(FrameCallback)} is invoked. The default delay value is 0. This
+   * can be used to avoid infinite animation tasks to be spawned when in LooperMode PAUSED or {@link
    * org.robolectric.util.Scheduler.IdleState#PAUSED} and displaying an animation.
    *
    * @deprecated Use the {@link Mode#PAUSED} looper and {@link #setPaused(boolean)} and {@link

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowColorDisplayManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowColorDisplayManager.java
@@ -16,7 +16,7 @@ import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
 import org.robolectric.util.reflector.WithType;
 
-/** Shadow for {@link ColorDisplayManager}. */
+/** Shadow for {@link android.hardware.display.ColorDisplayManager}. */
 @Implements(
     className = "android.hardware.display.ColorDisplayManager",
     isInAndroidSdk = false,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCompatibility.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCompatibility.java
@@ -15,7 +15,7 @@ import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 import org.robolectric.util.reflector.Static;
 
-/** Shadow for {@link Compatability}. */
+/** Shadow for {@link Compatibility}. */
 @Implements(value = Compatibility.class, isInAndroidSdk = false, minSdk = R)
 public class ShadowCompatibility {
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextWrapper.java
@@ -107,8 +107,8 @@ public class ShadowContextWrapper {
   }
 
   /**
-   * Returns all {@code Intent} started by {@link #startService(android.content.Intent)} without
-   * consuming them.
+   * Returns all {@code Intent} started by {@link Context#startService(Intent)} without consuming
+   * them.
    *
    * @return the list of {@code Intent}
    */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
@@ -1650,7 +1650,7 @@ public class ShadowDevicePolicyManager {
     return userProvisioningStatesMap.getOrDefault(userId, DevicePolicyManager.STATE_USER_UNMANAGED);
   }
 
-  /** Return a stub value set by {@link #setDevicePolicyState(DevicePolicyState policyState)} */
+  /** Return a stub value set by {@link #setDevicePolicyState(DevicePolicyState)} */
   @Implementation(minSdk = U.SDK_INT)
   protected @ClassName("android.app.admin.DevicePolicyState") Object getDevicePolicyState() {
     return devicePolicyState;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManagerGlobal.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayManagerGlobal.java
@@ -352,7 +352,7 @@ public class ShadowDisplayManagerGlobal {
   }
 
   /**
-   * Returns the current display saturation level; {@link android.os.Build.VERSION_CODES.P} only.
+   * Returns the current display saturation level; {@link android.os.Build.VERSION_CODES#P} only.
    */
   float getSaturationLevel() {
     return saturationLevel;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDropBoxManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDropBoxManager.java
@@ -31,7 +31,7 @@ public class ShadowDropBoxManager {
    * DropBoxManager.Entry#getText} can be used.
    *
    * @param tag can be any arbitrary string
-   * @param timestamp a unique timestamp for the entry, relative to {@link
+   * @param wallTimestamp a unique timestamp for the entry, relative to {@link
    *     System#currentTimeMillis()}
    * @param data must not be null
    */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowEnvironment.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowEnvironment.java
@@ -298,7 +298,7 @@ public class ShadowEnvironment {
   /**
    * Sets the {@link #getExternalStorageState(File)} for given directory.
    *
-   * @param externalStorageState Value to return from {@link #getExternalStorageState(File)}.
+   * @param state Value to return from {@link #getExternalStorageState(File)}.
    */
   public static void setExternalStorageState(File directory, String state) {
     storageState.put(directory.toPath(), state);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowImsMmTelManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowImsMmTelManager.java
@@ -12,6 +12,7 @@ import android.telephony.SubscriptionManager;
 import android.telephony.ims.ImsException;
 import android.telephony.ims.ImsMmTelManager;
 import android.telephony.ims.ImsMmTelManager.CapabilityCallback;
+import android.telephony.ims.ImsMmTelManager.RegistrationCallback;
 import android.telephony.ims.ImsReasonInfo;
 import android.telephony.ims.ImsRegistrationAttributes;
 import android.telephony.ims.RegistrationManager;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInCallService.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInCallService.java
@@ -19,6 +19,7 @@ import android.telecom.InCallService;
 import android.telecom.ParcelableCall;
 import android.telecom.Phone;
 import com.android.internal.os.SomeArgs;
+import com.android.internal.telecom.IInCallAdapter;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowIsoDep.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowIsoDep.java
@@ -16,8 +16,8 @@ import org.robolectric.shadow.api.Shadow;
  * but most hardware implementations will have a lower limit. If extended length apdus are not
  * supported, the theoretical max transceive length is 0x105 but, again, may be lower in practice.
  *
- * <p>Dictate the Apdu response returned in {@link transceive} via {@link #setTransceiveResponse} or
- * {@link #setNextTransceiveResponse}. The former will be returned with every call to transceive
+ * <p>Dictate the Apdu response returned in {@link #transceive} via {@link #setTransceiveResponse}
+ * or {@link #setNextTransceiveResponse}. The former will be returned with every call to transceive
  * while the later will be returned only once. If neither is set, transceive will throw an
  * IOException.
  */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTask.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTask.java
@@ -17,7 +17,7 @@ import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.reflector.ForType;
 
-/** A {@link AsyncTask} shadow for {@link LooperMode.Mode.LEGACY}. */
+/** A {@link AsyncTask} shadow for {@link LooperMode.Mode#LEGACY}. */
 @Implements(
     value = AsyncTask.class,
     shadowPicker = ShadowAsyncTask.Picker.class,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTaskLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTaskLoader.java
@@ -10,7 +10,7 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.RealObject;
 
-/** The shadow {@link AsyncTaskLoader} for {@link LooperMode.Mode.LEGACY}. */
+/** The shadow {@link AsyncTaskLoader} for {@link LooperMode.Mode#LEGACY}. */
 @Implements(
     value = AsyncTaskLoader.class,
     shadowPicker = ShadowAsyncTaskLoader.Picker.class,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyChoreographer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyChoreographer.java
@@ -14,9 +14,9 @@ import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.SoftThreadLocal;
 
 /**
- * The {@link Choreographer} shadow for {@link LooperMode.Mode.PAUSED}.
+ * The {@link Choreographer} shadow for {@link LooperMode.Mode#PAUSED}.
  *
- * <p>In {@link LooperMode.Mode.PAUSED} mode, Robolectric maintains its own concept of the current
+ * <p>In {@link LooperMode.Mode#PAUSED} mode, Robolectric maintains its own concept of the current
  * time from the Choreographer's point of view, aimed at making animations work correctly. Time
  * starts out at 0 and advances by {@code frameInterval} every time {@link
  * Choreographer#getFrameTimeNanos()} is called.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyCursorWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyCursorWindow.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
-/** Legacy shadow for {@link CursowWindow}. */
+/** Legacy shadow for {@link CursorWindow}. */
 @Implements(value = CursorWindow.class, isInAndroidSdk = false)
 public class ShadowLegacyCursorWindow extends ShadowCursorWindow {
   private static final WindowData WINDOW_DATA = new WindowData();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyLooper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyLooper.java
@@ -26,7 +26,7 @@ import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.Scheduler;
 
 /**
- * The shadow Looper implementation for {@link LooperMode.Mode.LEGACY}.
+ * The shadow Looper implementation for {@link LooperMode.Mode#LEGACY}.
  *
  * <p>Robolectric enqueues posted {@link Runnable}s to be run (on this thread) later. {@code
  * Runnable}s that are scheduled to run immediately can be triggered by calling {@link #idle()}.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyMessage.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyMessage.java
@@ -15,9 +15,9 @@ import org.robolectric.util.Scheduler;
 import org.robolectric.util.reflector.ForType;
 
 /**
- * The shadow {@link Message} for {@link LooperMode.Mode.LEGACY}.
+ * The shadow {@link Message} for {@link LooperMode.Mode#LEGACY}.
  *
- * <p>In {@link LooperMode.Mode.LEGACY}, each Message is associated with a Runnable posted to the
+ * <p>In {@link LooperMode.Mode#LEGACY}, each Message is associated with a Runnable posted to the
  * {@link Scheduler}.
  *
  * @see ShadowLooper

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyMessageQueue.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyMessageQueue.java
@@ -23,9 +23,9 @@ import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 
 /**
- * The shadow {@link MessageQueue} for {@link LooperMode.Mode.LEGACY}.
+ * The shadow {@link MessageQueue} for {@link LooperMode.Mode#LEGACY}.
  *
- * <p>In {@link LooperMode.Mode.LEGACY} Robolectric puts {@link android.os.Message}s into the
+ * <p>In {@link LooperMode.Mode#LEGACY} Robolectric puts {@link android.os.Message}s into the
  * scheduler queue instead of sending them to be handled on a separate thread. {@link
  * android.os.Message}s that are scheduled to be dispatched can be triggered by calling {@link
  * ShadowLooper#idleMainLooper}.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacySystemClock.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacySystemClock.java
@@ -9,10 +9,11 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.Resetter;
 
 /**
- * A shadow SystemClock for {@link LooperMode.Mode.LEGACY}
+ * A shadow SystemClock for {@link LooperMode.Mode#LEGACY}
  *
  * <p>In LEGACY LooperMode, Robolectric's concept of current time is base on the current time of the
  * UI Scheduler for consistency with previous implementations. This is not ideal, since both

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocaleManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocaleManager.java
@@ -59,7 +59,8 @@ public class ShadowLocaleManager {
    *
    * <p>Starting in Android U, this method just invokes the 3-arg version (below).
    *
-   * <p>Use this method in tests to substitute call for {@link LocaleManager#setApplicationLocales}.
+   * <p>Use this method in tests to substitute call for {@link
+   * LocaleManager#setApplicationLocales(LocaleList)}.
    */
   @Implementation(maxSdk = VERSION_CODES.TIRAMISU)
   protected void setApplicationLocales(String packageName, LocaleList locales) {
@@ -69,7 +70,8 @@ public class ShadowLocaleManager {
   /**
    * Stores the passed locales for the given package in-memory.
    *
-   * <p>Use this method in tests to substitute call for {@link LocaleManager#setApplicationLocales}.
+   * <p>Use this method in tests to substitute call for {@link
+   * LocaleManager#setApplicationLocales(LocaleList)}.
    */
   @Implementation(minSdk = U.SDK_INT)
   protected void setApplicationLocales(

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocationManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocationManager.java
@@ -1309,8 +1309,8 @@ public class ShadowLocationManager {
   }
 
   /**
-   * A convenience function equivalent to invoking {@link #simulateLocation(String, Location)} with
-   * the provider of the given location.
+   * A convenience function equivalent to invoking {@link #simulateLocation(Location)} with the
+   * provider of the given location.
    */
   public void simulateLocation(Location location) {
     simulateLocation(location.getProvider(), location);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLooper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLooper.java
@@ -102,7 +102,7 @@ public abstract class ShadowLooper {
    * Pauses execution of tasks posted to the ShadowLegacyLooper. This means that during tests, tasks
    * sent to the looper will not execute immediately, but will be queued in a way that is similar to
    * how a real looper works. These queued tasks must be executed explicitly by calling {@link
-   * #runToEndOftasks} or a similar method, otherwise they will not run at all before your test
+   * #runToEndOfTasks()} or a similar method, otherwise they will not run at all before your test
    * ends.
    *
    * @param looper the looper to pause
@@ -226,7 +226,7 @@ public abstract class ShadowLooper {
   /** Returns true if there are no pending tasks scheduled to be executed before current time. */
   public abstract boolean isIdle();
 
-  /** Not supported for the main Looper in {@link LooperMode.Mode.PAUSED}. */
+  /** Not supported for the main Looper in {@link LooperMode.Mode#PAUSED}. */
   public abstract void unPause();
 
   public abstract boolean isPaused();
@@ -234,11 +234,11 @@ public abstract class ShadowLooper {
   /**
    * Control the paused state of the Looper.
    *
-   * <p>Not supported for the main Looper in {@link LooperMode.Mode.PAUSED}.
+   * <p>Not supported for the main Looper in {@link LooperMode.Mode#PAUSED}.
    */
   public abstract boolean setPaused(boolean shouldPause);
 
-  /** Only supported for {@link LooperMode.Mode.LEGACY}. */
+  /** Only supported for {@link LooperMode.Mode#LEGACY}. */
   public abstract void resetScheduler();
 
   /** Causes all enqueued tasks to be discarded, and pause state to be reset */
@@ -248,7 +248,7 @@ public abstract class ShadowLooper {
    * Returns the {@link org.robolectric.util.Scheduler} that is being used to manage the enqueued
    * tasks. This scheduler is managed by the Looper's associated queue.
    *
-   * <p>Only supported for {@link LooperMode.Mode.LEGACY}.
+   * <p>Only supported for {@link LooperMode.Mode#LEGACY}.
    *
    * @return the {@link org.robolectric.util.Scheduler} that is being used to manage the enqueued
    *     tasks.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaExtractor.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaExtractor.java
@@ -38,7 +38,7 @@ import org.robolectric.shadows.util.DataSource;
  *       last call to {@link #readSampleData(ByteBuffer, int)}).
  *   <li>{@link MediaExtractor#getSampleTime()} and {@link MediaExtractor#getSampleSize()} are
  *       unimplemented.
- *   <li>{@link MediaExtractor#seekTo()} is unimplemented.
+ *   <li>{@link MediaExtractor#seekTo(long, int)} is unimplemented.
  * </ul>
  */
 @Implements(MediaExtractor.class)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessage.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessage.java
@@ -40,14 +40,14 @@ public abstract class ShadowMessage {
    *
    * @param r the {@link Runnable} instance that is scheduled to trigger this message.
    *     <p>#if ($api >= 21) * @see #recycleUnchecked() #else * @see #recycle() #end
-   *     <p>Only supported in {@link LooperMode.Mode.LEGACY}.
+   *     <p>Only supported in {@link LooperMode.Mode#LEGACY}.
    */
   public abstract void setScheduledRunnable(Runnable r);
 
   /**
    * Convenience method to provide getter access to the private field {@code Message.next}.
    *
-   * <p>Only supported in {@link LooperMode.Mode.LEGACY}
+   * <p>Only supported in {@link LooperMode.Mode#LEGACY}
    *
    * @return The next message in the current message chain.
    * @see #setNext(Message)
@@ -57,7 +57,7 @@ public abstract class ShadowMessage {
   /**
    * Convenience method to provide setter access to the private field {@code Message.next}.
    *
-   * <p>Only supported in {@link LooperMode.Mode.LEGACY}
+   * <p>Only supported in {@link LooperMode.Mode#LEGACY}
    *
    * @param next the new next message for the current message.
    * @see #getNext()

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessageQueue.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMessageQueue.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import android.os.Message;
 import android.os.MessageQueue;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.util.Scheduler;
 
 /**
@@ -25,28 +26,28 @@ public abstract class ShadowMessageQueue {
   /**
    * Return this queue's Scheduler.
    *
-   * <p>Only supported in {@link LooperMode.Mode.LEGACY}.
+   * <p>Only supported in {@link LooperMode.Mode#LEGACY}.
    */
   public abstract Scheduler getScheduler();
 
   /**
    * Set this queue's Scheduler.
    *
-   * <p>Only supported in {@link LooperMode.Mode.LEGACY}.
+   * <p>Only supported in {@link LooperMode.Mode#LEGACY}.
    */
   public abstract void setScheduler(Scheduler scheduler);
 
   /**
    * Retrieves the current Message at the top of the queue.
    *
-   * <p>Only supported in {@link LooperMode.Mode.LEGACY}.
+   * <p>Only supported in {@link LooperMode.Mode#LEGACY}.
    */
   public abstract Message getHead();
 
   /**
    * Sets the current Message at the top of the queue.
    *
-   * <p>Only supported in {@link LooperMode.Mode.LEGACY}.
+   * <p>Only supported in {@link LooperMode.Mode#LEGACY}.
    */
   public abstract void setHead(Message msg);
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeColorSpaceRgb.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeColorSpaceRgb.java
@@ -43,7 +43,7 @@ public class ShadowNativeColorSpaceRgb {
     }
   }
 
-  /** Shadow for {@link ColorSpace$Rgb$Native} that contains native functions. */
+  /** Shadow for {@link ColorSpace.Rgb.Native} that contains native functions. */
   @Implements(
       className = "android.graphics.ColorSpace$Rgb$Native",
       isInAndroidSdk = false,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeMatrix.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeMatrix.java
@@ -267,7 +267,7 @@ public class ShadowNativeMatrix extends ShadowMatrix {
     throw new UnsupportedOperationException("Legacy ShadowMatrix APIs are not supported");
   }
 
-  /** Shadow for {@link Matrix$ExtraNatives} that contains native functions. */
+  /** Shadow for {@link Matrix.ExtraNatives} that contains native functions. */
   @Implements(
       className = "android.graphics.Matrix$ExtraNatives",
       isInAndroidSdk = false,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeRecordingCanvasOP.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeRecordingCanvasOP.java
@@ -9,8 +9,8 @@ import org.robolectric.nativeruntime.BaseRecordingCanvasNatives;
 import org.robolectric.shadows.ShadowNativeRecordingCanvasOP.Picker;
 
 /**
- * Shadow for android.view.RecordingCanvas. This class was renamed to {@link BaseRecordingCanvas} in
- * Q.
+ * Shadow for android.view.RecordingCanvas. This class was renamed to {@link
+ * android.graphics.BaseRecordingCanvas} in Q.
  */
 @Implements(
     className = "android.view.RecordingCanvas",

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOverlayManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOverlayManager.java
@@ -24,12 +24,12 @@ import org.robolectric.util.reflector.ForType;
  * <p>This shadow exists because the overlays managed by the OverlayManager require set up at the
  * Android base image level. This is not something that can exist for host level unit tests.
  *
- * <p>To simulate the image configuration, unit tests must call the {@link addOverlayInfo} function
+ * <p>To simulate the image configuration, unit tests must call the {@link #addOverlayInfo} function
  * to define the available overlays.
  *
- * <p>This basic shadow only implements the {@link getOverlayInfo} and {@link setEnabled} functions,
- * enabling a basic workflow for enabling or disabling Runtime Resource Overlays (RROs). It enforces
- * the android.permissions.CHANGE_OVERLAY_PACKAGES permission.
+ * <p>This basic shadow only implements the {@link #getOverlayInfo} and {@link #setEnabled}
+ * functions, enabling a basic workflow for enabling or disabling Runtime Resource Overlays (RROs).
+ * It enforces the android.permissions.CHANGE_OVERLAY_PACKAGES permission.
  *
  * <p>It does not validate the android.permission.INTERACT_ACROSS_USERS or
  * android.INTERACT_ACROSS_USERS_FULL permissions, which are necessary when changing packages owned

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageBackwardCompatibility.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageBackwardCompatibility.java
@@ -9,8 +9,8 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /**
- * Shadow of {@link PackageBackwardCompatibility} to handle a scenario that can come up when
- * multiple Android versions end up on the classpath.
+ * Shadow of {@link android.content.pm.PackageBackwardCompatibility} to handle a scenario that can
+ * come up when multiple Android versions end up on the classpath.
  */
 @Implements(
     className = "android.content.pm.PackageBackwardCompatibility",

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcel.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowParcel.java
@@ -522,7 +522,7 @@ public class ShadowParcel {
    *
    * <ul>
    *   <li>Continuing to read past the end returns zeros/nulls.
-   *   <li>{@link setDataCapacity} never decreases buffer size.
+   *   <li>{@link Parcel#setDataCapacity} never decreases buffer size.
    *   <li>It is possible to partially or completely overwrite byte ranges in the buffer.
    *   <li>Zero bytes can be exchanged between primitive data types and empty array/string.
    * </ul>

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedAsyncTask.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedAsyncTask.java
@@ -7,6 +7,7 @@ import com.google.common.annotations.Beta;
 import java.util.concurrent.Executor;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
@@ -14,7 +15,7 @@ import org.robolectric.util.reflector.Direct;
 import org.robolectric.util.reflector.ForType;
 
 /**
- * A {@link AsyncTask} shadow for {@link LooperMode.Mode.PAUSED}
+ * A {@link AsyncTask} shadow for {@link LooperMode.Mode#PAUSED}
  *
  * <p>This is beta API, and will likely be renamed/removed in a future Robolectric release.
  */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedAsyncTaskLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedAsyncTaskLoader.java
@@ -11,9 +11,9 @@ import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
 
 /**
- * The shadow {@link AsyncTaskLoader} for {@link LooperMode.Mode.PAUSED}.
+ * The shadow {@link AsyncTaskLoader} for {@link LooperMode.Mode#PAUSED}.
  *
- * <p>In {@link LooperMode.Mode.PAUSED} mode, Robolectric just uses the real AsyncTaskLoader for
+ * <p>In {@link LooperMode.Mode#PAUSED} mode, Robolectric just uses the real AsyncTaskLoader for
  * now.
  */
 @Implements(

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedChoreographer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedChoreographer.java
@@ -28,9 +28,9 @@ import org.robolectric.versioning.AndroidVersions.T;
 import org.robolectric.versioning.AndroidVersions.U;
 
 /**
- * A {@link Choreographer} shadow for {@link LooperMode.Mode.PAUSED}.
+ * A {@link Choreographer} shadow for {@link LooperMode.Mode#PAUSED}.
  *
- * <p>This shadow is largely a no-op. In {@link LooperMode.Mode.PAUSED} mode, the shadowing is done
+ * <p>This shadow is largely a no-op. In {@link LooperMode.Mode#PAUSED} mode, the shadowing is done
  * at a lower level via {@link ShadowDisplayEventReceiver}.
  *
  * <p>This class should not be referenced directly - use {@link ShadowChoreographer} instead.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedLooper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedLooper.java
@@ -43,8 +43,7 @@ import org.robolectric.util.reflector.ForType;
 import org.robolectric.util.reflector.Static;
 
 /**
- * The shadow Looper for {@link LooperMode.Mode.PAUSED and @link
- * LooperMode.Mode.INSTRUMENTATION_TEST}.
+ * The shadow Looper for {@link LooperMode.Mode#PAUSED and {@link LooperMode.Mode#INSTRUMENTATION_TEST}.
  *
  * <p>This shadow differs from the legacy {@link ShadowLegacyLooper} in the following ways:\ - Has
  * no connection to {@link org.robolectric.util.Scheduler}. Its APIs are standalone - The main

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedMessage.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedMessage.java
@@ -10,7 +10,7 @@ import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.RealObject;
 
 /**
- * The shadow {@link Message} for {@link LooperMode.Mode.PAUSED}.
+ * The shadow {@link Message} for {@link LooperMode.Mode#PAUSED}.
  *
  * <p>This class should not be referenced directly. Use {@link ShadowMessage} instead.
  */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedMessageQueue.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedMessageQueue.java
@@ -30,7 +30,7 @@ import org.robolectric.util.reflector.ForType;
 import org.robolectric.versioning.AndroidVersions.V;
 
 /**
- * The shadow {@link} MessageQueue} for {@link LooperMode.Mode.PAUSED}
+ * The shadow {@link} MessageQueue} for {@link LooperMode.Mode#PAUSED}
  *
  * <p>This class should not be referenced directly. Use {@link ShadowMessageQueue} instead.
  */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedSystemClock.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedSystemClock.java
@@ -12,6 +12,7 @@ import javax.annotation.concurrent.GuardedBy;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.Resetter;
 
 /**
@@ -20,7 +21,7 @@ import org.robolectric.annotation.Resetter;
  * <p>In this variant, System times (both elapsed realtime and uptime) are controlled by this class.
  * The current times are fixed in place. You can manually advance both by calling {@link
  * SystemClock#setCurrentTimeMillis(long)} or just advance elapsed realtime only by calling {@link
- * deepSleep(long)}.
+ * #deepSleep(long)}.
  *
  * <p>{@link SystemClock#uptimeMillis()} and {@link SystemClock#currentThreadTimeMillis()} are
  * identical.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
@@ -190,7 +190,7 @@ public class ShadowPowerManager {
 
   /**
    * Returns how location features should behave when battery saver is on. When battery saver is
-   * off, this will always return {@link #LOCATION_MODE_NO_CHANGE}.
+   * off, this will always return {@link PowerManager#LOCATION_MODE_NO_CHANGE}.
    */
   @Implementation(minSdk = P)
   @PowerManager.LocationPowerSaveMode

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowResourcesManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowResourcesManager.java
@@ -21,7 +21,10 @@ public class ShadowResourcesManager {
     reflector(_ResourcesManager_.class).setResourcesManager(null);
   }
 
-  /** Exposes {@link ResourcesManager#applyCompatConfigurationLocked(int, Configuration)}. */
+  /**
+   * Exposes {@link ResourcesManager#applyConfigurationToResources(Configuration,
+   * CompatibilityInfo)}.
+   */
   public boolean callApplyConfigurationToResourcesLocked(
       Configuration configuration, CompatibilityInfo compatibilityInfo) {
     return reflector(_ResourcesManager_.class, realResourcesManager)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSQLiteConnection.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSQLiteConnection.java
@@ -89,7 +89,7 @@ public class ShadowSQLiteConnection {
    * order to improve SQLite performance. The Android default is <code>PERSIST</code> in SDKs <= 25
    * and <code>TRUNCATE</code> in SDKs > 25.
    *
-   * <p>Similarly to {@link setDefaultSyncMode}, if your test expects SQLite rollback journal to be
+   * <p>Similarly to {@link #setDefaultSyncMode}, if your test expects SQLite rollback journal to be
    * synced to disk, use <code>PERSIST</code> or <code>TRUNCATE</code>.
    */
   public static void setDefaultJournalMode(String value) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStatsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStatsManager.java
@@ -27,7 +27,7 @@ public class ShadowStatsManager {
     configDataMap.clear();
   }
 
-  /** Adds metrics data that the shadow should return from {@link StatsManager#getReports()}. */
+  /** Adds metrics data that the shadow should return from {@link StatsManager#getReports(long)}. */
   public static void addReportData(long configKey, byte[] data) {
     reportDataMap.put(configKey, data);
   }
@@ -42,7 +42,7 @@ public class ShadowStatsManager {
 
   /**
    * Retrieves the statsd configurations stored in the shadow as a result of {@link
-   * StatsManager#addConfig()} and {@link StatsManager#removeConfig()}.
+   * StatsManager#addConfig(long, byte[])} and {@link StatsManager#removeConfig(long)}.
    */
   public static byte[] getConfigData(long configKey) {
     return configDataMap.getOrDefault(configKey, new byte[] {});

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStorageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStorageManager.java
@@ -44,7 +44,7 @@ public class ShadowStorageManager {
   /**
    * Adds a {@link StorageVolume} to the list returned by {@link #getStorageVolumes()}.
    *
-   * @param StorageVolume to add to list
+   * @param storageVolume to add to list
    */
   public void addStorageVolume(StorageVolume storageVolume) {
     Preconditions.checkNotNull(storageVolume);
@@ -52,7 +52,7 @@ public class ShadowStorageManager {
   }
 
   /**
-   * Returns the storage volumes configured via {@link #addStorageVolume()}.
+   * Returns the storage volumes configured via {@link #addStorageVolume(StorageVolume)}.
    *
    * @return StorageVolume list
    */
@@ -70,7 +70,7 @@ public class ShadowStorageManager {
    * Checks whether File belongs to any {@link StorageVolume} in the list returned by {@link
    * #getStorageVolumes()}.
    *
-   * @param File to check
+   * @param file to check
    * @return StorageVolume for the file
    */
   @Implementation(minSdk = N)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSubscriptionManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSubscriptionManager.java
@@ -122,8 +122,8 @@ public class ShadowSubscriptionManager {
   }
 
   /**
-   * Cache of phone IDs used by {@link getPhoneId}. Managed by {@link putPhoneId} and {@link
-   * removePhoneId}.
+   * Cache of phone IDs used by {@link #getPhoneId}. Managed by {@link #putPhoneId} and {@link
+   * #removePhoneId}.
    */
   private static final Map<Integer, Integer> phoneIds = new HashMap<>();
 
@@ -147,7 +147,7 @@ public class ShadowSubscriptionManager {
 
   /**
    * List of listeners to be notified if the list of {@link SubscriptionInfo} changes. Managed by
-   * {@link #addOnSubscriptionsChangedListener} and {@link removeOnSubscriptionsChangedListener}.
+   * {@link #addOnSubscriptionsChangedListener} and {@link #removeOnSubscriptionsChangedListener}.
    */
   private final List<OnSubscriptionsChangedListener> listeners = new ArrayList<>();
 
@@ -275,7 +275,7 @@ public class ShadowSubscriptionManager {
    * SubscriptionManager#canManageSubscription(SubscriptionInfo)}. They may be active, or
    * installed-but-inactive. This is generally intended to be called by carrier apps that directly
    * manage their own eSIM profiles on the device in concert with {@link
-   * android.telephony.EuiccManager}.
+   * android.telephony.euicc.EuiccManager}.
    *
    * @param list - The subscription info list, can be null.
    */
@@ -369,7 +369,7 @@ public class ShadowSubscriptionManager {
   }
 
   /**
-   * Check if a listener exists in the {@link ShadowSubscriptionManager.listeners}.
+   * Check if a listener exists in the {@link ShadowSubscriptionManager#listeners}.
    *
    * @param listener The listener to check.
    * @return boolean True if the listener already added, otherwise false.
@@ -431,13 +431,13 @@ public class ShadowSubscriptionManager {
     return roamingSimSubscriptionIds.contains(simSubscriptionId);
   }
 
-  /** Adds a subscription ID-phone ID mapping to the map used by {@link getPhoneId}. */
+  /** Adds a subscription ID-phone ID mapping to the map used by {@link #getPhoneId}. */
   public static void putPhoneId(int subId, int phoneId) {
     phoneIds.put(subId, phoneId);
   }
 
   /**
-   * Removes a subscription ID-phone ID mapping from the map used by {@link getPhoneId}.
+   * Removes a subscription ID-phone ID mapping from the map used by {@link #getPhoneId}.
    *
    * @return the previous phone ID associated with the subscription ID, or null if there was no
    *     mapping for the subscription ID
@@ -448,15 +448,15 @@ public class ShadowSubscriptionManager {
 
   /**
    * Removes all mappings between subscription IDs and phone IDs from the map used by {@link
-   * getPhoneId}.
+   * #getPhoneId}.
    */
   public static void clearPhoneIds() {
     phoneIds.clear();
   }
 
   /**
-   * Uses the map of subscription IDs to phone IDs managed by {@link putPhoneId} and {@link
-   * removePhoneId} to return the phone ID for a given subscription ID.
+   * Uses the map of subscription IDs to phone IDs managed by {@link #putPhoneId} and {@link
+   * #removePhoneId} to return the phone ID for a given subscription ID.
    */
   @Implementation(minSdk = LOLLIPOP_MR1, maxSdk = P)
   @HiddenApi
@@ -509,7 +509,7 @@ public class ShadowSubscriptionManager {
   }
 
   /**
-   * When set to false methods requiring {@link android.Manifest.permission.READ_PHONE_STATE}
+   * When set to false methods requiring {@link android.Manifest.permission#READ_PHONE_STATE}
    * permission will throw a {@link SecurityException}. By default it's set to true for backwards
    * compatibility.
    */
@@ -524,7 +524,7 @@ public class ShadowSubscriptionManager {
   }
 
   /**
-   * When set to false methods requiring {@link android.Manifest.permission.READ_PHONE_NUMBERS}
+   * When set to false methods requiring {@link android.Manifest.permission#READ_PHONE_NUMBERS}
    * permission will throw a {@link SecurityException}. By default it's set to true for backwards
    * compatibility.
    */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSuspendDialogInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSuspendDialogInfo.java
@@ -67,8 +67,8 @@ public class ShadowSuspendDialogInfo {
   /**
    * Returns the action expected to happen on neutral button tap.
    *
-   * @return {@link SuspendDialogInfo.BUTTON_ACTION_MORE_DETAILS} or {@link
-   *     SuspendDialogInfo.BUTTON_ACTION_UNSUSPEND}
+   * @return {@link SuspendDialogInfo#BUTTON_ACTION_MORE_DETAILS} or {@link
+   *     SuspendDialogInfo#BUTTON_ACTION_UNSUSPEND}
    */
   @Implementation(minSdk = R)
   public int getNeutralButtonAction() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelecomManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelecomManager.java
@@ -812,7 +812,7 @@ public class ShadowTelecomManager {
     protected boolean isRinging = true;
 
     /**
-     * @deprecated Use {@link extras} instead.
+     * @deprecated Use {@link #extras} instead.
      */
     @Deprecated public final Bundle bundle;
 
@@ -826,7 +826,7 @@ public class ShadowTelecomManager {
   }
 
   /**
-   * When set to false methods requiring {@link android.Manifest.permission.READ_PHONE_STATE}
+   * When set to false methods requiring {@link android.Manifest.permission#READ_PHONE_STATE}
    * permission will throw a {@link SecurityException}. By default it's set to true for backwards
    * compatibility.
    */
@@ -841,7 +841,7 @@ public class ShadowTelecomManager {
   }
 
   /**
-   * When set to false methods requiring {@link android.Manifest.permission.CALL_PHONE} permission
+   * When set to false methods requiring {@link android.Manifest.permission#CALL_PHONE} permission
    * will throw a {@link SecurityException}. By default it's set to true for backwards
    * compatibility.
    */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
@@ -774,7 +774,7 @@ public class ShadowTelephonyManager {
   }
 
   /**
-   * Sets the value to be returned by calls to {@link getVoiceNetworkType}. This <b>should</b>
+   * Sets the value to be returned by calls to {@link #getVoiceNetworkType}. This <b>should</b>
    * correspond to one of the {@code NETWORK_TYPE_*} constants defined on {@link TelephonyManager},
    * but this is not enforced.
    */
@@ -833,16 +833,16 @@ public class ShadowTelephonyManager {
   }
 
   /**
-   * Sets the value to be returned by calls to {@link requestCellInfoUpdate}. Note that it does not
-   * set the value to be returned by calls to {@link getAllCellInfo}; for that, see {@link
-   * setAllCellInfo}.
+   * Sets the value to be returned by calls to {@link #requestCellInfoUpdate}. Note that it does not
+   * set the value to be returned by calls to {@link #getAllCellInfo}; for that, see {@link
+   * #setAllCellInfo}.
    */
   public void setCallbackCellInfos(List<CellInfo> callbackCellInfos) {
     ShadowTelephonyManager.callbackCellInfos = callbackCellInfos;
   }
 
   /**
-   * Sets the values to be returned by a presumed error condition in {@link requestCellInfoUpdate}.
+   * Sets the values to be returned by a presumed error condition in {@link #requestCellInfoUpdate}.
    * These values will persist until cleared: to clear, set (0, null) using this method.
    */
   public void setRequestCellInfoUpdateErrorValues(int errorCode, Throwable detail) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTrace.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTrace.java
@@ -168,7 +168,7 @@ public class ShadowTrace {
    * Do not use this method unless absolutely necessary. Prefer fixing the tests instead.
    *
    * <p>Sets whether to crash on incorrect usage (e.g., calling {@link #endSection()} before {@link
-   * beginSection(String)}. Default value - {@code true}.
+   * #beginSection(String)}. Default value - {@code true}.
    */
   public static void doNotUseSetCrashOnIncorrectUsage(boolean crashOnIncorrectUsage) {
     ShadowTrace.crashOnIncorrectUsage = crashOnIncorrectUsage;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsageStatsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsageStatsManager.java
@@ -114,7 +114,7 @@ public class ShadowUsageStatsManager {
 
   /**
    * Usage session observer registered via {@link
-   * UsageStatsManager#registerUsageSessionObserver(int, String[], long, TimeUnit, long, TimeUnit,
+   * UsageStatsManager#registerUsageSessionObserver(int, String[], Duration, Duration,
    * PendingIntent, PendingIntent)}.
    */
   @AutoValue
@@ -386,7 +386,7 @@ public class ShadowUsageStatsManager {
   /**
    * Returns the current standby bucket of the specified app that is set by {@code
    * setAppStandbyBucket}. If the standby bucket value has never been set, return {@link
-   * UsageStatsManager.STANDBY_BUCKET_ACTIVE}.
+   * UsageStatsManager#STANDBY_BUCKET_ACTIVE}.
    */
   @Implementation(minSdk = Build.VERSION_CODES.P)
   @HiddenApi
@@ -584,7 +584,7 @@ public class ShadowUsageStatsManager {
   /**
    * Returns the current app's standby bucket that is set by {@code setCurrentAppStandbyBucket}. If
    * the standby bucket value has never been set, return {@link
-   * UsageStatsManager.STANDBY_BUCKET_ACTIVE}.
+   * UsageStatsManager#STANDBY_BUCKET_ACTIVE}.
    */
   @Implementation(minSdk = Build.VERSION_CODES.P)
   @StandbyBuckets

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUserManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUserManager.java
@@ -814,7 +814,7 @@ public class ShadowUserManager {
    * Sets this process running under a restricted profile; controls the return value of {@link
    * UserManager#isRestrictedProfile()}.
    *
-   * @deprecated use {@link ShadowUserManager#addUser()} instead
+   * @deprecated use {@link ShadowUserManager#addUser(int, String, int)} instead
    */
   @Deprecated
   public void setIsRestrictedProfile(boolean isRestrictedProfile) {
@@ -1032,7 +1032,7 @@ public class ShadowUserManager {
 
   /**
    * Sets whether switching users is allowed or not; controls the return value of {@link
-   * UserManager#canSwitchUser()}
+   * UserManager#canSwitchUsers()}
    *
    * @deprecated use {@link #setUserSwitchability} instead
    */
@@ -1123,7 +1123,7 @@ public class ShadowUserManager {
 
   /**
    * Sets whether multiple users are supported; controls the return value of {@link
-   * UserManager#supportsMultipleUser}.
+   * UserManager#supportsMultipleUsers()}.
    */
   public void setSupportsMultipleUsers(boolean isMultiUserSupported) {
     userManagerState.isMultiUserSupported = isMultiUserSupported;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUwbManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUwbManager.java
@@ -62,8 +62,9 @@ public class ShadowUwbManager {
   }
 
   /**
-   * Simply returns the bundle provided by {@link ShadowUwbManager#setSpecificationInfo()}, allowing
-   * the tester to dictate available features.
+   * Simply returns the bundle provided by {@link
+   * ShadowUwbManager#setSpecificationInfo(PersistableBundle)}, allowing the tester to dictate
+   * available features.
    */
   @Implementation
   protected PersistableBundle getSpecificationInfo() {
@@ -71,7 +72,8 @@ public class ShadowUwbManager {
   }
 
   /**
-   * Returns the adapter state provided by {@link ShadowUwbManager#simulateAdapterStateChange()}.
+   * Returns the adapter state provided by {@link ShadowUwbManager#simulateAdapterStateChange(int,
+   * int)}.
    */
   @Implementation
   @AdapterState
@@ -81,7 +83,8 @@ public class ShadowUwbManager {
 
   /**
    * Instantiates a {@link ShadowRangingSession} with the adapter provided by {@link
-   * ShadowUwbManager#setUwbAdapter()}, allowing the tester dictate the results of ranging attempts.
+   * ShadowUwbManager#setUwbAdapter(ShadowRangingSession.Adapter)}, allowing the tester dictate the
+   * results of ranging attempts.
    *
    * @throws IllegalArgumentException if UWB is disabled.
    */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVibrator.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVibrator.java
@@ -4,6 +4,7 @@ import static android.os.Build.VERSION_CODES.R;
 import static android.os.Build.VERSION_CODES.S;
 
 import android.media.AudioAttributes;
+import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.os.vibrator.PrimitiveSegment;
 import android.util.SparseArray;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVisualizer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVisualizer.java
@@ -131,7 +131,7 @@ public class ShadowVisualizer {
   /**
    * Sets the error code to override setter methods in this class.
    *
-   * <p>When the error code is set to anything other than {@link Visualizer.SUCCESS} setters in the
+   * <p>When the error code is set to anything other than {@link Visualizer#SUCCESS} setters in the
    * Visualizer will early-out and return that error code.
    */
   public void setErrorCode(int errorCode) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWallpaperManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWallpaperManager.java
@@ -265,7 +265,7 @@ public class ShadowWallpaperManager {
 
   /**
    * Throws {@link SecurityException} if the caller doesn't have {@link
-   * permission.SET_WALLPAPER_COMPONENT}.
+   * permission#SET_WALLPAPER_COMPONENT}.
    */
   private static void enforceWallpaperComponentPermission() {
     // Robolectric doesn't stimulate IPC calls. When this code is executed, it will still be running

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWebView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWebView.java
@@ -227,7 +227,7 @@ public class ShadowWebView extends ShadowViewGroup {
 
   /**
    * Performs no callbacks on {@link WebViewClient} and {@link WebChromeClient} when any of {@link
-   * #loadUrl}, {@link loadData} or {@link #loadDataWithBaseURL} is called.
+   * #loadUrl}, {@link #loadData} or {@link #loadDataWithBaseURL} is called.
    */
   public void performNoPageLoadClientCallbacks() {
     this.pageLoadType = PageLoadType.UNDEFINED;
@@ -235,7 +235,7 @@ public class ShadowWebView extends ShadowViewGroup {
 
   /**
    * Performs callbacks on {@link WebViewClient} and {@link WebChromeClient} that simulates a
-   * successful page load when any of {@link #loadUrl}, {@link loadData} or {@link
+   * successful page load when any of {@link #loadUrl}, {@link #loadData} or {@link
    * #loadDataWithBaseURL} is called.
    */
   public void performSuccessfulPageLoadClientCallbacks() {
@@ -703,8 +703,8 @@ public class ShadowWebView extends ShadowViewGroup {
    * Defines a type of page load which is associated with a certain order of {@link WebViewClient}
    * and {@link WebChromeClient} callbacks.
    *
-   * <p>A page load is triggered either using {@link #loadUrl}, {@link loadData} or {@link
-   * loadDataWithBaseURL}.
+   * <p>A page load is triggered either using {@link #loadUrl}, {@link #loadData} or {@link
+   * #loadDataWithBaseURL}.
    */
   private enum PageLoadType {
     /** Default type, triggers no {@link WebViewClient} or {@link WebChromeClient} callbacks. */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
@@ -527,7 +527,7 @@ public class ShadowWifiManager {
   }
 
   /**
-   * Prevents a networkId from being updated using the {@link updateNetwork(WifiConfiguration)}
+   * Prevents a networkId from being updated using the {@link #updateNetwork(WifiConfiguration)}
    * method. This is to simulate the case where a separate application creates a network, and the
    * Android security model prevents your application from updating it.
    */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindow.java
@@ -117,16 +117,16 @@ public class ShadowWindow {
   }
 
   /**
-   * Calls {@link Window.OnFrameMetrisAvailableListener#onFrameMetricsAvailable()} on each current
-   * listener with 0 as the dropCountSinceLastInvocation.
+   * Calls {@link Window.OnFrameMetricsAvailableListener#onFrameMetricsAvailable(Window,
+   * FrameMetrics, int)} on each current listener with 0 as the dropCountSinceLastInvocation.
    */
   public void reportOnFrameMetricsAvailable(FrameMetrics frameMetrics) {
     reportOnFrameMetricsAvailable(frameMetrics, /* dropCountSinceLastInvocation= */ 0);
   }
 
   /**
-   * Calls {@link Window.OnFrameMetrisAvailableListener#onFrameMetricsAvailable()} on each current
-   * listener.
+   * Calls {@link Window.OnFrameMetricsAvailableListener#onFrameMetricsAvailable(Window,
+   * FrameMetrics, int)} on each current listener.
    *
    * @param frameMetrics the {@link FrameMetrics} instance passed to the listeners.
    * @param dropCountSinceLastInvocation the dropCountSinceLastInvocation passed to the listeners.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindowManagerGlobal.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindowManagerGlobal.java
@@ -143,7 +143,7 @@ public class ShadowWindowManagerGlobal {
    * ShadowWindowManagerGlobal#startPredictiveBackGesture}. One or more drag progress events can be
    * dispatched by calling {@link #moveBy}. The gesture must be ended by either calling {@link
    * #cancel()} or {@link #close()}, if {@link #cancel()} is called a subsequent call to {@link
-   * close()} will do nothing to allow using the gesture in a try with resources statement:
+   * #close()} will do nothing to allow using the gesture in a try with resources statement:
    *
    * <pre>
    * try (PredictiveBackGesture backGesture =

--- a/shadows/framework/src/main/java/org/robolectric/shadows/StreamConfigurationMapBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/StreamConfigurationMapBuilder.java
@@ -1,5 +1,7 @@
 package org.robolectric.shadows;
 
+import android.graphics.ImageFormat;
+import android.graphics.PixelFormat;
 import android.hardware.camera2.params.StreamConfiguration;
 import android.hardware.camera2.params.StreamConfigurationMap;
 import android.os.Build.VERSION_CODES;
@@ -61,7 +63,7 @@ public final class StreamConfigurationMapBuilder {
   /**
    * Adds an output size to be returned by {@link StreamConfigurationMap#getOutputSizes}.
    *
-   * <p>Calling this method is equivalent to calling {@link addOutputSize(int, Size)} with format
+   * <p>Calling this method is equivalent to calling {@link #addOutputSize(int, Size)} with format
    * {@link ImageFormat#PRIVATE}.
    */
   public StreamConfigurationMapBuilder addOutputSize(Size outputSize) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/UiccCardInfoBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/UiccCardInfoBuilder.java
@@ -58,7 +58,7 @@ public class UiccCardInfoBuilder {
   }
 
   /**
-   * @deprecated Use {@link setPhysicalSlotIndex} for Android T+ instead.
+   * @deprecated Use {@link #setPhysicalSlotIndex} for Android T+ instead.
    */
   @CanIgnoreReturnValue
   @Deprecated


### PR DESCRIPTION
This commit fixes broken Javadoc references in the `:shadows:framework` module:
- Add missing imports.
- Add missing arguments to methods.
- Add missing leading `#`.
- Fix typos