### PR TITLE
Deprecate `Config#instrumentedPackages()`

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/Config.java
+++ b/annotations/src/main/java/org/robolectric/annotation/Config.java
@@ -108,7 +108,11 @@ public @interface Config {
    * A list of instrumented packages, in addition to those that are already instrumented.
    *
    * @return A list of additional instrumented packages.
+   * @deprecated Use {@link
+   *     org.robolectric.internal.bytecode.InstrumentationConfiguration.Builder#addInstrumentedClass(String)}
+   *     instead. This will be removed in a future version of Robolectric.
    */
+  @Deprecated
   String[] instrumentedPackages() default {}; // DEFAULT_INSTRUMENTED_PACKAGES
 
   class Implementation implements Config {


### PR DESCRIPTION
This commit deprecates the `Config#instrumentedPackages()` method in favor of `InstrumentationConfiguration.Builder#addInstrumentedClass(String)`.

This is the first step to resolve #2848.