### PR TITLE
Add missing SCM metadata when generating POM files

### DIFF
--- a/buildSrc/src/main/java/org/robolectric/gradle/PomMetadata.kt
+++ b/buildSrc/src/main/java/org/robolectric/gradle/PomMetadata.kt
@@ -16,6 +16,12 @@ fun MavenPublication.applyPomMetadata(project: Project) {
       }
     }
 
+    scm {
+      url.set("https://github.com/robolectric/robolectric")
+      connection.set("scm:git:git://github.com/robolectric/robolectric.git")
+      developerConnection.set("scm:git:git@github.com:robolectric/robolectric.git")
+    }
+
     developers {
       developer {
         name.set("Brett Chabot")


### PR DESCRIPTION
This was inadvertently missed in
https://github.com/robolectric/robolectric/commit/38ab876dd5c435120adc51d67e5169fbabc9fa90.
