### PR TITLE
Deprecate `SQLiteMode`

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/SQLiteMode.java
+++ b/annotations/src/main/java/org/robolectric/annotation/SQLiteMode.java
@@ -9,13 +9,23 @@ import java.lang.annotation.Target;
 /**
  * A {@link org.robolectric.pluginapi.config.Configurer} annotation for controlling which SQLite
  * shadow implementation is used for the {@link android.database} package.
+ *
+ * @deprecated This annotation will be deleted in a forthcoming Robolectric release.
  */
 @Documented
+@Deprecated
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PACKAGE, ElementType.TYPE, ElementType.METHOD})
 public @interface SQLiteMode {
 
-  /** Specifies the different supported SQLite modes. */
+  /**
+   * Specifies the different supported SQLite modes.
+   *
+   * @deprecated This enum is deprecated along with {@link SQLiteMode}. The default behavior is now
+   *     equivalent to {@link SQLiteMode.Mode#NATIVE} mode, so this annotation is generally no
+   *     longer needed.
+   */
+  @Deprecated
   enum Mode {
     /**
      * Use the legacy SQLite implementation backed by sqlite4java.
@@ -24,7 +34,11 @@ public @interface SQLiteMode {
      */
     @Deprecated
     LEGACY,
-    /** Use the new SQLite implementation backed by native Android code from AOSP. */
+    /**
+     * Use the new SQLite implementation backed by native Android code from AOSP.
+     *
+     * @deprecated {@code NATIVE} is the default mode and does not need to be stated explicitly.
+     */
     NATIVE,
   }
 

--- a/robolectric/src/main/java/org/robolectric/plugins/SQLiteModeConfigurer.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/SQLiteModeConfigurer.java
@@ -6,7 +6,12 @@ import org.robolectric.annotation.SQLiteMode;
 import org.robolectric.pluginapi.config.Configurer;
 import org.robolectric.plugins.config.SingleValueConfigurer;
 
-/** Provides configuration to Robolectric for its @{@link SQLiteMode} annotation. */
+/**
+ * Provides configuration to Robolectric for its @{@link SQLiteMode} annotation.
+ *
+ * @deprecated This class will be deleted in a forthcoming Robolectric release.
+ */
+@Deprecated
 @AutoService(Configurer.class)
 public class SQLiteModeConfigurer extends SingleValueConfigurer<SQLiteMode, SQLiteMode.Mode> {
 


### PR DESCRIPTION
This commit completely deprecates `SQLiteMode` and `SQLiteModeConfigurer`.
`NATIVE` is the default since Robolectric 4.9 on Linux and macOs and 4.15 on Windows.