### PR TITLE
Use fully-qualified RuntimeEnvironment class name in ShadowProviderGenerator

### DIFF
--- a/integration_tests/rap/build.gradle.kts
+++ b/integration_tests/rap/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.robolectric.android.project)
+}
+
+android {
+  compileSdk = 35
+  namespace = "org.robolectric.rap"
+
+  defaultConfig { minSdk = 21 }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+  }
+
+  testOptions {
+    targetSdk = 35
+    unitTests.isIncludeAndroidResources = true
+  }
+}
+
+dependencies {
+  annotationProcessor(project(":processor"))
+  api(project(":shadows:framework"))
+  testImplementation(project(":robolectric"))
+  testImplementation(libs.junit4)
+  testImplementation(libs.truth)
+}
+
+tasks.withType<JavaCompile>().configureEach {
+  options.compilerArgs.add(
+    "-Aorg.robolectric.annotation.processing.shadowPackage=org.robolectric.rap"
+  )
+  options.compilerArgs.add("-Aorg.robolectric.annotation.processing.priority=1")
+}

--- a/integration_tests/rap/src/main/java/org/robolectric/rap/ExtendedShadowApplication.java
+++ b/integration_tests/rap/src/main/java/org/robolectric/rap/ExtendedShadowApplication.java
@@ -1,0 +1,17 @@
+package org.robolectric.rap;
+
+import static android.os.Build.VERSION_CODES.P;
+import static android.os.Build.VERSION_CODES.S;
+
+import android.app.Application;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.Resetter;
+import org.robolectric.shadows.ShadowApplication;
+
+/** This shadow tests the logic that emits resetters in RAP when a min/max sdk is specified */
+@Implements(value = Application.class, minSdk = P, maxSdk = S)
+public class ExtendedShadowApplication extends ShadowApplication {
+
+  @Resetter
+  public static void reset() {}
+}

--- a/integration_tests/rap/src/test/java/org/robolectric/rap/ExtendedShadowApplicationTest.java
+++ b/integration_tests/rap/src/test/java/org/robolectric/rap/ExtendedShadowApplicationTest.java
@@ -1,0 +1,21 @@
+package org.robolectric.rap;
+
+import static android.os.Build.VERSION_CODES.S;
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadow.api.Shadow;
+
+@RunWith(RobolectricTestRunner.class)
+public final class ExtendedShadowApplicationTest {
+  @Config(sdk = S)
+  @Test
+  public void behaviorBeingTested_expectedResult() {
+    ExtendedShadowApplication application = Shadow.extract(RuntimeEnvironment.getApplication());
+    assertThat(application).isNotNull();
+  }
+}

--- a/processor/src/main/java/org/robolectric/annotation/processing/generator/ShadowProviderGenerator.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/generator/ShadowProviderGenerator.java
@@ -165,17 +165,19 @@ public class ShadowProviderGenerator extends Generator {
       int minSdk = resetterInfo.getMinSdk();
       int maxSdk = resetterInfo.getMaxSdk();
       String ifClause;
+      // The fully-qualiied name 'org.robolectric.RuntimeEnvironment' is required because shadow
+      // packages may not be in the 'org.robolectric' package.
       if (minSdk != -1 && maxSdk != -1) {
         ifClause =
-            "if (RuntimeEnvironment.getApiLevel() >= "
+            "if (org.robolectric.RuntimeEnvironment.getApiLevel() >= "
                 + minSdk
-                + " && RuntimeEnvironment.getApiLevel() <= "
+                + " && org.robolectric.RuntimeEnvironment.getApiLevel() <= "
                 + maxSdk
                 + ") ";
       } else if (maxSdk != -1) {
-        ifClause = "if (RuntimeEnvironment.getApiLevel() <= " + maxSdk + ") ";
+        ifClause = "if (org.robolectric.RuntimeEnvironment.getApiLevel() <= " + maxSdk + ") ";
       } else if (minSdk != -1) {
-        ifClause = "if (RuntimeEnvironment.getApiLevel() >= " + minSdk + ") ";
+        ifClause = "if (org.robolectric.RuntimeEnvironment.getApiLevel() >= " + minSdk + ") ";
       } else {
         ifClause = "";
       }

--- a/processor/src/test/java/org/robolectric/annotation/processing/generator/ShadowProviderGeneratorTest.java
+++ b/processor/src/test/java/org/robolectric/annotation/processing/generator/ShadowProviderGeneratorTest.java
@@ -48,12 +48,17 @@ public class ShadowProviderGeneratorTest {
 
     assertThat(writer.toString())
         .contains(
-            "if (RuntimeEnvironment.getApiLevel() >= 19 && RuntimeEnvironment.getApiLevel() <= 20)"
+            "if (org.robolectric.RuntimeEnvironment.getApiLevel() >= 19 &&"
+                + " org.robolectric.RuntimeEnvironment.getApiLevel() <= 20)"
                 + " ShadowThing.reset19To20();");
     assertThat(writer.toString())
-        .contains("if (RuntimeEnvironment.getApiLevel() >= 21) ShadowThing.resetMin21();");
+        .contains(
+            "if (org.robolectric.RuntimeEnvironment.getApiLevel() >= 21)"
+                + " ShadowThing.resetMin21();");
     assertThat(writer.toString())
-        .contains("if (RuntimeEnvironment.getApiLevel() <= 18) ShadowThing.resetMax18();");
+        .contains(
+            "if (org.robolectric.RuntimeEnvironment.getApiLevel() <= 18)"
+                + " ShadowThing.resetMax18();");
   }
 
   private ResetterInfo resetterInfo(String shadowName, int minSdk, int maxSdk, String methodName) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,7 @@ include(
   ":integration_tests:sparsearray",
   ":integration_tests:testparameterinjector",
   ":integration_tests:versioning",
+  ":integration_tests:rap",
   ":junit",
   ":nativeruntime",
   ":pluginapi",


### PR DESCRIPTION
It is possible that shadow packages are not in the `org.robolectric` package. For instance, users can use the annotation param: -Aorg.robolectric.annotation.processing.shadowPackage=my.package

And the shadow package will be `my.package`.

Because of this, the it is much simpler to use the full-qualified RuntimeEnvironment class name.
