### PR TITLE
Update deprecation message in `ShadowRoleManager`

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRoleManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowRoleManager.java
@@ -170,7 +170,7 @@ public class ShadowRoleManager {
   }
 
   /**
-   * Remove a role previously added via {@link #addHeldRole(String)}.
+   * Remove a role previously added via {@link #addRoleHolder(String, String, UserHandle)}.
    *
    * @deprecated - Please use {@link ShadowRoleManager#removeRoleHolder}
    */
@@ -191,7 +191,7 @@ public class ShadowRoleManager {
   }
 
   /**
-   * Remove a role previously added via {@link #addAvailableRole(String)}.
+   * Remove a role previously added via {@link #addRoleHolder(String, String, UserHandle)}.
    *
    * @deprecated - Please use {@link ShadowRoleManager#removeRoleHolder}
    */


### PR DESCRIPTION
This Javadoc of the `removeHeldRole()` and `removeAvailableRole()` was pointing to a deprecated method.
This commit changes these Javadoc to mention the recommended alternatives instead.