### PR TITLE
Remove deprecated `Config#libraries()`

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/Config.java
+++ b/annotations/src/main/java/org/robolectric/annotation/Config.java
@@ -125,16 +125,6 @@ public @interface Config {
    */
   String[] instrumentedPackages() default {}; // DEFAULT_INSTRUMENTED_PACKAGES
 
-  /**
-   * A list of folders containing Android Libraries on which this project depends.
-   *
-   * @deprecated If you are using at least Android Studio 3.0 alpha 5 or Bazel's android_local_test
-   *     please migrate to the preferred way to configure
-   * @return A list of Android Libraries.
-   */
-  @Deprecated
-  String[] libraries() default {}; // DEFAULT_LIBRARIES;
-
   class Implementation implements Config {
     private final int[] sdk;
     private final int minSdk;
@@ -146,7 +136,6 @@ public @interface Config {
     private final Class<?>[] shadows;
     private final String[] instrumentedPackages;
     private final Class<? extends Application> application;
-    private final String[] libraries;
 
     public static Config fromProperties(Properties properties) {
       if (properties == null || properties.isEmpty()) return null;
@@ -161,8 +150,7 @@ public @interface Config {
           parseClasses(properties.getProperty("shadows", "")),
           parseStringArrayProperty(properties.getProperty("instrumentedPackages", "")),
           parseApplication(
-              properties.getProperty("application", DEFAULT_APPLICATION.getCanonicalName())),
-          parseStringArrayProperty(properties.getProperty("libraries", "")));
+              properties.getProperty("application", DEFAULT_APPLICATION.getCanonicalName())));
     }
 
     private static Class<?> parseClass(String className) {
@@ -259,8 +247,7 @@ public @interface Config {
         String assetDir,
         Class<?>[] shadows,
         String[] instrumentedPackages,
-        Class<? extends Application> application,
-        String[] libraries) {
+        Class<? extends Application> application) {
       this.sdk = sdk;
       this.minSdk = minSdk;
       this.maxSdk = maxSdk;
@@ -271,7 +258,6 @@ public @interface Config {
       this.shadows = shadows;
       this.instrumentedPackages = instrumentedPackages;
       this.application = application;
-      this.libraries = libraries;
 
       validate(this);
     }
@@ -326,11 +312,6 @@ public @interface Config {
       return instrumentedPackages;
     }
 
-    @Override
-    public String[] libraries() {
-      return libraries;
-    }
-
     @Nonnull
     @Override
     public Class<? extends Annotation> annotationType() {
@@ -361,8 +342,6 @@ public @interface Config {
           + Arrays.toString(instrumentedPackages)
           + ", application="
           + application
-          + ", libraries="
-          + Arrays.toString(libraries)
           + '}';
     }
   }
@@ -378,7 +357,6 @@ public @interface Config {
     protected Class<?>[] shadows = new Class[0];
     protected String[] instrumentedPackages = new String[0];
     protected Class<? extends Application> application = DEFAULT_APPLICATION;
-    protected String[] libraries = new String[0];
 
     public Builder() {}
 
@@ -393,7 +371,6 @@ public @interface Config {
       shadows = config.shadows();
       instrumentedPackages = config.instrumentedPackages();
       application = config.application();
-      libraries = config.libraries();
     }
 
     public Builder setSdk(int... sdk) {
@@ -443,11 +420,6 @@ public @interface Config {
 
     public Builder setApplication(Class<? extends Application> application) {
       this.application = application;
-      return this;
-    }
-
-    public Builder setLibraries(String... libraries) {
-      this.libraries = libraries;
       return this;
     }
 
@@ -504,11 +476,6 @@ public @interface Config {
       this.instrumentedPackages = instrumentedPackages.toArray(new String[0]);
       this.application = pick(this.application, overlayConfig.application(), DEFAULT_APPLICATION);
 
-      Set<String> libraries = new HashSet<>();
-      libraries.addAll(Arrays.asList(this.libraries));
-      libraries.addAll(Arrays.asList(overlayConfig.libraries()));
-      this.libraries = libraries.toArray(new String[0]);
-
       return this;
     }
 
@@ -533,8 +500,7 @@ public @interface Config {
           assetDir,
           shadows,
           instrumentedPackages,
-          application,
-          libraries);
+          application);
     }
 
     public static boolean isDefaultApplication(Class<? extends Application> clazz) {

--- a/robolectric/src/main/java/org/robolectric/internal/DefaultManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/DefaultManifestFactory.java
@@ -4,7 +4,6 @@ import static java.util.Collections.emptyList;
 
 import java.net.URL;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Properties;
 import org.robolectric.annotation.Config;
 import org.robolectric.res.Fs;
@@ -38,13 +37,8 @@ public class DefaultManifestFactory implements ManifestFactory {
       assetsDir = getResource(config.assetDir());
     }
 
-    List<ManifestIdentifier> libraryDirs = emptyList();
-    if (config.libraries().length > 0) {
-      Logger.info("@Config(libraries) specified while using Build System API, ignoring");
-    }
-
     return new ManifestIdentifier(
-        packageName, manifestFile, resourcesDir, assetsDir, libraryDirs, apkFile);
+        packageName, manifestFile, resourcesDir, assetsDir, emptyList(), apkFile);
   }
 
   private Path getResource(String pathStr) {

--- a/robolectric/src/main/java/org/robolectric/internal/MavenManifestFactory.java
+++ b/robolectric/src/main/java/org/robolectric/internal/MavenManifestFactory.java
@@ -26,7 +26,7 @@ public class MavenManifestFactory implements ManifestFactory {
   public ManifestIdentifier identify(Config config) {
     final String manifestPath = config.manifest();
     if (manifestPath.equals(Config.NONE)) {
-      return new ManifestIdentifier((String) null, null, null, null, null);
+      return new ManifestIdentifier(null, null, null, null, null);
     }
 
     // Try to locate the manifest file as a classpath resource; fallback to using the base dir.
@@ -48,25 +48,10 @@ public class MavenManifestFactory implements ManifestFactory {
     final Path assetDir = baseDir.resolve(config.assetDir());
 
     List<ManifestIdentifier> libraries;
-    if (config.libraries().length == 0) {
-      // If there is no library override, look through subdirectories.
-      try {
-        libraries = findLibraries(resDir);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    } else {
-      libraries = new ArrayList<>();
-      for (String libraryDirName : config.libraries()) {
-        Path libDir = baseDir.resolve(libraryDirName);
-        libraries.add(
-            new ManifestIdentifier(
-                null,
-                libDir.resolve(Config.DEFAULT_MANIFEST_NAME),
-                libDir.resolve(RES_FOLDER),
-                libDir.resolve(Config.DEFAULT_ASSET_FOLDER),
-                null));
-      }
+    try {
+      libraries = findLibraries(resDir);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
 
     return new ManifestIdentifier(packageName, manifestFile, resDir, assetDir, libraries);

--- a/robolectric/src/test/java/org/robolectric/plugins/HierarchicalConfigurationStrategyTest.java
+++ b/robolectric/src/test/java/org/robolectric/plugins/HierarchicalConfigurationStrategyTest.java
@@ -57,8 +57,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-test",
         "test/assets",
         new Class<?>[] {Test1.class},
-        new String[] {"com.example.test1"},
-        new String[] {"libs/test"});
+        new String[] {"com.example.test1"});
 
     assertConfig(
         configFor(Test1.class, "withDefaultsAnnotation"),
@@ -68,8 +67,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-test",
         "test/assets",
         new Class<?>[] {Test1.class},
-        new String[] {"com.example.test1"},
-        new String[] {"libs/test"});
+        new String[] {"com.example.test1"});
 
     assertConfig(
         configFor(Test1.class, "withOverrideAnnotation"),
@@ -79,8 +77,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-method",
         "method/assets",
         new Class<?>[] {Test1.class, Test2.class},
-        new String[] {"com.example.test1", "com.example.method1"},
-        new String[] {"libs/method", "libs/test"});
+        new String[] {"com.example.test1", "com.example.method1"});
   }
 
   @Test
@@ -93,7 +90,6 @@ public class HierarchicalConfigurationStrategyTest {
         "",
         "assets",
         new Class<?>[] {},
-        new String[] {},
         new String[] {});
 
     assertConfig(
@@ -104,7 +100,6 @@ public class HierarchicalConfigurationStrategyTest {
         "",
         "assets",
         new Class<?>[] {},
-        new String[] {},
         new String[] {});
 
     assertConfig(
@@ -115,8 +110,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-method",
         "method/assets",
         new Class<?>[] {Test1.class},
-        new String[] {"com.example.method2"},
-        new String[] {"libs/method"});
+        new String[] {"com.example.method2"});
   }
 
   @Test
@@ -130,8 +124,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-test",
         "test/assets",
         new Class<?>[] {Test1.class, Test1.class},
-        new String[] {"com.example.test1"},
-        new String[] {"libs/test"});
+        new String[] {"com.example.test1"});
 
     assertConfig(
         configFor(Test1B.class, "withDefaultsAnnotation"),
@@ -141,8 +134,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-test",
         "test/assets",
         new Class<?>[] {Test1.class, Test1.class},
-        new String[] {"com.example.test1"},
-        new String[] {"libs/test"});
+        new String[] {"com.example.test1"});
 
     assertConfig(
         configFor(Test1B.class, "withOverrideAnnotation"),
@@ -152,8 +144,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-method5",
         "method5/assets",
         new Class<?>[] {Test1.class, Test1.class, Test1B.class},
-        new String[] {"com.example.test1", "com.example.method5"},
-        new String[] {"libs/test"});
+        new String[] {"com.example.test1", "com.example.method5"});
   }
 
   @Test
@@ -167,8 +158,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-class6",
         "test/assets",
         new Class<?>[] {Test1.class, Test1.class, Test1C.class},
-        new String[] {"com.example.test1", "com.example.test6"},
-        new String[] {"libs/test"});
+        new String[] {"com.example.test1", "com.example.test6"});
 
     assertConfig(
         configFor(Test1C.class, "withDefaultsAnnotation"),
@@ -178,8 +168,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-class6",
         "test/assets",
         new Class<?>[] {Test1.class, Test1.class, Test1C.class},
-        new String[] {"com.example.test1", "com.example.test6"},
-        new String[] {"libs/test"});
+        new String[] {"com.example.test1", "com.example.test6"});
 
     assertConfig(
         configFor(Test1C.class, "withOverrideAnnotation"),
@@ -189,8 +178,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-method5",
         "method5/assets",
         new Class<?>[] {Test1.class, Test1.class, Test1C.class, Test1B.class},
-        new String[] {"com.example.test1", "com.example.method5", "com.example.test6"},
-        new String[] {"libs/test"});
+        new String[] {"com.example.test1", "com.example.method5", "com.example.test6"});
   }
 
   @Test
@@ -204,8 +192,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-subclass",
         "test/assets",
         new Class<?>[] {Test1.class},
-        new String[] {"com.example.test1"},
-        new String[] {"libs/test"});
+        new String[] {"com.example.test1"});
 
     assertConfig(
         configFor(Test1A.class, "withDefaultsAnnotation"),
@@ -215,8 +202,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-subclass",
         "test/assets",
         new Class<?>[] {Test1.class},
-        new String[] {"com.example.test1"},
-        new String[] {"libs/test"});
+        new String[] {"com.example.test1"});
 
     assertConfig(
         configFor(Test1A.class, "withOverrideAnnotation"),
@@ -226,8 +212,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-method",
         "method/assets",
         new Class<?>[] {Test1.class, Test2.class},
-        new String[] {"com.example.test1", "com.example.method1"},
-        new String[] {"libs/method", "libs/test"});
+        new String[] {"com.example.test1", "com.example.method1"});
   }
 
   @Test
@@ -241,7 +226,6 @@ public class HierarchicalConfigurationStrategyTest {
         "from-subclass",
         "assets",
         new Class<?>[] {},
-        new String[] {},
         new String[] {});
 
     assertConfig(
@@ -252,7 +236,6 @@ public class HierarchicalConfigurationStrategyTest {
         "from-subclass",
         "assets",
         new Class<?>[] {},
-        new String[] {},
         new String[] {});
 
     assertConfig(
@@ -263,8 +246,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-method",
         "method/assets",
         new Class<?>[] {Test1.class},
-        new String[] {"com.example.method2"},
-        new String[] {"libs/method"});
+        new String[] {"com.example.method2"});
   }
 
   @Test
@@ -293,8 +275,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-properties-file",
         "from/properties/file/assets",
         new Class<?>[] {ShadowView.class, ShadowViewGroup.class},
-        new String[] {"com.example.test1", "com.example.test2"},
-        new String[] {"libs/test", "libs/test2"});
+        new String[] {"com.example.test1", "com.example.test2"});
   }
 
   @Test
@@ -310,7 +291,6 @@ public class HierarchicalConfigurationStrategyTest {
         "",
         "assets",
         new Class<?>[] {},
-        new String[] {},
         new String[] {});
   }
 
@@ -333,8 +313,7 @@ public class HierarchicalConfigurationStrategyTest {
         "from-org-robolectric",
         "assets",
         new Class<?>[] {},
-        new String[] {},
-        new String[] {"FromOrgRobolectric", "FromOrg", "FromTopLevel"});
+        new String[] {});
   }
 
   @Test
@@ -350,7 +329,6 @@ public class HierarchicalConfigurationStrategyTest {
         "",
         "assets",
         new Class<?>[] {},
-        new String[] {},
         new String[] {});
   }
 
@@ -491,8 +469,7 @@ public class HierarchicalConfigurationStrategyTest {
       String qualifiers,
       String assetsDir,
       Class<?>[] shadows,
-      String[] instrumentedPackages,
-      String[] libraries) {
+      String[] instrumentedPackages) {
     assertThat(config.sdk()).isEqualTo(sdk);
     assertThat(config.manifest()).isEqualTo(manifest);
     assertThat(config.application()).isEqualTo(application);
@@ -502,7 +479,6 @@ public class HierarchicalConfigurationStrategyTest {
     assertThat(config.instrumentedPackages())
         .asList()
         .containsAtLeastElementsIn(instrumentedPackages);
-    assertThat(config.libraries()).asList().containsAtLeastElementsIn(libraries);
   }
 
   @Ignore
@@ -512,7 +488,6 @@ public class HierarchicalConfigurationStrategyTest {
       application = TestFakeApp.class,
       shadows = Test1.class,
       instrumentedPackages = "com.example.test1",
-      libraries = "libs/test",
       qualifiers = "from-test",
       assetDir = "test/assets")
   public static class Test1 {
@@ -530,7 +505,6 @@ public class HierarchicalConfigurationStrategyTest {
         application = TestApplication.class,
         shadows = Test2.class,
         instrumentedPackages = "com.example.method1",
-        libraries = "libs/method",
         qualifiers = "from-method",
         assetDir = "method/assets")
     public void withOverrideAnnotation() {}
@@ -552,7 +526,6 @@ public class HierarchicalConfigurationStrategyTest {
         application = TestFakeApp.class,
         shadows = Test1.class,
         instrumentedPackages = "com.example.method2",
-        libraries = "libs/method",
         qualifiers = "from-method",
         assetDir = "method/assets")
     public void withOverrideAnnotation() {}


### PR DESCRIPTION
This method was deprecated in #3889, released with Robolectric 4.0.