### PR TITLE
Deduplicate `MetaData#getColor()` and `ResourceHelper#getColor()`

### DIFF
--- a/resources/src/main/java/org/robolectric/manifest/MetaData.java
+++ b/resources/src/main/java/org/robolectric/manifest/MetaData.java
@@ -116,7 +116,6 @@ public final class MetaData {
     return value;
   }
 
-  // todo: this is copied from ResourceHelper, dedupe
   /**
    * Returns the color value represented by the given string value
    *
@@ -136,8 +135,7 @@ public final class MetaData {
       if (value.length() > 8) {
         throw new NumberFormatException(
             String.format(
-                "Color value '%s' is too long. Format is either"
-                    + "#AARRGGBB, #RRGGBB, #RGB, or #ARGB",
+                "Color value '%s' is too long. Format is either #AARRGGBB, #RRGGBB, #RGB, or #ARGB",
                 value));
       }
 
@@ -167,6 +165,6 @@ public final class MetaData {
       return (int) Long.parseLong(value, 16);
     }
 
-    throw new NumberFormatException();
+    throw new NumberFormatException("Color value cannot be null");
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/ResourceHelperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ResourceHelperTest.java
@@ -1,6 +1,7 @@
 package org.robolectric.shadows;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import android.util.TypedValue;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -12,6 +13,100 @@ import org.robolectric.annotation.Config;
 @RunWith(AndroidJUnit4.class)
 @Config(sdk = Config.NEWEST_SDK)
 public class ResourceHelperTest {
+  @Test
+  public void getColor_nullValue() {
+    NumberFormatException exception =
+        assertThrows(NumberFormatException.class, () -> ResourceHelper.getColor(null));
+
+    assertThat(exception.getMessage()).isEqualTo("Color value cannot be null");
+  }
+
+  @Test
+  public void getColor_emptyValue() {
+    NumberFormatException exception =
+        assertThrows(NumberFormatException.class, () -> ResourceHelper.getColor(""));
+
+    assertThat(exception.getMessage()).isEqualTo("Color value '' must start with #");
+  }
+
+  @Test
+  public void getColor_valueDoesNotStartWithHashtag() {
+    NumberFormatException exception =
+        assertThrows(NumberFormatException.class, () -> ResourceHelper.getColor("FF0000"));
+
+    assertThat(exception.getMessage()).isEqualTo("Color value 'FF0000' must start with #");
+  }
+
+  @Test
+  public void getColor_valueTooLong() {
+    NumberFormatException exception =
+        assertThrows(NumberFormatException.class, () -> ResourceHelper.getColor("#AABBCCDDEE"));
+
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "Color value 'AABBCCDDEE' is too long. Format is either #AARRGGBB, #RRGGBB, #RGB, or"
+                + " #ARGB");
+  }
+
+  @Test
+  public void getColor_RGBValue() {
+    int color = ResourceHelper.getColor("#abc");
+
+    assertThat(color).isEqualTo(-5588020);
+  }
+
+  @Test
+  public void getColor_invalidRGBValue() {
+    NumberFormatException exception =
+        assertThrows(NumberFormatException.class, () -> ResourceHelper.getColor("#zzz"));
+
+    assertThat(exception.getMessage()).isEqualTo("For input string: \"FFzzzzzz\" under radix 16");
+  }
+
+  @Test
+  public void getColor_ARGBValue() {
+    int color = ResourceHelper.getColor("#abcd");
+
+    assertThat(color).isEqualTo(-1430532899);
+  }
+
+  @Test
+  public void getColor_invalidARGBValue() {
+    NumberFormatException exception =
+        assertThrows(NumberFormatException.class, () -> ResourceHelper.getColor("#zzzz"));
+
+    assertThat(exception.getMessage()).isEqualTo("For input string: \"zzzzzzzz\" under radix 16");
+  }
+
+  @Test
+  public void getColor_RRGGBBValue() {
+    int color = ResourceHelper.getColor("#a1b2c3");
+
+    assertThat(color).isEqualTo(-6180157);
+  }
+
+  @Test
+  public void getColor_invalidRRGGBBValue() {
+    NumberFormatException exception =
+        assertThrows(NumberFormatException.class, () -> ResourceHelper.getColor("#zzzzzz"));
+
+    assertThat(exception.getMessage()).isEqualTo("For input string: \"FFzzzzzz\" under radix 16");
+  }
+
+  @Test
+  public void getColor_AARRGGBBValue() {
+    int color = ResourceHelper.getColor("#a1b2c3d4");
+
+    assertThat(color).isEqualTo(-1582119980);
+  }
+
+  @Test
+  public void getColor_invalidAARRGGBBValue() {
+    NumberFormatException exception =
+        assertThrows(NumberFormatException.class, () -> ResourceHelper.getColor("#zzzzzzzz"));
+
+    assertThat(exception.getMessage()).isEqualTo("For input string: \"zzzzzzzz\" under radix 16");
+  }
 
   @Test
   public void parseFloatAttribute() {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper.java
@@ -19,6 +19,7 @@ package org.robolectric.shadows;
 import android.util.TypedValue;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.robolectric.manifest.MetaData;
 import org.robolectric.util.Logger;
 
 /** Helper class to provide various conversion method used in handling android resources. */
@@ -47,49 +48,7 @@ public final class ResourceHelper {
    * @throws NumberFormatException if the conversion failed.
    */
   public static int getColor(String value) {
-    if (value != null) {
-      if (!value.startsWith("#")) {
-        throw new NumberFormatException(String.format("Color value '%s' must start with #", value));
-      }
-
-      value = value.substring(1);
-
-      // make sure it's not longer than 32bit
-      if (value.length() > 8) {
-        throw new NumberFormatException(
-            String.format(
-                "Color value '%s' is too long. Format is either"
-                    + "#AARRGGBB, #RRGGBB, #RGB, or #ARGB",
-                value));
-      }
-
-      if (value.length() == 3) { // RGB format
-        char[] color = new char[8];
-        color[0] = color[1] = 'F';
-        color[2] = color[3] = value.charAt(0);
-        color[4] = color[5] = value.charAt(1);
-        color[6] = color[7] = value.charAt(2);
-        value = new String(color);
-      } else if (value.length() == 4) { // ARGB format
-        char[] color = new char[8];
-        color[0] = color[1] = value.charAt(0);
-        color[2] = color[3] = value.charAt(1);
-        color[4] = color[5] = value.charAt(2);
-        color[6] = color[7] = value.charAt(3);
-        value = new String(color);
-      } else if (value.length() == 6) {
-        value = "FF" + value;
-      }
-
-      // this is a RRGGBB or AARRGGBB value
-
-      // Integer.parseInt will fail to inferFromValue strings like "ff191919", so we use
-      // a Long, but cast the result back into an int, since we know that we're only
-      // dealing with 32 bit values.
-      return (int) Long.parseLong(value, 16);
-    }
-
-    throw new NumberFormatException();
+    return MetaData.getColor(value);
   }
 
   /**


### PR DESCRIPTION
This commit removes the code duplication between `MetaData` and `ResourceHelper` for the `getColor` method by using the implementation of `MetaData` in `ResourceHelper`.
I've also added some tests to `ResourceHelper.getColor()`.