### PR TITLE
Remove deprecated `Scheduler#idleConstantly()`

### DIFF
--- a/robolectric/src/main/java/org/robolectric/android/internal/LooperDelegatingScheduler.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/LooperDelegatingScheduler.java
@@ -159,10 +159,4 @@ public class LooperDelegatingScheduler extends Scheduler {
   public Duration getLastScheduledTaskTime() {
     return shadowOf(looper).getLastScheduledTaskTime();
   }
-
-  @Override
-  @Deprecated
-  public void idleConstantly(boolean shouldIdleConstantly) {
-    throw new UnsupportedOperationException("idleConstantly is not supported in PAUSED LooperMode");
-  }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyLooper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyLooper.java
@@ -3,6 +3,8 @@ package org.robolectric.shadows;
 import static org.robolectric.RuntimeEnvironment.isMainThread;
 import static org.robolectric.shadow.api.Shadow.invokeConstructor;
 import static org.robolectric.util.ReflectionHelpers.ClassParameter.from;
+import static org.robolectric.util.Scheduler.IdleState.CONSTANT_IDLE;
+import static org.robolectric.util.Scheduler.IdleState.UNPAUSED;
 
 import android.os.Looper;
 import android.os.MessageQueue;
@@ -193,7 +195,7 @@ public class ShadowLegacyLooper extends ShadowLooper {
 
   @Override
   public void idleConstantly(boolean shouldIdleConstantly) {
-    getScheduler().idleConstantly(shouldIdleConstantly);
+    getScheduler().setIdleState(shouldIdleConstantly ? CONSTANT_IDLE : UNPAUSED);
   }
 
   @Override

--- a/utils/src/main/java/org/robolectric/util/Scheduler.java
+++ b/utils/src/main/java/org/robolectric/util/Scheduler.java
@@ -26,9 +26,9 @@ import javax.annotation.Nonnull;
  *       Scheduler will automatically run any {@link Runnable}s that are scheduled to run at or
  *       before the Scheduler's current time, but it won't automatically run any future events. To
  *       run future events the Scheduler needs to have its clock advanced.
- *   <li>idling constantly: if {@link #idleConstantly(boolean)} is called with true, then the
- *       Scheduler will continue looping through posted events (including future events), advancing
- *       its clock as it goes.
+ *   <li>idling constantly: if {@link #setIdleState(IdleState)} is called with `CONSTANT_IDLE`, then
+ *       the Scheduler will continue looping through posted events (including future events),
+ *       advancing its clock as it goes.
  * </ul>
  *
  * @deprecated Scheduler APIs only function when using LooperMode.LEGACY. Switch to
@@ -333,21 +333,6 @@ public class Scheduler {
       }
     }
     return Duration.ofMillis(currentMaxTime);
-  }
-
-  /**
-   * Set the idle state of the Scheduler. If necessary, the clock will be advanced and runnables
-   * executed as required by the newly-set state.
-   *
-   * @param shouldIdleConstantly If true the idle state will be set to {@link
-   *     IdleState#CONSTANT_IDLE}, otherwise it will be set to {@link IdleState#UNPAUSED}.
-   * @deprecated This method is ambiguous in how it should behave when turning off constant idle.
-   *     Use {@link #setIdleState(IdleState)} instead to explicitly set the state.
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public void idleConstantly(boolean shouldIdleConstantly) {
-    setIdleState(shouldIdleConstantly ? CONSTANT_IDLE : UNPAUSED);
   }
 
   private boolean nextTaskIsScheduledBefore(long endingTime) {

--- a/utils/src/test/java/org/robolectric/util/SchedulerTest.kt
+++ b/utils/src/test/java/org/robolectric/util/SchedulerTest.kt
@@ -56,16 +56,6 @@ class SchedulerTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
-  fun idleConstantly_setsIdleState() {
-    scheduler.idleState = UNPAUSED
-    scheduler.idleConstantly(true)
-    assertThat(scheduler.idleState).isSameInstanceAs(CONSTANT_IDLE)
-    scheduler.idleConstantly(false)
-    assertThat(scheduler.idleState).isSameInstanceAs(UNPAUSED)
-  }
-
-  @Test
   fun unPause_setsIdleState() {
     scheduler.idleState = PAUSED
     scheduler.unPause()
@@ -106,19 +96,6 @@ class SchedulerTest {
     scheduler.unPause()
     assertThat(transcript).containsExactly("one", "two")
     assertWithMessage("time").that(scheduler.currentTime).isEqualTo(time)
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  fun idleConstantlyTrue_shouldRunAllTasks() {
-    scheduler.postDelayed(AddToTranscript("one"), 0)
-    scheduler.postDelayed(AddToTranscript("two"), 0)
-    scheduler.postDelayed(AddToTranscript("three"), 1000)
-    assertThat(transcript).isEmpty()
-    val time = scheduler.currentTime
-    scheduler.idleConstantly(true)
-    assertThat(transcript).containsExactly("one", "two", "three")
-    assertWithMessage("time").that(scheduler.currentTime).isEqualTo(time + 1000)
   }
 
   @Test


### PR DESCRIPTION
This commit removes the deprecated `Scheduler#idleConstantly()` method.
It was deprecated in #2055, and released with Robolectric 3.1.