### PR TITLE
Use `Objects.requireNonNull()` instead of `Preconditions.checkNotNull()` from Guava

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager.java
@@ -12,7 +12,6 @@ import static org.robolectric.res.android.Util.LOG_FATAL_IF;
 import static org.robolectric.res.android.Util.isTruthy;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
@@ -1013,7 +1012,7 @@ public class CppAssetManager {
       final Ref<SortedVector<AssetDir.FileInfo>> pMergedInfo;
 
       LOG_FATAL_IF(mAssetPaths.isEmpty(), "No assets added to AssetManager");
-      Preconditions.checkNotNull(dirName);
+      Objects.requireNonNull(dirName);
 
       // printf("+++ openDir(%s) in '%s'\n", dirName, (final char*) mAssetBase);
 

--- a/resources/src/main/java/org/robolectric/res/android/NativeObjRegistry.java
+++ b/resources/src/main/java/org/robolectric/res/android/NativeObjRegistry.java
@@ -1,6 +1,6 @@
 package org.robolectric.res.android;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -50,7 +50,7 @@ public class NativeObjRegistry<T> {
    */
   @Deprecated
   public synchronized long getNativeObjectId(T o) {
-    checkNotNull(o);
+    requireNonNull(o);
     Long nativeId = nativeObjToIdMap.inverse().get(o);
     if (nativeId == null) {
       nativeId = nextId;
@@ -69,7 +69,7 @@ public class NativeObjRegistry<T> {
    * @throws IllegalStateException if the object was previously registered
    */
   public synchronized long register(T o) {
-    checkNotNull(o);
+    requireNonNull(o);
     Long nativeId = nativeObjToIdMap.inverse().get(o);
     if (nativeId != null) {
       if (debug) {

--- a/robolectric/src/main/java/org/robolectric/android/internal/IdlingResourceTimeoutException.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/IdlingResourceTimeoutException.java
@@ -1,6 +1,6 @@
 package org.robolectric.android.internal;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import androidx.test.internal.platform.util.TestOutputEmitter;
 import com.google.common.annotations.Beta;
@@ -21,7 +21,7 @@ public final class IdlingResourceTimeoutException extends RuntimeException {
   public IdlingResourceTimeoutException(List<String> resourceNames) {
     super(
         String.format(
-            Locale.ROOT, "Wait for %s to become idle timed out", checkNotNull(resourceNames)));
+            Locale.ROOT, "Wait for %s to become idle timed out", requireNonNull(resourceNames)));
     TestOutputEmitter.dumpThreadStates("ThreadState-IdlingResTimeoutExcep.txt");
   }
 }

--- a/robolectric/src/main/java/org/robolectric/android/internal/LocalActivityInvoker.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/LocalActivityInvoker.java
@@ -1,7 +1,7 @@
 package org.robolectric.android.internal;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 
 import android.app.Activity;
 import android.app.Instrumentation.ActivityResult;
@@ -62,7 +62,7 @@ public class LocalActivityInvoker implements ActivityInvoker {
           "You must start Activity first. Make sure you are using launchActivityForResult() to"
               + " launch an Activity.");
     }
-    checkNotNull(controller);
+    requireNonNull(controller);
     checkState(controller.get().isFinishing(), "You must finish your Activity first");
     ShadowActivity shadowActivity = Shadow.extract(controller.get());
     return new ActivityResult(shadowActivity.getResultCode(), shadowActivity.getResultIntent());
@@ -70,7 +70,7 @@ public class LocalActivityInvoker implements ActivityInvoker {
 
   @Override
   public void resumeActivity(Activity activity) {
-    checkNotNull(controller);
+    requireNonNull(controller);
     checkState(controller.get() == activity);
     ShadowInstrumentation.runOnMainSyncNoIdle(
         () -> {
@@ -95,7 +95,7 @@ public class LocalActivityInvoker implements ActivityInvoker {
 
   @Override
   public void pauseActivity(Activity activity) {
-    checkNotNull(controller);
+    requireNonNull(controller);
     checkState(controller.get() == activity);
     ShadowInstrumentation.runOnMainSyncNoIdle(
         () -> {
@@ -116,7 +116,7 @@ public class LocalActivityInvoker implements ActivityInvoker {
 
   @Override
   public void stopActivity(Activity activity) {
-    checkNotNull(controller);
+    requireNonNull(controller);
     checkState(controller.get() == activity);
     ShadowInstrumentation.runOnMainSyncNoIdle(
         () -> {
@@ -141,14 +141,14 @@ public class LocalActivityInvoker implements ActivityInvoker {
 
   @Override
   public void recreateActivity(Activity activity) {
-    checkNotNull(controller);
+    requireNonNull(controller);
     checkState(controller.get() == activity);
     ShadowInstrumentation.runOnMainSyncNoIdle(() -> controller.recreate());
   }
 
   @Override
   public void finishActivity(Activity activity) {
-    checkNotNull(controller);
+    requireNonNull(controller);
     checkState(controller.get() == activity);
     ShadowInstrumentation.runOnMainSyncNoIdle(
         () -> {

--- a/robolectric/src/main/java/org/robolectric/android/internal/LocalPermissionGranter.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/LocalPermissionGranter.java
@@ -1,6 +1,6 @@
 package org.robolectric.android.internal;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import android.app.Application;
 import androidx.test.internal.platform.content.PermissionGranter;
@@ -22,7 +22,7 @@ public class LocalPermissionGranter implements PermissionGranter {
 
   @Override
   public void requestPermissions() {
-    checkNotNull(permissions);
+    requireNonNull(permissions);
     Application application =
         (Application) InstrumentationRegistry.getInstrumentation().getTargetContext();
     ShadowApplication shadowApplication = Shadow.extract(application);

--- a/robolectric/src/main/java/org/robolectric/android/internal/LocalUiController.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/LocalUiController.java
@@ -1,7 +1,7 @@
 package org.robolectric.android.internal;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
@@ -80,7 +80,7 @@ public class LocalUiController implements UiController {
   // location
   @Override
   public boolean injectString(String str) throws InjectEventSecurityException {
-    checkNotNull(str);
+    requireNonNull(str);
     checkState(Looper.myLooper() == Looper.getMainLooper(), "Expecting to be on main thread!");
 
     // No-op if string is empty.
@@ -108,7 +108,7 @@ public class LocalUiController implements UiController {
     Log.d(TAG, String.format("Injecting string: \"%s\"", str));
 
     for (KeyEvent event : events) {
-      checkNotNull(
+      requireNonNull(
           event,
           String.format(
               "Failed to get event for character (%c) with key code (%s)",

--- a/robolectric/src/main/java/org/robolectric/junit/rules/SetSystemPropertyRule.java
+++ b/robolectric/src/main/java/org/robolectric/junit/rules/SetSystemPropertyRule.java
@@ -1,8 +1,8 @@
 package org.robolectric.junit.rules;
 
-import com.google.common.base.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -18,7 +18,7 @@ public class SetSystemPropertyRule implements TestRule {
   public SetSystemPropertyRule() {}
 
   public void set(String key, String value) {
-    Preconditions.checkNotNull(key);
+    Objects.requireNonNull(key);
     if (!originalProperties.containsKey(key)) {
       originalProperties.put(key, System.getProperty(key));
     }
@@ -26,7 +26,7 @@ public class SetSystemPropertyRule implements TestRule {
   }
 
   public void clear(String key) {
-    Preconditions.checkNotNull(key);
+    Objects.requireNonNull(key);
     if (!originalProperties.containsKey(key)) {
       originalProperties.put(key, System.getProperty(key));
     }

--- a/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
@@ -1,13 +1,13 @@
 package org.robolectric.plugins;
 
 import com.google.auto.service.AutoService;
-import com.google.common.base.Preconditions;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import javax.annotation.Priority;
@@ -54,7 +54,7 @@ public class DefaultSdkProvider implements SdkProvider {
 
   @Inject
   public DefaultSdkProvider(DependencyResolver dependencyResolver) {
-    this.dependencyResolver = Preconditions.checkNotNull(dependencyResolver);
+    this.dependencyResolver = Objects.requireNonNull(dependencyResolver);
     TreeMap<Integer, Sdk> tmpKnownSdks = new TreeMap<>();
     populateSdks(tmpKnownSdks);
 
@@ -104,7 +104,7 @@ public class DefaultSdkProvider implements SdkProvider {
       this.robolectricVersion = robolectricVersion;
       this.codeName = codeName;
       this.requiredJavaVersion = requiredJavaVersion;
-      Preconditions.checkNotNull(dependencyResolver);
+      Objects.requireNonNull(dependencyResolver);
     }
 
     @Override

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowInstrumentationTestLooperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowInstrumentationTestLooperTest.java
@@ -11,8 +11,8 @@ import static org.robolectric.Shadows.shadowOf;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
-import com.google.common.base.Preconditions;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
@@ -125,7 +125,7 @@ public class ShadowInstrumentationTestLooperTest {
     } catch (RuntimeException e) {
       exception = e;
     }
-    Preconditions.checkNotNull(exception);
+    Objects.requireNonNull(exception);
     ShadowPausedLooper.resetLoopers();
     handler.post(() -> didRun.set(true));
     shadowLooper.idle();

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperResetterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLooperResetterTest.java
@@ -1,9 +1,9 @@
 package org.robolectric.shadows;
 
 import static android.os.Looper.getMainLooper;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.truth.Truth.assertThat;
+import static java.util.Objects.requireNonNull;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.os.Handler;
@@ -52,7 +52,7 @@ public class ShadowLooperResetterTest {
   public static class BasicLooperTest {
 
     private void doPostToLooperTest() {
-      checkNotNull(getMainLooper());
+      requireNonNull(getMainLooper());
 
       AtomicBoolean didRun = new AtomicBoolean(false);
       new Handler(getMainLooper()).post(() -> didRun.set(true));
@@ -167,7 +167,7 @@ public class ShadowLooperResetterTest {
     }
 
     private void doDelayedPostToLooperTest() {
-      checkNotNull(handlerThread.getLooper());
+      requireNonNull(handlerThread.getLooper());
 
       AtomicBoolean didRun = new AtomicBoolean(false);
       new Handler(handlerThread.getLooper()).postDelayed(() -> didRun.set(true), 100);
@@ -217,7 +217,7 @@ public class ShadowLooperResetterTest {
     }
 
     private void doPostToChoreographerTest() {
-      checkNotNull(handlerThread.getLooper());
+      requireNonNull(handlerThread.getLooper());
       Handler handler = new Handler(handlerThread.getLooper());
 
       AtomicLong frameTimeNanosResult = new AtomicLong(-1);
@@ -282,7 +282,7 @@ public class ShadowLooperResetterTest {
     }
 
     private void doPostToChoreographerTest() {
-      checkNotNull(handlerThread.getLooper());
+      requireNonNull(handlerThread.getLooper());
       Handler handler = new Handler(handlerThread.getLooper());
 
       AtomicLong frameTimeNanosResult = new AtomicLong(-1);
@@ -364,7 +364,7 @@ public class ShadowLooperResetterTest {
     }
 
     private void doPostToChoreographerTest() {
-      checkNotNull(handlerThread.getLooper());
+      requireNonNull(handlerThread.getLooper());
       Handler handler = new Handler(handlerThread.getLooper());
 
       AtomicLong frameTimeNanosResult = new AtomicLong(-1);

--- a/shadows/framework/src/main/java/org/robolectric/android/controller/ActivityController.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/controller/ActivityController.java
@@ -6,7 +6,7 @@ import static android.os.Build.VERSION_CODES.O_MR1;
 import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.Q;
 import static android.os.Build.VERSION_CODES.TIRAMISU;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.robolectric.shadow.api.Shadow.extract;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
@@ -253,7 +253,7 @@ public class ActivityController<T extends Activity>
       // root can be null if looper was paused during visible. Flush the looper and try again
       shadowMainLooper.idle();
 
-      root = checkNotNull(getViewRoot());
+      root = requireNonNull(getViewRoot());
       callDispatchResized(root);
     }
 

--- a/shadows/framework/src/main/java/org/robolectric/fakes/FakeMediaProvider.java
+++ b/shadows/framework/src/main/java/org/robolectric/fakes/FakeMediaProvider.java
@@ -1,7 +1,7 @@
 package org.robolectric.fakes;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 import static org.robolectric.fakes.MediaUriMatcher.AUDIO_ALBUMART;
 import static org.robolectric.fakes.MediaUriMatcher.AUDIO_ALBUMART_FILE_ID;
 import static org.robolectric.fakes.MediaUriMatcher.AUDIO_ALBUMART_ID;
@@ -122,7 +122,7 @@ public final class FakeMediaProvider extends ContentProvider {
       String[] selectionArgs,
       String sortOrder,
       CancellationSignal cancellationSignal) {
-    checkNotNull(uri);
+    requireNonNull(uri);
     final SQLiteQueryBuilder qb = new SQLiteQueryBuilder();
 
     qb.setTables(TABLE_NAME);
@@ -227,7 +227,7 @@ public final class FakeMediaProvider extends ContentProvider {
 
   @Override
   public Uri insert(Uri uri, ContentValues originalValues) {
-    ContentValues values = new ContentValues(checkNotNull(originalValues));
+    ContentValues values = new ContentValues(requireNonNull(originalValues));
 
     final int match = uriMatcher.matchUri(uri);
     checkState(match != UriMatcher.NO_MATCH, "Unrecognized uri " + uri.toString());

--- a/shadows/framework/src/main/java/org/robolectric/shadows/BackupDataEntity.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/BackupDataEntity.java
@@ -1,7 +1,7 @@
 package org.robolectric.shadows;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 
 import com.google.auto.value.AutoValue;
 import java.nio.charset.StandardCharsets;
@@ -28,7 +28,7 @@ public abstract class BackupDataEntity {
    */
   public static BackupDataEntity createDeletedEntity(String key) {
     return new AutoValue_BackupDataEntity(
-        checkNotNull(key), /* dataSize= */ -1, /* data= */ new byte[0]);
+        requireNonNull(key), /* dataSize= */ -1, /* data= */ new byte[0]);
   }
 
   /**
@@ -53,6 +53,6 @@ public abstract class BackupDataEntity {
    */
   public static BackupDataEntity create(String key, byte[] data, int dataSize) {
     return new AutoValue_BackupDataEntity(
-        checkNotNull(key), dataSize, Arrays.copyOf(data, dataSize));
+        requireNonNull(key), dataSize, Arrays.copyOf(data, dataSize));
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/HardwareRenderingScreenshot.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/HardwareRenderingScreenshot.java
@@ -19,7 +19,7 @@ import android.view.Surface;
 import android.view.View;
 import android.view.ViewRootImpl;
 import com.android.internal.R;
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 import java.util.WeakHashMap;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.GraphicsMode;
@@ -65,7 +65,7 @@ public final class HardwareRenderingScreenshot {
     try (ImageReader imageReader =
         ImageReader.newInstance(width, height, PixelFormat.RGBA_8888, 1)) {
       ViewRootImpl viewRootImpl = view.getViewRootImpl();
-      Preconditions.checkNotNull(viewRootImpl, "View not attached");
+      Objects.requireNonNull(viewRootImpl, "View not attached");
       Surface surface = imageReader.getSurface();
 
       if (RuntimeEnvironment.getApiLevel() >= Q) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/IBluetoothManagerDelegates.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/IBluetoothManagerDelegates.java
@@ -1,7 +1,7 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.TIRAMISU;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothProfile;
@@ -47,8 +47,8 @@ class IBluetoothManagerDelegates {
   private static class IBluetoothManagerDelegateS extends IBluetoothManagerDelegateBase {
 
     public IBluetooth registerAdapter(IBluetoothManagerCallback callback) {
-      IBinder btBinder = checkNotNull(ServiceManager.getService(Context.BLUETOOTH_SERVICE));
-      IBluetooth btService = checkNotNull(IBluetooth.Stub.asInterface(btBinder));
+      IBinder btBinder = requireNonNull(ServiceManager.getService(Context.BLUETOOTH_SERVICE));
+      IBluetooth btService = requireNonNull(IBluetooth.Stub.asInterface(btBinder));
       Reflector.reflector(IBluetoothManagerCallbackReflectorS.class, callback)
           .onBluetoothServiceUp(btService);
       return btService;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/MediaCodecInfoBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/MediaCodecInfoBuilder.java
@@ -13,6 +13,7 @@ import android.media.MediaFormat;
 import android.util.Range;
 import com.google.common.base.Preconditions;
 import java.util.HashSet;
+import java.util.Objects;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
@@ -45,7 +46,7 @@ public class MediaCodecInfoBuilder {
    * @throws NullPointerException if name is null.
    */
   public MediaCodecInfoBuilder setName(String name) {
-    this.name = Preconditions.checkNotNull(name);
+    this.name = Objects.requireNonNull(name);
     return this;
   }
 
@@ -108,7 +109,7 @@ public class MediaCodecInfoBuilder {
   }
 
   public MediaCodecInfo build() {
-    Preconditions.checkNotNull(name, "Codec name is not set.");
+    Objects.requireNonNull(name, "Codec name is not set.");
 
     if (RuntimeEnvironment.getApiLevel() >= Q) {
       int flags = getCodecFlags();
@@ -200,7 +201,7 @@ public class MediaCodecInfoBuilder {
      * @throws IllegalArgumentException if mediaFormat does not have {@link MediaFormat#KEY_MIME}.
      */
     public CodecCapabilitiesBuilder setMediaFormat(MediaFormat mediaFormat) {
-      Preconditions.checkNotNull(mediaFormat);
+      Objects.requireNonNull(mediaFormat);
       Preconditions.checkArgument(
           mediaFormat.getString(MediaFormat.KEY_MIME) != null,
           "MIME type of the format is not set.");
@@ -237,7 +238,7 @@ public class MediaCodecInfoBuilder {
      * @throws NullPointerException if profileLevels is null.
      */
     public CodecCapabilitiesBuilder setProfileLevels(CodecProfileLevel[] profileLevels) {
-      this.profileLevels = Preconditions.checkNotNull(profileLevels);
+      this.profileLevels = Objects.requireNonNull(profileLevels);
       return this;
     }
 
@@ -296,8 +297,8 @@ public class MediaCodecInfoBuilder {
     }
 
     public CodecCapabilities build() {
-      Preconditions.checkNotNull(mediaFormat, "mediaFormat is not set.");
-      Preconditions.checkNotNull(profileLevels, "profileLevels is not set.");
+      Objects.requireNonNull(mediaFormat, "mediaFormat is not set.");
+      Objects.requireNonNull(profileLevels, "profileLevels is not set.");
 
       final String mime = mediaFormat.getString(MediaFormat.KEY_MIME);
       final boolean isVideoCodec = mime.startsWith("video/");
@@ -308,7 +309,7 @@ public class MediaCodecInfoBuilder {
 
       caps.profileLevels = profileLevels;
       if (isVideoCodec) {
-        Preconditions.checkNotNull(colorFormats, "colorFormats should not be null for video codec");
+        Objects.requireNonNull(colorFormats, "colorFormats should not be null for video codec");
         caps.colorFormats = colorFormats;
       } else {
         Preconditions.checkArgument(

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ModuleInfoBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ModuleInfoBuilder.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import android.content.pm.ModuleInfo;
 import javax.annotation.Nullable;
@@ -50,8 +50,8 @@ public final class ModuleInfoBuilder {
    */
   public ModuleInfo build() {
     // Check mandatory fields.
-    checkNotNull(name, "Mandatory field 'name' missing.");
-    checkNotNull(packageName, "Mandatory field 'packageName' missing.");
+    requireNonNull(name, "Mandatory field 'name' missing.");
+    requireNonNull(packageName, "Mandatory field 'packageName' missing.");
 
     ModuleInfo moduleInfo = new ModuleInfo();
     moduleInfo.setName(name);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/PackageRollbackInfoBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/PackageRollbackInfoBuilder.java
@@ -1,7 +1,7 @@
 package org.robolectric.shadows;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 
 import android.content.pm.VersionedPackage;
 import android.content.rollback.PackageRollbackInfo;
@@ -93,7 +93,7 @@ public final class PackageRollbackInfoBuilder {
 
   /** Sets ce snapshot inodes. */
   public PackageRollbackInfoBuilder setCeSnapshotInodes(SparseLongArray ceSnapshotInodes) {
-    checkNotNull(ceSnapshotInodes, "Field 'packageRolledBackFrom' not allowed to be null.");
+    requireNonNull(ceSnapshotInodes, "Field 'packageRolledBackFrom' not allowed to be null.");
     this.ceSnapshotInodes = ceSnapshotInodes;
     return this;
   }
@@ -117,8 +117,8 @@ public final class PackageRollbackInfoBuilder {
   /** Returns a {@link PackageRollbackInfo} with the data that was given. */
   public PackageRollbackInfo build() {
     // Check mandatory fields.
-    checkNotNull(packageRolledBackFrom, "Mandatory field 'packageRolledBackFrom' missing.");
-    checkNotNull(packageRolledBackTo, "Mandatory field 'packageRolledBackTo' missing.");
+    requireNonNull(packageRolledBackFrom, "Mandatory field 'packageRolledBackFrom' missing.");
+    requireNonNull(packageRolledBackTo, "Mandatory field 'packageRolledBackTo' missing.");
     checkState(RuntimeEnvironment.getApiLevel() >= VERSION_CODES.Q);
 
     int apiLevel = RuntimeEnvironment.getApiLevel();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/RollbackInfoBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/RollbackInfoBuilder.java
@@ -1,7 +1,7 @@
 package org.robolectric.shadows;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 
 import android.content.pm.VersionedPackage;
 import android.content.rollback.PackageRollbackInfo;
@@ -42,7 +42,7 @@ public final class RollbackInfoBuilder {
 
   /** Sets the packages of the rollback. */
   public RollbackInfoBuilder setPackages(List<PackageRollbackInfo> packages) {
-    checkNotNull(packages, "Field 'packages' not allowed to be null.");
+    requireNonNull(packages, "Field 'packages' not allowed to be null.");
     this.packages = packages;
     return this;
   }
@@ -55,7 +55,7 @@ public final class RollbackInfoBuilder {
 
   /** Sets the cause packages of the rollback. */
   public RollbackInfoBuilder setCausePackages(List<VersionedPackage> causePackages) {
-    checkNotNull(causePackages, "Field 'causePackages' not allowed to be null.");
+    requireNonNull(causePackages, "Field 'causePackages' not allowed to be null.");
     this.causePackages = causePackages;
     return this;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccessibilityManager.java
@@ -21,12 +21,12 @@ import android.view.accessibility.AccessibilityManager.AccessibilityStateChangeL
 import android.view.accessibility.AccessibilityManager.TouchExplorationStateChangeListener;
 import android.view.accessibility.IAccessibilityManager;
 import android.view.accessibility.IAccessibilityManager.WindowTransformationSpec;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -139,7 +139,7 @@ public class ShadowAccessibilityManager {
   }
 
   public void setAccessibilityServiceList(List<ServiceInfo> accessibilityServiceList) {
-    Preconditions.checkNotNull(accessibilityServiceList);
+    Objects.requireNonNull(accessibilityServiceList);
     ShadowAccessibilityManager.accessibilityServiceList = new ArrayList<>(accessibilityServiceList);
   }
 
@@ -152,7 +152,7 @@ public class ShadowAccessibilityManager {
 
   public void setEnabledAccessibilityServiceList(
       List<AccessibilityServiceInfo> enabledAccessibilityServiceList) {
-    Preconditions.checkNotNull(enabledAccessibilityServiceList);
+    Objects.requireNonNull(enabledAccessibilityServiceList);
     ShadowAccessibilityManager.enabledAccessibilityServiceList =
         new ArrayList<>(enabledAccessibilityServiceList);
   }
@@ -164,7 +164,7 @@ public class ShadowAccessibilityManager {
 
   public void setInstalledAccessibilityServiceList(
       List<AccessibilityServiceInfo> installedAccessibilityServiceList) {
-    Preconditions.checkNotNull(installedAccessibilityServiceList);
+    Objects.requireNonNull(installedAccessibilityServiceList);
     ShadowAccessibilityManager.installedAccessibilityServiceList =
         new ArrayList<>(installedAccessibilityServiceList);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -32,7 +32,7 @@ import static android.os.Build.VERSION_CODES.R;
 import static android.os.Build.VERSION_CODES.S;
 import static android.os.Build.VERSION_CODES.S_V2;
 import static android.os.Build.VERSION_CODES.TIRAMISU;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.robolectric.annotation.GetInstallerPackageNameMode.Mode.REALISTIC;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
@@ -2413,7 +2413,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
   @Implementation(minSdk = Q)
   @RequiresPermission(permission.SUSPEND_APPS)
   protected String[] getUnsuspendablePackages(String[] packageNames) {
-    checkNotNull(packageNames, "packageNames cannot be null");
+    requireNonNull(packageNames, "packageNames cannot be null");
     if (getContext().checkSelfPermission(permission.SUSPEND_APPS)
         != PackageManager.PERMISSION_GRANTED) {
       throw new SecurityException("Current process does not have " + permission.SUSPEND_APPS);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowArscAssetManager.java
@@ -20,7 +20,6 @@ import android.os.ParcelFileDescriptor;
 import android.util.SparseArray;
 import android.util.TypedValue;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import dalvik.system.VMRuntime;
 import java.io.FileDescriptor;
@@ -33,6 +32,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
@@ -1038,7 +1038,7 @@ public class ShadowArscAssetManager extends ShadowAssetManager.ArscBase {
   protected static int loadThemeAttributeValue(
       long themeHandle, int ident, TypedValue outValue, boolean resolve) {
     ResTableTheme theme =
-        Preconditions.checkNotNull(Registries.NATIVE_THEME_REGISTRY.getNativeObject(themeHandle));
+        Objects.requireNonNull(Registries.NATIVE_THEME_REGISTRY.getNativeObject(themeHandle));
     ResTable res = theme.getResTable();
 
     final Ref<Res_value> value = new Ref<>(null);
@@ -1276,7 +1276,7 @@ public class ShadowArscAssetManager extends ShadowAssetManager.ArscBase {
     //  }
 
     Path androidFrameworkJarPath = RuntimeEnvironment.getAndroidFrameworkJarPath();
-    Preconditions.checkNotNull(androidFrameworkJarPath);
+    Objects.requireNonNull(androidFrameworkJarPath);
 
     if (isSystem) {
       synchronized (ShadowArscAssetManager.class) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioSystem.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioSystem.java
@@ -4,7 +4,7 @@ import static android.os.Build.VERSION_CODES.Q;
 import static android.os.Build.VERSION_CODES.R;
 import static android.os.Build.VERSION_CODES.S;
 import static android.os.Build.VERSION_CODES.TIRAMISU;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import android.media.AudioAttributes;
 import android.media.AudioFormat;
@@ -96,8 +96,8 @@ public class ShadowAudioSystem {
    */
   public static void setDirectPlaybackSupport(
       @Nonnull AudioFormat format, @Nonnull AudioAttributes attr, int directPlaybackSupport) {
-    checkNotNull(format, "Illegal null AudioFormat");
-    checkNotNull(attr, "Illegal null AudioAttributes");
+    requireNonNull(format, "Illegal null AudioFormat");
+    requireNonNull(attr, "Illegal null AudioAttributes");
     directPlaybackSupportTable.put(format, attr.getUsage(), directPlaybackSupport);
   }
 
@@ -130,8 +130,8 @@ public class ShadowAudioSystem {
    */
   public static void setOffloadPlaybackSupport(
       @Nonnull AudioFormat format, @Nonnull AudioAttributes attr, int offloadSupport) {
-    checkNotNull(format, "Illegal null AudioFormat");
-    checkNotNull(attr, "Illegal null AudioAttributes");
+    requireNonNull(format, "Illegal null AudioFormat");
+    requireNonNull(attr, "Illegal null AudioAttributes");
     offloadPlaybackSupportTable.put(
         new OffloadSupportFormat(
             format.getEncoding(),

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioTrack.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioTrack.java
@@ -10,7 +10,7 @@ import static android.os.Build.VERSION_CODES.R;
 import static android.os.Build.VERSION_CODES.S;
 import static android.os.Build.VERSION_CODES.TIRAMISU;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.robolectric.shadow.api.Shadow.directlyOn;
 
 import android.annotation.RequiresApi;
@@ -131,8 +131,8 @@ public class ShadowAudioTrack {
    */
   public static void addDirectPlaybackSupport(
       @Nonnull AudioFormat format, @Nonnull AudioAttributes attr) {
-    checkNotNull(format);
-    checkNotNull(attr);
+    requireNonNull(format);
+    requireNonNull(attr);
     checkArgument(!isPcm(format.getEncoding()));
 
     directSupportedFormats.put(
@@ -438,7 +438,7 @@ public class ShadowAudioTrack {
 
   @Implementation(minSdk = M)
   public void setPlaybackParams(@Nonnull PlaybackParams params) {
-    playbackParams = checkNotNull(params, "Illegal null params");
+    playbackParams = requireNonNull(params, "Illegal null params");
   }
 
   /**

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothLeScanner.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowBluetoothLeScanner.java
@@ -1,8 +1,8 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.O;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
 
 import android.app.PendingIntent;
 import android.bluetooth.le.BluetoothLeScanner;
@@ -72,7 +72,7 @@ public class ShadowBluetoothLeScanner {
    */
   @Implementation
   protected void startScan(List<ScanFilter> filters, ScanSettings settings, ScanCallback callback) {
-    checkNotNull(callback);
+    requireNonNull(callback);
 
     if (filters != null) {
       filters = unmodifiableList(filters);
@@ -135,7 +135,7 @@ public class ShadowBluetoothLeScanner {
   }
 
   public void addScanResult(ScanResult scanResult) {
-    checkNotNull(scanResult);
+    requireNonNull(scanResult);
     this.scanResults.add(scanResult);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCameraManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCameraManager.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.Executor;
@@ -98,7 +99,7 @@ public class ShadowCameraManager {
   @Implementation
   @Nonnull
   protected CameraCharacteristics getCameraCharacteristics(@Nonnull String cameraId) {
-    Preconditions.checkNotNull(cameraId);
+    Objects.requireNonNull(cameraId);
     CameraCharacteristics characteristics = cameraIdToCharacteristics.get(cameraId);
     Preconditions.checkArgument(characteristics != null);
     return characteristics;
@@ -106,7 +107,7 @@ public class ShadowCameraManager {
 
   @Implementation(minSdk = VERSION_CODES.M)
   protected void setTorchMode(@Nonnull String cameraId, boolean enabled) {
-    Preconditions.checkNotNull(cameraId);
+    Objects.requireNonNull(cameraId);
     Preconditions.checkArgument(cameraIdToCharacteristics.keySet().contains(cameraId));
     cameraTorches.put(cameraId, enabled);
     for (Object callback : torchCallbacks) {
@@ -258,25 +259,25 @@ public class ShadowCameraManager {
   @Implementation
   protected void registerAvailabilityCallback(
       CameraManager.AvailabilityCallback callback, Handler handler) {
-    Preconditions.checkNotNull(callback);
+    Objects.requireNonNull(callback);
     registeredCallbacks.add(callback);
   }
 
   @Implementation
   protected void unregisterAvailabilityCallback(CameraManager.AvailabilityCallback callback) {
-    Preconditions.checkNotNull(callback);
+    Objects.requireNonNull(callback);
     registeredCallbacks.remove(callback);
   }
 
   @Implementation(minSdk = VERSION_CODES.M)
   protected void registerTorchCallback(CameraManager.TorchCallback callback, Handler handler) {
-    Preconditions.checkNotNull(callback);
+    Objects.requireNonNull(callback);
     torchCallbacks.add(callback);
   }
 
   @Implementation(minSdk = VERSION_CODES.M)
   protected void unregisterTorchCallback(CameraManager.TorchCallback callback) {
-    Preconditions.checkNotNull(callback);
+    Objects.requireNonNull(callback);
     torchCallbacks.remove(callback);
   }
 
@@ -329,7 +330,7 @@ public class ShadowCameraManager {
    * registered.
    */
   private void triggerOnCameraAvailable(@Nonnull String cameraId) {
-    Preconditions.checkNotNull(cameraId);
+    Objects.requireNonNull(cameraId);
     for (CameraManager.AvailabilityCallback callback : registeredCallbacks) {
       callback.onCameraAvailable(cameraId);
     }
@@ -340,7 +341,7 @@ public class ShadowCameraManager {
    * are registered.
    */
   private void triggerOnCameraUnavailable(@Nonnull String cameraId) {
-    Preconditions.checkNotNull(cameraId);
+    Objects.requireNonNull(cameraId);
     for (CameraManager.AvailabilityCallback callback : registeredCallbacks) {
       callback.onCameraUnavailable(cameraId);
     }
@@ -354,8 +355,8 @@ public class ShadowCameraManager {
    * @throws IllegalArgumentException if there's already an existing camera with the given id.
    */
   public void addCamera(@Nonnull String cameraId, @Nonnull CameraCharacteristics characteristics) {
-    Preconditions.checkNotNull(cameraId);
-    Preconditions.checkNotNull(characteristics);
+    Objects.requireNonNull(cameraId);
+    Objects.requireNonNull(characteristics);
     Preconditions.checkArgument(!cameraIdToCharacteristics.containsKey(cameraId));
 
     cameraIdToCharacteristics.put(cameraId, characteristics);
@@ -368,7 +369,7 @@ public class ShadowCameraManager {
    * @throws IllegalArgumentException if there is not an existing camera with the given id.
    */
   public void removeCamera(@Nonnull String cameraId) {
-    Preconditions.checkNotNull(cameraId);
+    Objects.requireNonNull(cameraId);
     Preconditions.checkArgument(cameraIdToCharacteristics.containsKey(cameraId));
 
     cameraIdToCharacteristics.remove(cameraId);
@@ -377,7 +378,7 @@ public class ShadowCameraManager {
 
   /** Returns what the supplied camera's torch is set to. */
   public boolean getTorchMode(@Nonnull String cameraId) {
-    Preconditions.checkNotNull(cameraId);
+    Objects.requireNonNull(cameraId);
     Preconditions.checkArgument(cameraIdToCharacteristics.keySet().contains(cameraId));
     return cameraTorches.get(cameraId);
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCrossProfileApps.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCrossProfileApps.java
@@ -5,7 +5,7 @@ import static android.content.pm.PackageManager.MATCH_DIRECT_BOOT_UNAWARE;
 import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.Q;
 import static android.os.Build.VERSION_CODES.R;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.Manifest.permission;
@@ -453,8 +453,8 @@ public class ShadowCrossProfileApps {
     private final UserHandle userHandle;
 
     public StartedMainActivity(ComponentName componentName, UserHandle userHandle) {
-      this.componentName = checkNotNull(componentName);
-      this.userHandle = checkNotNull(userHandle);
+      this.componentName = requireNonNull(componentName);
+      this.userHandle = requireNonNull(userHandle);
     }
 
     public ComponentName getComponentName() {
@@ -512,8 +512,8 @@ public class ShadowCrossProfileApps {
         @Nullable Intent intent,
         @Nullable Activity activity,
         @Nullable Bundle options) {
-      this.componentName = checkNotNull(componentName);
-      this.userHandle = checkNotNull(userHandle);
+      this.componentName = requireNonNull(componentName);
+      this.userHandle = requireNonNull(userHandle);
       this.intent = intent;
       this.activity = activity;
       this.options = options;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayHashManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDisplayHashManager.java
@@ -5,9 +5,9 @@ import static android.os.Build.VERSION_CODES.S;
 import android.view.displayhash.DisplayHash;
 import android.view.displayhash.DisplayHashManager;
 import android.view.displayhash.VerifiedDisplayHash;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -43,7 +43,7 @@ public class ShadowDisplayHashManager {
 
   @Implementation(minSdk = S)
   protected Set<String> getSupportedHashAlgorithms() {
-    return Preconditions.checkNotNull(supportedHashAlgorithms);
+    return Objects.requireNonNull(supportedHashAlgorithms);
   }
 
   @Implementation(minSdk = S)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFontBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowFontBuilder.java
@@ -8,13 +8,13 @@ import android.annotation.RequiresApi;
 import android.content.res.AssetManager;
 import android.graphics.fonts.Font;
 import android.graphics.fonts.FontStyle;
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
@@ -71,9 +71,9 @@ public class ShadowFontBuilder {
   protected static long nGetNativeAsset(
       AssetManager assetMgr, String path, boolean isAsset, int cookie) {
     // NPE_CHECK_RETURN_ZERO(env, assetMgr);
-    Preconditions.checkNotNull(assetMgr);
+    Objects.requireNonNull(assetMgr);
     // NPE_CHECK_RETURN_ZERO(env, path);
-    Preconditions.checkNotNull(path);
+    Objects.requireNonNull(path);
 
     // Guarded<AssetManager2>* mgr = AssetManagerForJavaObject(env, assetMgr);
     CppAssetManager2 mgr = ShadowArscAssetManager10.AssetManagerForJavaObject(assetMgr);
@@ -130,8 +130,8 @@ public class ShadowFontBuilder {
   @Implementation(minSdk = R)
   protected static ByteBuffer createBuffer(
       AssetManager am, String path, boolean isAsset, int cookie) throws IOException {
-    Preconditions.checkNotNull(am, "assetManager can not be null");
-    Preconditions.checkNotNull(path, "path can not be null");
+    Objects.requireNonNull(am, "assetManager can not be null");
+    Objects.requireNonNull(path, "path can not be null");
 
     try (InputStream assetStream =
         isAsset
@@ -160,9 +160,9 @@ public class ShadowFontBuilder {
       int weight,
       boolean italic,
       int ttcIndex) {
-    Preconditions.checkNotNull(buffer);
-    Preconditions.checkNotNull(filePath);
-    Preconditions.checkNotNull(localeList);
+    Objects.requireNonNull(buffer);
+    Objects.requireNonNull(filePath);
+    Objects.requireNonNull(localeList);
 
     buffer.rewind();
     // If users use one ttf file for different style, for example one ttf for bold and normal,

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
@@ -9,9 +9,9 @@ import static android.os.Build.VERSION_CODES.N;
 import static android.os.Build.VERSION_CODES.N_MR1;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.P;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static java.util.Objects.requireNonNull;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.app.Activity;
@@ -635,11 +635,10 @@ public class ShadowInstrumentation {
   }
 
   TargetAndRequestCode getTargetAndRequestCodeForIntent(Intent requestIntent) {
-    return checkNotNull(
+    return requireNonNull(
         intentRequestCodeMap.get(new Intent.FilterComparison(requestIntent)),
-        "No intent matches %s among %s",
-        requestIntent,
-        intentRequestCodeMap.keySet());
+        String.format(
+            "No intent matches %s among %s", requestIntent, intentRequestCodeMap.keySet()));
   }
 
   protected ComponentName startService(Intent intent) {
@@ -788,7 +787,7 @@ public class ShadowInstrumentation {
   }
 
   void declareComponentUnbindable(ComponentName component) {
-    checkNotNull(component);
+    requireNonNull(component);
     unbindableComponents.add(component);
   }
 
@@ -1194,7 +1193,7 @@ public class ShadowInstrumentation {
   public static void runOnMainSyncNoIdle(Runnable runnable) {
     if (ShadowLooper.looperMode() == LooperMode.Mode.INSTRUMENTATION_TEST
         && Looper.myLooper() != Looper.getMainLooper()) {
-      checkNotNull(getInstrumentation()).runOnMainSync(runnable);
+      requireNonNull(getInstrumentation()).runOnMainSync(runnable);
     } else {
       runnable.run();
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyBitmap.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyBitmap.java
@@ -5,9 +5,9 @@ import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.Q;
 import static android.os.Build.VERSION_CODES.S;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.Integer.max;
 import static java.lang.Integer.min;
+import static java.util.Objects.requireNonNull;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.graphics.Bitmap;
@@ -95,7 +95,7 @@ public class ShadowLegacyBitmap extends ShadowBitmap {
     if (width <= 0 || height <= 0) {
       throw new IllegalArgumentException("width and height must be > 0");
     }
-    checkNotNull(config);
+    requireNonNull(config);
     Bitmap scaledBitmap = ReflectionHelpers.callConstructor(Bitmap.class);
     ShadowLegacyBitmap shadowBitmap = Shadow.extract(scaledBitmap);
     shadowBitmap.setDescription("Bitmap (" + width + " x " + height + ")");
@@ -213,7 +213,7 @@ public class ShadowLegacyBitmap extends ShadowBitmap {
     if (Math.abs(stride) < width) {
       throw new IllegalArgumentException("abs(stride) must be >= width");
     }
-    checkNotNull(config);
+    requireNonNull(config);
     int lastScanline = offset + (height - 1) * stride;
     int length = colors.length;
     if (offset < 0
@@ -790,7 +790,7 @@ public class ShadowLegacyBitmap extends ShadowBitmap {
 
   @Implementation(minSdk = Q)
   protected void setColorSpace(ColorSpace colorSpace) {
-    this.colorSpace = checkNotNull(colorSpace);
+    this.colorSpace = requireNonNull(colorSpace);
   }
 
   @Implementation

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyCanvas.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyCanvas.java
@@ -17,9 +17,9 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.Rect;
 import android.graphics.RectF;
-import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -384,7 +384,7 @@ public class ShadowLegacyCanvas extends ShadowCanvas {
 
   @Implementation
   protected boolean getClipBounds(Rect bounds) {
-    Preconditions.checkNotNull(bounds);
+    Objects.requireNonNull(bounds);
     if (targetBitmap == null) {
       return false;
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyCursorWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyCursorWindow.java
@@ -7,11 +7,11 @@ import android.database.CursorWindow;
 import com.almworks.sqlite4java.SQLiteConstants;
 import com.almworks.sqlite4java.SQLiteException;
 import com.almworks.sqlite4java.SQLiteStatement;
-import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.robolectric.annotation.Implementation;
@@ -92,7 +92,7 @@ public class ShadowLegacyCursorWindow extends ShadowCursorWindow {
   @Implementation
   protected static boolean nativePutBlob(long windowPtr, byte[] value, int row, int column) {
     // Real Android will crash in native code if putString is called with a null value.
-    Preconditions.checkNotNull(value);
+    Objects.requireNonNull(value);
     return WINDOW_DATA
         .get(windowPtr)
         .putValue(new Value(value, Cursor.FIELD_TYPE_BLOB), row, column);
@@ -101,7 +101,7 @@ public class ShadowLegacyCursorWindow extends ShadowCursorWindow {
   @Implementation
   protected static boolean nativePutString(long windowPtr, String value, int row, int column) {
     // Real Android will crash in native code if putString is called with a null value.
-    Preconditions.checkNotNull(value);
+    Objects.requireNonNull(value);
     return WINDOW_DATA
         .get(windowPtr)
         .putValue(new Value(value, Cursor.FIELD_TYPE_STRING), row, column);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMotionEvent.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowMotionEvent.java
@@ -3,8 +3,8 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.P;
 import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 import static org.robolectric.shadows.NativeAndroidInput.AMOTION_EVENT_AXIS_ORIENTATION;
 import static org.robolectric.shadows.NativeAndroidInput.AMOTION_EVENT_AXIS_PRESSURE;
 import static org.robolectric.shadows.NativeAndroidInput.AMOTION_EVENT_AXIS_SIZE;
@@ -77,7 +77,7 @@ public class ShadowMotionEvent extends ShadowInputEvent {
 
   private static void validatePointerPropertiesArray(
       PointerProperties[] pointerPropertiesObjArray, int pointerCount) {
-    checkNotNull(pointerPropertiesObjArray, "pointerProperties array must not be null");
+    requireNonNull(pointerPropertiesObjArray, "pointerProperties array must not be null");
     checkState(
         pointerPropertiesObjArray.length >= pointerCount,
         "pointerProperties array must be large enough to hold all pointers");
@@ -85,7 +85,7 @@ public class ShadowMotionEvent extends ShadowInputEvent {
 
   private static void validatePointerCoordsObjArray(
       PointerCoords[] pointerCoordsObjArray, int pointerCount) {
-    checkNotNull(pointerCoordsObjArray, "pointerCoords array must not be null");
+    requireNonNull(pointerCoordsObjArray, "pointerCoords array must not be null");
     checkState(
         pointerCoordsObjArray.length >= pointerCount,
         "pointerCoords array must be large enough to hold all pointers");
@@ -100,11 +100,11 @@ public class ShadowMotionEvent extends ShadowInputEvent {
   }
 
   private static void validatePointerCoords(PointerCoords pointerCoordsObj) {
-    checkNotNull(pointerCoordsObj, "pointerCoords must not be null");
+    requireNonNull(pointerCoordsObj, "pointerCoords must not be null");
   }
 
   private static void validatePointerProperties(PointerProperties pointerPropertiesObj) {
-    checkNotNull(pointerPropertiesObj, "pointerProperties must not be null");
+    requireNonNull(pointerPropertiesObj, "pointerProperties must not be null");
   }
 
   private static NativeInput.PointerCoords pointerCoordsToNative(
@@ -228,7 +228,7 @@ public class ShadowMotionEvent extends ShadowInputEvent {
     NativeInput.PointerCoords[] rawPointerCoords = new NativeInput.PointerCoords[pointerCount];
     for (int i = 0; i < pointerCount; i++) {
       PointerCoords pointerCoordsObj = pointerCoordsObjArray[i];
-      checkNotNull(pointerCoordsObj);
+      requireNonNull(pointerCoordsObj);
       rawPointerCoords[i] = pointerCoordsToNative(pointerCoordsObj, xOffset, yOffset);
     }
 
@@ -312,7 +312,7 @@ public class ShadowMotionEvent extends ShadowInputEvent {
     NativeInput.PointerCoords[] rawPointerCoords = new NativeInput.PointerCoords[pointerCount];
     for (int i = 0; i < pointerCount; i++) {
       PointerCoords pointerCoordsObj = pointerCoordsObjArray[i];
-      checkNotNull(pointerCoordsObj);
+      requireNonNull(pointerCoordsObj);
       rawPointerCoords[i] =
           pointerCoordsToNative(pointerCoordsObj, event.getXOffset(), event.getYOffset());
     }
@@ -715,7 +715,7 @@ public class ShadowMotionEvent extends ShadowInputEvent {
 
   @Implementation
   protected void transform(Matrix matrix) {
-    checkNotNull(matrix);
+    requireNonNull(matrix);
     NativeInput.MotionEvent event = getNativeMotionEvent();
 
     float[] m = new float[9];

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeCursorWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeCursorWindow.java
@@ -4,7 +4,7 @@ import static org.robolectric.RuntimeEnvironment.getApiLevel;
 
 import android.database.CharArrayBuffer;
 import android.database.CursorWindow;
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.nativeruntime.CursorWindowNatives;
@@ -53,7 +53,7 @@ public class ShadowNativeCursorWindow extends ShadowCursorWindow {
   @Implementation
   protected static boolean nativePutBlob(long windowPtr, byte[] value, int row, int column) {
     // Real Android will crash in native code if putBlob is called with a null value.
-    Preconditions.checkNotNull(value);
+    Objects.requireNonNull(value);
     if (getApiLevel() <= U.SDK_INT) {
       return CursorWindowNatives.nativePutBlob(windowPtr, value, row, column);
     } else {
@@ -71,7 +71,7 @@ public class ShadowNativeCursorWindow extends ShadowCursorWindow {
   @Implementation
   protected static boolean nativePutString(long windowPtr, String value, int row, int column) {
     // Real Android will crash in native code if putString is called with a null value.
-    Preconditions.checkNotNull(value);
+    Objects.requireNonNull(value);
     if (getApiLevel() <= U.SDK_INT) {
       return CursorWindowNatives.nativePutString(windowPtr, value, row, column);
     } else {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeFont.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeFont.java
@@ -13,12 +13,12 @@ import android.graphics.RectF;
 import android.graphics.fonts.Font;
 import android.util.TypedValue;
 import com.google.common.base.Ascii;
-import com.google.common.base.Preconditions;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Objects;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -263,8 +263,8 @@ public class ShadowNativeFont {
 
   static ByteBuffer assetToBuffer(AssetManager am, String path, boolean isAsset, int cookie)
       throws IOException {
-    Preconditions.checkNotNull(am, "assetManager can not be null");
-    Preconditions.checkNotNull(path, "path can not be null");
+    Objects.requireNonNull(am, "assetManager can not be null");
+    Objects.requireNonNull(path, "path can not be null");
     try (InputStream assetStream =
         isAsset
             ? am.open(path, AssetManager.ACCESS_BUFFER)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeSystemFonts.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeSystemFonts.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.robolectric.annotation.Implementation;
@@ -51,7 +52,7 @@ public class ShadowNativeSystemFonts {
       long lastModifiedDate,
       int configVersion) {
     String fontDir = System.getProperty("robolectric.nativeruntime.fontdir");
-    Preconditions.checkNotNull(fontDir);
+    Objects.requireNonNull(fontDir);
     Preconditions.checkState(new File(fontDir).isDirectory(), "Missing fonts directory");
     Preconditions.checkState(
         fontDir.endsWith(File.separator), "Fonts directory must end with a slash");
@@ -77,7 +78,7 @@ public class ShadowNativeSystemFonts {
     // loaded, so we must ensure it is loaded for `robolectric.nativeruntime.fontdir` to be defined.
     DefaultNativeRuntimeLoader.injectAndLoad();
     String fontDir = System.getProperty("robolectric.nativeruntime.fontdir");
-    Preconditions.checkNotNull(fontDir);
+    Objects.requireNonNull(fontDir);
     Preconditions.checkState(new File(fontDir).isDirectory(), "Missing fonts directory");
     Preconditions.checkState(
         fontDir.endsWith(File.separator), "Fonts directory must end with a slash");

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeTypeface.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeTypeface.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.ClassName;
 import org.robolectric.annotation.Implementation;
@@ -71,7 +72,7 @@ public class ShadowNativeTypeface extends ShadowTypeface {
       ArrayMap<String, Typeface> fontMap,
       ArrayMap<String, FontFamily[]> fallbackMap) {
     String fontDir = System.getProperty("robolectric.nativeruntime.fontdir");
-    Preconditions.checkNotNull(fontDir);
+    Objects.requireNonNull(fontDir);
     Preconditions.checkState(new File(fontDir).isDirectory(), "Missing fonts directory");
     Preconditions.checkState(
         fontDir.endsWith(File.separator), "Fonts directory must end with a slash");
@@ -85,7 +86,7 @@ public class ShadowNativeTypeface extends ShadowTypeface {
     // `robolectric.nativeruntime.fontdir` system property is valid.
     DefaultNativeRuntimeLoader.injectAndLoad();
     String fontDir = System.getProperty("robolectric.nativeruntime.fontdir");
-    Preconditions.checkNotNull(fontDir);
+    Objects.requireNonNull(fontDir);
     Preconditions.checkState(new File(fontDir).isDirectory(), "Missing fonts directory");
     Preconditions.checkState(
         fontDir.endsWith(File.separator), "Fonts directory must end with a slash");

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNotificationManager.java
@@ -355,7 +355,7 @@ public class ShadowNotificationManager {
 
   @Implementation(minSdk = N)
   protected AutomaticZenRule getAutomaticZenRule(String id) {
-    Preconditions.checkNotNull(id);
+    Objects.requireNonNull(id);
     enforcePolicyAccess();
 
     return automaticZenRules.get(id);
@@ -374,13 +374,13 @@ public class ShadowNotificationManager {
 
   @Implementation(minSdk = N)
   protected String addAutomaticZenRule(AutomaticZenRule automaticZenRule) {
-    Preconditions.checkNotNull(automaticZenRule);
-    Preconditions.checkNotNull(automaticZenRule.getName());
+    Objects.requireNonNull(automaticZenRule);
+    Objects.requireNonNull(automaticZenRule.getName());
     Preconditions.checkState(
         automaticZenRule.getOwner() != null || automaticZenRule.getConfigurationActivity() != null,
         "owner/configurationActivity cannot be null at the same time");
 
-    Preconditions.checkNotNull(automaticZenRule.getConditionId());
+    Objects.requireNonNull(automaticZenRule.getConditionId());
     enforcePolicyAccess();
 
     String id = UUID.randomUUID().toString().replace("-", "");
@@ -391,12 +391,12 @@ public class ShadowNotificationManager {
   @Implementation(minSdk = N)
   protected boolean updateAutomaticZenRule(String id, AutomaticZenRule automaticZenRule) {
     // NotificationManagerService doesn't check that id is non-null.
-    Preconditions.checkNotNull(automaticZenRule);
-    Preconditions.checkNotNull(automaticZenRule.getName());
+    Objects.requireNonNull(automaticZenRule);
+    Objects.requireNonNull(automaticZenRule.getName());
     Preconditions.checkState(
         automaticZenRule.getOwner() != null || automaticZenRule.getConfigurationActivity() != null,
         "owner/configurationActivity cannot be null at the same time");
-    Preconditions.checkNotNull(automaticZenRule.getConditionId());
+    Objects.requireNonNull(automaticZenRule.getConditionId());
     enforcePolicyAccess();
 
     // ZenModeHelper throws slightly cryptic exceptions.
@@ -412,7 +412,7 @@ public class ShadowNotificationManager {
 
   @Implementation(minSdk = N)
   protected boolean removeAutomaticZenRule(String id) {
-    Preconditions.checkNotNull(id);
+    Objects.requireNonNull(id);
     enforcePolicyAccess();
     return automaticZenRules.remove(id) != null;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
@@ -97,6 +97,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -777,7 +778,7 @@ public class ShadowPackageManager {
    */
   @Deprecated
   public void addResolveInfoForIntentNoDefaults(Intent intent, ResolveInfo info) {
-    Preconditions.checkNotNull(info);
+    Objects.requireNonNull(info);
     List<ResolveInfo> infoList = resolveInfoForIntent.get(intent);
     if (infoList == null) {
       infoList = new ArrayList<>();

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedLooper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedLooper.java
@@ -14,12 +14,12 @@ import android.os.MessageQueue.IdleHandler;
 import android.os.SystemClock;
 import android.util.Log;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -472,7 +472,7 @@ public final class ShadowPausedLooper extends ShadowLooper {
     try {
       reflector(LooperReflector.class).loop();
     } catch (Exception e) {
-      Looper realLooper = Preconditions.checkNotNull(Looper.myLooper());
+      Looper realLooper = Objects.requireNonNull(Looper.myLooper());
       ShadowPausedMessageQueue shadowQueue = Shadow.extract(realLooper.getQueue());
 
       if (ignoreUncaughtExceptions) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPixelCopy.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPixelCopy.java
@@ -1,7 +1,7 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.O;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.graphics.Bitmap;
@@ -102,7 +102,7 @@ public class ShadowPixelCopy {
       throw new IllegalArgumentException("sourceRect is empty");
     }
 
-    View view = findViewForSurface(checkNotNull(source));
+    View view = findViewForSurface(requireNonNull(source));
     Rect adjustedSrcRect = null;
     if (srcRect != null) {
       adjustedSrcRect = new Rect(srcRect);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSensorManager.java
@@ -2,7 +2,7 @@ package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.O;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import android.hardware.Sensor;
 import android.hardware.SensorDirectChannel;
@@ -59,18 +59,18 @@ public class ShadowSensorManager {
    */
   @Deprecated
   public void addSensor(int sensorType, Sensor sensor) {
-    checkNotNull(sensor);
+    requireNonNull(sensor);
     sensorMap.put(sensorType, sensor);
   }
 
   /** Adds a {@link Sensor} to the {@link SensorManager} */
   public void addSensor(Sensor sensor) {
-    checkNotNull(sensor);
+    requireNonNull(sensor);
     sensorMap.put(sensor.getType(), sensor);
   }
 
   public void removeSensor(Sensor sensor) {
-    checkNotNull(sensor);
+    requireNonNull(sensor);
     sensorMap.get(sensor.getType()).remove(sensor);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowServiceManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowServiceManager.java
@@ -10,7 +10,7 @@ import static android.os.Build.VERSION_CODES.R;
 import static android.os.Build.VERSION_CODES.S;
 import static android.os.Build.VERSION_CODES.TIRAMISU;
 import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import android.accounts.IAccountManager;
 import android.app.IAlarmManager;
@@ -169,7 +169,7 @@ public class ShadowServiceManager {
       this.binderType = binderType;
       this.delegate = delegate;
       if (binderType == BinderType.DELEGATING_PROXY || binderType == BinderType.CONCRETE) {
-        checkNotNull(delegate);
+        requireNonNull(delegate);
       }
     }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStorageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowStorageManager.java
@@ -8,10 +8,10 @@ import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
 import android.os.UserManager;
 import android.os.storage.StorageManager;
 import android.os.storage.StorageVolume;
-import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.HiddenApi;
 import org.robolectric.annotation.Implementation;
@@ -47,7 +47,7 @@ public class ShadowStorageManager {
    * @param storageVolume to add to list
    */
   public void addStorageVolume(StorageVolume storageVolume) {
-    Preconditions.checkNotNull(storageVolume);
+    Objects.requireNonNull(storageVolume);
     storageVolumeList.add(storageVolume);
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemProperties.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowSystemProperties.java
@@ -1,10 +1,10 @@
 package org.robolectric.shadows;
 
 import android.os.SystemProperties;
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.Properties;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
@@ -93,7 +93,7 @@ public class ShadowSystemProperties {
       // load the prop from classpath
       ClassLoader cl = SystemProperties.class.getClassLoader();
       try (InputStream is = cl.getResourceAsStream("build.prop")) {
-        Preconditions.checkNotNull(is, "could not find build.prop");
+        Objects.requireNonNull(is, "could not find build.prop");
         buildProperties = new Properties();
         buildProperties.load(is);
         setDefaults(buildProperties);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowTelephonyManager.java
@@ -66,6 +66,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1557,7 +1558,7 @@ public class ShadowTelephonyManager {
    * @throws NullPointerException if telephonyDisplayInfo is null.
    */
   public void setTelephonyDisplayInfo(Object telephonyDisplayInfo) {
-    Preconditions.checkNotNull(telephonyDisplayInfo);
+    Objects.requireNonNull(telephonyDisplayInfo);
     this.telephonyDisplayInfo = telephonyDisplayInfo;
 
     for (PhoneStateListener listener :

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsageStatsManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsageStatsManager.java
@@ -1,7 +1,7 @@
 package org.robolectric.shadows;
 
 import static android.os.Build.VERSION_CODES.TIRAMISU;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import android.annotation.RequiresApi;
 import android.app.PendingIntent;
@@ -173,9 +173,9 @@ public class ShadowUsageStatsManager {
         @Nonnull PendingIntent callbackIntent) {
       this.observerId = observerId;
       this.packageNames = ImmutableList.copyOf(packageNames);
-      this.timeLimit = checkNotNull(timeLimit);
-      this.timeUsed = checkNotNull(timeUsed);
-      this.callbackIntent = checkNotNull(callbackIntent);
+      this.timeLimit = requireNonNull(timeLimit);
+      this.timeUsed = requireNonNull(timeUsed);
+      this.callbackIntent = requireNonNull(callbackIntent);
     }
 
     public int getObserverId() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsbManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowUsbManager.java
@@ -24,6 +24,7 @@ import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.ClassName;
@@ -182,8 +183,8 @@ public class ShadowUsbManager {
    * already exists, updates the USB device with new permission value.
    */
   public void addOrUpdateUsbDevice(UsbDevice usbDevice, boolean hasPermission) {
-    Preconditions.checkNotNull(usbDevice);
-    Preconditions.checkNotNull(usbDevice.getDeviceName());
+    Objects.requireNonNull(usbDevice);
+    Objects.requireNonNull(usbDevice.getDeviceName());
     usbDevices.put(usbDevice.getDeviceName(), usbDevice);
     if (hasPermission) {
       grantPermission(usbDevice);
@@ -194,7 +195,7 @@ public class ShadowUsbManager {
 
   /** Removes a USB device from available USB devices map. */
   public void removeUsbDevice(UsbDevice usbDevice) {
-    Preconditions.checkNotNull(usbDevice);
+    Objects.requireNonNull(usbDevice);
     usbDevices.remove(usbDevice.getDeviceName());
     revokePermission(usbDevice, RuntimeEnvironment.getApplication().getPackageName());
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWearableSensingManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWearableSensingManager.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 import android.app.wearable.WearableSensingManager;
 import android.app.wearable.WearableSensingManager.StatusCode;
@@ -65,16 +65,16 @@ public class ShadowWearableSensingManager {
       @Nullable ComponentName targetVisComponentName,
       @Nonnull Executor executor,
       @Nonnull @StatusCode Consumer<Integer> statusConsumer) {
-    checkNotNull(executor);
-    checkNotNull(statusConsumer);
+    requireNonNull(executor);
+    requireNonNull(statusConsumer);
     executor.execute(() -> statusConsumer.accept(startHotwordRecognitionResult));
   }
 
   @Implementation(minSdk = V.SDK_INT)
   protected void stopHotwordRecognition(
       @Nonnull Executor executor, @Nonnull @StatusCode Consumer<Integer> statusConsumer) {
-    checkNotNull(executor);
-    checkNotNull(statusConsumer);
+    requireNonNull(executor);
+    requireNonNull(statusConsumer);
     executor.execute(() -> statusConsumer.accept(stopHotwordRecognitionResult));
   }
 
@@ -92,7 +92,7 @@ public class ShadowWearableSensingManager {
    */
   public void setStartHotwordRecognitionResult(
       @Nonnull @StatusCode Integer startHotwordRecognitionResult) {
-    checkNotNull(startHotwordRecognitionResult);
+    requireNonNull(startHotwordRecognitionResult);
     ShadowWearableSensingManager.startHotwordRecognitionResult = startHotwordRecognitionResult;
   }
 
@@ -102,7 +102,7 @@ public class ShadowWearableSensingManager {
    */
   public void setStopHotwordRecognitionResult(
       @Nonnull @StatusCode Integer stopHotwordRecognitionResult) {
-    checkNotNull(stopHotwordRecognitionResult);
+    requireNonNull(stopHotwordRecognitionResult);
     ShadowWearableSensingManager.stopHotwordRecognitionResult = stopHotwordRecognitionResult;
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiManager.java
@@ -31,7 +31,6 @@ import android.os.Looper;
 import android.provider.Settings;
 import android.util.ArraySet;
 import android.util.Pair;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -42,6 +41,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -119,7 +119,7 @@ public class ShadowWifiManager {
 
   @Implementation(minSdk = Q)
   protected int addNetworkSuggestions(List<WifiNetworkSuggestion> networkSuggestions) {
-    Preconditions.checkNotNull(networkSuggestions);
+    Objects.requireNonNull(networkSuggestions);
     if (addNetworkSuggestionsResult == WifiManager.STATUS_NETWORK_SUGGESTIONS_SUCCESS) {
       lastAddedSuggestions = ImmutableList.copyOf(networkSuggestions);
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiP2pManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWifiP2pManager.java
@@ -7,9 +7,9 @@ import android.net.wifi.p2p.WifiP2pManager.ActionListener;
 import android.net.wifi.p2p.WifiP2pManager.Channel;
 import android.os.Handler;
 import android.os.Looper;
-import com.google.common.base.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
@@ -42,8 +42,8 @@ public class ShadowWifiP2pManager {
   @Implementation
   protected void setWifiP2pChannels(
       Channel c, int listeningChannel, int operatingChannel, ActionListener al) {
-    Preconditions.checkNotNull(c);
-    Preconditions.checkNotNull(al);
+    Objects.requireNonNull(c);
+    Objects.requireNonNull(al);
     ShadowWifiP2pManager.listeningChannel = listeningChannel;
     ShadowWifiP2pManager.operatingChannel = operatingChannel;
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindowManagerGlobal.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowWindowManagerGlobal.java
@@ -17,11 +17,11 @@ import static android.view.WindowInsets.Type.navigationBars;
 import static android.view.WindowInsets.Type.statusBars;
 import static android.view.WindowInsets.Type.systemBars;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Math.max;
 import static java.lang.Math.round;
 import static java.util.Arrays.stream;
+import static java.util.Objects.requireNonNull;
 import static org.robolectric.shadows.ShadowView.useRealGraphics;
 import static org.robolectric.shadows.SystemUi.systemUiForDisplay;
 import static org.robolectric.util.ReflectionHelpers.callConstructor;
@@ -515,7 +515,7 @@ public class ShadowWindowManagerGlobal {
         Rect[] rects = findAll(Rect.class, args);
         int requestedSizeIdx = sdk < S ? 3 : 2;
         configureWindowFrames(
-            checkNotNull(windowInfo),
+            requireNonNull(windowInfo),
             /* inAttrs= */ (WindowManager.LayoutParams) args[sdk <= R ? 2 : 1],
             /* requestedSize= */ new Point(
                 (int) args[requestedSizeIdx], (int) args[requestedSizeIdx + 1]),
@@ -668,7 +668,7 @@ public class ShadowWindowManagerGlobal {
     void sendInsetsControlChanged(
         IWindow window, @Nullable Integer type, boolean hasControlsChanged) {
       int sdk = RuntimeEnvironment.getApiLevel();
-      WindowInfo windowInfo = checkNotNull(windows.get(window));
+      WindowInfo windowInfo = requireNonNull(windows.get(window));
       InsetsState insetsState = new InsetsState(windowInfo.insetsState);
       // On R if we don't remove the sources that aren't changing we'll infinite loop when toggling
       // visibility of multiple bars.
@@ -702,7 +702,7 @@ public class ShadowWindowManagerGlobal {
 
     void sendResize(IWindow window) {
       int sdk = RuntimeEnvironment.getApiLevel();
-      WindowInfo windowInfo = checkNotNull(windows.get(window));
+      WindowInfo windowInfo = requireNonNull(windows.get(window));
       configureWindowFrames(
           windowInfo,
           windowInfo.attrs,

--- a/shadows/playservices/src/main/java/org/robolectric/shadows/gms/ShadowGoogleAuthUtil.java
+++ b/shadows/playservices/src/main/java/org/robolectric/shadows/gms/ShadowGoogleAuthUtil.java
@@ -10,10 +10,10 @@ import com.google.android.gms.auth.GoogleAuthUtil;
 import com.google.android.gms.auth.GooglePlayServicesAvailabilityException;
 import com.google.android.gms.auth.UserRecoverableAuthException;
 import com.google.android.gms.auth.UserRecoverableNotifiedException;
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
@@ -37,7 +37,7 @@ public class ShadowGoogleAuthUtil {
   }
 
   public static synchronized void provideImpl(GoogleAuthUtilImpl impl) {
-    googleAuthUtilImpl = Preconditions.checkNotNull(impl);
+    googleAuthUtilImpl = Objects.requireNonNull(impl);
   }
 
   @Resetter

--- a/shadows/playservices/src/main/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtil.java
+++ b/shadows/playservices/src/main/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtil.java
@@ -10,7 +10,7 @@ import android.content.res.Resources;
 import androidx.fragment.app.Fragment;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
-import com.google.common.base.Preconditions;
+import java.util.Objects;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -36,7 +36,7 @@ public class ShadowGooglePlayServicesUtil {
   }
 
   public static synchronized void provideImpl(GooglePlayServicesUtilImpl impl) {
-    googlePlayServicesUtilImpl = Preconditions.checkNotNull(impl);
+    googlePlayServicesUtilImpl = Objects.requireNonNull(impl);
   }
 
   @Resetter


### PR DESCRIPTION
This commit replaces some Guava usages with the equivalent Java API.

**Note:** there are also some usages of `Verify.verifyNotNull()`, which I didn't migrate because the behavior is different (throwing `VerifyException` vs. `NullPointerException`). Let me know if I should replace them with `Objects.requireNonNull()` too.