### PR TITLE
Ignore Play Services in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,9 @@
     "schedule:weekly"
   ],
   "ignoreDeps": [
+    "com.google.android.gms:play-services-auth",
+    "com.google.android.gms:play-services-base",
+    "com.google.android.gms:play-services-basement",
     "org.robolectric:nativeruntime-dist-compat"
   ],
   "labels": [


### PR DESCRIPTION
This PR updates Renovate's config to not update the Play Services dependencies.