### PR TITLE
Remove the deprecated `ShadowMap.convertToShadowName(String)` method

### DIFF
--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowMap.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/ShadowMap.java
@@ -183,17 +183,6 @@ public class ShadowMap {
     return invalidated.keySet();
   }
 
-  /**
-   * @deprecated do not use
-   */
-  @Deprecated
-  public static String convertToShadowName(String className) {
-    String shadowClassName =
-        "org.robolectric.shadows.Shadow" + className.substring(className.lastIndexOf(".") + 1);
-    shadowClassName = shadowClassName.replaceAll("\\$", "\\$Shadow");
-    return shadowClassName;
-  }
-
   public Builder newBuilder() {
     return new Builder(this);
   }


### PR DESCRIPTION
This commit removes the deprecated `ShadowMap.convertToShadowName(String)` method.
It was deprecated in #3654, released with Robolectric 3.7.
It is no longer used in the project, and there doesn't seem to be any meaningful usage on GitHub: https://github.com/search?q=convertToShadowName+-org%3Arobolectric+-is%3Afork&type=code