### PR TITLE
Migrate manual system properties to `SetSystemPropertyRule`

### DIFF
--- a/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/ActivityScenarioActivityContextTest.java
+++ b/integration_tests/androidx_test/src/test/java/org/robolectric/integrationtests/axt/ActivityScenarioActivityContextTest.java
@@ -7,12 +7,13 @@ import static com.google.common.truth.Truth.assertThat;
 import android.app.Application;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /**
  * Tests {@link androidx.test.core.app.ActivityScenario} with realistic Activity Contexts. Note that
@@ -20,18 +21,11 @@ import org.robolectric.annotation.Config;
  */
 @RunWith(AndroidJUnit4.class)
 public class ActivityScenarioActivityContextTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
-  private static String originalProperty;
-
-  @BeforeClass
-  public static void beforeClass() {
-    originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
-  }
-
-  @AfterClass
-  public static void afterClass() {
-    System.setProperty("robolectric.createActivityContexts", originalProperty);
+  @Before
+  public void setup() {
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
   }
 
   /**

--- a/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ScrollViewTest.java
+++ b/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ScrollViewTest.java
@@ -5,15 +5,18 @@ import static com.google.common.truth.Truth.assertThat;
 
 import android.app.Activity;
 import android.widget.ScrollView;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(minSdk = O)
 public final class ScrollViewTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   /**
    * Checks that even if {@code robolectric.useRealScrolling} is set to false, real scrolling code
@@ -21,16 +24,13 @@ public final class ScrollViewTest {
    */
   @Test
   public void smoothScrollTo_usesRealCode_whenRNGEnabled() {
-    try {
-      System.setProperty("robolectric.useRealScrolling", "false");
-      Activity activity = Robolectric.setupActivity(Activity.class);
-      ScrollView scrollView = new ScrollView(activity);
-      scrollView.smoothScrollTo(100, 100);
-      // Because the scroll view has no children, it should not get scrolled.
-      assertThat(scrollView.getScrollX()).isEqualTo(0);
-      assertThat(scrollView.getScrollY()).isEqualTo(0);
-    } finally {
-      System.clearProperty("robolectric.useRealScrolling");
-    }
+    setSystemPropertyRule.set("robolectric.useRealScrolling", "false");
+
+    Activity activity = Robolectric.setupActivity(Activity.class);
+    ScrollView scrollView = new ScrollView(activity);
+    scrollView.smoothScrollTo(100, 100);
+    // Because the scroll view has no children, it should not get scrolled.
+    assertThat(scrollView.getScrollX()).isEqualTo(0);
+    assertThat(scrollView.getScrollY()).isEqualTo(0);
   }
 }

--- a/integration_tests/testparameterinjector/src/test/java/org/robolectric/integrationtests/testparameterinjector/RobolectricTestParameterInjectorTest.java
+++ b/integration_tests/testparameterinjector/src/test/java/org/robolectric/integrationtests/testparameterinjector/RobolectricTestParameterInjectorTest.java
@@ -8,9 +8,9 @@ import android.os.Build.VERSION;
 import com.google.testing.junit.testparameterinjector.TestParameter;
 import java.util.ArrayList;
 import javax.annotation.Nonnull;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runner.RunWith;
@@ -21,6 +21,7 @@ import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.JUnit4;
 import org.robolectric.RobolectricTestParameterInjector;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @SuppressWarnings({
   "IgnoreWithoutReason",
@@ -30,17 +31,14 @@ import org.robolectric.annotation.Config;
 })
 @RunWith(JUnit4.class)
 public class RobolectricTestParameterInjectorTest {
-  private String priorAlwaysInclude;
-  private String priorEnabledSdks;
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private RunNotifier runNotifier;
 
   @Before
   public void setup() {
-    priorAlwaysInclude = System.getProperty("robolectric.alwaysIncludeVariantMarkersInTestName");
-    System.clearProperty("robolectric.alwaysIncludeVariantMarkersInTestName");
-
-    priorEnabledSdks = System.getProperty("robolectric.enabledSdks");
-    System.clearProperty("robolectric.enabledSdks");
+    setSystemPropertyRule.clear("robolectric.alwaysIncludeVariantMarkersInTestName");
+    setSystemPropertyRule.clear("robolectric.enabledSdks");
 
     runNotifier = new RunNotifier();
     runNotifier.addListener(
@@ -50,17 +48,6 @@ public class RobolectricTestParameterInjectorTest {
             throw new AssertionError("Unexpected test failure: " + failure, failure.getException());
           }
         });
-  }
-
-  @After
-  public void tearDown() {
-    if (priorAlwaysInclude != null) {
-      System.setProperty("robolectric.alwaysIncludeVariantMarkersInTestName", priorAlwaysInclude);
-    }
-
-    if (priorEnabledSdks != null) {
-      System.setProperty("robolectric.enabledSdks", priorEnabledSdks);
-    }
   }
 
   @Ignore

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccessibilityManagerTest.java
@@ -20,15 +20,18 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.util.ReflectionHelpers;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowAccessibilityManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private AccessibilityManager accessibilityManager;
 
@@ -273,8 +276,8 @@ public class ShadowAccessibilityManagerTest {
   @Test
   @Config(minSdk = O)
   public void accessibilityManager_activityContextEnabled_differentInstancesHaveSameServices() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       AccessibilityManager applicationAccessibilityManager =
@@ -293,8 +296,6 @@ public class ShadowAccessibilityManagerTest {
           activityAccessibilityManager.getInstalledAccessibilityServiceList();
 
       assertThat(activityServices).isEqualTo(applicationServices);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
@@ -25,14 +25,18 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.io.IOException;
 import java.util.Arrays;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowAccountManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private AccountManager am;
   private Activity activity;
   private Context appContext;
@@ -1138,8 +1142,8 @@ public class ShadowAccountManagerTest {
   @Test
   @Config(minSdk = O)
   public void accountManager_activityContextEnabled_differentInstancesRetrieveAccounts() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       AccountManager applicationAccountManager = appContext.getSystemService(AccountManager.class);
@@ -1154,8 +1158,6 @@ public class ShadowAccountManagerTest {
           activityAccountManager.getAccountsByType("com.example.account_type");
 
       assertThat(activityAccounts).isEqualTo(applicationAccounts);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityManagerTest.java
@@ -35,16 +35,19 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Locale;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowActivityManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private static final String PROCESS_NAME = "com.google.android.apps.app";
 
@@ -503,8 +506,8 @@ public class ShadowActivityManagerTest {
   @Test
   @Config(minSdk = O)
   public void activityManager_activityContextEnabled_retrievesConsistentLowRamDeviceStatus() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       ActivityManager applicationActivityManager =
@@ -520,8 +523,6 @@ public class ShadowActivityManagerTest {
       boolean activityLowRamStatus = activityActivityManager.isLowRamDevice();
 
       assertThat(activityLowRamStatus).isEqualTo(applicationLowRamStatus);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowActivityTest.java
@@ -74,6 +74,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
@@ -83,6 +84,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.annotation.LooperMode;
 import org.robolectric.annotation.LooperMode.Mode;
 import org.robolectric.fakes.RoboSplashScreen;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadows.ShadowActivity.IntentForResult;
 import org.robolectric.shadows.ShadowActivity.IntentSenderRequest;
 import org.robolectric.util.TestRunnable;
@@ -91,6 +93,8 @@ import org.robolectric.util.TestRunnable;
 @RunWith(AndroidJUnit4.class)
 @SuppressWarnings("RobolectricSystemContext") // preexisting when check was enabled
 public class ShadowActivityTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private Activity activity;
 
   @Test
@@ -1725,14 +1729,10 @@ public class ShadowActivityTest {
   @Test
   @Config(minSdk = VERSION_CODES.R)
   public void getDisplay_succeeds() {
-    try {
-      System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
 
-      Activity activity = Robolectric.setupActivity(Activity.class);
-      assertThat(activity.getDisplay()).isNotNull();
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", "false");
-    }
+    Activity activity = Robolectric.setupActivity(Activity.class);
+    assertThat(activity.getDisplay()).isNotNull();
   }
 
   /////////////////////////////

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAlarmManagerTest.java
@@ -29,15 +29,18 @@ import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadows.ShadowAlarmManager.ScheduledAlarm;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowAlarmManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private Context context;
   private AlarmManager alarmManager;
@@ -669,8 +672,7 @@ public class ShadowAlarmManagerTest {
   @Test
   @Config(minSdk = VERSION_CODES.O)
   public void alarmManager_instance_retrievesSameAlarmClockInfo() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
 
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
@@ -687,8 +689,6 @@ public class ShadowAlarmManagerTest {
       AlarmManager.AlarmClockInfo activityAlarmClock = activityAlarmManager.getNextAlarmClock();
 
       assertThat(activityAlarmClock).isEqualTo(applicationAlarmClock);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAmbientContextManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAmbientContextManagerTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -29,12 +30,15 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 /** Tests for {@link ShadowAmbientContextManager}. */
 @RunWith(RobolectricTestRunner.class)
 @Config(minSdk = VERSION_CODES.TIRAMISU)
 public class ShadowAmbientContextManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private Context context;
 
   @Before
@@ -192,8 +196,8 @@ public class ShadowAmbientContextManagerTest {
 
   @Test
   public void ambientContextManager_activityContextEnabled_differentInstancesQueryStatus() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       AmbientContextManager applicationAmbientContextManager =
@@ -236,8 +240,6 @@ public class ShadowAmbientContextManagerTest {
       assertThat(applicationStatus.get()).isEqualTo(activityStatus.get());
     } catch (Exception e) {
       fail("Test failed due to exception: " + e.getMessage());
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAppOpsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAppOpsManagerTest.java
@@ -44,6 +44,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -51,6 +52,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadows.ShadowAppOpsManager.ModeAndException;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
@@ -58,6 +60,7 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
 /** Unit tests for {@link ShadowAppOpsManager}. */
 @RunWith(AndroidJUnit4.class)
 public class ShadowAppOpsManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private static final String PACKAGE_NAME1 = "com.company1.pkg1";
   private static final String PACKAGE_NAME2 = "com.company2.pkg2";
@@ -773,8 +776,8 @@ public class ShadowAppOpsManagerTest {
   @Test
   @Config(minSdk = O)
   public void appOpsManager_activityContextEnabled_differentInstancesRetrieveOps() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       // Get the AppOpsManager instances
@@ -796,8 +799,6 @@ public class ShadowAppOpsManagerTest {
       List<PackageOps> activityPackageOpsList = shadowActivityAppOpsManager.getPackagesForOps(ops);
 
       assertThat(activityPackageOpsList).isEqualTo(applicationPackageOpsList);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetManagerTest.java
@@ -41,15 +41,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowAppWidgetManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private Context context;
   private AppWidgetManager appWidgetManager;
   private ShadowAppWidgetManager shadowAppWidgetManager;
@@ -603,8 +607,8 @@ public class ShadowAppWidgetManagerTest {
   @Test
   @Config(minSdk = O)
   public void appWidgetManager_activityContextEnabled_sharedState() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       AppWidgetManager applicationAppWidgetManager =
@@ -617,8 +621,6 @@ public class ShadowAppWidgetManagerTest {
       applicationAppWidgetManager.updateAppWidgetOptions(1, null);
 
       assertThat(activityAppWidgetManager.getAppWidgetOptions(1)).isNotNull();
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAudioManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAudioManagerTest.java
@@ -42,14 +42,18 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowAudioManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private static final float FAULT_TOLERANCE = 0.00001f;
   private final AudioManager.OnAudioFocusChangeListener listener = focusChange -> {};
   private final LocalOnModeChangedListener modeChangedListener = new LocalOnModeChangedListener();
@@ -1546,53 +1550,41 @@ public class ShadowAudioManagerTest {
   @Test
   @Config(minSdk = O)
   public void audioManager_activityContextEnabled_applicationInstanceIsNotSameAsActivityInstance() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
-    try {
-      AudioManager applicationAudioManager = appContext.getSystemService(AudioManager.class);
-      Activity activity = Robolectric.setupActivity(Activity.class);
-      AudioManager activityAudioManager = activity.getSystemService(AudioManager.class);
-      assertThat(applicationAudioManager).isNotSameInstanceAs(activityAudioManager);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
-    }
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
+    AudioManager applicationAudioManager = appContext.getSystemService(AudioManager.class);
+    Activity activity = Robolectric.setupActivity(Activity.class);
+    AudioManager activityAudioManager = activity.getSystemService(AudioManager.class);
+    assertThat(applicationAudioManager).isNotSameInstanceAs(activityAudioManager);
   }
 
   @Test
   @Config(minSdk = O)
   public void audioManager_activityContextEnabled_activityInstanceIsSameAsActivityInstance() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
-    try {
-      Activity activity = Robolectric.setupActivity(Activity.class);
-      AudioManager activityAudioManager = activity.getSystemService(AudioManager.class);
-      AudioManager anotherActivityAudioManager = activity.getSystemService(AudioManager.class);
-      assertThat(anotherActivityAudioManager).isSameInstanceAs(activityAudioManager);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
-    }
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
+    Activity activity = Robolectric.setupActivity(Activity.class);
+    AudioManager activityAudioManager = activity.getSystemService(AudioManager.class);
+    AudioManager anotherActivityAudioManager = activity.getSystemService(AudioManager.class);
+    assertThat(anotherActivityAudioManager).isSameInstanceAs(activityAudioManager);
   }
 
   @Test
   @Config(minSdk = O)
   public void audioManager_activityContextEnabled_differentInstancesChangesAffectEachOther() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
-    try {
-      AudioManager applicationAudioManager = appContext.getSystemService(AudioManager.class);
-      Activity activity = Robolectric.setupActivity(Activity.class);
-      AudioManager activityAudioManager = activity.getSystemService(AudioManager.class);
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
 
-      activityAudioManager.setMode(AudioManager.MODE_RINGTONE);
-      assertThat(activityAudioManager.getMode()).isEqualTo(AudioManager.MODE_RINGTONE);
-      assertThat(applicationAudioManager.getMode()).isEqualTo(AudioManager.MODE_RINGTONE);
+    AudioManager applicationAudioManager = appContext.getSystemService(AudioManager.class);
+    Activity activity = Robolectric.setupActivity(Activity.class);
+    AudioManager activityAudioManager = activity.getSystemService(AudioManager.class);
 
-      applicationAudioManager.setMode(AudioManager.MODE_NORMAL);
-      assertThat(activityAudioManager.getMode()).isEqualTo(AudioManager.MODE_NORMAL);
-      assertThat(applicationAudioManager.getMode()).isEqualTo(AudioManager.MODE_NORMAL);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
-    }
+    activityAudioManager.setMode(AudioManager.MODE_RINGTONE);
+    assertThat(activityAudioManager.getMode()).isEqualTo(AudioManager.MODE_RINGTONE);
+    assertThat(applicationAudioManager.getMode()).isEqualTo(AudioManager.MODE_RINGTONE);
+
+    applicationAudioManager.setMode(AudioManager.MODE_NORMAL);
+    assertThat(activityAudioManager.getMode()).isEqualTo(AudioManager.MODE_NORMAL);
+    assertThat(applicationAudioManager.getMode()).isEqualTo(AudioManager.MODE_NORMAL);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAutofillManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAutofillManagerTest.java
@@ -13,16 +13,20 @@ import android.content.Context;
 import android.view.autofill.AutofillManager;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Unit test for {@link ShadowAutofillManager}. */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = O)
 public class ShadowAutofillManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private final Context context = ApplicationProvider.getApplicationContext();
   private final AutofillManager autofillManager = context.getSystemService(AutofillManager.class);
 
@@ -64,8 +68,8 @@ public class ShadowAutofillManagerTest {
   @Test
   @Config(minSdk = O)
   public void autofillManager_activityContextEnabled_differentInstancesRetrieveSameInfo() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       AutofillManager applicationAutofillManager = context.getSystemService(AutofillManager.class);
@@ -79,9 +83,6 @@ public class ShadowAutofillManagerTest {
           applicationAutofillManager.isAutofillSupported(),
           activityAutofillManager.isAutofillSupported());
       assertEquals(applicationAutofillManager.isEnabled(), activityAutofillManager.isEnabled());
-
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBatteryManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBatteryManagerTest.java
@@ -12,14 +12,18 @@ import android.os.BatteryManager;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowBatteryManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private static final int TEST_ID = 123;
   private BatteryManager batteryManager;
   private ShadowBatteryManager shadowBatteryManager;
@@ -99,8 +103,8 @@ public class ShadowBatteryManagerTest {
   @Test
   @Config(minSdk = P)
   public void batteryManager_activityContextEnabled_sharedState() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       Context context = ApplicationProvider.getApplicationContext();
@@ -114,8 +118,6 @@ public class ShadowBatteryManagerTest {
       shadowApplicationBatteryManager.setIsCharging(true);
 
       assertThat(activityBatteryManager.isCharging()).isTrue();
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBiometricManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBiometricManagerTest.java
@@ -14,17 +14,21 @@ import android.hardware.biometrics.BiometricManager;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 /** Unit test for {@link ShadowBiometricManager} */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = Q)
 public class ShadowBiometricManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private BiometricManager biometricManager;
 
   @Before
@@ -107,8 +111,8 @@ public class ShadowBiometricManagerTest {
 
   @Test
   public void biometricManager_activityContextEnabled_differentInstancesRetrieveSameResult() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       BiometricManager applicationBiometricManager =
@@ -123,8 +127,6 @@ public class ShadowBiometricManagerTest {
       int activityCanAuthenticate = activityBiometricManager.canAuthenticate();
 
       assertThat(activityCanAuthenticate).isEqualTo(applicationCanAuthenticate);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBluetoothManagerTest.java
@@ -21,14 +21,18 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowBluetoothManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private static final String DEVICE_ADDRESS_1 = "00:11:22:AA:BB:CC";
   private static final String DEVICE_ADDRESS_2 = "11:22:33:BB:CC:DD";
   private static final int INVALID_PROFILE = -1;
@@ -164,8 +168,7 @@ public class ShadowBluetoothManagerTest {
   @Test
   @Config(minSdk = Build.VERSION_CODES.O)
   public void bluetoothManager_activityContextEnabled_retrievesSameAdapter() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
 
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
@@ -181,8 +184,6 @@ public class ShadowBluetoothManagerTest {
       BluetoothAdapter activityAdapter = activityBluetoothManager.getAdapter();
 
       assertThat(applicationAdapter).isEqualTo(activityAdapter);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraManagerTest.java
@@ -19,16 +19,19 @@ import android.os.Handler;
 import android.os.Looper;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Tests for {@link ShadowCameraManager}. */
 @RunWith(AndroidJUnit4.class)
 public class ShadowCameraManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private static final String CAMERA_ID_0 = "cameraId0";
   private static final String CAMERA_ID_1 = "cameraId1";
@@ -414,8 +417,8 @@ public class ShadowCameraManagerTest {
   @Config(minSdk = VERSION_CODES.O)
   public void cameraManager_activityContextEnabled_differentInstancesRetrieveCameraIdList()
       throws Exception {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       CameraManager applicationCameraManager =
@@ -440,8 +443,6 @@ public class ShadowCameraManagerTest {
       assertThat(activityCameraIdList[1]).isEqualTo(CAMERA_ID_1);
 
       assertThat(activityCameraIdList).isEqualTo(applicationCameraIdList);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCaptioningManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCaptioningManagerTest.java
@@ -20,6 +20,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
@@ -27,11 +28,13 @@ import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Tests for the ShadowCaptioningManager. */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = KITKAT)
 public final class ShadowCaptioningManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private final TestCaptioningChangeListener captioningChangeListener =
       new TestCaptioningChangeListener();
@@ -239,8 +242,8 @@ public final class ShadowCaptioningManagerTest {
   @Test
   @Config(minSdk = TIRAMISU)
   public void captioningManager_activityContextEnabled_differentInstancesRetrieveValues() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       CaptioningManager applicationCaptioningManager =
@@ -263,8 +266,6 @@ public final class ShadowCaptioningManagerTest {
 
       assertThat(applicationCaptioningEnabled).isEqualTo(activityCaptioningEnabled);
       assertThat(applicationCaptioningUiEnabled).isEqualTo(activityCaptioningUiEnabled);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCarrierConfigManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCarrierConfigManagerTest.java
@@ -15,16 +15,19 @@ import android.telephony.SubscriptionManager;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Junit test for {@link ShadowCarrierConfigManager}. */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = M)
 public class ShadowCarrierConfigManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private CarrierConfigManager carrierConfigManager;
 
@@ -163,8 +166,8 @@ public class ShadowCarrierConfigManagerTest {
   @Test
   @Config(minSdk = O)
   public void carrierConfigManager_activityContextEnabled_retrievesSameConfigs() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       CarrierConfigManager applicationCarrierConfigManager =
@@ -197,8 +200,6 @@ public class ShadowCarrierConfigManagerTest {
 
       applicationParcel.recycle();
       activityParcel.recycle();
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowClipboardManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowClipboardManagerTest.java
@@ -17,14 +17,17 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.time.Duration;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowClipboardManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private ClipboardManager clipboardManager;
 
@@ -160,8 +163,8 @@ public class ShadowClipboardManagerTest {
   @Test
   @Config(minSdk = O)
   public void clipboardManager_instance_retrievesSamePrimaryClip() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       ClipboardManager applicationClipboardManager =
@@ -179,8 +182,6 @@ public class ShadowClipboardManagerTest {
       ClipData activityClipData = activityClipboardManager.getPrimaryClip();
 
       assertThat(activityClipData.toString()).isEqualTo(applicationClipData.toString());
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowColorDisplayManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowColorDisplayManagerTest.java
@@ -11,18 +11,21 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Tests for ShadowColorDisplayManager. */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = Q)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING) // getAppSaturationLevel_afterReset* depends on order
 public class ShadowColorDisplayManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private static final String PACKAGE_NAME = "test_package_name";
 
@@ -158,8 +161,8 @@ public class ShadowColorDisplayManagerTest {
 
   @Test
   public void colorDisplayManager_activityContextEnabled_differentInstancesRetrieveSettings() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       ColorDisplayManager appColorDisplayManager =
@@ -177,9 +180,6 @@ public class ShadowColorDisplayManagerTest {
               .isNightDisplayActivated();
 
       assertThat(activityNightDisplayActivated).isEqualTo(appNightDisplayActivated);
-
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowConnectivityManagerTest.java
@@ -37,16 +37,20 @@ import java.util.Arrays;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.util.ReflectionHelpers;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowConnectivityManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private ConnectivityManager connectivityManager;
   private ShadowNetworkInfo shadowOfActiveNetworkInfo;
 
@@ -736,8 +740,8 @@ public class ShadowConnectivityManagerTest {
   @Test
   @Config(minSdk = VERSION_CODES.O)
   public void connectivityManager_instanceBasedOnSdkVersion() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       Activity activity = controller.get();
@@ -753,8 +757,6 @@ public class ShadowConnectivityManagerTest {
       Network activityActiveNetwork = activityConnectivityManager.getActiveNetwork();
 
       assertThat(activityActiveNetwork).isEqualTo(applicationActiveNetwork);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowContextHubManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowContextHubManagerTest.java
@@ -24,18 +24,22 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.List;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 /** Tests for {@link ShadowContextHubManager}. */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = Build.VERSION_CODES.N)
 public class ShadowContextHubManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   // Do not reference a non-public field in a test, because those get loaded outside the Robolectric
   // sandbox
   // DO NOT DO: private ContextHubManager contextHubManager;
@@ -171,8 +175,7 @@ public class ShadowContextHubManagerTest {
   @Test
   @Config(minSdk = 30)
   public void contextHubManager_instance_retrievesSameContextHubInfo() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
 
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
@@ -192,8 +195,6 @@ public class ShadowContextHubManagerTest {
       assertThat(activityContextHubs).isNotEmpty();
 
       assertThat(activityContextHubs).isEqualTo(applicationContextHubs);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCountDownTimerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCountDownTimerTest.java
@@ -5,15 +5,18 @@ import static org.robolectric.shadows.ShadowCountDownTimer.PROPERTY_USE_REAL_IMP
 
 import android.os.CountDownTimer;
 import java.util.Arrays;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.Shadows;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
 public class ShadowCountDownTimerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private static final String MESSAGE_TICK = "onTick() is called";
   private static final String MESSAGE_FINISH = "onFinish() is called";
 
@@ -22,7 +25,6 @@ public class ShadowCountDownTimerTest {
   private final long countDownInterval = 1000;
   private final boolean useRealCountDownTimer;
   private String message;
-  private String originalUseRealCountDownTimer;
 
   public ShadowCountDownTimerTest(boolean useRealCountDownTimer) {
     this.useRealCountDownTimer = useRealCountDownTimer;
@@ -30,9 +32,7 @@ public class ShadowCountDownTimerTest {
 
   @Before
   public void setUp() throws Exception {
-    originalUseRealCountDownTimer = System.getProperty(PROPERTY_USE_REAL_IMPL);
-
-    System.setProperty(PROPERTY_USE_REAL_IMPL, Boolean.toString(useRealCountDownTimer));
+    setSystemPropertyRule.set(PROPERTY_USE_REAL_IMPL, Boolean.toString(useRealCountDownTimer));
 
     CountDownTimer countDownTimer =
         new CountDownTimer(millisInFuture, countDownInterval) {
@@ -48,15 +48,6 @@ public class ShadowCountDownTimerTest {
           }
         };
     shadowCountDownTimer = Shadows.shadowOf(countDownTimer);
-  }
-
-  @After
-  public void tearDown() {
-    if (originalUseRealCountDownTimer != null) {
-      System.setProperty(PROPERTY_USE_REAL_IMPL, originalUseRealCountDownTimer);
-    } else {
-      System.clearProperty(PROPERTY_USE_REAL_IMPL);
-    }
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCrossProfileAppsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCrossProfileAppsTest.java
@@ -30,12 +30,14 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowCrossProfileApps.StartedActivity;
 import org.robolectric.shadows.ShadowCrossProfileApps.StartedMainActivity;
@@ -43,6 +45,8 @@ import org.robolectric.shadows.ShadowCrossProfileApps.StartedMainActivity;
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = P)
 public class ShadowCrossProfileAppsTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private final Application application = ApplicationProvider.getApplicationContext();
   private final UserHandle userHandle1 = UserHandle.of(10);
   private final UserHandle userHandle2 = UserHandle.of(11);
@@ -692,8 +696,8 @@ public class ShadowCrossProfileAppsTest {
   @Test
   public void
       crossProfileApps_activityContextEnabled_differentInstancesRetrieveTargetUserProfiles() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       CrossProfileApps applicationCrossProfileApps =
@@ -712,8 +716,6 @@ public class ShadowCrossProfileAppsTest {
           activityCrossProfileApps.getTargetUserProfiles();
 
       assertThat(activityTargetUserProfiles).isEqualTo(applicationTargetUserProfiles);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDevicePolicyManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDevicePolicyManagerTest.java
@@ -67,16 +67,19 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 /** Unit tests for {@link ShadowDevicePolicyManager}. */
 @RunWith(AndroidJUnit4.class)
 public final class ShadowDevicePolicyManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private static final byte[] PASSWORD_TOKEN = new byte[32];
 
@@ -2751,8 +2754,8 @@ public final class ShadowDevicePolicyManagerTest {
   @Test
   @Config(minSdk = O)
   public void devicePolicyManager_instance_retrievesSameAdminStatus() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       DevicePolicyManager applicationDpm =
@@ -2772,8 +2775,6 @@ public final class ShadowDevicePolicyManagerTest {
       boolean activityAdminActive = activityDpm.isAdminActive(testAdminComponent);
 
       assertThat(activityAdminActive).isEqualTo(applicationAdminActive);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDisplayManagerTest.java
@@ -26,16 +26,19 @@ import java.util.List;
 import java.util.Objects;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 /** Tests for {@link ShadowDisplayManager}. */
 @RunWith(AndroidJUnit4.class)
 public class ShadowDisplayManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private DisplayManager instance;
 
@@ -522,8 +525,8 @@ public class ShadowDisplayManagerTest {
   @Test
   @Config(minSdk = O)
   public void displayManager_activityContextEnabled_differentInstancesRetrieveDisplays() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       DisplayManager applicationDisplayManager =
@@ -547,8 +550,6 @@ public class ShadowDisplayManagerTest {
         assertThat(actDisplay.getWidth()).isEqualTo(appDisplay.getWidth());
         assertThat(actDisplay.getHeight()).isEqualTo(appDisplay.getHeight());
       }
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDownloadManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDownloadManagerTest.java
@@ -16,17 +16,20 @@ import android.os.Environment;
 import android.util.Pair;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.List;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadows.ShadowDownloadManager.CompletedDownload;
 import org.robolectric.shadows.ShadowDownloadManager.ShadowRequest;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowDownloadManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private final Uri uri = Uri.parse("http://example.com/foo.mp4");
   private final Uri destination = Uri.parse("file:///storage/foo.mp4");
@@ -422,8 +425,8 @@ public class ShadowDownloadManagerTest {
   @Test
   @Config(minSdk = Build.VERSION_CODES.O)
   public void downloadManager_activityContextEnabled_retrievesSameMimeTypeForDownloadedFile() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       DownloadManager applicationDownloadManager =
@@ -441,8 +444,6 @@ public class ShadowDownloadManagerTest {
       String activityMimeType = activityDownloadManager.getMimeTypeForDownloadedFile(testId);
 
       assertThat(activityMimeType).isEqualTo(applicationMimeType);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowDropBoxManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowDropBoxManagerTest.java
@@ -16,15 +16,18 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Unit tests for {@see ShadowDropboxManager}. */
 @RunWith(AndroidJUnit4.class)
 public class ShadowDropBoxManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private static final String TAG = "TAG";
   private static final String ANOTHER_TAG = "ANOTHER_TAG";
@@ -125,8 +128,8 @@ public class ShadowDropBoxManagerTest {
   @Test
   @Config(minSdk = O)
   public void dropBoxManager_activityContextEnabled_differentInstancesVerifyTagEnabled() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       DropBoxManager applicationDropBoxManager =
@@ -145,8 +148,6 @@ public class ShadowDropBoxManagerTest {
       boolean activityTagEnabled = activityDropBoxManager.isTagEnabled(tag);
 
       assertThat(activityTagEnabled).isEqualTo(applicationTagEnabled);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowEuiccManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowEuiccManagerTest.java
@@ -12,16 +12,20 @@ import android.telephony.euicc.EuiccManager;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Junit test for {@link ShadowEuiccManager}. */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = P)
 public class ShadowEuiccManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private EuiccManager euiccManager;
 
   @Before
@@ -64,8 +68,8 @@ public class ShadowEuiccManagerTest {
 
   @Test
   public void euiccManager_activityContextEnabled_differentInstancesRetrieveEids() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       EuiccManager applicationEuiccManager =
@@ -81,8 +85,6 @@ public class ShadowEuiccManagerTest {
       String activityEid = activityEuiccManager.getEid();
 
       assertThat(activityEid).isEqualTo(applicationEid);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowFileIntegrityManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowFileIntegrityManagerTest.java
@@ -10,16 +10,19 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.Objects;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = R)
 public final class ShadowFileIntegrityManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private FileIntegrityManager fileIntegrityManager;
 
@@ -44,8 +47,8 @@ public final class ShadowFileIntegrityManagerTest {
 
   @Test
   public void fileIntegrityManager_activityContextEnabled_retrievesSameValues() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       FileIntegrityManager applicationFileIntegrityManager =
@@ -65,8 +68,6 @@ public final class ShadowFileIntegrityManagerTest {
           Objects.requireNonNull(activityFileIntegrityManager).isApkVeritySupported();
 
       assertThat(activityApkVeritySupported).isEqualTo(applicationApkVeritySupported);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowFingerprintManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowFingerprintManagerTest.java
@@ -17,16 +17,19 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.security.Signature;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = M)
 public class ShadowFingerprintManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private FingerprintManager manager;
 
@@ -127,8 +130,7 @@ public class ShadowFingerprintManagerTest {
   @Test
   @Config(minSdk = VERSION_CODES.O)
   public void fingerprintManager_activityContextEnabled_differentInstancesHaveConsistentState() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
 
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
@@ -151,9 +153,6 @@ public class ShadowFingerprintManagerTest {
       boolean hasActivityEnrolledFingerprints =
           activityFingerprintManager.hasEnrolledFingerprints();
       assertThat(hasActivityEnrolledFingerprints).isEqualTo(hasApplicationEnrolledFingerprints);
-
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowInputMethodManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowInputMethodManagerTest.java
@@ -20,15 +20,18 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowInputMethodManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private InputMethodManager manager;
   private ShadowInputMethodManager shadow;
@@ -157,8 +160,8 @@ public class ShadowInputMethodManagerTest {
   @Config(minSdk = O)
   public void
       inputMethodManager_activityContextEnabled_differentInstancesRetrieveInputMethodList() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       InputMethodManager applicationInputMethodManager =
@@ -175,9 +178,6 @@ public class ShadowInputMethodManagerTest {
       boolean activityIsAcceptingText = activityInputMethodManager.isAcceptingText();
 
       assertThat(activityIsAcceptingText).isEqualTo(applicationIsAcceptingText);
-
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowKeyguardManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowKeyguardManagerTest.java
@@ -18,15 +18,19 @@ import android.content.Intent;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowKeyguardManagerTest {
   private static final int USER_ID = 1001;
+
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private KeyguardManager manager;
 
@@ -196,8 +200,8 @@ public class ShadowKeyguardManagerTest {
   @Test
   @Config(minSdk = O)
   public void keyguardManager_activityContextEnabled_retrievesSameState() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       KeyguardManager applicationKeyguardManager =
@@ -212,8 +216,6 @@ public class ShadowKeyguardManagerTest {
       boolean activityIsKeyguardLocked = activityKeyguardManager.isKeyguardLocked();
 
       assertThat(activityIsKeyguardLocked).isEqualTo(applicationIsKeyguardLocked);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLauncherAppsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLauncherAppsTest.java
@@ -44,12 +44,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
@@ -65,6 +67,9 @@ public class ShadowLauncherAppsTest {
   private static final String TEST_PACKAGE_NAME_2 = "test-package2";
   private static final String TEST_PACKAGE_NAME_3 = "test-package3";
   private static final UserHandle USER_HANDLE = UserHandle.CURRENT;
+
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private LauncherApps launcherApps;
 
   private static class DefaultCallback extends LauncherApps.Callback {
@@ -482,8 +487,7 @@ public class ShadowLauncherAppsTest {
   @Test
   @Config(minSdk = O)
   public void launcherApps_activityContextEnabled_differentInstancesRetrieveProfiles() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
 
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
@@ -501,8 +505,6 @@ public class ShadowLauncherAppsTest {
       assertThat(activityProfiles).isNotEmpty();
 
       assertThat(activityProfiles).isEqualTo(applicationProfiles);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLocaleManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLocaleManagerTest.java
@@ -10,12 +10,14 @@ import android.os.Build.VERSION_CODES;
 import android.os.LocaleList;
 import androidx.test.core.app.ApplicationProvider;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 @RunWith(RobolectricTestRunner.class)
@@ -23,6 +25,8 @@ import org.robolectric.shadow.api.Shadow;
 public final class ShadowLocaleManagerTest {
   private static final String DEFAULT_PACKAGE_NAME = "my.app";
   private static final LocaleList DEFAULT_LOCALES = LocaleList.forLanguageTags("en-XC,ar-XB");
+
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private LocaleManager localeManager;
   private ShadowLocaleManager shadowLocaleManager;
@@ -96,8 +100,8 @@ public final class ShadowLocaleManagerTest {
 
   @Test
   public void localeManager_activityContextEnabled_differentInstancesRetrieveLocales() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       LocaleManager applicationLocaleManager =
@@ -113,8 +117,6 @@ public final class ShadowLocaleManagerTest {
       LocaleList activityLocales = activityLocaleManager.getApplicationLocales();
 
       assertThat(activityLocales).isEqualTo(applicationLocales);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaRouterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaRouterTest.java
@@ -14,15 +14,19 @@ import android.media.MediaRouter.RouteInfo;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Tests for {@link ShadowMediaRouter}. */
 @RunWith(AndroidJUnit4.class)
 public final class ShadowMediaRouterTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private MediaRouter mediaRouter;
 
   @Before
@@ -134,8 +138,8 @@ public final class ShadowMediaRouterTest {
   @Test
   @Config(minSdk = O)
   public void mediaRouter_activityContextEnabled_differentInstancesRetrieveDefaultRoute() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       MediaRouter applicationMediaRouter =
@@ -153,8 +157,6 @@ public final class ShadowMediaRouterTest {
       MediaRouter.RouteInfo activityDefaultRoute = activityMediaRouter.getDefaultRoute();
 
       assertThat(activityDefaultRoute).isEqualTo(applicationDefaultRoute);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaSessionManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowMediaSessionManagerTest.java
@@ -13,6 +13,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -20,10 +21,12 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Tests for {@link ShadowMediaSessionManager} */
 @RunWith(AndroidJUnit4.class)
 public class ShadowMediaSessionManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private MediaSessionManager mediaSessionManager;
   private final Context context = ApplicationProvider.getApplicationContext();
@@ -68,8 +71,8 @@ public class ShadowMediaSessionManagerTest {
   @Test
   @Config(minSdk = O)
   public void mediaSessionManager_activityContextEnabled_differentInstancesRetrieveSessions() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       MediaSessionManager applicationMediaSessionManager =
@@ -86,8 +89,6 @@ public class ShadowMediaSessionManagerTest {
           activityMediaSessionManager.getActiveSessions(null);
 
       assertThat(activityControllers).isEqualTo(applicationControllers);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNetworkScoreManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNetworkScoreManagerTest.java
@@ -8,17 +8,20 @@ import android.content.Context;
 import android.net.NetworkScoreManager;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 /** ShadowNetworkScoreManagerTest tests {@link ShadowNetworkScoreManager}. */
 @RunWith(AndroidJUnit4.class)
 public final class ShadowNetworkScoreManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   @Test
   public void testGetActiveScorerPackage() {
@@ -45,8 +48,8 @@ public final class ShadowNetworkScoreManagerTest {
   @Config(minSdk = O)
   public void
       networkScoreManager_activityContextEnabled_differentInstancesRetrieveActiveScorerPackage() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       NetworkScoreManager applicationNetworkScoreManager =
@@ -61,8 +64,6 @@ public final class ShadowNetworkScoreManagerTest {
       String activityScorerPackage = activityNetworkScoreManager.getActiveScorerPackage();
 
       assertThat(activityScorerPackage).isEqualTo(applicationScorerPackage);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNotificationManagerTest.java
@@ -31,14 +31,18 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowNotificationManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private NotificationManager notificationManager;
   private final Notification notification1 = new Notification();
   private final Notification notification2 = new Notification();
@@ -823,8 +827,8 @@ public class ShadowNotificationManagerTest {
   @Test
   @Config(minSdk = O)
   public void notificationManager_activityContext_enabled_differentInstancesRetrieveChannels() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       NotificationManager applicationNotificationManager =
@@ -847,8 +851,6 @@ public class ShadowNotificationManagerTest {
           activityNotificationManager.getNotificationChannel("test_channel_id");
 
       assertThat(activityChannel).isEqualTo(applicationChannel);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPowerManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPowerManagerTest.java
@@ -32,18 +32,21 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.truth.Correspondence;
 import java.time.Duration;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowPowerManager.ShadowLowPowerStandbyPortsLock;
 import org.robolectric.versioning.AndroidVersions.U;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowPowerManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private Application context;
   private PowerManager powerManager;
@@ -741,8 +744,8 @@ public class ShadowPowerManagerTest {
   @Test
   @Config(minSdk = O)
   public void powerManager_activityContextEnabled_checkIsInteractive() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       PowerManager applicationPowerManager =
@@ -758,8 +761,6 @@ public class ShadowPowerManagerTest {
       boolean activityIsInteractive = activityPowerManager.isInteractive();
 
       assertThat(activityIsInteractive).isEqualTo(applicationIsInteractive);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRestrictionsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRestrictionsManagerTest.java
@@ -13,14 +13,17 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.collect.Iterables;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 public final class ShadowRestrictionsManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private RestrictionsManager restrictionsManager;
   private Context context;
@@ -57,8 +60,8 @@ public final class ShadowRestrictionsManagerTest {
   @Test
   @Config(minSdk = O)
   public void restrictionsManager_activityContextEnabled_hasConsistentRestrictionsProvider() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       RestrictionsManager applicationRestrictionsManager =
@@ -73,8 +76,6 @@ public final class ShadowRestrictionsManagerTest {
       boolean activityHasProvider = activityRestrictionsManager.hasRestrictionsProvider();
 
       assertThat(activityHasProvider).isEqualTo(applicationHasProvider);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRoleManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRoleManagerTest.java
@@ -19,16 +19,19 @@ import android.os.UserHandle;
 import androidx.test.core.content.pm.PackageInfoBuilder;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Unit tests for {@link org.robolectric.shadows.ShadowRoleManager}. */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = Build.VERSION_CODES.Q)
 public final class ShadowRoleManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private final RoleManager roleManager = getApplication().getSystemService(RoleManager.class);
 
@@ -126,8 +129,8 @@ public final class ShadowRoleManagerTest {
 
   @Test
   public void roleManager_activityContextEnabled_differentInstancesRetrieveRoles() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       RoleManager applicationRoleManager = roleManager;
@@ -142,8 +145,6 @@ public final class ShadowRoleManagerTest {
       boolean activityRoleHeld = activityRoleManager.isRoleHeld(RoleManager.ROLE_SMS);
 
       assertThat(activityRoleHeld).isEqualTo(applicationRoleHeld);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRollbackManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRollbackManagerTest.java
@@ -13,17 +13,20 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Test for {@link ShadowRollbackManager}. */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = Q)
 public final class ShadowRollbackManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private ShadowRollbackManager instance;
 
@@ -77,8 +80,8 @@ public final class ShadowRollbackManagerTest {
 
   @Test
   public void rollbackManager_reloadPersistedData_differentInstancesRetrieveRollbacks() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       RollbackManager applicationRollbackManager =
@@ -99,8 +102,6 @@ public final class ShadowRollbackManagerTest {
       assertThat(activityAvailableRollbacks).isNotNull();
 
       assertThat(activityAvailableRollbacks).isEqualTo(applicationAvailableRollbacks);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSafetyCenterManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSafetyCenterManagerTest.java
@@ -12,6 +12,7 @@ import android.safetycenter.SafetyEvent;
 import android.safetycenter.SafetySourceData;
 import android.safetycenter.SafetySourceErrorDetails;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
@@ -20,11 +21,13 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(minSdk = VERSION_CODES.TIRAMISU)
 public final class ShadowSafetyCenterManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   @Before
   public void setUp() {
@@ -499,8 +502,8 @@ public final class ShadowSafetyCenterManagerTest {
 
   @Test
   public void safetyCenterManager_activityContextEnabled_differentInstancesCheckEnabled() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       SafetyCenterManager applicationSafetyCenterManager =
@@ -516,8 +519,6 @@ public final class ShadowSafetyCenterManagerTest {
       boolean activityEnabled = activitySafetyCenterManager.isSafetyCenterEnabled();
 
       assertThat(activityEnabled).isEqualTo(applicationEnabled);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowScrollViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowScrollViewTest.java
@@ -8,87 +8,79 @@ import android.view.ViewGroup;
 import android.widget.ScrollView;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.GraphicsMode;
 import org.robolectric.annotation.GraphicsMode.Mode;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 @GraphicsMode(Mode.LEGACY)
 public class ShadowScrollViewTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   @Test
   public void shouldSmoothScrollTo() {
     // This test depends on broken scrolling behavior.
-    System.setProperty("robolectric.useRealScrolling", "false");
-    try {
-      ScrollView scrollView = new ScrollView(ApplicationProvider.getApplicationContext());
-      scrollView.smoothScrollTo(7, 6);
+    setSystemPropertyRule.set("robolectric.useRealScrolling", "false");
 
-      assertEquals(7, scrollView.getScrollX());
-      assertEquals(6, scrollView.getScrollY());
-    } finally {
-      System.clearProperty("robolectric.useRealScrolling");
-    }
+    ScrollView scrollView = new ScrollView(ApplicationProvider.getApplicationContext());
+    scrollView.smoothScrollTo(7, 6);
+
+    assertEquals(7, scrollView.getScrollX());
+    assertEquals(6, scrollView.getScrollY());
   }
 
   @Test
   public void shouldSmoothScrollBy() {
     // This test depends on broken scrolling behavior.
-    System.setProperty("robolectric.useRealScrolling", "false");
-    try {
-      ScrollView scrollView = new ScrollView(ApplicationProvider.getApplicationContext());
-      scrollView.smoothScrollTo(7, 6);
-      scrollView.smoothScrollBy(10, 20);
-      assertEquals(17, scrollView.getScrollX());
-      assertEquals(26, scrollView.getScrollY());
-    } finally {
-      System.clearProperty("robolectric.useRealScrolling");
-    }
+    setSystemPropertyRule.set("robolectric.useRealScrolling", "false");
+
+    ScrollView scrollView = new ScrollView(ApplicationProvider.getApplicationContext());
+    scrollView.smoothScrollTo(7, 6);
+    scrollView.smoothScrollBy(10, 20);
+    assertEquals(17, scrollView.getScrollX());
+    assertEquals(26, scrollView.getScrollY());
   }
 
   @Test
   public void realCode_shouldSmoothScrollTo() {
-    try {
-      System.setProperty("robolectric.useRealScrolling", "true");
-      Activity activity = Robolectric.setupActivity(Activity.class);
-      ScrollView scrollView = new ScrollView(activity);
-      View view = new View(activity);
-      view.setLayoutParams(new ViewGroup.LayoutParams(1000, 1000));
-      view.layout(
-          0,
-          0,
-          activity.findViewById(android.R.id.content).getWidth(),
-          activity.findViewById(android.R.id.content).getHeight());
-      scrollView.addView(view);
-      scrollView.smoothScrollTo(7, 6);
-      assertEquals(7, scrollView.getScrollX());
-      assertEquals(6, scrollView.getScrollY());
-    } finally {
-      System.clearProperty("robolectric.useRealScrolling");
-    }
+    setSystemPropertyRule.set("robolectric.useRealScrolling", "true");
+
+    Activity activity = Robolectric.setupActivity(Activity.class);
+    ScrollView scrollView = new ScrollView(activity);
+    View view = new View(activity);
+    view.setLayoutParams(new ViewGroup.LayoutParams(1000, 1000));
+    view.layout(
+        0,
+        0,
+        activity.findViewById(android.R.id.content).getWidth(),
+        activity.findViewById(android.R.id.content).getHeight());
+    scrollView.addView(view);
+    scrollView.smoothScrollTo(7, 6);
+    assertEquals(7, scrollView.getScrollX());
+    assertEquals(6, scrollView.getScrollY());
   }
 
   @Test
   public void realCode_shouldSmoothScrollBy() {
-    try {
-      System.setProperty("robolectric.useRealScrolling", "true");
-      Activity activity = Robolectric.setupActivity(Activity.class);
-      ScrollView scrollView = new ScrollView(activity);
-      View view = new View(activity);
-      view.setLayoutParams(new ViewGroup.LayoutParams(1000, 1000));
-      view.layout(
-          0,
-          0,
-          activity.findViewById(android.R.id.content).getWidth(),
-          activity.findViewById(android.R.id.content).getHeight());
-      scrollView.addView(view);
-      scrollView.smoothScrollTo(7, 6);
-      scrollView.smoothScrollBy(10, 20);
-      assertEquals(17, scrollView.getScrollX());
-      assertEquals(26, scrollView.getScrollY());
-    } finally {
-      System.clearProperty("robolectric.useRealScrolling");
-    }
+    setSystemPropertyRule.set("robolectric.useRealScrolling", "true");
+
+    Activity activity = Robolectric.setupActivity(Activity.class);
+    ScrollView scrollView = new ScrollView(activity);
+    View view = new View(activity);
+    view.setLayoutParams(new ViewGroup.LayoutParams(1000, 1000));
+    view.layout(
+        0,
+        0,
+        activity.findViewById(android.R.id.content).getWidth(),
+        activity.findViewById(android.R.id.content).getHeight());
+    scrollView.addView(view);
+    scrollView.smoothScrollTo(7, 6);
+    scrollView.smoothScrollBy(10, 20);
+    assertEquals(17, scrollView.getScrollX());
+    assertEquals(26, scrollView.getScrollY());
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSearchManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSearchManagerTest.java
@@ -7,22 +7,25 @@ import android.app.Activity;
 import android.app.SearchManager;
 import android.content.ComponentName;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowSearchManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   @Test
   @Config(minSdk = O)
   public void
       searchManager_activityContextEnabled_differentInstancesRetrieveGlobalSearchActivity() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       SearchManager applicationSearchManager =
@@ -37,8 +40,6 @@ public class ShadowSearchManagerTest {
       ComponentName activityGlobalSearchActivity = activitySearchManager.getGlobalSearchActivity();
 
       assertThat(activityGlobalSearchActivity).isEqualTo(applicationGlobalSearchActivity);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSensorManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSensorManagerTest.java
@@ -26,14 +26,17 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowSensorManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private SensorManager sensorManager;
   private ShadowSensorManager shadow;
@@ -345,8 +348,8 @@ public class ShadowSensorManagerTest {
   @Test
   @Config(minSdk = O)
   public void sensorManager_activityContextEnabled_retrievesSameSensors() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       SensorManager applicationSensorManager =
@@ -374,8 +377,6 @@ public class ShadowSensorManagerTest {
         assertThat(appSensor.getPower()).isEqualTo(actSensor.getPower());
         assertThat(appSensor.getMinDelay()).isEqualTo(actSensor.getMinDelay());
       }
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowShortcutManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowShortcutManagerTest.java
@@ -22,11 +22,13 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 /** Unit tests for ShadowShortcutManager. */
@@ -37,6 +39,8 @@ public final class ShadowShortcutManagerTest {
   private static final int DYNAMIC_SHORTCUT_COUNT = 4;
   private static final int CACHED_DYNAMIC_SHORTCUT_COUNT = 3;
   private static final int PINNED_SHORTCUT_COUNT = 2;
+
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private ShortcutManager shortcutManager;
 
@@ -394,8 +398,8 @@ public final class ShadowShortcutManagerTest {
   @Test
   @Config(minSdk = O)
   public void shortcutManager_activityContextEnabled_differentInstancesCheckRateLimiting() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       ShortcutManager applicationShortcutManager =
@@ -413,8 +417,6 @@ public final class ShadowShortcutManagerTest {
       boolean activityRateLimiting = activityShortcutManager.isRateLimitingActive();
 
       assertThat(activityRateLimiting).isEqualTo(applicationRateLimiting);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSliceManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSliceManagerTest.java
@@ -17,17 +17,20 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Tests for {@link ShadowSliceManager}. */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = VERSION_CODES.P)
 public final class ShadowSliceManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private static final String PACKAGE_NAME_1 = "com.google.testing.slicemanager.foo";
   private static final int PACKAGE_1_UID = 10;
@@ -101,8 +104,8 @@ public final class ShadowSliceManagerTest {
 
   @Test
   public void sliceManager_activityContextEnabled_differentInstancesRetrieveSlices() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       SliceManager applicationSliceManager =
@@ -127,9 +130,6 @@ public final class ShadowSliceManagerTest {
       List<Uri> applicationPinnedSlices = applicationSliceManager.getPinnedSlices();
       List<Uri> activityPinnedSlices = activitySliceManager.getPinnedSlices();
       assertThat(applicationPinnedSlices).isEqualTo(activityPinnedSlices);
-
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStatusBarManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStatusBarManagerTest.java
@@ -12,17 +12,20 @@ import android.app.Activity;
 import android.app.StatusBarManager;
 import android.content.Context;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 /** Unit tests for {@link ShadowStatusBarManager}. */
 @RunWith(AndroidJUnit4.class)
 public final class ShadowStatusBarManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private static final int TEST_NAV_BAR_MODE = 100;
 
@@ -94,8 +97,8 @@ public final class ShadowStatusBarManagerTest {
   @Test
   @Config(minSdk = O)
   public void statusBarManager_activityContextEnabled_performOperations() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       StatusBarManager applicationStatusBarManager =
@@ -121,8 +124,6 @@ public final class ShadowStatusBarManagerTest {
           .isEqualTo(StatusBarManager.DISABLE2_GLOBAL_ACTIONS);
       assertThat(activityShadowStatusBarManager.getDisable2Flags())
           .isEqualTo(StatusBarManager.DISABLE2_GLOBAL_ACTIONS);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowStorageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowStorageManagerTest.java
@@ -19,17 +19,20 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.io.File;
 import java.util.List;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.util.ReflectionHelpers;
 
 /** Unit tests for {@link ShadowStorageManager}. */
 @RunWith(AndroidJUnit4.class)
 public class ShadowStorageManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private final String internalStorage = "/storage/internal";
   private final String sdcardStorage = "/storage/sdcard";
@@ -142,8 +145,8 @@ public class ShadowStorageManagerTest {
   @Test
   @Config(minSdk = O)
   public void storageManager_activityContextEnabled_differentInstancesRetrieveVolumes() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       StorageManager applicationStorageManager =
@@ -158,8 +161,6 @@ public class ShadowStorageManagerTest {
       List<StorageVolume> activityVolumes = activityStorageManager.getStorageVolumes();
 
       assertThat(activityVolumes).isEqualTo(applicationVolumes);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSubscriptionManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSubscriptionManagerTest.java
@@ -23,18 +23,21 @@ import android.telephony.SubscriptionInfo;
 import android.telephony.SubscriptionManager;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadows.ShadowSubscriptionManager.SubscriptionInfoBuilder;
 
 /** Test for {@link ShadowSubscriptionManager}. */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = N)
 public class ShadowSubscriptionManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private SubscriptionManager subscriptionManager;
 
@@ -660,8 +663,8 @@ public class ShadowSubscriptionManagerTest {
   @Config(minSdk = O)
   public void
       subscriptionManager_activityContextEnabled_differentInstancesRetrieveDefaultSubscriptionInfo() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       SubscriptionManager applicationSubscriptionManager =
@@ -681,8 +684,6 @@ public class ShadowSubscriptionManagerTest {
           activitySubscriptionManager.getActiveSubscriptionInfo(defaultSubscriptionId);
 
       assertThat(applicationDefaultSubscriptionInfo).isEqualTo(activityDefaultSubscriptionInfo);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemHealthManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowSystemHealthManagerTest.java
@@ -12,16 +12,19 @@ import android.os.health.SystemHealthManager;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = N)
 public final class ShadowSystemHealthManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private static final int MY_UID = Process.myUid();
   private static final int OTHER_UID_1 = MY_UID + 1;
@@ -80,8 +83,8 @@ public final class ShadowSystemHealthManagerTest {
   @Config(minSdk = O)
   public void
       systemHealthManager_activityContextEnabled_differentInstancesRetrieveSameUidSnapshot() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       SystemHealthManager applicationSystemHealthManager =
@@ -96,8 +99,6 @@ public final class ShadowSystemHealthManagerTest {
       HealthStats activityHealthStats = activitySystemHealthManager.takeMyUidSnapshot();
 
       assertThat(activityHealthStats).isEqualTo(applicationHealthStats);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTelecomManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTelecomManagerTest.java
@@ -43,11 +43,13 @@ import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.android.controller.ServiceController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadows.ShadowTelecomManager.CallRequestMode;
 import org.robolectric.shadows.testing.TestConnectionService;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowTelecomManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
 
@@ -754,8 +756,8 @@ public class ShadowTelecomManagerTest {
   @Test
   @Config(minSdk = Build.VERSION_CODES.O)
   public void telecomManager_activityContextEnabled_differentInstancesRetrieveDefaultDialer() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       TelecomManager applicationTelecomManager =
@@ -770,8 +772,6 @@ public class ShadowTelecomManagerTest {
       String activityDefaultDialer = activityTelecomManager.getDefaultDialerPackage();
 
       assertThat(activityDefaultDialer).isEqualTo(applicationDefaultDialer);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTelephonyManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTelephonyManagerTest.java
@@ -92,11 +92,13 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowSubscriptionManager.SubscriptionInfoBuilder;
 import org.robolectric.util.ReflectionHelpers;
@@ -104,6 +106,7 @@ import org.robolectric.util.ReflectionHelpers.ClassParameter;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowTelephonyManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private TelephonyManager telephonyManager;
   private ShadowTelephonyManager shadowTelephonyManager;
@@ -1673,8 +1676,8 @@ public class ShadowTelephonyManagerTest {
   @Test
   @Config(minSdk = O)
   public void telephonyManager_activityContextEnabled_differentInstancesRetrievePhoneCount() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       TelephonyManager applicationTelephonyManager =
@@ -1691,8 +1694,6 @@ public class ShadowTelephonyManagerTest {
       int activityPhoneCount = activityTelephonyManager.getPhoneCount();
 
       assertThat(activityPhoneCount).isEqualTo(applicationPhoneCount);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTimeManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTimeManagerTest.java
@@ -9,17 +9,20 @@ import android.app.time.TimeZoneConfiguration;
 import android.os.Build;
 import androidx.test.core.app.ApplicationProvider;
 import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Tests for {@link ShadowTimeManager} */
 @RunWith(RobolectricTestRunner.class)
 @Config(minSdk = Build.VERSION_CODES.S)
 public final class ShadowTimeManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   @Test
   public void registeredAsSystemService() {
@@ -63,8 +66,8 @@ public final class ShadowTimeManagerTest {
   @Test
   @Config(minSdk = Build.VERSION_CODES.S)
   public void timeManager_activityContextEnabled_differentInstancesRetrieveTimeZoneCapabilities() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       TimeManager applicationTimeManager =
@@ -83,8 +86,6 @@ public final class ShadowTimeManagerTest {
           activityTimeManager.getTimeZoneCapabilitiesAndConfig();
 
       assertThat(activityCapabilities).isEqualTo(applicationCapabilities);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTranslationManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTranslationManagerTest.java
@@ -12,16 +12,20 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = VERSION_CODES.S)
 public class ShadowTranslationManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private final TranslationManager translationManager =
       ApplicationProvider.getApplicationContext().getSystemService(TranslationManager.class);
 
@@ -62,8 +66,8 @@ public class ShadowTranslationManagerTest {
   @Test
   @Config(minSdk = VERSION_CODES.S)
   public void translationManager_activityContextEnabled_differentInstancesRetrieveCapabilities() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       TranslationManager applicationTranslationManager =
@@ -81,8 +85,6 @@ public class ShadowTranslationManagerTest {
           activityTranslationManager.getOnDeviceTranslationCapabilities(1, 2);
 
       assertThat(activityCapabilities).isEqualTo(applicationCapabilities);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUsageStatsManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUsageStatsManagerTest.java
@@ -31,11 +31,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadows.ShadowUsageStatsManager.AppUsageLimitObserver;
 import org.robolectric.shadows.ShadowUsageStatsManager.AppUsageObserver;
 import org.robolectric.shadows.ShadowUsageStatsManager.UsageSessionObserver;
@@ -45,6 +47,7 @@ import org.robolectric.versioning.AndroidVersions.V;
 /** Test for {@link ShadowUsageStatsManager}. */
 @RunWith(AndroidJUnit4.class)
 public class ShadowUsageStatsManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private static final String TEST_PACKAGE_NAME1 = "com.company1.pkg1";
   private static final String TEST_PACKAGE_NAME2 = "com.company2.pkg2";
@@ -1040,8 +1043,8 @@ public class ShadowUsageStatsManagerTest {
   @Test
   @Config(minSdk = 28)
   public void usageStatsManager_activityContextEnabled_differentInstancesRetrieveBuckets() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       UsageStatsManager applicationUsageStatsManager =
@@ -1059,8 +1062,6 @@ public class ShadowUsageStatsManagerTest {
       int activityBucket = activityUsageStatsManager.getAppStandbyBucket();
 
       assertThat(applicationBucket).isEqualTo(activityBucket);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUsbManagerTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -38,12 +39,15 @@ import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadows.ShadowUsbManager._UsbManagerQ_;
 import org.robolectric.shadows.ShadowUsbManager._UsbManager_;
 
 /** Unit tests for {@link ShadowUsbManager}. */
 @RunWith(AndroidJUnit4.class)
 public class ShadowUsbManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private static final String DEVICE_NAME_1 = "usb1";
   private static final String DEVICE_NAME_2 = "usb2";
 
@@ -259,8 +263,8 @@ public class ShadowUsbManagerTest {
   @Test
   @Config(minSdk = O)
   public void usbManager_activityContextEnabled_differentInstancesRetrieveSameUsbDevices() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       UsbManager applicationUsbManager =
@@ -274,8 +278,6 @@ public class ShadowUsbManagerTest {
       HashMap<String, UsbDevice> activityDevices = activityUsbManager.getDeviceList();
 
       assertThat(activityDevices).isEqualTo(applicationDevices);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUserManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUserManagerTest.java
@@ -37,16 +37,19 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowUserManager.UserState;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowUserManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private UserManager userManager;
   private Context context;
@@ -1215,8 +1218,8 @@ public class ShadowUserManagerTest {
   @Test
   @Config(minSdk = O)
   public void userManager_activityContextEnabled_consistentAcrossContexts() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       UserManager applicationUserManager =
@@ -1232,8 +1235,6 @@ public class ShadowUserManagerTest {
       boolean isAdminActivity = activityUserManager.isAdminUser();
 
       assertThat(isAdminActivity).isEqualTo(isAdminApplication);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUwbManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUwbManagerTest.java
@@ -21,6 +21,7 @@ import android.uwb.UwbManager.AdapterStateCallback;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
@@ -29,12 +30,15 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 /** Unit tests for {@link ShadowUwbManager}. */
 @RunWith(RobolectricTestRunner.class)
 @Config(minSdk = S)
 public class ShadowUwbManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private /* RangingSession.Callback */ Object callbackObject;
   private /* AdapterStateCallback */ Object adapterStateCallbackObject;
   private /* UwbManager */ Object uwbManagerObject;
@@ -224,8 +228,8 @@ public class ShadowUwbManagerTest {
 
   @Test
   public void uwbManager_activityContextEnabled_differentInstancesRetrieveSpecificationInfo() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       UwbManager applicationUwbManager =
@@ -239,8 +243,6 @@ public class ShadowUwbManagerTest {
       PersistableBundle activitySpecificationInfo = activityUwbManager.getSpecificationInfo();
 
       assertThat(activitySpecificationInfo).isEqualTo(applicationSpecificationInfo);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowVcnManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowVcnManagerTest.java
@@ -25,11 +25,13 @@ import org.mockito.junit.MockitoRule;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Test for {@link ShadowVcnManager}. */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = S)
 public final class ShadowVcnManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   @Rule public final MockitoRule mockito = MockitoJUnit.rule();
   private ShadowVcnManager instance;
@@ -96,8 +98,8 @@ public final class ShadowVcnManagerTest {
 
   @Test
   public void vcnManager_activityContextEnabled_differentInstancesRetrieveSubscriptionGroups() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       VcnManager applicationVcnManager =
@@ -116,8 +118,6 @@ public final class ShadowVcnManagerTest {
       assertThat(activityConfiguredSubscriptionGroups).isNotNull();
       assertThat(activityConfiguredSubscriptionGroups)
           .isEqualTo(applicationConfiguredSubscriptionGroups);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewConfigurationTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewConfigurationTest.java
@@ -10,13 +10,16 @@ import android.view.ViewConfiguration;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowViewConfigurationTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private Application context;
   private ViewConfiguration viewConfiguration;
@@ -124,13 +127,9 @@ public class ShadowViewConfigurationTest {
   @Config(minSdk = Q)
   @Test
   public void getScaledMinimumScalingSpan_usePreviousBug() {
-    System.setProperty("robolectric.useRealMinScalingSpan", "false");
+    setSystemPropertyRule.set("robolectric.useRealMinScalingSpan", "false");
     ShadowViewConfiguration.reset(); // clear the static cache
-    try {
-      ViewConfiguration viewConfiguration = ViewConfiguration.get(context);
-      assertThat(viewConfiguration.getScaledMinimumScalingSpan()).isEqualTo(0);
-    } finally {
-      System.clearProperty("robolectric.useRealMinScalingSpan");
-    }
+    ViewConfiguration viewConfiguration = ViewConfiguration.get(context);
+    assertThat(viewConfiguration.getScaledMinimumScalingSpan()).isEqualTo(0);
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewGroupTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewGroupTest.java
@@ -30,19 +30,21 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.GraphicsMode;
 import org.robolectric.annotation.GraphicsMode.Mode;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 @GraphicsMode(Mode.LEGACY)
 public class ShadowViewGroupTest {
-  private String defaultLineSeparator;
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private ViewGroup root;
   private View child1;
   private View child2;
@@ -70,13 +72,7 @@ public class ShadowViewGroupTest {
     child3.addView(child3a);
     child3.addView(child3b);
 
-    defaultLineSeparator = System.lineSeparator();
-    System.setProperty("line.separator", "\n");
-  }
-
-  @After
-  public void tearDown() {
-    System.setProperty("line.separator", defaultLineSeparator);
+    setSystemPropertyRule.set("line.separator", "\n");
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowViewTest.java
@@ -54,6 +54,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.R;
@@ -63,11 +64,14 @@ import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.GraphicsMode;
 import org.robolectric.annotation.GraphicsMode.Mode;
 import org.robolectric.annotation.ResourcesMode;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.util.TestRunnable;
 
 @RunWith(AndroidJUnit4.class)
 @GraphicsMode(Mode.LEGACY)
 public class ShadowViewTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private View view;
   private List<String> transcript;
   private Application context;
@@ -422,13 +426,10 @@ public class ShadowViewTest {
   @Test
   public void scrollTo_shouldStoreTheScrolledCoordinates() {
     // This test depends on broken scrolling behavior.
-    System.setProperty("robolectric.useRealScrolling", "false");
-    try {
-      view.scrollTo(1, 2);
-      assertThat(shadowOf(view).scrollToCoordinates).isEqualTo(new Point(1, 2));
-    } finally {
-      System.clearProperty("robolectric.useRealScrolling");
-    }
+    setSystemPropertyRule.set("robolectric.useRealScrolling", "false");
+
+    view.scrollTo(1, 2);
+    assertThat(shadowOf(view).scrollToCoordinates).isEqualTo(new Point(1, 2));
   }
 
   @Test
@@ -442,17 +443,14 @@ public class ShadowViewTest {
   @Test
   public void scrollBy_shouldStoreTheScrolledCoordinates() {
     // This test depends on broken scrolling behavior.
-    System.setProperty("robolectric.useRealScrolling", "false");
-    try {
-      view.scrollTo(4, 5);
-      view.scrollBy(10, 20);
-      assertThat(shadowOf(view).scrollToCoordinates).isEqualTo(new Point(14, 25));
+    setSystemPropertyRule.set("robolectric.useRealScrolling", "false");
 
-      assertThat(view.getScrollX()).isEqualTo(14);
-      assertThat(view.getScrollY()).isEqualTo(25);
-    } finally {
-      System.clearProperty("robolectric.useRealScrolling");
-    }
+    view.scrollTo(4, 5);
+    view.scrollBy(10, 20);
+    assertThat(shadowOf(view).scrollToCoordinates).isEqualTo(new Point(14, 25));
+
+    assertThat(view.getScrollX()).isEqualTo(14);
+    assertThat(view.getScrollY()).isEqualTo(25);
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowVirtualDeviceManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowVirtualDeviceManagerTest.java
@@ -55,6 +55,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowVirtualDeviceManager.ShadowVirtualDevice;
 
@@ -62,6 +63,7 @@ import org.robolectric.shadows.ShadowVirtualDeviceManager.ShadowVirtualDevice;
 @Config(minSdk = UPSIDE_DOWN_CAKE)
 @RunWith(RobolectricTestRunner.class)
 public class ShadowVirtualDeviceManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   @Rule public final MockitoRule mockito = MockitoJUnit.rule();
 
@@ -363,8 +365,8 @@ public class ShadowVirtualDeviceManagerTest {
 
   @Test
   public void virtualDeviceManager_activityContextEnabled_retrievesSameVirtualDevices() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       VirtualDeviceManager applicationVirtualDeviceManager =
@@ -382,8 +384,6 @@ public class ShadowVirtualDeviceManagerTest {
       assertThat(applicationVirtualDevices).isNotNull();
       assertThat(activityVirtualDevices).isNotNull();
       assertThat(activityVirtualDevices).isEqualTo(applicationVirtualDevices);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowVpnManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowVpnManagerTest.java
@@ -11,17 +11,21 @@ import android.os.Build.VERSION_CODES;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = VERSION_CODES.R)
 public class ShadowVpnManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private VpnManager vpnManager;
   private ShadowVpnManager shadowVpnManager;
 
@@ -99,8 +103,8 @@ public class ShadowVpnManagerTest {
   @Test
   @Config(minSdk = VERSION_CODES.TIRAMISU)
   public void vpnManager_activityContextEnabled_differentInstancesInteract() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       VpnManager applicationVpnManager =
@@ -115,8 +119,6 @@ public class ShadowVpnManagerTest {
       VpnProfileState activityProfileState = activityVpnManager.getProvisionedVpnProfileState();
 
       assertThat(activityProfileState).isEqualTo(applicationProfileState);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWallpaperManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWallpaperManagerTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -38,11 +39,13 @@ import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.GraphicsMode;
 import org.robolectric.annotation.GraphicsMode.Mode;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadows.ShadowWallpaperManager.WallpaperCommandRecord;
 
 @RunWith(AndroidJUnit4.class)
 @GraphicsMode(Mode.LEGACY)
 public class ShadowWallpaperManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private static final Bitmap TEST_IMAGE_1 = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888);
 
@@ -689,8 +692,8 @@ public class ShadowWallpaperManagerTest {
   @Test
   @Config(minSdk = O)
   public void wallpaperManager_activityContextEnabled_retrievesSameWallpaper() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       Activity activity = controller.get();
@@ -706,8 +709,6 @@ public class ShadowWallpaperManagerTest {
       WallpaperInfo activityWallpaper = activityWallpaperManager.getWallpaperInfo();
 
       assertThat(activityWallpaper).isEqualTo(applicationWallpaper);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWearableSensingManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWearableSensingManagerTest.java
@@ -25,6 +25,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.versioning.AndroidVersions.U;
 import org.robolectric.versioning.AndroidVersions.V;
@@ -33,6 +34,7 @@ import org.robolectric.versioning.AndroidVersions.V;
 @Config(minSdk = U.SDK_INT)
 @RunWith(RobolectricTestRunner.class)
 public class ShadowWearableSensingManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   @Rule public final MockitoRule mockito = MockitoJUnit.rule();
 
@@ -168,8 +170,8 @@ public class ShadowWearableSensingManagerTest {
 
   @Test
   public void wearableSensingManager_activityContextEnabled_differentInstancesProvideDataStream() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       WearableSensingManager applicationWearableSensingManager =
@@ -198,8 +200,6 @@ public class ShadowWearableSensingManagerTest {
           activityPfd, executor, activityStatusConsumer);
 
       assertThat(activityStatus[0]).isEqualTo(applicationStatus[0]);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiAwareManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiAwareManagerTest.java
@@ -23,16 +23,20 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import javax.annotation.Nonnull;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Test for {@link ShadowWifiAwareManager} */
 @RunWith(AndroidJUnit4.class)
 @Config(minSdk = P)
 public final class ShadowWifiAwareManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private WifiAwareManager wifiAwareManager;
   private Binder binder;
   private Handler handler;
@@ -200,8 +204,8 @@ public final class ShadowWifiAwareManagerTest {
 
   @Test
   public void wifiAwareManager_activityContextEnabled_differentInstancesIsAvailable() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
+
     try (ActivityController<Activity> controller =
         Robolectric.buildActivity(Activity.class).setup()) {
       WifiAwareManager applicationWifiAwareManager =
@@ -218,8 +222,6 @@ public final class ShadowWifiAwareManagerTest {
       boolean activityIsAvailable = activityWifiAwareManager.isAvailable();
 
       assertThat(activityIsAvailable).isEqualTo(applicationIsAvailable);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiP2pManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWifiP2pManagerTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -25,9 +26,11 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowWifiP2pManagerTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   private Context context;
   private WifiP2pManager manager;
@@ -179,8 +182,7 @@ public class ShadowWifiP2pManagerTest {
   @Test
   @Config(minSdk = O)
   public void wifiP2pManager_activityContextEnabled_retrievesSameGroupInfo() {
-    String originalProperty = System.getProperty("robolectric.createActivityContexts", "");
-    System.setProperty("robolectric.createActivityContexts", "true");
+    setSystemPropertyRule.set("robolectric.createActivityContexts", "true");
 
     WifiP2pManager.Channel applicationChannel =
         manager.initialize(context, Looper.getMainLooper(), null);
@@ -227,8 +229,6 @@ public class ShadowWifiP2pManagerTest {
       assertThat(applicationGroupNameHolder[0]).isEqualTo(activityGroupNameHolder[0]);
     } catch (InterruptedException e) {
       throw new AssertionError("Failed because of latch interrupt", e);
-    } finally {
-      System.setProperty("robolectric.createActivityContexts", originalProperty);
     }
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowManagerGlobalTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWindowManagerGlobalTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -48,16 +49,18 @@ import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.GraphicsMode;
 import org.robolectric.annotation.GraphicsMode.Mode;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadows.SystemUi.NavigationBar;
 import org.robolectric.shadows.SystemUi.StatusBar;
 
 @RunWith(AndroidJUnit4.class)
 @GraphicsMode(Mode.LEGACY)
 public class ShadowWindowManagerGlobalTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   @Before
   public void setup() {
-    System.setProperty("robolectric.areWindowsMarkedVisible", "true");
+    setSystemPropertyRule.set("robolectric.areWindowsMarkedVisible", "true");
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/util/SQLiteLibraryLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/util/SQLiteLibraryLoaderTest.java
@@ -5,14 +5,17 @@ import static com.google.common.truth.TruthJUnit.assume;
 import static org.junit.Assert.assertThrows;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 import org.robolectric.shadows.util.SQLiteLibraryLoader;
 
 @RunWith(AndroidJUnit4.class)
 public class SQLiteLibraryLoaderTest {
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
+
   private static final SQLiteLibraryLoader.LibraryNameMapper LINUX =
       new LibraryMapperTest("lib", "so");
   private static final SQLiteLibraryLoader.LibraryNameMapper WINDOWS =
@@ -32,26 +35,11 @@ public class SQLiteLibraryLoaderTest {
   private static final String SYSTEM_PROPERTY_OS_NAME = "os.name";
   private static final String SYSTEM_PROPERTY_OS_ARCH = "os.arch";
 
-  /** Saved system properties. */
-  private String savedOs, savedArch;
-
   private SQLiteLibraryLoader loader;
 
   @Before
   public void setUp() {
     loader = new SQLiteLibraryLoader();
-  }
-
-  @Before
-  public void saveSystemProperties() {
-    savedOs = System.getProperty(SYSTEM_PROPERTY_OS_NAME);
-    savedArch = System.getProperty(SYSTEM_PROPERTY_OS_ARCH);
-  }
-
-  @After
-  public void restoreSystemProperties() {
-    System.setProperty(SYSTEM_PROPERTY_OS_NAME, savedOs);
-    System.setProperty(SYSTEM_PROPERTY_OS_ARCH, savedArch);
   }
 
   @Test
@@ -234,8 +222,8 @@ public class SQLiteLibraryLoaderTest {
     }
   }
 
-  private static void setNameAndArch(String name, String arch) {
-    System.setProperty(SYSTEM_PROPERTY_OS_NAME, name);
-    System.setProperty(SYSTEM_PROPERTY_OS_ARCH, arch);
+  private void setNameAndArch(String name, String arch) {
+    setSystemPropertyRule.set(SYSTEM_PROPERTY_OS_NAME, name);
+    setSystemPropertyRule.set(SYSTEM_PROPERTY_OS_ARCH, arch);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyTypeface.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyTypeface.java
@@ -207,7 +207,6 @@ public class ShadowLegacyTypeface extends ShadowTypeface {
     return result;
   }
 
-
   @Implementation(minSdk = O, maxSdk = R)
   protected static long nativeCreateFromArray(long[] familyArray, int weight, int italic) {
     // TODO: implement this properly


### PR DESCRIPTION
A lot of tests were still manually managing system properties.
This commit migrates those to the `SetSystemPropertyRule` rule.