### PR TITLE
Remove deprecated `ShadowApplication#getInstance()`

### DIFF
--- a/robolectric/src/main/java/org/robolectric/Robolectric.java
+++ b/robolectric/src/main/java/org/robolectric/Robolectric.java
@@ -2,6 +2,7 @@ package org.robolectric;
 
 import static android.os.Build.VERSION_CODES.P;
 import static com.google.common.base.Preconditions.checkState;
+import static org.robolectric.Shadows.shadowOf;
 
 import android.annotation.IdRes;
 import android.annotation.RequiresApi;
@@ -31,7 +32,6 @@ import org.robolectric.android.controller.ContentProviderController;
 import org.robolectric.android.controller.FragmentController;
 import org.robolectric.android.controller.IntentServiceController;
 import org.robolectric.android.controller.ServiceController;
-import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.util.Logger;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.Scheduler;
@@ -382,7 +382,7 @@ public class Robolectric {
    * @return Background scheduler.
    */
   public static Scheduler getBackgroundThreadScheduler() {
-    return ShadowApplication.getInstance().getBackgroundThreadScheduler();
+    return shadowOf(RuntimeEnvironment.getApplication()).getBackgroundThreadScheduler();
   }
 
   /** Execute all runnables that have been enqueued on the background scheduler. */

--- a/robolectric/src/test/java/org/robolectric/RobolectricTest.java
+++ b/robolectric/src/test/java/org/robolectric/RobolectricTest.java
@@ -28,7 +28,6 @@ import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.LooperMode;
-import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowLooper;
 import org.robolectric.shadows.ShadowView;
 import org.robolectric.util.ReflectionHelpers;
@@ -84,7 +83,7 @@ public class RobolectricTest {
 
   @Test
   public void checkActivities_shouldSetValueOnShadowApplication() {
-    ShadowApplication.getInstance().checkActivities(true);
+    shadowOf(RuntimeEnvironment.getApplication()).checkActivities(true);
     assertThrows(
         ActivityNotFoundException.class,
         () ->

--- a/robolectric/src/test/java/org/robolectric/fakes/RoboMenuTest.java
+++ b/robolectric/src/test/java/org/robolectric/fakes/RoboMenuTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -13,7 +14,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.shadows.ShadowApplication;
+import org.robolectric.RuntimeEnvironment;
 
 @RunWith(AndroidJUnit4.class)
 public class RoboMenuTest {
@@ -60,7 +61,7 @@ public class RoboMenuTest {
 
     assertNotNull(item);
 
-    Intent startedIntent = ShadowApplication.getInstance().getNextStartedActivity();
+    Intent startedIntent = shadowOf(RuntimeEnvironment.getApplication()).getNextStartedActivity();
     assertNotNull(startedIntent);
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextTest.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.P;
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.robolectric.Shadows.shadowOf;
 
 import android.content.Context;
 import android.content.Intent;
@@ -22,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.ResourcesMode;
 import org.robolectric.annotation.ResourcesMode.Mode;
@@ -46,7 +48,8 @@ public class ShadowContextTest {
   public void startForegroundService() {
     Intent intent = new Intent().setPackage("dummy.package");
     context.startForegroundService(intent);
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isEqualTo(intent);
+    assertThat(shadowOf(RuntimeEnvironment.getApplication()).getNextStartedService())
+        .isEqualTo(intent);
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/android/util/concurrent/RoboExecutorService.java
+++ b/shadows/framework/src/main/java/org/robolectric/android/util/concurrent/RoboExecutorService.java
@@ -1,5 +1,7 @@
 package org.robolectric.android.util.concurrent;
 
+import static org.robolectric.Shadows.shadowOf;
+
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -13,8 +15,8 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nonnull;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.LooperMode;
-import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.util.Scheduler;
 
 /**
@@ -53,7 +55,7 @@ public class RoboExecutorService implements ExecutorService {
   }
 
   public RoboExecutorService() {
-    this.scheduler = ShadowApplication.getInstance().getBackgroundThreadScheduler();
+    this.scheduler = shadowOf(RuntimeEnvironment.getApplication()).getBackgroundThreadScheduler();
   }
 
   @Override

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -7,6 +7,7 @@ import static android.os.Build.VERSION_CODES.O_MR1;
 import static android.os.Build.VERSION_CODES.Q;
 import static android.os.Build.VERSION_CODES.S;
 import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
+import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.annotation.AnimRes;
@@ -1070,10 +1071,6 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
         }
       }
     }
-  }
-
-  private ShadowPackageManager shadowOf(PackageManager packageManager) {
-    return Shadow.extract(packageManager);
   }
 
   @ForType(value = Activity.class, direct = true)

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -1,5 +1,6 @@
 package org.robolectric.shadows;
 
+import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 import static org.robolectric.shadows.ShadowLooper.assertLooperMode;
 
@@ -43,20 +44,12 @@ public class ShadowApplication extends ShadowContextWrapper {
   private ListPopupWindow latestListPopupWindow;
 
   /**
-   * @deprecated Use {@code shadowOf(ApplicationProvider#getApplicationContext())} instead.
-   */
-  @Deprecated
-  public static ShadowApplication getInstance() {
-    return Shadow.extract(RuntimeEnvironment.getApplication());
-  }
-
-  /**
    * Runs any background tasks previously queued by {@link android.os.AsyncTask#execute(Object[])}.
    *
    * <p>Note: calling this method does not pause or un-pause the scheduler.
    */
   public static void runBackgroundTasks() {
-    getInstance().getBackgroundThreadScheduler().advanceBy(0);
+    shadowOf(RuntimeEnvironment.getApplication()).getBackgroundThreadScheduler().advanceBy(0);
   }
 
   /** Configures the value to be returned by {@link Application#getProcessName()}. */

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowDevicePolicyManager.java
@@ -26,10 +26,12 @@ import android.annotation.SuppressLint;
 import android.annotation.SystemApi;
 import android.app.ApplicationPackageManager;
 import android.app.KeyguardManager;
+import android.app.admin.DeviceAdminReceiver;
 import android.app.admin.DevicePolicyManager;
 import android.app.admin.DevicePolicyManager.NearbyStreamingPolicy;
 import android.app.admin.DevicePolicyManager.PasswordComplexity;
 import android.app.admin.DevicePolicyManager.UserProvisioningState;
+import android.app.admin.DevicePolicyState;
 import android.app.admin.IDevicePolicyManager;
 import android.app.admin.SystemUpdateInfo;
 import android.app.admin.SystemUpdatePolicy;
@@ -927,10 +929,10 @@ public class ShadowDevicePolicyManager {
       }
       if (Arrays.asList(packageInfo.requestedPermissions).contains(permission)) {
         if (grantState == DevicePolicyManager.PERMISSION_GRANT_STATE_GRANTED) {
-          ShadowApplication.getInstance().grantPermissions(permission);
+          shadowOf(RuntimeEnvironment.getApplication()).grantPermissions(permission);
         }
         if (grantState == DevicePolicyManager.PERMISSION_GRANT_STATE_DENIED) {
-          ShadowApplication.getInstance().denyPermissions(permission);
+          shadowOf(RuntimeEnvironment.getApplication()).denyPermissions(permission);
         }
       } else {
         // the app does not require this permission

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTaskLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTaskLoader.java
@@ -1,5 +1,7 @@
 package org.robolectric.shadows;
 
+import static org.robolectric.Shadows.shadowOf;
+
 import android.content.AsyncTaskLoader;
 import android.content.Context;
 import java.util.concurrent.Callable;
@@ -47,7 +49,7 @@ public class ShadowLegacyAsyncTaskLoader<D> extends ShadowAsyncTaskLoader<D> {
           }
         };
 
-    ShadowApplication.getInstance().getBackgroundThreadScheduler().post(future);
+    shadowOf(RuntimeEnvironment.getApplication()).getBackgroundThreadScheduler().post(future);
   }
 
   private final class BackgroundWorker implements Callable<D> {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPopupWindow.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPopupWindow.java
@@ -1,9 +1,11 @@
 package org.robolectric.shadows;
 
+import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.view.WindowManager;
 import android.widget.PopupWindow;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -17,7 +19,7 @@ public class ShadowPopupWindow {
 
   @Implementation
   protected void invokePopup(WindowManager.LayoutParams p) {
-    ShadowApplication.getInstance().setLatestPopupWindow(realPopupWindow);
+    shadowOf(RuntimeEnvironment.getApplication()).setLatestPopupWindow(realPopupWindow);
     reflector(PopupWindowReflector.class, realPopupWindow).invokePopup(p);
   }
 


### PR DESCRIPTION
This method was deprecated in #4012, released with Robolectric 4.0.

> [!WARNING]
> This seems to be still quite used on GitHub.
> But since the replacement is rather straightforward, I'm submitting the removal anyway. Let me know if you prefer to keep this a bit longer.