### PR TITLE
Migrate from `Collections.sort(list)` to `list.sort()`

### DIFF
--- a/annotations/src/main/java/org/robolectric/versioning/AndroidVersions.java
+++ b/annotations/src/main/java/org/robolectric/versioning/AndroidVersions.java
@@ -25,7 +25,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -1075,7 +1074,7 @@ public final class AndroidVersions {
         }
       }
     }
-    Collections.sort(allReleases, AndroidRelease::compareTo);
+    allReleases.sort(AndroidRelease::compareTo);
 
     SdkInformation sdkInformation = new SdkInformation(allReleases, classesWithIllegalNames);
     sdkInformation.handleStaticErrors();

--- a/resources/src/main/java/org/robolectric/res/android/SortedVector.java
+++ b/resources/src/main/java/org/robolectric/res/android/SortedVector.java
@@ -20,8 +20,11 @@ public class SortedVector<T extends Comparable<T>> {
   }
 
   public void add(T info) {
-    mStorage.add(info);
-    Collections.sort(mStorage, Comparable::compareTo);
+    int i = Collections.binarySearch(mStorage, info);
+    if (i < 0) {
+      i = ~i;
+    }
+    mStorage.add(i, info);
   }
 
   public int size() {

--- a/shadows/framework/src/main/java/org/robolectric/fakes/RoboMenu.java
+++ b/shadows/framework/src/main/java/org/robolectric/fakes/RoboMenu.java
@@ -8,7 +8,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.SubMenu;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import org.robolectric.RuntimeEnvironment;
@@ -42,7 +41,7 @@ public class RoboMenu implements Menu {
     menuItem.setOrder(order);
     menuItems.add(menuItem);
     menuItem.setGroupId(groupId);
-    Collections.sort(menuItems, new CustomMenuItemComparator());
+    menuItems.sort(Comparator.comparingInt(MenuItem::getOrder));
     menuItem.setItemId(itemId);
     menuItem.setTitle(title);
     return menuItem;
@@ -197,13 +196,5 @@ public class RoboMenu implements Menu {
       }
     }
     return null;
-  }
-
-  private static class CustomMenuItemComparator implements Comparator<MenuItem> {
-
-    @Override
-    public int compare(MenuItem a, MenuItem b) {
-      return Integer.compare(a.getOrder(), b.getOrder());
-    }
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationPackageManager.java
@@ -709,7 +709,7 @@ public class ShadowApplicationPackageManager extends ShadowPackageManager {
           iterator.remove();
         }
       }
-      Collections.sort(result, new ResolveInfoComparator());
+      result.sort(new ResolveInfoComparator());
       return result;
     }
   }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowInstrumentation.java
@@ -43,6 +43,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -534,11 +535,8 @@ public class ShadowInstrumentation {
   }
 
   private void sortByPriority(List<Wrapper> wrappers) {
-    Collections.sort(
-        wrappers,
-        (o1, o2) ->
-            Integer.compare(
-                o2.getIntentFilter().getPriority(), o1.getIntentFilter().getPriority()));
+    wrappers.sort(
+        Comparator.<Wrapper>comparingInt(w -> w.getIntentFilter().getPriority()).reversed());
   }
 
   List<Intent> getBroadcastIntents() {


### PR DESCRIPTION
This commit replaces usages of `Collections.sort(list)` to use `list.sort()` directly.