### PR TITLE
Simplify Sonatype repositories setup

### DIFF
--- a/buildSrc/src/main/java/org/robolectric/gradle/SonatypeRepositories.kt
+++ b/buildSrc/src/main/java/org/robolectric/gradle/SonatypeRepositories.kt
@@ -11,10 +11,7 @@ fun PublishingExtension.sonatypeRepositories(isSnapshotVersion: Boolean) {
   repositories {
     maven {
       name = "CentralPortal"
-      val releasesRepoUrl = PUBLISH_URL
-      val snapshotsRepoUrl = PUBLISH_SNAPSHOTS_URL
-
-      url = if (isSnapshotVersion) URI(snapshotsRepoUrl) else URI(releasesRepoUrl)
+      url = URI(if (isSnapshotVersion) PUBLISH_SNAPSHOTS_URL else PUBLISH_URL)
 
       credentials {
         username = System.getProperty("sonatype-login", System.getenv("SONATYPE_LOGIN"))


### PR DESCRIPTION
This commit removes redundant variables declaration to use the constants for the repositories definition.