### PR TITLE
Shadow ApplicationSharedMemory.create() to avoid FileDescriptor.setInt$

### DIFF
--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationSharedMemory.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowApplicationSharedMemory.java
@@ -4,9 +4,12 @@ import static android.os.Build.VERSION_CODES.BAKLAVA;
 import static org.robolectric.util.reflector.Reflector.reflector;
 
 import com.android.internal.os.ApplicationSharedMemory;
+import java.io.FileDescriptor;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.Resetter;
+import org.robolectric.util.ReflectionHelpers;
+import org.robolectric.util.ReflectionHelpers.ClassParameter;
 import org.robolectric.util.reflector.Accessor;
 import org.robolectric.util.reflector.ForType;
 
@@ -16,6 +19,22 @@ import org.robolectric.util.reflector.ForType;
  */
 @Implements(value = ApplicationSharedMemory.class, isInAndroidSdk = false, minSdk = BAKLAVA)
 public class ShadowApplicationSharedMemory {
+
+  /**
+   * The real {@code create()} calls {@code FileDescriptor.setInt$}, which Robolectric routes
+   * through {@code jdk.internal.access.SharedSecrets} and fails with {@link IllegalAccessException}
+   * on JDK 9+ without an add-opens. Since there is no real shared memory here ({@link #nativeMap}
+   * is stubbed), build the inert instance directly instead, mirroring the real result so {@code
+   * isMapped()} stays {@code true}.
+   */
+  @Implementation
+  protected static ApplicationSharedMemory create() {
+    return ReflectionHelpers.callConstructor(
+        ApplicationSharedMemory.class,
+        ClassParameter.from(FileDescriptor.class, new FileDescriptor()),
+        ClassParameter.from(boolean.class, /* isMutable= */ true),
+        ClassParameter.from(long.class, /* mappedAddress= */ nativeMap(0, true)));
+  }
 
   @Implementation
   protected static long nativeMap(int fd, boolean isMutable) {


### PR DESCRIPTION
The real `ApplicationSharedMemory.create()` (called for Baklava+ during setup) invokes `FileDescriptor.setInt$`, which Robolectric routes through `jdk.internal.access.SharedSecrets` and fails with `IllegalAccessException` on JDK 9+ without an add-opens — masked in Robolectric's own build but hitting downstream consumers. Shadow `create()` to build the inert instance directly, since there is no real shared memory here (`nativeMap` is already stubbed).