### PR TITLE
Remove deprecated `PackageItemData#getClassName()` method

### DIFF
--- a/resources/src/main/java/org/robolectric/manifest/PackageItemData.java
+++ b/resources/src/main/java/org/robolectric/manifest/PackageItemData.java
@@ -1,7 +1,5 @@
 package org.robolectric.manifest;
 
-import com.google.errorprone.annotations.InlineMe;
-
 public class PackageItemData {
   protected final String name;
   protected final MetaData metaData;
@@ -13,15 +11,6 @@ public class PackageItemData {
 
   public String getName() {
     return name;
-  }
-
-  /**
-   * @deprecated - Use {@link #getName()} instead.
-   */
-  @Deprecated
-  @InlineMe(replacement = "this.getName()")
-  public final String getClassName() {
-    return getName();
   }
 
   public MetaData getMetaData() {

--- a/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
+++ b/robolectric/src/test/java/org/robolectric/manifest/AndroidManifestTest.java
@@ -126,21 +126,20 @@ public class AndroidManifestTest {
     AndroidManifest config = newConfig("TestAndroidManifestWithServices.xml");
     assertThat(config.getServices()).hasSize(2);
 
-    assertThat(config.getServices().get(0).getClassName()).isEqualTo("com.foo.Service");
+    assertThat(config.getServices().get(0).getName()).isEqualTo("com.foo.Service");
     assertThat(config.getServices().get(0).getActions())
         .contains("org.robolectric.ACTION_DIFFERENT_PACKAGE");
     assertThat(config.getServices().get(0).getIntentFilters()).isNotEmpty();
     assertThat(config.getServices().get(0).getIntentFilters().get(0).getMimeTypes())
         .containsExactly("image/jpeg");
 
-    assertThat(config.getServices().get(1).getClassName())
+    assertThat(config.getServices().get(1).getName())
         .isEqualTo("com.bar.ServiceWithoutIntentFilter");
     assertThat(config.getServices().get(1).getActions()).isEmpty();
     assertThat(config.getServices().get(1).getIntentFilters()).isEmpty();
 
-    assertThat(config.getServiceData("com.foo.Service").getClassName())
-        .isEqualTo("com.foo.Service");
-    assertThat(config.getServiceData("com.bar.ServiceWithoutIntentFilter").getClassName())
+    assertThat(config.getServiceData("com.foo.Service").getName()).isEqualTo("com.foo.Service");
+    assertThat(config.getServiceData("com.bar.ServiceWithoutIntentFilter").getName())
         .isEqualTo("com.bar.ServiceWithoutIntentFilter");
     assertThat(config.getServiceData("com.foo.Service").getPermission())
         .isEqualTo("com.foo.Permission");


### PR DESCRIPTION
This commit removes the deprecated `PackageItemData#getClassName()` method.
It was deprecated in #3566, and released with Robolectric 3.7.