### PR TITLE
Enable stricter plugin validation

### DIFF
--- a/simulator-gradle-plugin/build.gradle.kts
+++ b/simulator-gradle-plugin/build.gradle.kts
@@ -32,3 +32,8 @@ dependencies {
   compileOnly(libs.android.gradle.api)
   implementation(libs.kotlin.stdlib)
 }
+
+tasks.validatePlugins {
+  failOnWarning = true
+  enableStricterValidation = true
+}


### PR DESCRIPTION
* failOnWarning causes the build to fail when there is a validation warning.
* enableStricterValidation performs more advanced checks during validation.

For #10382
