### PR TITLE
Fix token in `sync_google_master.yml`

### DIFF
--- a/.github/workflows/sync_google_master.yml
+++ b/.github/workflows/sync_google_master.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Create the PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.ROBOLECTRIC_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
This commit updates the token used to create the PR in `sync_google_master.yml`.
The default one doesn't have enough rights to create PRs and have workflows to run.