### PR TITLE
Deprecate `AsyncTask` and `AsyncTaskLoader` shadows

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAsyncTask.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAsyncTask.java
@@ -3,7 +3,12 @@ package org.robolectric.shadows;
 import android.os.AsyncTask;
 import org.robolectric.annotation.Implements;
 
-/** The shadow API for {@link android.os.AsyncTask}. */
+/**
+ * The shadow API for {@link AsyncTask}.
+ *
+ * @deprecated {@link AsyncTask} is deprecated in the Android SDK.
+ */
+@Deprecated
 @Implements(value = AsyncTask.class, shadowPicker = ShadowAsyncTask.Picker.class)
 public abstract class ShadowAsyncTask<Params, Progress, Result> {
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAsyncTaskLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAsyncTaskLoader.java
@@ -9,9 +9,11 @@ import org.robolectric.annotation.LooperMode;
  *
  * <p>Different shadow implementations will be used based on the current {@link LooperMode.Mode}.
  *
+ * @deprecated {@link AsyncTaskLoader} is deprecated in the Android SDK.
  * @see ShadowLegacyAsyncTaskLoader
  * @see ShadowPausedAsyncTaskLoader
  */
+@Deprecated
 @Implements(value = AsyncTaskLoader.class, shadowPicker = ShadowAsyncTaskLoader.Picker.class)
 public abstract class ShadowAsyncTaskLoader<D> {
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTask.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTask.java
@@ -17,7 +17,12 @@ import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.RealObject;
 import org.robolectric.util.reflector.ForType;
 
-/** A {@link AsyncTask} shadow for {@link LooperMode.Mode#LEGACY}. */
+/**
+ * A {@link AsyncTask} shadow for {@link LooperMode.Mode#LEGACY}.
+ *
+ * @deprecated {@link AsyncTask} is deprecated in the Android SDK.
+ */
+@Deprecated
 @Implements(
     value = AsyncTask.class,
     shadowPicker = ShadowAsyncTask.Picker.class,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTaskLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTaskLoader.java
@@ -10,7 +10,12 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.RealObject;
 
-/** The shadow {@link AsyncTaskLoader} for {@link LooperMode.Mode#LEGACY}. */
+/**
+ * The shadow {@link AsyncTaskLoader} for {@link LooperMode.Mode#LEGACY}.
+ *
+ * @deprecated {@link AsyncTaskLoader} is deprecated in the Android SDK.
+ */
+@Deprecated
 @Implements(
     value = AsyncTaskLoader.class,
     shadowPicker = ShadowAsyncTaskLoader.Picker.class,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedAsyncTask.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedAsyncTask.java
@@ -17,8 +17,9 @@ import org.robolectric.util.reflector.ForType;
 /**
  * A {@link AsyncTask} shadow for {@link LooperMode.Mode#PAUSED}
  *
- * <p>This is beta API, and will likely be renamed/removed in a future Robolectric release.
+ * @deprecated {@link AsyncTask} is deprecated in the Android SDK.
  */
+@Deprecated
 @Implements(
     value = AsyncTask.class,
     shadowPicker = ShadowAsyncTask.Picker.class,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedAsyncTaskLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedAsyncTaskLoader.java
@@ -15,7 +15,10 @@ import org.robolectric.util.reflector.ForType;
  *
  * <p>In {@link LooperMode.Mode#PAUSED} mode, Robolectric just uses the real AsyncTaskLoader for
  * now.
+ *
+ * @deprecated {@link AsyncTaskLoader} is deprecated in the Android SDK.
  */
+@Deprecated
 @Implements(
     value = AsyncTaskLoader.class,
     shadowPicker = ShadowAsyncTaskLoader.Picker.class,


### PR DESCRIPTION
This commit deprecates the `AsyncTask` and `AsyncTaskLoader` shadows. These classes have been deprecated in the Android SDK for a while now.

I don't know if this is something you do in Robolectric to deprecate shadows when the corresponding Android API gets deprecated. Let me know if this is not needed.