### PR TITLE
Fix Javadoc for `VersionCalculator`

### DIFF
--- a/annotations/src/main/java/org/robolectric/versioning/VersionCalculator.java
+++ b/annotations/src/main/java/org/robolectric/versioning/VersionCalculator.java
@@ -15,8 +15,8 @@ import java.util.zip.ZipEntry;
 public class VersionCalculator {
 
   /**
-   * A temporary alias to {@link * android.os.Build.VERSION_CODES.CINNAMON_BUN}. This will be
-   * removed when Robolectric shadows compile against the CINNAMON_BUN SDK
+   * A temporary alias to {@link android.os.Build.VERSION_CODES.CINNAMON_BUN}. This will be removed
+   * when Robolectric shadows compile against the CINNAMON_BUN SDK
    */
   public static final int CINNAMON_BUN = 37;
 


### PR DESCRIPTION
The Javadoc was badly formatting, so it couldn't be displayed properly.
