### PR TITLE
Specify POM file when installing local android prebuilt

### DIFF
--- a/scripts/install-android-prebuilt.sh
+++ b/scripts/install-android-prebuilt.sh
@@ -64,25 +64,26 @@ build_signed_packages() {
 mavenize() {
     local FILE_NAME_BASE=android-all-${ROBOLECTRIC_VERSION}
     mvn install:install-file \
-      -Dfile=${JAR_DIR}/${FILE_NAME_BASE}.jar \
+      -Dfile="${JAR_DIR}/${FILE_NAME_BASE}.jar" \
       -DgroupId=org.robolectric \
       -DartifactId=android-all \
-      -Dversion=${ROBOLECTRIC_VERSION} \
-      -Dpackaging=jar
+      -Dversion="${ROBOLECTRIC_VERSION}" \
+      -Dpackaging=jar \
+      -DpomFile="${JAR_DIR}/${ANDROID_ALL_POM}"
 
     mvn install:install-file \
-      -Dfile=${JAR_DIR}/${FILE_NAME_BASE}-sources.jar \
+      -Dfile="${JAR_DIR}/${FILE_NAME_BASE}-sources.jar" \
       -DgroupId=org.robolectric \
       -DartifactId=android-all \
-      -Dversion=${ROBOLECTRIC_VERSION} \
+      -Dversion="${ROBOLECTRIC_VERSION}" \
       -Dpackaging=jar \
       -Dclassifier=sources
 
     mvn install:install-file \
-      -Dfile=${JAR_DIR}/${FILE_NAME_BASE}-javadoc.jar \
+      -Dfile="${JAR_DIR}/${FILE_NAME_BASE}-javadoc.jar" \
       -DgroupId=org.robolectric \
       -DartifactId=android-all \
-      -Dversion=${ROBOLECTRIC_VERSION} \
+      -Dversion="${ROBOLECTRIC_VERSION}" \
       -Dpackaging=jar \
       -Dclassifier=javadoc
 }

--- a/scripts/pom_template.xml
+++ b/scripts/pom_template.xml
@@ -5,11 +5,6 @@
     <artifactId>ARTIFACT_ID</artifactId>
     <version>VERSION</version>
     <packaging>jar</packaging>
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>9</version>
-    </parent>
     <name>Google Android ARTIFACT_ID Library</name>
     <description>
         A library jar that provides APIs for Applications written for the Google Android Platform.


### PR DESCRIPTION
When you install a jar file with the 'mvn' command but don't specify a POM file, 'mvn' tries to generate one for you. For some reason the 'mvn' on my local mac generates a bogus POM file that breaks the Robolectric build. Add the '-DpomFile' argument to specify the exact POM file. Also, remove some bogus items from the POM template.
