### PR TITLE
Address a couple of warnings in `:robolectric`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
@@ -551,26 +551,24 @@ public class ShadowContentResolverTest {
               streamCreateCount.incrementAndGet();
               AtomicBoolean isClosed = new AtomicBoolean();
               isClosed.set(false);
-              OutputStream outputStream =
-                  new OutputStream() {
-                    @Override
-                    public void close() {
-                      isClosed.set(true);
-                    }
+              return new OutputStream() {
+                @Override
+                public void close() {
+                  isClosed.set(true);
+                }
 
-                    @Override
-                    public void write(int arg0) throws IOException {
-                      if (isClosed.get()) {
-                        throw new IOException();
-                      }
-                    }
+                @Override
+                public void write(int arg0) throws IOException {
+                  if (isClosed.get()) {
+                    throw new IOException();
+                  }
+                }
 
-                    @Override
-                    public String toString() {
-                      return "outputstream for " + uri;
-                    }
-                  };
-              return outputStream;
+                @Override
+                public String toString() {
+                  return "outputStream for " + uri;
+                }
+              };
             });
 
     assertThat(streamCreateCount.get()).isEqualTo(0);
@@ -643,26 +641,24 @@ public class ShadowContentResolverTest {
               streamCreateCount.incrementAndGet();
               AtomicBoolean isClosed = new AtomicBoolean();
               isClosed.set(false);
-              OutputStream outputStream =
-                  new OutputStream() {
-                    @Override
-                    public void close() {
-                      isClosed.set(true);
-                    }
+              return new OutputStream() {
+                @Override
+                public void close() {
+                  isClosed.set(true);
+                }
 
-                    @Override
-                    public void write(int arg0) throws IOException {
-                      if (isClosed.get()) {
-                        throw new IOException();
-                      }
-                    }
+                @Override
+                public void write(int arg0) throws IOException {
+                  if (isClosed.get()) {
+                    throw new IOException();
+                  }
+                }
 
-                    @Override
-                    public String toString() {
-                      return "outputstream for " + uri;
-                    }
-                  };
-              return outputStream;
+                @Override
+                public String toString() {
+                  return "outputStream for " + uri;
+                }
+              };
             });
 
     assertThat(streamCreateCount.get()).isEqualTo(0);

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationListenerServiceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationListenerServiceTest.java
@@ -67,10 +67,9 @@ public final class ShadowNotificationListenerServiceTest {
     ImmutableList<Notification> dummyNotifications =
         ImmutableList.of(
             createDummyNotification(), createDummyNotification(), createDummyNotification());
-    dummyNotifications.stream()
-        .forEach(
-            notification ->
-                shadowService.addActiveNotification(DEFAULT_PACKAGE, DEFAULT_ID, notification));
+    dummyNotifications.forEach(
+        notification ->
+            shadowService.addActiveNotification(DEFAULT_PACKAGE, DEFAULT_ID, notification));
 
     StatusBarNotification[] activeNotifications = service.getActiveNotifications();
 
@@ -159,10 +158,9 @@ public final class ShadowNotificationListenerServiceTest {
     ImmutableList<Notification> dummyNotifications =
         ImmutableList.of(
             createDummyNotification(), createDummyNotification(), createDummyNotification());
-    dummyNotifications.stream()
-        .forEach(
-            notification ->
-                shadowService.addActiveNotification(DEFAULT_PACKAGE, DEFAULT_ID, notification));
+    dummyNotifications.forEach(
+        notification ->
+            shadowService.addActiveNotification(DEFAULT_PACKAGE, DEFAULT_ID, notification));
 
     service.cancelAllNotifications();
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowProcessTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowProcessTest.java
@@ -21,38 +21,38 @@ public class ShadowProcessTest {
 
   @Test
   public void shouldBeZeroWhenNotSet() {
-    assertThat(android.os.Process.myPid()).isEqualTo(0);
+    assertThat(Process.myPid()).isEqualTo(0);
   }
 
   @Test
   public void shouldGetMyPidAsSet() {
     ShadowProcess.setPid(3);
-    assertThat(android.os.Process.myPid()).isEqualTo(3);
+    assertThat(Process.myPid()).isEqualTo(3);
   }
 
   @Test
   public void shouldGetMyUidAsSet() {
     ShadowProcess.setUid(123);
-    assertThat(android.os.Process.myUid()).isEqualTo(123);
+    assertThat(Process.myUid()).isEqualTo(123);
   }
 
   @Test
   public void shouldGetKilledProcess() {
     ShadowProcess.clearKilledProcesses();
-    android.os.Process.killProcess(999);
+    Process.killProcess(999);
     assertThat(ShadowProcess.wasKilled(999)).isTrue();
   }
 
   @Test
   public void shouldClearKilledProcessesOnReset() {
-    android.os.Process.killProcess(999);
+    Process.killProcess(999);
     ShadowProcess.reset();
     assertThat(ShadowProcess.wasKilled(999)).isFalse();
   }
 
   @Test
   public void shouldClearKilledProcesses() {
-    android.os.Process.killProcess(999);
+    Process.killProcess(999);
     ShadowProcess.clearKilledProcesses();
     assertThat(ShadowProcess.wasKilled(999)).isFalse();
   }
@@ -60,23 +60,22 @@ public class ShadowProcessTest {
   @Test
   public void shouldGetMultipleKilledProcesses() {
     ShadowProcess.clearKilledProcesses();
-    android.os.Process.killProcess(999);
-    android.os.Process.killProcess(123);
+    Process.killProcess(999);
+    Process.killProcess(123);
     assertThat(ShadowProcess.wasKilled(999)).isTrue();
     assertThat(ShadowProcess.wasKilled(123)).isTrue();
   }
 
   @Test
   public void myTid_mainThread_returnsCurrentThreadId() {
-    assertThat(android.os.Process.myTid()).isEqualTo(Thread.currentThread().getId());
+    assertThat(Process.myTid()).isEqualTo(Thread.currentThread().getId());
   }
 
   @Test
   public void myTid_backgroundThread_returnsCurrentThreadId() throws Exception {
     AtomicBoolean ok = new AtomicBoolean(false);
 
-    Thread thread =
-        new Thread(() -> ok.set(android.os.Process.myTid() == Thread.currentThread().getId()));
+    Thread thread = new Thread(() -> ok.set(Process.myTid() == Thread.currentThread().getId()));
     thread.start();
     thread.join();
 
@@ -100,47 +99,43 @@ public class ShadowProcessTest {
 
   @Test
   public void getThreadPriority_notSet_returnsZero() {
-    assertThat(android.os.Process.getThreadPriority(123)).isEqualTo(0);
+    assertThat(Process.getThreadPriority(123)).isEqualTo(0);
   }
 
   @Test
   public void getThreadPriority_returnsThreadPriority() {
-    android.os.Process.setThreadPriority(123, android.os.Process.THREAD_PRIORITY_VIDEO);
+    Process.setThreadPriority(123, Process.THREAD_PRIORITY_VIDEO);
 
-    assertThat(android.os.Process.getThreadPriority(123))
-        .isEqualTo(android.os.Process.THREAD_PRIORITY_VIDEO);
+    assertThat(Process.getThreadPriority(123)).isEqualTo(Process.THREAD_PRIORITY_VIDEO);
   }
 
   @Test
   public void getThreadPriority_currentThread_returnsCurrentThreadPriority() {
-    android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_AUDIO);
+    Process.setThreadPriority(Process.THREAD_PRIORITY_AUDIO);
 
-    assertThat(android.os.Process.getThreadPriority(/* tid= */ 0))
-        .isEqualTo(android.os.Process.THREAD_PRIORITY_AUDIO);
+    assertThat(Process.getThreadPriority(/* tid= */ 0)).isEqualTo(Process.THREAD_PRIORITY_AUDIO);
   }
 
   @Test
   public void setThreadPriorityOneArgument_setsCurrentThreadPriority() {
-    android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_URGENT_AUDIO);
+    Process.setThreadPriority(Process.THREAD_PRIORITY_URGENT_AUDIO);
 
-    assertThat(android.os.Process.getThreadPriority(android.os.Process.myTid()))
-        .isEqualTo(android.os.Process.THREAD_PRIORITY_URGENT_AUDIO);
+    assertThat(Process.getThreadPriority(Process.myTid()))
+        .isEqualTo(Process.THREAD_PRIORITY_URGENT_AUDIO);
   }
 
   @Test
   public void setThreadPriorityOneArgument_setsCurrentThreadPriority_highestPriority() {
-    android.os.Process.setThreadPriority(THREAD_PRIORITY_HIGHEST);
+    Process.setThreadPriority(THREAD_PRIORITY_HIGHEST);
 
-    assertThat(android.os.Process.getThreadPriority(android.os.Process.myTid()))
-        .isEqualTo(THREAD_PRIORITY_HIGHEST);
+    assertThat(Process.getThreadPriority(Process.myTid())).isEqualTo(THREAD_PRIORITY_HIGHEST);
   }
 
   @Test
   public void setThreadPriorityOneArgument_setsCurrentThreadPriority_lowestPriority() {
-    android.os.Process.setThreadPriority(THREAD_PRIORITY_LOWEST);
+    Process.setThreadPriority(THREAD_PRIORITY_LOWEST);
 
-    assertThat(android.os.Process.getThreadPriority(android.os.Process.myTid()))
-        .isEqualTo(THREAD_PRIORITY_LOWEST);
+    assertThat(Process.getThreadPriority(Process.myTid())).isEqualTo(THREAD_PRIORITY_LOWEST);
   }
 
   @Test
@@ -148,7 +143,7 @@ public class ShadowProcessTest {
   public void shouldGetProcessNameAsSet() {
     ShadowProcess.setProcessName("com.foo.bar:baz");
 
-    assertThat(android.os.Process.myProcessName()).isEqualTo("com.foo.bar:baz");
+    assertThat(Process.myProcessName()).isEqualTo("com.foo.bar:baz");
   }
 
   @Test
@@ -158,6 +153,6 @@ public class ShadowProcessTest {
 
     ShadowProcess.reset();
 
-    assertThat(android.os.Process.myProcessName()).isEmpty();
+    assertThat(Process.myProcessName()).isEmpty();
   }
 }


### PR DESCRIPTION
This PR addresses a couple of warnings in the `:robolectric` module.

These are the last warnings changes that I had stashed locally.