### PR TITLE
Update Renovate to not update Apache HttpComponents

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,8 @@
     "com.google.android.gms:play-services-auth",
     "com.google.android.gms:play-services-base",
     "com.google.android.gms:play-services-basement",
+    "org.apache.httpcomponents:httpclient",
+    "org.apache.httpcomponents:httpcore",
     "org.robolectric:nativeruntime-dist-compat"
   ],
   "labels": [


### PR DESCRIPTION
This commit updates Renovate's configuration to not submit PR for Apache HttpComponents. These dependencies are only used in the HTTP client shadow, which is a legacy module.