### PR TITLE
integration_tests: Exclude androidTest for modules that not required

### DIFF
--- a/integration_tests/memoryleaks/build.gradle.kts
+++ b/integration_tests/memoryleaks/build.gradle.kts
@@ -18,6 +18,13 @@ android {
     targetSdk = 35
     unitTests.isIncludeAndroidResources = true
   }
+
+  androidComponents {
+    beforeVariants(selector().all()) { variantBuilder ->
+      // memoryleaks does not support AndroidTest.
+      variantBuilder.enableAndroidTest = false
+    }
+  }
 }
 
 dependencies {

--- a/integration_tests/rap/build.gradle.kts
+++ b/integration_tests/rap/build.gradle.kts
@@ -18,6 +18,13 @@ android {
     targetSdk = 35
     unitTests.isIncludeAndroidResources = true
   }
+
+  androidComponents {
+    beforeVariants(selector().all()) { variantBuilder ->
+      // rap does not support AndroidTest.
+      variantBuilder.enableAndroidTest = false
+    }
+  }
 }
 
 dependencies {

--- a/integration_tests/room/build.gradle.kts
+++ b/integration_tests/room/build.gradle.kts
@@ -18,6 +18,13 @@ android {
     targetSdk = 35
     unitTests.isIncludeAndroidResources = true
   }
+
+  androidComponents {
+    beforeVariants(selector().all()) { variantBuilder ->
+      // room does not support AndroidTest.
+      variantBuilder.enableAndroidTest = false
+    }
+  }
 }
 
 dependencies {

--- a/integration_tests/sparsearray/build.gradle.kts
+++ b/integration_tests/sparsearray/build.gradle.kts
@@ -23,6 +23,13 @@ android {
     targetSdk = 35
     unitTests.isIncludeAndroidResources = true
   }
+
+  androidComponents {
+    beforeVariants(selector().all()) { variantBuilder ->
+      // sparsearray does not support AndroidTest.
+      variantBuilder.enableAndroidTest = false
+    }
+  }
 }
 
 dependencies {

--- a/integration_tests/testparameterinjector/build.gradle.kts
+++ b/integration_tests/testparameterinjector/build.gradle.kts
@@ -18,6 +18,13 @@ android {
     targetSdk = 35
     unitTests.isIncludeAndroidResources = true
   }
+
+  androidComponents {
+    beforeVariants(selector().all()) { variantBuilder ->
+      // testparameterinjector does not support AndroidTest.
+      variantBuilder.enableAndroidTest = false
+    }
+  }
 }
 
 dependencies {


### PR DESCRIPTION
These modules use android library plugin but doesn't support androidTest tests, and this CL just removes androidTest for them to reduce extra building when running androidTest command.

