### PR TITLE
Update `@Config`'s `minSdk` in some tests

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCaptioningManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCaptioningManagerTest.java
@@ -1,6 +1,6 @@
 package org.robolectric.shadows;
 
-import static android.os.Build.VERSION_CODES.KITKAT;
+import static android.os.Build.VERSION_CODES.L;
 import static android.os.Build.VERSION_CODES.TIRAMISU;
 import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.Shadows.shadowOf;
@@ -32,7 +32,7 @@ import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Tests for the ShadowCaptioningManager. */
 @RunWith(AndroidJUnit4.class)
-@Config(minSdk = KITKAT)
+@Config(minSdk = L)
 public final class ShadowCaptioningManagerTest {
   @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 

--- a/robolectric/src/test/java/org/robolectric/shadows/SignalStrengthBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SignalStrengthBuilderTest.java
@@ -17,7 +17,7 @@ import org.robolectric.annotation.Config;
 
 /** Test for {@link SignalStrengthBuilder} */
 @RunWith(AndroidJUnit4.class)
-@Config(minSdk = Build.VERSION_CODES.ECLAIR_MR1)
+@Config(minSdk = Build.VERSION_CODES.L)
 public class SignalStrengthBuilderTest {
 
   @Test


### PR DESCRIPTION
There are a couple of tests that still reference old API levels for the `minSdk` in the `@Config` annotation.
This commit updates them to reference the project's current minSdk (21) instead.
