### PR TITLE
chore: Remove obsolete newDSL configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,3 @@ org.gradle.parallel=true
 # Give Kotlin's daemon 2g of memory
 # https://kotlinlang.org/docs/gradle-compilation-and-caches.html#kotlin-daemon-jvmargs-property
 kotlin.daemon.jvmargs=-Xmx2g
-# Enable AGP 9.0 new DSL and built-in Kotlin support
-android.newDsl=true
-android.builtInKotlin=true


### PR DESCRIPTION
It has been enabled by default.
