### PR TITLE
Replace PowerMock's Xstream module with Objenesis

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -185,7 +185,7 @@ okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp
 
 powermock-module-junit4-rule = { module = "org.powermock:powermock-module-junit4-rule", version.ref = "powermock" }
 powermock-api-mockito2 = { module = "org.powermock:powermock-api-mockito2", version.ref = "powermock" }
-powermock-classloading-xstream = { module = "org.powermock:powermock-classloading-xstream", version.ref = "powermock" }
+powermock-classloading-objenesis = { module = "org.powermock:powermock-classloading-objenesis", version.ref = "powermock" }
 
 robolectric-nativeruntime-dist-compat = { module = "org.robolectric:nativeruntime-dist-compat", version.ref = "robolectric-nativeruntime-dist-compat" }
 
@@ -255,7 +255,7 @@ jacoco-agent = { module = "org.jacoco:org.jacoco.agent", version.ref = "jacoco" 
 
 [bundles]
 play-services-for-shadows = ["androidx-fragment-for-shadows", "play-services-auth-for-shadows", "play-services-base-for-shadows", "play-services-basement-for-shadows"]
-powermock = ["powermock-module-junit4-rule", "powermock-api-mockito2", "powermock-classloading-xstream"]
+powermock = ["powermock-module-junit4-rule", "powermock-api-mockito2", "powermock-classloading-objenesis"]
 sqlite4java-native = ["sqlite4java-osx", "sqlite4java-linux-amd64", "sqlite4java-win32-x64", "sqlite4java-linux-i386", "sqlite4java-win32-x86"]
 
 [plugins]


### PR DESCRIPTION
I've enabled GitHub's automatic dependency submission (https://github.blog/changelog/2025-05-27-dependency-auto-submission-now-supports-gradle/).
Now can see all the project dependencies here: https://github.com/robolectric/robolectric/network/dependencies and the security alerts here: https://github.com/robolectric/robolectric/security/dependabot

Most of the reported security alerts come from Xstream, transitively through PowerMock: https://github.com/robolectric/robolectric/security/dependabot?q=package%3Acom.thoughtworks.xstream%3Axstream
This commit replaces the `powermock-classloading-xstream` module with `powermock-classloading-objenesis` (as documented here https://github.com/powermock/powermock/wiki/PowerMockRule).

An other solution would have been to update Xstream on our side, but we have no guarantee that it will keep working with PowerMock, as PowerMock doesn't seem to be updated anymore.