### PR TITLE
Remove deprecated `ShadowApplication#getBluetoothAdapter()` method

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -7,7 +7,6 @@ import android.app.ActivityThread;
 import android.app.AlertDialog;
 import android.app.Application;
 import android.app.Dialog;
-import android.bluetooth.BluetoothAdapter;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
@@ -210,14 +209,6 @@ public class ShadowApplication extends ShadowContextWrapper {
   public ShadowDialog getLatestDialog() {
     Dialog dialog = ShadowDialog.getLatestDialog();
     return dialog == null ? null : Shadow.extract(dialog);
-  }
-
-  /**
-   * @deprecated Use {@link BluetoothAdapter#getDefaultAdapter()} ()} instead.
-   */
-  @Deprecated
-  public BluetoothAdapter getBluetoothAdapter() {
-    return BluetoothAdapter.getDefaultAdapter();
   }
 
   public void declareActionUnbindable(String action) {


### PR DESCRIPTION
This commit removes the deprecated `ShadowApplication#getBluetoothAdapter()` method.
It was deprecated in #6417, and released with Robolectric 4.6.