### PR TITLE
Use Java 21 for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,6 +60,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version-file: .github/.java-version
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -216,3 +216,7 @@ val prefetchDependencies by
       } // End allprojects
     } // End doLast
   } // End task registration
+
+// The following line sets the CodeQL GitHub Action to use JDK 21:
+// languageVersion = JavaLanguageVersion.of(21)
+// See https://github.com/github/codeql-action/issues/1855


### PR DESCRIPTION
This is required for Android B, which uses Java 21 class bytecode.
