### PR TITLE
Remove deprecated `DependencyResolver#getLocalArtifactUrls(DependencyJar)`

### DIFF
--- a/pluginapi/src/main/java/org/robolectric/internal/dependency/DependencyResolver.java
+++ b/pluginapi/src/main/java/org/robolectric/internal/dependency/DependencyResolver.java
@@ -14,15 +14,4 @@ import java.net.URL;
  */
 public interface DependencyResolver {
   URL getLocalArtifactUrl(DependencyJar dependency);
-
-  /**
-   * Returns URLs representing the full transitive dependency graph of the given Maven dependency.
-   *
-   * @deprecated Robolectric will never ask for a dependency composed of more than one artifact, so
-   *     this method isn't necessary.
-   */
-  @Deprecated
-  default URL[] getLocalArtifactUrls(DependencyJar dependency) {
-    return new URL[] {getLocalArtifactUrl(dependency)};
-  }
 }

--- a/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
+++ b/plugins/maven-dependency-resolver/src/main/java/org/robolectric/internal/dependency/MavenDependencyResolver.java
@@ -71,11 +71,6 @@ public class MavenDependencyResolver implements DependencyResolver {
             createExecutorService());
   }
 
-  @Override
-  public URL[] getLocalArtifactUrls(DependencyJar dependency) {
-    return getLocalArtifactUrls(new DependencyJar[] {dependency});
-  }
-
   /**
    * Get an array of local artifact URLs for the given dependencies. The order of the URLs is
    * guaranteed to be the same as the input order of dependencies, i.e., urls[i] is the local

--- a/robolectric/src/main/java/org/robolectric/plugins/LegacyDependencyResolver.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/LegacyDependencyResolver.java
@@ -95,11 +95,6 @@ public class LegacyDependencyResolver implements DependencyResolver {
     return delegate.getLocalArtifactUrl(dependency);
   }
 
-  @Override
-  public URL[] getLocalArtifactUrls(DependencyJar dependency) {
-    return delegate.getLocalArtifactUrls(dependency);
-  }
-
   interface DefinitelyNotAClassLoader {
 
     URL getResource(String name);


### PR DESCRIPTION
This commit removes the deprecated `DependencyResolver#getLocalArtifactUrls(DependencyJar)` method.
- It was deprecated in Robolectric 4.2 (#4599).
- The project no longer uses that method.
- It is defined in an internal package, so external usages should be minimal.
- There doesn't seem to be a lot of usages on GitHub: https://github.com/search?q=getLocalArtifactUrls+-org%3Arobolectric+-is%3Afork&type=code