### PR TITLE
Fix various warnings in `:shadows:framework`

### DIFF
--- a/integration_tests/ctesque/src/sharedTest/java/android/content/res/AssetManagerTest.java
+++ b/integration_tests/ctesque/src/sharedTest/java/android/content/res/AssetManagerTest.java
@@ -2,6 +2,7 @@ package android.content.res;
 
 import static androidx.test.InstrumentationRegistry.getTargetContext;
 import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import android.content.Context;
 import android.os.ParcelFileDescriptor;
@@ -13,7 +14,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,8 +23,6 @@ import org.junit.runner.RunWith;
 public class AssetManagerTest {
 
   private AssetManager assetManager;
-
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   @Before
   public void setup() throws Exception {

--- a/shadows/framework/src/main/java/org/robolectric/android/Bootstrap.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/Bootstrap.java
@@ -88,7 +88,7 @@ public class Bootstrap {
       }
     }
 
-    for (i = (i < 0) ? 0 : i; i < qualifiersParts.length; i++) {
+    for (i = Math.max(i, 0); i < qualifiersParts.length; i++) {
       String qualifiersStr = qualifiersParts[i];
       int platformVersion = Qualifiers.getPlatformVersion(qualifiersStr);
       if (platformVersion != -1 && platformVersion != apiLevel) {

--- a/shadows/framework/src/main/java/org/robolectric/android/DeviceConfig.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/DeviceConfig.java
@@ -201,7 +201,7 @@ public class DeviceConfig {
     configuration.uiMode = uiModeType | uiModeNight;
 
     if (resTab.density != ResTable_config.DENSITY_DEFAULT) {
-      setDensity(resTab.density, apiLevel, configuration, displayMetrics);
+      setDensity(resTab.density, configuration, displayMetrics);
     }
     setDimensions(apiLevel, configuration, displayMetrics);
 
@@ -237,7 +237,7 @@ public class DeviceConfig {
   }
 
   private static void setDensity(
-      int densityDpi, int apiLevel, Configuration configuration, DisplayMetrics displayMetrics) {
+      int densityDpi, Configuration configuration, DisplayMetrics displayMetrics) {
     configuration.densityDpi = densityDpi;
     displayMetrics.densityDpi = densityDpi;
     displayMetrics.density = displayMetrics.densityDpi * DisplayMetrics.DENSITY_DEFAULT_SCALE;
@@ -361,7 +361,7 @@ public class DeviceConfig {
         throw new IllegalArgumentException("'nodpi' isn't actually a dpi");
       case ResTable_config.DENSITY_DPI_UNDEFINED:
         // DisplayMetrics.DENSITY_DEFAULT is mdpi
-        setDensity(DEFAULT_DENSITY, apiLevel, configuration, displayMetrics);
+        setDensity(DEFAULT_DENSITY, configuration, displayMetrics);
     }
     setDimensions(apiLevel, configuration, displayMetrics);
 
@@ -438,11 +438,6 @@ public class DeviceConfig {
 
   private static int getScreenLayoutLayoutDir(Configuration configuration) {
     return configuration.screenLayout & Configuration.SCREENLAYOUT_LAYOUTDIR_MASK;
-  }
-
-  private static void setScreenLayoutLayoutDir(Configuration configuration, int value) {
-    configuration.screenLayout =
-        (configuration.screenLayout & ~Configuration.SCREENLAYOUT_LAYOUTDIR_MASK) | value;
   }
 
   private static int getScreenLayoutRound(Configuration configuration) {

--- a/shadows/framework/src/main/java/org/robolectric/android/XmlResourceParserImpl.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/XmlResourceParserImpl.java
@@ -191,7 +191,7 @@ public class XmlResourceParserImpl implements XmlResourceParser {
   }
 
   /*package*/
-  public boolean isWhitespace(String text) throws XmlPullParserException {
+  public boolean isWhitespace(String text) {
     if (text == null) {
       return false;
     }
@@ -419,6 +419,7 @@ public class XmlResourceParserImpl implements XmlResourceParser {
           throw new IllegalArgumentException("END_DOCUMENT should not be found here.");
         }
       case (END_TAG):
+      case (TEXT):
         {
           return navigateToNextNode(currentNode);
         }
@@ -445,15 +446,11 @@ public class XmlResourceParserImpl implements XmlResourceParser {
             return END_TAG;
           }
         }
-      case (TEXT):
-        {
-          return navigateToNextNode(currentNode);
-        }
       default:
         {
           // This can only happen if mEventType is
           // assigned with an unmapped integer.
-          throw new RuntimeException("Robolectric-> Uknown XML event type: " + mEventType);
+          throw new RuntimeException("Robolectric-> Unknown XML event type: " + mEventType);
         }
     }
   }
@@ -465,9 +462,6 @@ public class XmlResourceParserImpl implements XmlResourceParser {
           throw new IllegalArgumentException("ATTRIBUTE_NODE");
         }
       case (Node.CDATA_SECTION_NODE):
-        {
-          return navigateToNextNode(node);
-        }
       case (Node.COMMENT_NODE):
         {
           return navigateToNextNode(node);
@@ -481,6 +475,8 @@ public class XmlResourceParserImpl implements XmlResourceParser {
           throw new IllegalArgumentException("DOCUMENT_NODE");
         }
       case (Node.DOCUMENT_TYPE_NODE):
+      case (Node.NOTATION_NODE):
+      case (Node.PROCESSING_INSTRUCTION_NODE):
         {
           throw new IllegalArgumentException("DOCUMENT_TYPE_NODE");
         }
@@ -496,14 +492,6 @@ public class XmlResourceParserImpl implements XmlResourceParser {
       case (Node.ENTITY_REFERENCE_NODE):
         {
           throw new IllegalArgumentException("ENTITY_REFERENCE_NODE");
-        }
-      case (Node.NOTATION_NODE):
-        {
-          throw new IllegalArgumentException("DOCUMENT_TYPE_NODE");
-        }
-      case (Node.PROCESSING_INSTRUCTION_NODE):
-        {
-          throw new IllegalArgumentException("DOCUMENT_TYPE_NODE");
         }
       case (Node.TEXT_NODE):
         {
@@ -713,9 +701,7 @@ public class XmlResourceParserImpl implements XmlResourceParser {
   public int getAttributeIntValue(int idx, int defaultValue) {
     try {
       return Integer.parseInt(getAttributeValue(idx));
-    } catch (NumberFormatException ex) {
-      return defaultValue;
-    } catch (IndexOutOfBoundsException ex) {
+    } catch (IndexOutOfBoundsException | NumberFormatException ex) {
       return defaultValue;
     }
   }
@@ -733,9 +719,7 @@ public class XmlResourceParserImpl implements XmlResourceParser {
   public float getAttributeFloatValue(int idx, float defaultValue) {
     try {
       return Float.parseFloat(getAttributeValue(idx));
-    } catch (NumberFormatException ex) {
-      return defaultValue;
-    } catch (IndexOutOfBoundsException ex) {
+    } catch (IndexOutOfBoundsException | NumberFormatException ex) {
       return defaultValue;
     }
   }

--- a/shadows/framework/src/main/java/org/robolectric/android/controller/ActivityController.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/controller/ActivityController.java
@@ -721,7 +721,7 @@ public class ActivityController<T extends Activity>
     return changedConfig;
   }
 
-  /** Accessor interface for android.app.Activity.NonConfigurationInstances's internals. */
+  /** Accessor interface for android.app.Activity.NonConfigurationInstances' internals. */
   @ForType(className = "android.app.Activity$NonConfigurationInstances")
   interface _NonConfigurationInstances_ {
 

--- a/shadows/framework/src/main/java/org/robolectric/fakes/RoboMenu.java
+++ b/shadows/framework/src/main/java/org/robolectric/fakes/RoboMenu.java
@@ -203,13 +203,7 @@ public class RoboMenu implements Menu {
 
     @Override
     public int compare(MenuItem a, MenuItem b) {
-      if (a.getOrder() == b.getOrder()) {
-        return 0;
-      } else if (a.getOrder() > b.getOrder()) {
-        return 1;
-      } else {
-        return -1;
-      }
+      return Integer.compare(a.getOrder(), b.getOrder());
     }
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/AssociationInfoBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/AssociationInfoBuilder.java
@@ -26,7 +26,6 @@ public class AssociationInfoBuilder {
   // We have two different constructors for AssociationInfo across
   // T branches. aosp has the constructor that takes a new "revoked" parameter.
   private boolean revoked;
-  private boolean pending;
   private long lastTimeConnectedMs;
   private int systemDataSyncFlags;
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/CellInfoLteBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/CellInfoLteBuilder.java
@@ -83,7 +83,7 @@ public class CellInfoLteBuilder {
       try {
         // This reflection is highly brittle but there is currently no choice as CellConfigLte is
         // entirely @hide.
-        Class cellConfigLteClass = Class.forName("android.telephony.CellConfigLte");
+        Class<?> cellConfigLteClass = Class.forName("android.telephony.CellConfigLte");
         return cellInfoLteReflector.newCellInfoLte(
             cellConnectionStatus,
             isRegistered,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ClassNameResolver.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ClassNameResolver.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-public class ClassNameResolver<T> {
+public class ClassNameResolver {
 
   public static <T> Class<T> resolve(String packageName, String className)
       throws ClassNotFoundException {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/FrameMetricsBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/FrameMetricsBuilder.java
@@ -75,7 +75,7 @@ public final class FrameMetricsBuilder {
     timingData[getStartIndexForMetric(FrameMetrics.SYNC_DURATION)] =
         timingData[getEndIndexForMetric(FrameMetrics.DRAW_DURATION)] + syncDelayTimeNanos;
 
-    // Finally we calculate the remainder of the durations after enqueing the sync.
+    // Finally we calculate the remainder of the durations after enqueuing the sync.
     // Note that we don't directly compute the value for TOTAL_DURATION, as it's generated from the
     // start of UNKNOWN_DELAY_DURATION to the end of SWAP_BUFFERS_DURATION.
     for (@Metric int metric = FrameMetrics.SYNC_DURATION; metric < getMetricsCount(); metric++) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/HealthStatsBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/HealthStatsBuilder.java
@@ -201,7 +201,7 @@ final class HealthStatsBuilder {
   }
 
   @VisibleForTesting
-  static final int[] toSortedIntArray(Set<Integer> set) {
+  static int[] toSortedIntArray(Set<Integer> set) {
     int[] result = new int[set.size()];
     Object[] inputObjArray = set.toArray();
     for (int i = 0; i < inputObjArray.length; i++) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/NetworkRegistrationInfoTestBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/NetworkRegistrationInfoTestBuilder.java
@@ -130,9 +130,9 @@ public class NetworkRegistrationInfoTestBuilder {
   private interface NetworkRegistrationInfoReflector {
 
     @Accessor("mDataSpecificInfo")
-    public void setDataSpecificInfo(DataSpecificRegistrationInfo value);
+    void setDataSpecificInfo(DataSpecificRegistrationInfo value);
 
     @Accessor("mVoiceSpecificInfo")
-    public void setVoiceSpecificInfo(VoiceSpecificRegistrationInfo value);
+    void setVoiceSpecificInfo(VoiceSpecificRegistrationInfo value);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper.java
@@ -48,7 +48,7 @@ public final class ResourceHelper {
    */
   public static int getColor(String value) {
     if (value != null) {
-      if (value.startsWith("#") == false) {
+      if (!value.startsWith("#")) {
         throw new NumberFormatException(String.format("Color value '%s' must start with #", value));
       }
 
@@ -182,13 +182,13 @@ public final class ResourceHelper {
    */
   public static boolean parseFloatAttribute(
       String attribute, String value, TypedValue outValue, boolean requireUnit) {
-    assert requireUnit == false || attribute != null;
+    assert !requireUnit || attribute != null;
 
     // remove the space before and after
     value = value.trim();
     int len = value.length();
 
-    if (len <= 0) {
+    if (len == 0) {
       return false;
     }
 
@@ -247,7 +247,7 @@ public final class ResourceHelper {
           outValue.assetCookie = 0;
           outValue.string = null;
 
-          if (requireUnit == false) {
+          if (!requireUnit) {
             outValue.type = TypedValue.TYPE_FLOAT;
             outValue.data = Float.floatToIntBits(f);
           } else {
@@ -255,9 +255,8 @@ public final class ResourceHelper {
             applyUnit(sUnitNames[1], outValue, sFloatOut);
             computeTypedValue(outValue, f, sFloatOut[0]);
 
-            System.out.println(
-                String.format(
-                    "Dimension \"%1$s\" in attribute \"%2$s\" is missing unit!", value, attribute));
+            System.out.printf(
+                "Dimension \"%1$s\" in attribute \"%2$s\" is missing unit!%n", value, attribute);
           }
           return true;
         }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper2.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper2.java
@@ -93,7 +93,7 @@ public final class ResourceHelper2 {
     value = value.trim();
     int len = value.length();
 
-    if (len <= 0) {
+    if (len == 0) {
       return false;
     }
 
@@ -141,7 +141,7 @@ public final class ResourceHelper2 {
           outValue.assetCookie = 0;
           outValue.string = null;
 
-          if (requireUnit == false) {
+          if (!requireUnit) {
             outValue.type = TypedValue.TYPE_FLOAT;
             outValue.data = Float.floatToIntBits(f);
           } else {
@@ -149,10 +149,9 @@ public final class ResourceHelper2 {
             applyUnit(sUnitNames[1], outValue, sFloatOut);
             computeTypedValue(outValue, f, sFloatOut[0], "dp");
 
-            System.out.println(
-                String.format(
-                    "Dimension \"%1$s\" in attribute \"%2$s\" is missing unit!",
-                    value, attribute == null ? "(unknown)" : attribute));
+            System.out.printf(
+                "Dimension \"%1$s\" in attribute \"%2$s\" is missing unit!%n",
+                value, attribute == null ? "(unknown)" : attribute);
           }
           return true;
         }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ResourceModeShadowPicker.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ResourceModeShadowPicker.java
@@ -59,7 +59,7 @@ public class ResourceModeShadowPicker<T> implements ShadowPicker<T> {
       return binary14ShadowClass;
     } else if (RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.Q) {
       return binary10ShadowClass;
-    } else if (RuntimeEnvironment.getApiLevel() >= Build.VERSION_CODES.P) {
+    } else if (RuntimeEnvironment.getApiLevel() == Build.VERSION_CODES.P) {
       return binary9ShadowClass;
     } else {
       return binaryShadowClass;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ServiceStateBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ServiceStateBuilder.java
@@ -133,9 +133,9 @@ public class ServiceStateBuilder {
   private interface ServiceStateReflector {
 
     @Accessor("mIsUsingCarrierAggregation")
-    public void setIsUsingCarrierAggregation(boolean value);
+    void setIsUsingCarrierAggregation(boolean value);
 
     @Accessor("mNetworkRegistrationInfos")
-    public void setNetworkRegistrationInfos(List<NetworkRegistrationInfo> value);
+    void setNetworkRegistrationInfos(List<NetworkRegistrationInfo> value);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
@@ -274,13 +274,11 @@ public class ShadowAccessibilityManager {
 
     @Override
     public void handleMessage(@Nonnull Message message) {
-      switch (message.what) {
-        case DO_SET_STATE:
-          ReflectionHelpers.callInstanceMethod(
-              accessibilityManager, "setState", ClassParameter.from(int.class, message.arg1));
-          return;
-        default:
-          Log.w("AccessibilityManager", "Unknown message type: " + message.what);
+      if (message.what == DO_SET_STATE) {
+        ReflectionHelpers.callInstanceMethod(
+            accessibilityManager, "setState", ClassParameter.from(int.class, message.arg1));
+      } else {
+        Log.w("AccessibilityManager", "Unknown message type: " + message.what);
       }
     }
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityNodeInfo.java
@@ -13,7 +13,6 @@ import android.view.accessibility.AccessibilityWindowInfo;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
@@ -554,9 +553,8 @@ public class ShadowAccessibilityNodeInfo {
 
     // Here we take the actions out of the pairs and stick them into a separate LinkedList to return
     List<Integer> actionsOnly = new ArrayList<>();
-    Iterator<Pair<Integer, Bundle>> iter = performedActionAndArgsList.iterator();
-    while (iter.hasNext()) {
-      actionsOnly.add(iter.next().first);
+    for (Pair<Integer, Bundle> integerBundlePair : performedActionAndArgsList) {
+      actionsOnly.add(integerBundlePair.first);
     }
 
     return Collections.unmodifiableList(actionsOnly);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityService.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityService.java
@@ -71,8 +71,7 @@ public class ShadowAccessibilityService extends ShadowService {
 
   /**
    * Returns a representation of interactive windows shown on the device's default display. Mirrors
-   * the values provided to {@link #setWindows(List<AccessibilityWindowInfo>)}. Returns an empty
-   * list if not set.
+   * the values provided to {@link #setWindows(List)}. Returns an empty list if not set.
    */
   @Implementation
   protected List<AccessibilityWindowInfo> getWindows() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
@@ -781,7 +781,7 @@ public class ShadowAccountManager {
     return listeners;
   }
 
-  private abstract class BaseRoboAccountManagerFuture<T> implements AccountManagerFuture<T> {
+  private abstract static class BaseRoboAccountManagerFuture<T> implements AccountManagerFuture<T> {
     protected final AccountManagerCallback<T> callback;
     private final Handler handler;
     protected T result;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppIntegrityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAppIntegrityManager.java
@@ -36,7 +36,7 @@ public class ShadowAppIntegrityManager {
    */
   @Implementation
   protected String getCurrentRuleSetVersion() {
-    return recordedRuleSet.isPresent() ? recordedRuleSet.get().getVersion() : "None";
+    return recordedRuleSet.map(RuleSet::getVersion).orElse("None");
   }
 
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -702,7 +702,6 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
         } catch (NameNotFoundException e) {
           Log.d(TAG, "ComponentInfo doesn't match flags:" + e.getMessage());
           iterator.remove();
-          continue;
         }
       }
       Collections.sort(result, new ResolveInfoComparator());
@@ -1011,7 +1010,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
     }
     // Android don't override the enabled field of component with the actual value.
     boolean isEnabledForFiltering =
-        isComponentEnabled && (Build.VERSION.SDK_INT >= 24 ? isApplicationEnabled : true);
+        isComponentEnabled && (VERSION.SDK_INT < 24 || isApplicationEnabled);
     if ((flags & MATCH_DISABLED_COMPONENTS) == 0 && !isEnabledForFiltering) {
       throw new NameNotFoundException("Disabled component: " + componentInfo);
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager.java
@@ -1342,7 +1342,6 @@ public class ShadowArscAssetManager extends ShadowAssetManager.ArscBase {
       throws FileNotFoundException {
     final Ref<Long> startOffset = new Ref<>(-1L);
     final Ref<Long> length = new Ref<>(-1L);
-    ;
     FileDescriptor fd = a.openFileDescriptor(startOffset, length);
 
     if (fd == null) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscResourcesImpl.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscResourcesImpl.java
@@ -67,7 +67,6 @@ public class ShadowArscResourcesImpl extends ShadowResourcesImpl {
   public AssetFileDescriptor openRawResourceFd(int id) throws Resources.NotFoundException {
     InputStream inputStream =
         reflector(ResourcesImplReflector.class, realResourcesImpl).openRawResource(id);
-    ;
     if (!(inputStream instanceof FileInputStream)) {
       // todo fixme
       return null;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBiometricManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBiometricManager.java
@@ -35,7 +35,6 @@ public class ShadowBiometricManager {
     authenticatorType = BiometricManager.Authenticators.EMPTY_SET;
   }
 
-  @SuppressWarnings("deprecation")
   @RequiresPermission(USE_BIOMETRIC)
   @Implementation
   protected int canAuthenticate() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBitmapFactory.java
@@ -129,7 +129,7 @@ public class ShadowBitmapFactory {
     // If a real FileDescriptor is used, attempt to get the image size.
     if (fd != null && fd.valid()) {
       try (FileInputStream fileInputStream = new FileInputStream(fd);
-          BufferedInputStream bufferedInputStream = new BufferedInputStream(fileInputStream); ) {
+          BufferedInputStream bufferedInputStream = new BufferedInputStream(fileInputStream)) {
         image = getImageFromStream(bufferedInputStream);
       } catch (IOException e) {
         Logger.warn("Error getting size of bitmap file", e);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothDevice.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothDevice.java
@@ -51,8 +51,8 @@ public class ShadowBluetoothDevice {
    * their ShadowBluetoothGatt's may inject an interceptor, which will be called with the newly
    * constructed BluetoothGatt before {@link ShadowBluetoothDevice#connectGatt} returns.
    */
-  public static interface BluetoothGattConnectionInterceptor {
-    public void onNewGattConnection(BluetoothGatt gatt);
+  public interface BluetoothGattConnectionInterceptor {
+    void onNewGattConnection(BluetoothGatt gatt);
   }
 
   @Deprecated // Prefer {@link android.bluetooth.BluetoothAdapter#getRemoteDevice}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothGatt.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothGatt.java
@@ -53,7 +53,6 @@ public class ShadowBluetoothGatt {
   @ReflectorObject protected BluetoothGattReflector bluetoothGattReflector;
 
   @SuppressLint("PrivateApi")
-  @SuppressWarnings("unchecked")
   public static BluetoothGatt newInstance(BluetoothDevice device) {
     try {
       Class<?> iBluetoothGattClass =
@@ -86,7 +85,7 @@ public class ShadowBluetoothGatt {
                   Integer.TYPE
                 },
                 new Object[] {null, device, 0, false, 0});
-      } else if (apiLevel >= O) {
+      } else if (apiLevel == O) {
         bluetoothGatt =
             Shadow.newInstance(
                 BluetoothGatt.class,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextHubManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowContextHubManager.java
@@ -51,7 +51,7 @@ public class ShadowContextHubManager {
   private static final Map<Integer, NanoAppInstanceInfo> nanoAppUidToInfo =
       new ConcurrentHashMap<>();
   private static final Multimap<ContextHubInfo, Integer> contextHubToNanoappUid =
-      Multimaps.synchronizedMultimap(HashMultimap.<ContextHubInfo, Integer>create());
+      Multimaps.synchronizedMultimap(HashMultimap.create());
   private static final Map<Long, ContextHubInfo> nanoAppIdToInfo = new ConcurrentHashMap<>();
   private static final HashMultimap<String, ContextHubClient> attributionTagToClientMap =
       HashMultimap.create();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDebug.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDebug.java
@@ -8,7 +8,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
@@ -69,7 +69,7 @@ public class ShadowDebug {
     }
 
     try {
-      Files.asCharSink(new File(tracingFilename), Charset.forName("UTF-8")).write("trace data");
+      Files.asCharSink(new File(tracingFilename), StandardCharsets.UTF_8).write("trace data");
     } catch (IOException e) {
       throw new RuntimeException("Writing trace file failed", e);
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDeviceConfig.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDeviceConfig.java
@@ -16,15 +16,15 @@ public class ShadowDeviceConfig {
     //noinspection SynchronizationOnLocalVariableOrMethodParameter
     synchronized (lock) {
       if (RuntimeEnvironment.getApiLevel() == Build.VERSION_CODES.Q) {
-        Map singleListeners =
+        Map<?, ?> singleListeners =
             ReflectionHelpers.getStaticField(DeviceConfig.class, "sSingleListeners");
         singleListeners.clear();
       }
 
-      Map listeners = ReflectionHelpers.getStaticField(DeviceConfig.class, "sListeners");
+      Map<?, ?> listeners = ReflectionHelpers.getStaticField(DeviceConfig.class, "sListeners");
       listeners.clear();
 
-      Map namespaces = ReflectionHelpers.getStaticField(DeviceConfig.class, "sNamespaces");
+      Map<?, ?> namespaces = ReflectionHelpers.getStaticField(DeviceConfig.class, "sNamespaces");
       namespaces.clear();
     }
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplay.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplay.java
@@ -273,11 +273,10 @@ public class ShadowDisplay {
 
     ShadowDisplayManager.changeDisplay(
         displayId,
-        displayConfig -> {
-          displayConfig.hdrCapabilities =
-              new HdrCapabilities(
-                  supportedHdrTypes, maxLuminance, maxAverageLuminance, minLuminance);
-        });
+        displayConfig ->
+            displayConfig.hdrCapabilities =
+                new HdrCapabilities(
+                    supportedHdrTypes, maxLuminance, maxAverageLuminance, minLuminance));
   }
 
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
@@ -1023,7 +1023,7 @@ public class ShadowInstrumentation {
       }
       return PERMISSION_DENIED;
     } else {
-      Set<String> grantedPermissionsForPidUid = grantedPermissionsMap.get(new Pair(pid, uid));
+      Set<String> grantedPermissionsForPidUid = grantedPermissionsMap.get(new Pair<>(pid, uid));
       return grantedPermissionsForPidUid != null && grantedPermissionsForPidUid.contains(permission)
           ? PERMISSION_GRANTED
           : PERMISSION_DENIED;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowIsoDep.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowIsoDep.java
@@ -25,7 +25,6 @@ import org.robolectric.shadow.api.Shadow;
 public class ShadowIsoDep extends ShadowBasicTagTechnology {
 
   @SuppressLint("PrivateApi")
-  @SuppressWarnings("unchecked")
   public static IsoDep newInstance() {
     return Shadow.newInstance(IsoDep.class, new Class<?>[] {Tag.class}, new Object[] {null});
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyBitmap.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyBitmap.java
@@ -262,7 +262,7 @@ public class ShadowLegacyBitmap extends ShadowBitmap {
     shadowBitmap.appendDescription(shadowSrcBitmap.getDescription());
     shadowBitmap.appendDescription(" scaled to " + dstWidth + " x " + dstHeight);
     if (filter) {
-      shadowBitmap.appendDescription(" with filter " + filter);
+      shadowBitmap.appendDescription(" with filter true");
     }
 
     shadowBitmap.createdFromBitmap = src;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyCanvas.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyCanvas.java
@@ -180,7 +180,7 @@ public class ShadowLegacyCanvas extends ShadowCanvas {
     }
 
     if (src != null) {
-      descriptionBuilder.append(" taken from ").append(src.toString());
+      descriptionBuilder.append(" taken from ").append(src);
     }
     appendDescription(descriptionBuilder.toString());
   }
@@ -203,7 +203,7 @@ public class ShadowLegacyCanvas extends ShadowCanvas {
     }
 
     if (src != null) {
-      descriptionBuilder.append(" taken from ").append(src.toString());
+      descriptionBuilder.append(" taken from ").append(src);
     }
     appendDescription(descriptionBuilder.toString());
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyMatrix.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyMatrix.java
@@ -198,7 +198,7 @@ public class ShadowLegacyMatrix extends ShadowMatrix {
 
   @Implementation
   protected boolean preRotate(float degrees) {
-    preOps.addFirst(ROTATE + " " + Float.toString(degrees));
+    preOps.addFirst(ROTATE + " " + degrees);
     return preConcat(SimpleMatrix.rotate(degrees));
   }
 
@@ -246,7 +246,7 @@ public class ShadowLegacyMatrix extends ShadowMatrix {
 
   @Implementation
   protected boolean postRotate(float degrees) {
-    postOps.addLast(ROTATE + " " + Float.toString(degrees));
+    postOps.addLast(ROTATE + " " + degrees);
     return postConcat(SimpleMatrix.rotate(degrees));
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacySQLiteConnection.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacySQLiteConnection.java
@@ -611,10 +611,7 @@ public class ShadowLegacySQLiteConnection extends ShadowSQLiteConnection {
         final StatementOperation<T> statementOperation) {
       synchronized (lock) {
         final SQLiteStatement statement = getStatement(connectionPtr, statementPtr);
-        return execute(
-            () -> {
-              return statementOperation.call(statement);
-            });
+        return execute(() -> statementOperation.call(statement));
       }
     }
 
@@ -744,7 +741,7 @@ public class ShadowLegacySQLiteConnection extends ShadowSQLiteConnection {
       final int baseErrorCode = errorCode & 0xff;
       // Remove redundant error code prefix from sqlite4java. The error code is added
       // as a suffix below.
-      String errorMessageWithoutCode = sqliteErrorMessage.replaceAll("^\\[\\d+\\] ?", "");
+      String errorMessageWithoutCode = sqliteErrorMessage.replaceAll("^\\[\\d+] ?", "");
       StringBuilder fullMessage = new StringBuilder(errorMessageWithoutCode);
       fullMessage.append(" (code ");
       fullMessage.append(errorCode);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocationManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLocationManager.java
@@ -276,10 +276,7 @@ public class ShadowLocationManager {
       if (criteria.isBearingRequired() && !hasBearingSupport()) {
         return false;
       }
-      if (!criteria.isCostAllowed() && hasMonetaryCost) {
-        return false;
-      }
-      return true;
+      return criteria.isCostAllowed() || !hasMonetaryCost;
     }
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLog.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLog.java
@@ -14,6 +14,7 @@ import java.io.PrintStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
@@ -330,10 +331,10 @@ public class ShadowLog {
 
       LogItem log = (LogItem) o;
       return type == log.type
-          && !(timeString != null ? !timeString.equals(log.timeString) : log.timeString != null)
-          && !(msg != null ? !msg.equals(log.msg) : log.msg != null)
-          && !(tag != null ? !tag.equals(log.tag) : log.tag != null)
-          && !(throwable != null ? !throwable.equals(log.throwable) : log.throwable != null);
+          && Objects.equals(timeString, log.timeString)
+          && Objects.equals(msg, log.msg)
+          && Objects.equals(tag, log.tag)
+          && Objects.equals(throwable, log.throwable);
     }
 
     @Override

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaActionSound.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaActionSound.java
@@ -31,7 +31,7 @@ public class ShadowMediaActionSound {
   @SuppressWarnings("NonFinalStaticField")
   private static boolean mustPlayShutterSoundInternal = false;
 
-  private static final HashMap<Integer, AtomicInteger> initializePlayCountMap() {
+  private static HashMap<Integer, AtomicInteger> initializePlayCountMap() {
     HashMap<Integer, AtomicInteger> playCount = new HashMap<>();
     for (int sound : ALL_SOUNDS) {
       playCount.put(sound, new AtomicInteger(0));

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaCodec.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaCodec.java
@@ -408,7 +408,7 @@ public class ShadowMediaCodec {
 
     if (isAsync) {
       // Dequeue the buffer to signal its availability to the client.
-      outputBuffersPendingDequeue.remove(Integer.valueOf(index));
+      outputBuffersPendingDequeue.remove(index);
       // Signal output buffer availability.
       postFakeNativeEvent(EVENT_CALLBACK, CB_OUTPUT_AVAILABLE, index, outputBufferInfos[index]);
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMediaPlayer.java
@@ -162,7 +162,6 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
    * Class for grouping events that are meant to fire at the same time. Also schedules the next
    * event to run.
    */
-  @SuppressWarnings("serial")
   private static class RunList extends ArrayList<MediaEvent> implements MediaEvent {
 
     public RunList() {
@@ -180,7 +179,7 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
   }
 
   public interface MediaEvent {
-    public void run(MediaPlayer mp, ShadowMediaPlayer smp);
+    void run(MediaPlayer mp, ShadowMediaPlayer smp);
   }
 
   /**
@@ -375,7 +374,7 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
    *
    * @see #setCreateListener
    */
-  public static interface CreateListener {
+  public interface CreateListener {
     /**
      * Method that is invoked when a new {@link MediaPlayer} is created. This method is invoked at
      * the end of the constructor, after all of the default setup has been completed.
@@ -384,7 +383,7 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
      * @param shadow reference to the corresponding shadow object for the newly-created media player
      *     (provided for convenience).
      */
-    public void onCreate(MediaPlayer player, ShadowMediaPlayer shadow);
+    void onCreate(MediaPlayer player, ShadowMediaPlayer shadow);
   }
 
   /** Current state of the media player. */
@@ -1517,7 +1516,7 @@ public class ShadowMediaPlayer extends ShadowPlayerBase {
   /** Allows test cases to simulate seek completion by invoking callback. */
   public void invokeSeekCompleteListener() {
     int duration = getMediaInfo().duration;
-    setCurrentPosition(pendingSeek > duration ? duration : pendingSeek < 0 ? 0 : pendingSeek);
+    setCurrentPosition(pendingSeek > duration ? duration : Math.max(pendingSeek, 0));
     pendingSeek = -1;
     if (state == STARTED) {
       doStart();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeAllocationRegistry.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeAllocationRegistry.java
@@ -39,7 +39,7 @@ public class ShadowNativeAllocationRegistry {
   @Implementation(minSdk = Baklava.SDK_INT)
   protected void __constructor__(
       ClassLoader classLoader,
-      Class clazz,
+      Class<?> clazz,
       long freeFunction,
       long size,
       boolean mallocAllocation) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeTypeface.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeTypeface.java
@@ -90,7 +90,6 @@ public class ShadowNativeTypeface extends ShadowTypeface {
     return new File(fontDir);
   }
 
-  @SuppressWarnings("unchecked")
   @Implementation(minSdk = O, maxSdk = O_MR1)
   protected static @ClassName("android.graphics.FontFamily") Object makeFamilyFromParsed(
       @ClassName("android.text.FontConfig$Family") Object family,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNoopNativeAllocationRegistry.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNoopNativeAllocationRegistry.java
@@ -41,7 +41,7 @@ public class ShadowNoopNativeAllocationRegistry {
   @Implementation(minSdk = Baklava.SDK_INT)
   protected void __constructor__(
       ClassLoader classLoader,
-      Class clazz,
+      Class<?> clazz,
       long freeFunction,
       long size,
       boolean mallocAllocation) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotification.java
@@ -155,8 +155,7 @@ public class ShadowNotification {
       ByteArrayOutputStream buf = new ByteArrayOutputStream();
       ShadowView shadowView = Shadow.extract(view);
       shadowView.dump(new PrintStream(buf), 4);
-      throw new IllegalArgumentException(
-          "no id." + resourceName + " found in view:\n" + buf.toString());
+      throw new IllegalArgumentException("no id." + resourceName + " found in view:\n" + buf);
     }
     return subView;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -364,7 +365,7 @@ public class ShadowNotificationManager {
   protected Map<String, AutomaticZenRule> getAutomaticZenRules() {
     enforcePolicyAccess();
 
-    ImmutableMap.Builder<String, AutomaticZenRule> rules = new ImmutableMap.Builder();
+    ImmutableMap.Builder<String, AutomaticZenRule> rules = new ImmutableMap.Builder<>();
     for (Map.Entry<String, AutomaticZenRule> entry : automaticZenRules.entrySet()) {
       rules.put(entry.getKey(), copyAutomaticZenRule(entry.getValue()));
     }
@@ -547,8 +548,7 @@ public class ShadowNotificationManager {
     public boolean equals(Object o) {
       if (!(o instanceof Key)) return false;
       Key other = (Key) o;
-      return (this.tag == null ? other.tag == null : this.tag.equals(other.tag))
-          && this.id == other.id;
+      return Objects.equals(this.tag, other.tag) && this.id == other.id;
     }
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOpenGLMatrix.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowOpenGLMatrix.java
@@ -112,11 +112,11 @@ public class ShadowOpenGLMatrix {
     if (rhsVecOffset + 4 > rhsVec.length) {
       throw new IllegalArgumentException("rhsVecOffset + 4 > rhsVec.length");
     }
-    final float x = rhsVec[rhsVecOffset + 0];
+    final float x = rhsVec[rhsVecOffset];
     final float y = rhsVec[rhsVecOffset + 1];
     final float z = rhsVec[rhsVecOffset + 2];
     final float w = rhsVec[rhsVecOffset + 3];
-    resultVec[resultVecOffset + 0] =
+    resultVec[resultVecOffset] =
         lhsMat[I(0, 0, lhsMatOffset)] * x
             + lhsMat[I(1, 0, lhsMatOffset)] * y
             + lhsMat[I(2, 0, lhsMatOffset)] * z

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
@@ -251,11 +251,11 @@ public class ShadowPackageManager {
           permission.WRITE_CALENDAR,
           createPermissionInfo(
               permission.WRITE_CALENDAR,
-              "add or modify calendar events and send email to guests without owners\' knowledge",
+              "add or modify calendar events and send email to guests without owners' knowledge",
               "Allows the app to add, remove, change events that you can modify on your phone,"
                   + " including those of friends or co-workers. This may allow the app to send"
                   + " messages that appear to come from calendar owners, or modify events without"
-                  + " the owners\' knowledge.",
+                  + " the owners' knowledge.",
               PermissionInfo.PROTECTION_DANGEROUS,
               permission_group.CALENDAR),
           permission.GET_ACCOUNTS,
@@ -271,7 +271,7 @@ public class ShadowPackageManager {
               permission.READ_CONTACTS,
               "read your contacts",
               "Allows the app to read data about your contacts stored on your phone, including the"
-                  + " frequency with which you\'ve called, emailed, or communicated in other ways"
+                  + " frequency with which you've called, emailed, or communicated in other ways"
                   + " with specific individuals. This permission allows apps to save your contact"
                   + " data, and malicious apps may share contact data without your knowledge.",
               PermissionInfo.PROTECTION_DANGEROUS,
@@ -281,7 +281,7 @@ public class ShadowPackageManager {
               permission.WRITE_CONTACTS,
               "modify your contacts",
               "Allows the app to modify the data about your contacts stored on your phone,"
-                  + " including the frequency with which you\'ve called, emailed, or communicated"
+                  + " including the frequency with which you've called, emailed, or communicated"
                   + " in other ways with specific contacts. This permission allows apps to delete"
                   + " contact data.",
               PermissionInfo.PROTECTION_DANGEROUS,
@@ -817,8 +817,7 @@ public class ShadowPackageManager {
     } else if (resolveInfo.providerInfo != null) {
       return resolveInfo.providerInfo.packageName;
     }
-    throw new IllegalStateException(
-        "Could not find package name for ResolveInfo " + resolveInfo.toString());
+    throw new IllegalStateException("Could not find package name for ResolveInfo " + resolveInfo);
   }
 
   public void addActivityIcon(ComponentName component, Drawable drawable) {
@@ -1117,7 +1116,7 @@ public class ShadowPackageManager {
   }
 
   public void addDrawableResolution(String packageName, int resourceId, Drawable drawable) {
-    drawables.put(new Pair(packageName, resourceId), drawable);
+    drawables.put(new Pair<>(packageName, resourceId), drawable);
   }
 
   public void setNameForUid(int uid, String name) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPath.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPath.java
@@ -48,15 +48,13 @@ public abstract class ShadowPath {
 
       if (Float.compare(point.x, x) != 0) return false;
       if (Float.compare(point.y, y) != 0) return false;
-      if (type != point.type) return false;
-
-      return true;
+      return type == point.type;
     }
 
     @Override
     public int hashCode() {
-      int result = (x != +0.0f ? Float.floatToIntBits(x) : 0);
-      result = 31 * result + (y != +0.0f ? Float.floatToIntBits(y) : 0);
+      int result = (x != 0.0f ? Float.floatToIntBits(x) : 0);
+      result = 31 * result + (y != 0.0f ? Float.floatToIntBits(y) : 0);
       result = 31 * result + (type != null ? type.hashCode() : 0);
       return result;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPathParser.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPathParser.java
@@ -240,23 +240,23 @@ public class ShadowPathParser {
       for (int k = 0; k < val.length; k += incr) {
         switch (cmd) {
           case 'm': // moveto - Start a new sub-path (relative)
-            path.rMoveTo(val[k + 0], val[k + 1]);
-            currentX += val[k + 0];
+            path.rMoveTo(val[k], val[k + 1]);
+            currentX += val[k];
             currentY += val[k + 1];
             break;
           case 'M': // moveto - Start a new sub-path
-            path.moveTo(val[k + 0], val[k + 1]);
-            currentX = val[k + 0];
+            path.moveTo(val[k], val[k + 1]);
+            currentX = val[k];
             currentY = val[k + 1];
             break;
           case 'l': // lineto - Draw a line from the current point (relative)
-            path.rLineTo(val[k + 0], val[k + 1]);
-            currentX += val[k + 0];
+            path.rLineTo(val[k], val[k + 1]);
+            currentX += val[k];
             currentY += val[k + 1];
             break;
           case 'L': // lineto - Draw a line from the current point
-            path.lineTo(val[k + 0], val[k + 1]);
-            currentX = val[k + 0];
+            path.lineTo(val[k], val[k + 1]);
+            currentX = val[k];
             currentY = val[k + 1];
             break;
           case 'z': // closepath - Close the current subpath
@@ -264,23 +264,23 @@ public class ShadowPathParser {
             path.close();
             break;
           case 'h': // horizontal lineto - Draws a horizontal line (relative)
-            path.rLineTo(val[k + 0], 0);
-            currentX += val[k + 0];
+            path.rLineTo(val[k], 0);
+            currentX += val[k];
             break;
           case 'H': // horizontal lineto - Draws a horizontal line
-            path.lineTo(val[k + 0], currentY);
-            currentX = val[k + 0];
+            path.lineTo(val[k], currentY);
+            currentX = val[k];
             break;
           case 'v': // vertical lineto - Draws a vertical line from the current point (r)
-            path.rLineTo(0, val[k + 0]);
-            currentY += val[k + 0];
+            path.rLineTo(0, val[k]);
+            currentY += val[k];
             break;
           case 'V': // vertical lineto - Draws a vertical line from the current point
-            path.lineTo(currentX, val[k + 0]);
-            currentY = val[k + 0];
+            path.lineTo(currentX, val[k]);
+            currentY = val[k];
             break;
           case 'c': // curveto - Draws a cubic Bézier curve (relative)
-            path.rCubicTo(val[k + 0], val[k + 1], val[k + 2], val[k + 3], val[k + 4], val[k + 5]);
+            path.rCubicTo(val[k], val[k + 1], val[k + 2], val[k + 3], val[k + 4], val[k + 5]);
 
             ctrlPointX = currentX + val[k + 2];
             ctrlPointY = currentY + val[k + 3];
@@ -289,7 +289,7 @@ public class ShadowPathParser {
 
             break;
           case 'C': // curveto - Draws a cubic Bézier curve
-            path.cubicTo(val[k + 0], val[k + 1], val[k + 2], val[k + 3], val[k + 4], val[k + 5]);
+            path.cubicTo(val[k], val[k + 1], val[k + 2], val[k + 3], val[k + 4], val[k + 5]);
             currentX = val[k + 4];
             currentY = val[k + 5];
             ctrlPointX = val[k + 2];
@@ -308,12 +308,12 @@ public class ShadowPathParser {
             path.rCubicTo(
                 reflectiveCtrlPointX,
                 reflectiveCtrlPointY,
-                val[k + 0],
+                val[k],
                 val[k + 1],
                 val[k + 2],
                 val[k + 3]);
 
-            ctrlPointX = currentX + val[k + 0];
+            ctrlPointX = currentX + val[k];
             ctrlPointY = currentY + val[k + 1];
             currentX += val[k + 2];
             currentY += val[k + 3];
@@ -331,25 +331,25 @@ public class ShadowPathParser {
             path.cubicTo(
                 reflectiveCtrlPointX,
                 reflectiveCtrlPointY,
-                val[k + 0],
+                val[k],
                 val[k + 1],
                 val[k + 2],
                 val[k + 3]);
-            ctrlPointX = val[k + 0];
+            ctrlPointX = val[k];
             ctrlPointY = val[k + 1];
             currentX = val[k + 2];
             currentY = val[k + 3];
             break;
           case 'q': // Draws a quadratic Bézier (relative)
-            path.rQuadTo(val[k + 0], val[k + 1], val[k + 2], val[k + 3]);
-            ctrlPointX = currentX + val[k + 0];
+            path.rQuadTo(val[k], val[k + 1], val[k + 2], val[k + 3]);
+            ctrlPointX = currentX + val[k];
             ctrlPointY = currentY + val[k + 1];
             currentX += val[k + 2];
             currentY += val[k + 3];
             break;
           case 'Q': // Draws a quadratic Bézier
-            path.quadTo(val[k + 0], val[k + 1], val[k + 2], val[k + 3]);
-            ctrlPointX = val[k + 0];
+            path.quadTo(val[k], val[k + 1], val[k + 2], val[k + 3]);
+            ctrlPointX = val[k];
             ctrlPointY = val[k + 1];
             currentX = val[k + 2];
             currentY = val[k + 3];
@@ -364,10 +364,10 @@ public class ShadowPathParser {
               reflectiveCtrlPointX = currentX - ctrlPointX;
               reflectiveCtrlPointY = currentY - ctrlPointY;
             }
-            path.rQuadTo(reflectiveCtrlPointX, reflectiveCtrlPointY, val[k + 0], val[k + 1]);
+            path.rQuadTo(reflectiveCtrlPointX, reflectiveCtrlPointY, val[k], val[k + 1]);
             ctrlPointX = currentX + reflectiveCtrlPointX;
             ctrlPointY = currentY + reflectiveCtrlPointY;
-            currentX += val[k + 0];
+            currentX += val[k];
             currentY += val[k + 1];
             break;
           case 'T': // Draws a quadratic Bézier curve (reflective control point)
@@ -380,10 +380,10 @@ public class ShadowPathParser {
               reflectiveCtrlPointX = 2 * currentX - ctrlPointX;
               reflectiveCtrlPointY = 2 * currentY - ctrlPointY;
             }
-            path.quadTo(reflectiveCtrlPointX, reflectiveCtrlPointY, val[k + 0], val[k + 1]);
+            path.quadTo(reflectiveCtrlPointX, reflectiveCtrlPointY, val[k], val[k + 1]);
             ctrlPointX = reflectiveCtrlPointX;
             ctrlPointY = reflectiveCtrlPointY;
-            currentX = val[k + 0];
+            currentX = val[k];
             currentY = val[k + 1];
             break;
           case 'a': // Draws an elliptical arc
@@ -394,7 +394,7 @@ public class ShadowPathParser {
                 currentY,
                 val[k + 5] + currentX,
                 val[k + 6] + currentY,
-                val[k + 0],
+                val[k],
                 val[k + 1],
                 val[k + 2],
                 val[k + 3] != 0,
@@ -411,7 +411,7 @@ public class ShadowPathParser {
                 currentY,
                 val[k + 5],
                 val[k + 6],
-                val[k + 0],
+                val[k],
                 val[k + 1],
                 val[k + 2],
                 val[k + 3] != 0,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPendingIntent.java
@@ -418,7 +418,7 @@ public class ShadowPendingIntent {
   }
 
   /**
-   * @return {@true} iff this PendingIntent has been canceled
+   * @return {@code true} iff this PendingIntent has been canceled
    */
   public boolean isCanceled() {
     return canceled;
@@ -514,10 +514,7 @@ public class ShadowPendingIntent {
       }
     }
 
-    if (this.requestCode != that.requestCode) {
-      return false;
-    }
-    return true;
+    return this.requestCode == that.requestCode;
   }
 
   @Override

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPowerManager.java
@@ -311,11 +311,11 @@ public class ShadowPowerManager {
   @Implementation(minSdk = M)
   protected boolean isIgnoringBatteryOptimizations(String packageName) {
     Boolean result = ignoringBatteryOptimizations.get(packageName);
-    return result == null ? false : result;
+    return result != null && result;
   }
 
   public void setIgnoringBatteryOptimizations(String packageName, boolean value) {
-    ignoringBatteryOptimizations.put(packageName, Boolean.valueOf(value));
+    ignoringBatteryOptimizations.put(packageName, value);
   }
 
   /**
@@ -489,7 +489,7 @@ public class ShadowPowerManager {
 
     @Implementation
     protected synchronized void acquire(long timeout) {
-      Long timeoutMillis = timeout + SystemClock.elapsedRealtime();
+      long timeoutMillis = timeout + SystemClock.elapsedRealtime();
       if (timeoutMillis > 0) {
         acquireInternal(Optional.of(timeoutMillis));
       } else {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRemoteCallbackList.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRemoteCallbackList.java
@@ -94,7 +94,7 @@ public class ShadowRemoteCallbackList<E extends IInterface> {
         throw new IllegalStateException("beginBroadcast() called while already in a broadcast");
       }
       final int N = broadcastCount = callbacks.size();
-      if (N <= 0) {
+      if (N == 0) {
         return 0;
       }
       Object[] active = activeBroadcast;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemServiceRegistry.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemServiceRegistry.java
@@ -131,7 +131,7 @@ public class ShadowSystemServiceRegistry {
     e.printStackTrace();
   }
 
-  private static Class classForName(String className) {
+  private static Class<?> classForName(String className) {
     try {
       return Class.forName(className);
     } catch (ClassNotFoundException e) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextToSpeech.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTextToSpeech.java
@@ -367,6 +367,6 @@ public class ShadowTextToSpeech {
   interface TextToSpeechReflector {
 
     @Direct
-    int speak(final String text, final int queueMode, final HashMap params);
+    int speak(final String text, final int queueMode, final HashMap<?, ?> params);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTime.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTime.java
@@ -1,5 +1,6 @@
 package org.robolectric.shadows;
 
+import android.annotation.SuppressLint;
 import android.text.format.Time;
 import android.util.TimeFormatException;
 import org.robolectric.annotation.Implementation;
@@ -27,13 +28,14 @@ public class ShadowTime {
     return -1;
   }
 
+  @SuppressLint("DefaultLocale")
   @Implementation
   protected void checkChar(String s, int spos, char expected) {
     char c = s.charAt(spos);
     if (c != expected) {
       throwTimeFormatException(
           String.format(
-              "Unexpected character 0x%02d at pos=%d.  Expected 0x%02d (\'%c\').",
+              "Unexpected character 0x%02d at pos=%d.  Expected 0x%02d ('%c').",
               (int) c, spos, (int) expected, expected));
     }
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTrace.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTrace.java
@@ -30,10 +30,10 @@ public class ShadowTrace {
   private static final String TAG = "ShadowTrace";
 
   private static final ThreadLocal<Deque<String>> currentSections =
-      ThreadLocal.withInitial(() -> new ArrayDeque<>());
+      ThreadLocal.withInitial(ArrayDeque::new);
 
   private static final ThreadLocal<Queue<String>> previousSections =
-      ThreadLocal.withInitial((Supplier<Deque<String>>) () -> new ArrayDeque<>());
+      ThreadLocal.withInitial((Supplier<Deque<String>>) ArrayDeque::new);
 
   private static final Set<AsyncTraceSection> currentAsyncSections = new HashSet<>();
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTypeface.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTypeface.java
@@ -1,6 +1,7 @@
 package org.robolectric.shadows;
 
 import android.graphics.Typeface;
+import java.util.Objects;
 import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowTypeface.Picker;
 
@@ -39,13 +40,7 @@ public abstract class ShadowTypeface {
       if (style != fontDesc.style) {
         return false;
       }
-      if (familyName != null
-          ? !familyName.equals(fontDesc.familyName)
-          : fontDesc.familyName != null) {
-        return false;
-      }
-
-      return true;
+      return Objects.equals(familyName, fontDesc.familyName);
     }
 
     @Override

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUserManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUserManager.java
@@ -745,7 +745,7 @@ public class ShadowUserManager {
    */
   @Implementation(minSdk = M)
   protected boolean isSystemUser() {
-    if (userManagerState.isSystemUser == false) {
+    if (!userManagerState.isSystemUser) {
       return false;
     } else {
       return reflector(UserManagerReflector.class, realObject).isSystemUser();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVibrator.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVibrator.java
@@ -191,7 +191,7 @@ public class ShadowVibrator {
       if (this == o) {
         return true;
       }
-      if (o == null || !getClass().isInstance(o)) {
+      if (!getClass().isInstance(o)) {
         return false;
       }
       PrimitiveEffect that = (PrimitiveEffect) o;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowViewGroup.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowViewGroup.java
@@ -26,9 +26,7 @@ public class ShadowViewGroup extends ShadowView {
   @Implementation
   protected void addView(final View child, final int index, final ViewGroup.LayoutParams params) {
     Runnable addViewRunnable =
-        () -> {
-          reflector(ViewGroupReflector.class, realViewGroup).addView(child, index, params);
-        };
+        () -> reflector(ViewGroupReflector.class, realViewGroup).addView(child, index, params);
     if (ShadowLooper.looperMode() == Mode.LEGACY) {
       shadowMainLooper().runPaused(addViewRunnable);
     } else {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/SharedLibraryInfoBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/SharedLibraryInfoBuilder.java
@@ -87,7 +87,7 @@ public final class SharedLibraryInfoBuilder {
           ClassParameter.from(int.class, type),
           ClassParameter.from(VersionedPackage.class, declaringPackage),
           ClassParameter.from(List.class, dependentPackages));
-    } else if (apiLevel <= VERSION_CODES.P) {
+    } else if (apiLevel == VERSION_CODES.P) {
       return ReflectionHelpers.callConstructor(
           SharedLibraryInfo.class,
           ClassParameter.from(String.class, name),

--- a/shadows/framework/src/main/java/org/robolectric/shadows/_Activity_.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/_Activity_.java
@@ -255,7 +255,7 @@ public interface _Activity_ {
           null,
           null,
           null);
-    } else if (apiLevel > Build.VERSION_CODES.R) {
+    } else {
       attach(
           baseContext,
           activityThread,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/util/DataSource.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/util/DataSource.java
@@ -99,17 +99,14 @@ public class DataSource {
     if (this == obj) {
       return true;
     }
-    if (obj == null || !(obj instanceof DataSource)) {
+    if (!(obj instanceof DataSource)) {
       return false;
     }
     final DataSource other = (DataSource) obj;
     if (dataSource == null) {
-      if (other.dataSource != null) {
-        return false;
-      }
-    } else if (!dataSource.equals(other.dataSource)) {
-      return false;
+      return other.dataSource == null;
+    } else {
+      return dataSource.equals(other.dataSource);
     }
-    return true;
   }
 }


### PR DESCRIPTION
This PR fixes various warnings in the `:shadows:framework`. These include:
- Remove redundant modifiers (`static`, `public`, ...).
- Add missing generic types.
- Simplifying logical checks.