### PR TITLE
Restore some dependency downgrades

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,7 +94,7 @@ mockito = "5.23.0"
 mockk = "1.14.11"
 
 # https://github.com/takahirom/roborazzi/releases
-roborazzi = "1.64.0"
+roborazzi = "1.65.0"
 
 # https://square.github.io/okhttp/changelogs/changelog/
 okhttp = "5.4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ error-prone = "2.50.0"
 error-prone-gradle = "5.1.0"
 
 # https://kotlinlang.org/docs/releases.html#release-details
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 
 # https://github.com/google/ksp/releases
 ksp = "2.3.10"


### PR DESCRIPTION
Some dependency updates were reverted in https://github.com/robolectric/robolectric/commit/8179e8f2d8e518c49661828941c31c2d2f2e6ed8
