### PR TITLE
Remove the deprecated `XmlResourceParserImpl` constructor.

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/android/XmlResourceParserImpl.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/XmlResourceParserImpl.java
@@ -13,7 +13,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import org.robolectric.res.AttributeResource;
-import org.robolectric.res.Fs;
 import org.robolectric.res.ResName;
 import org.robolectric.res.ResourceTable;
 import org.robolectric.res.StringResources;
@@ -59,20 +58,6 @@ public class XmlResourceParserImpl implements XmlResourceParser {
   private boolean mDecNextDepth = false;
   private int mDepth = 0;
   private int mEventType = START_DOCUMENT;
-
-  /**
-   * @deprecated use {@link XmlResourceParserImpl#XmlResourceParserImpl(Document, Path, String,
-   *     String, ResourceTable)} instead.
-   */
-  @Deprecated
-  public XmlResourceParserImpl(
-      Document document,
-      String fileName,
-      String packageName,
-      String applicationPackageName,
-      ResourceTable resourceTable) {
-    this(document, Fs.fromUrl(fileName), packageName, applicationPackageName, resourceTable);
-  }
 
   public XmlResourceParserImpl(
       Document document,


### PR DESCRIPTION
This constructor was deprecated in #4265, released with Robolectric 4.2.
It is no longer used in the project, and the migration to the other constructor is quite straightforward.