### PR TITLE
[Demo Branch] Allow SandboxTestRunner to throw Coroutine Supressed Exceptions

### DIFF
--- a/integration_tests/kotlin/src/test/kotlin/org/robolectric/integrationtests/kotlin/exception/RobolectricExceptionCollectorTest.kt
+++ b/integration_tests/kotlin/src/test/kotlin/org/robolectric/integrationtests/kotlin/exception/RobolectricExceptionCollectorTest.kt
@@ -1,48 +1,49 @@
 package org.robolectric.integrationtests.kotlin.exception
 
 import android.app.Activity
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.shadows.ShadowLooper
 
 @RunWith(RobolectricTestRunner::class)
 @OptIn(DelicateCoroutinesApi::class)
-class DummyExceptionTest {
+class RobolectricExceptionCollectorTest {
 
-    lateinit var uninitializedProperty: String
-
-    @Test
-    fun `GIVEN throwUncaughtExceptions property is true, THEN an exception is thrown`() {
-        val controller = Robolectric.buildActivity(Activity::class.java)
-        controller.setup().resume()
-        val exception = assertThrows(
-            UninitializedPropertyAccessException::class.java
-        ) {
-            controller.use {
-                uninitializedProperty.toUByte() // Throws UninitializedPropertyAccessException
-            }
-        }
-        assert(exception != null)
-    }
+    lateinit var pleaseDontUseMe: String
 
     @Test
-    fun `GIVEN throwUncaughtExceptions property is false, THEN the exception is swallowed`() {
-        // Set false on purpose
+    fun `GIVEN throwUncaughtExceptions property true, WHEN coroutine fails, THEN an exception is thrown`() {
+        // Set to true to make this test and the subsequent one fail too
         System.setProperty("robolectric.throwUncaughtExceptions", "false")
         val controller = Robolectric.buildActivity(Activity::class.java)
         controller.setup().resume()
         controller.use {
             GlobalScope.launch {
-                uninitializedProperty.toUByte()
+                // Throws UninitializedPropertyAccessException
+                pleaseDontUseMe.toUByte()
             }
         }
+        assert(true)
+    }
+
+    @Test
+    fun `GIVEN throwUncaughtExceptions property is false, THEN the exception is swallowed`() {
+        // Test crashes if set to true, OR if previous test also crashed!
+        System.setProperty("robolectric.throwUncaughtExceptions", "false")
+        val controller = Robolectric.buildActivity(Activity::class.java)
+        controller.setup().resume()
+        controller.use {
+            GlobalScope.launch {
+                // Throws UninitializedPropertyAccessException
+                pleaseDontUseMe.toUByte()
+            }
+        }
+        assert(true)
     }
 }

--- a/junit/src/main/java/org/robolectric/internal/SandboxTestRunner.java
+++ b/junit/src/main/java/org/robolectric/internal/SandboxTestRunner.java
@@ -4,23 +4,7 @@ import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 
 import com.google.common.base.Splitter;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Queue;
-import java.util.WeakHashMap;
-import javax.annotation.Nonnull;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -57,6 +41,25 @@ import org.robolectric.util.PerfStatsCollector.Event;
 import org.robolectric.util.ReflectionHelpers;
 import org.robolectric.util.Util;
 import org.robolectric.util.inject.Injector;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.WeakHashMap;
+
+import javax.annotation.Nonnull;
 
 /**
  * Sandbox test runner that runs each test in a sandboxed class loader environment. Typically this
@@ -478,6 +481,11 @@ public class SandboxTestRunner extends BlockJUnit4ClassRunner {
 
     Queue<Throwable> thrown = new ArrayDeque<>();
 
+    // We can also check BEFORE the next test starts as well..
+    if (Boolean.parseBoolean(System.getProperty("robolectric.throwUncaughtExceptions", "true"))) {
+      RobolectricExceptionCollector.throwFirstSuppressedException();
+    }
+
     try {
       if (USE_LEGACY_SANDBOX_FLOW) {
         // Only invoke @BeforeClass once per class
@@ -524,6 +532,11 @@ public class SandboxTestRunner extends BlockJUnit4ClassRunner {
         first.addSuppressed(thrown.remove());
       }
       throw Util.sneakyThrow(first);
+    }
+    // Here we again check for this property
+    if (Boolean.parseBoolean(System.getProperty("robolectric.throwUncaughtExceptions", "true"))) {
+      // And then after all said and done we check again for exception
+      RobolectricExceptionCollector.throwFirstSuppressedException();
     }
   }
 

--- a/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
+++ b/robolectric/src/main/java/org/robolectric/RobolectricTestRunner.java
@@ -36,6 +36,7 @@ import org.robolectric.internal.AndroidSandbox;
 import org.robolectric.internal.DefaultManifestFactory;
 import org.robolectric.internal.ManifestFactory;
 import org.robolectric.internal.ManifestIdentifier;
+import org.robolectric.internal.RobolectricExceptionCollector;
 import org.robolectric.internal.SandboxManager;
 import org.robolectric.internal.SandboxTestRunner;
 import org.robolectric.internal.TestEnvironment;
@@ -78,6 +79,11 @@ public class RobolectricTestRunner extends SandboxTestRunner {
     // validation introduced in Bouncy Castle 1.71.
     // https://github.com/bcgit/bc-java/issues/1144
     System.setProperty("org.bouncycastle.rsa.max_mr_tests", "0");
+    // Installs the Robolectric Exception Collector if needed.
+    // This is for demo purpose only to toggle the property and show it works via test.
+    if (Boolean.parseBoolean(System.getProperty("robolectric.throwUncaughtExceptions", "true"))) {
+      RobolectricExceptionCollector.install();
+    }
   }
 
   protected static ImmutableList<RunListener> loadRunListeners() {


### PR DESCRIPTION
### Overview
Hello!

In our codebase, we’ve noticed that Robolectric tests currently swallow exceptions thrown from background threads and coroutines.

As a result, these coroutine exceptions are not surfaced within the test itself and can leak into other test classes within the same module, making failures difficult to trace back to their origin.

This purpose of this PR is just as a demo to explore a (maybe naive) approach for catching coroutine exceptions earlier within the Robolectric sandbox, similar to how `Kotlinx Coroutines` does it here for example:

https://github.com/Kotlin/kotlinx.coroutines/blob/8c27d51025d56a7b8de8eec2fb234b0094ce84f1/kotlinx-coroutines-test/common/src/internal/ExceptionCollector.kt#L29

To experiment with possible integration points, I introduced a `robolectric.throwUncaughtExceptions` system property as a way to understand where in the lifecycle exception collection could be controlled.

I've also attached example tests in this PR to make it easy to demo:

```
    lateinit var pleaseDontUseMe: String

    @Test
    fun `GIVEN throwUncaughtExceptions property true, WHEN coroutine fails, THEN an exception is thrown`() {
        // This already set to true globally in SandboxTestRunner but setting false here to make test pass
        // Set to true to make this test and the subsequent one fail too
        System.setProperty("robolectric.throwUncaughtExceptions", "false")
        val controller = Robolectric.buildActivity(Activity::class.java)
        controller.setup().resume()
        controller.use {
            GlobalScope.launch {
                // Throws UninitializedPropertyAccessException
                pleaseDontUseMe.toUByte()
            }
        }
        assert(true)
    }
```

Current State: test will pass, with  `UninitializedPropertyAccessException` suppressed.
Desired State: test will fail, with `UninitializedPropertyAccessException` thrown.

### Proposed Changes

We would have an opt-in with a flag or system property to have more aggressive exception handlers. With the idea being that any exception caught within Robolectric does not leak into other test suites or KotlinX pure JVM tests later on.

I may be misunderstanding some internal assumptions, especially around threading or sandbox isolation, so I would greatly appreciate feedback on whether this behaviour is intentional and, if not, the best place in the lifecycle to surface these coroutine exceptions more deterministically. 

If there’s a preferred pattern or hook for catching exceptions and failing earlier, I would be grateful for guidance.

What are your thoughts on this?