### PR TITLE
Fix for Decoroutinator

### DIFF
--- a/sandbox/src/main/java/org/robolectric/config/AndroidConfigurer.java
+++ b/sandbox/src/main/java/org/robolectric/config/AndroidConfigurer.java
@@ -65,7 +65,7 @@ public class AndroidConfigurer {
         .doNotAcquirePackage("org.xml.")
         .doNotAcquirePackage("org.specs2") // Required for Maven SureFire / RoboSpecs.
         .doNotAcquirePackage("scala.") // Required for Maven SureFire / RoboSpecs.
-        .doNotAcquirePackage("dev.reformator.stacktracedecoroutinator."); // Have to be loaded in the same CL as Kotlin.
+        .doNotAcquirePackage("dev.reformator.stacktracedecoroutinator."); // Decoroutinator must be loaded in the same classloader as Kotlin to avoid class loading issues. See https://github.com/Anamorphosee/stacktrace-decoroutinator/issues/71
 
     builder
         .addClassNameTranslation(


### PR DESCRIPTION
[Decoroutinator](https://github.com/Anamorphosee/stacktrace-decoroutinator) patches some of Kotlin standard libraries classes. Robolectric puts Kotlin stdlib and Decoroutinator in different class loaders which leads to a `not a subtype` exception during the SPI lookup. (See more at https://github.com/Anamorphosee/stacktrace-decoroutinator/issues/71) 

This PR puts Decoroutinator and Kotlin stdlib in the same (application's) class loader.
