### PR TITLE
Deprecate `shadows:httpclient`

### DIFF
--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/ShadowAndroidHttpClient.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/ShadowAndroidHttpClient.java
@@ -17,6 +17,10 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.util.ReflectionHelpers;
 
+/**
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
+ */
+@Deprecated
 @Implements(AndroidHttpClient.class)
 public class ShadowAndroidHttpClient {
 

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/DefaultRequestDirector.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/DefaultRequestDirector.java
@@ -131,7 +131,9 @@ import org.apache.http.protocol.HttpRequestExecutor;
  * </ul>
  *
  * @since 4.0
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
  */
+@Deprecated
 public class DefaultRequestDirector implements RequestDirector {
 
   private final Log log;

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttp.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttp.java
@@ -5,7 +5,12 @@ import org.apache.http.Header;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 
-/** Collection of static methods used interact with HTTP requests / responses. */
+/**
+ * Collection of static methods used interact with HTTP requests / responses.
+ *
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
+ */
+@Deprecated
 public class FakeHttp {
   private static FakeHttpLayer instance = new FakeHttpLayer();
 

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttpLayer.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/FakeHttpLayer.java
@@ -20,6 +20,10 @@ import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
 
+/**
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
+ */
+@Deprecated
 public class FakeHttpLayer {
   private final List<HttpResponseGenerator> pendingHttpResponses = new ArrayList<>();
   private final List<HttpRequestInfo> httpRequestInfos = new ArrayList<>();

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpEntityStub.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpEntityStub.java
@@ -9,6 +9,10 @@ import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 
+/**
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
+ */
+@Deprecated
 public class HttpEntityStub implements HttpEntity {
   @Override
   public boolean isRepeatable() {

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpRedirect.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpRedirect.java
@@ -37,7 +37,9 @@ import org.apache.http.client.methods.HttpRequestBase;
  * Redirect request (can be either GET or HEAD).
  *
  * @since 4.0
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
  */
+@Deprecated
 class HttpRedirect extends HttpRequestBase {
 
   private final String method;

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpRequestInfo.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpRequestInfo.java
@@ -5,6 +5,10 @@ import org.apache.http.HttpRequest;
 import org.apache.http.client.RequestDirector;
 import org.apache.http.protocol.HttpContext;
 
+/**
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
+ */
+@Deprecated
 public class HttpRequestInfo {
   HttpRequest httpRequest;
   HttpHost httpHost;

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpResponseGenerator.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpResponseGenerator.java
@@ -3,6 +3,10 @@ package org.robolectric.shadows.httpclient;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 
+/**
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
+ */
+@Deprecated
 public interface HttpResponseGenerator {
   HttpResponse getResponse(HttpRequest request);
 }

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpResponseStub.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/HttpResponseStub.java
@@ -9,6 +9,10 @@ import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.params.HttpParams;
 
+/**
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
+ */
+@Deprecated
 public class HttpResponseStub implements HttpResponse {
   @Override
   public StatusLine getStatusLine() {

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ParamsParser.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ParamsParser.java
@@ -13,6 +13,10 @@ import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URLEncodedUtils;
 
+/**
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
+ */
+@Deprecated
 public class ParamsParser {
 
   public static Map<String, String> parseParams(HttpRequest request) {

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/RequestMatcher.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/RequestMatcher.java
@@ -2,6 +2,10 @@ package org.robolectric.shadows.httpclient;
 
 import org.apache.http.HttpRequest;
 
+/**
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
+ */
+@Deprecated
 public interface RequestMatcher {
   boolean matches(HttpRequest request);
 }

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/ShadowDefaultRequestDirector.java
@@ -32,6 +32,10 @@ import org.robolectric.annotation.RealObject;
 import org.robolectric.annotation.Resetter;
 import org.robolectric.util.Util;
 
+/**
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
+ */
+@Deprecated
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(DefaultRequestDirector.class)
 public class ShadowDefaultRequestDirector {

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/StatusLineStub.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/StatusLineStub.java
@@ -3,6 +3,10 @@ package org.robolectric.shadows.httpclient;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 
+/**
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
+ */
+@Deprecated
 public class StatusLineStub implements StatusLine {
   @Override
   public ProtocolVersion getProtocolVersion() {

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/TestHttpResponse.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/TestHttpResponse.java
@@ -19,6 +19,10 @@ import org.apache.http.StatusLine;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpParams;
 
+/**
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
+ */
+@Deprecated
 public class TestHttpResponse extends HttpResponseStub {
 
   private final int statusCode;

--- a/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/package-info.java
+++ b/shadows/httpclient/src/main/java/org/robolectric/shadows/httpclient/package-info.java
@@ -4,6 +4,8 @@
  * <p>To use this in your project, add the artifact {@code org.robolectric:shadows-httpclient} to
  * your project. These shadows are only provided for legacy compatibility. They are no longer
  * actively maintained and will be removed in a future release.
+ *
+ * @deprecated Apache HTTP client is deprecated in Android. Please migrate to an other solution
  */
 @Deprecated
 package org.robolectric.shadows.httpclient;


### PR DESCRIPTION
The corresponding APIs have been deprecated for many years in the Android SDK.
This commit deprecates the corresponding shadow APIs so they can be removed in a future version.