### PR TITLE
Update `validate_commit_message.yml` to use `renovate[bot]`

### DIFF
--- a/.github/workflows/validate_commit_message.yml
+++ b/.github/workflows/validate_commit_message.yml
@@ -37,7 +37,7 @@ jobs:
           fi
 
       - name: Validate commit body
-        if: github.actor != 'dependabot[bot]'
+        if: github.actor != 'renovate[bot]'
         run: |
           # Check that the commit has a body
           commit_body="$(git log -1 --pretty=format:'%b' | grep -v 'PiperOrigin-RevId')"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -241,7 +241,7 @@ play-services-basement = { module = "com.google.android.gms:play-services-baseme
 
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless-gradle" }
 
-# Not used, but helps dependabot trigger updates for Jacoco
+# Not used, but helps Renovate trigger updates for Jacoco
 jacoco-agent = { module = "org.jacoco:org.jacoco.agent", version.ref = "jacoco" }
 
 [bundles]


### PR DESCRIPTION
This commit updates the `validate_commit_message.yml` workflow to check for `renovate[bot]` instead of `dependabot[bot]`.