### PR TITLE
Bump the snapshot version to 4.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,6 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.robolectric:robolectric:4.15-SNAPSHOT"
+    testImplementation "org.robolectric:robolectric:4.16-SNAPSHOT"
 }
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-thisVersion=4.15-SNAPSHOT
+thisVersion=4.16-SNAPSHOT
 
 # This project uses AndroidX instead of Support Libraries
 # https://developer.android.com/jetpack/androidx/migrate#migrate_an_existing_project_using_android_studio


### PR DESCRIPTION
This commit updates the snapshot version to 4.16 in the Readme and `gradle.properties` files.