### PR TITLE
Fix generic usage on `AsyncTask` shadows

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTask.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTask.java
@@ -23,7 +23,8 @@ import org.robolectric.util.reflector.ForType;
     shadowPicker = ShadowAsyncTask.Picker.class,
     // TODO: turn off shadowOf generation. Figure out why this is needed
     isInAndroidSdk = false)
-public class ShadowLegacyAsyncTask<Params, Progress, Result> extends ShadowAsyncTask {
+public class ShadowLegacyAsyncTask<Params, Progress, Result>
+    extends ShadowAsyncTask<Params, Progress, Result> {
 
   @RealObject private AsyncTask<Params, Progress, Result> realAsyncTask;
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTaskLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTaskLoader.java
@@ -15,7 +15,7 @@ import org.robolectric.annotation.RealObject;
     value = AsyncTaskLoader.class,
     shadowPicker = ShadowAsyncTaskLoader.Picker.class,
     isInAndroidSdk = false)
-public class ShadowLegacyAsyncTaskLoader<D> extends ShadowAsyncTaskLoader {
+public class ShadowLegacyAsyncTaskLoader<D> extends ShadowAsyncTaskLoader<D> {
   @RealObject private AsyncTaskLoader<D> realObject;
   private BackgroundWorker worker;
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedAsyncTask.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedAsyncTask.java
@@ -25,7 +25,8 @@ import org.robolectric.util.reflector.ForType;
     // TODO: turn off shadowOf generation. Figure out why this is needed
     isInAndroidSdk = false)
 @Beta
-public class ShadowPausedAsyncTask<Params, Progress, Result> extends ShadowAsyncTask {
+public class ShadowPausedAsyncTask<Params, Progress, Result>
+    extends ShadowAsyncTask<Params, Progress, Result> {
 
   private static Executor executorOverride = null;
 


### PR DESCRIPTION
This commit fixes the generic definition on the `ShadowAsyncTask` classes.