### PR TITLE
Use Gradle API to select AAR dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,14 +2,6 @@ import groovy.util.Node
 import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.robolectric.gradle.ShadowsPlugin.ShadowsPluginExtension
 
-// https://github.com/gradle/gradle/issues/21267
-val axtCoreVersion by project.extra { libs.versions.androidx.test.core.get() }
-val axtJunitVersion by project.extra { libs.versions.androidx.test.ext.junit.get() }
-val axtMonitorVersion by project.extra { libs.versions.androidx.test.monitor.get() }
-val axtRunnerVersion by project.extra { libs.versions.androidx.test.runner.get() }
-val axtTruthVersion by project.extra { libs.versions.androidx.test.ext.truth.get() }
-val espressoVersion by project.extra { libs.versions.androidx.test.espresso.get() }
-
 // For use of external initialization scripts...
 val allSdks by project.extra(AndroidSdk.ALL_SDKS)
 val configAnnotationProcessing by project.extra(emptyList<Project>())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -128,6 +128,9 @@ play-services-for-shadows = "17.0.0"
 # https://developers.google.com/android/guides/releases
 play-services-basement = "18.0.1"
 
+# https://github.com/google/TestParameterInjector/tags
+test-parameter-injector = "1.18"
+
 [libraries]
 android-gradle-api = { module = "com.android.tools.build:gradle-api", version.ref = "android-gradle" }
 
@@ -222,6 +225,7 @@ androidx-test-runner = { module = "androidx.test:runner", version.ref = "android
 androidx-test-services = { module = "androidx.test.services:test-services", version.ref = "androidx-test-services" }
 
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-test-espresso" }
+androidx-test-espresso-idling-resource = { module = "androidx.test.espresso:espresso-idling-resource", version.ref = "androidx-test-espresso" }
 androidx-test-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "androidx-test-espresso" }
 
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext-junit" }
@@ -240,6 +244,8 @@ play-services-base-for-shadows = { module = "com.google.android.gms:play-service
 play-services-basement-for-shadows = { module = "com.google.android.gms:play-services-basement", version.ref = "play-services-for-shadows" }
 
 play-services-basement = { module = "com.google.android.gms:play-services-basement", version.ref = "play-services-basement" }
+
+test-parameter-injector = { module = "com.google.testparameterinjector:test-parameter-injector", version.ref = "test-parameter-injector" }
 
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless-gradle" }
 

--- a/integration_tests/mockito-kotlin/build.gradle.kts
+++ b/integration_tests/mockito-kotlin/build.gradle.kts
@@ -11,15 +11,13 @@ tasks.compileKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
 tasks.compileTestKotlin.configure { compilerOptions.jvmTarget = JvmTarget.JVM_1_8 }
 
-val axtJunitVersion: String by rootProject.extra
-
 dependencies {
   api(project(":robolectric"))
   compileOnly(AndroidSdk.MAX_SDK.coordinates)
 
   testCompileOnly(AndroidSdk.MAX_SDK.coordinates)
   testRuntimeOnly(AndroidSdk.MAX_SDK.coordinates)
-  testImplementation("androidx.test.ext:junit:$axtJunitVersion@aar")
+  testImplementation(variantOf(libs.androidx.test.ext.junit) { artifactType("aar") })
   testImplementation(libs.junit4)
   testImplementation(libs.truth)
   testImplementation(libs.kotlin.stdlib)

--- a/robolectric/build.gradle.kts
+++ b/robolectric/build.gradle.kts
@@ -3,13 +3,6 @@ plugins {
   alias(libs.plugins.robolectric.java.module)
 }
 
-val axtCoreVersion: String by rootProject.extra
-val axtJunitVersion: String by rootProject.extra
-val axtMonitorVersion: String by rootProject.extra
-val axtRunnerVersion: String by rootProject.extra
-val axtTruthVersion: String by rootProject.extra
-val espressoVersion: String by rootProject.extra
-
 dependencies {
   annotationProcessor(libs.auto.service)
   annotationProcessor(libs.error.prone.core)
@@ -40,9 +33,9 @@ dependencies {
   compileOnly(libs.junit4)
   compileOnly(libs.androidx.annotation)
 
-  api("androidx.test:monitor:$axtMonitorVersion@aar")
-  implementation("androidx.test.espresso:espresso-idling-resource:$espressoVersion@aar")
-  implementation("com.google.testparameterinjector:test-parameter-injector:1.18@jar")
+  api(variantOf(libs.androidx.test.monitor) { artifactType("aar") })
+  implementation(variantOf(libs.androidx.test.espresso.idling.resource) { artifactType("aar") })
+  implementation(variantOf(libs.test.parameter.injector) { artifactType("jar") })
 
   testImplementation(libs.androidx.annotation)
   testImplementation(libs.junit4)
@@ -50,10 +43,10 @@ dependencies {
   testImplementation(libs.mockito)
   testImplementation(libs.mockito.subclass)
   testImplementation(libs.hamcrest)
-  testImplementation("androidx.test:core:$axtCoreVersion@aar")
-  testImplementation("androidx.test.ext:junit:$axtJunitVersion@aar")
-  testImplementation("androidx.test.ext:truth:$axtTruthVersion@aar")
-  testImplementation("androidx.test:runner:$axtRunnerVersion@aar")
+  testImplementation(variantOf(libs.androidx.test.core) { artifactType("aar") })
+  testImplementation(variantOf(libs.androidx.test.ext.junit) { artifactType("aar") })
+  testImplementation(variantOf(libs.androidx.test.ext.truth) { artifactType("aar") })
+  testImplementation(variantOf(libs.androidx.test.runner) { artifactType("aar") })
   testImplementation(libs.guava)
   testImplementation(libs.guava.testlib)
   testCompileOnly(AndroidSdk.MAX_SDK.coordinates) // compile against latest Android SDK

--- a/shadows/framework/build.gradle.kts
+++ b/shadows/framework/build.gradle.kts
@@ -39,8 +39,6 @@ tasks.jar.configure { dependsOn(copySqliteNatives) }
 
 tasks.javadoc.configure { dependsOn(copySqliteNatives) }
 
-val axtMonitorVersion: String by rootProject.extra
-
 dependencies {
   api(project(":annotations"))
   api(project(":nativeruntime"))
@@ -51,8 +49,7 @@ dependencies {
   api(project(":utils"))
   api(project(":utils:reflector"))
 
-  api("androidx.test:monitor:$axtMonitorVersion@aar")
-
+  api(variantOf(libs.androidx.test.monitor) { artifactType("aar") })
   implementation(libs.error.prone.annotations)
   compileOnly(libs.findbugs.jsr305)
   api(libs.sqlite4java)

--- a/shadows/httpclient/build.gradle.kts
+++ b/shadows/httpclient/build.gradle.kts
@@ -10,7 +10,6 @@ shadows {
 }
 
 val earlyRuntime = configurations.create("earlyRuntime")
-val axtJunitVersion: String by rootProject.extra
 
 dependencies {
   api(project(":annotations"))
@@ -25,7 +24,7 @@ dependencies {
   testImplementation(project(":robolectric"))
   testImplementation(libs.junit4)
   testImplementation(libs.truth)
-  testImplementation("androidx.test.ext:junit:$axtJunitVersion@aar")
+  testImplementation(variantOf(libs.androidx.test.ext.junit) { artifactType("aar") })
 
   testCompileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates)
   testRuntimeOnly(AndroidSdk.S.coordinates)


### PR DESCRIPTION
This commit removes the workaround to enforce AAR module type to use a Gradle API instead.
This was suggested in https://github.com/gradle/gradle/issues/21267#issuecomment-2571562721.