### PR TITLE
Replace `Asset#toIntExact()` with `Math#toIntExact()`

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/Asset.java
+++ b/resources/src/main/java/org/robolectric/res/android/Asset.java
@@ -755,7 +755,7 @@ public abstract class Asset {
       }
 
       /* adjust count if we're near EOF */
-      maxLen = toIntExact(mLength - mOffset);
+      maxLen = Math.toIntExact(mLength - mOffset);
       if (count > maxLen) count = maxLen;
 
       if (!isTruthy(count)) {
@@ -766,13 +766,13 @@ public abstract class Asset {
         /* copy from mapped area */
         // printf("map read\n");
         // memcpy(buf, (String)mMap.getDataPtr() + mOffset, count);
-        System.arraycopy(mMap.getDataPtr(), toIntExact(mOffset), buf, bufOffset, count);
+        System.arraycopy(mMap.getDataPtr(), Math.toIntExact(mOffset), buf, bufOffset, count);
         actual = count;
       } else if (mBuf != null) {
         /* copy from buffer */
         // printf("buf read\n");
         // memcpy(buf, (String)mBuf + mOffset, count);
-        System.arraycopy(mBuf, toIntExact(mOffset), buf, bufOffset, count);
+        System.arraycopy(mBuf, Math.toIntExact(mOffset), buf, bufOffset, count);
         actual = count;
       } else {
         /* read from the file */
@@ -886,7 +886,7 @@ public abstract class Asset {
 
         /* zero-length files are allowed; not sure about zero-len allocs */
         /* (works fine with gcc + x86linux) */
-        allocLen = toIntExact(mLength);
+        allocLen = Math.toIntExact(mLength);
         if (mLength == 0) allocLen = 1;
 
         buf = new byte[allocLen];
@@ -903,7 +903,7 @@ public abstract class Asset {
             // fseek(mFp, mStart, SEEK_SET);
             mFp.seek(mStart);
             // if (fread(buf, 1, mLength, mFp) != (size_t) mLength) {
-            if (mFp.read(buf, 0, toIntExact(mLength)) != (int) mLength) {
+            if (mFp.read(buf, 0, Math.toIntExact(mLength)) != (int) mLength) {
               ALOGE("failed reading %d bytes\n", mLength);
               // delete[] buf;
               return null;
@@ -924,7 +924,7 @@ public abstract class Asset {
 
         map = new FileMap();
         // if (!map.create(null, fileno(mFp), mStart, mLength, true)) {
-        if (!map.create(null, -1, mStart, toIntExact(mLength), true)) {
+        if (!map.create(null, -1, mStart, Math.toIntExact(mLength), true)) {
           // delete map;
           return null;
         }
@@ -1247,7 +1247,7 @@ public abstract class Asset {
       assert (mBuf != null);
 
       /* adjust count if we're near EOF */
-      maxLen = toIntExact(mUncompressedLen - mOffset);
+      maxLen = Math.toIntExact(mUncompressedLen - mOffset);
       if (count > maxLen) count = maxLen;
 
       if (!isTruthy(count)) return 0;
@@ -1255,7 +1255,7 @@ public abstract class Asset {
       /* copy from buffer */
       // printf("comp buf read\n");
       //      memcpy(buf, (String)mBuf + mOffset, count);
-      System.arraycopy(mBuf, toIntExact(mOffset), buf, bufOffset, count);
+      System.arraycopy(mBuf, Math.toIntExact(mOffset), buf, bufOffset, count);
       actual = count;
       //       }
 
@@ -1371,13 +1371,5 @@ public abstract class Asset {
     public String toString() {
       return "_CompressedAsset{mMap=" + mMap + '}';
     }
-  }
-
-  // todo: remove when Android supports this
-  static int toIntExact(long value) {
-    if ((int) value != value) {
-      throw new ArithmeticException("integer overflow");
-    }
-    return (int) value;
   }
 }

--- a/resources/src/main/java/org/robolectric/res/android/CppAssetManager.java
+++ b/resources/src/main/java/org/robolectric/res/android/CppAssetManager.java
@@ -1,6 +1,5 @@
 package org.robolectric.res.android;
 
-import static org.robolectric.res.android.Asset.toIntExact;
 import static org.robolectric.res.android.CppAssetManager.FileType.kFileTypeDirectory;
 import static org.robolectric.res.android.Util.ALOGD;
 import static org.robolectric.res.android.Util.ALOGE;
@@ -986,7 +985,7 @@ public class CppAssetManager {
           "Opened uncompressed entry %s in zip %s mode %s: %s",
           entryName.string(), pZipFile.mFileName, mode, pAsset);
     } else {
-      pAsset = Asset.createFromCompressedMap(dataMap, toIntExact(uncompressedLen.get()), mode);
+      pAsset = Asset.createFromCompressedMap(dataMap, Math.toIntExact(uncompressedLen.get()), mode);
       ALOGV(
           "Opened compressed entry %s in zip %s mode %s: %s",
           entryName.string(), pZipFile.mFileName, mode, pAsset);

--- a/resources/src/main/java/org/robolectric/res/android/FileMap.java
+++ b/resources/src/main/java/org/robolectric/res/android/FileMap.java
@@ -2,7 +2,6 @@ package org.robolectric.res.android;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.robolectric.res.android.Asset.toIntExact;
 import static org.robolectric.res.android.Util.ALOGV;
 
 import com.google.common.collect.ImmutableMap;
@@ -198,7 +197,7 @@ public class FileMap {
     // mBaseLength = adjLength;
     mDataOffset = offset;
     // mDataPtr = mBasePtr + adjust;
-    mDataLength = toIntExact(entry.getSize());
+    mDataLength = Math.toIntExact(entry.getSize());
 
     // assert(mBasePtr != 0);
 

--- a/resources/src/main/java/org/robolectric/res/android/ZipFileRO.java
+++ b/resources/src/main/java/org/robolectric/res/android/ZipFileRO.java
@@ -1,6 +1,5 @@
 package org.robolectric.res.android;
 
-import static org.robolectric.res.android.Asset.toIntExact;
 import static org.robolectric.res.android.Errors.NAME_NOT_FOUND;
 import static org.robolectric.res.android.Errors.NO_ERROR;
 import static org.robolectric.res.android.Util.ALOGW;
@@ -285,7 +284,7 @@ public class ZipFileRO {
         mHandle.zipFile,
         entry.entry,
         entry.dataOffset,
-        toIntExact(entry.entry.getCompressedSize()),
+        Math.toIntExact(entry.entry.getCompressedSize()),
         true)) {
       // delete newMap;
       return null;


### PR DESCRIPTION
Robolectric now uses Java 8, allowing us to use that method directly.