### PR TITLE
Ensure decoroutinator is loaded into the same class loader of Kotlin

### DIFF
--- a/sandbox/src/main/java/org/robolectric/config/AndroidConfigurer.java
+++ b/sandbox/src/main/java/org/robolectric/config/AndroidConfigurer.java
@@ -64,7 +64,10 @@ public class AndroidConfigurer {
         .doNotAcquirePackage("org.w3c.")
         .doNotAcquirePackage("org.xml.")
         .doNotAcquirePackage("org.specs2") // Required for Maven SureFire / RoboSpecs.
-        .doNotAcquirePackage("scala."); // Required for Maven SureFire / RoboSpecs.
+        .doNotAcquirePackage("scala.") // Required for Maven SureFire / RoboSpecs.
+        // Decoroutinator must be loaded in the same classloader as Kotlin to avoid class loading
+        // issues. See https://github.com/Anamorphosee/stacktrace-decoroutinator/issues/71
+        .doNotAcquirePackage("dev.reformator.stacktracedecoroutinator.");
 
     builder
         .addClassNameTranslation(


### PR DESCRIPTION
Ensure Decoroutinator is loaded into the same classloader of Kotlin.

See https://github.com/Anamorphosee/stacktrace-decoroutinator/issues/71.

For https://github.com/robolectric/robolectric/pull/10843.
