### PR TITLE
Don't access static fields via instance in `:shadows:framework`

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
@@ -140,7 +140,7 @@ public class ShadowAccessibilityManager {
 
   public void setAccessibilityServiceList(List<ServiceInfo> accessibilityServiceList) {
     Preconditions.checkNotNull(accessibilityServiceList);
-    this.accessibilityServiceList = new ArrayList<>(accessibilityServiceList);
+    ShadowAccessibilityManager.accessibilityServiceList = new ArrayList<>(accessibilityServiceList);
   }
 
   @Nullable
@@ -153,7 +153,8 @@ public class ShadowAccessibilityManager {
   public void setEnabledAccessibilityServiceList(
       List<AccessibilityServiceInfo> enabledAccessibilityServiceList) {
     Preconditions.checkNotNull(enabledAccessibilityServiceList);
-    this.enabledAccessibilityServiceList = new ArrayList<>(enabledAccessibilityServiceList);
+    ShadowAccessibilityManager.enabledAccessibilityServiceList =
+        new ArrayList<>(enabledAccessibilityServiceList);
   }
 
   @Implementation
@@ -164,7 +165,8 @@ public class ShadowAccessibilityManager {
   public void setInstalledAccessibilityServiceList(
       List<AccessibilityServiceInfo> installedAccessibilityServiceList) {
     Preconditions.checkNotNull(installedAccessibilityServiceList);
-    this.installedAccessibilityServiceList = new ArrayList<>(installedAccessibilityServiceList);
+    ShadowAccessibilityManager.installedAccessibilityServiceList =
+        new ArrayList<>(installedAccessibilityServiceList);
   }
 
   @Implementation
@@ -188,7 +190,7 @@ public class ShadowAccessibilityManager {
   }
 
   public void setEnabled(boolean enabled) {
-    this.enabled = enabled;
+    ShadowAccessibilityManager.enabled = enabled;
     ReflectionHelpers.setField(realAccessibilityManager, "mIsEnabled", enabled);
     for (AccessibilityStateChangeListener l : onAccessibilityStateChangeListeners.keySet()) {
       if (l != null) {
@@ -203,7 +205,7 @@ public class ShadowAccessibilityManager {
   }
 
   public void setTouchExplorationEnabled(boolean touchExplorationEnabled) {
-    this.touchExplorationEnabled = touchExplorationEnabled;
+    ShadowAccessibilityManager.touchExplorationEnabled = touchExplorationEnabled;
     List<TouchExplorationStateChangeListener> listeners;
     if (getApiLevel() >= O) {
       listeners =

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
@@ -766,7 +766,7 @@ public class ShadowAccountManager {
    *     response.
    */
   public void setAuthenticationErrorOnNextResponse(boolean authenticationErrorOnNextResponse) {
-    this.authenticationErrorOnNextResponse = authenticationErrorOnNextResponse;
+    ShadowAccountManager.authenticationErrorOnNextResponse = authenticationErrorOnNextResponse;
   }
 
   /**
@@ -775,7 +775,7 @@ public class ShadowAccountManager {
    * @param removeAccountIntent the intent to surface as {@link AccountManager#KEY_INTENT}.
    */
   public void setRemoveAccountIntent(Intent removeAccountIntent) {
-    this.removeAccountIntent = removeAccountIntent;
+    ShadowAccountManager.removeAccountIntent = removeAccountIntent;
   }
 
   public Map<OnAccountsUpdateListener, Set<String>> getListeners() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivityManager.java
@@ -217,8 +217,8 @@ public class ShadowActivityManager {
    * @param tasks List of running tasks.
    */
   public void setTasks(List<ActivityManager.RunningTaskInfo> tasks) {
-    this.tasks.clear();
-    this.tasks.addAll(tasks);
+    ShadowActivityManager.tasks.clear();
+    ShadowActivityManager.tasks.addAll(tasks);
   }
 
   /**
@@ -228,8 +228,8 @@ public class ShadowActivityManager {
    * @param appTasks List of app tasks.
    */
   public void setAppTasks(List<ActivityManager.AppTask> appTasks) {
-    this.appTasks.clear();
-    this.appTasks.addAll(appTasks);
+    ShadowActivityManager.appTasks.clear();
+    ShadowActivityManager.appTasks.addAll(appTasks);
   }
 
   /**
@@ -239,16 +239,16 @@ public class ShadowActivityManager {
    * @param recentTasks List of recent tasks.
    */
   public void setRecentTasks(List<ActivityManager.RecentTaskInfo> recentTasks) {
-    this.recentTasks.clear();
-    this.recentTasks.addAll(recentTasks);
+    ShadowActivityManager.recentTasks.clear();
+    ShadowActivityManager.recentTasks.addAll(recentTasks);
   }
 
   /**
    * @param services List of running services.
    */
   public void setServices(List<ActivityManager.RunningServiceInfo> services) {
-    this.services.clear();
-    this.services.addAll(services);
+    ShadowActivityManager.services.clear();
+    ShadowActivityManager.services.addAll(services);
   }
 
   /**
@@ -277,7 +277,7 @@ public class ShadowActivityManager {
    * @param memoryInfo Set the application's memory info.
    */
   public void setMemoryInfo(ActivityManager.MemoryInfo memoryInfo) {
-    this.memoryInfo = memoryInfo;
+    ShadowActivityManager.memoryInfo = memoryInfo;
   }
 
   @Implementation(minSdk = O)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppWidgetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppWidgetManager.java
@@ -412,7 +412,7 @@ public class ShadowAppWidgetManager {
   }
 
   public void setValidWidgetProviderComponentName(boolean validWidgetProviderComponentName) {
-    this.validWidgetProviderComponentName = validWidgetProviderComponentName;
+    ShadowAppWidgetManager.validWidgetProviderComponentName = validWidgetProviderComponentName;
   }
 
   private static class WidgetInfo {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
@@ -215,7 +215,7 @@ public class ShadowAudioManager {
     if (!AudioManager.isValidRingerMode(ringerMode)) {
       return;
     }
-    this.ringerMode = ringerMode;
+    ShadowAudioManager.ringerMode = ringerMode;
   }
 
   @Implementation
@@ -231,8 +231,8 @@ public class ShadowAudioManager {
     if (lockMode) {
       return;
     }
-    int previousMode = this.mode;
-    this.mode = mode;
+    int previousMode = ShadowAudioManager.mode;
+    ShadowAudioManager.mode = mode;
     if (RuntimeEnvironment.getApiLevel() >= S && mode != previousMode) {
       dispatchModeChangedListeners(mode);
     }
@@ -264,12 +264,12 @@ public class ShadowAudioManager {
 
   /** Sets whether subsequent calls to {@link #setMode} will succeed or not. */
   public void lockMode(boolean lockMode) {
-    this.lockMode = lockMode;
+    ShadowAudioManager.lockMode = lockMode;
   }
 
   @Implementation
   protected int getMode() {
-    return this.mode;
+    return mode;
   }
 
   @ForType(className = "android.media.AudioManager$ModeDispatcherStub")
@@ -335,7 +335,7 @@ public class ShadowAudioManager {
 
   @Implementation
   protected void setBluetoothScoOn(boolean isBluetoothScoOn) {
-    this.isBluetoothScoOn = isBluetoothScoOn;
+    ShadowAudioManager.isBluetoothScoOn = isBluetoothScoOn;
   }
 
   @Implementation
@@ -439,7 +439,7 @@ public class ShadowAudioManager {
   }
 
   public void setIsBluetoothScoAvailableOffCall(boolean isBluetoothScoAvailableOffCall) {
-    this.isBluetoothScoAvailableOffCall = isBluetoothScoAvailableOffCall;
+    ShadowAudioManager.isBluetoothScoAvailableOffCall = isBluetoothScoAvailableOffCall;
   }
 
   public void setIsStreamMute(int streamType, boolean isMuted) {
@@ -751,7 +751,7 @@ public class ShadowAudioManager {
 
   /** Sets whether subsequent calls to {@link #setCommunicationDevice} will succeed. */
   public void lockCommunicationDevice(boolean lockCommunicationDevice) {
-    this.lockCommunicationDevice = lockCommunicationDevice;
+    ShadowAudioManager.lockCommunicationDevice = lockCommunicationDevice;
   }
 
   @Implementation(minSdk = S)
@@ -875,7 +875,7 @@ public class ShadowAudioManager {
   }
 
   public void setIsMusicActive(boolean isMusicActive) {
-    this.isMusicActive = isMusicActive;
+    ShadowAudioManager.isMusicActive = isMusicActive;
   }
 
   public AudioFocusRequest getLastAudioFocusRequest() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAutofillManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAutofillManager.java
@@ -56,7 +56,7 @@ public class ShadowAutofillManager {
    * AutofillManager#getAutofillServiceComponentName()}.
    */
   public void setAutofillServiceComponentName(@Nullable ComponentName componentName) {
-    this.autofillServiceComponentName = componentName;
+    autofillServiceComponentName = componentName;
   }
 
   /**
@@ -64,7 +64,7 @@ public class ShadowAutofillManager {
    * AutofillManager#isAutofillSupported()}.
    */
   public void setAutofillSupported(boolean supported) {
-    this.autofillSupported = supported;
+    autofillSupported = supported;
   }
 
   /**
@@ -72,6 +72,6 @@ public class ShadowAutofillManager {
    * AutofillManager#isEnabled()}.
    */
   public void setEnabled(boolean enabled) {
-    this.enabled = enabled;
+    ShadowAutofillManager.enabled = enabled;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBatteryManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBatteryManager.java
@@ -63,6 +63,6 @@ public class ShadowBatteryManager {
     Preconditions.checkArgument(
         chargeTimeRemaining == -1 || chargeTimeRemaining >= 0,
         "chargeTimeRemaining must be -1 or non-negative.");
-    this.chargeTimeRemaining = chargeTimeRemaining;
+    ShadowBatteryManager.chargeTimeRemaining = chargeTimeRemaining;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCarrierConfigManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCarrierConfigManager.java
@@ -95,7 +95,7 @@ public class ShadowCarrierConfigManager {
   }
 
   public void setReadPhoneStatePermission(boolean readPhoneStatePermission) {
-    this.readPhoneStatePermission = readPhoneStatePermission;
+    ShadowCarrierConfigManager.readPhoneStatePermission = readPhoneStatePermission;
   }
 
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowClipboardManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowClipboardManager.java
@@ -70,7 +70,7 @@ public class ShadowClipboardManager {
       }
     }
 
-    this.clip = clip;
+    ShadowClipboardManager.clip = clip;
 
     for (OnPrimaryClipChangedListener listener : listeners) {
       listener.onPrimaryClipChanged();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowConnectivityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowConnectivityManager.java
@@ -339,7 +339,7 @@ public class ShadowConnectivityManager {
    * @param captivePortalServerUrl the url of captive portal.
    */
   public void setCaptivePortalServerUrl(String captivePortalServerUrl) {
-    this.captivePortalServerUrl = captivePortalServerUrl;
+    ShadowConnectivityManager.captivePortalServerUrl = captivePortalServerUrl;
   }
 
   @HiddenApi

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
@@ -275,7 +275,7 @@ public class ShadowDevicePolicyManager {
 
   private void init(Context context) {
     this.context = context;
-    this.applicationPackageManager =
+    applicationPackageManager =
         (ApplicationPackageManager) context.getApplicationContext().getPackageManager();
     organizationColor = DEFAULT_ORGANIZATION_COLOR;
     storageEncryptionStatus = DevicePolicyManager.ENCRYPTION_STATUS_UNSUPPORTED;
@@ -769,7 +769,7 @@ public class ShadowDevicePolicyManager {
     if (isAutoTimeZoneEnabled) {
       return false;
     }
-    this.timeZone = timeZone;
+    ShadowDevicePolicyManager.timeZone = timeZone;
     return true;
   }
 
@@ -861,7 +861,7 @@ public class ShadowDevicePolicyManager {
   @Implementation
   protected int setStorageEncryption(ComponentName admin, boolean encrypt) {
     enforceActiveAdmin(admin);
-    this.storageEncryptionRequested = encrypt;
+    storageEncryptionRequested = encrypt;
     return storageEncryptionStatus;
   }
 
@@ -1238,7 +1238,7 @@ public class ShadowDevicePolicyManager {
 
   /** Sets the password complexity. */
   public void setPasswordComplexity(@PasswordComplexity int passwordComplexity) {
-    this.passwordComplexity = passwordComplexity;
+    ShadowDevicePolicyManager.passwordComplexity = passwordComplexity;
   }
 
   @PasswordComplexity
@@ -1472,7 +1472,7 @@ public class ShadowDevicePolicyManager {
 
   @Implementation(minSdk = M)
   protected void setSystemUpdatePolicy(ComponentName admin, SystemUpdatePolicy policy) {
-    this.policy = policy;
+    ShadowDevicePolicyManager.policy = policy;
   }
 
   /**
@@ -1638,7 +1638,7 @@ public class ShadowDevicePolicyManager {
 
   /** Sets the value returned by {@link #getPolicyManagedProfiles(UserHandle)}. */
   public void setPolicyManagedProfiles(List<UserHandle> policyManagedProfiles) {
-    this.policyManagedProfiles = policyManagedProfiles;
+    ShadowDevicePolicyManager.policyManagedProfiles = policyManagedProfiles;
   }
 
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowEuiccManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowEuiccManager.java
@@ -52,6 +52,6 @@ public class ShadowEuiccManager {
 
   /** Set the value to be returned by {@link EuiccManager#getEid}. */
   public void setEid(String eid) {
-    this.eid = eid;
+    ShadowEuiccManager.eid = eid;
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFileIntegrityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFileIntegrityManager.java
@@ -15,7 +15,7 @@ public class ShadowFileIntegrityManager {
 
   /** Sets the value of {@link #isApkVeritySupported}. */
   public void setIsApkVeritySupported(boolean isApkVeritySupported) {
-    this.isApkVeritySupported = isApkVeritySupported;
+    ShadowFileIntegrityManager.isApkVeritySupported = isApkVeritySupported;
   }
 
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFingerprintManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFingerprintManager.java
@@ -113,14 +113,14 @@ public class ShadowFingerprintManager {
       } else {
         cancel.setOnCancelListener(
             () -> {
-              this.pendingCallback = null;
-              this.pendingCryptoObject = null;
+              pendingCallback = null;
+              pendingCryptoObject = null;
             });
       }
     }
 
-    this.pendingCryptoObject = crypto;
-    this.pendingCallback = callback;
+    pendingCryptoObject = crypto;
+    pendingCallback = callback;
   }
 
   /**
@@ -180,12 +180,12 @@ public class ShadowFingerprintManager {
   }
 
   private void setEnrolledFingerprints(Fingerprint... fingerprints) {
-    this.fingerprints = Arrays.asList(fingerprints);
+    ShadowFingerprintManager.fingerprints = Arrays.asList(fingerprints);
   }
 
   /** Sets the return value of {@link FingerprintManager#isHardwareDetected()}. */
   public void setIsHardwareDetected(boolean isHardwareDetected) {
-    this.isHardwareDetected = isHardwareDetected;
+    ShadowFingerprintManager.isHardwareDetected = isHardwareDetected;
   }
 
   /**
@@ -193,7 +193,7 @@ public class ShadowFingerprintManager {
    */
   @Implementation(minSdk = M)
   protected boolean isHardwareDetected() {
-    return this.isHardwareDetected;
+    return isHardwareDetected;
   }
 
   @Implementation(minSdk = VERSION_CODES.S)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInputMethodManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInputMethodManager.java
@@ -144,8 +144,7 @@ public class ShadowInputMethodManager {
 
   public void setSoftInputVisibilityHandler(
       SoftInputVisibilityChangeHandler visibilityChangeHandler) {
-    this.visibilityChangeHandler =
-        Optional.<SoftInputVisibilityChangeHandler>of(visibilityChangeHandler);
+    ShadowInputMethodManager.visibilityChangeHandler = Optional.of(visibilityChangeHandler);
   }
 
   private void setSoftInputVisibility(boolean visible) {
@@ -181,7 +180,7 @@ public class ShadowInputMethodManager {
    * #getInputMethodList()}.
    */
   public void setInputMethodInfoList(List<InputMethodInfo> inputMethodInfoList) {
-    this.inputMethodInfoList = inputMethodInfoList;
+    ShadowInputMethodManager.inputMethodInfoList = inputMethodInfoList;
   }
 
   /**
@@ -200,7 +199,7 @@ public class ShadowInputMethodManager {
    * #getCurrentInputMethodSubtype()}.
    */
   public void setCurrentInputMethodSubtype(InputMethodSubtype inputMethodSubtype) {
-    this.inputMethodSubtype = Optional.of(inputMethodSubtype);
+    ShadowInputMethodManager.inputMethodSubtype = Optional.of(inputMethodSubtype);
   }
 
   /**
@@ -219,7 +218,7 @@ public class ShadowInputMethodManager {
    * #getEnabledInputMethodList()}.
    */
   public void setEnabledInputMethodInfoList(List<InputMethodInfo> inputMethodInfoList) {
-    this.enabledInputMethodInfoList = inputMethodInfoList;
+    enabledInputMethodInfoList = inputMethodInfoList;
   }
 
   @Implementation

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLauncherApps.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLauncherApps.java
@@ -379,9 +379,9 @@ public class ShadowLauncherApps {
 
   @Implementation
   protected void unregisterCallback(LauncherApps.Callback callback) {
-    int index = Iterables.indexOf(this.callbacks, pair -> pair.first == callback);
+    int index = Iterables.indexOf(callbacks, pair -> pair.first == callback);
     if (index != -1) {
-      this.callbacks.remove(index);
+      callbacks.remove(index);
     }
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -127,7 +127,7 @@ public class ShadowNotificationManager {
   }
 
   public void setImportance(int importance) {
-    this.importance = importance;
+    ShadowNotificationManager.importance = importance;
   }
 
   @Implementation(minSdk = M)
@@ -465,7 +465,7 @@ public class ShadowNotificationManager {
    * the default behavior.
    */
   public void setEnforceMaxNotificationLimit(boolean enforceMaxNotificationLimit) {
-    this.enforceMaxNotificationLimit = enforceMaxNotificationLimit;
+    ShadowNotificationManager.enforceMaxNotificationLimit = enforceMaxNotificationLimit;
   }
 
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
@@ -161,7 +161,7 @@ public class ShadowPowerManager {
 
   /** Sets the value returned by {@link #isDeviceIdleMode()}. */
   public void setIsDeviceIdleMode(boolean isDeviceIdleMode) {
-    this.isDeviceIdleMode = isDeviceIdleMode;
+    ShadowPowerManager.isDeviceIdleMode = isDeviceIdleMode;
     getContext().sendBroadcast(new Intent(PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED));
   }
 
@@ -209,7 +209,7 @@ public class ShadowPowerManager {
     checkState(
         locationMode <= PowerManager.MAX_LOCATION_MODE,
         "Location Power Save Mode must be no more than " + PowerManager.MAX_LOCATION_MODE);
-    this.locationMode = locationMode;
+    ShadowPowerManager.locationMode = locationMode;
   }
 
   /** This function returns the current thermal status of the device. */
@@ -225,12 +225,12 @@ public class ShadowPowerManager {
     checkState(
         listener instanceof PowerManager.OnThermalStatusChangedListener,
         "Listener must implement PowerManager.OnThermalStatusChangedListener");
-    this.thermalListeners.add(listener);
+    thermalListeners.add(listener);
   }
 
   /** This function gets listeners for thermal status change. */
   public ImmutableSet<Object> getThermalStatusListeners() {
-    return ImmutableSet.copyOf(this.thermalListeners);
+    return ImmutableSet.copyOf(thermalListeners);
   }
 
   /** This function removes a listener for thermal status change. */
@@ -240,7 +240,7 @@ public class ShadowPowerManager {
     checkState(
         listener instanceof PowerManager.OnThermalStatusChangedListener,
         "Listener must implement PowerManager.OnThermalStatusChangedListener");
-    this.thermalListeners.remove(listener);
+    thermalListeners.remove(listener);
   }
 
   /** Sets the value returned by {@link #getCurrentThermalStatus()}. */
@@ -251,7 +251,7 @@ public class ShadowPowerManager {
     checkState(
         thermalStatus <= PowerManager.THERMAL_STATUS_SHUTDOWN,
         "Thermal status must be no more than " + PowerManager.THERMAL_STATUS_SHUTDOWN);
-    this.thermalStatus = thermalStatus;
+    ShadowPowerManager.thermalStatus = thermalStatus;
     for (Object listener : thermalListeners) {
       ((PowerManager.OnThermalStatusChangedListener) listener)
           .onThermalStatusChanged(thermalStatus);
@@ -329,8 +329,8 @@ public class ShadowPowerManager {
   @Implementation(minSdk = S)
   protected void setBatteryDischargePrediction(
       @Nonnull Duration timeRemaining, boolean isPersonalized) {
-    this.batteryDischargePrediction = timeRemaining;
-    this.isBatteryDischargePredictionPersonalized = isPersonalized;
+    batteryDischargePrediction = timeRemaining;
+    isBatteryDischargePredictionPersonalized = isPersonalized;
   }
 
   /**
@@ -345,7 +345,7 @@ public class ShadowPowerManager {
   @Nullable
   @Implementation(minSdk = S)
   protected Duration getBatteryDischargePrediction() {
-    return this.batteryDischargePrediction;
+    return batteryDischargePrediction;
   }
 
   /**
@@ -358,7 +358,7 @@ public class ShadowPowerManager {
    */
   @Implementation(minSdk = S)
   protected boolean isBatteryDischargePredictionPersonalized() {
-    return this.isBatteryDischargePredictionPersonalized;
+    return isBatteryDischargePredictionPersonalized;
   }
 
   @Implementation
@@ -386,12 +386,12 @@ public class ShadowPowerManager {
 
   /** Sets the value returned by {@link #isAmbientDisplayAvailable()}. */
   public void setAmbientDisplayAvailable(boolean available) {
-    this.isAmbientDisplayAvailable = available;
+    isAmbientDisplayAvailable = available;
   }
 
   /** Sets the value returned by {@link #isRebootingUserspaceSupported()}. */
   public void setIsRebootingUserspaceSupported(boolean supported) {
-    this.isRebootingUserspaceSupported = supported;
+    isRebootingUserspaceSupported = supported;
   }
 
   /**
@@ -592,7 +592,7 @@ public class ShadowPowerManager {
 
   @TargetApi(TIRAMISU)
   public void setLowPowerStandbySupported(boolean lowPowerStandbySupported) {
-    this.lowPowerStandbySupported = lowPowerStandbySupported;
+    ShadowPowerManager.lowPowerStandbySupported = lowPowerStandbySupported;
   }
 
   @Implementation(minSdk = TIRAMISU)
@@ -602,7 +602,7 @@ public class ShadowPowerManager {
 
   @Implementation(minSdk = TIRAMISU)
   public void setLowPowerStandbyEnabled(boolean lowPowerStandbyEnabled) {
-    this.lowPowerStandbyEnabled = lowPowerStandbyEnabled;
+    ShadowPowerManager.lowPowerStandbyEnabled = lowPowerStandbyEnabled;
   }
 
   @Implementation(minSdk = UPSIDE_DOWN_CAKE)
@@ -628,7 +628,7 @@ public class ShadowPowerManager {
 
   @TargetApi(UPSIDE_DOWN_CAKE)
   public void setExemptFromLowPowerStandby(boolean exemptFromLowPowerStandby) {
-    this.exemptFromLowPowerStandby = exemptFromLowPowerStandby;
+    ShadowPowerManager.exemptFromLowPowerStandby = exemptFromLowPowerStandby;
   }
 
   @Implementation(minSdk = UPSIDE_DOWN_CAKE)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRestrictionsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRestrictionsManager.java
@@ -21,7 +21,7 @@ public class ShadowRestrictionsManager {
    * RestrictionsManager#getApplicationRestrictions()}.
    */
   public void setApplicationRestrictions(Bundle applicationRestrictions) {
-    this.applicationRestrictions = applicationRestrictions;
+    ShadowRestrictionsManager.applicationRestrictions = applicationRestrictions;
   }
 
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
@@ -122,12 +122,12 @@ public class ShadowSensorManager {
   }
 
   public void setForceListenersToFail(boolean forceListenersToFail) {
-    this.forceListenersToFail.set(forceListenersToFail);
+    ShadowSensorManager.forceListenersToFail.set(forceListenersToFail);
   }
 
   @Implementation
   protected boolean registerListener(SensorEventListener listener, Sensor sensor, int rate) {
-    if (this.forceListenersToFail.get()) {
+    if (forceListenersToFail.get()) {
       return false;
     }
     listeners.put(listener, sensor);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowShortcutManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowShortcutManager.java
@@ -151,7 +151,7 @@ public class ShadowShortcutManager {
     for (ShortcutInfo shortcutInfo : manifestShortcuts) {
       shortcutInfo.addFlags(ShortcutInfo.FLAG_MANIFEST);
     }
-    this.manifestShortcuts = manifestShortcuts;
+    ShadowShortcutManager.manifestShortcuts = manifestShortcuts;
   }
 
   @Implementation
@@ -183,7 +183,7 @@ public class ShadowShortcutManager {
   }
 
   public void setIsRequestPinShortcutSupported(boolean isRequestPinShortcutSupported) {
-    this.isRequestPinShortcutSupported = isRequestPinShortcutSupported;
+    ShadowShortcutManager.isRequestPinShortcutSupported = isRequestPinShortcutSupported;
   }
 
   @Implementation

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSubscriptionManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSubscriptionManager.java
@@ -514,7 +514,7 @@ public class ShadowSubscriptionManager {
    * compatibility.
    */
   public void setReadPhoneStatePermission(boolean readPhoneStatePermission) {
-    this.readPhoneStatePermission = readPhoneStatePermission;
+    ShadowSubscriptionManager.readPhoneStatePermission = readPhoneStatePermission;
   }
 
   private void checkReadPhoneStatePermission() {
@@ -529,7 +529,7 @@ public class ShadowSubscriptionManager {
    * compatibility.
    */
   public void setReadPhoneNumbersPermission(boolean readPhoneNumbersPermission) {
-    this.readPhoneNumbersPermission = readPhoneNumbersPermission;
+    ShadowSubscriptionManager.readPhoneNumbersPermission = readPhoneNumbersPermission;
   }
 
   private void checkReadPhoneNumbersPermission() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelecomManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelecomManager.java
@@ -134,7 +134,7 @@ public class ShadowTelecomManager {
   }
 
   public void setCallRequestMode(CallRequestMode callRequestMode) {
-    this.callRequestMode = callRequestMode;
+    ShadowTelecomManager.callRequestMode = callRequestMode;
   }
 
   /**
@@ -152,7 +152,7 @@ public class ShadowTelecomManager {
 
   /** Sets the result of {@link TelecomManager#isOutgoingCallPermitted(PhoneAccountHandle)}. */
   public void setIsOutgoingCallPermitted(boolean isOutgoingCallPermitted) {
-    this.isOutgoingCallPermitted = isOutgoingCallPermitted;
+    ShadowTelecomManager.isOutgoingCallPermitted = isOutgoingCallPermitted;
   }
 
   /**
@@ -352,13 +352,13 @@ public class ShadowTelecomManager {
   @Implementation(minSdk = M)
   @HiddenApi
   public boolean setDefaultDialer(String packageName) {
-    this.defaultDialerPackageName = packageName;
+    defaultDialerPackageName = packageName;
     return true;
   }
 
   /** Set returned value of {@link #getDefaultDialerPackage()}. */
   public void setDefaultDialerPackage(String packageName) {
-    this.defaultDialerPackageName = packageName;
+    defaultDialerPackageName = packageName;
   }
 
   @Implementation(minSdk = M)
@@ -369,7 +369,7 @@ public class ShadowTelecomManager {
 
   /** Set returned value of {@link #getSystemDialerPackage()}. */
   public void setSystemDialerPackage(String packageName) {
-    this.systemDefaultDialerPackageName = packageName;
+    systemDefaultDialerPackageName = packageName;
   }
 
   public void setVoicemailNumber(PhoneAccountHandle accountHandle, String number) {
@@ -398,7 +398,7 @@ public class ShadowTelecomManager {
 
   /** Sets the return value for {@link TelecomManager#isInCall}. */
   public void setIsInCall(boolean isInCall) {
-    this.isInCall = isInCall;
+    ShadowTelecomManager.isInCall = isInCall;
   }
 
   /**
@@ -418,8 +418,8 @@ public class ShadowTelecomManager {
    * TelecomManager#isInCall}.
    */
   public void setIsInEmergencyCall(boolean isInEmergencyCall) {
-    this.isInEmergencyCall = isInEmergencyCall;
-    this.isInCall = isInEmergencyCall;
+    ShadowTelecomManager.isInEmergencyCall = isInEmergencyCall;
+    isInCall = isInEmergencyCall;
   }
 
   /**
@@ -704,7 +704,7 @@ public class ShadowTelecomManager {
   }
 
   public void setHandleMmiValue(boolean handleMmiValue) {
-    this.handleMmiValue = handleMmiValue;
+    ShadowTelecomManager.handleMmiValue = handleMmiValue;
   }
 
   @Implementation
@@ -742,7 +742,7 @@ public class ShadowTelecomManager {
    */
   @Implementation(minSdk = N)
   protected Intent createManageBlockedNumbersIntent() {
-    return this.manageBlockNumbersIntent;
+    return manageBlockNumbersIntent;
   }
 
   /**
@@ -750,12 +750,12 @@ public class ShadowTelecomManager {
    * ShadowTelecomManager#createManageBlockedNumbersIntent()}
    */
   public void setManageBlockNumbersIntent(Intent intent) {
-    this.manageBlockNumbersIntent = intent;
+    manageBlockNumbersIntent = intent;
   }
 
   @Implementation(maxSdk = LOLLIPOP_MR1)
   public void setSimCallManager(PhoneAccountHandle simCallManager) {
-    this.simCallManager = simCallManager;
+    ShadowTelecomManager.simCallManager = simCallManager;
   }
 
   /**
@@ -796,7 +796,7 @@ public class ShadowTelecomManager {
 
   @Implementation(minSdk = O)
   protected boolean isOutgoingCallPermitted(PhoneAccountHandle phoneAccountHandle) {
-    return this.isOutgoingCallPermitted;
+    return isOutgoingCallPermitted;
   }
 
   /**
@@ -831,7 +831,7 @@ public class ShadowTelecomManager {
    * compatibility.
    */
   public void setReadPhoneStatePermission(boolean readPhoneStatePermission) {
-    this.readPhoneStatePermission = readPhoneStatePermission;
+    ShadowTelecomManager.readPhoneStatePermission = readPhoneStatePermission;
   }
 
   private void checkReadPhoneStatePermission() {
@@ -846,7 +846,7 @@ public class ShadowTelecomManager {
    * compatibility.
    */
   public void setCallPhonePermission(boolean callPhonePermission) {
-    this.callPhonePermission = callPhonePermission;
+    ShadowTelecomManager.callPhonePermission = callPhonePermission;
   }
 
   private void checkCallPhonePermission() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTimeManager.java
@@ -46,7 +46,7 @@ public class ShadowTimeManager {
         throw new IllegalArgumentException("Unrecognized capability=" + capability);
     }
 
-    this.timeZoneCapabilities = builder.build();
+    timeZoneCapabilities = builder.build();
   }
 
   @Implementation
@@ -102,7 +102,7 @@ public class ShadowTimeManager {
   @Implementation
   @SystemApi
   protected boolean updateTimeZoneConfiguration(TimeZoneConfiguration configuration) {
-    this.timeZoneConfiguration = configuration;
+    timeZoneConfiguration = configuration;
     return true;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsbManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsbManager.java
@@ -174,7 +174,7 @@ public class ShadowUsbManager {
 
   /** Sets the currently attached Usb accessory returned in #getAccessoryList. */
   public void setAttachedUsbAccessory(UsbAccessory usbAccessory) {
-    this.attachedUsbAccessory = usbAccessory;
+    attachedUsbAccessory = usbAccessory;
   }
 
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUwbManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUwbManager.java
@@ -37,7 +37,7 @@ public class ShadowUwbManager {
 
   @Implementation
   protected void registerAdapterStateCallback(Executor executor, AdapterStateCallback callback) {
-    this.callback = callback;
+    ShadowUwbManager.callback = callback;
     callback.onStateChanged(adapterState, stateChangedReason);
   }
 
@@ -51,14 +51,14 @@ public class ShadowUwbManager {
    * @throws IllegalArgumentException if the callback is missing.
    */
   public void simulateAdapterStateChange(@AdapterState int state, @StateChangeReason int reason) {
-    if (this.callback == null) {
+    if (callback == null) {
       throw new IllegalArgumentException("AdapterStateCallback should not be null");
     }
 
     adapterState = state;
     stateChangedReason = reason;
 
-    this.callback.onStateChanged(state, reason);
+    callback.onStateChanged(state, reason);
   }
 
   /**
@@ -103,12 +103,12 @@ public class ShadowUwbManager {
 
   /** Sets the UWB adapter to use for new {@link ShadowRangingSession}s. */
   public void setUwbAdapter(ShadowRangingSession.Adapter adapter) {
-    this.adapter = adapter;
+    ShadowUwbManager.adapter = adapter;
   }
 
   /** Sets the bundle to be returned by {@link android.uwb.UwbManager#getSpecificationInfo}. */
   public void setSpecificationInfo(PersistableBundle specificationInfo) {
-    this.specificationInfo = new PersistableBundle(specificationInfo);
+    ShadowUwbManager.specificationInfo = new PersistableBundle(specificationInfo);
   }
 
   /**
@@ -148,8 +148,8 @@ public class ShadowUwbManager {
       stateChanged = true;
     }
 
-    if (this.callback != null && stateChanged) {
-      this.callback.onStateChanged(
+    if (callback != null && stateChanged) {
+      callback.onStateChanged(
           adapterState, AdapterStateCallback.STATE_CHANGED_REASON_SYSTEM_POLICY);
     }
   }
@@ -165,7 +165,7 @@ public class ShadowUwbManager {
 
   /** Sets the list of bundles to be returned by {@link android.uwb.UwbManager#getChipInfos}. */
   public void setChipInfos(List<PersistableBundle> chipInfos) {
-    this.chipInfos = new ArrayList<>(chipInfos);
+    ShadowUwbManager.chipInfos = new ArrayList<>(chipInfos);
   }
 
   @Resetter

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVirtualDeviceManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVirtualDeviceManager.java
@@ -58,7 +58,7 @@ public class ShadowVirtualDeviceManager {
   @Implementation
   protected void __constructor__(IVirtualDeviceManager service, Context context) {
     this.context = context;
-    this.service = service;
+    ShadowVirtualDeviceManager.service = service;
   }
 
   @Implementation

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWallpaperManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWallpaperManager.java
@@ -91,7 +91,7 @@ public class ShadowWallpaperManager {
    */
   @Implementation
   protected boolean hasResourceWallpaper(int resid) {
-    return resid == this.lockScreenId || resid == this.homeScreenId;
+    return resid == lockScreenId || resid == homeScreenId;
   }
 
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWearableSensingManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWearableSensingManager.java
@@ -51,11 +51,11 @@ public class ShadowWearableSensingManager {
   }
 
   public void setProvideDataStreamResult(@StatusCode Integer provideDataStreamResult) {
-    this.provideDataStreamResult = provideDataStreamResult;
+    ShadowWearableSensingManager.provideDataStreamResult = provideDataStreamResult;
   }
 
   public void setProvideDataResult(@StatusCode Integer provideDataResult) {
-    this.provideDataResult = provideDataResult;
+    ShadowWearableSensingManager.provideDataResult = provideDataResult;
   }
 
   public ParcelFileDescriptor getLastParcelFileDescriptor() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiAwareManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiAwareManager.java
@@ -84,31 +84,31 @@ public class ShadowWifiAwareManager {
 
   /** Sets the availability of the wifiAwareManager. */
   public void setAvailable(boolean available) {
-    this.available = available;
+    ShadowWifiAwareManager.available = available;
   }
 
   /** Sets parameter to pass to AttachCallback#onAttach(WifiAwareSession session) */
   public void setWifiAwareSession(WifiAwareSession session) {
-    this.session = session;
+    ShadowWifiAwareManager.session = session;
   }
 
   /** Sets the boolean value indicating if a wifiAwareSession has been detached. */
   public void setSessionDetached(boolean sessionDetached) {
-    this.sessionDetached = sessionDetached;
+    ShadowWifiAwareManager.sessionDetached = sessionDetached;
   }
 
   /**
    * Sets parameter to pass to DiscoverySessionCallback#onPublishStarted(PublishDiscoverySession)
    */
   public void setDiscoverySessionToPublish(PublishDiscoverySession publishDiscoverySession) {
-    this.discoverySessionToPublish = publishDiscoverySession;
+    discoverySessionToPublish = publishDiscoverySession;
   }
 
   /**
    * Sets param to pass to DiscoverySessionCallback#onSubscribeStarted(SubscribeDiscoverySession)
    */
   public void setDiscoverySessionToSubscribe(SubscribeDiscoverySession subscribeDiscoverySession) {
-    this.discoverySessionToSubscribe = subscribeDiscoverySession;
+    discoverySessionToSubscribe = subscribeDiscoverySession;
   }
 
   @Resetter

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiP2pManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiP2pManager.java
@@ -44,8 +44,8 @@ public class ShadowWifiP2pManager {
       Channel c, int listeningChannel, int operatingChannel, ActionListener al) {
     Preconditions.checkNotNull(c);
     Preconditions.checkNotNull(al);
-    this.listeningChannel = listeningChannel;
-    this.operatingChannel = operatingChannel;
+    ShadowWifiP2pManager.listeningChannel = listeningChannel;
+    ShadowWifiP2pManager.operatingChannel = operatingChannel;
   }
 
   @Implementation
@@ -91,7 +91,7 @@ public class ShadowWifiP2pManager {
   }
 
   public void setNextActionFailure(int nextActionFailure) {
-    this.nextActionFailure = nextActionFailure;
+    ShadowWifiP2pManager.nextActionFailure = nextActionFailure;
   }
 
   public void setGroupInfo(Channel channel, WifiP2pGroup wifiP2pGroup) {


### PR DESCRIPTION
In multiple manager classes, most fields are now `static`. However, when accessing them, they are still referenced through `this`, which is wrong. This PR fixes that by either removing `this.` where possible, or using the class name instead.