### PR TITLE
Fix failing test on `master`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowRemoteViewsAdapterTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowRemoteViewsAdapterTest.java
@@ -1,6 +1,7 @@
 package org.robolectric.shadows;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
 
 import android.content.Context;
 import android.content.Intent;
@@ -9,7 +10,6 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.RemoteViews;
 import android.widget.RemoteViewsAdapter;
-import android.widget.RemoteViewsAdapter.RemoteAdapterConnectionCallback;
 import android.widget.RemoteViewsService;
 import android.widget.RemoteViewsService.RemoteViewsFactory;
 import android.widget.TextView;
@@ -43,9 +43,7 @@ public class ShadowRemoteViewsAdapterTest {
   @Test
   @Config(minSdk = VERSION_CODES.O)
   public void getViewApi26AndLater_populatedWithExpectedItems() {
-    RemoteViewsAdapter adapter =
-        new RemoteViewsAdapter(
-            context, createTestIntent(), new FakeRemoteAdapterConnectionCallback(), false);
+    RemoteViewsAdapter adapter = new RemoteViewsAdapter(context, createTestIntent(), mock(), false);
 
     assertThat(adapter.getCount()).isEqualTo(3);
     assertThat(((TextView) adapter.getView(0, null, parent)).getText().toString()).isEqualTo("one");
@@ -57,9 +55,7 @@ public class ShadowRemoteViewsAdapterTest {
   @Test
   @Config(minSdk = VERSION_CODES.O)
   public void constructorApi26AndLater_intentPassedToService() {
-    RemoteViewsAdapter unused =
-        new RemoteViewsAdapter(
-            context, createTestIntent(), new FakeRemoteAdapterConnectionCallback(), false);
+    RemoteViewsAdapter unused = new RemoteViewsAdapter(context, createTestIntent(), mock(), false);
 
     assertThat(capturedIntent.getComponent().getClassName())
         .isEqualTo(TestRemoteViewsService.class.getName());
@@ -124,22 +120,5 @@ public class ShadowRemoteViewsAdapterTest {
     public boolean hasStableIds() {
       return true;
     }
-  }
-
-  private static class FakeRemoteAdapterConnectionCallback
-      implements RemoteAdapterConnectionCallback {
-    @Override
-    public boolean onRemoteAdapterConnected() {
-      return false;
-    }
-
-    @Override
-    public void onRemoteAdapterDisconnected() {}
-
-    @Override
-    public void deferNotifyDataSetChanged() {}
-
-    @Override
-    public void setRemoteViewsAdapter(Intent intent, boolean b) {}
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/HardwareRenderingScreenshot.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/HardwareRenderingScreenshot.java
@@ -79,7 +79,10 @@ public final class HardwareRenderingScreenshot {
                 k -> {
                   if (Boolean.parseBoolean(System.getProperty(USE_EMBEDDED_VIEW_ROOT, "false"))) {
                     ShadowViewRootImpl shadowViewRootImpl = Shadow.extract(viewRootImpl);
-                    return shadowViewRootImpl.getThreadedRenderer();
+                    // Required to avoid a VerifyError when this lambda class is loaded on SDK <
+                    // 29, where ThreadedRenderer is not a subclass of HardwareRenderer.
+                    Object threadedRenderer = shadowViewRootImpl.getThreadedRenderer();
+                    return (HardwareRenderer) threadedRenderer;
                   } else {
                     return new HardwareRenderer();
                   }


### PR DESCRIPTION
## Fix `NoClassDefFoundError` in `ShadowRemoteViewsAdapterTest`

`ShadowRemoteViewsAdapterTest` is failing on `master` following the latest merge of `google` into `master`.
`RemoteAdapterConnectionCallback` may not be available at compile time, causing a `NoClassDefFoundError`.
This commit switches the no-op implementation with a mock.

## Fix `VerifyError` in `ViewAnimationTest`

The lambda in `HardwareRenderingScreenshot` was extracted out of the class, so the API check was not performed.
This commit replaces it with an anonymous class to prevent the `VerifyError`.