### PR TITLE
Remove spaces around `=` in XML files

### DIFF
--- a/integration_tests/androidx_test/src/test/AndroidManifest-ActivityScenario.xml
+++ b/integration_tests/androidx_test/src/test/AndroidManifest-ActivityScenario.xml
@@ -14,13 +14,13 @@
         android:exported="true"/>
     <activity
         android:name="org.robolectric.integrationtests.axt.ActivityScenarioTest$TranscriptActivity"
-        android:exported = "true"/>
+        android:exported="true"/>
     <activity
         android:name="org.robolectric.integrationtests.axt.ActivityScenarioTest$ActivityWithCustomConstructor"
         android:exported="true"/>
     <activity
         android:name="org.robolectric.integrationtests.axt.ActivityScenarioTest$OnCreatePackageNameActivity"
-        android:exported = "true"/>
+        android:exported="true"/>
     <activity-alias
         android:name="org.robolectric.integrationtests.axt.ActivityScenarioTestAlias"
         android:targetActivity="org.robolectric.integrationtests.axt.ActivityScenarioTest$TranscriptActivity" />

--- a/integration_tests/androidx_test/src/test/AndroidManifest-Intents.xml
+++ b/integration_tests/androidx_test/src/test/AndroidManifest-Intents.xml
@@ -10,7 +10,7 @@
   <application>
     <activity
         android:name="org.robolectric.integrationtests.axt.IntentsTest$ResultCapturingActivity"
-        android:exported = "true">
+        android:exported="true">
         </activity>
   </application>
 

--- a/integration_tests/nativegraphics/src/main/res/drawable/vector_icon_transformation_6.xml
+++ b/integration_tests/nativegraphics/src/main/res/drawable/vector_icon_transformation_6.xml
@@ -18,7 +18,7 @@
         android:width="64dp"
         android:viewportHeight="400"
         android:viewportWidth="400"
-        android:alpha = "0.5" >
+        android:alpha="0.5" >
 
     <group android:name="backgroundGroup">
         <path


### PR DESCRIPTION
This commit remove extra spaces around `=` in XML files.