### PR TITLE
Added custom ThreadFactory to name threads in LocalUiController

### DIFF
--- a/robolectric/src/main/java/org/robolectric/android/internal/LocalUiController.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/LocalUiController.java
@@ -32,7 +32,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowLooper;
@@ -46,7 +48,16 @@ public class LocalUiController implements UiController {
 
   private static long idlingResourceErrorTimeoutMs = SECONDS.toMillis(26);
   private final HashSet<IdlingResourceProxyImpl> syncedIdlingResources = new HashSet<>();
-  private final ExecutorService looperIdlingExecutor = Executors.newCachedThreadPool();
+  private final ExecutorService looperIdlingExecutor =
+      Executors.newCachedThreadPool(
+          new ThreadFactory() {
+            private final AtomicInteger count = new AtomicInteger(1);
+
+            @Override
+            public Thread newThread(Runnable r) {
+              return new Thread(r, "LocalUiController-" + count.getAndIncrement());
+            }
+          });
 
   /**
    * Sets the error timeout for idling resources.


### PR DESCRIPTION
### Overview

### Proposed Changes
Added a custom ThreadFactory to the ExecutorService in LocalUiController so that created threads have descriptive names :) .

### Why This Change?
- Makes it easier to identify and debug threads.
- Helps in thread allowlist checks and improves maintainability.

Fixes #10291