### PR TITLE
Fix warnings in Gradle files

### DIFF
--- a/build-logic/convention/src/main/java/org/robolectric/gradle/AndroidProjectConfigPlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/AndroidProjectConfigPlugin.kt
@@ -22,7 +22,7 @@ class AndroidProjectConfigPlugin : Plugin<Project> {
       outFile = File(outDir, "robolectric-deps.properties")
 
       project.extensions.configure<LibraryExtension> {
-        sourceSets.getByName("test").resources.srcDir(outDir)
+        sourceSets.getByName("test").resources.directories.add(outDir.absolutePath)
       }
     }
 

--- a/build-logic/convention/src/main/java/org/robolectric/gradle/RoboJavaModulePlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/RoboJavaModulePlugin.kt
@@ -51,7 +51,7 @@ class RoboJavaModulePlugin : Plugin<Project> {
       dependsOn(provideBuildClasspath)
 
       // Otherwise Gradle runs static inner classes like TestRunnerSequenceTest$SimpleTest
-      exclude("**/*\$*")
+      exclude("**/*$*")
 
       configureTestTask()
     }

--- a/build-logic/convention/src/main/java/org/robolectric/gradle/ShadowsPlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/ShadowsPlugin.kt
@@ -23,7 +23,6 @@ import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.extra
 import org.gradle.kotlin.dsl.named
-import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
 import org.gradle.process.CommandLineArgumentProvider
 
@@ -33,7 +32,10 @@ class ShadowsPlugin : Plugin<Project> {
 
     val shadows = project.extensions.create<ShadowsPluginExtension>("shadows")
 
-    project.dependencies.add("annotationProcessor", project.project(":processor"))
+    project.dependencies.add(
+      "annotationProcessor",
+      project.dependencyFactory.createProjectDependency(":processor"),
+    )
 
     // Write generated Java into its own dir. See https://github.com/gradle/gradle/issues/4956
     val generatedSrcDir =
@@ -80,8 +82,10 @@ class ShadowsPlugin : Plugin<Project> {
       }
     }
 
-    var configAnnotationProcessing: List<Project> by project.rootProject.extra
-    configAnnotationProcessing += project
+    @Suppress("UNCHECKED_CAST")
+    val configAnnotationProcessing =
+      project.rootProject.extra["configAnnotationProcessing"] as List<Project>
+    project.rootProject.extra["configAnnotationProcessing"] = configAnnotationProcessing + project
 
     // Prevents sporadic compilation error:
     // 'Bad service configuration file, or exception thrown while constructing

--- a/build-logic/convention/src/main/java/org/robolectric/gradle/SpotlessPlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/SpotlessPlugin.kt
@@ -22,7 +22,7 @@ class SpotlessPlugin : Plugin<Project> {
         ktfmt("0.49").googleStyle()
       }
 
-      // Only apply yaml and json formatting for root project
+      // Only apply YAML and JSON formatting for root project
       // to avoid some files are added into multiple project's spotless targets.
       if (project.rootProject == project) {
         // Add configurations for JSON files

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,10 +9,11 @@ import org.robolectric.gradle.AndroidSdk
 import org.robolectric.gradle.ShadowsPlugin.ShadowsPluginExtension
 
 // For use of external initialization scripts...
-val allSdks by project.extra(AndroidSdk.ALL_SDKS)
-val configAnnotationProcessing by project.extra(emptyList<Project>())
+project.extra["allSdks"] = AndroidSdk.ALL_SDKS
 
-val thisVersion: String by project
+project.extra["configAnnotationProcessing"] = emptyList<Project>()
+
+val thisVersion = project.property("thisVersion") as String
 
 plugins {
   // Define versions for plugins used in subprojects. 'apply false' is used to load the plugin
@@ -35,6 +36,8 @@ allprojects {
 }
 
 project.afterEvaluate {
+  @Suppress("UNCHECKED_CAST")
+  val configAnnotationProcessing = project.extra["configAnnotationProcessing"] as List<Project>
   val ideaProject = rootProject.extensions.getByType<IdeaModel>().project
   ideaProject.ipr.withXml {
     val compilerConfiguration =
@@ -131,20 +134,22 @@ gradle.projectsEvaluated {
     }
   }
 
-  val aggregateJsondocs by
-    tasks.registering(Copy::class) {
-      project.subprojects
-        .filter { it.pluginManager.hasPlugin(libs.plugins.robolectric.shadows.get().pluginId) }
-        .forEach { subproject ->
-          dependsOn(subproject.tasks.named("compileJava"))
-          from(subproject.layout.buildDirectory.dir("docs/json"))
-        }
+  tasks.register<Copy>("aggregateJsondocs") {
+    project.subprojects
+      .filter { it.pluginManager.hasPlugin(libs.plugins.robolectric.shadows.get().pluginId) }
+      .forEach { subproject ->
+        dependsOn(subproject.tasks.named("compileJava"))
+        from(subproject.layout.buildDirectory.dir("docs/json"))
+      }
 
-      into(layout.buildDirectory.dir("docs/json"))
-    }
+    into(layout.buildDirectory.dir("docs/json"))
+  }
 }
 
-val aggregateDocs by tasks.registering { dependsOn(":aggregateJavadocs", ":aggregateJsondocs") }
+val aggregateDocs =
+  tasks.register("aggregateDocs") { dependsOn(":aggregateJavadocs", ":aggregateJsondocs") }
+
+@Suppress("UNCHECKED_CAST") val allSdks = project.extra["allSdks"] as List<AndroidSdk>
 
 val prefetchSdkTasks =
   allSdks.map { androidSdk ->
@@ -236,8 +241,8 @@ abstract class PrefetchSdkTask : DefaultTask() {
   }
 }
 
-val prefetchDependencies by
-  tasks.registering {
+val prefetchDependencies =
+  tasks.register("prefetchDependencies") {
     doLast {
       allprojects.forEach { p ->
         p.configurations.forEach { config ->

--- a/integration_tests/androidx_test/build.gradle.kts
+++ b/integration_tests/androidx_test/build.gradle.kts
@@ -31,14 +31,14 @@ android {
     val sharedTestResourceDir = sharedTestDir + "resources"
     val sharedAndroidManifest = sharedTestDir + "AndroidManifest.xml"
 
-    val test by getting
-    test.resources.srcDirs(sharedTestResourceDir)
-    test.java.srcDirs(sharedTestSourceDir)
+    val test = getByName("test")
+    test.resources.directories.add(sharedTestResourceDir)
+    test.java.directories.add(sharedTestSourceDir)
     test.manifest.srcFile(sharedAndroidManifest)
 
-    val androidTest by getting
-    androidTest.resources.srcDirs(sharedTestResourceDir)
-    androidTest.java.srcDirs(sharedTestSourceDir)
+    val androidTest = getByName("androidTest")
+    androidTest.resources.directories.add(sharedTestResourceDir)
+    androidTest.java.directories.add(sharedTestSourceDir)
     androidTest.manifest.srcFile(sharedAndroidManifest)
   }
 }

--- a/integration_tests/ctesque/build.gradle.kts
+++ b/integration_tests/ctesque/build.gradle.kts
@@ -35,13 +35,13 @@ android {
     val sharedTestSourceDir = sharedTestDir + "java"
     val sharedTestResourceDir = sharedTestDir + "resources"
 
-    val test by getting
-    test.resources.srcDirs(sharedTestResourceDir)
-    test.java.srcDirs(sharedTestSourceDir)
+    val test = getByName("test")
+    test.resources.directories.add(sharedTestResourceDir)
+    test.java.directories.add(sharedTestSourceDir)
 
-    val androidTest by getting
-    androidTest.resources.srcDirs(sharedTestResourceDir)
-    androidTest.java.srcDirs(sharedTestSourceDir)
+    val androidTest = getByName("androidTest")
+    androidTest.resources.directories.add(sharedTestResourceDir)
+    androidTest.java.directories.add(sharedTestSourceDir)
   }
 }
 

--- a/preinstrumented/build.gradle.kts
+++ b/preinstrumented/build.gradle.kts
@@ -25,8 +25,8 @@ dependencies {
   testImplementation(libs.mockito.subclass)
 }
 
-val instrumentAll by
-  tasks.registering {
+val instrumentAll =
+  tasks.register("instrumentAll") {
     dependsOn(":prefetchSdks", "build")
 
     doLast {
@@ -51,9 +51,9 @@ val instrumentAll by
     }
   }
 
-val emptySourcesJar by tasks.registering(Jar::class) { archiveClassifier.set("sources") }
+val emptySourcesJar = tasks.register<Jar>("emptySourcesJar") { archiveClassifier.set("sources") }
 
-val emptyJavadocJar by tasks.registering(Jar::class) { archiveClassifier.set("javadoc") }
+val emptyJavadocJar = tasks.register<Jar>("emptyJavadocJar") { archiveClassifier.set("javadoc") }
 
 // Avoid publishing the preinstrumented jars by default. They are published
 // manually when the instrumentation configuration changes to maximize Gradle

--- a/shadows/httpclient/build.gradle.kts
+++ b/shadows/httpclient/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
   testImplementation(AndroidSdk.MAX_SDK.coordinates)
 }
 
-// httpcore needs to come before android-all on runtime classpath; the gradle IntelliJ plugin
+// httpcore needs to come before android-all on runtime classpath; the Gradle IntelliJ plugin
 //   needs the compileClasspath order patched too (bug?)
 val mainSourceSet = sourceSets.getByName("main")
 


### PR DESCRIPTION
We had a bunch of deprecation warnings in our Gradle files, mostly coming from the recent Gradle 9.6.0 update.
