### PR TITLE
Use `@RequiresApi` instead of `@TargetApi` in `:shadows:framework`

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/EpsBearerQosSessionAttributesBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/EpsBearerQosSessionAttributesBuilder.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import android.annotation.TargetApi;
+import android.annotation.RequiresApi;
 import android.os.Build.VERSION_CODES;
 import android.telephony.data.EpsBearerQosSessionAttributes;
 import java.net.InetSocketAddress;
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /** Class to build {@link EpsBearerQosSessionAttributes}. */
-@TargetApi(VERSION_CODES.S)
+@RequiresApi(VERSION_CODES.S)
 public final class EpsBearerQosSessionAttributesBuilder {
 
   private int qci;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/NrQosSessionAttributesBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/NrQosSessionAttributesBuilder.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import android.annotation.TargetApi;
+import android.annotation.RequiresApi;
 import android.os.Build.VERSION_CODES;
 import android.telephony.data.NrQosSessionAttributes;
 import java.net.InetSocketAddress;
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /** Class to build {@link NrQosSessionAttributes}. */
-@TargetApi(VERSION_CODES.S)
+@RequiresApi(VERSION_CODES.S)
 public final class NrQosSessionAttributesBuilder {
 
   private int fiveQi;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
@@ -12,8 +12,8 @@ import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
+import android.annotation.RequiresApi;
 import android.annotation.RequiresPermission;
-import android.annotation.TargetApi;
 import android.media.AudioAttributes;
 import android.media.AudioDeviceCallback;
 import android.media.AudioDeviceInfo;
@@ -599,7 +599,7 @@ public class ShadowAudioManager {
    * #addOutputDevice(AudioDeviceInfo, boolean)}, {@link #removeOutputDevice(AudioDeviceInfo,
    * boolean)}.
    */
-  @TargetApi(VERSION_CODES.S)
+  @RequiresApi(VERSION_CODES.S)
   public void setAvailableCommunicationDevices(
       List<AudioDeviceInfo> availableCommunicationDevices) {
     this.availableCommunicationDevices = new ArrayList<>(availableCommunicationDevices);
@@ -656,7 +656,7 @@ public class ShadowAudioManager {
    * AudioDeviceCallback} if the device was not present before and indicated by {@code
    * notifyAudioDeviceCallbacks}.
    */
-  @TargetApi(VERSION_CODES.S)
+  @RequiresApi(VERSION_CODES.S)
   public void addAvailableCommunicationDevice(
       AudioDeviceInfo communicationDevice, boolean notifyAudioDeviceCallbacks) {
     boolean changed =
@@ -672,7 +672,7 @@ public class ShadowAudioManager {
    * AudioDeviceCallback} if the device was present before and indicated by {@code
    * notifyAudioDeviceCallbacks}.
    */
-  @TargetApi(VERSION_CODES.S)
+  @RequiresApi(VERSION_CODES.S)
   public void removeAvailableCommunicationDevice(
       AudioDeviceInfo communicationDevice, boolean notifyAudioDeviceCallbacks) {
     boolean changed = this.availableCommunicationDevices.remove(communicationDevice);
@@ -804,7 +804,7 @@ public class ShadowAudioManager {
    * <p>Note that there is no public {@link AudioPlaybackConfiguration} constructor, so the
    * configurations returned are specified by their audio attributes only.
    */
-  @TargetApi(VERSION_CODES.O)
+  @RequiresApi(VERSION_CODES.O)
   public void setActivePlaybackConfigurationsFor(List<AudioAttributes> audioAttributes) {
     setActivePlaybackConfigurationsFor(audioAttributes, /* notifyCallbackListeners= */ false);
   }
@@ -813,7 +813,7 @@ public class ShadowAudioManager {
    * Same as {@link #setActivePlaybackConfigurationsFor(List)}, but also notifies callbacks if
    * notifyCallbackListeners is true.
    */
-  @TargetApi(VERSION_CODES.O)
+  @RequiresApi(VERSION_CODES.O)
   public void setActivePlaybackConfigurationsFor(
       List<AudioAttributes> audioAttributes, boolean notifyCallbackListeners) {
     if (RuntimeEnvironment.getApiLevel() < O) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBuild.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBuild.java
@@ -5,7 +5,7 @@ import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.S;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
-import android.annotation.TargetApi;
+import android.annotation.RequiresApi;
 import android.os.Build;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -141,7 +141,7 @@ public class ShadowBuild {
    *
    * <p>It will be reset for the next test.
    */
-  @TargetApi(S)
+  @RequiresApi(S)
   public static void setVersionMediaPerformanceClass(int performanceClass) {
     ReflectionHelpers.setStaticField(
         Build.VERSION.class, "MEDIA_PERFORMANCE_CLASS", performanceClass);
@@ -161,7 +161,7 @@ public class ShadowBuild {
    *
    * <p>It will be reset for the next test.
    */
-  @TargetApi(M)
+  @RequiresApi(M)
   public static void setVersionSecurityPatch(String securityPatch) {
     ReflectionHelpers.setStaticField(Build.VERSION.class, "SECURITY_PATCH", securityPatch);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentCaptureManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContentCaptureManager.java
@@ -3,7 +3,7 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.Q;
 import static android.os.Build.VERSION_CODES.R;
 
-import android.annotation.TargetApi;
+import android.annotation.RequiresApi;
 import android.content.ComponentName;
 import android.os.ParcelFileDescriptor;
 import android.view.contentcapture.ContentCaptureCondition;
@@ -56,7 +56,7 @@ public class ShadowContentCaptureManager {
    * Configures {@link DataShareError} to be raised on calls to {@link #shareData(DataShareRequest,
    * Executor, DataShareWriteAdapter)}.
    */
-  @TargetApi(R)
+  @RequiresApi(R)
   public void setDataShareErrorCode(@DataShareError int dataShareErrorCode) {
     this.dataShareErrorCode = dataShareErrorCode;
   }
@@ -65,7 +65,7 @@ public class ShadowContentCaptureManager {
    * Configures whether or not to raise request rejection on calls to {@link
    * #shareData(DataShareRequest, Executor, DataShareWriteAdapter)}.
    */
-  @TargetApi(R)
+  @RequiresApi(R)
   public void setShouldRejectRequest(boolean shouldRejectRequest) {
     this.shouldRejectRequest = shouldRejectRequest;
   }
@@ -75,7 +75,7 @@ public class ShadowContentCaptureManager {
    * DataShareWriteAdapter#onWrite(ParcelFileDescriptor)} will receive on calls to {@link
    * #shareData(DataShareRequest, Executor, DataShareWriteAdapter)}.
    */
-  @TargetApi(R)
+  @RequiresApi(R)
   public void setShareDataParcelFileDescriptor(ParcelFileDescriptor parcelFileDescriptor) {
     this.parcelFileDescriptor = parcelFileDescriptor;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextHubClient.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextHubClient.java
@@ -3,7 +3,6 @@ package org.robolectric.shadows;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.annotation.RequiresApi;
-import android.annotation.TargetApi;
 import android.hardware.location.ContextHubClient;
 import android.hardware.location.ContextHubInfo;
 import android.hardware.location.ContextHubTransaction;
@@ -60,7 +59,7 @@ public class ShadowContextHubClient {
   @ForType(ContextHubClient.class)
   interface ContextHubClientReflector {
     @Constructor
-    @TargetApi(VERSION_CODES.P)
+    @RequiresApi(VERSION_CODES.P)
     ContextHubClient newContextHubClient();
 
     @Constructor

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInCallService.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInCallService.java
@@ -7,7 +7,7 @@ import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
 import static org.robolectric.shadow.api.Shadow.invokeConstructor;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
-import android.annotation.TargetApi;
+import android.annotation.RequiresApi;
 import android.bluetooth.BluetoothDevice;
 import android.os.Build.VERSION;
 import android.os.Bundle;
@@ -168,7 +168,7 @@ public class ShadowInCallService extends ShadowService {
   /**
    * @return the last value provided to {@code requestBluetoothAudio()}.
    */
-  @TargetApi(P)
+  @RequiresApi(P)
   public BluetoothDevice getBluetoothAudio() {
     return bluetoothDevice;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowJobScheduler.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowJobScheduler.java
@@ -4,8 +4,8 @@ import static android.os.Build.VERSION_CODES.N;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.S;
 
+import android.annotation.RequiresApi;
 import android.annotation.SystemApi;
-import android.annotation.TargetApi;
 import android.app.JobSchedulerImpl;
 import android.app.job.JobInfo;
 import android.app.job.JobScheduler;
@@ -126,7 +126,7 @@ public abstract class ShadowJobScheduler {
     }
 
     @Override
-    @TargetApi(S)
+    @RequiresApi(S)
     public void failExpeditedJob(boolean enabled) {
       failExpeditedJobEnabled = enabled;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaCodecList.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaCodecList.java
@@ -3,7 +3,7 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.Q;
 
-import android.annotation.TargetApi;
+import android.annotation.RequiresApi;
 import android.media.MediaCodecInfo;
 import android.media.MediaCodecList;
 import java.util.ArrayList;
@@ -34,7 +34,7 @@ public class ShadowMediaCodecList {
    * @param mediaCodecInfo {@link MediaCodecInfo} describing the codec. Use {@link
    *     MediaCodecInfoBuilder} to create an instance of it.
    */
-  @TargetApi(Q)
+  @RequiresApi(Q)
   public static void addCodec(MediaCodecInfo mediaCodecInfo) {
     mediaCodecInfos.add(mediaCodecInfo);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
@@ -16,9 +16,9 @@ import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toCollection;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
+import android.annotation.RequiresApi;
 import android.annotation.RequiresPermission;
 import android.annotation.SystemApi;
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Binder;
@@ -590,7 +590,7 @@ public class ShadowPowerManager {
     return lowPowerStandbySupported;
   }
 
-  @TargetApi(TIRAMISU)
+  @RequiresApi(TIRAMISU)
   public void setLowPowerStandbySupported(boolean lowPowerStandbySupported) {
     ShadowPowerManager.lowPowerStandbySupported = lowPowerStandbySupported;
   }
@@ -613,7 +613,7 @@ public class ShadowPowerManager {
     return allowedFeatures.contains(feature);
   }
 
-  @TargetApi(UPSIDE_DOWN_CAKE)
+  @RequiresApi(UPSIDE_DOWN_CAKE)
   public void addAllowedInLowPowerStandby(String feature) {
     allowedFeatures.add(feature);
   }
@@ -626,7 +626,7 @@ public class ShadowPowerManager {
     return exemptFromLowPowerStandby;
   }
 
-  @TargetApi(UPSIDE_DOWN_CAKE)
+  @RequiresApi(UPSIDE_DOWN_CAKE)
   public void setExemptFromLowPowerStandby(boolean exemptFromLowPowerStandby) {
     ShadowPowerManager.exemptFromLowPowerStandby = exemptFromLowPowerStandby;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelecomManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelecomManager.java
@@ -10,8 +10,8 @@ import static android.os.Build.VERSION_CODES.R;
 import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
 import static com.google.common.base.Verify.verifyNotNull;
 
+import android.annotation.RequiresApi;
 import android.annotation.SystemApi;
-import android.annotation.TargetApi;
 import android.bluetooth.BluetoothDevice;
 import android.content.ComponentName;
 import android.content.Context;
@@ -527,7 +527,7 @@ public class ShadowTelecomManager {
    * <p>Specifically, this method sets up the relevant {@link ConnectionService} and returns the
    * result of {@link ConnectionService#onCreateIncomingConnection}.
    */
-  @TargetApi(M)
+  @RequiresApi(M)
   @Nullable
   public Connection allowIncomingCall(IncomingCallRecord call) {
     if (call.isHandled) {
@@ -547,7 +547,7 @@ public class ShadowTelecomManager {
    * <p>Specifically, this method sets up the relevant {@link ConnectionService} and calls {@link
    * ConnectionService#onCreateIncomingConnectionFailed}.
    */
-  @TargetApi(O)
+  @RequiresApi(O)
   public void denyIncomingCall(IncomingCallRecord call) {
     if (call.isHandled) {
       throw new IllegalStateException("Call has already been allowed or denied.");
@@ -606,7 +606,7 @@ public class ShadowTelecomManager {
    * <p>Specifically, this method sets up the relevant {@link ConnectionService} and returns the
    * result of {@link ConnectionService#onCreateOutgoingConnection}.
    */
-  @TargetApi(M)
+  @RequiresApi(M)
   @Nullable
   public Connection allowOutgoingCall(OutgoingCallRecord call) {
     if (call.isHandled) {
@@ -626,7 +626,7 @@ public class ShadowTelecomManager {
    * <p>Specifically, this method sets up the relevant {@link ConnectionService} and calls {@link
    * ConnectionService#onCreateOutgoingConnectionFailed}.
    */
-  @TargetApi(O)
+  @RequiresApi(O)
   public void denyOutgoingCall(OutgoingCallRecord call) {
     if (call.isHandled) {
       throw new IllegalStateException("Call has already been allowed or denied.");

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsageStatsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsageStatsManager.java
@@ -4,7 +4,7 @@ import static android.os.Build.VERSION_CODES.TIRAMISU;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
-import android.annotation.TargetApi;
+import android.annotation.RequiresApi;
 import android.app.PendingIntent;
 import android.app.PendingIntent.CanceledException;
 import android.app.usage.BroadcastResponseStats;
@@ -605,7 +605,7 @@ public class ShadowUsageStatsManager {
   }
 
   /** Sets what app usage observers will consider the source of usage for an activity. */
-  @TargetApi(Build.VERSION_CODES.Q)
+  @RequiresApi(Build.VERSION_CODES.Q)
   public void setUsageSource(@UsageSource int usageSource) {
     currentUsageSource = usageSource;
   }
@@ -652,7 +652,7 @@ public class ShadowUsageStatsManager {
     idToResponseStats.keySet().removeIf(id -> id == idToRemove || idToRemove == 0);
   }
 
-  @TargetApi(Build.VERSION_CODES.TIRAMISU)
+  @RequiresApi(Build.VERSION_CODES.TIRAMISU)
   public void addBroadcastResponseStats(Object /*BroadcastResponseStats*/ statsObject) {
     BroadcastResponseStats stats = (BroadcastResponseStats) statsObject;
     Map<Long, Object /*BroadcastResponseStats*/> idToStats =
@@ -781,32 +781,32 @@ public class ShadowUsageStatsManager {
       return this;
     }
 
-    @TargetApi(Build.VERSION_CODES.Q)
+    @RequiresApi(Build.VERSION_CODES.Q)
     public EventBuilder setInstanceId(int instanceId) {
       event.mInstanceId = instanceId;
       return this;
     }
 
-    @TargetApi(Build.VERSION_CODES.Q)
+    @RequiresApi(Build.VERSION_CODES.Q)
     public EventBuilder setTaskRootPackage(String taskRootPackage) {
       event.mTaskRootPackage = taskRootPackage;
       return this;
     }
 
-    @TargetApi(Build.VERSION_CODES.Q)
+    @RequiresApi(Build.VERSION_CODES.Q)
     public EventBuilder setTaskRootClass(String taskRootClass) {
       event.mTaskRootClass = taskRootClass;
       return this;
     }
 
-    @TargetApi(Build.VERSION_CODES.P)
+    @RequiresApi(Build.VERSION_CODES.P)
     public EventBuilder setAppStandbyBucket(int bucket) {
       event.mBucketAndReason &= 0xFFFF;
       event.mBucketAndReason |= bucket << 16;
       return this;
     }
 
-    @TargetApi(V.SDK_INT)
+    @RequiresApi(V.SDK_INT)
     public EventBuilder setExtras(PersistableBundle extras) {
       EventReflector eventReflector = reflector(EventReflector.class, event);
       eventReflector.setExtras(extras);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsbManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsbManager.java
@@ -9,7 +9,7 @@ import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
 import static org.robolectric.util.ReflectionHelpers.callConstructor;
 import static org.robolectric.util.ReflectionHelpers.getStaticField;
 
-import android.annotation.TargetApi;
+import android.annotation.RequiresApi;
 import android.content.Intent;
 import android.hardware.usb.UsbAccessory;
 import android.hardware.usb.UsbDevice;
@@ -246,7 +246,7 @@ public class ShadowUsbManager {
   }
 
   /** Adds a USB port with given ID and {@link UsbPortStatus} parameters to UsbManager for Q+. */
-  @TargetApi(Q)
+  @RequiresApi(Q)
   public void addPort(
       String portId,
       int statusCurrentMode,


### PR DESCRIPTION
This PR replaces `@TargetApi` usages with `@RequiresApi` in the `:shadows:framework` module.