### PR TITLE
Update shadows/httpclient to use prebuilt legacy http client for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,8 +68,7 @@ jobs:
           -Drobolectric.alwaysIncludeVariantMarkersInTestName=true \
           -Dorg.gradle.workers.max=2 \
           -x :integration_tests:nativegraphics:test \
-          -x :integration_tests:roborazzi:test \
-          -x :shadows:httpclient:test # TODO(hoisie) - Re-enable once fixed.
+          -x :integration_tests:roborazzi:test
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4

--- a/buildSrc/src/main/java/AndroidSdk.kt
+++ b/buildSrc/src/main/java/AndroidSdk.kt
@@ -50,8 +50,6 @@ class AndroidSdk(
   companion object {
     private const val PREINSTRUMENTED_VERSION = 7
 
-    // TODO: remove LOLLIPOP_MR1 once shadows/httpclient is compiled against org.apache.http.legacy
-    val LOLLIPOP_MR1 = AndroidSdk(22, "5.1.1_r9", "r2")
     val M = AndroidSdk(23, "6.0.1_r3", "r1")
     val N = AndroidSdk(24, "7.0.0_r1", "r1")
     val N_MR1 = AndroidSdk(25, "7.1.0_r7", "r1")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -128,6 +128,9 @@ play-services-for-shadows = "17.0.0"
 # https://developers.google.com/android/guides/releases
 play-services-basement = "18.0.1"
 
+# Only used for shadows/httpclient tests
+legacy-apache-http-client = "1.0"
+
 [libraries]
 android-gradle-api = { module = "com.android.tools.build:gradle-api", version.ref = "android-gradle" }
 
@@ -245,6 +248,9 @@ spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.re
 
 # Not used, but helps Renovate trigger updates for Jacoco
 jacoco-agent = { module = "org.jacoco:org.jacoco.agent", version.ref = "jacoco" }
+
+# Only used for shadows/httpclient tests
+legacy-apache-http-client = { module = "org.robolectric:legacy-apache-http-client-for-robolectric-testing", version.ref = "legacy-apache-http-client" }
 
 [bundles]
 play-services-for-shadows = ["androidx-fragment-for-shadows", "play-services-auth-for-shadows", "play-services-base-for-shadows", "play-services-basement-for-shadows"]

--- a/shadows/httpclient/build.gradle.kts
+++ b/shadows/httpclient/build.gradle.kts
@@ -20,15 +20,15 @@ dependencies {
   // We should keep httpclient version for low level API compatibility.
   earlyRuntime(libs.apache.http.core)
   api(libs.apache.http.client)
-  compileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates)
+  compileOnly(AndroidSdk.MAX_SDK.coordinates)
+  compileOnly(libs.legacy.apache.http.client)
 
   testImplementation(project(":robolectric"))
   testImplementation(libs.junit4)
   testImplementation(libs.truth)
   testImplementation("androidx.test.ext:junit:$axtJunitVersion@aar")
-
-  testCompileOnly(AndroidSdk.LOLLIPOP_MR1.coordinates)
-  testRuntimeOnly(AndroidSdk.S.coordinates)
+  testImplementation(libs.legacy.apache.http.client)
+  testImplementation(AndroidSdk.MAX_SDK.coordinates)
 }
 
 // httpcore needs to come before android-all on runtime classpath; the gradle IntelliJ plugin


### PR DESCRIPTION
Update shadows/httpclient to use prebuilt legacy http client for tests

This change adds a dependency on
`org.robolectric:legacy-apache-http-client-for-robolectric-testing` for the
`shadows/httpclient` module. This is necessary because LOLLIPOP was removed
from Robolctric, which is the last version that contained the legacy/obsolete
Android http client.
