### PR TITLE
Remove `isInAndroidSdk = false` from ShadowVirtualDeviceManager.

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVirtualDeviceManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowVirtualDeviceManager.java
@@ -54,7 +54,7 @@ import org.robolectric.util.reflector.ForType;
 import org.robolectric.util.reflector.WithType;
 
 /** Shadow for VirtualDeviceManager. */
-@Implements(value = VirtualDeviceManager.class, minSdk = UPSIDE_DOWN_CAKE, isInAndroidSdk = false)
+@Implements(value = VirtualDeviceManager.class, minSdk = UPSIDE_DOWN_CAKE)
 public class ShadowVirtualDeviceManager {
 
   private static final List<VirtualDeviceManager.VirtualDevice> mVirtualDevices = new ArrayList<>();


### PR DESCRIPTION
Remove `isInAndroidSdk = false` from ShadowVirtualDeviceManager.

This change reflects that VirtualDeviceManager is now available in the Android SDK for the supported minSdk version.
