### PR TITLE
Fix `NoSuchFileException` spam in unit tests logs

### DIFF
--- a/utils/src/main/java/org/robolectric/util/TempDirectory.java
+++ b/utils/src/main/java/org/robolectric/util/TempDirectory.java
@@ -137,6 +137,10 @@ public class TempDirectory {
   }
 
   public void destroy() {
+    if (!Files.isDirectory(basePath)) {
+      return;
+    }
+
     try {
       clearDirectory(basePath);
       Files.delete(basePath);
@@ -157,10 +161,10 @@ public class TempDirectory {
   private static void clearDirectory(final Path directory) throws IOException {
     Files.walkFileTree(
         directory,
-        new SimpleFileVisitor<Path>() {
+        new SimpleFileVisitor<>() {
           @Nonnull
           @Override
-          public FileVisitResult visitFile(Path file, @Nonnull BasicFileAttributes attrs)
+          public FileVisitResult visitFile(@Nonnull Path file, @Nonnull BasicFileAttributes attrs)
               throws IOException {
             // Avoid deleting the obsolete temp directory marker
             if (!(OsUtil.isWindows()


### PR DESCRIPTION
When running the unit tests, we often get spammed by stacktraces similar to:
```
java.nio.file.NoSuchFileException: /tmp/robolectric-temp_dir4809833000115193958
    at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
    at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
    at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
    at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
    at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:171)
    at java.base/sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99)
    at java.base/java.nio.file.Files.readAttributes(Files.java:1854)
    at java.base/java.nio.file.FileTreeWalker.getAttributes(FileTreeWalker.java:220)
    at java.base/java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:277)
    at java.base/java.nio.file.FileTreeWalker.walk(FileTreeWalker.java:323)
    at java.base/java.nio.file.Files.walkFileTree(Files.java:2792)
    at java.base/java.nio.file.Files.walkFileTree(Files.java:2870)
    at org.robolectric.util.TempDirectory.clearDirectory(TempDirectory.java:158)
    at org.robolectric.util.TempDirectory.destroy(TempDirectory.java:141)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    at java.base/java.lang.Thread.run(Thread.java:1583)
```

It seems that sometimes the temp directory does not exist, so `Files.walkFileTree` throws an exception.
This adds a safety check to ensure that we only call `Files.walkFileTree` when the temp directory exists.

To check this, you can look at the logs of the various `Tests / unit-tests (*)` checks, and make sure that you don't have any stacktrace similar to the one above.