### PR TITLE
Deprecate the `:shadows:playservices` module

### DIFF
--- a/shadows/playservices/src/main/java/org/robolectric/shadows/gms/ShadowGoogleAuthUtil.java
+++ b/shadows/playservices/src/main/java/org/robolectric/shadows/gms/ShadowGoogleAuthUtil.java
@@ -23,7 +23,10 @@ import org.robolectric.annotation.Resetter;
  * GoogleAuthUtilImpl} implementation. Use {@link #provideImpl(GoogleAuthUtilImpl)} to set the
  * implementation instance. By default, a {@link GoogleAuthUtilImpl} is used in call redirection.
  * Use mocks or subclassing {@link GoogleAuthUtilImpl} to achieve desired behaviors.
+ *
+ * @deprecated This package is no longer maintained and will be removed in Robolectric 4.16.
  */
+@Deprecated
 @Implements(GoogleAuthUtil.class)
 public class ShadowGoogleAuthUtil {
 

--- a/shadows/playservices/src/main/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtil.java
+++ b/shadows/playservices/src/main/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtil.java
@@ -22,7 +22,10 @@ import org.robolectric.annotation.Resetter;
  * #provideImpl(GooglePlayServicesUtilImpl)} to set the implementation instance. By default, a
  * {@link GooglePlayServicesUtilImpl} is used in call redirection. Use mocks or subclassing {@link
  * GooglePlayServicesUtilImpl} to achieve desired behaviors.
+ *
+ * @deprecated This package is no longer maintained and will be removed in Robolectric 4.16.
  */
+@Deprecated
 @Implements(GooglePlayServicesUtil.class)
 public class ShadowGooglePlayServicesUtil {
   private static GooglePlayServicesUtilImpl googlePlayServicesUtilImpl =

--- a/shadows/playservices/src/main/java/org/robolectric/shadows/gms/common/ShadowGoogleApiAvailability.java
+++ b/shadows/playservices/src/main/java/org/robolectric/shadows/gms/common/ShadowGoogleApiAvailability.java
@@ -10,6 +10,10 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.shadow.api.Shadow;
 
+/**
+ * @deprecated This package is no longer maintained and will be removed in Robolectric 4.16.
+ */
+@Deprecated
 @Implements(GoogleApiAvailability.class)
 public class ShadowGoogleApiAvailability {
   private int availabilityCode = ConnectionResult.SERVICE_MISSING;

--- a/shadows/playservices/src/main/java/org/robolectric/shadows/gms/package-info.java
+++ b/shadows/playservices/src/main/java/org/robolectric/shadows/gms/package-info.java
@@ -1,7 +1,10 @@
 /**
  * Shadows for the Google Play Services Library.
  *
- * <p>To use this in your project, add the artifact {@code org.robolectric:shadows-play-services} to
+ * <p>To use this in your project, add the artifact {@code org.robolectric:shadows-playservices} to
  * your project.
+ *
+ * @deprecated This package is no longer maintained and will be removed in Robolectric 4.16.
  */
+@Deprecated
 package org.robolectric.shadows.gms;


### PR DESCRIPTION
This module doesn't seem to be actively maintained and uses outdated dependencies.

@hoisie @brettchabot are you fine with deprecating this module and removing it in a future version of Robolectric?
I'll go through the [usages on GitHub](https://github.com/search?q=%22shadows-playservices%22%20-is%3Afork%20-is%3Aarchived%20-org%3Arobolectric&type=code) (and [shadows-play-services](https://github.com/search?q=%22shadows-play-services%22%20-is%3Afork%20-is%3Aarchived%20-org%3Arobolectric&type=code)) to see if they are needed and potentially submit PRs.

This closes #4425 