### PR TITLE
Update outdated `minSdk` parameters

### DIFF
--- a/integration_tests/sdkcompat/src/test/java/org/robolectric/integrationtests/sdkcompat/NormalCompatibilityTest.kt
+++ b/integration_tests/sdkcompat/src/test/java/org/robolectric/integrationtests/sdkcompat/NormalCompatibilityTest.kt
@@ -99,7 +99,7 @@ class NormalCompatibilityTest {
   }
 
   @Test
-  @Config(minSdk = 19, maxSdk = 27)
+  @Config(maxSdk = 27)
   fun `MainActivity created correctly using default constructor on api lower than 28`() {
     buildActivity(MainActivity::class.java).use { controller ->
       val activity = controller.setup().get()

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowInstrumentationTestLooperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowInstrumentationTestLooperTest.java
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.LooperMode.Mode;
 import org.robolectric.shadow.api.Shadow;
@@ -28,7 +27,6 @@ import org.robolectric.shadow.api.Shadow;
 public class ShadowInstrumentationTestLooperTest {
 
   @Test
-  @Config(minSdk = 18)
   public void testThreadIsNotMainThread() {
     assertFalse(Looper.getMainLooper().isCurrentThread());
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRemoteCallbackListTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRemoteCallbackListTest.java
@@ -10,7 +10,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowRemoteCallbackListTest {
@@ -33,7 +32,6 @@ public class ShadowRemoteCallbackListTest {
   }
 
   @Test
-  @Config(minSdk = 17)
   public void getRegisteredCallbackCount_callbackRegistered_reflectsInReturnValue() {
     fooRemoteCallbackList.register(new Foo());
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewGroupTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewGroupTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
-import org.robolectric.annotation.Config;
 import org.robolectric.annotation.GraphicsMode;
 import org.robolectric.annotation.GraphicsMode.Mode;
 
@@ -186,7 +185,6 @@ public class ShadowViewGroupTest {
   }
 
   @Test
-  @Config(minSdk = 17) // TODO: mysteriously fails on github CI on API 16
   public void hasFocus_shouldReturnTrueIfAnyChildHasFocus() {
     ContainerActivity containerActivity = Robolectric.setupActivity(ContainerActivity.class);
     makeFocusable(

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWebViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWebViewTest.java
@@ -453,7 +453,6 @@ public class ShadowWebViewTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  @Config(minSdk = 19)
   public void evaluateJavascript() {
     ValueCallback<String> callback = mock(ValueCallback.class);
     assertThat(shadowOf(webView).getLastEvaluatedJavascript()).isNull();
@@ -660,7 +659,6 @@ public class ShadowWebViewTest {
   }
 
   @Test
-  @Config(minSdk = 19)
   public void canSetWebContentsDebuggingEnabled() {
     WebView.setWebContentsDebuggingEnabled(false);
     WebView.setWebContentsDebuggingEnabled(true);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOs.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOs.java
@@ -7,7 +7,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /** A Shadow for android.system.Os */
-@Implements(value = Os.class, minSdk = 21)
+@Implements(value = Os.class)
 public final class ShadowOs {
 
   private ShadowOs() {}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOsConstants.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOsConstants.java
@@ -7,7 +7,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 /** */
-@Implements(value = OsConstants.class, minSdk = 21)
+@Implements(value = OsConstants.class)
 public final class ShadowOsConstants {
   @Implementation
   protected static void initConstants() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRemoteCallbackList.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRemoteCallbackList.java
@@ -134,7 +134,7 @@ public class ShadowRemoteCallbackList<E extends IInterface> {
     broadcastCount = -1;
   }
 
-  @Implementation(minSdk = 17)
+  @Implementation
   protected int getRegisteredCallbackCount() {
     return callbacks.size();
   }


### PR DESCRIPTION
Robolectric now supports API 21, so having `minSdk` set to a value lower than 21 is not needed.