### PR TITLE
Ignore MissingClass error from Manifest

### DIFF
--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           distribution: 'adopt'
           java-version-file: .github/.java-version
+      
+      - name: Check Android Lint
+        run: |
+          ./gradlew lint --continue
 
       - name: Download google-java-format
         run: |

--- a/integration_tests/androidx_test/src/main/AndroidManifest.xml
+++ b/integration_tests/androidx_test/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
 <!--
   Manifest for ATSL integration tests
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.READ_CONTACTS"/>
 
@@ -37,11 +38,14 @@
             android:exported="true"
             android:theme="@style/Theme.AppCompat.NoActionBar" />
         <activity android:name="org.robolectric.integrationtests.axt.ActivityTestRuleTest$TranscriptActivity"
-            android:exported="true" />
+            android:exported="true"
+            tools:ignore="MissingClass" />
         <activity android:name="org.robolectric.integrationtests.axt.IntentsTest$ResultCapturingActivity"
-            android:exported="true" />
+            android:exported="true"
+            tools:ignore="MissingClass" />
         <activity android:name="org.robolectric.integrationtests.axt.IntentsTest$DummyActivity"
-            android:exported="true" />
+            android:exported="true"
+            tools:ignore="MissingClass" />
         <activity android:name="org.robolectric.integrationtests.axt.ActivityWithSwitchCompat"
             android:exported="true"
             android:theme="@style/Theme.AppCompat" />

--- a/integration_tests/androidx_test/src/sharedTest/AndroidManifest.xml
+++ b/integration_tests/androidx_test/src/sharedTest/AndroidManifest.xml
@@ -7,7 +7,8 @@
       tools:replace="android:appComponentFactory">
     <activity
         android:name="org.robolectric.integrationtests.axt.ActivityTestRuleTest$TranscriptActivity"
-        android:exported="true"/>
+        android:exported="true"
+        tools:ignore="MissingClass"/>
     <activity
         android:name="org.robolectric.integrationtests.axt.EspressoActivity"
         android:exported="true"/>
@@ -33,7 +34,8 @@
         android:targetActivity="org.robolectric.integrationtests.axt.ActivityScenarioTest$TranscriptActivity" />
     <activity
         android:name="org.robolectric.integrationtests.axt.IntentsTest$ResultCapturingActivity"
-        android:exported="true"/>
+        android:exported="true"
+        tools:ignore="MissingClass"/>
     <activity
         android:name="org.robolectric.integrationtests.axt.ActivityScenarioTest$OnCreatePackageNameActivity"
         android:exported="true"/>

--- a/integration_tests/androidx_test/src/test/AndroidManifest-ActivityTestRule.xml
+++ b/integration_tests/androidx_test/src/test/AndroidManifest-ActivityTestRule.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="org.robolectric.integrationtests.axt">
 
   <uses-sdk
@@ -10,7 +11,8 @@
   <application>
     <activity
         android:name="org.robolectric.integrationtests.axt.ActivityTestRuleTest$TranscriptActivity"
-        android:exported="true"/>
+        android:exported="true"
+        tools:ignore="MissingClass"/>
   </application>
 
   <instrumentation

--- a/integration_tests/androidx_test/src/test/AndroidManifest-Intents.xml
+++ b/integration_tests/androidx_test/src/test/AndroidManifest-Intents.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="org.robolectric.integrationtests.axt">
 
   <uses-sdk
@@ -10,7 +11,8 @@
   <application>
     <activity
         android:name="org.robolectric.integrationtests.axt.IntentsTest$ResultCapturingActivity"
-        android:exported="true">
+        android:exported="true"
+        tools:ignore="MissingClass">
         </activity>
     <activity
       android:name="org.robolectric.integrationtests.axt.IntentsTest$ActivityWithViewFilter"


### PR DESCRIPTION
### Overview

was running `./gradlew lint` command locally as per #10957 and ran into issues with `MissingClass` error for a few activities listed there in the Manifest.

### Proposed Changes
Added `tools:ignore`, unless the team wanted to delete said activities from the manifest.