### PR TITLE
Update `ActivityData#getTargetAttr()` to use its `xmlns` argument

### DIFF
--- a/resources/src/main/java/org/robolectric/manifest/ActivityData.java
+++ b/resources/src/main/java/org/robolectric/manifest/ActivityData.java
@@ -211,6 +211,6 @@ public class ActivityData {
   }
 
   public static String getTargetAttr(String xmlns) {
-    return withXMLNS("android", TARGET_ACTIVITY);
+    return withXMLNS(xmlns, TARGET_ACTIVITY);
   }
 }


### PR DESCRIPTION
Currently, the `ActivityData#getTargetAttr()` method does not use its `xmlns` argument.
Instead, it uses a hardcoded `android` value internally.
However, every usage of `getTargetAttr()` provides `android` as an argument.
So this commit replaces the hardcoded value with the provided argument.