### PR TITLE
Migrate to new macOS images

### DIFF
--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         device: [
-          macos-13, # Tests Mac x86_64
-          macos-14, # Tests Mac arm64
+          macos-15-intel, # Tests Mac x86_64
+          macos-latest, # Tests Mac arm64
           ubuntu-latest, # Tests Linux x86_64
           windows-latest, # Tests Windows x86_64
         ]


### PR DESCRIPTION
macOS 13 has retired.
