### PR TITLE
Switch to `GetInstallerPackageNameMode.Mode.REALISTIC` by default

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/GetInstallerPackageNameMode.java
+++ b/annotations/src/main/java/org/robolectric/annotation/GetInstallerPackageNameMode.java
@@ -1,5 +1,6 @@
 package org.robolectric.annotation;
 
+import android.content.pm.PackageManager;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -7,16 +8,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A {@link org.robolectric.pluginapi.config.Configurer} annotation for controlling how Robolectric
- * executes {@code PackageManager#getInstallerPackageName} method.
+ * A {@link org.robolectric.pluginapi.config.Configurer Configurer} annotation for controlling how
+ * Robolectric executes {@link PackageManager#getInstallerPackageName} method.
  *
- * <p>'getInstallerPackageName' method in PackageManager must throw IllegalArgumentException if the
- * installer package is not present. The legacy robolectric behavior returns a null value for these
- * cases.
+ * <p>{@code getInstallerPackageName} method in {@code PackageManager} must throw an {@link
+ * IllegalArgumentException} if the installer package is not present. The legacy Robolectric
+ * behavior returns {@code null} in this case.
  *
  * <p>This annotation can be applied to tests to have Robolectric perform the legacy mechanism of
- * not throwing IllegalArgumentException and instead return 'null', when installer package name is
- * not found.
+ * not throwing {@code IllegalArgumentException} and instead return {@code null}, when installer
+ * package name is not found.
  *
  * <p>This annotation will be deleted in a forthcoming Robolectric release.
  */
@@ -29,9 +30,20 @@ public @interface GetInstallerPackageNameMode {
    * Specifies the different {@code ShadowApplicationPackageManager#getInstallerPackageName} modes.
    */
   enum Mode {
-    /** Robolectric's prior behavior when calling getInstallerPackageName method. */
+    /**
+     * Robolectric's prior behavior when calling the {@code getInstallerPackageName} method.
+     *
+     * @deprecated This mode behaves differently than the Android framework.
+     */
+    @Deprecated
     LEGACY,
-    /** The new, real behavior when calling getInstallerPackageName method. */
+
+    /**
+     * The new, real behavior when calling the {@code getInstallerPackageName} method.
+     *
+     * @deprecated This is the default mode. It doesn't need to be set explicitly.
+     */
+    @Deprecated
     REALISTIC,
   }
 

--- a/robolectric/src/main/java/org/robolectric/plugins/GetInstallerPackageNameModeConfigurer.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/GetInstallerPackageNameModeConfigurer.java
@@ -22,8 +22,7 @@ public class GetInstallerPackageNameModeConfigurer
   @Nonnull
   @Override
   public GetInstallerPackageNameMode.Mode defaultConfig() {
-    // TODO: switch to REALISTIC
-    return GetInstallerPackageNameMode.Mode.LEGACY;
+    return GetInstallerPackageNameMode.Mode.REALISTIC;
   }
 
   @Override

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerTest.java
@@ -3512,9 +3512,9 @@ public class ShadowPackageManagerTest {
 
   @Test
   public void installerPackageName() {
-    packageManager.setInstallerPackageName("target.package", "installer.package");
+    packageManager.setInstallerPackageName(context.getPackageName(), "installer.package");
 
-    assertThat(packageManager.getInstallerPackageName("target.package"))
+    assertThat(packageManager.getInstallerPackageName(context.getPackageName()))
         .isEqualTo("installer.package");
   }
 
@@ -3532,20 +3532,22 @@ public class ShadowPackageManagerTest {
       packageManager.getInstallerPackageName("target.package");
       fail("Exception expected");
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().contains("target.package");
+      assertThat(e).hasMessageThat().isEqualTo("Package is not installed: target.package");
     }
   }
 
   @Test
   @GetInstallerPackageNameMode(Mode.REALISTIC)
   public void installerPackageName_uninstalledAndRealisticSettings() {
+    packageManager.setInstallerPackageName(context.getPackageName(), "installer.pkg");
+    shadowOf(packageManager).deletePackage(context.getPackageName());
     try {
-      packageManager.setInstallerPackageName(context.getPackageName(), "installer.pkg");
-      shadowOf(packageManager).deletePackage(context.getPackageName());
       packageManager.getInstallerPackageName(context.getPackageName());
       fail("Exception expected");
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageThat().contains(context.getPackageName());
+      assertThat(e)
+          .hasMessageThat()
+          .isEqualTo("Package is not installed: " + context.getPackageName());
     }
   }
 


### PR DESCRIPTION
This commit switches the `GetInstallerPackageNameMode` mode to `REALISTIC` by default.
This `LEGACY` mode has been the default since the introduction of the configurer in #5465 (Robolectric 4.4).
This also deprecates the two modes, so they can be removed in a future version of Robolectric.