### PR TITLE
Remove unused field in `Sandbox`

### DIFF
--- a/sandbox/src/main/java/org/robolectric/internal/bytecode/Sandbox.java
+++ b/sandbox/src/main/java/org/robolectric/internal/bytecode/Sandbox.java
@@ -22,7 +22,6 @@ public class Sandbox {
   private final SandboxClassLoader sandboxClassLoader;
   private final ExecutorService executorService;
   private ShadowInvalidator shadowInvalidator;
-  public ClassHandler classHandler; // todo not public
   private ShadowMap shadowMap = ShadowMap.EMPTY;
 
   public Sandbox(
@@ -78,8 +77,6 @@ public class Sandbox {
   protected void clearModeInvalidatedClasses() {}
 
   public void configure(ClassHandler classHandler, Interceptors interceptors) {
-    this.classHandler = classHandler;
-
     ClassLoader robolectricClassLoader = getRobolectricClassLoader();
     Class<?> robolectricInternalsClass = bootstrappedClass(RobolectricInternals.class);
     ShadowInvalidator invalidator = getShadowInvalidator();


### PR DESCRIPTION
There's a TODO on `Sandbox#classHandler` to remove it from the public API. But this field is not actually used (only set).
So this commit removes this field completely.