### PR TITLE
fixed negative ids that which cause ArrayOutOfBounds

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/ResourceUtils.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResourceUtils.java
@@ -28,7 +28,7 @@ class ResourceUtils {
 
   static int get_entry_id(int resid) {
     //    return static_cast<uint16_t>(resid & 0x0000ffff);
-    return (short) (resid & 0x0000FFFF);
+    return resid & 0x0000FFFF;
   }
 
   static boolean is_internal_resid(int resid) {


### PR DESCRIPTION
### Overview

Hello there. We got this exception in our 6.5kk sloc project:

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -32362 out of bounds for length 34479
	at org.robolectric.res.android.LoadedArsc$TypeSpec.GetFlagsForEntryIndex(LoadedArsc.java:115)
	at org.robolectric.res.android.CppAssetManager2.FindEntry(CppAssetManager2.java:693)
	at org.robolectric.res.android.CppAssetManager2.GetResource(CppAssetManager2.java:860)
	at org.robolectric.res.android.CppAssetManager2.ResolveReference(CppAssetManager2.java:918)
	at org.robolectric.res.android.AttributeResolution9.RetrieveAttributes(AttributeResolution9.java:484)
	at org.robolectric.shadows.ShadowArscAssetManager9.nativeRetrieveAttributes(ShadowArscAssetManager9.java:1551)
	at android.content.res.AssetManager.nativeRetrieveAttributes(AssetManager.java)
	at android.content.res.AssetManager.retrieveAttributes(AssetManager.java:1012)
	at android.content.res.Resources.obtainAttributes(Resources.java:1814)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
	at org.robolectric.shadows.ShadowResources$ResourcesReflector$$Reflector6.obtainAttributes(Unknown Source)
	at org.robolectric.shadows.ShadowResources.obtainAttributes(ShadowResources.java:98)
	at android.content.res.Resources.obtainAttributes(Resources.java)
	at android.content.pm.PackageParser.parseActivity(PackageParser.java:4104)
	at android.content.pm.PackageParser.parseBaseApplication(PackageParser.java:3639)
	at android.content.pm.PackageParser.parseBaseApkCommon(PackageParser.java:2053)
	at android.content.pm.PackageParser.parseBaseApk(PackageParser.java:1942)
	at android.content.pm.PackageParser.parseBaseApk(PackageParser.java:1337)
	... 24 more
```

I tracked down that negative index and found out that this negative index occurs from signed short overflow on `get_entry_id `.

### Proposed Changes

Proposed change is just removing cast to short. Looks like reference C++ code is using cast to *unsigned* short, so it is straightforward bug, that can be reproduced only with >32k resources with same type+package.

Also we already using patched version in our project and it resolves the issue.