### PR TITLE
Skip throwing IllegalStateException when in INSTRUMENTATION_TEST mode

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedLooper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPausedLooper.java
@@ -636,7 +636,11 @@ public final class ShadowPausedLooper extends ShadowLooper {
       do {
         msg = getNextExecutableMessage();
         if (msg == null) {
-          throw new IllegalStateException("Runnable is not in the queue");
+          if (looperMode() != LooperMode.Mode.INSTRUMENTATION_TEST) {
+            throw new IllegalStateException("Runnable is not in the queue");
+          } else {
+            break;
+          }
         }
         msg.getTarget().dispatchMessage(msg);
         triggerIdleHandlersIfNeeded(msg);
@@ -660,7 +664,11 @@ public final class ShadowPausedLooper extends ShadowLooper {
       do {
         msg = getNextExecutableMessage();
         if (msg == null) {
-          throw new IllegalStateException("Runnable is not in the queue");
+          if (looperMode() != LooperMode.Mode.INSTRUMENTATION_TEST) {
+            throw new IllegalStateException("Runnable is not in the queue");
+          } else {
+            break;
+          }
         }
         msg.getTarget().dispatchMessage(msg);
 


### PR DESCRIPTION
Fixes #10123

### Overview

This PR is aimed to fix consequences of race condition when multiple threads posting and idling main looper could lead to it exhausting messages of one another. This leads to illegalstateexception when the later thread tries to find his runnable excecuted by the former one

### Proposed Changes

Just mute the exception. I don't really see any other way to simulate runnable queue idling that would exclude race condition
