### PR TITLE
Update to `google-java-format` 1.32.0

### DIFF
--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Download google-java-format
         run: |
-          googleJavaFormatVersion="1.30.0"
+          googleJavaFormatVersion="1.32.0"
           curl -L -o $HOME/google-java-format.jar https://github.com/google/google-java-format/releases/download/v${googleJavaFormatVersion}/google-java-format-${googleJavaFormatVersion}-all-deps.jar
           curl -L -o $HOME/google-java-format-diff.py https://raw.githubusercontent.com/google/google-java-format/v${googleJavaFormatVersion}/scripts/google-java-format-diff.py
           chmod +x $HOME/google-java-format-diff.py


### PR DESCRIPTION
This PR updates to `google-java-format` 1.32.0

Release notes:
- 1.31.0: https://github.com/google/google-java-format/releases/tag/v1.31.0
- 1.32.0: https://github.com/google/google-java-format/releases/tag/v1.32.0