### PR TITLE
Update deprecation message for `Robolectric.AttributeSetBuilder`

### DIFF
--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -19,6 +19,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Looper;
 import android.util.AttributeSet;
+import android.util.Xml;
 import android.view.View;
 import java.lang.reflect.Modifier;
 import javax.annotation.Nullable;
@@ -34,6 +35,7 @@ import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.util.Logger;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.Scheduler;
+import org.xmlpull.v1.XmlPullParser;
 
 public class Robolectric {
 
@@ -327,7 +329,7 @@ public class Robolectric {
   /**
    * Builder of {@link AttributeSet}s.
    *
-   * @deprecated Use {@link org.robolectric.android.AttributeSetBuilder} instead.
+   * @deprecated Use {@link Xml#asAttributeSet(XmlPullParser)} instead.
    */
   @Deprecated
   public interface AttributeSetBuilder {

--- a/robolectric/src/main/java/org/robolectric/android/AttributeSetBuilder.java
+++ b/robolectric/src/main/java/org/robolectric/android/AttributeSetBuilder.java
@@ -2,12 +2,14 @@ package org.robolectric.android;
 
 import android.annotation.IdRes;
 import android.util.AttributeSet;
+import android.util.Xml;
 import org.robolectric.Robolectric;
+import org.xmlpull.v1.XmlPullParser;
 
 /**
  * Builder of {@link AttributeSet}s.
  *
- * @deprecated use Xml.asAttributeSet instead. Not supported in {@link
+ * @deprecated use {@link Xml#asAttributeSet(XmlPullParser)} instead. Not supported in {@link
  *     org.robolectric.annotation.ResourcesMode.Mode#NATIVE}
  */
 @Deprecated


### PR DESCRIPTION
This commit updates the deprecation message for `Robolectric.AttributeSetBuilder`. The recommended alternative (ie. using `org.robolectric.android.AttributeSetBuilder`) is also deprecated. Instead, `android.util.Xml#asAttributeSet(XmlPullParser)` should be used.