### PR TITLE
Replace deprecated usages of `ExpectedException.none()`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/junit/rules/BackgroundTestRuleTest.java
+++ b/robolectric/src/test/java/org/robolectric/junit/rules/BackgroundTestRuleTest.java
@@ -1,24 +1,18 @@
 package org.robolectric.junit.rules;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.hamcrest.Matchers.is;
 
 import android.os.Looper;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 
 /** Tests for {@link BackgroundTestRule}. */
 @RunWith(AndroidJUnit4.class)
 public final class BackgroundTestRuleTest {
 
-  private final BackgroundTestRule rule = new BackgroundTestRule();
-  private final ExpectedException expectedException = ExpectedException.none();
-
-  @Rule public RuleChain chain = RuleChain.outerRule(expectedException).around(rule);
+  @Rule public final BackgroundTestRule rule = new BackgroundTestRule();
 
   @Test
   @BackgroundTestRule.BackgroundTest
@@ -31,11 +25,9 @@ public final class BackgroundTestRuleTest {
     assertThat(Looper.myLooper()).isEqualTo(Looper.getMainLooper());
   }
 
-  @Test
+  @Test(expected = Exception.class)
   @BackgroundTestRule.BackgroundTest
   public void testFailInBackground() throws Exception {
-    Exception exception = new Exception("Fail!");
-    expectedException.expect(is(exception));
-    throw exception;
+    throw new Exception("Fail!");
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAssetManagerTest.java
@@ -1,6 +1,7 @@
 package org.robolectric.shadows;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import android.content.res.AssetManager;
@@ -14,9 +15,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
@@ -26,8 +25,6 @@ import org.robolectric.annotation.ResourcesMode.Mode;
 @RunWith(AndroidJUnit4.class)
 @ResourcesMode(Mode.BINARY)
 public class ShadowAssetManagerTest {
-
-  @Rule public ExpectedException expectedException = ExpectedException.none();
 
   private AssetManager assetManager;
   private Resources resources;
@@ -39,12 +36,12 @@ public class ShadowAssetManagerTest {
   }
 
   @Test
-  public void openFd_shouldProvideFileDescriptorForDeflatedAsset() throws Exception {
-    expectedException.expect(FileNotFoundException.class);
-    expectedException.expectMessage(
-        "This file can not be opened as a file descriptor; it is probably compressed");
-
-    assetManager.openFd("deflatedAsset.xml");
+  public void openFd_shouldProvideFileDescriptorForDeflatedAsset() {
+    FileNotFoundException exception =
+        assertThrows(FileNotFoundException.class, () -> assetManager.openFd("deflatedAsset.xml"));
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo("This file can not be opened as a file descriptor; it is probably compressed");
   }
 
   @Test

--- a/shadows/playservices/src/test/java/org/robolectric/shadows/gms/ShadowGoogleAuthUtilTest.java
+++ b/shadows/playservices/src/test/java/org/robolectric/shadows/gms/ShadowGoogleAuthUtilTest.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows.gms;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -13,9 +14,7 @@ import com.google.android.gms.auth.GoogleAuthUtil;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -35,8 +34,6 @@ public class ShadowGoogleAuthUtilTest {
 
   @Mock private GoogleAuthUtilImpl mockGoogleAuthUtil;
 
-  @Rule public ExpectedException thrown = ExpectedException.none();
-
   @Before
   public void setup() {
     mock = MockitoAnnotations.openMocks(this);
@@ -55,12 +52,11 @@ public class ShadowGoogleAuthUtilTest {
 
   @Test
   public void provideImplementation_nullValueNotAllowed() {
-    thrown.expect(NullPointerException.class);
-    ShadowGoogleAuthUtil.provideImpl(null);
+    assertThrows(NullPointerException.class, () -> ShadowGoogleAuthUtil.provideImpl(null));
   }
 
   @Test
-  public void getImplementation_shouldGetSetted() {
+  public void getImplementation_shouldGetSet() {
     ShadowGoogleAuthUtil.provideImpl(mockGoogleAuthUtil);
     GoogleAuthUtilImpl googleAuthUtil = ShadowGoogleAuthUtil.getImpl();
     assertSame(googleAuthUtil, mockGoogleAuthUtil);
@@ -127,19 +123,20 @@ public class ShadowGoogleAuthUtilTest {
   }
 
   @Test
-  public void getTokenWithNotification_nullCallBackThrowIllegalArgumentException()
-      throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    GoogleAuthUtil.getTokenWithNotification(
-        RuntimeEnvironment.getApplication(), "name", "scope", null, null);
+  public void getTokenWithNotification_nullCallBackThrowIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            GoogleAuthUtil.getTokenWithNotification(
+                RuntimeEnvironment.getApplication(), "name", "scope", null, null));
   }
 
   @Test
-  public void getTokenWithNotification_nullAuthorityThrowIllegalArgumentException()
-      throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    assertNotNull(
-        GoogleAuthUtil.getTokenWithNotification(
-            RuntimeEnvironment.getApplication(), "name", "scope", null, null, null));
+  public void getTokenWithNotification_nullAuthorityThrowIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            GoogleAuthUtil.getTokenWithNotification(
+                RuntimeEnvironment.getApplication(), "name", "scope", null, null, null));
   }
 }

--- a/shadows/playservices/src/test/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtilTest.java
+++ b/shadows/playservices/src/test/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtilTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -13,9 +14,7 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -31,8 +30,6 @@ import org.robolectric.shadows.gms.ShadowGooglePlayServicesUtil.GooglePlayServic
 public class ShadowGooglePlayServicesUtilTest {
 
   @Mock private GooglePlayServicesUtilImpl mockGooglePlayServicesUtil;
-
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   private AutoCloseable mock;
 
@@ -53,12 +50,11 @@ public class ShadowGooglePlayServicesUtilTest {
 
   @Test
   public void provideImplementation_nullValueNotAllowed() {
-    thrown.expect(NullPointerException.class);
-    ShadowGooglePlayServicesUtil.provideImpl(null);
+    assertThrows(NullPointerException.class, () -> ShadowGooglePlayServicesUtil.provideImpl(null));
   }
 
   @Test
-  public void getImplementation_shouldGetSetted() {
+  public void getImplementation_shouldGetSet() {
     ShadowGooglePlayServicesUtil.provideImpl(mockGooglePlayServicesUtil);
     ShadowGooglePlayServicesUtil.GooglePlayServicesUtilImpl googlePlayServicesUtil =
         ShadowGooglePlayServicesUtil.getImpl();


### PR DESCRIPTION
The `ExpectedException.none()` method was deprecated in jUnit 4.13. The recommended alternative is to use `assertThrows()` instead.

There's still one usage in `ExpectedLogMessagesRuleTest`, where it seems complicated to migrate away from it.