### PR TITLE
Validate listener in `ShadowAccountManager#addOnAccountsUpdatedListener()`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowAccountManagerTest.java
@@ -3,6 +3,7 @@ package org.robolectric.shadows;
 import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
 import static android.os.Build.VERSION_CODES.O;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.shadows.ShadowLooper.shadowMainLooper;
@@ -456,15 +457,24 @@ public class ShadowAccountManagerTest {
   }
 
   @Test
+  public void testAccountsUpdateListener_nullListener() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> am.addOnAccountsUpdatedListener(null, null, false));
+    assertThat(exception).hasMessageThat().isEqualTo("the listener is null");
+  }
+
+  @Test
   public void testAccountsUpdateListener_duplicate() {
     TestOnAccountsUpdateListener listener = new TestOnAccountsUpdateListener();
     am.addOnAccountsUpdatedListener(listener, null, false);
-    am.addOnAccountsUpdatedListener(listener, null, false);
-    assertThat(listener.getInvocationCount()).isEqualTo(0);
 
-    Account account = new Account("name", "type");
-    shadowOf(am).addAccount(account);
-    assertThat(listener.getInvocationCount()).isEqualTo(1);
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> am.addOnAccountsUpdatedListener(listener, null, false));
+    assertThat(exception).hasMessageThat().isEqualTo("this listener is already added");
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAccountManager.java
@@ -263,9 +263,12 @@ public class ShadowAccountManager {
       @Nullable Handler handler,
       boolean updateImmediately,
       @Nullable String[] accountTypes) {
-    // TODO: Match real method behavior by throwing IllegalStateException.
+    if (listener == null) {
+      throw new IllegalArgumentException("the listener is null");
+    }
+
     if (listeners.containsKey(listener)) {
-      return;
+      throw new IllegalStateException("this listener is already added");
     }
 
     Set<String> types = null;


### PR DESCRIPTION
This commit addresses the TODO in `ShadowAccountManager#addOnAccountsUpdatedListener()` to:
- Check that the provided listener is not `null`.
- Check that the provided listener was not already added.

These changes align our implementation with the Android one: https://developer.android.com/reference/kotlin/android/accounts/AccountManager?hl=en#addonaccountsupdatedlistener_1

<img width="870" alt="Screenshot 2025-06-06 at 09 40 54" src="https://github.com/user-attachments/assets/ce415ded-d896-45c9-b797-42e9085c8cd0" />