### PR TITLE
Set the simulator gradle plugin version to 1.0-SNAPSHOT

### DIFF
--- a/simulator-gradle-plugin/build.gradle.kts
+++ b/simulator-gradle-plugin/build.gradle.kts
@@ -6,6 +6,10 @@ plugins {
   signing
 }
 
+// The simulator gradle plugin is versioned separately from the Robolectric library. It is
+// indifferent to the Robolectric version and doesn't need to be updated each Robolectric release.
+version = "1.0-SNAPSHOT"
+
 gradlePlugin {
   website.set("https://robolectric.org/simulator")
   vcsUrl.set("https://github.com/robolectric/robolectric")


### PR DESCRIPTION
The simulator gradle plugin does not need to have the same Vversion as the Robolectric library. Use separate versioning so it can be updated at a different cadence.
