### PR TITLE
Add fallback 400 when mStyle is null for legacy CustomFallbackBuilder build

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowTypefaceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowTypefaceTest.java
@@ -182,4 +182,17 @@ public class ShadowTypefaceTest {
     assertThat(typeface2).isNotNull();
     assertThat(typeface2.toString()).isNotEmpty();
   }
+
+  @Test
+  @Config(minSdk = Q)
+  public void createTypeface_customFallbackBuilderWithoutSetStyle_fallbackTo400()
+      throws IOException {
+    Font font = new Font.Builder(fontFile).build();
+    FontFamily family = new FontFamily.Builder(font).build();
+    Typeface typeface = new Typeface.CustomFallbackBuilder(family).build();
+    assertThat(typeface).isNotNull();
+    // See
+    // https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android10-release/graphics/java/android/graphics/Typeface.java#791 .
+    assertThat(shadowOf(typeface).getFontDescription().getStyle()).isEqualTo(400);
+  }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyTypeface.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLegacyTypeface.java
@@ -258,8 +258,10 @@ public class ShadowLegacyTypeface extends ShadowTypeface {
     protected Typeface build() {
       Typeface result = reflector(CustomFallbackBuilderReflector.class, realBuilder).build();
       FontStyle style = reflector(CustomFallbackBuilderReflector.class, realBuilder).getStyle();
+      // See
+      // https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android10-release/graphics/java/android/graphics/Typeface.java#791.
       ((ShadowLegacyTypeface) Shadow.extract(result)).description =
-          new FontDesc(null, style.getWeight());
+          new FontDesc(null, style == null ? 400 : style.getWeight());
       return result;
     }
   }


### PR DESCRIPTION
Fix https://github.com/robolectric/robolectric/issues/10709.

See https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android10-release/graphics/java/android/graphics/Typeface.java#791.

