### PR TITLE
Use `Config.OLDEST_SDK` in tests instead of hardcoded value

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/AppWidgetProviderInfoBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/AppWidgetProviderInfoBuilderTest.java
@@ -57,19 +57,19 @@ public class AppWidgetProviderInfoBuilderTest {
   }
 
   @Test
-  @Config(minSdk = L)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void getProfile_shouldReturnUserHandleWithAssignedUID() {
     assertThat(appWidgetProviderInfo.getProfile().getIdentifier()).isEqualTo(applicationInfo.uid);
   }
 
   @Test
-  @Config(minSdk = L)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void loadIcon_shouldReturnNonNullIcon() {
     assertThat(appWidgetProviderInfo.loadIcon(context, 240)).isNotNull();
   }
 
   @Test
-  @Config(minSdk = L)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void loadLabel_shouldReturnAssignedLabel() {
     assertThat(appWidgetProviderInfo.loadLabel(packageManager))
         .isEqualTo(providerInfo.nonLocalizedLabel.toString());

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAppWidgetManagerTest.java
@@ -1,6 +1,5 @@
 package org.robolectric.shadows;
 
-import static android.os.Build.VERSION_CODES.L;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.VANILLA_ICE_CREAM;
 import static android.os.Looper.getMainLooper;
@@ -265,7 +264,7 @@ public class ShadowAppWidgetManagerTest {
   }
 
   @Test
-  @Config(minSdk = L)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void getInstalledProvidersForProfile_returnsWidgetList() {
     UserHandle userHandle = UserHandle.CURRENT;
     assertTrue(appWidgetManager.getInstalledProvidersForProfile(userHandle).isEmpty());

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowBuildTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowBuildTest.java
@@ -1,6 +1,5 @@
 package org.robolectric.shadows;
 
-import static android.os.Build.VERSION_CODES.L;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.O;
 import static android.os.Build.VERSION_CODES.R;
@@ -134,7 +133,7 @@ public class ShadowBuildTest {
   }
 
   @Test
-  @Config(minSdk = L)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void supported32BitAbis() {
     assertThat(Build.SUPPORTED_32_BIT_ABIS).isEqualTo(new String[] {"armeabi-v7a", "armeabi"});
     ShadowBuild.setSupported32BitAbis(new String[] {"x86"});
@@ -142,7 +141,7 @@ public class ShadowBuildTest {
   }
 
   @Test
-  @Config(minSdk = L)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void supported64BitAbis() {
     assertThat(Build.SUPPORTED_64_BIT_ABIS).isEqualTo(new String[] {"armeabi-v7a", "armeabi"});
     ShadowBuild.setSupported64BitAbis(new String[] {"x86_64"});
@@ -150,7 +149,7 @@ public class ShadowBuildTest {
   }
 
   @Test
-  @Config(minSdk = L)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void supportedAbis() {
     assertThat(Build.SUPPORTED_ABIS).isEqualTo(new String[] {"armeabi-v7a"});
     ShadowBuild.setSupportedAbis(new String[] {"x86"});

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCaptioningManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCaptioningManagerTest.java
@@ -1,6 +1,5 @@
 package org.robolectric.shadows;
 
-import static android.os.Build.VERSION_CODES.L;
 import static android.os.Build.VERSION_CODES.TIRAMISU;
 import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.Shadows.shadowOf;
@@ -32,7 +31,7 @@ import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 /** Tests for the ShadowCaptioningManager. */
 @RunWith(AndroidJUnit4.class)
-@Config(minSdk = L)
+@Config(minSdk = Config.OLDEST_SDK)
 public final class ShadowCaptioningManagerTest {
   @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLauncherAppsTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLauncherAppsTest.java
@@ -210,7 +210,7 @@ public class ShadowLauncherAppsTest {
   }
 
   @Test
-  @Config(minSdk = L)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void testIsActivityEnabled() {
     ComponentName c1 = new ComponentName(ApplicationProvider.getApplicationContext(), "Activity1");
     ComponentName c2 = new ComponentName(ApplicationProvider.getApplicationContext(), "Activity2");

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowWebViewTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowWebViewTest.java
@@ -644,13 +644,13 @@ public class ShadowWebViewTest {
   }
 
   @Test
-  @Config(minSdk = 21)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void canEnableSlowWholeDocumentDraw() {
     WebView.enableSlowWholeDocumentDraw();
   }
 
   @Test
-  @Config(minSdk = 21)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void canClearClientCertPreferences() {
     WebView.clearClientCertPreferences(null);
   }

--- a/robolectric/src/test/java/org/robolectric/shadows/SignalStrengthBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SignalStrengthBuilderTest.java
@@ -17,7 +17,7 @@ import org.robolectric.annotation.Config;
 
 /** Test for {@link SignalStrengthBuilder} */
 @RunWith(AndroidJUnit4.class)
-@Config(minSdk = Build.VERSION_CODES.L)
+@Config(minSdk = Config.OLDEST_SDK)
 public class SignalStrengthBuilderTest {
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/WifiScanResultBuilderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/WifiScanResultBuilderTest.java
@@ -83,7 +83,7 @@ public final class WifiScanResultBuilderTest {
   }
 
   @Test
-  @Config(minSdk = VERSION_CODES.LOLLIPOP)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void setCapabilities_setsCapabilitiesField() {
     String capabilities = "wpa2";
     ScanResult scanResult = new WifiScanResultBuilder().setCapabilities(capabilities).build();
@@ -92,7 +92,7 @@ public final class WifiScanResultBuilderTest {
   }
 
   @Test
-  @Config(minSdk = VERSION_CODES.LOLLIPOP)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void setBssid_setsBssidField() {
     String bssid = "01:AB:CD:EF:12";
     ScanResult scanResult = new WifiScanResultBuilder().setBssid(bssid).build();
@@ -101,7 +101,7 @@ public final class WifiScanResultBuilderTest {
   }
 
   @Test
-  @Config(minSdk = VERSION_CODES.LOLLIPOP)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void setRssi_setsLevelField() {
     int rssi = -80;
     ScanResult scanResult = new WifiScanResultBuilder().setRssi(rssi).build();
@@ -110,7 +110,7 @@ public final class WifiScanResultBuilderTest {
   }
 
   @Test
-  @Config(minSdk = VERSION_CODES.LOLLIPOP)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void setFrequency_setsFrequencyField() {
     int frequency = 2412;
     ScanResult scanResult = new WifiScanResultBuilder().setFrequency(frequency).build();
@@ -119,7 +119,7 @@ public final class WifiScanResultBuilderTest {
   }
 
   @Test
-  @Config(minSdk = VERSION_CODES.LOLLIPOP)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void setTimestamp_setsTimestampField() {
     int durationMicros = 500000000;
     Duration timeSinceSeen = Duration.ofSeconds(TimeUnit.MICROSECONDS.toSeconds(durationMicros));
@@ -180,7 +180,7 @@ public final class WifiScanResultBuilderTest {
   }
 
   @Test
-  @Config(minSdk = VERSION_CODES.LOLLIPOP)
+  @Config(minSdk = Config.OLDEST_SDK)
   public void buildFromEmpty_checkCommonDefaultValues() {
     ScanResult scanResult = new WifiScanResultBuilder().build();
 


### PR DESCRIPTION
As suggested in https://github.com/robolectric/robolectric/pull/10321#issuecomment-2917049208, this commit replaces some hardcoded minSdk with `Config.OLDEST_SDK`.