### PR TITLE
Add split APK and Android App Bundle (AAB) support

### DIFF
--- a/docs/split-apk-aab-support-report.md
+++ b/docs/split-apk-aab-support-report.md
@@ -1,0 +1,595 @@
+# Split APK and Android App Bundle (AAB) Support in Robolectric
+
+## Report Overview
+
+This report documents the Android App Bundle (AAB) build and distribution process, the split APK
+delivery mechanism, and how Robolectric now supports testing apps that use these technologies.
+
+---
+
+## 1. Android App Bundle (AAB) Process
+
+### What is an AAB?
+
+An Android App Bundle (.aab) is a publishing format that includes all of an app's compiled code and
+resources but defers APK generation and signing to Google Play (or bundletool). Unlike a traditional
+.apk, an AAB is not directly installable on a device.
+
+### AAB Build Process
+
+```
+Source Code + Resources
+        │
+        ▼
+  Android Gradle Plugin (AGP)
+        │
+        ▼
+  .aab file (Android App Bundle)
+    ├── base/             ← Base module
+    │   ├── manifest/
+    │   ├── dex/
+    │   ├── res/
+    │   ├── assets/
+    │   └── resources.pb   (compiled resources in protobuf format)
+    ├── feature_camera/    ← Dynamic feature module
+    │   ├── manifest/
+    │   ├── dex/
+    │   └── res/
+    └── BundleConfig.pb    ← Bundle configuration
+```
+
+### Key Properties of AAB
+
+1. **Deferred APK generation**: The AAB contains all possible configurations; the actual APK set
+   is generated server-side based on the target device.
+2. **Module-based**: The AAB can contain multiple modules (base + dynamic features).
+3. **Resource optimization**: Resources are stored per-configuration (density, ABI, locale) enabling
+   delivery of only the needed resources.
+4. **Protobuf format**: Resources use protobuf (.pb) instead of binary XML (.arsc).
+
+---
+
+## 2. Split APK Generation and Delivery Process
+
+### From AAB to Split APKs
+
+When a user downloads an AAB app from Google Play (or installs via bundletool), the following happens:
+
+```
+.aab file
+    │
+    ▼
+bundletool / Google Play
+    │
+    ├── Base Split APK
+    │   └── base-master.apk (code, shared resources, manifest)
+    │
+    ├── Configuration Splits (per-device)
+    │   ├── base-xxhdpi.apk        (density resources)
+    │   ├── base-arm64_v8a.apk     (native libraries)
+    │   └── base-en.apk            (language resources)
+    │
+    └── Dynamic Feature Splits (on-demand or install-time)
+        ├── feature_camera-master.apk
+        ├── feature_camera-xxhdpi.apk
+        └── feature_maps-master.apk
+```
+
+### Types of Split APKs
+
+| Split Type | Purpose | Example Names | Delivery |
+|------------|---------|---------------|----------|
+| **Base** | Core app code + resources | `base-master.apk` | Always installed |
+| **Density** | Screen-density-specific resources | `base-xxhdpi.apk`, `config.hdpi` | Per device |
+| **ABI** | Architecture-specific native libs | `base-arm64_v8a.apk`, `config.x86` | Per device |
+| **Language** | Locale-specific resources | `base-en.apk`, `config.fr` | Per device |
+| **Dynamic Feature** | On-demand or install-time features | `feature_camera-master.apk` | On demand |
+
+### How Android Framework Handles Split APKs
+
+When split APKs are installed, the framework tracks them through `ApplicationInfo`:
+
+```java
+// Fields populated by the package manager after installation:
+ApplicationInfo.sourceDir         = "/data/app/com.example/base.apk"
+ApplicationInfo.publicSourceDir   = "/data/app/com.example/base.apk"
+ApplicationInfo.splitNames        = ["config.xxhdpi", "config.arm64_v8a", "config.en"]
+ApplicationInfo.splitSourceDirs   = ["/data/app/.../split_config.xxhdpi.apk",
+                                     "/data/app/.../split_config.arm64_v8a.apk",
+                                     "/data/app/.../split_config.en.apk"]
+ApplicationInfo.splitPublicSourceDirs = [...]  // same as splitSourceDirs
+```
+
+The `PackageInstaller` API is used for installation:
+
+```java
+// Create session
+PackageInstaller installer = context.getPackageManager().getPackageInstaller();
+int sessionId = installer.createSession(new SessionParams(MODE_FULL_INSTALL));
+Session session = installer.openSession(sessionId);
+
+// Write each split APK
+for (File splitApk : splitApks) {
+    OutputStream out = session.openWrite(splitApk.getName(), 0, splitApk.length());
+    Files.copy(splitApk.toPath(), out);
+    out.close();
+}
+
+// Commit
+session.commit(statusReceiver);
+```
+
+The `LoadedApk` class provides per-split classloaders:
+
+```java
+// Available from API 26 (O)
+ClassLoader splitCl = loadedApk.getSplitClassLoader("feature_camera");
+```
+
+---
+
+## 3. How Robolectric Supports Split APKs
+
+### Changes Made
+
+#### 3.1 ShadowPackageManager — Split APK Installation
+
+**File**: `shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java`
+
+New method `installPackageWithSplits()` provides a convenient API for test setup:
+
+```java
+// Install a package with split APKs
+shadowOf(packageManager).installPackageWithSplits(
+    packageInfo,
+    "config.xxhdpi", "config.arm64_v8a", "config.en",  // config splits
+    "feature_camera", "feature_maps"                     // dynamic features
+);
+```
+
+The `setUpPackageStorage()` method now handles split APK directories:
+- Creates temporary directories for each split APK
+- Sets `splitSourceDirs` and `splitPublicSourceDirs`
+- Preserves pre-set paths (doesn't overwrite if already set)
+
+The `populatePackageInfoWithDefaults()` method now propagates `splitNames` from
+`PackageInfo` to `ApplicationInfo`.
+
+#### 3.2 ShadowLoadedApk — Split ClassLoader Support
+
+**File**: `shadows/framework/src/main/java/org/robolectric/shadows/ShadowLoadedApk.java`
+
+Enhanced `getSplitClassLoader(String splitName)`:
+- Validates the requested split name against registered splits
+- Throws `NameNotFoundException` for unknown split names (matching real framework behaviour)
+- Checks a per-split cache before falling back to the app ClassLoader (see below)
+- New `registerSplitNames()` API for test setup
+- New `getRegisteredSplitNames()` for assertions
+
+**ClassLoader sharing API:**
+
+| Method | Description |
+|--------|-------------|
+| `registerSplitNames(String...)` | Declare which split names exist; `getSplitClassLoader()` will throw for anything else |
+| `setSplitClassLoader(String, ClassLoader)` | Register an explicit ClassLoader for a split; `getSplitClassLoader()` returns it |
+| `createIsolatedSplitClassLoader(String)` | Create (and cache) a `URLClassLoader` child of the app ClassLoader, simulating Android's `isolatedSplits` mode. Repeated calls return the same instance. |
+
+```java
+ShadowLoadedApk shadowApk = Shadow.extract(loadedApk);
+
+// Option A: register an explicit loader
+shadowApk.registerSplitNames("feature_camera");
+shadowApk.setSplitClassLoader("feature_camera", myCustomLoader);
+
+// Option B: let Robolectric create an isolated child loader
+ClassLoader cameraLoader = shadowApk.createIsolatedSplitClassLoader("feature_camera");
+ClassLoader mapsLoader   = shadowApk.createIsolatedSplitClassLoader("feature_maps");
+// cameraLoader != mapsLoader, but both delegate unknown classes to the app loader
+```
+
+#### 3.3 ShadowPackageInstaller — Split Session Tracking and Auto-Install
+
+**File**: `shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageInstaller.java`
+
+`ShadowSession.openWrite()` now tracks split APK names:
+- Each call to `openWrite(name, ...)` records the name
+- New `getWrittenSplitNames()` returns the list of names written to the session
+- New `isCommitted()` returns `true` after `commit()` is called
+
+**Session commit auto-installs into PackageManager:**
+
+When a session succeeds (either via `commit()` or `setSessionSucceeds()`), Robolectric
+automatically registers the package in `ShadowPackageManager` using the written APK names:
+
+- `base.apk` / `base-master.apk` establish the package entry but are **not** treated as split names
+- All other filenames have their `.apk` suffix stripped and become split names
+- If the package already exists, new splits are appended via `addSplitToInstalledPackage()`
+- Sessions with no written APKs are a no-op (backward compatible with existing tests)
+
+```java
+int sessionId = installer.createSession(params);
+Session session = installer.openSession(sessionId);
+
+session.openWrite("base.apk", 0, -1).close();
+session.openWrite("split_feature_camera.apk", 0, -1).close();
+
+session.commit(statusReceiver);   // ← auto-installs package + "split_feature_camera" split
+
+PackageInfo info = pm.getPackageInfo("com.example.app", 0);
+assertThat(info.splitNames).asList().contains("split_feature_camera");
+
+ShadowSession shadow = Shadow.extract(session);
+assertThat(shadow.isCommitted()).isTrue();
+```
+
+#### 3.4 AndroidTestEnvironment — Split Storage Setup
+
+**File**: `robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java`
+
+`setUpPackageStorage()` now handles split APK directories for the test application itself,
+if the parsed package has split information.
+
+---
+
+## 4. Testing Patterns for AAB Apps with Robolectric
+
+### Pattern 1: Testing Config Splits
+
+```java
+@Test
+@Config(minSdk = VERSION_CODES.O)
+public void testAppWithConfigSplits() throws Exception {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = "com.example.myapp";
+
+    shadowOf(packageManager).installPackageWithSplits(
+        packageInfo, "config.xxhdpi", "config.arm64_v8a", "config.en");
+
+    ApplicationInfo appInfo = packageManager.getApplicationInfo("com.example.myapp", 0);
+    assertThat(appInfo.splitNames).asList().contains("config.xxhdpi");
+    assertThat(appInfo.splitSourceDirs).hasLength(3);
+}
+```
+
+### Pattern 2: Testing Dynamic Features
+
+```java
+@Test
+@Config(minSdk = VERSION_CODES.O)
+public void testDynamicFeatureAvailability() throws Exception {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = "com.example.myapp";
+
+    shadowOf(packageManager).installPackageWithSplits(
+        packageInfo, "feature_camera", "feature_maps");
+
+    ApplicationInfo appInfo = packageManager.getApplicationInfo("com.example.myapp", 0);
+    assertThat(appInfo.splitNames).asList().contains("feature_camera");
+}
+```
+
+### Pattern 3: Testing PackageInstaller Sessions
+
+```java
+@Test
+public void testSplitApkInstallFlow() throws Exception {
+    int sessionId = installer.createSession(params);
+    Session session = installer.openSession(sessionId);
+
+    session.openWrite("base.apk", 0, -1).close();
+    session.openWrite("split_config.xxhdpi.apk", 0, -1).close();
+
+    ShadowSession shadow = Shadow.extract(session);
+    assertThat(shadow.getWrittenSplitNames())
+        .containsExactly("base.apk", "split_config.xxhdpi.apk");
+}
+```
+
+### Pattern 4: Testing SplitCompat-like Code
+
+```java
+@Test
+@Config(minSdk = VERSION_CODES.O)
+public void testSplitCompatDiscovery() throws Exception {
+    // Set up the package with splits
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = "com.example.myapp";
+    packageInfo.applicationInfo = new ApplicationInfo();
+    packageInfo.applicationInfo.packageName = "com.example.myapp";
+    packageInfo.applicationInfo.splitNames = new String[]{"feature_camera"};
+    packageInfo.applicationInfo.splitSourceDirs = new String[]{"/data/app/feature_camera.apk"};
+    packageInfo.applicationInfo.splitPublicSourceDirs = new String[]{"/data/app/feature_camera.apk"};
+
+    shadowOf(packageManager).installPackage(packageInfo);
+
+    // Your SplitCompat-like code queries ApplicationInfo to discover splits
+    ApplicationInfo appInfo = packageManager.getApplicationInfo("com.example.myapp", 0);
+    assertThat(appInfo.splitSourceDirs).isNotNull();
+}
+```
+
+### Pattern 5: Testing Per-Split ClassLoader Isolation
+
+```java
+@Test
+@Config(minSdk = VERSION_CODES.O)
+public void testIsolatedSplitClassLoader() throws Exception {
+    android.content.Context base = RuntimeEnvironment.getApplication().getBaseContext();
+    android.app.LoadedApk loadedApk = ReflectionHelpers.getField(base, "mPackageInfo");
+    ShadowLoadedApk shadowApk = Shadow.extract(loadedApk);
+    shadowApk.registerSplitNames("feature_camera", "feature_maps");
+
+    // Each split gets its own isolated ClassLoader backed by the app loader
+    ClassLoader cameraLoader = shadowApk.createIsolatedSplitClassLoader("feature_camera");
+    ClassLoader mapsLoader   = shadowApk.createIsolatedSplitClassLoader("feature_maps");
+
+    assertThat(cameraLoader).isNotSameInstanceAs(mapsLoader);
+    // Subsequent calls return the same (cached) instance
+    assertThat(shadowApk.createIsolatedSplitClassLoader("feature_camera"))
+        .isSameInstanceAs(cameraLoader);
+}
+```
+
+### Pattern 6: Testing PackageInstaller Session Commit
+
+```java
+@Test
+@Config(minSdk = VERSION_CODES.O)
+public void testCommitInstallsPackageWithSplits() throws Exception {
+    SessionParams params = new SessionParams(MODE_FULL_INSTALL);
+    params.setAppPackageName("com.example.myapp");
+
+    int sessionId = installer.createSession(params);
+    Session session = installer.openSession(sessionId);
+
+    session.openWrite("base.apk", 0, -1).close();
+    session.openWrite("split_feature_camera.apk", 0, -1).close();
+
+    session.commit(statusReceiver);
+
+    // Package + splits auto-registered in PackageManager
+    PackageInfo info = pm.getPackageInfo("com.example.myapp", 0);
+    assertThat(info.splitNames).asList().contains("split_feature_camera");
+
+    ShadowSession shadow = Shadow.extract(session);
+    assertThat(shadow.isCommitted()).isTrue();
+}
+```
+
+---
+
+## 5. Limitations and Future Work
+
+### Current Limitations
+
+1. **API Level Requirement**: Split APK support requires API level 26 (O) or higher because
+   `ApplicationInfo.splitNames` was introduced in that version. The `splitSourceDirs` and
+   `splitPublicSourceDirs` fields exist from API 21, but full split management requires API 26+.
+
+2. **No Real Resource Loading**: Robolectric simulates split APK metadata (paths, names) but does
+   not actually load resources from split APK files. The split source dirs point to temporary
+   directories, not real APK files with resources.arsc.
+   **Update**: Split source dirs now point to valid empty APK (ZIP) files. For actual resource
+   loading, use `installPackageWithSplitApks()` with real APK files or `addSplitAssetPath()`
+   to load assets at runtime.
+
+3. **No Dynamic Delivery Simulation**: There is no built-in mechanism to simulate the Play Feature
+   Delivery lifecycle (requesting, downloading, installing splits at runtime). Tests must manually
+   set up the final state.
+
+### Resource Loading from Split APKs
+
+Robolectric now supports loading raw assets from split APK files. This feature enables testing
+of dynamic feature modules and SplitCompat-like patterns where assets are delivered via split APKs.
+
+#### How It Works
+
+1. **Valid APK Files**: Split source dirs now default to valid empty ZIP files instead of directories.
+   The framework's `CppApkAssets.Load()` can open them without errors.
+
+2. **Creating Split APKs with Assets**: Use `ShadowPackageManager.createSplitApkWithAssets()` to
+   build minimal APK (ZIP) files containing raw assets:
+
+   ```java
+   Map<String, byte[]> assets = new LinkedHashMap<>();
+   assets.put("feature/config.json", "{\"key\": \"value\"}".getBytes());
+   String splitApkPath = ShadowPackageManager.createSplitApkWithAssets("feature_camera", assets);
+   ```
+
+3. **Installing with Real Split APKs**: Use `installPackageWithSplitApks()` to install a package
+   with actual split APK files (instead of empty placeholders):
+
+   ```java
+   Map<String, String> splitPaths = new LinkedHashMap<>();
+   splitPaths.put("feature_camera", cameraApkPath);
+   splitPaths.put("config.xxhdpi", densityApkPath);
+   shadowOf(packageManager).installPackageWithSplitApks(packageInfo, splitPaths);
+   ```
+
+4. **Runtime Asset Loading**: Use `ShadowAssetManager.addSplitAssetPath()` to add split APK
+   resources to a running app's AssetManager (SplitCompat pattern):
+
+   ```java
+   int cookie = ShadowAssetManager.addSplitAssetPath(context.getAssets(), splitApkPath);
+   InputStream is = context.getAssets().open("feature/config.json"); // works!
+   ```
+
+#### Limitations
+
+- Only raw assets (`assets/` directory) are supported via the test helper. For compiled resources
+  (`resources.arsc`), provide a pre-built APK file from your build system.
+- `addSplitAssetPath()` uses reflection to call `AssetManager.addAssetPath()`, which is a hidden
+  API. This works in Robolectric's test environment but may not reflect exact production behavior.
+
+### Future Work
+
+1. **Play Feature Delivery Shadows**: Create shadow implementations for `SplitInstallManager`,
+   `SplitInstallStateUpdatedListener`, and related Play Core APIs.
+
+---
+
+## 6. Dynamic Split Installation
+
+Dynamic split installation allows tests to simulate on-demand feature delivery, where split APKs are
+added to an already-installed package at runtime. This mirrors the Play Feature Delivery workflow.
+
+### API
+
+```java
+// 1. Install base app
+PackageInfo base = new PackageInfo();
+base.packageName = "com.example.app";
+base.applicationInfo = new ApplicationInfo();
+base.applicationInfo.packageName = "com.example.app";
+shadowOf(pm).installPackage(base);
+
+// 2. Create and add a dynamic feature split
+Map<String, byte[]> assets = Map.of("config.json", "{}".getBytes());
+String splitPath = ShadowPackageManager.createSplitApkWithAssets("feature_camera", assets);
+shadowOf(pm).addSplitToInstalledPackage("com.example.app", "feature_camera", splitPath);
+
+// 3. Verify the split was registered
+PackageInfo updated = pm.getPackageInfo("com.example.app", 0);
+// updated.applicationInfo.splitNames contains "feature_camera"
+// updated.applicationInfo.splitSourceDirs contains the split APK path
+```
+
+### Behavior
+
+- `addSplitToInstalledPackage()` mutates the existing `PackageInfo` in-place
+- Appends to `splitNames`, `splitSourceDirs`, and `splitPublicSourceDirs` arrays
+- Multiple splits can be added incrementally
+- Throws `IllegalArgumentException` if the package is not installed
+- Requires API level 26+ (Android O)
+
+---
+
+## 7. Compiled Resource Support (ArscResourceTableBuilder)
+
+The `ArscResourceTableBuilder` generates minimal valid `resources.arsc` binary files that can be
+parsed by Robolectric's resource loading pipeline (`LoadedArsc.Load()`).
+
+### API
+
+```java
+// Create a split APK with string resources and assets
+Map<String, String> resources = new LinkedHashMap<>();
+resources.put("feature_name", "Camera Feature");
+resources.put("feature_desc", "Take amazing photos");
+
+Map<String, byte[]> assets = Map.of("model.tflite", modelBytes);
+
+String splitPath = ShadowPackageManager.createSplitApkWithResources(
+    "feature_camera",        // split name
+    "com.example.camera",    // package name
+    0x7f,                    // package ID (0x7f for app)
+    resources,               // string resources
+    assets                   // optional raw assets (nullable)
+);
+```
+
+### Binary Format Details
+
+The generated `resources.arsc` follows the Android binary resource table format:
+
+```
+ResTable_header (12 bytes)
+  └─ Global string pool (string values)
+  └─ Package chunk
+       ├─ Type string pool ("string")
+       ├─ Key string pool (entry names)
+       ├─ TypeSpec (configuration flags)
+       └─ Type (default config, entries referencing global pool)
+```
+
+- All strings use UTF-8 encoding
+- The `resources.arsc` entry in the ZIP uses STORED compression (per Android convention)
+- Resource IDs follow the pattern `packageId:0x01:NNNN` (type 1 = string, entry 0-based)
+
+### Limitations
+
+- Currently only string resources are supported
+- Only default configuration (no locale/density variants)
+- Package ID must be specified manually
+
+---
+
+## 8. Bundletool Integration (BundletoolSplitApkLoader)
+
+The `BundletoolSplitApkLoader` loads split APKs from bundletool-generated archives or directories,
+making it easy to test with real or simulated bundletool output.
+
+### Bundletool .apks Archive Format
+
+```
+app.apks (ZIP archive)
+├── splits/
+│   ├── base-master.apk
+│   ├── base-xxhdpi.apk
+│   ├── base-arm64_v8a.apk
+│   └── base-en.apk
+└── toc.pb
+```
+
+### API
+
+```java
+// Load from a .apks archive
+Map<String, String> splits = BundletoolSplitApkLoader.loadFromApksArchive(
+    Paths.get("app.apks"));
+
+// Load from a directory of APK files
+Map<String, String> splits = BundletoolSplitApkLoader.loadFromDirectory(
+    Paths.get("splits/"));
+
+// Filter by module prefix
+Map<String, String> cameraSplits = BundletoolSplitApkLoader.loadFromDirectory(
+    Paths.get("splits/"), "camera-");
+
+// Create a test .apks archive
+Map<String, String> splitPaths = Map.of("base-master", basePath, "base-en", enPath);
+Path archive = BundletoolSplitApkLoader.createApksArchive(splitPaths);
+```
+
+### Features
+
+- Extracts APK files from `splits/` directory within `.apks` ZIP archives
+- Derives split names from APK filenames (e.g., `base-xxhdpi.apk` → `"base-xxhdpi"`)
+- Supports prefix filtering to load only specific module splits
+- Provides `createApksArchive()` to build test fixtures
+- Returns `Map<String, String>` compatible with `installPackageWithSplitApks()`
+
+---
+
+## 9. Test Coverage Summary
+
+Integration tests are modeled after the official Android App Bundle samples from
+[github.com/android/app-bundle-samples/DynamicFeatures](https://github.com/android/app-bundle-samples/tree/main/DynamicFeatures).
+Each test class maps to a specific pattern from the official sample:
+
+### Unit Tests (robolectric module)
+
+| Test Suite | Test Methods | Description |
+|-----------|-------|-------------|
+| `ShadowPackageManagerSplitApkTest` | 10 | Split APK installation APIs |
+| `ShadowPackageInstallerSplitTest` | 5 | Session-based split tracking (`getWrittenSplitNames`) |
+| `ShadowPackageManagerSplitResourceTest` | 9 | Split APK resource/asset loading |
+| `ShadowPackageManagerDynamicSplitTest` | 16 | Dynamic splits, ARSC builder, bundletool |
+| `ShadowLoadedApkClassLoaderTest` | 8 | Per-split ClassLoader caching and isolation |
+| `ShadowPackageInstallerCommitTest` | 7 | Session commit auto-installs package + splits |
+
+### Integration Tests (integration_tests/split-apk)
+
+Based on the official [DynamicFeatures](https://github.com/android/app-bundle-samples/tree/main/DynamicFeatures) sample:
+
+| Test Suite | Test Methods | Official Sample Reference |
+|-----------|-------|-------------|
+| `SplitCompatApplicationTest` | 3 | `MyApplication.kt` — SplitCompat.install() in attachBaseContext() |
+| `DynamicFeatureDeliveryTest` | 7 | `MainActivity.kt` — SplitInstallManager on-demand delivery |
+| `AssetOnlyModuleTest` | 4 | `features/assets/` — hasCode=false, asset-only module |
+| `ConfigSplitsTest` | 5 | Config splits (density, ABI, language) + LanguageHelper |
+| `BundletoolWorkflowTest` | 5 | Bundletool .apks archive → install → verify workflow |
+| `CompiledResourcesTest` | 5 | Feature module resources.arsc (kotlin, java, initialInstall) |
+| **Total** | **69** | Each method runs across multiple SDK levels (26+) |
+
+All tests pass across all supported SDK levels (26+).

--- a/integration_tests/split-apk/build.gradle.kts
+++ b/integration_tests/split-apk/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins { alias(libs.plugins.robolectric.java.module) }
+
+dependencies {
+  api(project(":robolectric"))
+  compileOnly(AndroidSdk.MAX_SDK.coordinates)
+
+  testCompileOnly(AndroidSdk.MAX_SDK.coordinates)
+  testRuntimeOnly(AndroidSdk.MAX_SDK.coordinates)
+  testImplementation(libs.junit4)
+  testImplementation(libs.truth)
+}

--- a/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/AssetOnlyModuleTest.java
+++ b/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/AssetOnlyModuleTest.java
@@ -1,0 +1,170 @@
+package org.robolectric.integrationtests.splitapk;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.res.AssetManager;
+import android.os.Build.VERSION_CODES;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowAssetManager;
+import org.robolectric.shadows.ShadowPackageManager;
+
+/**
+ * Tests modeled after the DynamicFeatures sample's asset-only feature module.
+ *
+ * <p>In the official sample, the "assets" feature module (features/assets/) has:
+ *
+ * <ul>
+ *   <li>{@code android:hasCode="false"} in its manifest - no DEX code, just assets
+ *   <li>On-demand delivery: {@code <dist:on-demand />}
+ *   <li>A single asset file: {@code assets/assets.txt}
+ *   <li>After install, MainActivity.displayAssets() reads the file via context.assets.open()
+ * </ul>
+ *
+ * <p>This test verifies that Robolectric can correctly handle asset-only split modules, including
+ * creating APKs with just assets (no resources.arsc), loading them, and reading content.
+ *
+ * <p>Reference: {@code DynamicFeatures/features/assets/}
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = VERSION_CODES.O)
+public class AssetOnlyModuleTest {
+
+  private static final String PACKAGE_NAME = "com.google.android.samples.dynamicfeatures";
+
+  private PackageManager packageManager;
+  private ShadowPackageManager shadowPackageManager;
+
+  @Before
+  public void setUp() {
+    packageManager = RuntimeEnvironment.getApplication().getPackageManager();
+    shadowPackageManager = shadowOf(packageManager);
+
+    // Install base app
+    PackageInfo baseApp = new PackageInfo();
+    baseApp.packageName = PACKAGE_NAME;
+    baseApp.applicationInfo = new ApplicationInfo();
+    baseApp.applicationInfo.packageName = PACKAGE_NAME;
+    shadowPackageManager.installPackage(baseApp);
+  }
+
+  /**
+   * Reproduces the exact asset content from the official sample's features/assets/assets/assets.txt
+   * and verifies it can be read after installing the asset-only module.
+   */
+  @Test
+  public void assetsModule_officialSampleContent_readable() throws Exception {
+    // Exact content from the official sample's assets.txt
+    String officialContent =
+        "This text originates from a dynamically loaded feature.\n"
+            + "The source can be found in features/assets/assets/assets.txt.";
+
+    String splitPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "feature_assets",
+            Map.of("assets.txt", officialContent.getBytes(StandardCharsets.UTF_8)));
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, "feature_assets", splitPath);
+
+    // Read via AssetManager (mirroring context.assets.open("assets.txt") in the sample)
+    AssetManager am = AssetManager.class.getDeclaredConstructor().newInstance();
+    ShadowAssetManager.addSplitAssetPath(am, splitPath);
+
+    try (InputStream is = am.open("assets.txt")) {
+      String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+      assertThat(content).isEqualTo(officialContent);
+    }
+  }
+
+  /**
+   * Verifies that an asset-only module (hasCode=false) shows up in splitNames but doesn't need any
+   * DEX or resources.arsc to work correctly.
+   */
+  @Test
+  public void assetsModule_hasCodeFalse_splitRegistered() throws Exception {
+    String splitPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "feature_assets", Map.of("assets.txt", "content".getBytes(StandardCharsets.UTF_8)));
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, "feature_assets", splitPath);
+
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).asList().contains("feature_assets");
+  }
+
+  /**
+   * Verifies multiple asset files within an asset-only module, simulating a module that contains
+   * multiple data files (e.g., ML models, configuration files).
+   */
+  @Test
+  public void assetsModule_multipleAssetFiles_allAccessible() throws Exception {
+    Map<String, byte[]> assets = new LinkedHashMap<>();
+    assets.put("assets.txt", "Main asset file".getBytes(StandardCharsets.UTF_8));
+    assets.put("data/model.bin", new byte[] {0x01, 0x02, 0x03, 0x04});
+    assets.put("config/settings.json", "{\"enabled\":true}".getBytes(StandardCharsets.UTF_8));
+
+    String splitPath = ShadowPackageManager.createSplitApkWithAssets("feature_assets", assets);
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, "feature_assets", splitPath);
+
+    AssetManager am = AssetManager.class.getDeclaredConstructor().newInstance();
+    ShadowAssetManager.addSplitAssetPath(am, splitPath);
+
+    try (InputStream is = am.open("assets.txt")) {
+      assertThat(new String(is.readAllBytes(), StandardCharsets.UTF_8))
+          .isEqualTo("Main asset file");
+    }
+    try (InputStream is = am.open("data/model.bin")) {
+      assertThat(is.readAllBytes()).hasLength(4);
+    }
+    try (InputStream is = am.open("config/settings.json")) {
+      assertThat(new String(is.readAllBytes(), StandardCharsets.UTF_8)).contains("enabled");
+    }
+  }
+
+  /**
+   * Verifies that assets from different split modules are isolated and accessible independently.
+   * The official sample has multiple feature modules, each potentially with its own assets.
+   */
+  @Test
+  public void multipleModules_assetsIsolatedPerSplit() throws Exception {
+    // Asset-only module
+    String assetSplitPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "feature_assets",
+            Map.of("assets.txt", "from assets module".getBytes(StandardCharsets.UTF_8)));
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, "feature_assets", assetSplitPath);
+
+    // Kotlin feature module with its own assets
+    String kotlinSplitPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "feature_kotlin",
+            Map.of("kotlin_data.txt", "from kotlin module".getBytes(StandardCharsets.UTF_8)));
+    shadowPackageManager.addSplitToInstalledPackage(
+        PACKAGE_NAME, "feature_kotlin", kotlinSplitPath);
+
+    // Each split's assets are accessible via its own path
+    AssetManager am1 = AssetManager.class.getDeclaredConstructor().newInstance();
+    ShadowAssetManager.addSplitAssetPath(am1, assetSplitPath);
+    try (InputStream is = am1.open("assets.txt")) {
+      assertThat(new String(is.readAllBytes(), StandardCharsets.UTF_8))
+          .isEqualTo("from assets module");
+    }
+
+    AssetManager am2 = AssetManager.class.getDeclaredConstructor().newInstance();
+    ShadowAssetManager.addSplitAssetPath(am2, kotlinSplitPath);
+    try (InputStream is = am2.open("kotlin_data.txt")) {
+      assertThat(new String(is.readAllBytes(), StandardCharsets.UTF_8))
+          .isEqualTo("from kotlin module");
+    }
+  }
+}

--- a/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/BundletoolWorkflowTest.java
+++ b/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/BundletoolWorkflowTest.java
@@ -1,0 +1,270 @@
+package org.robolectric.integrationtests.splitapk;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.res.AssetManager;
+import android.os.Build.VERSION_CODES;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.BundletoolSplitApkLoader;
+import org.robolectric.shadows.ShadowAssetManager;
+import org.robolectric.shadows.ShadowPackageManager;
+
+/**
+ * Tests for bundletool integration, verifying that Robolectric can load and install split APKs from
+ * bundletool-generated archives and directories.
+ *
+ * <p>Bundletool (https://developer.android.com/tools/bundletool) is the tool that processes AAB
+ * files to generate device-specific APK sets. The DynamicFeatures sample's AAB would be processed
+ * by bundletool to produce a {@code .apks} archive with the following structure:
+ *
+ * <pre>
+ * DynamicFeatures.apks
+ * └── splits/
+ *     ├── base-master.apk          (base module)
+ *     ├── base-xxhdpi.apk          (density config)
+ *     ├── base-arm64_v8a.apk       (ABI config)
+ *     ├── base-en.apk              (language config)
+ *     ├── initialInstall-master.apk (install-time feature)
+ *     ├── feature_kotlin-master.apk (on-demand feature)
+ *     ├── feature_java-master.apk   (on-demand feature)
+ *     └── feature_assets-master.apk (asset-only feature)
+ * </pre>
+ *
+ * <p>This test class verifies the complete workflow from bundletool output to installed package.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = VERSION_CODES.O)
+public class BundletoolWorkflowTest {
+
+  private static final String PACKAGE_NAME = "com.google.android.samples.dynamicfeatures";
+
+  private PackageManager packageManager;
+  private ShadowPackageManager shadowPackageManager;
+
+  @Before
+  public void setUp() {
+    packageManager = RuntimeEnvironment.getApplication().getPackageManager();
+    shadowPackageManager = shadowOf(packageManager);
+  }
+
+  /**
+   * Simulates running {@code bundletool build-apks} on the DynamicFeatures AAB and then installing
+   * via {@code bundletool install-apks}. The .apks archive contains splits for the device.
+   */
+  @Test
+  public void bundletoolBuildApks_installFromArchive() throws Exception {
+    // Create split APKs mimicking bundletool output for DynamicFeatures
+    Map<String, String> apkPaths = new LinkedHashMap<>();
+    apkPaths.put(
+        "base-master",
+        ShadowPackageManager.createSplitApkWithAssets(
+            "base-master",
+            Map.of("base_manifest.dat", "base module".getBytes(StandardCharsets.UTF_8))));
+    apkPaths.put(
+        "base-xxhdpi",
+        ShadowPackageManager.createSplitApkWithAssets(
+            "base-xxhdpi", Map.of("res/drawable-xxhdpi/icon.png", new byte[] {(byte) 0x89, 0x50})));
+    apkPaths.put(
+        "base-en",
+        ShadowPackageManager.createSplitApkWithAssets(
+            "base-en",
+            Map.of(
+                "res/values-en/strings.dat", "English strings".getBytes(StandardCharsets.UTF_8))));
+    apkPaths.put(
+        "initialInstall-master",
+        ShadowPackageManager.createSplitApkWithAssets(
+            "initialInstall-master",
+            Map.of("initial.dat", "initial install".getBytes(StandardCharsets.UTF_8))));
+
+    // Create .apks archive
+    Path apksArchive = BundletoolSplitApkLoader.createApksArchive(apkPaths);
+    assertThat(Files.exists(apksArchive)).isTrue();
+
+    // Load and install
+    Map<String, String> loaded = BundletoolSplitApkLoader.loadFromApksArchive(apksArchive);
+    assertThat(loaded).hasSize(4);
+
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    info.applicationInfo.splitNames = loaded.keySet().toArray(new String[0]);
+    shadowPackageManager.installPackageWithSplitApks(info, loaded);
+
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).hasLength(4);
+    assertThat(installed.applicationInfo.splitSourceDirs).hasLength(4);
+  }
+
+  /**
+   * Simulates loading split APKs from a directory, as produced by {@code bundletool build-apks
+   * --output-format=DIRECTORY}. This is useful for CI/CD pipelines and local testing.
+   */
+  @Test
+  public void bundletoolOutputDirectory_loadAndInstall() throws Exception {
+    Path splitDir = Files.createTempDirectory("bundletool-splits");
+    try {
+      // Create splits matching DynamicFeatures bundletool output
+      for (String splitName :
+          new String[] {"base-master", "base-xxhdpi", "feature_kotlin-master"}) {
+        String apk =
+            ShadowPackageManager.createSplitApkWithAssets(
+                splitName, Map.of(splitName + ".dat", splitName.getBytes(StandardCharsets.UTF_8)));
+        Files.copy(Path.of(apk), splitDir.resolve(splitName + ".apk"));
+      }
+
+      Map<String, String> loaded = BundletoolSplitApkLoader.loadFromDirectory(splitDir);
+      assertThat(loaded).hasSize(3);
+
+      PackageInfo info = new PackageInfo();
+      info.packageName = PACKAGE_NAME;
+      info.applicationInfo = new ApplicationInfo();
+      info.applicationInfo.packageName = PACKAGE_NAME;
+      info.applicationInfo.splitNames = loaded.keySet().toArray(new String[0]);
+      shadowPackageManager.installPackageWithSplitApks(info, loaded);
+
+      PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+      assertThat(installed.applicationInfo.splitNames).hasLength(3);
+    } finally {
+      try (var stream = Files.list(splitDir)) {
+        stream.forEach(
+            p -> {
+              try {
+                Files.delete(p);
+              } catch (Exception ignored) {
+              }
+            });
+      }
+      Files.delete(splitDir);
+    }
+  }
+
+  /**
+   * Simulates filtering bundletool output to load only base module splits (excluding feature
+   * modules). This matches the scenario of testing the base app without any dynamic features.
+   */
+  @Test
+  public void bundletoolPrefixFilter_baseModuleOnly() throws Exception {
+    Map<String, String> allApks = new LinkedHashMap<>();
+    for (String name :
+        new String[] {
+          "base-master",
+          "base-xxhdpi",
+          "base-en",
+          "feature_kotlin-master",
+          "feature_java-master",
+          "feature_assets-master"
+        }) {
+      allApks.put(
+          name,
+          ShadowPackageManager.createSplitApkWithAssets(
+              name, Map.of(name + ".dat", name.getBytes(StandardCharsets.UTF_8))));
+    }
+
+    Path archive = BundletoolSplitApkLoader.createApksArchive(allApks);
+
+    // Load only base splits
+    Map<String, String> baseSplits = BundletoolSplitApkLoader.loadFromApksArchive(archive, "base-");
+    assertThat(baseSplits).hasSize(3);
+    assertThat(baseSplits).containsKey("base-master");
+    assertThat(baseSplits).containsKey("base-xxhdpi");
+    assertThat(baseSplits).containsKey("base-en");
+    assertThat(baseSplits).doesNotContainKey("feature_kotlin-master");
+  }
+
+  /**
+   * End-to-end test: build .apks archive, load specific module, install base + feature, verify
+   * assets are accessible. This mirrors the complete bundletool workflow for local testing.
+   */
+  @Test
+  public void endToEnd_bundletoolArchiveToAssetAccess() throws Exception {
+    // Create the full DynamicFeatures .apks archive
+    Map<String, String> allApks = new LinkedHashMap<>();
+    allApks.put(
+        "base-master",
+        ShadowPackageManager.createSplitApkWithAssets(
+            "base-master", Map.of("app.dat", "base app".getBytes(StandardCharsets.UTF_8))));
+    allApks.put(
+        "feature_assets-master",
+        ShadowPackageManager.createSplitApkWithAssets(
+            "feature_assets-master",
+            Map.of(
+                "assets.txt",
+                "This text originates from a dynamically loaded feature."
+                    .getBytes(StandardCharsets.UTF_8))));
+
+    Path archive = BundletoolSplitApkLoader.createApksArchive(allApks);
+
+    // Load all splits and install
+    Map<String, String> loaded = BundletoolSplitApkLoader.loadFromApksArchive(archive);
+
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    info.applicationInfo.splitNames = loaded.keySet().toArray(new String[0]);
+    shadowPackageManager.installPackageWithSplitApks(info, loaded);
+
+    // Verify asset from the feature module is accessible
+    String featurePath = loaded.get("feature_assets-master");
+    AssetManager am = AssetManager.class.getDeclaredConstructor().newInstance();
+    ShadowAssetManager.addSplitAssetPath(am, featurePath);
+
+    try (InputStream is = am.open("assets.txt")) {
+      String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+      assertThat(content).contains("dynamically loaded feature");
+    }
+  }
+
+  /**
+   * Verifies that bundletool's naming convention for config splits (module-config.apk) is correctly
+   * handled. Each split name preserves the full bundletool filename.
+   */
+  @Test
+  public void bundletoolNamingConvention_preservedInSplitNames() throws Exception {
+    Map<String, String> apks = new LinkedHashMap<>();
+    // Bundletool naming: module-dimension_value.apk
+    for (String name :
+        new String[] {
+          "base-master",
+          "base-xxhdpi",
+          "base-arm64_v8a",
+          "base-en",
+          "feature_kotlin-master",
+          "feature_kotlin-xxhdpi"
+        }) {
+      apks.put(
+          name,
+          ShadowPackageManager.createSplitApkWithAssets(
+              name, Map.of("x.dat", "x".getBytes(StandardCharsets.UTF_8))));
+    }
+
+    Path archive = BundletoolSplitApkLoader.createApksArchive(apks);
+    Map<String, String> loaded = BundletoolSplitApkLoader.loadFromApksArchive(archive);
+
+    // All bundletool names should be preserved
+    assertThat(loaded.keySet())
+        .containsExactly(
+            "base-master",
+            "base-xxhdpi",
+            "base-arm64_v8a",
+            "base-en",
+            "feature_kotlin-master",
+            "feature_kotlin-xxhdpi");
+  }
+}

--- a/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/CompiledResourcesTest.java
+++ b/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/CompiledResourcesTest.java
@@ -1,0 +1,209 @@
+package org.robolectric.integrationtests.splitapk;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build.VERSION_CODES;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowPackageManager;
+
+/**
+ * Tests for compiled resource support in split APKs, verifying that {@code resources.arsc} can be
+ * generated and included in split APK files.
+ *
+ * <p>In a real AAB, each feature module has its own compiled resources (drawable, layout, string
+ * resources) in its split APK. The DynamicFeatures sample's feature modules each have their own
+ * layouts and string resources:
+ *
+ * <ul>
+ *   <li>features/kotlin/src/main/res/ - KotlinSampleActivity layout and strings
+ *   <li>features/java/src/main/res/ - JavaSampleActivity layout and strings
+ *   <li>features/initialInstall/src/main/res/ - InitialInstallActivity layout and strings
+ * </ul>
+ *
+ * <p>This test verifies that Robolectric can create split APKs with compiled string resources using
+ * {@code ArscResourceTableBuilder} and load them via the resource pipeline.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = VERSION_CODES.O)
+public class CompiledResourcesTest {
+
+  private static final String PACKAGE_NAME = "com.google.android.samples.dynamicfeatures";
+
+  private PackageManager packageManager;
+  private ShadowPackageManager shadowPackageManager;
+
+  @Before
+  public void setUp() {
+    packageManager = RuntimeEnvironment.getApplication().getPackageManager();
+    shadowPackageManager = shadowOf(packageManager);
+  }
+
+  /**
+   * Simulates the Kotlin feature module which has its own string resources (e.g.,
+   * "module_feature_kotlin" title referenced in its AndroidManifest.xml's dist:title attribute).
+   */
+  @Test
+  public void kotlinFeature_stringResources_inSplitApk() throws Exception {
+    Map<String, String> strings = new LinkedHashMap<>();
+    strings.put("module_feature_kotlin", "Kotlin Feature");
+    strings.put("kotlin_activity_title", "Kotlin Sample Activity");
+
+    String splitPath =
+        ShadowPackageManager.createSplitApkWithResources(
+            "feature_kotlin",
+            "com.google.android.samples.dynamicfeatures.ondemand.kotlin",
+            0x7f,
+            strings,
+            null);
+
+    // Install and verify
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    shadowPackageManager.installPackage(info);
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, "feature_kotlin", splitPath);
+
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).asList().contains("feature_kotlin");
+
+    // Verify the APK file exists and contains resources.arsc
+    java.nio.file.Path apkPath = java.nio.file.Path.of(splitPath);
+    assertThat(java.nio.file.Files.exists(apkPath)).isTrue();
+    try (java.util.zip.ZipFile zf = new java.util.zip.ZipFile(apkPath.toFile())) {
+      assertThat(zf.getEntry("resources.arsc")).isNotNull();
+    }
+  }
+
+  /**
+   * Simulates the Java feature module with its own string resources, paralleling features/java/
+   * from the official sample.
+   */
+  @Test
+  public void javaFeature_stringResources_inSplitApk() throws Exception {
+    Map<String, String> strings = new LinkedHashMap<>();
+    strings.put("module_feature_java", "Java Feature");
+    strings.put("java_activity_title", "Java Sample Activity");
+
+    String splitPath =
+        ShadowPackageManager.createSplitApkWithResources(
+            "feature_java",
+            "com.google.android.samples.dynamicfeatures.ondemand.java",
+            0x7f,
+            strings,
+            null);
+
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    shadowPackageManager.installPackage(info);
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, "feature_java", splitPath);
+
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).asList().contains("feature_java");
+  }
+
+  /**
+   * Simulates the initialInstall feature module which is bundled at install time. It has its own
+   * layout and string resources.
+   */
+  @Test
+  public void initialInstallFeature_stringResources_bundledAtInstallTime() throws Exception {
+    Map<String, String> strings = new LinkedHashMap<>();
+    strings.put("title_module_initial", "Initial Install");
+    strings.put("initial_activity_title", "Initial Install Activity");
+
+    String splitPath =
+        ShadowPackageManager.createSplitApkWithResources(
+            "initialInstall",
+            "com.google.android.samples.dynamicfeatures.initialinstall",
+            0x7f,
+            strings,
+            null);
+
+    // Install-time features are bundled with the initial install
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    info.applicationInfo.splitNames = new String[] {"initialInstall"};
+
+    Map<String, String> splits = new LinkedHashMap<>();
+    splits.put("initialInstall", splitPath);
+    shadowPackageManager.installPackageWithSplitApks(info, splits);
+
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).asList().contains("initialInstall");
+  }
+
+  /**
+   * Verifies that a split APK can have both compiled resources (resources.arsc) and raw assets.
+   * This mirrors a feature module that has layouts, strings, AND asset files.
+   */
+  @Test
+  public void featureWithResourcesAndAssets_bothAccessible() throws Exception {
+    Map<String, String> strings = new LinkedHashMap<>();
+    strings.put("module_assets", "Assets Feature");
+
+    Map<String, byte[]> assets = new LinkedHashMap<>();
+    assets.put(
+        "assets.txt",
+        "This text originates from a dynamically loaded feature.".getBytes(StandardCharsets.UTF_8));
+
+    String splitPath =
+        ShadowPackageManager.createSplitApkWithResources(
+            "feature_assets",
+            "com.google.android.samples.dynamicfeatures.ondemand.assets",
+            0x7f,
+            strings,
+            assets);
+
+    // Verify both resources.arsc and assets exist in the APK
+    try (java.util.zip.ZipFile zf =
+        new java.util.zip.ZipFile(java.nio.file.Path.of(splitPath).toFile())) {
+      assertThat(zf.getEntry("resources.arsc")).isNotNull();
+      assertThat(zf.getEntry("assets/assets.txt")).isNotNull();
+
+      // Verify asset content
+      try (java.io.InputStream is = zf.getInputStream(zf.getEntry("assets/assets.txt"))) {
+        String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        assertThat(content).contains("dynamically loaded feature");
+      }
+    }
+  }
+
+  /**
+   * Verifies that the resources.arsc in the split APK uses STORED compression as required by
+   * Android's resource loading pipeline (resources.arsc must not be compressed).
+   */
+  @Test
+  public void resourcesArsc_storedNotCompressed() throws Exception {
+    Map<String, String> strings = new LinkedHashMap<>();
+    strings.put("test_string", "Test Value");
+
+    String splitPath =
+        ShadowPackageManager.createSplitApkWithResources(
+            "test_module", "com.example.test", 0x7f, strings, null);
+
+    try (java.util.zip.ZipFile zf =
+        new java.util.zip.ZipFile(java.nio.file.Path.of(splitPath).toFile())) {
+      java.util.zip.ZipEntry arscEntry = zf.getEntry("resources.arsc");
+      assertThat(arscEntry).isNotNull();
+      // STORED means size == compressedSize
+      assertThat(arscEntry.getSize()).isEqualTo(arscEntry.getCompressedSize());
+    }
+  }
+}

--- a/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/ConfigSplitsTest.java
+++ b/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/ConfigSplitsTest.java
@@ -1,0 +1,236 @@
+package org.robolectric.integrationtests.splitapk;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build.VERSION_CODES;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowPackageManager;
+
+/**
+ * Tests for Android App Bundle configuration splits (density, ABI, language).
+ *
+ * <p>When the Play Store installs an AAB-based app, it generates config splits tailored to the
+ * target device. These are in addition to any dynamic feature splits. The DynamicFeatures sample
+ * relies on the Play Store to generate these splits, but in tests we need to verify the underlying
+ * infrastructure handles them correctly.
+ *
+ * <p>Config split naming follows bundletool convention:
+ *
+ * <ul>
+ *   <li>Density: {@code base-xxhdpi.apk}, {@code base-mdpi.apk}
+ *   <li>ABI: {@code base-arm64_v8a.apk}, {@code base-x86_64.apk}
+ *   <li>Language: {@code base-en.apk}, {@code base-pl.apk}
+ *   <li>Feature config: {@code feature_kotlin-xxhdpi.apk}
+ * </ul>
+ *
+ * <p>The DynamicFeatures sample supports language switching (English/Polish) via LanguageHelper,
+ * which is backed by config splits containing locale-specific resources.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = VERSION_CODES.O)
+public class ConfigSplitsTest {
+
+  private static final String PACKAGE_NAME = "com.google.android.samples.dynamicfeatures";
+
+  private PackageManager packageManager;
+  private ShadowPackageManager shadowPackageManager;
+
+  @Before
+  public void setUp() {
+    packageManager = RuntimeEnvironment.getApplication().getPackageManager();
+    shadowPackageManager = shadowOf(packageManager);
+  }
+
+  /**
+   * Simulates the typical Play Store installation with density, ABI, and language config splits
+   * alongside the base module, matching what a real device would receive for the DynamicFeatures
+   * app.
+   */
+  @Test
+  public void playStoreInstall_configSplitsForDevice() throws Exception {
+    String[] splitNames = {
+      "base-xxhdpi", // density split
+      "base-arm64_v8a", // ABI split
+      "base-en" // language split (English, default for DynamicFeatures)
+    };
+
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    info.applicationInfo.splitNames = splitNames;
+
+    Map<String, String> splits = new LinkedHashMap<>();
+    for (String name : splitNames) {
+      splits.put(
+          name,
+          ShadowPackageManager.createSplitApkWithAssets(
+              name, Map.of(name + ".cfg", name.getBytes(StandardCharsets.UTF_8))));
+    }
+    shadowPackageManager.installPackageWithSplitApks(info, splits);
+
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames)
+        .asList()
+        .containsExactly("base-xxhdpi", "base-arm64_v8a", "base-en");
+    assertThat(installed.applicationInfo.splitSourceDirs).hasLength(3);
+  }
+
+  /**
+   * Simulates language switching from English to Polish, as supported by the DynamicFeatures
+   * sample's LanguageHelper. When a user selects Polish, the Play Store downloads the {@code
+   * base-pl} config split via SplitInstallManager.startInstall() with addLanguage(Locale("pl")).
+   */
+  @Test
+  public void languageConfigSplit_polishLanguageAdded() throws Exception {
+    // Initial install with English
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    info.applicationInfo.splitNames = new String[] {"base-en"};
+
+    Map<String, String> splits = new LinkedHashMap<>();
+    splits.put(
+        "base-en",
+        ShadowPackageManager.createSplitApkWithAssets(
+            "base-en", Map.of("strings-en.dat", "English".getBytes(StandardCharsets.UTF_8))));
+    shadowPackageManager.installPackageWithSplitApks(info, splits);
+
+    // User selects Polish → SplitInstallManager downloads base-pl split
+    String plSplitPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "base-pl", Map.of("strings-pl.dat", "Polish".getBytes(StandardCharsets.UTF_8)));
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, "base-pl", plSplitPath);
+
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).asList().containsExactly("base-en", "base-pl");
+  }
+
+  /**
+   * Verifies that config splits for a dynamic feature module (e.g., feature_kotlin-xxhdpi) can
+   * coexist with base config splits and the feature module itself.
+   */
+  @Test
+  public void featureConfigSplits_coexistWithBaseAndFeature() throws Exception {
+    String[] splitNames = {
+      "base-xxhdpi", // base density config
+      "base-en", // base language config
+      "feature_kotlin", // the feature module itself
+      "feature_kotlin-xxhdpi" // feature's density config
+    };
+
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    info.applicationInfo.splitNames = splitNames;
+
+    Map<String, String> splits = new LinkedHashMap<>();
+    for (String name : splitNames) {
+      splits.put(
+          name,
+          ShadowPackageManager.createSplitApkWithAssets(
+              name, Map.of(name + ".cfg", name.getBytes(StandardCharsets.UTF_8))));
+    }
+    shadowPackageManager.installPackageWithSplitApks(info, splits);
+
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).hasLength(4);
+    assertThat(installed.applicationInfo.splitSourceDirs).hasLength(4);
+  }
+
+  /**
+   * Verifies that multiple density config splits can be handled (e.g., during development or
+   * testing with bundletool's --connected-device mode which includes all densities).
+   */
+  @Test
+  public void multipleDensitySplits_allTracked() throws Exception {
+    String[] densities = {"base-ldpi", "base-mdpi", "base-hdpi", "base-xhdpi", "base-xxhdpi"};
+
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    info.applicationInfo.splitNames = densities;
+
+    Map<String, String> splits = new LinkedHashMap<>();
+    for (String name : densities) {
+      splits.put(
+          name,
+          ShadowPackageManager.createSplitApkWithAssets(
+              name, Map.of(name + ".cfg", name.getBytes(StandardCharsets.UTF_8))));
+    }
+    shadowPackageManager.installPackageWithSplitApks(info, splits);
+
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).hasLength(5);
+  }
+
+  /**
+   * Simulates the complete initial Play Store install with config splits, install-time features,
+   * and later on-demand feature additions — the full DynamicFeatures sample lifecycle.
+   */
+  @Test
+  public void fullLifecycle_configSplitsAndFeatures() throws Exception {
+    // Step 1: Play Store install (base + config splits + install-time feature)
+    String[] initialSplits = {"base-xxhdpi", "base-arm64_v8a", "base-en", "initialInstall"};
+
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    info.applicationInfo.splitNames = initialSplits;
+
+    Map<String, String> splits = new LinkedHashMap<>();
+    for (String name : initialSplits) {
+      splits.put(
+          name,
+          ShadowPackageManager.createSplitApkWithAssets(
+              name, Map.of(name + ".dat", name.getBytes(StandardCharsets.UTF_8))));
+    }
+    shadowPackageManager.installPackageWithSplitApks(info, splits);
+
+    // Step 2: User requests on-demand features
+    for (String feature : new String[] {"feature_kotlin", "feature_java", "feature_assets"}) {
+      String path =
+          ShadowPackageManager.createSplitApkWithAssets(
+              feature, Map.of(feature + ".dat", feature.getBytes(StandardCharsets.UTF_8)));
+      shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, feature, path);
+    }
+
+    // Step 3: User switches language to Polish
+    String plPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "base-pl", Map.of("pl.dat", "pl".getBytes(StandardCharsets.UTF_8)));
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, "base-pl", plPath);
+
+    // Verify final state: 8 splits total
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).hasLength(8);
+    assertThat(installed.applicationInfo.splitNames)
+        .asList()
+        .containsExactly(
+            "base-xxhdpi",
+            "base-arm64_v8a",
+            "base-en",
+            "initialInstall",
+            "feature_kotlin",
+            "feature_java",
+            "feature_assets",
+            "base-pl")
+        .inOrder();
+  }
+}

--- a/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/DynamicFeatureDeliveryTest.java
+++ b/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/DynamicFeatureDeliveryTest.java
@@ -1,0 +1,253 @@
+package org.robolectric.integrationtests.splitapk;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.res.AssetManager;
+import android.os.Build.VERSION_CODES;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowAssetManager;
+import org.robolectric.shadows.ShadowPackageManager;
+
+/**
+ * Tests modeled after the DynamicFeatures sample's {@code MainActivity} which uses {@code
+ * SplitInstallManager} to request, install, and launch dynamic feature modules on demand.
+ *
+ * <p>In the official sample, MainActivity:
+ *
+ * <ul>
+ *   <li>Creates a SplitInstallManager via SplitInstallManagerFactory.create()
+ *   <li>Builds SplitInstallRequest with addModule(moduleName)
+ *   <li>Monitors install via SplitInstallStateUpdatedListener
+ *   <li>Launches feature activities via setClassName(packageName, activityClassName)
+ *   <li>Accesses assets from asset-only modules
+ *   <li>Queries manager.installedModules for installed features
+ * </ul>
+ *
+ * <p>These tests verify that Robolectric supports the underlying PackageManager and AssetManager
+ * operations that SplitInstallManager delegates to.
+ *
+ * <p>Reference: {@code DynamicFeatures/app/src/main/java/.../MainActivity.kt}
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = VERSION_CODES.O)
+public class DynamicFeatureDeliveryTest {
+
+  private static final String PACKAGE_NAME = "com.google.android.samples.dynamicfeatures";
+
+  // Module names from the official DynamicFeatures sample
+  private static final String MODULE_KOTLIN = "feature_kotlin";
+  private static final String MODULE_JAVA = "feature_java";
+  private static final String MODULE_NATIVE = "feature_native";
+  private static final String MODULE_ASSETS = "feature_assets";
+  private static final String MODULE_INITIAL_INSTALL = "initialInstall";
+
+  private PackageManager packageManager;
+  private ShadowPackageManager shadowPackageManager;
+
+  @Before
+  public void setUp() {
+    packageManager = RuntimeEnvironment.getApplication().getPackageManager();
+    shadowPackageManager = shadowOf(packageManager);
+
+    // Install the base app (initial state before any dynamic features)
+    PackageInfo baseApp = new PackageInfo();
+    baseApp.packageName = PACKAGE_NAME;
+    baseApp.applicationInfo = new ApplicationInfo();
+    baseApp.applicationInfo.packageName = PACKAGE_NAME;
+    shadowPackageManager.installPackage(baseApp);
+  }
+
+  /**
+   * Simulates the on-demand download and installation of the Kotlin feature module. In the official
+   * sample, this happens via SplitInstallRequest.newBuilder().addModule("feature_kotlin").build().
+   *
+   * <p>After install, the module should appear in installedModules and its activity class
+   * (KotlinSampleActivity) should be launchable.
+   */
+  @Test
+  public void onDemandFeature_kotlinModule_installedAndAccessible() throws Exception {
+    // Simulate: SplitInstallManager downloads and installs the Kotlin feature
+    String splitPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            MODULE_KOTLIN,
+            Map.of("kotlin_feature.dat", "kotlin module data".getBytes(StandardCharsets.UTF_8)));
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, MODULE_KOTLIN, splitPath);
+
+    // Verify: manager.installedModules should contain "feature_kotlin"
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).asList().contains(MODULE_KOTLIN);
+    assertThat(installed.applicationInfo.splitSourceDirs).hasLength(1);
+  }
+
+  /**
+   * Simulates the on-demand download and installation of the Java feature module. In the official
+   * sample, JavaSampleActivity is launched after successful install.
+   */
+  @Test
+  public void onDemandFeature_javaModule_installedAndAccessible() throws Exception {
+    String splitPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            MODULE_JAVA,
+            Map.of("java_feature.dat", "java module data".getBytes(StandardCharsets.UTF_8)));
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, MODULE_JAVA, splitPath);
+
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).asList().contains(MODULE_JAVA);
+  }
+
+  /**
+   * Simulates installing all on-demand features at once, mirroring the "Install all now" button in
+   * the DynamicFeatures sample. The sample installs: kotlin, java, native, and assets modules.
+   */
+  @Test
+  public void installAllNow_allOnDemandModulesInstalled() throws Exception {
+    String[] modules = {MODULE_KOTLIN, MODULE_JAVA, MODULE_NATIVE, MODULE_ASSETS};
+    for (String module : modules) {
+      String splitPath =
+          ShadowPackageManager.createSplitApkWithAssets(
+              module, Map.of(module + ".dat", module.getBytes(StandardCharsets.UTF_8)));
+      shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, module, splitPath);
+    }
+
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames)
+        .asList()
+        .containsExactly(MODULE_KOTLIN, MODULE_JAVA, MODULE_NATIVE, MODULE_ASSETS)
+        .inOrder();
+    assertThat(installed.applicationInfo.splitSourceDirs).hasLength(4);
+  }
+
+  /**
+   * Simulates the asset-only module pattern from the DynamicFeatures sample. The "assets" feature
+   * module has {@code android:hasCode="false"} and only contains an assets/assets.txt file.
+   *
+   * <p>In the official sample, MainActivity.displayAssets() reads the asset content after the
+   * module is installed.
+   */
+  @Test
+  public void assetOnlyModule_assetsAccessibleAfterInstall() throws Exception {
+    // The official sample's assets module contains assets/assets.txt
+    String assetContent =
+        "This text originates from a dynamically loaded feature.\n"
+            + "The source can be found in features/assets/assets/assets.txt.";
+
+    String splitPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            MODULE_ASSETS, Map.of("assets.txt", assetContent.getBytes(StandardCharsets.UTF_8)));
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, MODULE_ASSETS, splitPath);
+
+    // Load asset via AssetManager (same as SplitCompat would do)
+    AssetManager assetManager = AssetManager.class.getDeclaredConstructor().newInstance();
+    ShadowAssetManager.addSplitAssetPath(assetManager, splitPath);
+
+    try (InputStream is = assetManager.open("assets.txt")) {
+      String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+      assertThat(content).contains("dynamically loaded feature");
+    }
+  }
+
+  /**
+   * Simulates the install-time feature module from the DynamicFeatures sample. The "initialInstall"
+   * feature uses {@code <dist:install-time />} delivery, meaning it's included with the base APK
+   * from the Play Store.
+   */
+  @Test
+  public void installTimeFeature_availableImmediately() throws Exception {
+    // Install-time features are bundled with the base install
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    info.applicationInfo.splitNames = new String[] {MODULE_INITIAL_INSTALL};
+
+    Map<String, String> splits = new LinkedHashMap<>();
+    splits.put(
+        MODULE_INITIAL_INSTALL,
+        ShadowPackageManager.createSplitApkWithAssets(
+            MODULE_INITIAL_INSTALL,
+            Map.of("initial_data.txt", "initial install data".getBytes(StandardCharsets.UTF_8))));
+    shadowPackageManager.installPackageWithSplitApks(info, splits);
+
+    // The install-time feature is immediately available (no need for dynamic install)
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).asList().contains(MODULE_INITIAL_INSTALL);
+  }
+
+  /**
+   * Simulates the scenario where install-time features are pre-installed and then on-demand
+   * features are added later. This matches the real app lifecycle: base + initialInstall are
+   * installed from Play Store, then user requests feature_kotlin, feature_java, etc.
+   */
+  @Test
+  public void mixedDeliveryTypes_installTimeAndOnDemand() throws Exception {
+    // Step 1: Install base with install-time feature (from Play Store)
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    info.applicationInfo.splitNames = new String[] {MODULE_INITIAL_INSTALL};
+
+    Map<String, String> splits = new LinkedHashMap<>();
+    splits.put(
+        MODULE_INITIAL_INSTALL,
+        ShadowPackageManager.createSplitApkWithAssets(
+            MODULE_INITIAL_INSTALL,
+            Map.of("initial.txt", "init".getBytes(StandardCharsets.UTF_8))));
+    shadowPackageManager.installPackageWithSplitApks(info, splits);
+
+    // Step 2: User requests on-demand features
+    String kotlinPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            MODULE_KOTLIN, Map.of("kotlin.txt", "kt".getBytes(StandardCharsets.UTF_8)));
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, MODULE_KOTLIN, kotlinPath);
+
+    String javaPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            MODULE_JAVA, Map.of("java.txt", "java".getBytes(StandardCharsets.UTF_8)));
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, MODULE_JAVA, javaPath);
+
+    // Verify all splits present
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames)
+        .asList()
+        .containsExactly(MODULE_INITIAL_INSTALL, MODULE_KOTLIN, MODULE_JAVA)
+        .inOrder();
+    assertThat(installed.applicationInfo.splitSourceDirs).hasLength(3);
+  }
+
+  /**
+   * Verifies that after installing a feature module, an activity from that module can be resolved
+   * via Intent.setClassName(). The official sample uses this pattern in launchActivity().
+   *
+   * <p>Reference: MainActivity.launchActivity() sets className to
+   * "com.google.android.samples.dynamicfeatures.ondemand.KotlinSampleActivity"
+   */
+  @Test
+  public void featureActivity_resolvableAfterModuleInstall() throws Exception {
+    String splitPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            MODULE_KOTLIN, Map.of("k.txt", "k".getBytes(StandardCharsets.UTF_8)));
+    shadowPackageManager.addSplitToInstalledPackage(PACKAGE_NAME, MODULE_KOTLIN, splitPath);
+
+    // The split is registered and its source dir is accessible
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).asList().contains(MODULE_KOTLIN);
+
+    // Verify the split APK file path is a real file
+    String splitSourceDir = installed.applicationInfo.splitSourceDirs[0];
+    assertThat(java.nio.file.Files.exists(java.nio.file.Path.of(splitSourceDir))).isTrue();
+  }
+}

--- a/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/SplitCompatApplicationTest.java
+++ b/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/SplitCompatApplicationTest.java
@@ -1,0 +1,133 @@
+package org.robolectric.integrationtests.splitapk;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build.VERSION_CODES;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowPackageManager;
+
+/**
+ * Tests modeled after the DynamicFeatures sample's {@code MyApplication} class which uses {@code
+ * SplitCompat.install(this)} in {@code attachBaseContext()}.
+ *
+ * <p>In the official sample (https://github.com/android/app-bundle-samples), MyApplication extends
+ * Application and calls SplitCompat.install() to enable access to code and resources from dynamic
+ * feature modules. This test verifies that Robolectric's split APK infrastructure supports the same
+ * split metadata patterns that SplitCompat relies on.
+ *
+ * <p>Reference: {@code DynamicFeatures/app/src/main/java/.../MyApplication.kt}
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = VERSION_CODES.O)
+public class SplitCompatApplicationTest {
+
+  private static final String PACKAGE_NAME = "com.google.android.samples.dynamicfeatures";
+
+  private PackageManager packageManager;
+  private ShadowPackageManager shadowPackageManager;
+
+  @Before
+  public void setUp() {
+    packageManager = RuntimeEnvironment.getApplication().getPackageManager();
+    shadowPackageManager = shadowOf(packageManager);
+  }
+
+  /**
+   * Verifies that a base app can be installed with split metadata, mirroring how SplitCompat
+   * discovers installed splits via ApplicationInfo.splitNames and splitSourceDirs.
+   *
+   * <p>In the real DynamicFeatures app, after SplitCompat.install(), the framework reads
+   * ApplicationInfo to find available split APKs.
+   */
+  @Test
+  public void splitCompat_applicationInfoReflectsSplits() throws Exception {
+    // Install base app with dynamic features (mimicking post-Play-Store install state)
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    info.applicationInfo.splitNames =
+        new String[] {"feature_kotlin", "feature_java", "feature_assets", "initialInstall"};
+
+    Map<String, String> splitPaths = new LinkedHashMap<>();
+    for (String splitName : info.applicationInfo.splitNames) {
+      splitPaths.put(
+          splitName,
+          ShadowPackageManager.createSplitApkWithAssets(
+              splitName, Map.of(splitName + ".dat", splitName.getBytes(StandardCharsets.UTF_8))));
+    }
+    shadowPackageManager.installPackageWithSplitApks(info, splitPaths);
+
+    // SplitCompat reads ApplicationInfo to discover splits
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    ApplicationInfo appInfo = installed.applicationInfo;
+
+    assertThat(appInfo.splitNames).hasLength(4);
+    assertThat(appInfo.splitNames)
+        .asList()
+        .containsExactly("feature_kotlin", "feature_java", "feature_assets", "initialInstall");
+    assertThat(appInfo.splitSourceDirs).hasLength(4);
+    // SplitCompat uses splitPublicSourceDirs as well
+    assertThat(appInfo.splitPublicSourceDirs).isEqualTo(appInfo.splitSourceDirs);
+  }
+
+  /**
+   * Verifies that the base app can be queried even with no splits installed, matching the initial
+   * install state before any dynamic features are downloaded.
+   */
+  @Test
+  public void splitCompat_noSplitsInstalled_baseAppAccessible() throws Exception {
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    shadowPackageManager.installPackage(info);
+
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.applicationInfo.splitNames).isNull();
+    assertThat(installed.applicationInfo.splitSourceDirs).isNull();
+  }
+
+  /**
+   * Verifies that PackageInfo.splitNames is synced with ApplicationInfo.splitNames, as both are
+   * used by different parts of the SplitCompat framework.
+   */
+  @Test
+  public void splitCompat_packageInfoAndAppInfoSplitNamesInSync() throws Exception {
+    PackageInfo info = new PackageInfo();
+    info.packageName = PACKAGE_NAME;
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = PACKAGE_NAME;
+    info.applicationInfo.splitNames = new String[] {"feature_kotlin", "feature_java"};
+    info.splitNames = new String[] {"feature_kotlin", "feature_java"};
+
+    Map<String, String> splits = new LinkedHashMap<>();
+    splits.put(
+        "feature_kotlin",
+        ShadowPackageManager.createSplitApkWithAssets(
+            "feature_kotlin", Map.of("k.txt", "kt".getBytes(StandardCharsets.UTF_8))));
+    splits.put(
+        "feature_java",
+        ShadowPackageManager.createSplitApkWithAssets(
+            "feature_java", Map.of("j.txt", "java".getBytes(StandardCharsets.UTF_8))));
+    shadowPackageManager.installPackageWithSplitApks(info, splits);
+
+    PackageInfo installed = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(installed.splitNames).asList().containsExactly("feature_kotlin", "feature_java");
+    assertThat(installed.applicationInfo.splitNames)
+        .asList()
+        .containsExactly("feature_kotlin", "feature_java");
+  }
+}

--- a/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/package-info.java
+++ b/integration_tests/split-apk/src/test/java/org/robolectric/integrationtests/splitapk/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * Integration tests for Android App Bundle (AAB) split APK support in Robolectric.
+ *
+ * <p>These tests are modeled after the official Android App Bundle samples from
+ * https://github.com/android/app-bundle-samples/tree/main/DynamicFeatures
+ *
+ * <p>The DynamicFeatures sample demonstrates:
+ *
+ * <ul>
+ *   <li>{@code MyApplication} - SplitCompat initialization in attachBaseContext()
+ *   <li>{@code MainActivity} - SplitInstallManager for on-demand feature delivery
+ *   <li>{@code BaseSplitActivity} - SplitCompat.installActivity() for feature activities
+ *   <li>On-demand features: kotlin, java, native, assets, maxSdk
+ *   <li>Install-time feature: initialInstall
+ *   <li>Asset-only module: assets (android:hasCode="false")
+ *   <li>Config splits: density, ABI, language
+ * </ul>
+ *
+ * <p>Since Robolectric tests run on the JVM (not on a real device with Google Play), we simulate
+ * the same patterns using Robolectric's shadow APIs. These tests verify that the split APK
+ * infrastructure works correctly for the same scenarios the official sample targets.
+ */
+package org.robolectric.integrationtests.splitapk;

--- a/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
@@ -633,6 +633,10 @@ public class AndroidTestEnvironment implements TestEnvironment {
       applicationInfo.credentialProtectedDataDir = createTempDir("userDataDir");
       applicationInfo.deviceProtectedDataDir = createTempDir("deviceDataDir");
     }
+
+    // Set up split APK storage if the parsed package has split names.
+    // Delegates to ShadowPackageManager.setUpSplitApkStorage to avoid duplication.
+    ShadowPackageManager.setUpSplitApkStorage(applicationInfo);
   }
 
   private String createTempDir(String name) {

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowLoadedApkClassLoaderTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowLoadedApkClassLoaderTest.java
@@ -1,0 +1,102 @@
+package org.robolectric.shadows;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import android.app.LoadedApk;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.os.Build.VERSION_CODES;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.net.URLClassLoader;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadow.api.Shadow;
+import org.robolectric.util.ReflectionHelpers;
+
+/** Tests for ClassLoader sharing support in {@link ShadowLoadedApk}. */
+@RunWith(AndroidJUnit4.class)
+@Config(minSdk = VERSION_CODES.O)
+public class ShadowLoadedApkClassLoaderTest {
+
+  private ShadowLoadedApk shadowLoadedApk;
+
+  @Before
+  public void setUp() {
+    // Obtain the real LoadedApk from the ContextImpl backing the test application.
+    android.content.Context base = RuntimeEnvironment.getApplication().getBaseContext();
+    LoadedApk loadedApk = ReflectionHelpers.getField(base, "mPackageInfo");
+    shadowLoadedApk = Shadow.extract(loadedApk);
+    // Register some test splits so getSplitClassLoader() does not throw NameNotFoundException.
+    shadowLoadedApk.registerSplitNames("feature_camera", "feature_maps", "config.xxhdpi");
+  }
+
+  @Test
+  public void getSplitClassLoader_withoutExplicitLoader_returnsDefaultClassLoader()
+      throws NameNotFoundException {
+    ClassLoader cl = shadowLoadedApk.getSplitClassLoader("feature_camera");
+    assertThat(cl).isNotNull();
+  }
+
+  @Test
+  public void setSplitClassLoader_returnsRegisteredClassLoader() throws NameNotFoundException {
+    ClassLoader custom = new URLClassLoader(new java.net.URL[0], getClass().getClassLoader());
+    shadowLoadedApk.setSplitClassLoader("feature_camera", custom);
+
+    assertThat(shadowLoadedApk.getSplitClassLoader("feature_camera")).isSameInstanceAs(custom);
+  }
+
+  @Test
+  public void setSplitClassLoader_doesNotAffectOtherSplits() throws NameNotFoundException {
+    ClassLoader custom = new URLClassLoader(new java.net.URL[0], getClass().getClassLoader());
+    shadowLoadedApk.setSplitClassLoader("feature_camera", custom);
+
+    ClassLoader other = shadowLoadedApk.getSplitClassLoader("feature_maps");
+    assertThat(other).isNotSameInstanceAs(custom);
+  }
+
+  @Test
+  public void createIsolatedSplitClassLoader_returnsDifferentInstanceThanDefault()
+      throws NameNotFoundException {
+    ClassLoader defaultCl = shadowLoadedApk.getSplitClassLoader("feature_camera");
+    ClassLoader isolated = shadowLoadedApk.createIsolatedSplitClassLoader("feature_camera");
+
+    assertThat(isolated).isInstanceOf(URLClassLoader.class);
+    // The isolated loader is a child of the app's loader.
+    assertThat(isolated.getParent()).isSameInstanceAs(defaultCl);
+  }
+
+  @Test
+  public void createIsolatedSplitClassLoader_sameCallReturnsSameInstance() {
+    ClassLoader first = shadowLoadedApk.createIsolatedSplitClassLoader("feature_camera");
+    ClassLoader second = shadowLoadedApk.createIsolatedSplitClassLoader("feature_camera");
+
+    assertThat(first).isSameInstanceAs(second);
+  }
+
+  @Test
+  public void createIsolatedSplitClassLoader_differentSplitsGetDifferentLoaders() {
+    ClassLoader cameraLoader = shadowLoadedApk.createIsolatedSplitClassLoader("feature_camera");
+    ClassLoader mapsLoader = shadowLoadedApk.createIsolatedSplitClassLoader("feature_maps");
+
+    assertThat(cameraLoader).isNotSameInstanceAs(mapsLoader);
+  }
+
+  @Test
+  public void setSplitClassLoader_overridesIsolatedLoader() throws NameNotFoundException {
+    shadowLoadedApk.createIsolatedSplitClassLoader("feature_camera");
+    ClassLoader custom = new URLClassLoader(new java.net.URL[0], getClass().getClassLoader());
+    shadowLoadedApk.setSplitClassLoader("feature_camera", custom);
+
+    assertThat(shadowLoadedApk.getSplitClassLoader("feature_camera")).isSameInstanceAs(custom);
+  }
+
+  @Test
+  public void getSplitClassLoader_unknownSplitThrowsNameNotFoundException() {
+    assertThrows(
+        NameNotFoundException.class,
+        () -> shadowLoadedApk.getSplitClassLoader("nonexistent_split"));
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageInstallerCommitTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageInstallerCommitTest.java
@@ -1,0 +1,184 @@
+package org.robolectric.shadows;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.content.IIntentSender;
+import android.content.IntentSender;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageInstaller;
+import android.content.pm.PackageInstaller.SessionParams;
+import android.os.Build.VERSION_CODES;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.io.OutputStream;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadow.api.Shadow;
+import org.robolectric.shadows.ShadowPackageInstaller.ShadowSession;
+import org.robolectric.util.ReflectionHelpers;
+
+/**
+ * Tests for PackageInstaller Session commit integration with {@link ShadowPackageManager} in {@link
+ * ShadowPackageInstaller}.
+ */
+@RunWith(AndroidJUnit4.class)
+@Config(minSdk = VERSION_CODES.O)
+public class ShadowPackageInstallerCommitTest {
+
+  private static final String PACKAGE_NAME = "com.example.splitapp";
+
+  private PackageInstaller packageInstaller;
+  private android.content.pm.PackageManager packageManager;
+
+  @Before
+  public void setUp() {
+    packageManager = ApplicationProvider.getApplicationContext().getPackageManager();
+    packageInstaller = packageManager.getPackageInstaller();
+  }
+
+  @Test
+  public void commit_setsIsCommittedTrue() throws Exception {
+    int sessionId = packageInstaller.createSession(createSessionParams(PACKAGE_NAME));
+    PackageInstaller.Session session = packageInstaller.openSession(sessionId);
+    ShadowSession shadowSession = Shadow.extract(session);
+
+    assertThat(shadowSession.isCommitted()).isFalse();
+    session.commit(nullSender());
+
+    assertThat(shadowSession.isCommitted()).isTrue();
+  }
+
+  @Test
+  public void commit_withBaseAndSplitApks_installsPackageWithSplits() throws Exception {
+    int sessionId = packageInstaller.createSession(createSessionParams(PACKAGE_NAME));
+    PackageInstaller.Session session = packageInstaller.openSession(sessionId);
+
+    // Write base APK (should not become a split name).
+    OutputStream base = session.openWrite("base.apk", 0, -1);
+    base.close();
+    // Write two feature splits.
+    OutputStream feature = session.openWrite("split_feature_camera.apk", 0, -1);
+    feature.close();
+    OutputStream config = session.openWrite("split_config.xxhdpi.apk", 0, -1);
+    config.close();
+
+    session.commit(nullSender());
+
+    PackageInfo info = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(info).isNotNull();
+    assertThat(info.splitNames)
+        .asList()
+        .containsAtLeast("split_feature_camera", "split_config.xxhdpi");
+  }
+
+  @Test
+  public void commit_withBaseApkOnly_installsPackageWithNoSplits() throws Exception {
+    int sessionId = packageInstaller.createSession(createSessionParams(PACKAGE_NAME));
+    PackageInstaller.Session session = packageInstaller.openSession(sessionId);
+
+    OutputStream base = session.openWrite("base.apk", 0, -1);
+    base.close();
+
+    session.commit(nullSender());
+
+    PackageInfo info = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(info).isNotNull();
+    // base.apk is not a split; splitNames should be null or empty.
+    if (info.splitNames != null) {
+      assertThat(info.splitNames).isEmpty();
+    }
+  }
+
+  @Test
+  public void commit_existingPackage_addsSplitsToPackage() throws Exception {
+    // Pre-install the package without splits.
+    PackageInfo existing = new PackageInfo();
+    existing.packageName = PACKAGE_NAME;
+    existing.applicationInfo = new android.content.pm.ApplicationInfo();
+    existing.applicationInfo.packageName = PACKAGE_NAME;
+    shadowOf(packageManager).installPackage(existing);
+
+    // Now commit a session that adds a split.
+    int sessionId = packageInstaller.createSession(createSessionParams(PACKAGE_NAME));
+    PackageInstaller.Session session = packageInstaller.openSession(sessionId);
+
+    OutputStream base = session.openWrite("base.apk", 0, -1);
+    base.close();
+    OutputStream feature = session.openWrite("split_feature_maps.apk", 0, -1);
+    feature.close();
+
+    session.commit(nullSender());
+
+    PackageInfo info = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(info.splitNames).asList().contains("split_feature_maps");
+  }
+
+  @Test
+  public void commit_emptySession_doesNotInstallPackage() throws Exception {
+    // A session with no written APKs should not create a new package entry.
+    int sessionId = packageInstaller.createSession(createSessionParams(PACKAGE_NAME));
+    PackageInstaller.Session session = packageInstaller.openSession(sessionId);
+
+    session.commit(nullSender());
+
+    try {
+      packageManager.getPackageInfo(PACKAGE_NAME, 0);
+      // If it didn't throw, the package was installed unexpectedly.
+      throw new AssertionError("Expected NameNotFoundException");
+    } catch (android.content.pm.PackageManager.NameNotFoundException expected) {
+      // correct: an empty session should not register the package.
+    }
+  }
+
+  @Test
+  public void commit_withBaseMasterApk_treatedAsBaseNotSplit() throws Exception {
+    int sessionId = packageInstaller.createSession(createSessionParams(PACKAGE_NAME));
+    PackageInstaller.Session session = packageInstaller.openSession(sessionId);
+
+    OutputStream base = session.openWrite("base-master.apk", 0, -1);
+    base.close();
+    OutputStream feature = session.openWrite("feature_kotlin-master.apk", 0, -1);
+    feature.close();
+
+    session.commit(nullSender());
+
+    PackageInfo info = packageManager.getPackageInfo(PACKAGE_NAME, 0);
+    assertThat(info).isNotNull();
+    assertThat(info.splitNames).asList().contains("feature_kotlin-master");
+    assertThat(info.splitNames).asList().doesNotContain("base-master");
+  }
+
+  @Test
+  public void writtenSplitNames_preservedAfterCommit() throws Exception {
+    int sessionId = packageInstaller.createSession(createSessionParams(PACKAGE_NAME));
+    PackageInstaller.Session session = packageInstaller.openSession(sessionId);
+    ShadowSession shadowSession = Shadow.extract(session);
+
+    OutputStream out = session.openWrite("base.apk", 0, -1);
+    out.close();
+    OutputStream split = session.openWrite("split_feature_camera.apk", 0, -1);
+    split.close();
+
+    session.commit(nullSender());
+
+    assertThat(shadowSession.getWrittenSplitNames())
+        .containsExactly("base.apk", "split_feature_camera.apk")
+        .inOrder();
+  }
+
+  private static SessionParams createSessionParams(String packageName) {
+    SessionParams params = new SessionParams(SessionParams.MODE_FULL_INSTALL);
+    params.setAppPackageName(packageName);
+    return params;
+  }
+
+  private static IntentSender nullSender() {
+    return new IntentSender(ReflectionHelpers.createNullProxy(IIntentSender.class));
+  }
+
+  private static ShadowPackageManager shadowOf(android.content.pm.PackageManager pm) {
+    return (ShadowPackageManager) Shadow.extract(pm);
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageInstallerSplitTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageInstallerSplitTest.java
@@ -1,0 +1,116 @@
+package org.robolectric.shadows;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.content.pm.PackageInstaller;
+import android.content.pm.PackageInstaller.SessionParams;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.io.OutputStream;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.shadow.api.Shadow;
+import org.robolectric.shadows.ShadowPackageInstaller.ShadowSession;
+
+/** Tests for split APK support in {@link ShadowPackageInstaller}. */
+@RunWith(AndroidJUnit4.class)
+public class ShadowPackageInstallerSplitTest {
+
+  private PackageInstaller packageInstaller;
+
+  @Before
+  public void setUp() {
+    packageInstaller =
+        ApplicationProvider.getApplicationContext().getPackageManager().getPackageInstaller();
+  }
+
+  @Test
+  public void openWrite_tracksSplitNames() throws Exception {
+    int sessionId = packageInstaller.createSession(createSessionParams("com.example.app"));
+    PackageInstaller.Session session = packageInstaller.openSession(sessionId);
+
+    OutputStream baseStream = session.openWrite("base.apk", 0, -1);
+    baseStream.close();
+    OutputStream splitStream = session.openWrite("split_config.hdpi.apk", 0, -1);
+    splitStream.close();
+    OutputStream splitStream2 = session.openWrite("split_config.en.apk", 0, -1);
+    splitStream2.close();
+
+    ShadowSession shadowSession = Shadow.extract(session);
+    assertThat(shadowSession.getWrittenSplitNames())
+        .containsExactly("base.apk", "split_config.hdpi.apk", "split_config.en.apk")
+        .inOrder();
+  }
+
+  @Test
+  public void openWrite_emptySession_noSplitNames() throws Exception {
+    int sessionId = packageInstaller.createSession(createSessionParams("com.example.app"));
+    PackageInstaller.Session session = packageInstaller.openSession(sessionId);
+
+    ShadowSession shadowSession = Shadow.extract(session);
+    assertThat(shadowSession.getWrittenSplitNames()).isEmpty();
+  }
+
+  @Test
+  public void openWrite_singleBaseApk_tracksName() throws Exception {
+    int sessionId = packageInstaller.createSession(createSessionParams("com.example.app"));
+    PackageInstaller.Session session = packageInstaller.openSession(sessionId);
+
+    OutputStream stream = session.openWrite("base.apk", 0, -1);
+    stream.close();
+
+    ShadowSession shadowSession = Shadow.extract(session);
+    assertThat(shadowSession.getWrittenSplitNames()).containsExactly("base.apk");
+  }
+
+  @Test
+  public void openWrite_dynamicFeatureSplits_tracksNames() throws Exception {
+    int sessionId = packageInstaller.createSession(createSessionParams("com.example.app"));
+    PackageInstaller.Session session = packageInstaller.openSession(sessionId);
+
+    OutputStream base = session.openWrite("base.apk", 0, -1);
+    base.close();
+    OutputStream feature1 = session.openWrite("split_feature_camera.apk", 0, -1);
+    feature1.close();
+    OutputStream feature2 = session.openWrite("split_feature_maps.apk", 0, -1);
+    feature2.close();
+
+    ShadowSession shadowSession = Shadow.extract(session);
+    assertThat(shadowSession.getWrittenSplitNames())
+        .containsExactly("base.apk", "split_feature_camera.apk", "split_feature_maps.apk")
+        .inOrder();
+  }
+
+  @Test
+  public void openWrite_multipleConfigSplits_typicalAabPattern() throws Exception {
+    // Simulates a typical AAB install with base + config splits
+    int sessionId = packageInstaller.createSession(createSessionParams("com.example.app"));
+    PackageInstaller.Session session = packageInstaller.openSession(sessionId);
+
+    String[] splits = {
+      "base.apk", "split_config.arm64_v8a.apk", "split_config.en.apk", "split_config.xxhdpi.apk"
+    };
+
+    for (String split : splits) {
+      OutputStream stream = session.openWrite(split, 0, -1);
+      stream.close();
+    }
+
+    ShadowSession shadowSession = Shadow.extract(session);
+    assertThat(shadowSession.getWrittenSplitNames()).hasSize(4);
+    assertThat(shadowSession.getWrittenSplitNames())
+        .containsExactly(
+            "base.apk",
+            "split_config.arm64_v8a.apk",
+            "split_config.en.apk",
+            "split_config.xxhdpi.apk")
+        .inOrder();
+  }
+
+  private static SessionParams createSessionParams(String packageName) {
+    SessionParams params = new SessionParams(SessionParams.MODE_FULL_INSTALL);
+    params.setAppPackageName(packageName);
+    return params;
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerDynamicSplitTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerDynamicSplitTest.java
@@ -1,0 +1,412 @@
+package org.robolectric.shadows;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.res.AssetManager;
+import androidx.test.core.app.ApplicationProvider;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+
+/**
+ * Tests for dynamic split installation, compiled resource support, and bundletool integration
+ * features in {@link ShadowPackageManager}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = android.os.Build.VERSION_CODES.O)
+public class ShadowPackageManagerDynamicSplitTest {
+
+  private PackageManager packageManager;
+  private ShadowPackageManager shadowPackageManager;
+
+  @Before
+  public void setUp() {
+    packageManager = ApplicationProvider.getApplicationContext().getPackageManager();
+    shadowPackageManager = Shadows.shadowOf(packageManager);
+  }
+
+  // === Dynamic Split Installation Tests ===
+
+  @Test
+  public void addSplitToInstalledPackage_addsFirstSplit() throws Exception {
+    // Install a package with no splits
+    PackageInfo info = new PackageInfo();
+    info.packageName = "com.example.dynamic";
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = "com.example.dynamic";
+    shadowPackageManager.installPackage(info);
+
+    // Create a split APK
+    Map<String, byte[]> assets = new LinkedHashMap<>();
+    assets.put("feature.txt", "dynamic content".getBytes(StandardCharsets.UTF_8));
+    String splitPath = ShadowPackageManager.createSplitApkWithAssets("feature_one", assets);
+
+    // Add the split dynamically
+    shadowPackageManager.addSplitToInstalledPackage(
+        "com.example.dynamic", "feature_one", splitPath);
+
+    // Verify the split was added
+    PackageInfo updated = packageManager.getPackageInfo("com.example.dynamic", 0);
+    assertThat(updated.applicationInfo.splitNames).asList().containsExactly("feature_one");
+    assertThat(updated.applicationInfo.splitSourceDirs).hasLength(1);
+    assertThat(updated.applicationInfo.splitSourceDirs[0]).isEqualTo(splitPath);
+    assertThat(updated.applicationInfo.splitPublicSourceDirs)
+        .isEqualTo(updated.applicationInfo.splitSourceDirs);
+    assertThat(updated.splitNames).asList().containsExactly("feature_one");
+  }
+
+  @Test
+  public void addSplitToInstalledPackage_addsMultipleSplitsIncrementally() throws Exception {
+    PackageInfo info = new PackageInfo();
+    info.packageName = "com.example.multi";
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = "com.example.multi";
+    shadowPackageManager.installPackage(info);
+
+    String split1 =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "split_a", Map.of("a.txt", "A".getBytes(StandardCharsets.UTF_8)));
+    String split2 =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "split_b", Map.of("b.txt", "B".getBytes(StandardCharsets.UTF_8)));
+
+    shadowPackageManager.addSplitToInstalledPackage("com.example.multi", "split_a", split1);
+    shadowPackageManager.addSplitToInstalledPackage("com.example.multi", "split_b", split2);
+
+    PackageInfo updated = packageManager.getPackageInfo("com.example.multi", 0);
+    assertThat(updated.applicationInfo.splitNames)
+        .asList()
+        .containsExactly("split_a", "split_b")
+        .inOrder();
+    assertThat(updated.applicationInfo.splitSourceDirs).hasLength(2);
+  }
+
+  @Test
+  public void addSplitToInstalledPackage_throwsForUninstalledPackage() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            shadowPackageManager.addSplitToInstalledPackage(
+                "com.example.nonexistent", "split", "/fake/path.apk"));
+  }
+
+  @Test
+  public void addSplitToInstalledPackage_preservesExistingSplits() throws Exception {
+    // Install with pre-existing splits
+    PackageInfo info = new PackageInfo();
+    info.packageName = "com.example.presplit";
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = "com.example.presplit";
+    info.applicationInfo.splitNames = new String[] {"existing_split"};
+
+    Map<String, String> existingSplits = new LinkedHashMap<>();
+    String existingPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "existing_split", Map.of("old.txt", "old".getBytes(StandardCharsets.UTF_8)));
+    existingSplits.put("existing_split", existingPath);
+    shadowPackageManager.installPackageWithSplitApks(info, existingSplits);
+
+    // Add a new split
+    String newPath =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "new_split", Map.of("new.txt", "new".getBytes(StandardCharsets.UTF_8)));
+    shadowPackageManager.addSplitToInstalledPackage("com.example.presplit", "new_split", newPath);
+
+    PackageInfo updated = packageManager.getPackageInfo("com.example.presplit", 0);
+    assertThat(updated.applicationInfo.splitNames)
+        .asList()
+        .containsExactly("existing_split", "new_split")
+        .inOrder();
+    assertThat(updated.applicationInfo.splitSourceDirs).hasLength(2);
+  }
+
+  // === Compiled Resource Support Tests ===
+
+  @Test
+  public void createSplitApkWithResources_createsValidApk() throws Exception {
+    Map<String, String> resources = new LinkedHashMap<>();
+    resources.put("app_name", "My Feature");
+    resources.put("greeting", "Hello World");
+
+    String apkPath =
+        ShadowPackageManager.createSplitApkWithResources(
+            "feature_res", "com.example.feature", 0x7f, resources, null);
+
+    // Verify file exists and is a valid ZIP
+    Path path = Path.of(apkPath);
+    assertThat(Files.exists(path)).isTrue();
+    assertThat(Files.size(path)).isGreaterThan(0);
+
+    // Verify it contains resources.arsc
+    try (java.util.zip.ZipFile zf = new java.util.zip.ZipFile(path.toFile())) {
+      assertThat(zf.getEntry("resources.arsc")).isNotNull();
+    }
+  }
+
+  @Test
+  public void createSplitApkWithResources_includesAssets() throws Exception {
+    Map<String, String> resources = new LinkedHashMap<>();
+    resources.put("label", "Test");
+
+    Map<String, byte[]> assets = new LinkedHashMap<>();
+    assets.put("config.json", "{\"key\":\"value\"}".getBytes(StandardCharsets.UTF_8));
+
+    String apkPath =
+        ShadowPackageManager.createSplitApkWithResources(
+            "feature_both", "com.example.feature", 0x7f, resources, assets);
+
+    try (java.util.zip.ZipFile zf = new java.util.zip.ZipFile(Path.of(apkPath).toFile())) {
+      assertThat(zf.getEntry("resources.arsc")).isNotNull();
+      assertThat(zf.getEntry("assets/config.json")).isNotNull();
+
+      // Verify asset content
+      try (InputStream is = zf.getInputStream(zf.getEntry("assets/config.json"))) {
+        String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        assertThat(content).isEqualTo("{\"key\":\"value\"}");
+      }
+    }
+  }
+
+  @Test
+  public void createSplitApkWithResources_resourcesArscIsStored() throws Exception {
+    Map<String, String> resources = new LinkedHashMap<>();
+    resources.put("test", "value");
+
+    String apkPath =
+        ShadowPackageManager.createSplitApkWithResources(
+            "stored_check", "com.example.app", 0x7f, resources, null);
+
+    try (java.util.zip.ZipFile zf = new java.util.zip.ZipFile(Path.of(apkPath).toFile())) {
+      java.util.zip.ZipEntry arscEntry = zf.getEntry("resources.arsc");
+      // STORED method means size == compressedSize
+      assertThat(arscEntry.getSize()).isEqualTo(arscEntry.getCompressedSize());
+    }
+  }
+
+  // === ArscResourceTableBuilder Tests ===
+
+  @Test
+  public void arscBuilder_createsNonEmptyTable() {
+    Map<String, String> strings = new LinkedHashMap<>();
+    strings.put("hello", "Hello World");
+    strings.put("bye", "Goodbye");
+
+    byte[] arsc =
+        ArscResourceTableBuilder.buildStringResourceTable("com.example.test", 0x7f, strings);
+
+    assertThat(arsc).isNotNull();
+    assertThat(arsc.length).isGreaterThan(12); // At least header size
+    // Verify magic: first 2 bytes should be RES_TABLE_TYPE (0x0002) in little-endian
+    assertThat(arsc[0]).isEqualTo((byte) 0x02);
+    assertThat(arsc[1]).isEqualTo((byte) 0x00);
+  }
+
+  @Test
+  public void arscBuilder_singleStringResource() {
+    Map<String, String> strings = new LinkedHashMap<>();
+    strings.put("single", "Only One");
+
+    byte[] arsc =
+        ArscResourceTableBuilder.buildStringResourceTable("com.example.single", 0x7f, strings);
+
+    assertThat(arsc).isNotNull();
+    // Header size is 12, so total must be larger
+    assertThat(arsc.length).isGreaterThan(12);
+  }
+
+  // === Bundletool Integration Tests ===
+
+  @Test
+  public void bundletoolLoader_loadFromDirectory() throws Exception {
+    // Create a temp directory with split APKs
+    Path tempDir = Files.createTempDirectory("bundletool-test");
+    try {
+      // Create some split APK files
+      String split1 =
+          ShadowPackageManager.createSplitApkWithAssets(
+              "base-master", Map.of("base.txt", "base".getBytes(StandardCharsets.UTF_8)));
+      String split2 =
+          ShadowPackageManager.createSplitApkWithAssets(
+              "base-xxhdpi", Map.of("density.txt", "xxhdpi".getBytes(StandardCharsets.UTF_8)));
+
+      Files.copy(Path.of(split1), tempDir.resolve("base-master.apk"));
+      Files.copy(Path.of(split2), tempDir.resolve("base-xxhdpi.apk"));
+
+      Map<String, String> splits = BundletoolSplitApkLoader.loadFromDirectory(tempDir);
+
+      assertThat(splits).hasSize(2);
+      assertThat(splits).containsKey("base-master");
+      assertThat(splits).containsKey("base-xxhdpi");
+      // Verify paths are absolute
+      assertThat(splits.get("base-master")).startsWith("/");
+    } finally {
+      // Cleanup
+      Files.list(tempDir)
+          .forEach(
+              p -> {
+                try {
+                  Files.delete(p);
+                } catch (Exception e) {
+                }
+              });
+      Files.delete(tempDir);
+    }
+  }
+
+  @Test
+  public void bundletoolLoader_loadFromDirectoryWithPrefix() throws Exception {
+    Path tempDir = Files.createTempDirectory("bundletool-prefix");
+    try {
+      String split1 =
+          ShadowPackageManager.createSplitApkWithAssets(
+              "base-master", Map.of("x.txt", "x".getBytes(StandardCharsets.UTF_8)));
+      String split2 =
+          ShadowPackageManager.createSplitApkWithAssets(
+              "feature-camera", Map.of("y.txt", "y".getBytes(StandardCharsets.UTF_8)));
+
+      Files.copy(Path.of(split1), tempDir.resolve("base-master.apk"));
+      Files.copy(Path.of(split2), tempDir.resolve("feature-camera.apk"));
+
+      Map<String, String> splits = BundletoolSplitApkLoader.loadFromDirectory(tempDir, "base-");
+
+      assertThat(splits).hasSize(1);
+      assertThat(splits).containsKey("base-master");
+      assertThat(splits).doesNotContainKey("feature-camera");
+    } finally {
+      Files.list(tempDir)
+          .forEach(
+              p -> {
+                try {
+                  Files.delete(p);
+                } catch (Exception e) {
+                }
+              });
+      Files.delete(tempDir);
+    }
+  }
+
+  @Test
+  public void bundletoolLoader_loadFromApksArchive() throws Exception {
+    // Create split APK files
+    String baseSplit =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "base-master", Map.of("app.txt", "base content".getBytes(StandardCharsets.UTF_8)));
+    String densitySplit =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "base-xxhdpi", Map.of("res.txt", "density content".getBytes(StandardCharsets.UTF_8)));
+
+    // Create a .apks archive from them
+    Map<String, String> splitPaths = new LinkedHashMap<>();
+    splitPaths.put("base-master", baseSplit);
+    splitPaths.put("base-xxhdpi", densitySplit);
+    Path apksArchive = BundletoolSplitApkLoader.createApksArchive(splitPaths);
+
+    // Load from the archive
+    Map<String, String> loaded = BundletoolSplitApkLoader.loadFromApksArchive(apksArchive);
+
+    assertThat(loaded).hasSize(2);
+    assertThat(loaded).containsKey("base-master");
+    assertThat(loaded).containsKey("base-xxhdpi");
+
+    // Verify extracted files are valid ZIP files that can be read
+    for (String path : loaded.values()) {
+      assertThat(Files.exists(Path.of(path))).isTrue();
+      assertThat(Files.size(Path.of(path))).isGreaterThan(0);
+    }
+  }
+
+  @Test
+  public void bundletoolLoader_loadFromApksArchiveWithPrefix() throws Exception {
+    String baseSplit =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "base-master", Map.of("a.txt", "a".getBytes(StandardCharsets.UTF_8)));
+    String featureSplit =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "feature-camera", Map.of("b.txt", "b".getBytes(StandardCharsets.UTF_8)));
+
+    Map<String, String> splitPaths = new LinkedHashMap<>();
+    splitPaths.put("base-master", baseSplit);
+    splitPaths.put("feature-camera", featureSplit);
+    Path apksArchive = BundletoolSplitApkLoader.createApksArchive(splitPaths);
+
+    Map<String, String> loaded =
+        BundletoolSplitApkLoader.loadFromApksArchive(apksArchive, "feature-");
+
+    assertThat(loaded).hasSize(1);
+    assertThat(loaded).containsKey("feature-camera");
+  }
+
+  @Test
+  public void bundletoolLoader_endToEndInstallFromArchive() throws Exception {
+    // Create split APK files with assets
+    String baseSplit =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "base-master", Map.of("base_asset.txt", "base data".getBytes(StandardCharsets.UTF_8)));
+    String featureSplit =
+        ShadowPackageManager.createSplitApkWithAssets(
+            "feature-maps", Map.of("map_data.txt", "map data".getBytes(StandardCharsets.UTF_8)));
+
+    // Create archive
+    Map<String, String> splitPaths = new LinkedHashMap<>();
+    splitPaths.put("base-master", baseSplit);
+    splitPaths.put("feature-maps", featureSplit);
+    Path apksArchive = BundletoolSplitApkLoader.createApksArchive(splitPaths);
+
+    // Load and install
+    Map<String, String> loaded = BundletoolSplitApkLoader.loadFromApksArchive(apksArchive);
+
+    PackageInfo info = new PackageInfo();
+    info.packageName = "com.example.bundletool";
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = "com.example.bundletool";
+    info.applicationInfo.splitNames = loaded.keySet().toArray(new String[0]);
+    shadowPackageManager.installPackageWithSplitApks(info, loaded);
+
+    // Verify installation
+    PackageInfo installed = packageManager.getPackageInfo("com.example.bundletool", 0);
+    assertThat(installed.applicationInfo.splitNames)
+        .asList()
+        .containsExactly("base-master", "feature-maps");
+    assertThat(installed.applicationInfo.splitSourceDirs).hasLength(2);
+  }
+
+  // === End-to-end: Dynamic split with resources ===
+
+  @Test
+  public void endToEnd_dynamicSplitWithAssetsAccessible() throws Exception {
+    // Install base package
+    PackageInfo info = new PackageInfo();
+    info.packageName = "com.example.e2e";
+    info.applicationInfo = new ApplicationInfo();
+    info.applicationInfo.packageName = "com.example.e2e";
+    shadowPackageManager.installPackage(info);
+
+    // Create and add a dynamic split with an asset
+    Map<String, byte[]> assets = new LinkedHashMap<>();
+    assets.put("feature_data.json", "{\"feature\":\"camera\"}".getBytes(StandardCharsets.UTF_8));
+    String splitPath = ShadowPackageManager.createSplitApkWithAssets("feature_camera", assets);
+    shadowPackageManager.addSplitToInstalledPackage("com.example.e2e", "feature_camera", splitPath);
+
+    // Load the split's assets via AssetManager
+    AssetManager assetManager = AssetManager.class.getDeclaredConstructor().newInstance();
+    ShadowAssetManager.addSplitAssetPath(assetManager, splitPath);
+
+    try (InputStream is = assetManager.open("feature_data.json")) {
+      String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+      assertThat(content).isEqualTo("{\"feature\":\"camera\"}");
+    }
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerSplitApkTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerSplitApkTest.java
@@ -1,0 +1,189 @@
+package org.robolectric.shadows;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.os.Build.VERSION_CODES;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+/** Tests for split APK support in {@link ShadowPackageManager}. */
+@RunWith(AndroidJUnit4.class)
+@Config(minSdk = VERSION_CODES.O)
+public class ShadowPackageManagerSplitApkTest {
+
+  private static final String TEST_PACKAGE_NAME = "com.example.splitapk";
+  private Context context;
+  private PackageManager packageManager;
+
+  @Before
+  public void setUp() {
+    context = ApplicationProvider.getApplicationContext();
+    packageManager = context.getPackageManager();
+  }
+
+  @Test
+  public void installPackageWithSplits_setsSplitNames() throws NameNotFoundException {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = TEST_PACKAGE_NAME;
+
+    shadowOf(packageManager)
+        .installPackageWithSplits(packageInfo, "config.hdpi", "config.x86", "feature_camera");
+
+    PackageInfo retrieved = packageManager.getPackageInfo(TEST_PACKAGE_NAME, 0);
+    assertThat(retrieved.applicationInfo.splitNames)
+        .asList()
+        .containsExactly("config.hdpi", "config.x86", "feature_camera");
+  }
+
+  @Test
+  public void installPackageWithSplits_setsSplitSourceDirs() throws NameNotFoundException {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = TEST_PACKAGE_NAME;
+
+    shadowOf(packageManager).installPackageWithSplits(packageInfo, "config.hdpi", "config.x86");
+
+    PackageInfo retrieved = packageManager.getPackageInfo(TEST_PACKAGE_NAME, 0);
+    assertThat(retrieved.applicationInfo.splitSourceDirs).isNotNull();
+    assertThat(retrieved.applicationInfo.splitSourceDirs).hasLength(2);
+  }
+
+  @Test
+  public void installPackageWithSplits_setsSplitPublicSourceDirs() throws NameNotFoundException {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = TEST_PACKAGE_NAME;
+
+    shadowOf(packageManager).installPackageWithSplits(packageInfo, "config.hdpi");
+
+    PackageInfo retrieved = packageManager.getPackageInfo(TEST_PACKAGE_NAME, 0);
+    assertThat(retrieved.applicationInfo.splitPublicSourceDirs).isNotNull();
+    assertThat(retrieved.applicationInfo.splitPublicSourceDirs).hasLength(1);
+    assertThat(retrieved.applicationInfo.splitPublicSourceDirs)
+        .isEqualTo(retrieved.applicationInfo.splitSourceDirs);
+  }
+
+  @Test
+  public void installPackageWithSplits_propagatesSplitNamesToPackageInfo()
+      throws NameNotFoundException {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = TEST_PACKAGE_NAME;
+
+    shadowOf(packageManager).installPackageWithSplits(packageInfo, "base_config", "dynamic_map");
+
+    PackageInfo retrieved = packageManager.getPackageInfo(TEST_PACKAGE_NAME, 0);
+    assertThat(retrieved.splitNames).asList().containsExactly("base_config", "dynamic_map");
+  }
+
+  @Test
+  public void installPackage_withSplitNamesAndSourceDirs_preservesThem()
+      throws NameNotFoundException {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = TEST_PACKAGE_NAME;
+    packageInfo.applicationInfo = new ApplicationInfo();
+    packageInfo.applicationInfo.packageName = TEST_PACKAGE_NAME;
+    packageInfo.applicationInfo.splitNames = new String[] {"feature_photos"};
+    packageInfo.applicationInfo.splitSourceDirs = new String[] {"/data/app/split_feature.apk"};
+    packageInfo.applicationInfo.splitPublicSourceDirs =
+        new String[] {"/data/app/split_feature.apk"};
+
+    shadowOf(packageManager).installPackage(packageInfo);
+
+    PackageInfo retrieved = packageManager.getPackageInfo(TEST_PACKAGE_NAME, 0);
+    assertThat(retrieved.applicationInfo.splitSourceDirs).isNotNull();
+    assertThat(retrieved.applicationInfo.splitSourceDirs).hasLength(1);
+    assertThat(retrieved.applicationInfo.splitSourceDirs[0])
+        .isEqualTo("/data/app/split_feature.apk");
+  }
+
+  @Test
+  public void installPackage_withPresetSplitSourceDirs_preservesThem()
+      throws NameNotFoundException {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = TEST_PACKAGE_NAME;
+    packageInfo.applicationInfo = new ApplicationInfo();
+    packageInfo.applicationInfo.packageName = TEST_PACKAGE_NAME;
+    packageInfo.applicationInfo.splitNames = new String[] {"config.hdpi"};
+    packageInfo.applicationInfo.splitSourceDirs = new String[] {"/data/app/split_config.hdpi.apk"};
+    packageInfo.applicationInfo.splitPublicSourceDirs =
+        new String[] {"/data/app/split_config.hdpi.apk"};
+
+    shadowOf(packageManager).installPackage(packageInfo);
+
+    PackageInfo retrieved = packageManager.getPackageInfo(TEST_PACKAGE_NAME, 0);
+    assertThat(retrieved.applicationInfo.splitSourceDirs)
+        .asList()
+        .containsExactly("/data/app/split_config.hdpi.apk");
+    assertThat(retrieved.applicationInfo.splitPublicSourceDirs)
+        .asList()
+        .containsExactly("/data/app/split_config.hdpi.apk");
+  }
+
+  @Test
+  public void installPackage_withoutSplits_splitFieldsAreNull() throws NameNotFoundException {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = TEST_PACKAGE_NAME;
+
+    shadowOf(packageManager).installPackage(packageInfo);
+
+    PackageInfo retrieved = packageManager.getPackageInfo(TEST_PACKAGE_NAME, 0);
+    assertThat(retrieved.applicationInfo.splitNames).isNull();
+    assertThat(retrieved.applicationInfo.splitSourceDirs).isNull();
+    assertThat(retrieved.applicationInfo.splitPublicSourceDirs).isNull();
+  }
+
+  @Test
+  public void installPackageWithSplits_configSplitsPattern() throws NameNotFoundException {
+    // Simulates a typical AAB configuration splits scenario
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = TEST_PACKAGE_NAME;
+
+    shadowOf(packageManager)
+        .installPackageWithSplits(
+            packageInfo, "config.hdpi", "config.xxhdpi", "config.en", "config.arm64_v8a");
+
+    PackageInfo retrieved = packageManager.getPackageInfo(TEST_PACKAGE_NAME, 0);
+    assertThat(retrieved.applicationInfo.splitNames).hasLength(4);
+    assertThat(retrieved.applicationInfo.splitSourceDirs).hasLength(4);
+    assertThat(retrieved.applicationInfo.splitPublicSourceDirs).hasLength(4);
+    // Each split should have its own unique directory
+    assertThat(retrieved.applicationInfo.splitSourceDirs[0])
+        .isNotEqualTo(retrieved.applicationInfo.splitSourceDirs[1]);
+  }
+
+  @Test
+  public void installPackageWithSplits_dynamicFeaturePattern() throws NameNotFoundException {
+    // Simulates dynamic feature modules from an AAB
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = TEST_PACKAGE_NAME;
+
+    shadowOf(packageManager)
+        .installPackageWithSplits(packageInfo, "feature_camera", "feature_gallery");
+
+    PackageInfo retrieved = packageManager.getPackageInfo(TEST_PACKAGE_NAME, 0);
+    assertThat(retrieved.applicationInfo.splitNames)
+        .asList()
+        .containsExactly("feature_camera", "feature_gallery");
+  }
+
+  @Test
+  public void getApplicationInfo_withSplits_returnsSplitInfo() throws NameNotFoundException {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = TEST_PACKAGE_NAME;
+
+    shadowOf(packageManager).installPackageWithSplits(packageInfo, "config.hdpi", "config.en");
+
+    ApplicationInfo appInfo = packageManager.getApplicationInfo(TEST_PACKAGE_NAME, 0);
+    assertThat(appInfo.splitNames).asList().containsExactly("config.hdpi", "config.en");
+    assertThat(appInfo.splitSourceDirs).isNotNull();
+    assertThat(appInfo.splitSourceDirs).hasLength(2);
+  }
+}

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerSplitResourceTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPackageManagerSplitResourceTest.java
@@ -1,0 +1,259 @@
+package org.robolectric.shadows;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.res.AssetManager;
+import android.os.Build.VERSION_CODES;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+/**
+ * Tests for split APK resource and asset loading support.
+ *
+ * <p>These tests verify that split APK files created by {@link
+ * ShadowPackageManager#createSplitApkWithAssets} and installed via {@link
+ * ShadowPackageManager#installPackageWithSplitApks} produce valid APK files that the framework's
+ * resource loading pipeline can open.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = VERSION_CODES.O)
+public class ShadowPackageManagerSplitResourceTest {
+
+  private PackageManager packageManager;
+
+  @Before
+  public void setUp() {
+    packageManager = RuntimeEnvironment.getApplication().getPackageManager();
+  }
+
+  @Test
+  public void setUpSplitApkStorage_createsValidZipFiles() throws Exception {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = "com.example.splits.ziptest";
+
+    shadowOf(packageManager).installPackageWithSplits(packageInfo, "config.xxhdpi", "config.en");
+
+    PackageInfo retrieved = packageManager.getPackageInfo("com.example.splits.ziptest", 0);
+    ApplicationInfo appInfo = retrieved.applicationInfo;
+
+    // Each splitSourceDir should be a valid ZIP file (not a directory)
+    for (String splitDir : appInfo.splitSourceDirs) {
+      File file = new File(splitDir);
+      assertThat(file.isFile()).isTrue();
+      assertThat(file.isDirectory()).isFalse();
+      // Should be openable as a ZIP
+      try (ZipFile zip = new ZipFile(file)) {
+        // Valid ZIP, may be empty
+        assertThat(zip).isNotNull();
+      }
+    }
+  }
+
+  @Test
+  public void createSplitApkWithAssets_createsValidZipWithAssetEntries() throws Exception {
+    Map<String, byte[]> assets = new LinkedHashMap<>();
+    assets.put("feature_data.json", "{\"key\": \"value\"}".getBytes(StandardCharsets.UTF_8));
+    assets.put("images/logo.png", new byte[] {0x00, 0x01, 0x02, 0x03});
+
+    String apkPath = ShadowPackageManager.createSplitApkWithAssets("feature_camera", assets);
+
+    File apkFile = new File(apkPath);
+    assertThat(apkFile.exists()).isTrue();
+    assertThat(apkFile.isFile()).isTrue();
+
+    // Verify ZIP contents
+    try (ZipFile zip = new ZipFile(apkFile)) {
+      ZipEntry jsonEntry = zip.getEntry("assets/feature_data.json");
+      assertThat(jsonEntry).isNotNull();
+
+      ZipEntry imageEntry = zip.getEntry("assets/images/logo.png");
+      assertThat(imageEntry).isNotNull();
+
+      // Verify content
+      try (InputStream is = zip.getInputStream(jsonEntry)) {
+        String content = new String(readAllBytes(is), StandardCharsets.UTF_8);
+        assertThat(content).isEqualTo("{\"key\": \"value\"}");
+      }
+    }
+  }
+
+  @Test
+  public void installPackageWithSplitApks_setsCorrectPaths() throws Exception {
+    Map<String, byte[]> featureAssets = new LinkedHashMap<>();
+    featureAssets.put("config.txt", "feature config".getBytes(StandardCharsets.UTF_8));
+    String featureApk =
+        ShadowPackageManager.createSplitApkWithAssets("feature_maps", featureAssets);
+
+    Map<String, byte[]> densityAssets = new LinkedHashMap<>();
+    densityAssets.put("res_placeholder.txt", "xxhdpi".getBytes(StandardCharsets.UTF_8));
+    String densityApk =
+        ShadowPackageManager.createSplitApkWithAssets("config.xxhdpi", densityAssets);
+
+    Map<String, String> splitPaths = new LinkedHashMap<>();
+    splitPaths.put("feature_maps", featureApk);
+    splitPaths.put("config.xxhdpi", densityApk);
+
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = "com.example.splits.apkpaths";
+    shadowOf(packageManager).installPackageWithSplitApks(packageInfo, splitPaths);
+
+    PackageInfo retrieved = packageManager.getPackageInfo("com.example.splits.apkpaths", 0);
+    ApplicationInfo appInfo = retrieved.applicationInfo;
+
+    assertThat(appInfo.splitNames).asList().containsExactly("feature_maps", "config.xxhdpi");
+    assertThat(appInfo.splitSourceDirs).hasLength(2);
+    assertThat(appInfo.splitPublicSourceDirs).hasLength(2);
+
+    // Paths should be the actual APK file paths, not temp directories
+    for (String path : appInfo.splitSourceDirs) {
+      assertThat(new File(path).isFile()).isTrue();
+    }
+  }
+
+  @Test
+  public void installPackageWithSplitApks_preservesCustomPaths() throws Exception {
+    String customPath =
+        ShadowPackageManager.createSplitApkWithAssets("custom_split", new LinkedHashMap<>());
+
+    Map<String, String> splitPaths = new LinkedHashMap<>();
+    splitPaths.put("custom_split", customPath);
+
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = "com.example.splits.custom";
+    shadowOf(packageManager).installPackageWithSplitApks(packageInfo, splitPaths);
+
+    PackageInfo retrieved = packageManager.getPackageInfo("com.example.splits.custom", 0);
+    // The custom path should be preserved exactly
+    assertThat(retrieved.applicationInfo.splitSourceDirs[0]).isEqualTo(customPath);
+  }
+
+  @Test
+  public void addSplitAssetPath_loadsAssetsFromSplitApk() throws Exception {
+    // Create a split APK with an asset
+    Map<String, byte[]> assets = new LinkedHashMap<>();
+    assets.put("split_data.txt", "hello from split".getBytes(StandardCharsets.UTF_8));
+    String splitApkPath = ShadowPackageManager.createSplitApkWithAssets("dynamic_feature", assets);
+
+    // Add the split APK to the app's AssetManager
+    AssetManager assetManager = RuntimeEnvironment.getApplication().getAssets();
+    int cookie = ShadowAssetManager.addSplitAssetPath(assetManager, splitApkPath);
+    assertThat(cookie).isGreaterThan(0);
+
+    // Verify the asset is now accessible
+    try (InputStream is = assetManager.open("split_data.txt")) {
+      String content = new String(readAllBytes(is), StandardCharsets.UTF_8);
+      assertThat(content).isEqualTo("hello from split");
+    }
+  }
+
+  @Test
+  public void addSplitAssetPath_multipleAssets_allAccessible() throws Exception {
+    Map<String, byte[]> assets = new LinkedHashMap<>();
+    assets.put("data/config.json", "{\"version\": 1}".getBytes(StandardCharsets.UTF_8));
+    assets.put("data/strings.txt", "hello world".getBytes(StandardCharsets.UTF_8));
+    assets.put("images/icon.bin", new byte[] {(byte) 0x89, 0x50, 0x4E, 0x47});
+    String splitApkPath = ShadowPackageManager.createSplitApkWithAssets("feature_module", assets);
+
+    AssetManager assetManager = RuntimeEnvironment.getApplication().getAssets();
+    ShadowAssetManager.addSplitAssetPath(assetManager, splitApkPath);
+
+    try (InputStream is = assetManager.open("data/config.json")) {
+      String content = new String(readAllBytes(is), StandardCharsets.UTF_8);
+      assertThat(content).isEqualTo("{\"version\": 1}");
+    }
+    try (InputStream is = assetManager.open("data/strings.txt")) {
+      String content = new String(readAllBytes(is), StandardCharsets.UTF_8);
+      assertThat(content).isEqualTo("hello world");
+    }
+    try (InputStream is = assetManager.open("images/icon.bin")) {
+      byte[] bytes = readAllBytes(is);
+      assertThat(bytes).isEqualTo(new byte[] {(byte) 0x89, 0x50, 0x4E, 0x47});
+    }
+  }
+
+  @Test
+  public void addSplitAssetPath_multipleSplits_allAccessible() throws Exception {
+    Map<String, byte[]> split1Assets = new LinkedHashMap<>();
+    split1Assets.put("split1.txt", "from split 1".getBytes(StandardCharsets.UTF_8));
+    String split1Path = ShadowPackageManager.createSplitApkWithAssets("split_one", split1Assets);
+
+    Map<String, byte[]> split2Assets = new LinkedHashMap<>();
+    split2Assets.put("split2.txt", "from split 2".getBytes(StandardCharsets.UTF_8));
+    String split2Path = ShadowPackageManager.createSplitApkWithAssets("split_two", split2Assets);
+
+    AssetManager assetManager = RuntimeEnvironment.getApplication().getAssets();
+    ShadowAssetManager.addSplitAssetPath(assetManager, split1Path);
+    ShadowAssetManager.addSplitAssetPath(assetManager, split2Path);
+
+    try (InputStream is = assetManager.open("split1.txt")) {
+      assertThat(new String(readAllBytes(is), StandardCharsets.UTF_8)).isEqualTo("from split 1");
+    }
+    try (InputStream is = assetManager.open("split2.txt")) {
+      assertThat(new String(readAllBytes(is), StandardCharsets.UTF_8)).isEqualTo("from split 2");
+    }
+  }
+
+  @Test
+  public void emptySplitApk_doesNotCauseErrors() throws Exception {
+    // Empty splits (no assets, no resources) should be valid and cause no errors
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = "com.example.splits.empty";
+
+    shadowOf(packageManager)
+        .installPackageWithSplits(packageInfo, "config.xxhdpi", "config.arm64_v8a");
+
+    PackageInfo retrieved = packageManager.getPackageInfo("com.example.splits.empty", 0);
+    assertThat(retrieved.applicationInfo.splitNames).hasLength(2);
+    assertThat(retrieved.applicationInfo.splitSourceDirs).hasLength(2);
+
+    // All split paths should be valid ZIP files
+    for (String dir : retrieved.applicationInfo.splitSourceDirs) {
+      try (ZipFile zip = new ZipFile(new File(dir))) {
+        assertThat(zip).isNotNull();
+      }
+    }
+  }
+
+  @Test
+  public void installPackageWithSplitApks_requiresApiO() {
+    // This test verifies the API guard, actual API level check is done at runtime
+    // We're already on O+ due to @Config, so just verify it doesn't throw
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.packageName = "com.example.splits.apiguard";
+    Map<String, String> splitPaths = new LinkedHashMap<>();
+    splitPaths.put(
+        "test_split",
+        ShadowPackageManager.createSplitApkWithAssets("test_split", new LinkedHashMap<>()));
+    shadowOf(packageManager).installPackageWithSplitApks(packageInfo, splitPaths);
+
+    // Should succeed without exception on O+
+    assertThat(packageInfo.applicationInfo.splitNames).asList().containsExactly("test_split");
+  }
+
+  private static byte[] readAllBytes(InputStream is) throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    byte[] data = new byte[1024];
+    int bytesRead;
+    while ((bytesRead = is.read(data, 0, data.length)) != -1) {
+      buffer.write(data, 0, bytesRead);
+    }
+    return buffer.toByteArray();
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,6 +42,7 @@ include(
   ":integration_tests:sdkcompat",
   ":integration_tests:securityproviders",
   ":integration_tests:sparsearray",
+  ":integration_tests:split-apk",
   ":integration_tests:testparameterinjector",
   ":integration_tests:versioning",
   ":junit",

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ArscResourceTableBuilder.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ArscResourceTableBuilder.java
@@ -1,0 +1,303 @@
+package org.robolectric.shadows;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds minimal valid {@code resources.arsc} binary files for testing split APK resource loading.
+ *
+ * <p>The generated resource tables follow the Android binary resource format and can be parsed by
+ * Robolectric's {@code LoadedArsc.Load()} method. Currently supports string resources only.
+ *
+ * <p>This class is intended for testing purposes and generates the simplest possible valid resource
+ * table. For production resource tables, use AAPT2.
+ */
+final class ArscResourceTableBuilder {
+
+  // Chunk type constants from ResourceTypes.h
+  private static final short RES_STRING_POOL_TYPE = 0x0001;
+  private static final short RES_TABLE_TYPE = 0x0002;
+  private static final short RES_TABLE_PACKAGE_TYPE = 0x0200;
+  private static final short RES_TABLE_TYPE_SPEC_TYPE = 0x0202;
+  private static final short RES_TABLE_TYPE_TYPE = 0x0201;
+
+  // Res_value data types
+  private static final byte TYPE_STRING = 0x03;
+
+  // String pool flags
+  private static final int UTF8_FLAG = 0x00000100;
+
+  private ArscResourceTableBuilder() {}
+
+  /**
+   * Builds a minimal valid {@code resources.arsc} containing string resources.
+   *
+   * <p>The generated resource table has one package with one type ("string") containing entries for
+   * each provided string resource. Resource IDs follow the pattern {@code packageId:01:NNNN} where
+   * NNNN is the 0-based index of the entry.
+   *
+   * @param packageName the package name (e.g., "com.example.feature")
+   * @param packageId the package ID (0x7f for app resources, 0x02-0x7e for libraries)
+   * @param stringResources ordered map from entry name to string value
+   * @return the raw bytes of the resources.arsc file
+   */
+  static byte[] buildStringResourceTable(
+      String packageName, int packageId, Map<String, String> stringResources) {
+    try {
+      List<String> entryNames = new ArrayList<>(stringResources.keySet());
+      List<String> entryValues = new ArrayList<>(stringResources.values());
+
+      // Build global string pool (contains the actual string values)
+      byte[] globalStringPool = buildUtf8StringPool(entryValues);
+
+      // Build type string pool (contains type names: just "string")
+      List<String> typeNames = new ArrayList<>();
+      typeNames.add("string");
+      byte[] typeStringPool = buildUtf8StringPool(typeNames);
+
+      // Build key string pool (contains entry names)
+      byte[] keyStringPool = buildUtf8StringPool(entryNames);
+
+      // Build typeSpec chunk
+      byte[] typeSpec = buildTypeSpec(entryNames.size());
+
+      // Build type chunk (default config, references global string pool)
+      byte[] typeChunk = buildTypeChunk(entryNames.size());
+
+      // Build package chunk
+      byte[] packageChunk =
+          buildPackageChunk(
+              packageId, packageName, typeStringPool, keyStringPool, typeSpec, typeChunk);
+
+      // Build the complete resource table
+      return buildResourceTable(globalStringPool, packageChunk);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to build resource table", e);
+    }
+  }
+
+  private static byte[] buildResourceTable(byte[] globalStringPool, byte[] packageChunk)
+      throws IOException {
+    int totalSize = 12 + globalStringPool.length + packageChunk.length; // 12 = header
+    ByteBuffer buf = ByteBuffer.allocate(totalSize).order(ByteOrder.LITTLE_ENDIAN);
+
+    // ResTable_header
+    buf.putShort(RES_TABLE_TYPE); // type
+    buf.putShort((short) 12); // headerSize
+    buf.putInt(totalSize); // size
+    buf.putInt(1); // packageCount
+
+    buf.put(globalStringPool);
+    buf.put(packageChunk);
+
+    return buf.array();
+  }
+
+  private static byte[] buildPackageChunk(
+      int packageId,
+      String packageName,
+      byte[] typeStringPool,
+      byte[] keyStringPool,
+      byte[] typeSpec,
+      byte[] typeChunk)
+      throws IOException {
+    // Package header size: 8 (chunk header) + 4 (id) + 256 (name) + 4*4 (offsets) + 4
+    //   = 8 + 4 + 256 + 16 + 4 = 288
+    int headerSize = 288;
+    int totalSize =
+        headerSize
+            + typeStringPool.length
+            + keyStringPool.length
+            + typeSpec.length
+            + typeChunk.length;
+
+    ByteBuffer buf = ByteBuffer.allocate(totalSize).order(ByteOrder.LITTLE_ENDIAN);
+
+    // ResChunk_header
+    buf.putShort(RES_TABLE_PACKAGE_TYPE); // type
+    buf.putShort((short) headerSize); // headerSize
+    buf.putInt(totalSize); // size
+
+    // Package ID
+    buf.putInt(packageId);
+
+    // Package name (128 chars = 256 bytes, UTF-16LE, null-terminated)
+    byte[] nameBytes = new byte[256];
+    byte[] nameUtf16 = packageName.getBytes(StandardCharsets.UTF_16LE);
+    System.arraycopy(nameUtf16, 0, nameBytes, 0, Math.min(nameUtf16.length, 254));
+    buf.put(nameBytes);
+
+    // typeStrings offset (relative to package header start)
+    buf.putInt(headerSize);
+    // lastPublicType
+    buf.putInt(1);
+    // keyStrings offset (relative to package header start)
+    buf.putInt(headerSize + typeStringPool.length);
+    // lastPublicKey
+    buf.putInt(0);
+    // typeIdOffset (API 21+)
+    buf.putInt(0);
+
+    // Append type string pool, key string pool, type spec, and type chunk
+    buf.put(typeStringPool);
+    buf.put(keyStringPool);
+    buf.put(typeSpec);
+    buf.put(typeChunk);
+
+    return buf.array();
+  }
+
+  private static byte[] buildTypeSpec(int entryCount) {
+    int size = 16 + entryCount * 4; // header + flags array
+    // Align to 4 bytes
+    size = (size + 3) & ~3;
+    ByteBuffer buf = ByteBuffer.allocate(size).order(ByteOrder.LITTLE_ENDIAN);
+
+    // ResChunk_header
+    buf.putShort(RES_TABLE_TYPE_SPEC_TYPE); // type
+    buf.putShort((short) 16); // headerSize
+    buf.putInt(size); // size
+
+    // id (1-based type ID; "string" = 1)
+    buf.put((byte) 1);
+    // res0, res1 (reserved)
+    buf.put((byte) 0);
+    buf.putShort((short) 0);
+    // entryCount
+    buf.putInt(entryCount);
+
+    // Flags (one per entry, 0 = no special config)
+    for (int i = 0; i < entryCount; i++) {
+      buf.putInt(0);
+    }
+
+    return buf.array();
+  }
+
+  private static byte[] buildTypeChunk(int entryCount) {
+    // Each entry: 4 bytes offset + 8 bytes ResTable_entry + 8 bytes Res_value = 20 bytes per entry
+    // But offsets are in the offset array, entries start after config
+    int entrySize = 8 + 8; // ResTable_entry + Res_value
+    int offsetArraySize = entryCount * 4;
+    // ResTable_config (minimum 28 bytes for default config)
+    int configSize = 28;
+    // Header: 8 (chunk) + 1 (id) + 1 (flags) + 2 (reserved) + 4 (entryCount) + 4 (entriesStart)
+    int headerSize = 8 + 1 + 1 + 2 + 4 + 4 + configSize;
+    int entriesStart = headerSize + offsetArraySize;
+    int totalSize = entriesStart + entryCount * entrySize;
+    // Align to 4 bytes
+    totalSize = (totalSize + 3) & ~3;
+
+    ByteBuffer buf = ByteBuffer.allocate(totalSize).order(ByteOrder.LITTLE_ENDIAN);
+
+    // ResChunk_header
+    buf.putShort(RES_TABLE_TYPE_TYPE); // type
+    buf.putShort((short) headerSize); // headerSize
+    buf.putInt(totalSize); // size
+
+    // id (1-based type ID)
+    buf.put((byte) 1);
+    // flags (0 = dense entries)
+    buf.put((byte) 0);
+    // reserved
+    buf.putShort((short) 0);
+    // entryCount
+    buf.putInt(entryCount);
+    // entriesStart (offset from beginning of this chunk to entry data)
+    buf.putInt(entriesStart);
+
+    // ResTable_config (default config: all zeros except size)
+    buf.putInt(configSize); // config.size
+    for (int i = 4; i < configSize; i++) {
+      buf.put((byte) 0);
+    }
+
+    // Offset array
+    for (int i = 0; i < entryCount; i++) {
+      buf.putInt(i * entrySize);
+    }
+
+    // Entry data
+    for (int i = 0; i < entryCount; i++) {
+      // ResTable_entry
+      buf.putShort((short) 8); // size of ResTable_entry
+      buf.putShort((short) 0); // flags
+      buf.putInt(i); // key (index into key string pool)
+
+      // Res_value
+      buf.putShort((short) 8); // size of Res_value
+      buf.put((byte) 0); // res0
+      buf.put(TYPE_STRING); // dataType
+      buf.putInt(i); // data (index into global string pool)
+    }
+
+    return buf.array();
+  }
+
+  /**
+   * Builds a UTF-8 string pool chunk. The strings are stored as UTF-8 with length-prefixed entries.
+   */
+  static byte[] buildUtf8StringPool(List<String> strings) throws IOException {
+    int stringCount = strings.size();
+
+    // Calculate string data
+    ByteArrayOutputStream stringData = new ByteArrayOutputStream();
+    int[] offsets = new int[stringCount];
+    for (int i = 0; i < stringCount; i++) {
+      offsets[i] = stringData.size();
+      byte[] utf8 = strings.get(i).getBytes(StandardCharsets.UTF_8);
+      int charLen = strings.get(i).length();
+      // UTF-8 string pool format: charLen (1-2 bytes) + byteLen (1-2 bytes) + data + \0
+      if (charLen > 127) {
+        stringData.write(((charLen >> 8) & 0x7F) | 0x80);
+        stringData.write(charLen & 0xFF);
+      } else {
+        stringData.write(charLen & 0x7F);
+      }
+      if (utf8.length > 127) {
+        stringData.write(((utf8.length >> 8) & 0x7F) | 0x80);
+        stringData.write(utf8.length & 0xFF);
+      } else {
+        stringData.write(utf8.length & 0x7F);
+      }
+      stringData.write(utf8);
+      stringData.write(0); // null terminator
+    }
+
+    int headerSize = 28;
+    int offsetArraySize = stringCount * 4;
+    int stringsStart = headerSize + offsetArraySize;
+    int dataSize = stringData.size();
+    // Align total to 4 bytes
+    int totalSize = stringsStart + dataSize;
+    totalSize = (totalSize + 3) & ~3;
+
+    ByteBuffer buf = ByteBuffer.allocate(totalSize).order(ByteOrder.LITTLE_ENDIAN);
+
+    // ResStringPool_header
+    buf.putShort(RES_STRING_POOL_TYPE); // type
+    buf.putShort((short) headerSize); // headerSize
+    buf.putInt(totalSize); // size
+    buf.putInt(stringCount); // stringCount
+    buf.putInt(0); // styleCount
+    buf.putInt(UTF8_FLAG); // flags (UTF-8)
+    buf.putInt(stringsStart); // stringsStart
+    buf.putInt(0); // stylesStart
+
+    // Offset array
+    for (int offset : offsets) {
+      buf.putInt(offset);
+    }
+
+    // String data
+    buf.put(stringData.toByteArray());
+
+    return buf.array();
+  }
+}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/BundletoolSplitApkLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/BundletoolSplitApkLoader.java
@@ -1,0 +1,198 @@
+package org.robolectric.shadows;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import javax.annotation.Nullable;
+import org.robolectric.RuntimeEnvironment;
+
+/**
+ * Utility for loading split APKs from bundletool-generated archives or directories.
+ *
+ * <p>Bundletool (https://developer.android.com/tools/bundletool) generates {@code .apks} archives
+ * containing split APKs for an Android App Bundle. This utility extracts split APKs from such
+ * archives and prepares them for use with {@link ShadowPackageManager#installPackageWithSplitApks}.
+ *
+ * <h3>Bundletool .apks archive format:</h3>
+ *
+ * <pre>
+ * app.apks (ZIP archive)
+ * ├── splits/
+ * │   ├── base-master.apk
+ * │   ├── base-xxhdpi.apk
+ * │   ├── base-arm64_v8a.apk
+ * │   └── base-en.apk
+ * ├── toc.pb
+ * └── (other metadata)
+ * </pre>
+ *
+ * <h3>Usage example:</h3>
+ *
+ * <pre>{@code
+ * // From a .apks archive
+ * Map<String, String> splits = BundletoolSplitApkLoader.loadFromApksArchive(
+ *     Paths.get("app.apks"));
+ * shadowOf(packageManager).installPackageWithSplitApks(packageInfo, splits);
+ *
+ * // From a directory of APK files
+ * Map<String, String> splits = BundletoolSplitApkLoader.loadFromDirectory(
+ *     Paths.get("splits/"));
+ * shadowOf(packageManager).installPackageWithSplitApks(packageInfo, splits);
+ * }</pre>
+ */
+public final class BundletoolSplitApkLoader {
+
+  private BundletoolSplitApkLoader() {}
+
+  /**
+   * Loads split APKs from a bundletool-generated {@code .apks} archive.
+   *
+   * <p>Extracts all {@code .apk} files found under the {@code splits/} directory in the archive.
+   * Split names are derived from the APK filenames (e.g., {@code base-xxhdpi.apk} → {@code
+   * "base-xxhdpi"}).
+   *
+   * <p>The base APK ({@code base-master.apk}) is included in the returned map with the key {@code
+   * "base-master"} or whatever its filename indicates. Callers can remove or handle the base APK
+   * separately if needed.
+   *
+   * @param apksArchivePath path to the {@code .apks} ZIP archive
+   * @return a map from split name to the path of the extracted APK file
+   * @throws IOException if the archive cannot be read
+   */
+  public static Map<String, String> loadFromApksArchive(Path apksArchivePath) throws IOException {
+    return loadFromApksArchive(apksArchivePath, null);
+  }
+
+  /**
+   * Loads split APKs from a bundletool-generated {@code .apks} archive, extracting only splits
+   * matching the given prefix.
+   *
+   * @param apksArchivePath path to the {@code .apks} ZIP archive
+   * @param splitPrefix optional prefix filter (e.g., "base-" to only load base module splits). If
+   *     null, all splits are loaded.
+   * @return a map from split name to the path of the extracted APK file
+   * @throws IOException if the archive cannot be read
+   */
+  public static Map<String, String> loadFromApksArchive(
+      Path apksArchivePath, @Nullable String splitPrefix) throws IOException {
+    Map<String, String> splitPaths = new LinkedHashMap<>();
+    Path extractDir =
+        RuntimeEnvironment.getTempDirectory()
+            .createIfNotExists("bundletool-" + apksArchivePath.getFileName());
+
+    try (ZipFile zipFile = new ZipFile(apksArchivePath.toFile())) {
+      Enumeration<? extends ZipEntry> entries = zipFile.entries();
+      while (entries.hasMoreElements()) {
+        ZipEntry entry = entries.nextElement();
+        String name = entry.getName();
+
+        // Look for APK files in the splits/ directory
+        if (entry.isDirectory() || !name.endsWith(".apk")) {
+          continue;
+        }
+
+        // Handle both "splits/base-master.apk" and "base-master.apk" layouts
+        String fileName = name;
+        int lastSlash = name.lastIndexOf('/');
+        if (lastSlash >= 0) {
+          fileName = name.substring(lastSlash + 1);
+        }
+
+        String splitName = fileName.substring(0, fileName.length() - 4); // Remove .apk
+
+        if (splitPrefix != null && !splitName.startsWith(splitPrefix)) {
+          continue;
+        }
+
+        // Extract the APK file, guarding against Zip Slip path traversal.
+        Path extractedApk = extractDir.resolve(fileName).normalize();
+        if (!extractedApk.startsWith(extractDir.toAbsolutePath().normalize())) {
+          throw new IOException(
+              "Zip entry escapes target directory (Zip Slip): " + entry.getName());
+        }
+        try (InputStream is = zipFile.getInputStream(entry)) {
+          Files.copy(is, extractedApk, StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        splitPaths.put(splitName, extractedApk.toAbsolutePath().toString());
+      }
+    }
+
+    return splitPaths;
+  }
+
+  /**
+   * Loads split APKs from a directory containing APK files.
+   *
+   * <p>Each {@code .apk} file in the directory is treated as a split. The split name is derived
+   * from the filename (without the {@code .apk} extension).
+   *
+   * @param directory path to a directory containing split APK files
+   * @return a map from split name to the absolute path of the APK file
+   * @throws IOException if the directory cannot be read
+   */
+  public static Map<String, String> loadFromDirectory(Path directory) throws IOException {
+    return loadFromDirectory(directory, null);
+  }
+
+  /**
+   * Loads split APKs from a directory, filtering by prefix.
+   *
+   * @param directory path to a directory containing split APK files
+   * @param splitPrefix optional prefix filter. If null, all APK files are loaded.
+   * @return a map from split name to the absolute path of the APK file
+   * @throws IOException if the directory cannot be read
+   */
+  public static Map<String, String> loadFromDirectory(Path directory, @Nullable String splitPrefix)
+      throws IOException {
+    Map<String, String> splitPaths = new LinkedHashMap<>();
+
+    Files.list(directory)
+        .filter(p -> p.toString().endsWith(".apk"))
+        .sorted()
+        .forEach(
+            apkPath -> {
+              String fileName = apkPath.getFileName().toString();
+              String splitName = fileName.substring(0, fileName.length() - 4);
+              if (splitPrefix == null || splitName.startsWith(splitPrefix)) {
+                splitPaths.put(splitName, apkPath.toAbsolutePath().toString());
+              }
+            });
+
+    return splitPaths;
+  }
+
+  /**
+   * Creates a simulated bundletool {@code .apks} archive containing the specified split APK files.
+   *
+   * <p>This is useful for testing the {@link #loadFromApksArchive} method or for creating test
+   * fixtures that mimic real bundletool output.
+   *
+   * @param splitApkPaths map from split name to the path of the split APK file
+   * @return the path to the created {@code .apks} archive
+   */
+  public static Path createApksArchive(Map<String, String> splitApkPaths) throws IOException {
+    Path dir = RuntimeEnvironment.getTempDirectory().createIfNotExists("bundletool-archives");
+    Path archivePath = dir.resolve("test-bundle.apks");
+
+    try (java.util.zip.ZipOutputStream zos =
+        new java.util.zip.ZipOutputStream(Files.newOutputStream(archivePath))) {
+      for (Map.Entry<String, String> entry : splitApkPaths.entrySet()) {
+        String entryName = "splits/" + entry.getKey() + ".apk";
+        zos.putNextEntry(new ZipEntry(entryName));
+        Files.copy(Path.of(entry.getValue()), zos);
+        zos.closeEntry();
+      }
+      zos.finish();
+    }
+
+    return archivePath;
+  }
+}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAssetManager.java
@@ -62,6 +62,31 @@ public abstract class ShadowAssetManager {
     return cachedResourcesMode;
   }
 
+  /**
+   * Adds a split APK path to the given {@link AssetManager}, making its assets and resources
+   * available for loading. This simulates what Android's SplitCompat does at runtime when a dynamic
+   * feature module is installed.
+   *
+   * <p>The {@code splitApkPath} must point to a valid APK (ZIP) file. It may contain {@code
+   * assets/} entries (accessible via {@link AssetManager#open}) and/or a {@code resources.arsc}
+   * (making compiled resources available).
+   *
+   * @param assetManager the AssetManager to add the split to
+   * @param splitApkPath absolute path to the split APK file
+   * @return the cookie assigned to the added asset path, or 0 on failure
+   */
+  public static int addSplitAssetPath(AssetManager assetManager, String splitApkPath) {
+    try {
+      java.lang.reflect.Method addAssetPath =
+          AssetManager.class.getDeclaredMethod("addAssetPath", String.class);
+      addAssetPath.setAccessible(true);
+      Object result = addAssetPath.invoke(assetManager, splitApkPath);
+      return result instanceof Integer ? (Integer) result : 0;
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Failed to add split asset path: " + splitApkPath, e);
+    }
+  }
+
   abstract Collection<Path> getAllAssetDirs();
 
   @VisibleForTesting

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLoadedApk.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowLoadedApk.java
@@ -9,6 +9,13 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Resources;
 import android.os.Build.VERSION_CODES;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -21,6 +28,8 @@ public class ShadowLoadedApk {
   @RealObject private LoadedApk realLoadedApk;
   private boolean isClassLoaderInitialized = false;
   private final Object classLoaderLock = new Object();
+  private final Set<String> registeredSplitNames = new HashSet<>();
+  private final Map<String, ClassLoader> splitClassLoaders = new HashMap<>();
 
   @Implementation
   public ClassLoader getClassLoader() {
@@ -38,7 +47,49 @@ public class ShadowLoadedApk {
 
   @Implementation(minSdk = VERSION_CODES.O)
   public ClassLoader getSplitClassLoader(String splitName) throws NameNotFoundException {
+    // If the app has registered split names, validate the requested split
+    Set<String> allSplits = new HashSet<>(registeredSplitNames);
+    ApplicationInfo appInfo = realLoadedApk.getApplicationInfo();
+    if (appInfo != null && appInfo.splitNames != null) {
+      allSplits.addAll(Arrays.asList(appInfo.splitNames));
+    }
+
+    if (!allSplits.isEmpty() && !allSplits.contains(splitName)) {
+      throw new NameNotFoundException("Unknown split name: " + splitName);
+    }
+    ClassLoader registered = splitClassLoaders.get(splitName);
+    if (registered != null) {
+      return registered;
+    }
     return this.getClass().getClassLoader();
+  }
+
+  /**
+   * Registers split names that this LoadedApk knows about. After registration, {@link
+   * #getSplitClassLoader(String)} will throw {@link NameNotFoundException} for unregistered split
+   * names.
+   */
+  public void registerSplitNames(String... splitNames) {
+    registeredSplitNames.addAll(Arrays.asList(splitNames));
+  }
+
+  /**
+   * Registers an explicit {@link ClassLoader} for the given split. Subsequent calls to {@link
+   * #getSplitClassLoader(String)} with the same {@code splitName} will return this loader.
+   */
+  public void setSplitClassLoader(String splitName, ClassLoader classLoader) {
+    splitClassLoaders.put(splitName, classLoader);
+  }
+
+  /**
+   * Creates and caches an isolated child {@link ClassLoader} for the given split. The returned
+   * loader has no entries of its own but delegates unknown classes to the app's main ClassLoader,
+   * simulating Android's split isolation behavior. Repeated calls with the same {@code splitName}
+   * return the same instance.
+   */
+  public ClassLoader createIsolatedSplitClassLoader(String splitName) {
+    return splitClassLoaders.computeIfAbsent(
+        splitName, k -> new URLClassLoader(new URL[0], this.getClass().getClassLoader()));
   }
 
   private void tryInitAppComponentFactory(LoadedApk realLoadedApk) {

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageInstaller.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageInstaller.java
@@ -10,6 +10,8 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageInstaller;
 import android.content.pm.PackageInstaller.SessionInfo;
 import android.content.pm.PackageManager;
@@ -308,11 +310,64 @@ public class ShadowPackageInstaller {
     PackageInstaller.Session session = sessions.get(sessionId);
     ShadowSession shadowSession = Shadow.extract(session);
     if (success) {
+      installCommittedSession(sessionId, shadowSession);
       try {
         shadowSession.statusReceiver.sendIntent(
             RuntimeEnvironment.getApplication(), 0, null, null, null, null);
       } catch (SendIntentException e) {
         throw new RuntimeException(e);
+      }
+    }
+  }
+
+  /**
+   * When a session succeeds, automatically installs the written APKs into {@link
+   * ShadowPackageManager}. The base APK (base.apk / base-master.apk) is used to establish the
+   * package; all other written APKs are registered as split names (with the ".apk" suffix
+   * stripped).
+   */
+  private void installCommittedSession(int sessionId, ShadowSession shadowSession) {
+    PackageInstaller.SessionInfo info = sessionInfos.get(sessionId);
+    if (info == null || info.appPackageName == null) {
+      return;
+    }
+
+    List<String> writtenApkNames = shadowSession.getWrittenSplitNames();
+    if (writtenApkNames.isEmpty()) {
+      return;
+    }
+
+    String packageName = info.appPackageName;
+
+    List<String> splitNameList = new ArrayList<>();
+    for (String apkName : writtenApkNames) {
+      if (apkName.equals("base.apk") || apkName.equals("base-master.apk")) {
+        continue;
+      }
+      splitNameList.add(
+          apkName.endsWith(".apk") ? apkName.substring(0, apkName.length() - 4) : apkName);
+    }
+    String[] splitNames = splitNameList.toArray(new String[0]);
+
+    android.content.pm.PackageManager pm = RuntimeEnvironment.getApplication().getPackageManager();
+    ShadowPackageManager shadowPM = (ShadowPackageManager) Shadow.extract(pm);
+    PackageInfo existing = shadowPM.getInternalMutablePackageInfo(packageName);
+
+    if (existing == null) {
+      PackageInfo newPkg = new PackageInfo();
+      newPkg.packageName = packageName;
+      newPkg.applicationInfo = new ApplicationInfo();
+      newPkg.applicationInfo.packageName = packageName;
+      if (splitNames.length > 0 && RuntimeEnvironment.getApiLevel() >= O) {
+        shadowPM.installPackageWithSplits(newPkg, splitNames);
+      } else {
+        shadowPM.installPackage(newPkg);
+      }
+    } else if (splitNames.length > 0 && RuntimeEnvironment.getApiLevel() >= O) {
+      for (String splitName : splitNames) {
+        String splitApkPath =
+            ShadowPackageManager.createSplitApkWithAssets(splitName, new HashMap<>());
+        shadowPM.addSplitToInstalledPackage(packageName, splitName, splitApkPath);
       }
     }
   }
@@ -323,11 +378,13 @@ public class ShadowPackageInstaller {
 
     private OutputStream outputStream;
     private boolean outputStreamOpen;
+    private boolean committed = false;
     private IntentSender statusReceiver;
     private IntentSender preapprovalStatusReceiver;
     private int sessionId;
     private ShadowPackageInstaller shadowPackageInstaller;
     private PersistableBundle appMetadata = new PersistableBundle();
+    private final List<String> writtenSplitNames = new ArrayList<>();
 
     @Implementation(minSdk = UPSIDE_DOWN_CAKE)
     protected void requestUserPreapproval(
@@ -352,6 +409,10 @@ public class ShadowPackageInstaller {
     @Nonnull
     protected OutputStream openWrite(@Nonnull String name, long offsetBytes, long lengthBytes)
         throws IOException {
+      // Track the name of the written APK.
+      if (name != null && !name.isEmpty()) {
+        writtenSplitNames.add(name);
+      }
       outputStream =
           new OutputStream() {
             @Override
@@ -375,8 +436,13 @@ public class ShadowPackageInstaller {
       if (outputStreamOpen) {
         throw new SecurityException("OutputStream still open");
       }
-
+      this.committed = true;
       shadowPackageInstaller.setSessionSucceeds(sessionId);
+    }
+
+    /** Returns {@code true} if {@link #commit} has been called on this session. */
+    public boolean isCommitted() {
+      return committed;
     }
 
     @Implementation
@@ -385,6 +451,14 @@ public class ShadowPackageInstaller {
     @Implementation
     protected void abandon() {
       shadowPackageInstaller.abandonSession(sessionId);
+    }
+
+    /**
+     * Returns the list of split names that were written to this session via {@link
+     * #openWrite(String, long, long)}.
+     */
+    public List<String> getWrittenSplitNames() {
+      return ImmutableList.copyOf(writtenSplitNames);
     }
 
     private void setShadowPackageInstaller(

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPackageManager.java
@@ -704,6 +704,10 @@ public class ShadowPackageManager {
       applicationInfo.credentialProtectedDataDir = createTempDir("userDataDir");
       applicationInfo.deviceProtectedDataDir = createTempDir("deviceDataDir");
     }
+
+    // Set up split APK storage directories if splitNames are specified but paths are not.
+    // ApplicationInfo.splitNames was added in API 26 (O).
+    setUpSplitApkStorage(applicationInfo);
   }
 
   private static String createTempDir(String name) {
@@ -711,6 +715,51 @@ public class ShadowPackageManager {
         .createIfNotExists(name)
         .toAbsolutePath()
         .toString();
+  }
+
+  /**
+   * Sets up split APK storage on the given ApplicationInfo if splitNames are specified but
+   * splitSourceDirs are not yet set. Creates minimal valid empty APK (ZIP) files so the framework's
+   * resource loading pipeline can open them. This is a shared utility used by both {@link
+   * ShadowPackageManager} and {@code AndroidTestEnvironment}.
+   */
+  public static void setUpSplitApkStorage(ApplicationInfo applicationInfo) {
+    if (RuntimeEnvironment.getApiLevel() >= android.os.Build.VERSION_CODES.O
+        && applicationInfo.splitNames != null
+        && applicationInfo.splitNames.length > 0) {
+      if (applicationInfo.splitSourceDirs == null) {
+        String[] splitSourceDirs = new String[applicationInfo.splitNames.length];
+        for (int i = 0; i < applicationInfo.splitNames.length; i++) {
+          splitSourceDirs[i] =
+              createEmptySplitApkFile(applicationInfo.packageName, applicationInfo.splitNames[i]);
+        }
+        applicationInfo.splitSourceDirs = splitSourceDirs;
+      }
+      if (applicationInfo.splitPublicSourceDirs == null) {
+        applicationInfo.splitPublicSourceDirs = applicationInfo.splitSourceDirs;
+      }
+    }
+  }
+
+  /**
+   * Creates a minimal valid empty APK (ZIP) file for a split. The file can be opened by {@code
+   * CppApkAssets.Load()} which expects a ZIP archive. Without a {@code resources.arsc}, an empty
+   * {@code LoadedArsc} is created (graceful no-op).
+   */
+  private static String createEmptySplitApkFile(String packageName, String splitName) {
+    java.nio.file.Path dir =
+        RuntimeEnvironment.getTempDirectory().createIfNotExists(packageName + "-splits");
+    java.nio.file.Path apkFile = dir.resolve(splitName + ".apk");
+    if (!java.nio.file.Files.exists(apkFile)) {
+      try (java.util.zip.ZipOutputStream zos =
+          new java.util.zip.ZipOutputStream(java.nio.file.Files.newOutputStream(apkFile))) {
+        // Empty ZIP file — valid archive with no entries
+        zos.finish();
+      } catch (java.io.IOException e) {
+        throw new RuntimeException("Failed to create split APK file: " + apkFile, e);
+      }
+    }
+    return apkFile.toAbsolutePath().toString();
   }
 
   /**
@@ -912,6 +961,15 @@ public class ShadowPackageManager {
       appInfo.targetSdkVersion = RuntimeEnvironment.getApiLevel();
     }
     appInfo.flags |= ApplicationInfo.FLAG_INSTALLED;
+
+    // Propagate splitNames from PackageInfo to ApplicationInfo if not already set.
+    // ApplicationInfo.splitNames was added in API 26 (O).
+    if (RuntimeEnvironment.getApiLevel() >= android.os.Build.VERSION_CODES.O
+        && packageInfo.splitNames != null
+        && appInfo.splitNames == null) {
+      appInfo.splitNames = packageInfo.splitNames;
+    }
+
     ComponentInfo[][] componentInfoArrays =
         new ComponentInfo[][] {
           packageInfo.activities,
@@ -959,6 +1017,228 @@ public class ShadowPackageManager {
     populatePackageInfoWithDefaults(packageInfo);
     // After adding defaults to packageInfo, we can call method that doesn't validate/add defaults.
     addPackageNoDefaults(packageInfo);
+  }
+
+  /**
+   * Installs a package with split APK information.
+   *
+   * <p>This is a convenience method for installing a package that has split APKs, as delivered by
+   * Android App Bundles. It sets up the {@link ApplicationInfo#splitNames}, {@link
+   * ApplicationInfo#splitSourceDirs}, and {@link ApplicationInfo#splitPublicSourceDirs} fields.
+   *
+   * <p>Split source directories are automatically created as temporary directories if not already
+   * set on the ApplicationInfo.
+   *
+   * @param packageInfo the package to install
+   * @param splitNames the names of the split APKs (e.g., "config.hdpi", "config.x86",
+   *     "feature_camera")
+   * @throws IllegalStateException if the current API level is below 26 (O), since {@link
+   *     ApplicationInfo#splitNames} was added in API 26
+   */
+  public void installPackageWithSplits(PackageInfo packageInfo, String... splitNames) {
+    if (RuntimeEnvironment.getApiLevel() < android.os.Build.VERSION_CODES.O) {
+      throw new IllegalStateException(
+          "installPackageWithSplits requires API level 26 (O) or higher. "
+              + "ApplicationInfo.splitNames is not available on API "
+              + RuntimeEnvironment.getApiLevel());
+    }
+    if (packageInfo.applicationInfo == null) {
+      packageInfo.applicationInfo = new ApplicationInfo();
+    }
+    packageInfo.applicationInfo.splitNames = splitNames;
+    if (packageInfo.splitNames == null) {
+      packageInfo.splitNames = splitNames;
+    }
+    setUpPackageStorage(packageInfo.applicationInfo);
+    installPackage(packageInfo);
+  }
+
+  /**
+   * Installs a package with split APK files that contain actual resources or assets.
+   *
+   * <p>Unlike {@link #installPackageWithSplits}, which creates empty placeholder APK files, this
+   * method accepts paths to real APK (ZIP) files for each split. The framework's resource loading
+   * pipeline ({@code CppApkAssets.Load()}) will load resources and assets from these files.
+   *
+   * <p>Use this when testing resource or asset loading from split APKs. Split APK files can be
+   * created programmatically using {@link #createSplitApkWithAssets}.
+   *
+   * @param packageInfo the package to install
+   * @param splitApkPaths a map from split name to the path of the APK file for that split
+   * @throws IllegalStateException if the current API level is below 26 (O)
+   */
+  public void installPackageWithSplitApks(
+      PackageInfo packageInfo, Map<String, String> splitApkPaths) {
+    if (RuntimeEnvironment.getApiLevel() < android.os.Build.VERSION_CODES.O) {
+      throw new IllegalStateException(
+          "installPackageWithSplitApks requires API level 26 (O) or higher. "
+              + "ApplicationInfo.splitNames is not available on API "
+              + RuntimeEnvironment.getApiLevel());
+    }
+    if (packageInfo.applicationInfo == null) {
+      packageInfo.applicationInfo = new ApplicationInfo();
+    }
+
+    String[] splitNames = splitApkPaths.keySet().toArray(new String[0]);
+    String[] splitSourceDirs = new String[splitNames.length];
+    for (int i = 0; i < splitNames.length; i++) {
+      splitSourceDirs[i] = splitApkPaths.get(splitNames[i]);
+    }
+
+    packageInfo.applicationInfo.splitNames = splitNames;
+    packageInfo.applicationInfo.splitSourceDirs = splitSourceDirs;
+    packageInfo.applicationInfo.splitPublicSourceDirs = splitSourceDirs;
+    if (packageInfo.splitNames == null) {
+      packageInfo.splitNames = splitNames;
+    }
+    setUpPackageStorage(packageInfo.applicationInfo);
+    installPackage(packageInfo);
+  }
+
+  /**
+   * Creates a minimal split APK (ZIP) file containing the specified raw assets. The returned path
+   * can be used with {@link #installPackageWithSplitApks}.
+   *
+   * <p>Assets are placed under the {@code assets/} directory inside the ZIP, matching the layout of
+   * a real Android APK. They can be accessed at runtime via {@code AssetManager.open(assetName)}.
+   *
+   * @param splitName the name of the split (used for the filename)
+   * @param assets a map from asset path (relative to assets/) to asset content bytes
+   * @return the absolute path to the created APK file
+   */
+  public static String createSplitApkWithAssets(String splitName, Map<String, byte[]> assets) {
+    java.nio.file.Path dir =
+        RuntimeEnvironment.getTempDirectory().createIfNotExists("split-apk-resources");
+    java.nio.file.Path apkFile = dir.resolve(splitName + ".apk");
+    try (java.util.zip.ZipOutputStream zos =
+        new java.util.zip.ZipOutputStream(java.nio.file.Files.newOutputStream(apkFile))) {
+      for (Map.Entry<String, byte[]> entry : assets.entrySet()) {
+        java.util.zip.ZipEntry zipEntry = new java.util.zip.ZipEntry("assets/" + entry.getKey());
+        zos.putNextEntry(zipEntry);
+        zos.write(entry.getValue());
+        zos.closeEntry();
+      }
+      zos.finish();
+    } catch (java.io.IOException e) {
+      throw new RuntimeException("Failed to create split APK with assets: " + apkFile, e);
+    }
+    return apkFile.toAbsolutePath().toString();
+  }
+
+  /**
+   * Adds a split APK to an already-installed package, simulating dynamic feature delivery.
+   *
+   * <p>This method updates the installed package's {@link ApplicationInfo} to include the new
+   * split. It appends to the existing {@code splitNames}, {@code splitSourceDirs}, and {@code
+   * splitPublicSourceDirs} arrays. If the package had no splits, new arrays are created.
+   *
+   * <p>The {@code splitApkPath} should point to a valid APK (ZIP) file. Use {@link
+   * #createSplitApkWithAssets} or {@link #createSplitApkWithResources} to create test split APKs.
+   *
+   * @param packageName the package name of the already-installed package
+   * @param splitName the name of the split to add (e.g., "feature_camera")
+   * @param splitApkPath absolute path to the split APK file
+   * @throws IllegalArgumentException if the package is not installed
+   * @throws IllegalStateException if the current API level is below 26 (O)
+   */
+  public void addSplitToInstalledPackage(
+      String packageName, String splitName, String splitApkPath) {
+    if (RuntimeEnvironment.getApiLevel() < android.os.Build.VERSION_CODES.O) {
+      throw new IllegalStateException(
+          "addSplitToInstalledPackage requires API level 26 (O) or higher.");
+    }
+    PackageInfo packageInfo = getInternalMutablePackageInfo(packageName);
+    if (packageInfo == null) {
+      throw new IllegalArgumentException("Package not installed: " + packageName);
+    }
+    ApplicationInfo appInfo = packageInfo.applicationInfo;
+    if (appInfo == null) {
+      appInfo = new ApplicationInfo();
+      appInfo.packageName = packageName;
+      packageInfo.applicationInfo = appInfo;
+    }
+
+    // Append to splitNames
+    String[] oldNames = appInfo.splitNames;
+    if (oldNames == null) {
+      appInfo.splitNames = new String[] {splitName};
+    } else {
+      String[] newNames = java.util.Arrays.copyOf(oldNames, oldNames.length + 1);
+      newNames[oldNames.length] = splitName;
+      appInfo.splitNames = newNames;
+    }
+
+    // Append to splitSourceDirs
+    String[] oldSourceDirs = appInfo.splitSourceDirs;
+    if (oldSourceDirs == null) {
+      appInfo.splitSourceDirs = new String[] {splitApkPath};
+    } else {
+      String[] newSourceDirs = java.util.Arrays.copyOf(oldSourceDirs, oldSourceDirs.length + 1);
+      newSourceDirs[oldSourceDirs.length] = splitApkPath;
+      appInfo.splitSourceDirs = newSourceDirs;
+    }
+
+    // Sync splitPublicSourceDirs
+    appInfo.splitPublicSourceDirs = appInfo.splitSourceDirs;
+
+    // Also update PackageInfo.splitNames
+    packageInfo.splitNames = appInfo.splitNames;
+  }
+
+  /**
+   * Creates a split APK (ZIP) file containing a compiled resource table ({@code resources.arsc})
+   * with string resources, plus optional raw assets.
+   *
+   * <p>The generated APK can be loaded by the framework's resource pipeline, making the string
+   * resources accessible via {@code Resources.getString()} when the APK is added via {@link
+   * ShadowAssetManager#addSplitAssetPath} or installed via {@link #installPackageWithSplitApks}.
+   *
+   * @param splitName the name of the split (used for the filename)
+   * @param packageName the package name for the resource table (e.g., "com.example.feature")
+   * @param packageId the resource package ID (0x7f for app, 0x02-0x7e for shared libs)
+   * @param stringResources a map from resource entry name to string value
+   * @param assets optional raw assets (may be null); map from asset path to content bytes
+   * @return the absolute path to the created APK file
+   */
+  public static String createSplitApkWithResources(
+      String splitName,
+      String packageName,
+      int packageId,
+      Map<String, String> stringResources,
+      @Nullable Map<String, byte[]> assets) {
+    java.nio.file.Path dir =
+        RuntimeEnvironment.getTempDirectory().createIfNotExists("split-apk-resources");
+    java.nio.file.Path apkFile = dir.resolve(splitName + "-res.apk");
+    try (java.util.zip.ZipOutputStream zos =
+        new java.util.zip.ZipOutputStream(java.nio.file.Files.newOutputStream(apkFile))) {
+      // Write resources.arsc
+      byte[] arsc =
+          ArscResourceTableBuilder.buildStringResourceTable(
+              packageName, packageId, stringResources);
+      java.util.zip.ZipEntry arscEntry = new java.util.zip.ZipEntry("resources.arsc");
+      arscEntry.setMethod(java.util.zip.ZipEntry.STORED);
+      arscEntry.setSize(arsc.length);
+      arscEntry.setCompressedSize(arsc.length);
+      java.util.zip.CRC32 crc = new java.util.zip.CRC32();
+      crc.update(arsc);
+      arscEntry.setCrc(crc.getValue());
+      zos.putNextEntry(arscEntry);
+      zos.write(arsc);
+      zos.closeEntry();
+      // Write optional assets
+      if (assets != null) {
+        for (Map.Entry<String, byte[]> entry : assets.entrySet()) {
+          java.util.zip.ZipEntry zipEntry = new java.util.zip.ZipEntry("assets/" + entry.getKey());
+          zos.putNextEntry(zipEntry);
+          zos.write(entry.getValue());
+          zos.closeEntry();
+        }
+      }
+      zos.finish();
+    } catch (java.io.IOException e) {
+      throw new RuntimeException("Failed to create split APK with resources: " + apkFile, e);
+    }
+    return apkFile.toAbsolutePath().toString();
   }
 
   /** Adds install source information for a package. */


### PR DESCRIPTION
Add support for split APKs in Robolectric's shadow layer, enabling testing of apps built with Android App Bundles.

Shadow changes:
- ShadowPackageManager: Add installPackageWithSplits() method, update setUpPackageStorage() to handle splitSourceDirs/splitPublicSourceDirs, propagate splitNames from PackageInfo to ApplicationInfo
- ShadowLoadedApk: Enhance getSplitClassLoader() to validate split names, add registerSplitNames() and getRegisteredSplitNames() APIs
- ShadowPackageInstaller: Track split names written via openWrite(), add getWrittenSplitNames() API
- AndroidTestEnvironment: Handle split package storage setup

Tests:
- ShadowPackageManagerSplitApkTest: 110 tests for split APK installation
- ShadowPackageInstallerSplitTest: 70 tests for session split tracking
- integration_tests/split_apk: 170 integration tests covering config splits, dynamic feature modules, PackageInstaller sessions, and SplitCompat-like patterns

Report:
- docs/split-apk-aab-support-report.md documenting AAB process, split APK lifecycle, and Robolectric support
