### PR TITLE
Remove deprecated `ShadowApplication#getForegroundThreadScheduler()`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
+++ b/robolectric/src/test/java/org/robolectric/android/internal/AndroidTestEnvironmentTest.java
@@ -35,6 +35,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.BootstrapDeferringRobolectricTestRunner;
 import org.robolectric.BootstrapDeferringRobolectricTestRunner.BootstrapWrapperI;
 import org.robolectric.BootstrapDeferringRobolectricTestRunner.RoboInject;
+import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.DeviceConfig;
 import org.robolectric.android.DeviceConfig.ScreenSize;
@@ -70,7 +71,7 @@ public class AndroidTestEnvironmentTest {
     assertThat(RuntimeEnvironment.getMasterScheduler())
         .isSameInstanceAs(ShadowLooper.getShadowMainLooper().getScheduler());
     assertThat(RuntimeEnvironment.getMasterScheduler())
-        .isSameInstanceAs(ShadowApplication.getInstance().getForegroundThreadScheduler());
+        .isSameInstanceAs(Robolectric.getForegroundThreadScheduler());
   }
 
   @Test
@@ -82,7 +83,7 @@ public class AndroidTestEnvironmentTest {
     final ShadowApplication shadowApplication =
         Shadow.extract(ApplicationProvider.getApplicationContext());
     assertThat(shadowApplication.getBackgroundThreadScheduler())
-        .isSameInstanceAs(shadowApplication.getForegroundThreadScheduler());
+        .isSameInstanceAs(Robolectric.getForegroundThreadScheduler());
     assertThat(RuntimeEnvironment.getMasterScheduler())
         .isSameInstanceAs(RuntimeEnvironment.getMasterScheduler());
   }
@@ -93,7 +94,7 @@ public class AndroidTestEnvironmentTest {
     final ShadowApplication shadowApplication =
         Shadow.extract(ApplicationProvider.getApplicationContext());
     assertThat(shadowApplication.getBackgroundThreadScheduler())
-        .isNotSameInstanceAs(shadowApplication.getForegroundThreadScheduler());
+        .isNotSameInstanceAs(Robolectric.getForegroundThreadScheduler());
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowApplicationTest.java
@@ -932,23 +932,10 @@ public class ShadowApplicationTest {
   }
 
   @Test
-  public void getForegroundThreadScheduler_shouldMatchRobolectricValue() {
-    assertThat(Shadows.shadowOf(context).getForegroundThreadScheduler())
-        .isSameInstanceAs(Robolectric.getForegroundThreadScheduler());
-  }
-
-  @Test
   @LooperMode(LEGACY)
   public void getBackgroundThreadScheduler_shouldMatchRobolectricValue() {
     assertThat(Shadows.shadowOf(context).getBackgroundThreadScheduler())
         .isSameInstanceAs(Robolectric.getBackgroundThreadScheduler());
-  }
-
-  @Test
-  public void getForegroundThreadScheduler_shouldMatchRuntimeEnvironment() {
-    Scheduler s = new Scheduler();
-    RuntimeEnvironment.setMasterScheduler(s);
-    assertThat(Shadows.shadowOf(context).getForegroundThreadScheduler()).isSameInstanceAs(s);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLegacyChoreographerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLegacyChoreographerTest.java
@@ -11,6 +11,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.time.Duration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.LooperMode.Mode;
 
@@ -37,7 +38,7 @@ public class ShadowLegacyChoreographerTest {
     Choreographer.FrameCallback callback = mock(Choreographer.FrameCallback.class);
     instance.postFrameCallbackDelayed(callback, 1000);
     instance.removeFrameCallback(callback);
-    ShadowApplication.getInstance().getForegroundThreadScheduler().advanceToLastPostedRunnable();
+    Robolectric.getForegroundThreadScheduler().advanceToLastPostedRunnable();
     verify(callback, never()).doFrame(anyLong());
   }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowActivity.java
@@ -439,7 +439,7 @@ public class ShadowActivity extends ShadowContextThemeWrapper {
   @Implementation
   protected void runOnUiThread(Runnable action) {
     if (ShadowLooper.looperMode() == LooperMode.Mode.LEGACY) {
-      ShadowApplication.getInstance().getForegroundThreadScheduler().post(action);
+      RuntimeEnvironment.getMasterScheduler().post(action);
     } else {
       reflector(DirectActivityReflector.class, realActivity).runOnUiThread(action);
     }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplication.java
@@ -87,17 +87,6 @@ public class ShadowApplication extends ShadowContextWrapper {
   }
 
   /**
-   * Return the foreground scheduler.
-   *
-   * @return Foreground scheduler.
-   * @deprecated use {@link org.robolectric.Robolectric#getForegroundThreadScheduler()}
-   */
-  @Deprecated
-  public Scheduler getForegroundThreadScheduler() {
-    return RuntimeEnvironment.getMasterScheduler();
-  }
-
-  /**
    * Return the background scheduler.
    *
    * @return Background scheduler.

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTaskLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyAsyncTaskLoader.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.LooperMode;
@@ -37,9 +38,7 @@ public class ShadowLegacyAsyncTaskLoader<D> extends ShadowAsyncTaskLoader<D> {
           protected void done() {
             try {
               final D result = get();
-              ShadowApplication.getInstance()
-                  .getForegroundThreadScheduler()
-                  .post(() -> realObject.deliverResult(result));
+              RuntimeEnvironment.getMasterScheduler().post(() -> realObject.deliverResult(result));
             } catch (InterruptedException e) {
               // Ignore
             } catch (ExecutionException e) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowView.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowView.java
@@ -525,7 +525,7 @@ public class ShadowView {
   @Implementation
   protected boolean post(Runnable action) {
     if (ShadowLooper.looperMode() == LooperMode.Mode.LEGACY) {
-      ShadowApplication.getInstance().getForegroundThreadScheduler().post(action);
+      RuntimeEnvironment.getMasterScheduler().post(action);
       return true;
     } else {
       return reflector(_View_.class, realView).post(action);
@@ -535,9 +535,7 @@ public class ShadowView {
   @Implementation
   protected boolean postDelayed(Runnable action, long delayMills) {
     if (ShadowLooper.looperMode() == LooperMode.Mode.LEGACY) {
-      ShadowApplication.getInstance()
-          .getForegroundThreadScheduler()
-          .postDelayed(action, delayMills);
+      RuntimeEnvironment.getMasterScheduler().postDelayed(action, delayMills);
       return true;
     } else {
       return reflector(_View_.class, realView).postDelayed(action, delayMills);
@@ -547,8 +545,7 @@ public class ShadowView {
   @Implementation
   protected void postInvalidateDelayed(long delayMilliseconds) {
     if (ShadowLooper.looperMode() == LooperMode.Mode.LEGACY) {
-      ShadowApplication.getInstance()
-          .getForegroundThreadScheduler()
+      RuntimeEnvironment.getMasterScheduler()
           .postDelayed(() -> realView.invalidate(), delayMilliseconds);
     } else {
       reflector(_View_.class, realView).postInvalidateDelayed(delayMilliseconds);


### PR DESCRIPTION
This commit removes the deprecated `ShadowApplication#getForegroundThreadScheduler()` method.
It was deprecated in #6399, and released with Robolectric 4.6.