### PR TITLE
Add `addedInSdk` attribute to `@ClassName`

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/ClassName.java
+++ b/annotations/src/main/java/org/robolectric/annotation/ClassName.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
  *    // Generally, &#64;ClassName will be used together with Object type.
  *    &#64;Implementation
  *    public &#64;ClassName("com.android.RealReturnType") Object setBar(
- *        &#64;ClassName("com.android.RealClassName") Object para1,
+ *        &#64;ClassName("com.android.RealClassName", addedInSdk = 36) Object para1,
  *        int para2,
  *        String para3) {
  *
@@ -39,4 +39,7 @@ public @interface ClassName {
    * Class#getCanonicalName()}; e.g. {@code Foo$Bar} instead of {@code Foo.Bar}.
    */
   String value();
+
+  /** The SDK version in which the class was introduced. */
+  int addedInSdk() default Implementation.DEFAULT_SDK;
 }


### PR DESCRIPTION
This allows specifying the SDK version in which a class referenced by `@ClassName` was introduced. This is helpful when bumping the min SDK version, since we can easily find the `@ClassName` that are no longer needed.

This commit only focuses on adding the argument to confirm that this suggestion is valid. Then I'll submit other PRs to add it to the various usages of `@ClassName`.