### PR TITLE
Fix condition in `ResourceHelper#parseFloatAttribute()`

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper.java
@@ -55,8 +55,8 @@ public final class ResourceHelper {
    * Returns the TypedValue color type represented by the given string value
    *
    * @param value the color value
-   * @return the color as an int. For backwards compatibility, will return a default of ARGB8 if
-   *     value format is unrecognized.
+   * @return the TypedValue color type. For backwards compatibility, will return a default of ARGB8
+   *     if value format is unrecognized.
    */
   public static int getColorType(String value) {
     if (value != null && value.startsWith("#")) {
@@ -171,7 +171,7 @@ public final class ResourceHelper {
     }
 
     // check the first character
-    if (buf[0] < '0' && buf[0] > '9' && buf[0] != '.' && buf[0] != '-') {
+    if ((buf[0] < '0' || buf[0] > '9') && buf[0] != '.' && buf[0] != '-') {
       return false;
     }
 

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper2.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ResourceHelper2.java
@@ -106,7 +106,7 @@ public final class ResourceHelper2 {
     }
 
     // check the first character
-    if (buf[0] < '0' && buf[0] > '9' && buf[0] != '.' && buf[0] != '-') {
+    if ((buf[0] < '0' || buf[0] > '9') && buf[0] != '.' && buf[0] != '-') {
       return false;
     }
 


### PR DESCRIPTION
This commit fixes a check in the mentioned method. Before this change, the condition would always evaluate to `false`.
The same change was also applied to `ResourceHelper2`.
I'm adding tests to these classes, and they'll come in a dedicated PR.