### PR TITLE
Add configuration for Gemini Code Assist

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,5 @@
+# See the following for configuration options and the default values
+# https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github#default-configuration
+code_review:
+  pull_request_opened:
+    summary: false


### PR DESCRIPTION
This commit disables the PR summary comment posted by Gemini.
The documentation and available options are here: https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github