### PR TITLE
Remove some deprecated methods in `ShadowApplication`

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -19,7 +19,6 @@ import android.content.ServiceConnection;
 import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
-import android.os.PowerManager;
 import android.widget.ListPopupWindow;
 import android.widget.PopupWindow;
 import android.widget.Toast;
@@ -241,30 +240,6 @@ public class ShadowApplication extends ShadowContextWrapper {
    */
   public void declareComponentUnbindable(ComponentName component) {
     getShadowInstrumentation().declareComponentUnbindable(component);
-  }
-
-  /**
-   * @deprecated use ShadowPowerManager.getLatestWakeLock
-   */
-  @Deprecated
-  public PowerManager.WakeLock getLatestWakeLock() {
-    return ShadowPowerManager.getLatestWakeLock();
-  }
-
-  /**
-   * @deprecated use PowerManager APIs instead
-   */
-  @Deprecated
-  public void addWakeLock(PowerManager.WakeLock wl) {
-    ShadowPowerManager.addWakeLock(wl);
-  }
-
-  /**
-   * @deprecated use ShadowPowerManager.clearWakeLocks
-   */
-  @Deprecated
-  public void clearWakeLocks() {
-    ShadowPowerManager.clearWakeLocks();
   }
 
   private final Map<String, Object> singletons = new HashMap<>();


### PR DESCRIPTION
This commit removes the following deprecated methods from `ShadowApplication`:
- `getLatestWakeLock()`.
- `addWakeLock()`.
- `clearWakeLocks()`.

These methods were deprecated in #6229, released with Robolectric 4.6.
They are no longer used in the project, and the migration is straightforward.