### PR TITLE
Update the `simulator-gradle-plugin` to depends on AGP `gradle-api`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -135,7 +135,6 @@ test-parameter-injector = "1.18"
 gradle-plugin-publish = "1.3.1"
 
 [libraries]
-android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
 android-gradle-api = { module = "com.android.tools.build:gradle-api", version.ref = "android-gradle" }
 
 android-tools-common = { module = "com.android.tools:common", version.ref = "android-tools-common" }

--- a/simulator-gradle-plugin/build.gradle.kts
+++ b/simulator-gradle-plugin/build.gradle.kts
@@ -29,6 +29,6 @@ afterEvaluate {
 }
 
 dependencies {
-  compileOnly(libs.android.gradle)
+  compileOnly(libs.android.gradle.api)
   implementation(libs.kotlin.stdlib)
 }

--- a/simulator-gradle-plugin/src/main/kotlin/org/robolectric/simulator/gradle/SimulatorPlugin.kt
+++ b/simulator-gradle-plugin/src/main/kotlin/org/robolectric/simulator/gradle/SimulatorPlugin.kt
@@ -1,12 +1,14 @@
 package org.robolectric.simulator.gradle
 
-import com.android.build.gradle.AppExtension
+import com.android.build.gradle.AppPlugin
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.getByName
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
 
 /** A plugin to launch the Robolectric simulator. */
 class SimulatorPlugin : Plugin<Project> {
@@ -18,22 +20,14 @@ class SimulatorPlugin : Plugin<Project> {
   }
 
   override fun apply(project: Project) {
-    val androidExtension = getAndroidExtension(project)
-    if (androidExtension == null) {
-      return
-    }
-
-    project.afterEvaluate {
-      project.tasks.register("simulate", JavaExec::class.java) {
+    project.plugins.withType<AppPlugin> {
+      project.tasks.register<JavaExec>("simulate") {
         group = "simulation"
         description = "Runs the Robolectric simulator"
         configureTask(project, this)
       }
     }
   }
-
-  private fun getAndroidExtension(project: Project) =
-    project.extensions.findByType(AppExtension::class.java)
 
   /** Checks if a version string is at least 4.15, when the simulator was introduced. */
   private fun supportsSimulator(currentVersion: String): Boolean {


### PR DESCRIPTION
Make the simulator Gradle plugin more flexible by not assuming the order in which plugins are defined.
This also depends on AGP's `gradle-api` artefact instead of `gradle`.