### PR TITLE
Fail the build if Lint reports an error in `:integration_tests:ctesque`

### DIFF
--- a/integration_tests/ctesque/build.gradle.kts
+++ b/integration_tests/ctesque/build.gradle.kts
@@ -13,8 +13,6 @@ android {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 
-  lint { abortOnError = false }
-
   testOptions {
     targetSdk = 36
     unitTests {


### PR DESCRIPTION
Currently, this setting was disabled. But since there are no error, we can safely turn it on.

Part of #10957
