### PR TITLE
Fix aggregateDocs gradle task.

### DIFF
--- a/build-logic/convention/src/main/java/org/robolectric/gradle/AggregateJavadocPlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/AggregateJavadocPlugin.kt
@@ -40,7 +40,15 @@ class AggregateJavadocPlugin : Plugin<Project> {
   }
 
   private fun getJavadocTasks(project: Project): Set<Javadoc> {
-    return project.getAllTasks(true).values.flatten().filterIsInstance<Javadoc>().toSet()
+    return project
+      .getAllTasks(true)
+      .values
+      .flatten()
+      .filterIsInstance<Javadoc>()
+      .filter {
+        it.project.pluginManager.hasPlugin("org.robolectric.gradle.DeployedRoboJavaModulePlugin")
+      }
+      .toSet()
   }
 
   private companion object {


### PR DESCRIPTION
./gradlew aggregateDocs was failing with a IllegalResolutionException on :integration_tests:firebase.

Trying to build javadoc from a integration_tests subproject doesn't make sense.
This commit addresses the issue by filtering the aggregateDocs task so it only applies to projects with the DeployedRoboJavaModulePlugin plugin.


