### PR TITLE
Increase PR limit for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,5 +52,7 @@
         "androidx.fragment:fragment"
       ]
     }
-  ]
+  ],
+  "prHourlyLimit": 5,
+  "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
Currently, Renovate only creates at most 2 PRs per hour.
But often, we have 4/5 dependencies to update per week.
With this, we have more PR automatically suggested, without any manual action.

I've also disabled automatic rebase, unless there is a conflict.
This is to limit having too many parallel jobs running.