### PR TITLE
Enable newDSL and builtIn kotlin for AGP 9.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,8 +13,6 @@ plugins {
   alias(libs.plugins.detekt) apply false
   alias(libs.plugins.error.prone)
   alias(libs.plugins.idea)
-  alias(libs.plugins.kotlin.android) apply false
-  alias(libs.plugins.kotlin.jvm) apply false
   alias(libs.plugins.robolectric.spotless)
   alias(libs.plugins.robolectric.javadoc)
   alias(libs.plugins.roborazzi) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,6 @@ org.gradle.parallel=true
 # Give Kotlin's daemon 2g of memory
 # https://kotlinlang.org/docs/gradle-compilation-and-caches.html#kotlin-daemon-jvmargs-property
 kotlin.daemon.jvmargs=-Xmx2g
-# Temporarily disable AGP 9.0 new DSL and built in Kotlin support
-android.newDsl=false
-android.builtInKotlin=false
+# Enable AGP 9.0 new DSL and built-in Kotlin support
+android.newDsl=true
+android.builtInKotlin=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -276,8 +276,6 @@ idea = { id = "idea" }
 gradle-plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "gradle-plugin-publish" }
 jacoco = { id = "jacoco" }
 java = { id = "java" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 robolectric-android-project = { id = "org.robolectric.gradle.AndroidProjectConfigPlugin" }
 robolectric-deployed-java-module = { id = "org.robolectric.gradle.DeployedRoboJavaModulePlugin" }

--- a/integration_tests/composeui/build.gradle.kts
+++ b/integration_tests/composeui/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.detekt)
-  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.robolectric.android.project)
   alias(libs.plugins.robolectric.spotless)
 }

--- a/integration_tests/junit-vintage-engine/build.gradle.kts
+++ b/integration_tests/junit-vintage-engine/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.detekt)
-  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.robolectric.android.project)
   alias(libs.plugins.robolectric.spotless)
 }

--- a/integration_tests/kotlin/build.gradle.kts
+++ b/integration_tests/kotlin/build.gradle.kts
@@ -2,9 +2,9 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.detekt)
-  alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.robolectric.java.module)
   alias(libs.plugins.robolectric.spotless)
+  kotlin("jvm")
 }
 
 kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_11 } }

--- a/integration_tests/mockito-kotlin/build.gradle.kts
+++ b/integration_tests/mockito-kotlin/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+  kotlin("jvm")
   alias(libs.plugins.detekt)
-  alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.robolectric.java.module)
   alias(libs.plugins.robolectric.spotless)
 }

--- a/integration_tests/mockk/build.gradle.kts
+++ b/integration_tests/mockk/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+  kotlin("jvm")
   alias(libs.plugins.detekt)
-  alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.robolectric.java.module)
   alias(libs.plugins.robolectric.spotless)
 }

--- a/integration_tests/roborazzi/build.gradle.kts
+++ b/integration_tests/roborazzi/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.detekt)
-  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.robolectric.android.project)
   alias(libs.plugins.robolectric.spotless)
   alias(libs.plugins.roborazzi)

--- a/integration_tests/sdkcompat/build.gradle.kts
+++ b/integration_tests/sdkcompat/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.detekt)
-  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.robolectric.android.project)
   alias(libs.plugins.robolectric.spotless)
 }

--- a/integration_tests/sparsearray/build.gradle.kts
+++ b/integration_tests/sparsearray/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.detekt)
-  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.robolectric.android.project)
   alias(libs.plugins.robolectric.spotless)
 }

--- a/plugins/maven-dependency-resolver/build.gradle.kts
+++ b/plugins/maven-dependency-resolver/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+  kotlin("jvm")
   alias(libs.plugins.detekt)
-  alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.robolectric.deployed.java.module)
   alias(libs.plugins.robolectric.java.module)
   alias(libs.plugins.robolectric.spotless)

--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+  kotlin("jvm")
   alias(libs.plugins.detekt)
-  alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.robolectric.deployed.java.module)
   alias(libs.plugins.robolectric.java.module)
   alias(libs.plugins.robolectric.spotless)


### PR DESCRIPTION
Looks like it's not very hard for us to enable newDSL and builtIn kotlin.