### PR TITLE
Remove unnecessary `@Config(manifest)` usages

### DIFF
--- a/integration_tests/kotlin/src/test/kotlin/org/robolectric/integrationtests/kotlin/ParameterizedRobolectricTestRunnerTest.kt
+++ b/integration_tests/kotlin/src/test/kotlin/org/robolectric/integrationtests/kotlin/ParameterizedRobolectricTestRunnerTest.kt
@@ -6,12 +6,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.ParameterizedRobolectricTestRunner.Parameters
-import org.robolectric.annotation.Config
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
 class ParameterizedRobolectricTestRunnerTest(private var uri: Uri) {
   @Test
-  @Config(manifest = Config.NONE)
   fun parse() {
     val currentUri = Uri.parse("http://host/")
     assertThat(currentUri).isEqualTo(uri)

--- a/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerConfigTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerConfigTest.java
@@ -27,13 +27,13 @@ public final class ParameterizedRobolectricTestRunnerConfigTest {
   }
 
   @Test
-  @Config(manifest = Config.NONE, shadows = ShadowCursorWrapper1.class)
+  @Config(shadows = ShadowCursorWrapper1.class)
   public void getType1() {
     assertThat(new CursorWrapper(null).getType(expectedType)).isEqualTo(1);
   }
 
   @Test
-  @Config(manifest = Config.NONE, shadows = ShadowCursorWrapperEcho.class)
+  @Config(shadows = ShadowCursorWrapperEcho.class)
   public void getTypeEcho() {
     assertThat(new CursorWrapper(null).getType(expectedType)).isEqualTo(expectedType);
   }

--- a/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerNormalTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerNormalTest.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
 
 /**
  * Parameterized tests using basic java classes.
@@ -39,25 +38,21 @@ public final class ParameterizedRobolectricTestRunnerNormalTest {
   }
 
   @Test
-  @Config(manifest = Config.NONE)
   public void add() {
     assertThat(first + second).isEqualTo(expectedSum);
   }
 
   @Test
-  @Config(manifest = Config.NONE)
   public void subtract() {
     assertThat(first - second).isEqualTo(expectedDifference);
   }
 
   @Test
-  @Config(manifest = Config.NONE)
   public void multiple() {
     assertThat(first * second).isEqualTo(expectedProduct);
   }
 
   @Test
-  @Config(manifest = Config.NONE)
   public void divide() {
     assertThat(first / second).isEqualTo(expectedQuotient);
   }

--- a/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerParameterTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerParameterTest.java
@@ -8,11 +8,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner.Parameter;
 import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
-import org.robolectric.annotation.Config;
 
 /** Tests for the {@link Parameter} annotation */
 @RunWith(ParameterizedRobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
 public final class ParameterizedRobolectricTestRunnerParameterTest {
 
   @Parameter(value = 0)

--- a/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerUriTest.java
+++ b/robolectric/src/test/java/org/robolectric/ParameterizedRobolectricTestRunnerUriTest.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.Config;
 
 /**
  * Parameterized tests using an Android class.
@@ -29,7 +28,6 @@ public final class ParameterizedRobolectricTestRunnerUriTest {
   }
 
   @Test
-  @Config(manifest = Config.NONE)
   public void parse() {
     assertThat(Uri.parse(basePath).buildUpon().path(resourcePath).build()).isEqualTo(expectedUri);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContentResolverTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.robolectric.Shadows.shadowOf;
-import static org.robolectric.annotation.Config.NONE;
 
 import android.accounts.Account;
 import android.annotation.SuppressLint;
@@ -1233,7 +1232,6 @@ public class ShadowContentResolverTest {
   }
 
   @Test
-  @Config(manifest = NONE)
   @SuppressWarnings("RobolectricSystemContext") // preexisting when check was enabled
   public void getProvider_shouldNotReturnAnyProviderWhenManifestIsNull() {
     Application application = new Application();

--- a/shadows/playservices/src/test/java/org/robolectric/shadows/gms/ShadowGoogleAuthUtilTest.java
+++ b/shadows/playservices/src/test/java/org/robolectric/shadows/gms/ShadowGoogleAuthUtilTest.java
@@ -25,9 +25,7 @@ import org.robolectric.shadows.gms.ShadowGoogleAuthUtil.GoogleAuthUtilImpl;
 
 /** Unit test for {@link ShadowGoogleAuthUtil}. */
 @RunWith(RobolectricTestRunner.class)
-@Config(
-    manifest = Config.NONE,
-    shadows = {ShadowGoogleAuthUtil.class})
+@Config(shadows = {ShadowGoogleAuthUtil.class})
 public class ShadowGoogleAuthUtilTest {
 
   private AutoCloseable mock;

--- a/shadows/playservices/src/test/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtilTest.java
+++ b/shadows/playservices/src/test/java/org/robolectric/shadows/gms/ShadowGooglePlayServicesUtilTest.java
@@ -24,9 +24,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.gms.ShadowGooglePlayServicesUtil.GooglePlayServicesUtilImpl;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(
-    manifest = Config.NONE,
-    shadows = {ShadowGooglePlayServicesUtil.class})
+@Config(shadows = {ShadowGooglePlayServicesUtil.class})
 public class ShadowGooglePlayServicesUtilTest {
 
   @Mock private GooglePlayServicesUtilImpl mockGooglePlayServicesUtil;

--- a/shadows/playservices/src/test/java/org/robolectric/shadows/gms/common/ShadowGoogleApiAvailabilityTest.java
+++ b/shadows/playservices/src/test/java/org/robolectric/shadows/gms/common/ShadowGoogleApiAvailabilityTest.java
@@ -20,9 +20,7 @@ import org.robolectric.shadows.gms.Shadows;
 
 /** Created by diegotori on 2/14/16. */
 @RunWith(RobolectricTestRunner.class)
-@Config(
-    manifest = Config.NONE,
-    shadows = {ShadowGoogleApiAvailability.class})
+@Config(shadows = {ShadowGoogleApiAvailability.class})
 public class ShadowGoogleApiAvailabilityTest {
 
   private Context roboContext;


### PR DESCRIPTION
This commit removes unnecessary `@Config(manifest)` usages.