### PR TITLE
chore: Give a valid package name for ProvideBuildClasspathTask.kt

### DIFF
--- a/build-logic/convention/src/main/java/org/robolectric/gradle/AndroidProjectConfigPlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/AndroidProjectConfigPlugin.kt
@@ -1,6 +1,5 @@
 package org.robolectric.gradle
 
-import ProvideBuildClasspathTask
 import com.android.SdkConstants.FD_GENERATED
 import com.android.build.api.dsl.LibraryExtension
 import java.io.File

--- a/build-logic/convention/src/main/java/org/robolectric/gradle/ProvideBuildClasspathTask.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/ProvideBuildClasspathTask.kt
@@ -1,3 +1,5 @@
+package org.robolectric.gradle
+
 import java.io.File
 import java.util.Properties
 import org.gradle.api.DefaultTask

--- a/build-logic/convention/src/main/java/org/robolectric/gradle/RoboJavaModulePlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/RoboJavaModulePlugin.kt
@@ -1,6 +1,5 @@
 package org.robolectric.gradle
 
-import ProvideBuildClasspathTask
 import java.io.File
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin


### PR DESCRIPTION
The new package name is org.robolectric.gradle.
