### PR TITLE
Remove redundant Gradle declarations

### DIFF
--- a/integration_tests/composeui/build.gradle.kts
+++ b/integration_tests/composeui/build.gradle.kts
@@ -24,11 +24,11 @@ android {
 
   testOptions {
     targetSdk = 36
-    unitTests { isIncludeAndroidResources = true }
+    unitTests.isIncludeAndroidResources = true
   }
 
   androidComponents {
-    beforeVariants(selector().all()) { variantBuilder ->
+    beforeVariants { variantBuilder ->
       // composeui does not support AndroidTest now.
       variantBuilder.enableAndroidTest = false
     }

--- a/integration_tests/memoryleaks/build.gradle.kts
+++ b/integration_tests/memoryleaks/build.gradle.kts
@@ -20,7 +20,7 @@ android {
   }
 
   androidComponents {
-    beforeVariants(selector().all()) { variantBuilder ->
+    beforeVariants { variantBuilder ->
       // memoryleaks does not support AndroidTest.
       variantBuilder.enableAndroidTest = false
     }

--- a/integration_tests/rap/build.gradle.kts
+++ b/integration_tests/rap/build.gradle.kts
@@ -20,7 +20,7 @@ android {
   }
 
   androidComponents {
-    beforeVariants(selector().all()) { variantBuilder ->
+    beforeVariants { variantBuilder ->
       // rap does not support AndroidTest.
       variantBuilder.enableAndroidTest = false
     }

--- a/integration_tests/roborazzi/build.gradle.kts
+++ b/integration_tests/roborazzi/build.gradle.kts
@@ -43,7 +43,7 @@ android {
   }
 
   androidComponents {
-    beforeVariants(selector().all()) { variantBuilder ->
+    beforeVariants { variantBuilder ->
       // Roborazzi does not support AndroidTest.
       variantBuilder.enableAndroidTest = false
     }

--- a/integration_tests/room/build.gradle.kts
+++ b/integration_tests/room/build.gradle.kts
@@ -20,7 +20,7 @@ android {
   }
 
   androidComponents {
-    beforeVariants(selector().all()) { variantBuilder ->
+    beforeVariants { variantBuilder ->
       // room does not support AndroidTest.
       variantBuilder.enableAndroidTest = false
     }

--- a/integration_tests/sparsearray/build.gradle.kts
+++ b/integration_tests/sparsearray/build.gradle.kts
@@ -25,7 +25,7 @@ android {
   }
 
   androidComponents {
-    beforeVariants(selector().all()) { variantBuilder ->
+    beforeVariants { variantBuilder ->
       // sparsearray does not support AndroidTest.
       variantBuilder.enableAndroidTest = false
     }

--- a/integration_tests/testparameterinjector/build.gradle.kts
+++ b/integration_tests/testparameterinjector/build.gradle.kts
@@ -20,7 +20,7 @@ android {
   }
 
   androidComponents {
-    beforeVariants(selector().all()) { variantBuilder ->
+    beforeVariants { variantBuilder ->
       // testparameterinjector does not support AndroidTest.
       variantBuilder.enableAndroidTest = false
     }

--- a/testapp/build.gradle.kts
+++ b/testapp/build.gradle.kts
@@ -8,7 +8,6 @@ android {
     minSdk = 21
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    vectorDrawables.useSupportLibrary = true
   }
 
   lint {


### PR DESCRIPTION
`selector().all()` is the default value for `androidComponents.beforeVariants`, so I've removed them.
I've also removed `vectorDrawables.useSupportLibrary`, since it's no longer necessary with min SDK >= 21.