### PR TITLE
Support more api 37

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ ENV ANDROID_HOME=/home/$USERNAME/Android/Sdk
 ENV ANDROID_SDK_ROOT=/home/$USERNAME/Android/Sdk
 ENV CMDLINE_HOME="${HOME}/Android/Sdk/cmdline-tools"
 ENV CMDLINE="${HOME}/Android/Sdk/cmdline-tools/cmdline-tools/bin"
-ENV ANDROID_SDK_ZIP_FILE_VERSION=13114758
+ENV ANDROID_SDK_ZIP_FILE_VERSION=14742923
 
 ENV PATH=${PATH}:${ANDROID_HOME}/platform-tools
 ENV PATH=${PATH}:${ANDROID_HOME}/platforms
@@ -39,6 +39,7 @@ RUN chmod +r+w+x -Rv ${HOME}/Android/Sdk
 RUN yes | sdkmanager --licenses
 RUN yes | sdkmanager --install "build-tools;35.0.0"
 RUN yes | sdkmanager --install "build-tools;36.0.0"
+RUN yes | sdkmanager --install "build-tools;37.0.0"
 RUN yes | sdkmanager --install "platforms;android-23"
 RUN yes | sdkmanager --install "platforms;android-24"
 RUN yes | sdkmanager --install "platforms;android-25"
@@ -53,5 +54,6 @@ RUN yes | sdkmanager --install "platforms;android-33"
 RUN yes | sdkmanager --install "platforms;android-34"
 RUN yes | sdkmanager --install "platforms;android-35"
 RUN yes | sdkmanager --install "platforms;android-36"
+RUN yes | sdkmanager --install "platforms;android-37.0"
 RUN yes | sdkmanager --install "cmdline-tools;latest"
 RUN yes | sdkmanager --install "platform-tools"

--- a/build-logic/convention/src/main/java/org/robolectric/gradle/GradleManagedDevicePlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/GradleManagedDevicePlugin.kt
@@ -1,6 +1,8 @@
 package org.robolectric.gradle
 
 import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.ManagedVirtualDevice.PageAlignment.DEFAULT_FOR_SDK_VERSION
+import com.android.build.api.dsl.ManagedVirtualDevice.PageAlignment.FORCE_16KB_PAGES
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.findByType
@@ -22,13 +24,14 @@ class GradleManagedDevicePlugin : Plugin<Project> {
       animationsDisabled = true
 
       managedDevices {
-        // ./gradlew -Pandroid.sdk.channel=3 nexusOneApi`ExpectedApiLevelDebugAndroidTest
+        // ./gradlew -Pandroid.sdk.channel=3 nexusOneApiExpectedApiLevelDebugAndroidTest
         // e.g. ./gradlew -Pandroid.sdk.channel=3 nexusOneApi36DebugAndroidTest
         API_LEVELS.forEach { apiLevel ->
           localDevices.register("nexusOneApi$apiLevel") {
             device = "Nexus One"
             this.apiLevel = apiLevel
-            systemImageSource = "aosp-atd"
+            systemImageSource = if (apiLevel == 37) "google" else "aosp-atd"
+            pageAlignment = if (apiLevel == 37) FORCE_16KB_PAGES else DEFAULT_FOR_SDK_VERSION
           }
         }
         // ./gradlew -Pandroid.sdk.channel=3 nexusOneIntegrationTestGroupDebugAndroidTest
@@ -40,6 +43,6 @@ class GradleManagedDevicePlugin : Plugin<Project> {
   } // apply
 
   private companion object {
-    private val API_LEVELS = 30..36
+    private val API_LEVELS = 30..37
   }
 }


### PR DESCRIPTION
1. GMD.
2. Docker image.

Emulator testing still hangs at 36 until upstream action supports API 37.