### PR TITLE
fix: store Paint.fontVariationSettings so the getter returns the value previously set

### DIFF
--- a/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativePaintTest.java
+++ b/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/ShadowNativePaintTest.java
@@ -1251,7 +1251,37 @@ public class ShadowNativePaintTest {
 
   @Test
   public void testSetFontVariationSettings_defaultTypeface() {
-    new Paint().setFontVariationSettings("'wght' 400");
+    Paint paint = new Paint();
+    paint.setFontVariationSettings("'wght' 400");
+    assertThat(paint.getFontVariationSettings()).isEqualTo("'wght' 400");
+  }
+
+  @Test
+  public void testGetFontVariationSettings_returnsValueSetByDefaultTypeface() {
+    Paint paint = new Paint();
+    paint.setFontVariationSettings("'wght' 250");
+    assertThat(paint.getFontVariationSettings()).isEqualTo("'wght' 250");
+  }
+
+  @Test
+  public void testGetFontVariationSettings_returnsNullByDefault() {
+    assertThat(new Paint().getFontVariationSettings()).isNull();
+  }
+
+  @Test
+  public void testGetFontVariationSettings_returnsNullAfterClearingWithNull() {
+    Paint paint = new Paint();
+    paint.setFontVariationSettings("'wght' 250");
+    paint.setFontVariationSettings(null);
+    assertThat(paint.getFontVariationSettings()).isNull();
+  }
+
+  @Test
+  public void testGetFontVariationSettings_returnsNullAfterClearingWithEmpty() {
+    Paint paint = new Paint();
+    paint.setFontVariationSettings("'wght' 250");
+    paint.setFontVariationSettings("");
+    assertThat(paint.getFontVariationSettings()).isNull();
   }
 
   @Test

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPaintTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPaintTest.java
@@ -1,5 +1,6 @@
 package org.robolectric.shadows;
 
+import static android.os.Build.VERSION_CODES.O;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -10,6 +11,7 @@ import android.graphics.Paint;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
 import org.robolectric.annotation.GraphicsMode;
 import org.robolectric.annotation.GraphicsMode.Mode;
 
@@ -179,5 +181,37 @@ public class ShadowPaintTest {
     paint.setFilterBitmap(false);
     assertThat(paint.isFilterBitmap()).isFalse();
     assertThat(paint.getFlags() & Paint.FILTER_BITMAP_FLAG).isEqualTo(0);
+  }
+
+  @Test
+  @Config(minSdk = O)
+  public void testGetFontVariationSettings_returnsValueSetByDefaultTypeface() {
+    Paint paint = new Paint();
+    paint.setFontVariationSettings("'wght' 250");
+    assertThat(paint.getFontVariationSettings()).isEqualTo("'wght' 250");
+  }
+
+  @Test
+  @Config(minSdk = O)
+  public void testGetFontVariationSettings_returnsNullByDefault() {
+    assertThat(new Paint().getFontVariationSettings()).isNull();
+  }
+
+  @Test
+  @Config(minSdk = O)
+  public void testGetFontVariationSettings_returnsNullAfterClearingWithNull() {
+    Paint paint = new Paint();
+    paint.setFontVariationSettings("'wght' 250");
+    paint.setFontVariationSettings(null);
+    assertThat(paint.getFontVariationSettings()).isNull();
+  }
+
+  @Test
+  @Config(minSdk = O)
+  public void testGetFontVariationSettings_returnsNullAfterClearingWithEmpty() {
+    Paint paint = new Paint();
+    paint.setFontVariationSettings("'wght' 250");
+    paint.setFontVariationSettings("");
+    assertThat(paint.getFontVariationSettings()).isNull();
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPaint.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowPaint.java
@@ -11,6 +11,7 @@ import static android.os.Build.VERSION_CODES.Q;
 import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
 import static android.os.Build.VERSION_CODES.VANILLA_ICE_CREAM;
 import static org.robolectric.annotation.TextLayoutMode.Mode.REALISTIC;
+import static org.robolectric.util.reflector.Reflector.reflector;
 
 import android.graphics.ColorFilter;
 import android.graphics.Paint;
@@ -27,6 +28,8 @@ import org.robolectric.annotation.TextLayoutMode;
 import org.robolectric.config.ConfigurationRegistry;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.util.ReflectionHelpers.ClassParameter;
+import org.robolectric.util.reflector.Accessor;
+import org.robolectric.util.reflector.ForType;
 
 @SuppressWarnings({"UnusedDeclaration"})
 @Implements(Paint.class)
@@ -608,5 +611,25 @@ public class ShadowPaint {
       boolean isRtl,
       int offset) {
     return nGetRunAdvance(0, text, start, end, contextStart, contextEnd, isRtl, offset);
+  }
+
+  @Implementation(minSdk = O)
+  protected boolean setFontVariationSettings(String fontVariationSettings) {
+    // Legacy graphics mode has no native typeface backend, so the upstream implementation
+    // cannot run: both the axis-filtering path (Typeface.isSupportedAxes) and the clearing
+    // path (Typeface.createFromTypefaceWithVariation) require native code. Manage the field
+    // directly so getFontVariationSettings() round-trips what was set.
+    String settings =
+        (fontVariationSettings == null || fontVariationSettings.isEmpty())
+            ? null
+            : fontVariationSettings;
+    reflector(PaintReflector.class, paint).setFontVariationSettingsField(settings);
+    return true;
+  }
+
+  @ForType(Paint.class)
+  interface PaintReflector {
+    @Accessor("mFontVariationSettings")
+    void setFontVariationSettingsField(String settings);
   }
 }


### PR DESCRIPTION
    Legacy graphics mode has no native typeface backend, so upstream
    Paint.setFontVariationSettings fails: both Typeface.isSupportedAxes() (axis filter) and
    Typeface.createFromTypefaceWithVariation() (clear path) require native code. The setter
    either silently drops the string or throws "native typeface cannot be made", and the
    getter then returns null.
    
    Shadow setFontVariationSettings in ShadowPaint to write mFontVariationSettings directly
    via reflection so the getter round-trips what was set.
    
    Native graphics mode is unaffected: upstream already succeeds because the bundled Roboto
    family in fonts.xml has multiple weight files, which makes the native typeface report
    'wght' as a synthetic supported axis. The ShadowNativePaintTest cases added here serve as
    regression guards for that behavior.


Fixes #11126
