### PR TITLE
chore: Add hint and integration tests of rap for AGP 9.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -269,6 +269,7 @@ sqlite4java-native = ["sqlite4java-osx", "sqlite4java-linux-amd64", "sqlite4java
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "android-gradle" }
+android-legacy-kapt = { id = "com.android.legacy-kapt", version.ref = "android-gradle" }
 application = { id = "application" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt-gradle" }
 error-prone = { id = "net.ltgt.errorprone", version.ref = "error-prone-gradle" }

--- a/integration_tests/rap-kotlin/build.gradle.kts
+++ b/integration_tests/rap-kotlin/build.gradle.kts
@@ -1,0 +1,50 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.android.legacy.kapt)
+  alias(libs.plugins.robolectric.android.project)
+}
+
+android {
+  compileSdk = 36
+  namespace = "org.robolectric.rap.kotlin"
+
+  defaultConfig { minSdk = 23 }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+  }
+
+  testOptions {
+    targetSdk = 36
+    unitTests.isIncludeAndroidResources = true
+  }
+}
+
+androidComponents {
+  beforeVariants { variantBuilder ->
+    // rap-kotlin does not support AndroidTest.
+    variantBuilder.enableAndroidTest = false
+  }
+}
+
+kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_11 } }
+
+// AGP 9 built-in Kotlin disables kotlin-kapt, so use the compatibility plugin.
+kapt {
+  arguments {
+    arg("org.robolectric.annotation.processing.shadowPackage", "org.robolectric.rap.kotlin")
+    arg("org.robolectric.annotation.processing.priority", "1")
+  }
+}
+
+dependencies {
+  api(project(":shadows:framework"))
+  implementation(libs.kotlin.stdlib)
+  kapt(project(":processor"))
+  testImplementation(project(":robolectric"))
+  testImplementation(libs.junit4)
+  testImplementation(libs.truth)
+}

--- a/integration_tests/rap-kotlin/src/main/kotlin/org/robolectric/rap/kotlin/ExtendedShadowApplication.kt
+++ b/integration_tests/rap-kotlin/src/main/kotlin/org/robolectric/rap/kotlin/ExtendedShadowApplication.kt
@@ -1,0 +1,10 @@
+package org.robolectric.rap.kotlin
+
+import android.app.Application
+import android.os.Build.VERSION_CODES.P
+import android.os.Build.VERSION_CODES.S
+import org.robolectric.annotation.Implements
+import org.robolectric.shadows.ShadowApplication
+
+@Implements(value = Application::class, minSdk = P, maxSdk = S)
+class ExtendedShadowApplication : ShadowApplication()

--- a/integration_tests/rap-kotlin/src/test/java/org/robolectric/rap/kotlin/ExtendedShadowApplicationTest.java
+++ b/integration_tests/rap-kotlin/src/test/java/org/robolectric/rap/kotlin/ExtendedShadowApplicationTest.java
@@ -1,0 +1,21 @@
+package org.robolectric.rap.kotlin;
+
+import static android.os.Build.VERSION_CODES.S;
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadow.api.Shadow;
+
+@RunWith(RobolectricTestRunner.class)
+public final class ExtendedShadowApplicationTest {
+  @Config(sdk = S)
+  @Test
+  public void behaviorBeingTested_expectedResult() {
+    ExtendedShadowApplication application = Shadow.extract(RuntimeEnvironment.getApplication());
+    assertThat(application).isNotNull();
+  }
+}

--- a/processor/README.md
+++ b/processor/README.md
@@ -56,6 +56,29 @@ In this early stage, RAP is mostly targeted at those contributing to Robolectric
 
 However, with some few modifications some of the features (such as the constraint enforcement, or custom <code>shadowOf()</code>/global <code>reset()</code> methods) could also be of benefit to users of Robolectric who are developing their own custom shadows. This feature may be added in a future version
 
+### AGP 9 and built-in Kotlin
+
+With Android Gradle Plugin 9 and `android.buildInKotlin`, the `kotlin-kapt` plugin is not available.
+If your custom shadows are written in Kotlin, apply `com.android.legacy-kapt` and configure RAP through `kapt`:
+
+```kotlin
+plugins {
+  id("com.android.library")
+  id("com.android.legacy-kapt")
+}
+
+dependencies { kapt("org.robolectric:processor:<version>") }
+
+kapt {
+  arguments {
+    arg(
+      "org.robolectric.annotation.processing.shadowPackage",
+      "com.example.shadows"
+    )
+  }
+}
+```
+
 ## Future enhancements
 
 In developing RAP I forsaw a number of enhancements that would be potentially useful:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,7 @@ include(
   ":integration_tests:play_services",
   ":integration_tests:powermock",
   ":integration_tests:rap",
+  ":integration_tests:rap-kotlin",
   ":integration_tests:roborazzi",
   ":integration_tests:room",
   ":integration_tests:sdkcompat",


### PR DESCRIPTION
Add rap-kotlin tests first from https://github.com/robolectric/robolectric/pull/10996.