### PR TITLE
Make `:preinstrumented:clean` compatible with Gradle's Configuration Cache

### DIFF
--- a/preinstrumented/build.gradle.kts
+++ b/preinstrumented/build.gradle.kts
@@ -149,10 +149,8 @@ fun sdksToInstrument(): List<AndroidSdk> {
   return AndroidSdk.ALL_SDKS
 }
 
-tasks.named("clean") {
-  doFirst {
-    AndroidSdk.ALL_SDKS.forEach { androidSdk ->
-      delete(layout.buildDirectory.file(androidSdk.preinstrumentedJarFileName))
-    }
+tasks.named<Delete>("clean") {
+  AndroidSdk.ALL_SDKS.forEach { androidSdk ->
+    delete(layout.buildDirectory.file(androidSdk.preinstrumentedJarFileName))
   }
 }


### PR DESCRIPTION
I've removed the `doFirst` wrapper to directly use the provided `delete` method.