### PR TITLE
Configure Renovate to ignore `androidx.fragment:fragment` in `:shadows:playservices`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -42,6 +42,14 @@
       "matchPackageNames": [
         "androidx.*"
       ]
+    },
+    {
+      "enabled": false,
+      "matchCurrentVersion": "1.2.0",
+      "matchManagers": "gradle",
+      "matchPackageNames": [
+        "androidx.fragment:fragment"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This commit configures Renovate to disable updates for `androidx.fragment:fragment` in the `:shadows:playservices` module.