### PR TITLE
Remove deprecated methods in `:shadows:httpclient`

### DIFF
--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttp.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttp.java
@@ -1,6 +1,5 @@
 package org.robolectric.shadows.httpclient;
 
-import com.google.errorprone.annotations.InlineMe;
 import java.util.List;
 import org.apache.http.Header;
 import org.apache.http.HttpRequest;
@@ -20,25 +19,6 @@ public class FakeHttp {
   public static void addPendingHttpResponse(
       int statusCode, String responseBody, Header... headers) {
     getFakeHttpLayer().addPendingHttpResponse(statusCode, responseBody, headers);
-  }
-
-  /**
-   * Sets up an HTTP response to be returned by calls to Apache's {@code HttpClient} implementers.
-   *
-   * @param statusCode the status code of the response
-   * @param responseBody the body of the response
-   * @param contentType the contentType of the response
-   * @deprecated use {@link #addPendingHttpResponse(int, String, org.apache.http.Header...)} instead
-   */
-  @Deprecated
-  @InlineMe(
-      replacement =
-          "FakeHttp.getFakeHttpLayer().addPendingHttpResponse(statusCode, responseBody,"
-              + " contentType)",
-      imports = "org.robolectric.shadows.httpclient.FakeHttp")
-  public static void addPendingHttpResponseWithContentType(
-      int statusCode, String responseBody, Header contentType) {
-    getFakeHttpLayer().addPendingHttpResponse(statusCode, responseBody, contentType);
   }
 
   /**

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
@@ -1,6 +1,5 @@
 package org.robolectric.shadows.httpclient;
 
-import com.google.errorprone.annotations.InlineMe;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -134,22 +133,6 @@ public class ShadowDefaultRequestDirector {
         params);
   }
 
-  /**
-   * Get the sent {@link HttpRequest} for the given index.
-   *
-   * @param index The index
-   * @deprecated Use {@link FakeHttp#getSentHttpRequestInfo(int)} instead. This method will be
-   *     removed in Robolectric 4.13.
-   * @return HttpRequest
-   */
-  @Deprecated
-  @InlineMe(
-      replacement = "FakeHttp.getFakeHttpLayer().getSentHttpRequestInfo(index).getHttpRequest()",
-      imports = "org.robolectric.shadows.httpclient.FakeHttp")
-  public static HttpRequest getSentHttpRequest(int index) {
-    return FakeHttp.getFakeHttpLayer().getSentHttpRequestInfo(index).getHttpRequest();
-  }
-
   public static HttpRequest getLatestSentHttpRequest() {
     return getLatestSentHttpRequestInfo().getHttpRequest();
   }
@@ -157,22 +140,6 @@ public class ShadowDefaultRequestDirector {
   public static HttpRequestInfo getLatestSentHttpRequestInfo() {
     int requestCount = FakeHttp.getFakeHttpLayer().getSentHttpRequestInfos().size();
     return FakeHttp.getFakeHttpLayer().getSentHttpRequestInfo(requestCount - 1);
-  }
-
-  /**
-   * Get the sent {@link HttpRequestInfo} for the given index.
-   *
-   * @param index The index
-   * @deprecated Use {@link FakeHttp#getSentHttpRequest(int)} instead. This method will be removed
-   *     in Robolectric 4.13.
-   * @return HttpRequestInfo
-   */
-  @Deprecated
-  @InlineMe(
-      replacement = "FakeHttp.getFakeHttpLayer().getSentHttpRequestInfo(index)",
-      imports = "org.robolectric.shadows.httpclient.FakeHttp")
-  public static HttpRequestInfo getSentHttpRequestInfo(int index) {
-    return FakeHttp.getFakeHttpLayer().getSentHttpRequestInfo(index);
   }
 
   @Implementation


### PR DESCRIPTION
These methods have been deprecated for a long time, and they have a straightforward replacement.