### PR TITLE
Add missing `@Deprecated` annotation in `SQLiteMode`

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/SQLiteMode.java
+++ b/annotations/src/main/java/org/robolectric/annotation/SQLiteMode.java
@@ -40,6 +40,7 @@ public @interface SQLiteMode {
      *
      * @deprecated {@code NATIVE} is the default mode and does not need to be stated explicitly.
      */
+    @Deprecated
     NATIVE,
   }
 


### PR DESCRIPTION
It looks like the annotation was forgotten in #10653.
