### PR TITLE
Remove deprecated `ShadowApplication#setSystemService()` method

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityManagerTest.java
@@ -220,7 +220,6 @@ public class ShadowActivityManagerTest {
 
   @Test
   public void switchUser() {
-    shadowOf(application).setSystemService(Context.USER_SERVICE, userManager);
     shadowOf(userManager).addUser(10, "secondary_user", 0);
     activityManager.switchUser(10);
     assertThat(UserHandle.myUserId()).isEqualTo(10);
@@ -241,7 +240,6 @@ public class ShadowActivityManagerTest {
 
   @Test
   public void getCurrentUser_nonDefault_returnValueSet() {
-    shadowOf(application).setSystemService(Context.USER_SERVICE, userManager);
     shadowOf(userManager).addUser(10, "secondary_user", 0);
     activityManager.switchUser(10);
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -340,16 +340,6 @@ public class ShadowApplication extends ShadowContextWrapper {
   }
 
   /**
-   * @deprecated Do not depend on this method to override services as it will be removed in a future
-   *     update. The preferred method is use the shadow of the corresponding service.
-   */
-  @Deprecated
-  public void setSystemService(String key, Object service) {
-    ShadowContextImpl shadowContext = Shadow.extract(realApplication.getBaseContext());
-    shadowContext.setSystemService(key, service);
-  }
-
-  /**
    * Enables or disables predictive back for the current application.
    *
    * <p>This is the equivalent of specifying {code android:enableOnBackInvokedCallback} on the


### PR DESCRIPTION
This commit removes the deprecated `ShadowApplication#setSystemService()` method.
It was deprecated in #2394, when it was introduced, and released with Robolectric 3.1.