### PR TITLE
Disable parallel for aggregateDocs task temporarily

### DIFF
--- a/.github/workflows/gradle_tasks_validation.yml
+++ b/.github/workflows/gradle_tasks_validation.yml
@@ -34,7 +34,8 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Run aggregateDocs
-        run: ./gradlew clean aggregateDocs
+        # Disable parallel as a workaround for Gradle 9's concurrent model.
+        run: ./gradlew clean aggregateDocs --no-parallel
 
       - name: Upload docs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
It's a workaround to make it work with Gradle 9's new concurrent model.