### PR TITLE
Remove deprecated `ShadowApplication#getAppWidgetManager()` method

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetManagerTest.java
@@ -24,6 +24,7 @@ import android.appwidget.AppWidgetProviderInfo;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.Resources.NotFoundException;
@@ -58,6 +59,14 @@ public class ShadowAppWidgetManagerTest {
     context = ApplicationProvider.getApplicationContext();
     appWidgetManager = AppWidgetManager.getInstance(context);
     shadowAppWidgetManager = shadowOf(appWidgetManager);
+  }
+
+  @Test
+  public void getInstance_shouldReturnSameInstance() {
+    assertNotNull(appWidgetManager);
+    assertSame(appWidgetManager, AppWidgetManager.getInstance(context));
+    assertSame(appWidgetManager, AppWidgetManager.getInstance(new ContextWrapper(context)));
+    assertSame(appWidgetManager, context.getSystemService(Context.APPWIDGET_SERVICE));
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -7,7 +7,6 @@ import android.app.ActivityThread;
 import android.app.AlertDialog;
 import android.app.Application;
 import android.app.Dialog;
-import android.appwidget.AppWidgetManager;
 import android.bluetooth.BluetoothAdapter;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -193,15 +192,6 @@ public class ShadowApplication extends ShadowContextWrapper {
   /** Clears the list of {@link Wrapper}s for registered receivers */
   public void clearRegisteredReceivers() {
     getShadowInstrumentation().clearRegisteredReceivers();
-  }
-
-  /**
-   * @deprecated Please use {@link Context#getSystemService(String)} with {@link
-   *     Context#APPWIDGET_SERVICE} instead.
-   */
-  @Deprecated
-  public AppWidgetManager getAppWidgetManager() {
-    return (AppWidgetManager) realApplication.getSystemService(Context.APPWIDGET_SERVICE);
   }
 
   /**


### PR DESCRIPTION
This commit removes the `ShadowApplication#getAppWidgetManager()` deprecated method.

It was deprecated in https://github.com/robolectric/robolectric/commit/98cc2e81f27e5e3e49f94a7519db536e250eab6b, released with Robolectric 4.1.
It is no longer used in the project, and the migration is straightforward.

It also restores the test that was removed in the mentioned commit.