### PR TITLE
Fix `:processor:generateSdksFile` task not found

### DIFF
--- a/build-logic/convention/src/main/java/org/robolectric/gradle/ShadowsPlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/ShadowsPlugin.kt
@@ -28,6 +28,10 @@ import org.gradle.process.CommandLineArgumentProvider
 
 class ShadowsPlugin : Plugin<Project> {
   override fun apply(project: Project) {
+    if (project.path != ":processor") {
+      project.evaluationDependsOn(":processor")
+    }
+
     project.pluginManager.apply("idea")
 
     val shadows = project.extensions.create<ShadowsPluginExtension>("shadows")


### PR DESCRIPTION
The `ShadowsPlugin` now explicitly depends on the `:generateSdksFile` being available in the `:processor` module.
This change adds a check to ensure that the `:processor` module is evaluated before the current project.
