### PR TITLE
Remove deprecated methods in `AndroidManifest`

### DIFF
--- a/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
+++ b/resources/src/main/java/org/robolectric/manifest/AndroidManifest.java
@@ -840,21 +840,4 @@ public class AndroidManifest implements UsesSdk {
   public Path getApkFile() {
     return apkFile;
   }
-
-  /**
-   * @deprecated Do not use.
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public final boolean supportsLegacyResourcesMode() {
-    return true;
-  }
-
-  /**
-   * @deprecated Do not use.
-   */
-  @Deprecated
-  public synchronized boolean supportsBinaryResourcesMode() {
-    return true;
-  }
 }


### PR DESCRIPTION
This commit removes the deprecated `supportsLegacyResourcesMode()` and `supportsBinaryResourcesMode()` methods in `AndroidManifest`.
- They are deprecated since Robolectric 3.6.
- They are no longer used in the project.
- `supportsLegacyResourcesMode` doesn't seem to be used on GitHub: https://github.com/search?q=supportsLegacyResourcesMode+-org%3Arobolectric+-is%3Afork+&type=code
- `supportsBinaryResourcesMode` doesn't seem to be used on GitHub: https://github.com/search?q=supportsBinaryResourcesMode+-org%3Arobolectric+-is%3Afork+&type=code