### PR TITLE
Simplify `@Config` annotation

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/Config.java
+++ b/annotations/src/main/java/org/robolectric/annotation/Config.java
@@ -425,7 +425,7 @@ public @interface Config {
       String qualifiersOverlayValue = overlayConfig.qualifiers();
       if (qualifiersOverlayValue != null && !qualifiersOverlayValue.isEmpty()) {
         if (qualifiersOverlayValue.startsWith("+")) {
-          this.qualifiers = this.qualifiers + " " + qualifiersOverlayValue;
+          this.qualifiers += " " + qualifiersOverlayValue;
         } else {
           this.qualifiers = qualifiersOverlayValue;
         }

--- a/annotations/src/main/java/org/robolectric/annotation/internal/ConfigUtils.java
+++ b/annotations/src/main/java/org/robolectric/annotation/internal/ConfigUtils.java
@@ -1,5 +1,6 @@
 package org.robolectric.annotation.internal;
 
+import android.os.Build;
 import org.robolectric.annotation.Config;
 
 public class ConfigUtils {
@@ -36,7 +37,7 @@ public class ConfigUtils {
           return Integer.parseInt(spec);
         } catch (NumberFormatException e) {
           try {
-            return (int) android.os.Build.VERSION_CODES.class.getField(part).get(null);
+            return (int) Build.VERSION_CODES.class.getField(part).get(null);
           } catch (Exception e2) {
             throw new IllegalArgumentException("unknown SDK \"" + part + "\"");
           }


### PR DESCRIPTION
This commit makes a small simplification in the `@Config` annotation when building the qualifiers list.

This also adds an import in `ConfigUtils` instead of using FQCN.