### PR TITLE
Reuse `ShadowUIModeManager` in `ShadowUIModeManagerTest`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowUIModeManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowUIModeManagerTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadow.api.Shadow;
 
 /** Tests for {@link ShadowUIModeManager}. */
 @RunWith(AndroidJUnit4.class)
@@ -34,28 +33,28 @@ public class ShadowUIModeManagerTest {
   public void setUp() {
     context = ApplicationProvider.getApplicationContext();
     uiModeManager = (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
-    shadowUiModeManager = Shadow.extract(uiModeManager);
+    shadowUiModeManager = shadowOf(uiModeManager);
   }
 
   @Test
   @Config(minSdk = M)
   public void testModeSwitch() {
     assertThat(uiModeManager.getCurrentModeType()).isEqualTo(Configuration.UI_MODE_TYPE_UNDEFINED);
-    assertThat(shadowOf(uiModeManager).getLastFlags()).isEqualTo(0);
+    assertThat(shadowUiModeManager.getLastFlags()).isEqualTo(0);
 
     uiModeManager.enableCarMode(1);
     assertThat(uiModeManager.getCurrentModeType()).isEqualTo(Configuration.UI_MODE_TYPE_CAR);
-    assertThat(shadowOf(uiModeManager).getLastFlags()).isEqualTo(1);
+    assertThat(shadowUiModeManager.getLastFlags()).isEqualTo(1);
 
     uiModeManager.disableCarMode(2);
     assertThat(uiModeManager.getCurrentModeType()).isEqualTo(Configuration.UI_MODE_TYPE_NORMAL);
-    assertThat(shadowOf(uiModeManager).getLastFlags()).isEqualTo(2);
+    assertThat(shadowUiModeManager.getLastFlags()).isEqualTo(2);
   }
 
   @Test
   public void testModeType() {
     assertThat(uiModeManager.getCurrentModeType()).isEqualTo(Configuration.UI_MODE_TYPE_UNDEFINED);
-    shadowOf(uiModeManager).setCurrentModeType(Configuration.UI_MODE_TYPE_DESK);
+    shadowUiModeManager.setCurrentModeType(Configuration.UI_MODE_TYPE_DESK);
     assertThat(uiModeManager.getCurrentModeType()).isEqualTo(Configuration.UI_MODE_TYPE_DESK);
   }
 
@@ -66,8 +65,8 @@ public class ShadowUIModeManagerTest {
     int flags = 1;
     uiModeManager.enableCarMode(priority, flags);
     assertThat(uiModeManager.getCurrentModeType()).isEqualTo(Configuration.UI_MODE_TYPE_CAR);
-    assertThat(shadowOf(uiModeManager).getLastCarModePriority()).isEqualTo(priority);
-    assertThat(shadowOf(uiModeManager).getLastFlags()).isEqualTo(flags);
+    assertThat(shadowUiModeManager.getLastCarModePriority()).isEqualTo(priority);
+    assertThat(shadowUiModeManager.getLastFlags()).isEqualTo(flags);
   }
 
   private static final int INVALID_NIGHT_MODE = -4242;
@@ -145,7 +144,7 @@ public class ShadowUIModeManagerTest {
 
   @Test
   public void getDefaultIsNightModeOn_shouldBeFalse() {
-    assertThat(((ShadowUIModeManager) Shadow.extract(uiModeManager)).isNightModeOn()).isFalse();
+    assertThat(shadowUiModeManager.isNightModeOn()).isFalse();
   }
 
   @Config(minSdk = TIRAMISU)
@@ -177,7 +176,7 @@ public class ShadowUIModeManagerTest {
             uiModeManager.setNightModeActivatedForCustomMode(
                 UiModeManager.MODE_NIGHT_CUSTOM_TYPE_BEDTIME, true))
         .isTrue();
-    assertThat(((ShadowUIModeManager) Shadow.extract(uiModeManager)).isNightModeOn()).isTrue();
+    assertThat(shadowUiModeManager.isNightModeOn()).isTrue();
   }
 
   @Config(minSdk = TIRAMISU)
@@ -190,7 +189,7 @@ public class ShadowUIModeManagerTest {
             uiModeManager.setNightModeActivatedForCustomMode(
                 UiModeManager.MODE_NIGHT_CUSTOM_TYPE_BEDTIME, false))
         .isTrue();
-    assertThat(((ShadowUIModeManager) Shadow.extract(uiModeManager)).isNightModeOn()).isFalse();
+    assertThat(shadowUiModeManager.isNightModeOn()).isFalse();
   }
 
   @Config(minSdk = TIRAMISU)
@@ -199,7 +198,7 @@ public class ShadowUIModeManagerTest {
     uiModeManager.setNightModeCustomType(UiModeManager.MODE_NIGHT_CUSTOM_TYPE_BEDTIME);
 
     assertThat(uiModeManager.setNightModeActivatedForCustomMode(123, true)).isFalse();
-    assertThat(((ShadowUIModeManager) Shadow.extract(uiModeManager)).isNightModeOn()).isFalse();
+    assertThat(shadowUiModeManager.isNightModeOn()).isFalse();
   }
 
   @Config(minSdk = TIRAMISU)
@@ -211,7 +210,7 @@ public class ShadowUIModeManagerTest {
             uiModeManager.setNightModeActivatedForCustomMode(
                 UiModeManager.MODE_NIGHT_CUSTOM_TYPE_SCHEDULE, true))
         .isFalse();
-    assertThat(((ShadowUIModeManager) Shadow.extract(uiModeManager)).isNightModeOn()).isFalse();
+    assertThat(shadowUiModeManager.isNightModeOn()).isFalse();
   }
 
   @Config(minSdk = TIRAMISU)
@@ -312,7 +311,7 @@ public class ShadowUIModeManagerTest {
   public void setContrast_whenSet_valueIsReturnedByGetContrast() {
     float expectedContrast = -0.16f;
 
-    shadowOf(uiModeManager).setContrast(expectedContrast);
+    shadowUiModeManager.setContrast(expectedContrast);
 
     float actualContrast = uiModeManager.getContrast();
     assertThat(actualContrast).isEqualTo(expectedContrast);
@@ -321,13 +320,13 @@ public class ShadowUIModeManagerTest {
   @Test
   @Config(minSdk = UPSIDE_DOWN_CAKE)
   public void setContrast_whenCalledWithValueAboveOne_throws() {
-    assertThrows(IllegalArgumentException.class, () -> shadowOf(uiModeManager).setContrast(1.1f));
+    assertThrows(IllegalArgumentException.class, () -> shadowUiModeManager.setContrast(1.1f));
   }
 
   @Test
   @Config(minSdk = UPSIDE_DOWN_CAKE)
   public void setContrast_whenCalledWithValueBelowMinusOne_throws() {
-    assertThrows(IllegalArgumentException.class, () -> shadowOf(uiModeManager).setContrast(-1.1f));
+    assertThrows(IllegalArgumentException.class, () -> shadowUiModeManager.setContrast(-1.1f));
   }
 
   private void setPermissions(String... permissions) {
@@ -335,6 +334,6 @@ public class ShadowUIModeManagerTest {
     pi.packageName = context.getPackageName();
     pi.versionCode = 1;
     pi.requestedPermissions = permissions;
-    ((ShadowPackageManager) Shadow.extract(context.getPackageManager())).installPackage(pi);
+    shadowOf(context.getPackageManager()).installPackage(pi);
   }
 }


### PR DESCRIPTION
This commit replaces repetitive `shadowOf(uiModeManager)` in favor of the `shadowUiModeManager` field.

This resubmits #10356