### PR TITLE
Enable Gradle's Configuration Cache and adjust some properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,14 +12,27 @@ kotlin.stdlib.default.dependency=false
 # https://docs.gradle.org/current/userguide/performance.html#enable_the_build_cache
 org.gradle.caching=true
 
+# Enable Gradle's Configuration Cache
+# https://docs.gradle.org/current/userguide/performance.html#enable_configuration_cache
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
+
+# Enable Gradle's Configuration on Demand
+# https://docs.gradle.org/current/userguide/configuration_on_demand.html
+org.gradle.configureondemand=true
+
 # Increase Gradle's max memory due to OutOfMemoryException during compilation
 # https://docs.gradle.org/current/userguide/performance.html#increase_the_heap_size
-org.gradle.jvmargs=-Xmx2g
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 
 # Enable Gradle's parallel execution
 # https://docs.gradle.org/current/userguide/performance.html#parallel_execution
 org.gradle.parallel=true
 
-# Give Kotlin's daemon 2g of memory
+# Enable Gradle's parallelism for the Tooling API
+# https://docs.gradle.org/current/userguide/performance.html#sec:configure_tooling_api_actions_parallelism
+org.gradle.tooling.parallel=true
+
+# Give Kotlin's daemon 4g of memory
 # https://kotlinlang.org/docs/gradle-compilation-and-caches.html#kotlin-daemon-jvmargs-property
-kotlin.daemon.jvmargs=-Xmx2g
+kotlin.daemon.jvmargs=-Xmx4g


### PR DESCRIPTION
I've asked Gemini 3 how to improve Robolectric build time with Gradle, and this is what it suggested:
- Enable Gradle's Configuration Cache
- Enable Gradle's Configuration on Demand
- Enable Gradle's Parallelism for the Tooling API
- Increase the memory limit