### PR TITLE
fix native library loading failing due to logging

### DIFF
--- a/nativeruntime/src/main/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoader.java
+++ b/nativeruntime/src/main/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoader.java
@@ -376,7 +376,7 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
   private void loadLibrary(TempDirectory tempDirectory) throws IOException {
     Path libraryPath = tempDirectory.getBasePath().resolve(libraryName());
     URL libraryResource = Resources.getResource(nativeLibraryPath());
-    Logger.info("Loading android native library from: " + libraryResource);
+    Logger.info("Loading android native library from: %s", libraryResource);
     Resources.asByteSource(libraryResource).copyTo(Files.asByteSink(libraryPath.toFile()));
     System.load(libraryPath.toAbsolutePath().toString());
   }


### PR DESCRIPTION
### Overview

`DefaultNativeRuntimeLoader` may (seemingly silently?) fail to load the native runtime due to a malformed log format string. `Logger.info` accepts a format string and arguments, which are ultimately passed to `printf`, but this call site passes a single string containing the `toString` of a `URL`. URLs may contain encoded characters (e.g. `%2d` for `-`) which will be interpreted as format directives, leading to `MissingFormatArgumentException` being thrown.

This exception seems to be swallowed (it doesn't seem to fail any tests?), but `loaded` is set to `true` regardless and therefore linking with any native APIs will cause tests to fail with `UnsatisfiedLinkError` (making the root cause of this problem quite obscure).

### Proposed Changes

This PR fixes the log statement to use a format argument for the URL. For others coming across this bug, a temporary workaround is to set the `robolectric.logging.enabled` system property to `false` (but you will not get any logging from Robolectric).
