### PR TITLE
Support Java 11 in the simulator gradle plugin

### DIFF
--- a/simulator-gradle-plugin/build.gradle.kts
+++ b/simulator-gradle-plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
   alias(libs.plugins.gradle.plugin.publish)
   `kotlin-dsl`
@@ -22,6 +24,13 @@ gradlePlugin {
     }
   }
 }
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_11
+  targetCompatibility = JavaVersion.VERSION_11
+}
+
+kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_11 } }
 
 afterEvaluate {
   val isSnapshotVersion = project.version.toString().endsWith("-SNAPSHOT")


### PR DESCRIPTION
This will make it possible to simulate Android T and Android S using Java 11.
