### PR TITLE
Fix issue with DateUtils.isToday()

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDateUtilsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDateUtilsTest.java
@@ -3,7 +3,6 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
 import static android.os.Build.VERSION_CODES.M;
 import static com.google.common.truth.Truth.assertThat;
-import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 
 import android.app.Application;
 import android.os.SystemClock;
@@ -16,7 +15,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.LooperMode;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowDateUtilsTest {
@@ -62,7 +60,6 @@ public class ShadowDateUtilsTest {
   }
 
   @Test
-  @LooperMode(LEGACY)
   public void isToday_shouldReturnFalseForNotToday() {
     long today = java.util.Calendar.getInstance().getTimeInMillis();
     SystemClock.setCurrentTimeMillis(today);

--- a/sandbox/src/main/java/org/robolectric/config/AndroidConfigurer.java
+++ b/sandbox/src/main/java/org/robolectric/config/AndroidConfigurer.java
@@ -109,5 +109,8 @@ public class AndroidConfigurer {
     for (String packagePrefix : shadowProviders.getInstrumentedPackages()) {
       builder.addInstrumentedPackage(packagePrefix);
     }
+
+    // Avoid intercepting calls to System.currentTimeMillis in DateUtils.
+    builder.doNotInterceptClass("android.text.format.DateUtils");
   }
 }

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassInstrumentor.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ClassInstrumentor.java
@@ -496,7 +496,7 @@ public class ClassInstrumentor {
           if (mnode.owner.equals(mutableClass.internalClassName)
               || mnode.owner.equals(mutableClass.classNode.superName)) {
             if (!"<init>".equals(mnode.name)) {
-              throw new AssertionError("Invalid MethodInsnNode name");
+              throw new AssertionError("Expected MethodInsnNode to have name <init>");
             }
 
             // remove all instructions in the range 0 (the start) to invokespecial
@@ -655,7 +655,7 @@ public class ClassInstrumentor {
           targetMethod.desc = mutableClass.config.remapParams(targetMethod.desc);
           if (isGregorianCalendarBooleanConstructor(targetMethod)) {
             replaceGregorianCalendarBooleanConstructor(instructions, targetMethod);
-          } else if (mutableClass.config.shouldIntercept(targetMethod)) {
+          } else if (mutableClass.config.shouldIntercept(targetMethod, mutableClass)) {
             interceptInvokeVirtualMethod(mutableClass, instructions, targetMethod);
           }
           break;

--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/InstrumentationConfiguration.java
@@ -57,6 +57,7 @@ public class InstrumentationConfiguration {
   private final Set<String> classesToNotAcquire;
   private final Set<String> packagesToNotAcquire;
   private final Set<String> packagesToNotInstrument;
+  private final Set<String> classesToNotIntercept;
   private int cachedHashCode;
 
   private final TypeMapper typeMapper;
@@ -71,6 +72,7 @@ public class InstrumentationConfiguration {
       Collection<String> packagesToNotAcquire,
       Collection<String> classesToNotInstrument,
       Collection<String> packagesToNotInstrument,
+      Collection<String> classesToNotIntercept,
       String classesToNotInstrumentRegex) {
     this.classNameTranslations = ImmutableMap.copyOf(classNameTranslations);
     this.interceptedMethods = ImmutableSet.copyOf(interceptedMethods);
@@ -80,6 +82,7 @@ public class InstrumentationConfiguration {
     this.packagesToNotAcquire = ImmutableSet.copyOf(packagesToNotAcquire);
     this.classesToNotInstrument = ImmutableSet.copyOf(classesToNotInstrument);
     this.packagesToNotInstrument = ImmutableSet.copyOf(packagesToNotInstrument);
+    this.classesToNotIntercept = ImmutableSet.copyOf(classesToNotIntercept);
     this.classesToNotInstrumentRegex = classesToNotInstrumentRegex;
     this.cachedHashCode = 0;
 
@@ -241,9 +244,12 @@ public class InstrumentationConfiguration {
     return typeMapper.mappedTypeName(internalName);
   }
 
-  boolean shouldIntercept(MethodInsnNode targetMethod) {
+  boolean shouldIntercept(MethodInsnNode targetMethod, MutableClass callingClass) {
     if (targetMethod.name.equals("<init>")) {
       return false; // sorry, can't strip out calls to super() in constructor
+    }
+    if (classesToNotIntercept.contains(callingClass.getName())) {
+      return false;
     }
     return methodsToIntercept.contains(new MethodRef(targetMethod.owner, targetMethod.name))
         || methodsToIntercept.contains(new MethodRef(targetMethod.owner, "*"));
@@ -270,6 +276,7 @@ public class InstrumentationConfiguration {
     public final Collection<String> instrumentedClasses = new HashSet<>();
     public final Collection<String> classesToNotInstrument = new HashSet<>();
     public final Collection<String> packagesToNotInstrument = new HashSet<>();
+    private final Collection<String> classesToNotIntercept = new HashSet<>();
     public String classesToNotInstrumentRegex;
 
     public Builder() {}
@@ -336,6 +343,11 @@ public class InstrumentationConfiguration {
       return this;
     }
 
+    public Builder doNotInterceptClass(String className) {
+      this.classesToNotIntercept.add(className);
+      return this;
+    }
+
     public InstrumentationConfiguration build() {
       // Remove redundant packages, e.g. remove 'android.os' if 'android.' is present.
       List<String> minimalPackages = new ArrayList<>(instrumentedPackages);
@@ -369,6 +381,7 @@ public class InstrumentationConfiguration {
           packagesToNotAcquire,
           classesToNotInstrument,
           packagesToNotInstrument,
+          classesToNotIntercept,
           classesToNotInstrumentRegex);
     }
   }


### PR DESCRIPTION
Previously the uses of System.currentTimeMillis() were being intercepted in DateUtils. However, the usage of currentTimeMillis in DateUtils is not scheduler-related, and calling the JVM's version is important for application code.

Fixes #3912

PiperOrigin-RevId: 338287997

-----

This replaces #6004.