### PR TITLE
Make `:shadows:framework:copySqliteNatives` compatible with Configuration Cache

### DIFF
--- a/shadows/framework/build.gradle.kts
+++ b/shadows/framework/build.gradle.kts
@@ -11,18 +11,19 @@ shadows {
   sdkCheckMode = "ERROR"
 }
 
-val sqlite4java = configurations.create("sqlite4java")
-val sqlite4javaVersion = libs.versions.sqlite4java.get()
+val sqlite4java = configurations.register("sqlite4java")
+val sqlite4javaVersion = libs.versions.sqlite4java
 
-val copySqliteNatives by
-  tasks.registering(Copy::class) {
+val copySqliteNatives =
+  tasks.register<Copy>("copySqliteNatives") {
     from(sqlite4java) {
       include("**/*.dll")
       include("**/*.so")
       include("**/*.dylib")
 
+      val sqliteVersion = sqlite4javaVersion.get()
       rename { filename ->
-        val filenameMatch = "^([^\\-]+)-(.+)-${sqlite4javaVersion}\\.(.+)".toRegex().find(filename)
+        val filenameMatch = "^([^\\-]+)-(.+)-$sqliteVersion\\.(.+)".toRegex().find(filename)
         if (filenameMatch != null) {
           val platformFilename = filenameMatch.groupValues[1]
           val platformFolder = filenameMatch.groupValues[2]
@@ -34,7 +35,7 @@ val copySqliteNatives by
         }
       }
     }
-    into(project.file(layout.buildDirectory.dir("resources/main/sqlite4java")))
+    into(project.layout.buildDirectory.dir("resources/main/sqlite4java"))
   }
 
 tasks.jar.configure { dependsOn(copySqliteNatives) }


### PR DESCRIPTION
Based on #10817, and Gradle's problem report, `:shadows:framework:copySqliteNatives` is not compatible with Configuration Cache.
This PR fixes that by:
- Using Gradle's Lazy API:
  - Register the `sqlite4java` configuration instead of creating it.
  - Use a `Provider` for `sqlite4javaVersion` instead of directly accessing the version.
- Removing the unnecessary `project.file()` wrapper for the copy destination.

I've run the `copySqliteNatives` task locally, and the files appear to be created in the right location.