### PR TITLE
Update `google-java-format` to 1.27.0

### DIFF
--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Download google-java-format
         run: |
-          googleJavaFormatVersion="1.26.0"
+          googleJavaFormatVersion="1.27.0"
           curl -L -o $HOME/google-java-format.jar https://github.com/google/google-java-format/releases/download/v${googleJavaFormatVersion}/google-java-format-${googleJavaFormatVersion}-all-deps.jar
           curl -L -o $HOME/google-java-format-diff.py https://raw.githubusercontent.com/google/google-java-format/v${googleJavaFormatVersion}/scripts/google-java-format-diff.py
           chmod +x $HOME/google-java-format-diff.py


### PR DESCRIPTION
Release notes: https://github.com/google/google-java-format/releases/tag/v1.27.0