### PR TITLE
Remove Gemini Code Assist

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,5 +1,0 @@
-# See the following for configuration options and the default values
-# https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github#default-configuration
-code_review:
-  pull_request_opened:
-    summary: false


### PR DESCRIPTION
Gemini Code Assist has been sunset: https://github.com/robolectric/robolectric.github.io/pull/635#issuecomment-5043242481
