### PR TITLE
Restrict snapshot release to the main repo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,7 +172,7 @@ jobs:
       SONATYPE_LOGIN: ${{ secrets.SONATYPE_LOGIN }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
     needs: unit-tests
-    if: github.ref == 'refs/heads/master'
+    if: github.repository == 'robolectric/robolectric' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This commit adds a check so snapshots publication only happens for the `robolectric/robolectric` repository (i.e. not from forks).