### PR TITLE
fixed SIZEOF initial value in ResTable_package to avoid "RES_TABLE_PA…

### DIFF
--- a/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
+++ b/resources/src/main/java/org/robolectric/res/android/ResourceTypes.java
@@ -977,7 +977,7 @@ public class ResourceTypes {
    * ResTable_typeSpec structures containing the entry values for each resource type.
    */
   static class ResTable_package extends WithOffset {
-    public static final int SIZEOF = ResChunk_header.SIZEOF + 4 + 128 + 20;
+    public static final int SIZEOF = ResChunk_header.SIZEOF + 4 + 128 * SIZEOF_SHORT + 20;
 
     final ResChunk_header header;
 


### PR DESCRIPTION
fixed SIZEOF initial value in ResTable_package to avoid "RES_TABLE_PACKAGE_TYPE type ID offset too large." error in some cases
it is related to this issue: https://github.com/robolectric/robolectric/issues/11331


While i was trying to find the cause of issue https://github.com/robolectric/robolectric/issues/11331, I noticed that ResTable_package.SIZEOF does not match the actual binary layout defined by AOSP. The name field is a UTF-16 array (char[128]), which occupies 256 bytes, but the Java constant only accounts for 128 bytes. This causes the package header size to be inconsistent with the field offsets used elsewhere in the parser and may result in fields such as typeIdOffset being interpreted incorrectly for valid resource tables.