### PR TITLE
Remove unused method in `AndroidVersionInitTools`

### DIFF
--- a/annotations/src/main/java/org/robolectric/versioning/AndroidVersionInitTools.java
+++ b/annotations/src/main/java/org/robolectric/versioning/AndroidVersionInitTools.java
@@ -1,7 +1,6 @@
 package org.robolectric.versioning;
 
 import java.io.IOException;
-import java.util.Properties;
 import java.util.jar.JarFile;
 import org.robolectric.versioning.AndroidVersions.AndroidRelease;
 
@@ -15,9 +14,5 @@ public final class AndroidVersionInitTools {
 
   public static AndroidRelease computeReleaseVersion(JarFile jarFile) throws IOException {
     return AndroidVersions.computeReleaseVersion(jarFile);
-  }
-
-  public static AndroidRelease computeCurrentSdkFromBuildProps(Properties buildProps) {
-    return AndroidVersions.computeCurrentSdkFromBuildProps(buildProps);
   }
 }


### PR DESCRIPTION
This commit removes the unused `computeCurrentSdkFromBuildProps()` method from `AndroidVersionInitTools`.
It didn't go through the usual deprecation process. Let me know if I should deprecate it first.