### PR TITLE
Remove unnecessary config block in DeployedRoboJavaModulePlugin

### DIFF
--- a/buildSrc/src/main/java/org/robolectric/gradle/DeployedRoboJavaModulePlugin.kt
+++ b/buildSrc/src/main/java/org/robolectric/gradle/DeployedRoboJavaModulePlugin.kt
@@ -3,7 +3,6 @@ package org.robolectric.gradle
 import java.net.URI
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.plugins.BasePluginExtension
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
@@ -24,11 +23,6 @@ class DeployedRoboJavaModulePlugin : Plugin<Project> {
     val projectVersion = project.version.toString()
     val isSnapshotVersion = projectVersion.endsWith("-SNAPSHOT")
     val mavenArtifactName = project.path.substring(1).split(":").joinToString("-")
-
-    project.extensions.configure<BasePluginExtension> {
-      // For Maven local install
-      archivesName.set(mavenArtifactName)
-    }
 
     project.extensions.configure<JavaPluginExtension> {
       val sourcesJar =


### PR DESCRIPTION
This doesn't seem necessary anymore, publishToMavenLocal works without this block.
