### PR TITLE
Run SDK 36 integration tests with Emulator on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 29, 35 ]
+        api-level: [ 29, 36 ]
 
     steps:
       - name: Free disk space
@@ -115,9 +115,6 @@ jobs:
         id: determine-target
         run: |
           TARGET="google_apis"
-          if [[ ${{ matrix.api-level }} -ge 34 ]]; then
-            TARGET="aosp_atd"
-          fi
           echo "TARGET=$TARGET" >> $GITHUB_OUTPUT
 
       - name: AVD cache


### PR DESCRIPTION
Looks like emulator action is slow responsible for new aosp-atd, so this CL just switches to use google_apis always.