### PR TITLE
Replace usages of `ImmutableMap#build()` with `ImmutableMap#buildOrThrow()`

### DIFF
--- a/processor/src/test/java/org/robolectric/annotation/processing/Utils.java
+++ b/processor/src/test/java/org/robolectric/annotation/processing/Utils.java
@@ -19,7 +19,7 @@ public class Utils {
           .put(PACKAGE_OPT, "org.robolectric")
           .put(JSON_DOCS_DIR, Files.createTempDir().toString())
           .put(SDK_CHECK_MODE, "OFF")
-          .build();
+          .buildOrThrow();
 
   public static final JavaFileObject SHADOW_PROVIDER_SOURCE =
       forResource("mock-source/org/robolectric/internal/ShadowProvider.java");

--- a/resources/src/main/java/org/robolectric/res/android/DataType.java
+++ b/resources/src/main/java/org/robolectric/res/android/DataType.java
@@ -55,7 +55,7 @@ public enum DataType {
     for (DataType type : values()) {
       builder.put(type.code(), type);
     }
-    FROM_BYTE = builder.build();
+    FROM_BYTE = builder.buildOrThrow();
   }
 
   DataType(int code) {

--- a/resources/src/main/java/org/robolectric/res/android/FileMap.java
+++ b/resources/src/main/java/org/robolectric/res/android/FileMap.java
@@ -274,7 +274,7 @@ public class FileMap {
         offset += 46 + fileNameLength + extraLength + fieldCommentLength;
       }
 
-      return result.build();
+      return result.buildOrThrow();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCamera.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCamera.java
@@ -53,7 +53,7 @@ public class ShadowCamera {
           .put("flash-mode", Camera.Parameters.FLASH_MODE_AUTO)
           .put("max-num-focus-areas", "1")
           .put("max-num-metering-areas", "1")
-          .build();
+          .buildOrThrow();
 
   private static int lastOpenedCameraId;
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDebug.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDebug.java
@@ -33,7 +33,7 @@ public class ShadowDebug {
 
   @Implementation(minSdk = M)
   protected static Map<String, String> getRuntimeStats() {
-    return ImmutableMap.<String, String>builder().build();
+    return ImmutableMap.<String, String>builder().buildOrThrow();
   }
 
   @Implementation

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacySQLiteConnection.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacySQLiteConnection.java
@@ -734,7 +734,7 @@ public class ShadowLegacySQLiteConnection extends ShadowSQLiteConnection {
             .put(264, "SQLITE_READONLY_RECOVERY")
             .put(776, "SQLITE_READONLY_ROLLBACK")
             .put(284, "SQLITE_WARNING_AUTOINDEX")
-            .build();
+            .buildOrThrow();
 
     private static RuntimeException getSqliteException(
         final String sqliteErrorMessage, final int errorCode) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -369,7 +369,7 @@ public class ShadowNotificationManager {
     for (Map.Entry<String, AutomaticZenRule> entry : automaticZenRules.entrySet()) {
       rules.put(entry.getKey(), copyAutomaticZenRule(entry.getValue()));
     }
-    return rules.build();
+    return rules.buildOrThrow();
   }
 
   @Implementation(minSdk = N)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSettings.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSettings.java
@@ -43,7 +43,7 @@ public class ShadowSettings {
     private static final ImmutableMap<String, Optional<Object>> DEFAULTS =
         ImmutableMap.<String, Optional<Object>>builder()
             .put(Settings.System.ANIMATOR_DURATION_SCALE, Optional.of(1))
-            .build();
+            .buildOrThrow();
     private static final Map<String, Optional<Object>> settings = new ConcurrentHashMap<>(DEFAULTS);
 
     @Implementation
@@ -346,7 +346,7 @@ public class ShadowSettings {
     private static final ImmutableMap<String, Optional<Object>> DEFAULTS =
         ImmutableMap.<String, Optional<Object>>builder()
             .put(Settings.Global.ANIMATOR_DURATION_SCALE, Optional.of(1))
-            .build();
+            .buildOrThrow();
     private static final Map<String, Optional<Object>> settings = new ConcurrentHashMap<>(DEFAULTS);
 
     @Implementation


### PR DESCRIPTION
As explained in the Javadoc, it is recommended to use `buildOrThrow()` for clarity.
The `build()` method is meant to be deprecated in a future version of Guava.
It is an alias of `buildOrThrow()`, so there is no change in behavior.

This replaces and updates https://github.com/robolectric/robolectric/pull/7023, originally submitted by @JuliaSullivanGoogle.

<img width="616" alt="Screenshot 2025-02-22 at 00 32 58" src="https://github.com/user-attachments/assets/8e1080e8-3439-48d5-a776-249dd6c8716e" />
