### PR TITLE
Add more information to the generated POM file

### DIFF
--- a/buildSrc/src/main/java/org/robolectric/gradle/PomMetadata.kt
+++ b/buildSrc/src/main/java/org/robolectric/gradle/PomMetadata.kt
@@ -7,7 +7,7 @@ fun MavenPublication.applyPomMetadata(project: Project) {
   pom {
     name.set(project.name)
     description.set("An alternative Android testing framework.")
-    url.set("http://robolectric.org")
+    url.set("https://robolectric.org")
 
     licenses {
       license {
@@ -27,19 +27,46 @@ fun MavenPublication.applyPomMetadata(project: Project) {
         name.set("Brett Chabot")
         email.set("brettchabot@google.com")
         organization.set("Google Inc.")
-        organizationUrl.set("http://google.com")
+        organizationUrl.set("https://google.com")
       }
 
       developer {
         name.set("Michael Hoisie")
         email.set("hoisie@google.com")
         organization.set("Google Inc.")
-        organizationUrl.set("http://google.com")
+        organizationUrl.set("https://google.com")
       }
 
       developer {
         name.set("Christian Williams")
         email.set("antixian666@gmail.com")
+      }
+    }
+
+    issueManagement {
+      system.set("GitHub Issues")
+      url.set("https://github.com/robolectric/robolectric/issues")
+    }
+
+    ciManagement {
+      system.set("GitHub Actions")
+      url.set("https://github.com/robolectric/robolectric/actions")
+    }
+
+    // TODO Simplify this once https://github.com/gradle/gradle/issues/28759 is released
+    withXml {
+      asNode().appendNode("distributionManagement").apply {
+        appendNode("repository").apply {
+          appendNode("id", "sonatype-nexus")
+          appendNode("name", "Sonatype Nexus")
+          appendNode("url", "https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+        }
+
+        appendNode("snapshotRepository").apply {
+          appendNode("id", "sonatype-nexus-snapshots")
+          appendNode("name", "Sonatype Nexus Snapshots")
+          appendNode("url", "https://oss.sonatype.org/content/repositories/snapshots/")
+        }
       }
     }
   }


### PR DESCRIPTION
This commit adds more information to the deployed `pom.xml` file:
- Add a link to the issues.
- Add a link to the CI.
- Add information about where the artefacts are deployed.

It also switches the URLs to use HTTPS.