### PR TITLE
Remove duplicated Test Parameter Injector dependency

### DIFF
--- a/integration_tests/testparameterinjector/build.gradle.kts
+++ b/integration_tests/testparameterinjector/build.gradle.kts
@@ -30,7 +30,7 @@ android {
 dependencies {
   // Testing dependencies
   testImplementation(project(":robolectric"))
-  testImplementation("com.google.testparameterinjector:test-parameter-injector:1.19@jar")
+  testImplementation(variantOf(libs.test.parameter.injector) { artifactType("jar") })
   testImplementation(libs.findbugs.jsr305)
   testImplementation(libs.junit4)
   testImplementation(libs.truth)


### PR DESCRIPTION
This commit uses the version catalog in the Test Parameter Injector integration module.
This avoids duplicated PRs like #10680 and #10681.