### PR TITLE
Remove custom `Provider` class

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/Provider.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/Provider.java
@@ -1,5 +1,0 @@
-package org.robolectric.shadows;
-
-public interface Provider<T> {
-  T get();
-}


### PR DESCRIPTION
With the merge of #10196, this class is no longer used.