### PR TITLE
Migrate to `Objects#requireNonNull()`

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioManager.java
@@ -29,7 +29,6 @@ import android.os.Build.VERSION_CODES;
 import android.os.Handler;
 import android.os.Parcel;
 import android.view.KeyEvent;
-import com.android.internal.util.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
@@ -974,7 +973,7 @@ public class ShadowAudioManager {
   @RequiresPermission(android.Manifest.permission.MODIFY_AUDIO_ROUTING)
   protected int registerAudioPolicy(
       @Nonnull @ClassName("android.media.audiopolicy.AudioPolicy") Object audioPolicy) {
-    Preconditions.checkNotNull(audioPolicy, "Illegal null AudioPolicy argument");
+    Objects.requireNonNull(audioPolicy, "Illegal null AudioPolicy argument");
     AudioPolicy policy = (AudioPolicy) audioPolicy;
     String id = getIdForAudioPolicy(audioPolicy);
     if (registeredAudioPolicies.containsKey(id)) {
@@ -989,7 +988,7 @@ public class ShadowAudioManager {
   @Implementation(minSdk = Q)
   protected void unregisterAudioPolicy(
       @Nonnull @ClassName("android.media.audiopolicy.AudioPolicy") Object audioPolicy) {
-    Preconditions.checkNotNull(audioPolicy, "Illegal null AudioPolicy argument");
+    Objects.requireNonNull(audioPolicy, "Illegal null AudioPolicy argument");
     AudioPolicy policy = (AudioPolicy) audioPolicy;
     registeredAudioPolicies.remove(getIdForAudioPolicy(policy));
     policy.setRegistration(null);

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
@@ -49,7 +49,7 @@ import android.os.PersistableBundle;
 import android.os.Process;
 import android.os.UserHandle;
 import android.text.TextUtils;
-import com.android.internal.util.Preconditions;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.concurrent.GuardedBy;

--- a/simulator/src/main/java/org/robolectric/simulator/AppLoader.java
+++ b/simulator/src/main/java/org/robolectric/simulator/AppLoader.java
@@ -59,8 +59,8 @@ public class AppLoader implements Runnable {
     ResolveInfo resolveInfo = resolveInfoList.get(0);
     ActivityInfo activityInfo = resolveInfo.activityInfo;
 
-    Preconditions.checkNotNull(activityInfo);
-    Preconditions.checkNotNull(activityInfo.name);
+    Objects.requireNonNull(activityInfo);
+    Objects.requireNonNull(activityInfo.name);
     // Start the main Activity
     try {
       Class<? extends Activity> activityClass =


### PR DESCRIPTION
This commit continues the work done in #10175:
- Replace Guava's `Preconditions#checkNotNull()` with `Objects#requireNonNull()`.
- Replace Android's internal `Preconditions#checkNotNull()` with `Objects#requireNonNull()`.
- Replace Android's internal `Preconditions#checkArgument()` with Guava's `Preconditions#checkArgument()`.