### PR TITLE
Sign all  .module  metadata files.

### DIFF
--- a/build-logic/convention/src/main/java/org/robolectric/gradle/DeployedRoboJavaModulePlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/DeployedRoboJavaModulePlugin.kt
@@ -78,9 +78,13 @@ class DeployedRoboJavaModulePlugin : Plugin<Project> {
         sonatypeRepositories(isSnapshotVersion)
 
         project.extensions.configure<SigningExtension> {
-          setRequired { !isSnapshotVersion && project.gradle.taskGraph.hasTask("uploadArchives") }
+          setRequired {
+            !isSnapshotVersion &&
+              (project.gradle.taskGraph.hasTask("uploadArchives") ||
+                project.gradle.taskGraph.hasTask("publish"))
+          }
 
-          sign(publications.getByName("mavenJava"))
+          sign(publications)
         }
       }
     }


### PR DESCRIPTION
Attempting to publish the 4.17-beta-1 release was failing with errors like 'Missing signature for file: sandbox-4.17-beta-1.module'.

This commit attempts to address the issue by modifying Robolectric's plugin sign in logic to pass the entire publications container to be signed.


