### PR TITLE
Add basic build file for the simulator

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -57,6 +57,7 @@ include(
   ":shadows:framework",
   ":shadows:httpclient",
   ":shadows:playservices",
+  ":simulator",
   ":testapp",
   ":utils",
   ":utils:reflector",

--- a/simulator/build.gradle
+++ b/simulator/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+  alias(libs.plugins.robolectric.deployed.java.module)
+  alias(libs.plugins.robolectric.java.module)
+}
+
+dependencies {
+  annotationProcessor(libs.error.prone.core)
+  annotationProcessor(libs.auto.service)
+
+  api(project(":robolectric"))
+  compileOnly(AndroidSdk.MAX_SDK.coordinates)
+  compileOnly(libs.auto.service.annotations)
+
+  api(libs.guava)
+}

--- a/simulator/src/main/java/org/robolectric/simulator/AppLoader.java
+++ b/simulator/src/main/java/org/robolectric/simulator/AppLoader.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.ConscryptMode;


### PR DESCRIPTION
Also add the import to java.util.Objects in AppLoader.

This is just to ensure that the simulator build doesn't break due to refactoring.

