### PR TITLE
Remove deprecated `Config#resourceDir()`

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/Config.java
+++ b/annotations/src/main/java/org/robolectric/annotation/Config.java
@@ -38,7 +38,6 @@ public @interface Config {
   String DEFAULT_MANIFEST_NAME = "AndroidManifest.xml";
   Class<? extends Application> DEFAULT_APPLICATION = DefaultApplication.class;
   String DEFAULT_QUALIFIERS = "";
-  String DEFAULT_RES_FOLDER = "res";
   String DEFAULT_ASSET_FOLDER = "assets";
 
   int ALL_SDKS = -2;
@@ -100,19 +99,6 @@ public @interface Config {
   String qualifiers() default DEFAULT_QUALIFIERS;
 
   /**
-   * The directory from which to load resources. This should be relative to the directory containing
-   * AndroidManifest.xml.
-   *
-   * <p>If not specified, Robolectric defaults to {@code res}.
-   *
-   * @deprecated If you are using at least Android Studio 3.0 alpha 5 or Bazel's android_local_test
-   *     please migrate to the preferred way to configure
-   * @return Android resource directory.
-   */
-  @Deprecated
-  String resourceDir() default DEFAULT_RES_FOLDER;
-
-  /**
    * The directory from which to load assets. This should be relative to the directory containing
    * AndroidManifest.xml.
    *
@@ -156,7 +142,6 @@ public @interface Config {
     private final float fontScale;
     private final String manifest;
     private final String qualifiers;
-    private final String resourceDir;
     private final String assetDir;
     private final Class<?>[] shadows;
     private final String[] instrumentedPackages;
@@ -172,7 +157,6 @@ public @interface Config {
           properties.getProperty("manifest", DEFAULT_VALUE_STRING),
           properties.getProperty("qualifiers", DEFAULT_QUALIFIERS),
           Float.parseFloat(properties.getProperty("fontScale", "1.0f")),
-          properties.getProperty("resourceDir", DEFAULT_RES_FOLDER),
           properties.getProperty("assetDir", DEFAULT_ASSET_FOLDER),
           parseClasses(properties.getProperty("shadows", "")),
           parseStringArrayProperty(properties.getProperty("instrumentedPackages", "")),
@@ -272,7 +256,6 @@ public @interface Config {
         String manifest,
         String qualifiers,
         float fontScale,
-        String resourceDir,
         String assetDir,
         Class<?>[] shadows,
         String[] instrumentedPackages,
@@ -284,7 +267,6 @@ public @interface Config {
       this.manifest = manifest;
       this.qualifiers = qualifiers;
       this.fontScale = fontScale;
-      this.resourceDir = resourceDir;
       this.assetDir = assetDir;
       this.shadows = shadows;
       this.instrumentedPackages = instrumentedPackages;
@@ -330,11 +312,6 @@ public @interface Config {
     }
 
     @Override
-    public String resourceDir() {
-      return resourceDir;
-    }
-
-    @Override
     public String assetDir() {
       return assetDir;
     }
@@ -375,9 +352,6 @@ public @interface Config {
           + ", qualifiers='"
           + qualifiers
           + '\''
-          + ", resourceDir='"
-          + resourceDir
-          + '\''
           + ", assetDir='"
           + assetDir
           + '\''
@@ -400,7 +374,6 @@ public @interface Config {
     protected float fontScale = 1.0f;
     protected String manifest = Config.DEFAULT_VALUE_STRING;
     protected String qualifiers = Config.DEFAULT_QUALIFIERS;
-    protected String resourceDir = Config.DEFAULT_RES_FOLDER;
     protected String assetDir = Config.DEFAULT_ASSET_FOLDER;
     protected Class<?>[] shadows = new Class[0];
     protected String[] instrumentedPackages = new String[0];
@@ -416,7 +389,6 @@ public @interface Config {
       manifest = config.manifest();
       qualifiers = config.qualifiers();
       fontScale = config.fontScale();
-      resourceDir = config.resourceDir();
       assetDir = config.assetDir();
       shadows = config.shadows();
       instrumentedPackages = config.instrumentedPackages();
@@ -446,11 +418,6 @@ public @interface Config {
 
     public Builder setQualifiers(String qualifiers) {
       this.qualifiers = qualifiers;
-      return this;
-    }
-
-    public Builder setResourceDir(String resourceDir) {
-      this.resourceDir = resourceDir;
       return this;
     }
 
@@ -489,10 +456,7 @@ public @interface Config {
      * values, rather than markers like {@code -1} or {@code --default}.
      */
     public static Builder defaults() {
-      return new Builder()
-          .setManifest(DEFAULT_MANIFEST_NAME)
-          .setResourceDir(DEFAULT_RES_FOLDER)
-          .setAssetDir(DEFAULT_ASSET_FOLDER);
+      return new Builder().setManifest(DEFAULT_MANIFEST_NAME).setAssetDir(DEFAULT_ASSET_FOLDER);
     }
 
     public Builder overlay(Config overlayConfig) {
@@ -528,8 +492,6 @@ public @interface Config {
         }
       }
 
-      this.resourceDir =
-          pick(this.resourceDir, overlayConfig.resourceDir(), Config.DEFAULT_RES_FOLDER);
       this.assetDir = pick(this.assetDir, overlayConfig.assetDir(), Config.DEFAULT_ASSET_FOLDER);
 
       List<Class<?>> shadows = new ArrayList<>(Arrays.asList(this.shadows));
@@ -568,7 +530,6 @@ public @interface Config {
           manifest,
           qualifiers,
           fontScale,
-          resourceDir,
           assetDir,
           shadows,
           instrumentedPackages,

--- a/robolectric/src/main/java/org/robolectric/internal/DefaultManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/DefaultManifestFactory.java
@@ -34,10 +34,6 @@ public class DefaultManifestFactory implements ManifestFactory {
       manifestFile = getResource(manifestConfig);
     }
 
-    if (!Config.DEFAULT_RES_FOLDER.equals(config.resourceDir())) {
-      resourcesDir = getResource(config.resourceDir());
-    }
-
     if (!Config.DEFAULT_ASSET_FOLDER.equals(config.assetDir())) {
       assetsDir = getResource(config.assetDir());
     }

--- a/robolectric/src/main/java/org/robolectric/internal/MavenManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/MavenManifestFactory.java
@@ -20,6 +20,7 @@ import org.robolectric.res.Fs;
 @Deprecated
 @SuppressWarnings("NewApi")
 public class MavenManifestFactory implements ManifestFactory {
+  private static final String RES_FOLDER = "res";
 
   @Override
   public ManifestIdentifier identify(Config config) {
@@ -43,7 +44,7 @@ public class MavenManifestFactory implements ManifestFactory {
 
     final String packageName = "org.robolectric.default";
     final Path baseDir = manifestFile.getParent();
-    final Path resDir = baseDir.resolve(config.resourceDir());
+    final Path resDir = baseDir.resolve(RES_FOLDER);
     final Path assetDir = baseDir.resolve(config.assetDir());
 
     List<ManifestIdentifier> libraries;
@@ -62,7 +63,7 @@ public class MavenManifestFactory implements ManifestFactory {
             new ManifestIdentifier(
                 null,
                 libDir.resolve(Config.DEFAULT_MANIFEST_NAME),
-                libDir.resolve(Config.DEFAULT_RES_FOLDER),
+                libDir.resolve(RES_FOLDER),
                 libDir.resolve(Config.DEFAULT_ASSET_FOLDER),
                 null));
       }
@@ -121,13 +122,12 @@ public class MavenManifestFactory implements ManifestFactory {
           // Ignore directories without any files
           Path[] libraryBaseDirFiles = Fs.listFiles(libraryDir);
           if (libraryBaseDirFiles.length > 0) {
-            List<ManifestIdentifier> libraries =
-                findLibraries(libraryDir.resolve(Config.DEFAULT_RES_FOLDER));
+            List<ManifestIdentifier> libraries = findLibraries(libraryDir.resolve(RES_FOLDER));
             libraryBaseDirs.add(
                 new ManifestIdentifier(
                     null,
                     libraryDir.resolve(Config.DEFAULT_MANIFEST_NAME),
-                    libraryDir.resolve(Config.DEFAULT_RES_FOLDER),
+                    libraryDir.resolve(RES_FOLDER),
                     libraryDir.resolve(Config.DEFAULT_ASSET_FOLDER),
                     libraries));
           }

--- a/robolectric/src/test/java/org/robolectric/ConfigTest.java
+++ b/robolectric/src/test/java/org/robolectric/ConfigTest.java
@@ -18,7 +18,6 @@ public class ConfigTest {
   public void testDefaults() {
     Config defaults = Config.Builder.defaults().build();
     assertThat(defaults.manifest()).isEqualTo("AndroidManifest.xml");
-    assertThat(defaults.resourceDir()).isEqualTo("res");
     assertThat(defaults.assetDir()).isEqualTo("assets");
   }
 

--- a/robolectric/src/test/java/org/robolectric/plugins/HierarchicalConfigurationStrategyTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/HierarchicalConfigurationStrategyTest.java
@@ -55,7 +55,6 @@ public class HierarchicalConfigurationStrategyTest {
         "foo",
         TestFakeApp.class,
         "from-test",
-        "test/res",
         "test/assets",
         new Class<?>[] {Test1.class},
         new String[] {"com.example.test1"},
@@ -67,7 +66,6 @@ public class HierarchicalConfigurationStrategyTest {
         "foo",
         TestFakeApp.class,
         "from-test",
-        "test/res",
         "test/assets",
         new Class<?>[] {Test1.class},
         new String[] {"com.example.test1"},
@@ -79,7 +77,6 @@ public class HierarchicalConfigurationStrategyTest {
         "furf",
         TestApplication.class,
         "from-method",
-        "method/res",
         "method/assets",
         new Class<?>[] {Test1.class, Test2.class},
         new String[] {"com.example.test1", "com.example.method1"},
@@ -94,7 +91,6 @@ public class HierarchicalConfigurationStrategyTest {
         "AndroidManifest.xml",
         DEFAULT_APPLICATION,
         "",
-        "res",
         "assets",
         new Class<?>[] {},
         new String[] {},
@@ -106,7 +102,6 @@ public class HierarchicalConfigurationStrategyTest {
         "AndroidManifest.xml",
         DEFAULT_APPLICATION,
         "",
-        "res",
         "assets",
         new Class<?>[] {},
         new String[] {},
@@ -118,7 +113,6 @@ public class HierarchicalConfigurationStrategyTest {
         "furf",
         TestFakeApp.class,
         "from-method",
-        "method/res",
         "method/assets",
         new Class<?>[] {Test1.class},
         new String[] {"com.example.method2"},
@@ -134,7 +128,6 @@ public class HierarchicalConfigurationStrategyTest {
         "foo",
         TestFakeApp.class,
         "from-test",
-        "test/res",
         "test/assets",
         new Class<?>[] {Test1.class, Test1.class},
         new String[] {"com.example.test1"},
@@ -146,7 +139,6 @@ public class HierarchicalConfigurationStrategyTest {
         "foo",
         TestFakeApp.class,
         "from-test",
-        "test/res",
         "test/assets",
         new Class<?>[] {Test1.class, Test1.class},
         new String[] {"com.example.test1"},
@@ -158,7 +150,6 @@ public class HierarchicalConfigurationStrategyTest {
         "foo",
         TestFakeApp.class,
         "from-method5",
-        "test/res",
         "method5/assets",
         new Class<?>[] {Test1.class, Test1.class, Test1B.class},
         new String[] {"com.example.test1", "com.example.method5"},
@@ -174,7 +165,6 @@ public class HierarchicalConfigurationStrategyTest {
         "foo",
         TestFakeApp.class,
         "from-class6",
-        "class6/res",
         "test/assets",
         new Class<?>[] {Test1.class, Test1.class, Test1C.class},
         new String[] {"com.example.test1", "com.example.test6"},
@@ -186,7 +176,6 @@ public class HierarchicalConfigurationStrategyTest {
         "foo",
         TestFakeApp.class,
         "from-class6",
-        "class6/res",
         "test/assets",
         new Class<?>[] {Test1.class, Test1.class, Test1C.class},
         new String[] {"com.example.test1", "com.example.test6"},
@@ -198,7 +187,6 @@ public class HierarchicalConfigurationStrategyTest {
         "foo",
         TestFakeApp.class,
         "from-method5",
-        "class6/res",
         "method5/assets",
         new Class<?>[] {Test1.class, Test1.class, Test1C.class, Test1B.class},
         new String[] {"com.example.test1", "com.example.method5", "com.example.test6"},
@@ -214,7 +202,6 @@ public class HierarchicalConfigurationStrategyTest {
         "foo",
         TestFakeApp.class,
         "from-subclass",
-        "test/res",
         "test/assets",
         new Class<?>[] {Test1.class},
         new String[] {"com.example.test1"},
@@ -226,7 +213,6 @@ public class HierarchicalConfigurationStrategyTest {
         "foo",
         TestFakeApp.class,
         "from-subclass",
-        "test/res",
         "test/assets",
         new Class<?>[] {Test1.class},
         new String[] {"com.example.test1"},
@@ -238,7 +224,6 @@ public class HierarchicalConfigurationStrategyTest {
         "furf",
         TestApplication.class,
         "from-method",
-        "method/res",
         "method/assets",
         new Class<?>[] {Test1.class, Test2.class},
         new String[] {"com.example.test1", "com.example.method1"},
@@ -254,7 +239,6 @@ public class HierarchicalConfigurationStrategyTest {
         "AndroidManifest.xml",
         DEFAULT_APPLICATION,
         "from-subclass",
-        "res",
         "assets",
         new Class<?>[] {},
         new String[] {},
@@ -266,7 +250,6 @@ public class HierarchicalConfigurationStrategyTest {
         "AndroidManifest.xml",
         DEFAULT_APPLICATION,
         "from-subclass",
-        "res",
         "assets",
         new Class<?>[] {},
         new String[] {},
@@ -278,7 +261,6 @@ public class HierarchicalConfigurationStrategyTest {
         "furf",
         TestFakeApp.class,
         "from-method",
-        "method/res",
         "method/assets",
         new Class<?>[] {Test1.class},
         new String[] {"com.example.method2"},
@@ -309,7 +291,6 @@ public class HierarchicalConfigurationStrategyTest {
         "--none",
         TestFakeApp.class,
         "from-properties-file",
-        "from/properties/file/res",
         "from/properties/file/assets",
         new Class<?>[] {ShadowView.class, ShadowViewGroup.class},
         new String[] {"com.example.test1", "com.example.test2"},
@@ -327,7 +308,6 @@ public class HierarchicalConfigurationStrategyTest {
         "AndroidManifest.xml",
         DEFAULT_APPLICATION,
         "",
-        "res",
         "assets",
         new Class<?>[] {},
         new String[] {},
@@ -351,7 +331,6 @@ public class HierarchicalConfigurationStrategyTest {
         "AndroidManifest.xml",
         DEFAULT_APPLICATION,
         "from-org-robolectric",
-        "res",
         "assets",
         new Class<?>[] {},
         new String[] {},
@@ -369,7 +348,6 @@ public class HierarchicalConfigurationStrategyTest {
         "AndroidManifest.xml",
         DEFAULT_APPLICATION,
         "",
-        "res",
         "assets",
         new Class<?>[] {},
         new String[] {},
@@ -511,7 +489,6 @@ public class HierarchicalConfigurationStrategyTest {
       String manifest,
       Class<? extends Application> application,
       String qualifiers,
-      String resourceDir,
       String assetsDir,
       Class<?>[] shadows,
       String[] instrumentedPackages,
@@ -520,7 +497,6 @@ public class HierarchicalConfigurationStrategyTest {
     assertThat(config.manifest()).isEqualTo(manifest);
     assertThat(config.application()).isEqualTo(application);
     assertThat(config.qualifiers()).isEqualTo(qualifiers);
-    assertThat(config.resourceDir()).isEqualTo(resourceDir);
     assertThat(config.assetDir()).isEqualTo(assetsDir);
     assertThat(config.shadows()).asList().containsAtLeastElementsIn(shadows).inOrder();
     assertThat(config.instrumentedPackages())
@@ -538,7 +514,6 @@ public class HierarchicalConfigurationStrategyTest {
       instrumentedPackages = "com.example.test1",
       libraries = "libs/test",
       qualifiers = "from-test",
-      resourceDir = "test/res",
       assetDir = "test/assets")
   public static class Test1 {
     @Test
@@ -557,7 +532,6 @@ public class HierarchicalConfigurationStrategyTest {
         instrumentedPackages = "com.example.method1",
         libraries = "libs/method",
         qualifiers = "from-method",
-        resourceDir = "method/res",
         assetDir = "method/assets")
     public void withOverrideAnnotation() {}
   }
@@ -580,7 +554,6 @@ public class HierarchicalConfigurationStrategyTest {
         instrumentedPackages = "com.example.method2",
         libraries = "libs/method",
         qualifiers = "from-method",
-        resourceDir = "method/res",
         assetDir = "method/assets")
     public void withOverrideAnnotation() {}
   }
@@ -619,8 +592,7 @@ public class HierarchicalConfigurationStrategyTest {
   @Config(
       qualifiers = "from-class6",
       shadows = Test1C.class,
-      instrumentedPackages = "com.example.test6",
-      resourceDir = "class6/res")
+      instrumentedPackages = "com.example.test6")
   public static class Test1C extends Test1B {}
 
   private static class SpyConfigurer implements Configurer<String> {


### PR DESCRIPTION
This method was deprecated in #3889, released with Robolectric 4.0.
