### PR TITLE
Fix the `:aggregateJavadocs` not found error

### DIFF
--- a/build-logic/convention/src/main/java/org/robolectric/gradle/AggregateJavadocPlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/AggregateJavadocPlugin.kt
@@ -20,21 +20,20 @@ class AggregateJavadocPlugin : Plugin<Project> {
       return
     }
 
-    rootProject.gradle.projectsEvaluated {
+    rootProject.tasks.register<Javadoc>(AGGREGATE_JAVADOCS_TASK_NAME) {
       val javadocTasks = getJavadocTasks(rootProject)
       if (javadocTasks.isNotEmpty()) {
-        rootProject.tasks.register<Javadoc>(AGGREGATE_JAVADOCS_TASK_NAME) {
-          description = "Aggregates Javadoc API documentation of all subprojects."
-          group = JavaBasePlugin.DOCUMENTATION_GROUP
+        description = "Aggregates Javadoc API documentation of all subprojects."
+        group = JavaBasePlugin.DOCUMENTATION_GROUP
 
-          dependsOn(javadocTasks)
-          source(javadocTasks.map { it.source })
+        dependsOn(javadocTasks)
+        source(javadocTasks.map { it.source })
 
-          val javadocDirectory = rootProject.layout.buildDirectory.dir("docs/javadoc").get().asFile
+        val javadocDirectory = rootProject.layout.buildDirectory.dir("docs/javadoc").get().asFile
 
-          destinationDir = javadocDirectory
-          classpath = rootProject.files(javadocTasks.map { it.classpath })
-        }
+        destinationDir = javadocDirectory
+        classpath = rootProject.files(javadocTasks.map { it.classpath })
+        isFailOnError = false
       }
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,10 +96,6 @@ project.afterEvaluate {
   }
 }
 
-rootProject.gradle.projectsEvaluated {
-  rootProject.tasks.named<Javadoc>("aggregateJavadocs").configure { isFailOnError = false }
-}
-
 gradle.projectsEvaluated {
   val headerHtml =
     """
@@ -133,17 +129,17 @@ gradle.projectsEvaluated {
       }
     }
   }
+}
 
-  tasks.register<Copy>("aggregateJsondocs") {
-    project.subprojects
-      .filter { it.pluginManager.hasPlugin(libs.plugins.robolectric.shadows.get().pluginId) }
-      .forEach { subproject ->
-        dependsOn(subproject.tasks.named("compileJava"))
-        from(subproject.layout.buildDirectory.dir("docs/json"))
-      }
+tasks.register<Copy>("aggregateJsondocs") {
+  project.subprojects
+    .filter { it.pluginManager.hasPlugin(libs.plugins.robolectric.shadows.get().pluginId) }
+    .forEach { subproject ->
+      dependsOn(subproject.tasks.named("compileJava"))
+      from(subproject.layout.buildDirectory.dir("docs/json"))
+    }
 
-    into(layout.buildDirectory.dir("docs/json"))
-  }
+  into(layout.buildDirectory.dir("docs/json"))
 }
 
 val aggregateDocs =


### PR DESCRIPTION
When Configuration Cache is enabled, the build fails because the `:aggregateJavadocs` task can not be found.

This PR fixes that by:
- Always registering the `:aggregateJavadocs` in `AggregateJavadocPlugin`.
- Removing the `rootProject.gradle.projectsEvaluated` wrapper in `AggregateJavadocPlugin`.
- Moving the `:aggregateJsondocs` definition out of the `gradle.projectsEvaluated` block.

I've tested these changes both on `master` and in https://github.com/robolectric/robolectric/pull/10817 using the following command: `./gradlew clean aggregateDocs --no-parallel`.

**Note:** I've also moved the `isFailOnError` option inside `AggregateJavadocPlugin`.
Since the plugin is only applied on the root project, we can get rid of a `rootProject.gradle.projectsEvaluated` block.
