### PR TITLE
Update AGP group in Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,7 @@
       "groupName": "Android Gradle Plugin",
       "matchManagers": "gradle",
       "matchPackageNames": [
+        "com.android.library",
         "com.android.tools:common",
         "com.android.tools.build:gradle*"
       ]


### PR DESCRIPTION
This commit updates Renovate's configuration so it includes the `com.android.library` package in the AGP group. Previously, it would create a separate PR for it (see #10085 and #10100).