### PR TITLE
Update the API groups in `tests.yml`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-versions: [ '23,24,25', '26,27,28', '29,30,31', '32,33', '34,35,36' ]
+        api-versions: [ '23,24,25', '26,27,28', '29,30,31', '32,33,34', '35,36' ]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
This commit regroup the API levels in the tests matrix for GitHub Actions.