### PR TITLE
Create a workflow to automate the sync of `google` into `master`

### DIFF
--- a/.github/workflows/sync_google_master.yml
+++ b/.github/workflows/sync_google_master.yml
@@ -1,0 +1,25 @@
+name: Sync the google branch into master
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync_google_master:
+    name: "Sync google into master"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: google
+          token: ${{ secrets.ROBOLECTRIC_PAT }}
+
+      - name: Create the PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b sync_google_master
+          git push --set-upstream origin sync_google_master
+          gh pr create --base master --head sync_google_master --title "Merge branch google into master" --body ""

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ Although complex, this distributed development model enables Android developers
 in different environments to use and contribute to Robolectric, while allowing
 changes to eventually make their way to public Robolectric releases.
 
+> [!TIP]
+> You can trigger the
+> [`sync_google_master`](https://github.com/robolectric/robolectric/actions/workflows/sync_google_master.yml)
+> workflow to create a PR to sync the `google` branch into `master`.
+
 ## Using Snapshots
 
 If you would like to live on the bleeding edge, you can try running against a snapshot build. Keep in mind that snapshots represent the most recent changes on the `master` and may contain bugs.


### PR DESCRIPTION
This commit creates a new workflow to be able to create a PR to merge `google` into `master`.
A link to trigger the workflow has been added to the `README.md` file.

> [!NOTE]
> - I've tested this workflow on my fork (https://github.com/MGaetan89/robolectric/pull/2).
> - I've added a custom PAT to the Robolectric organisation so the created PR can have CI running. I'm not sure if I've set the right permissions on it, so I'll fine-tune it once this PR is merged.