### PR TITLE
Downgrade Conscrypt to 2.5.2 to restore GLIBC 2.34 compatibility

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
   ],
   "ignoreDeps": [
     "com.google.android.gms:play-services-basement",
+    "org.conscrypt:conscrypt-openjdk-uber",
     "org.apache.httpcomponents:httpclient",
     "org.apache.httpcomponents:httpcore",
     "org.robolectric:nativeruntime-dist-compat",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,10 @@ android-tools-common = "32.2.1"
 androidstubs = "36"
 
 # https://github.com/google/conscrypt/tags
-conscrypt = "2.6.1"
+# Do not upgrade past 2.5.2: the native libraries shipped by 2.6.0 and later are built against
+# GLIBC 2.35, which makes them fail to load on distributions still on GLIBC 2.34 such as RHEL 9 and
+# Rocky Linux 9. See https://github.com/robolectric/robolectric/issues/11362.
+conscrypt = "2.5.2"
 
 # https://github.com/bcgit/bc-java/tags
 bouncycastle = "1.85"

--- a/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
+++ b/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java
@@ -111,8 +111,8 @@ public class AndroidTestEnvironment implements TestEnvironment {
 
   private static final String CONSCRYPT_PROVIDER = "Conscrypt";
   private static final BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
-  // Cache the Conscrypt provider to avoid creating it multiple times across tests. It is
-  // initialized lazily as some platforms may not support it.
+  // Cache the Conscrypt provider to avoid creating it multiple times across tests. Note Conscrypt
+  // is not supported in Mac Arm64, so it cannot be eagerly initialized.
   private static final AtomicReference<OpenSSLProvider> cachedConscryptProvider =
       new AtomicReference<>();
 

--- a/robolectric/src/main/java/org/robolectric/plugins/ConscryptModeConfigurer.java
+++ b/robolectric/src/main/java/org/robolectric/plugins/ConscryptModeConfigurer.java
@@ -1,12 +1,15 @@
 package org.robolectric.plugins;
 
+import static com.google.common.base.StandardSystemProperty.OS_ARCH;
 
 import com.google.auto.service.AutoService;
+import java.util.Locale;
 import java.util.Properties;
 import org.robolectric.annotation.ConscryptMode;
 import org.robolectric.annotation.ConscryptMode.Mode;
 import org.robolectric.pluginapi.config.Configurer;
 import org.robolectric.plugins.config.SingleValueConfigurer;
+import org.robolectric.util.OsUtil;
 
 /** Provides configuration to Robolectric for its @{@link ConscryptMode} annotation. */
 @AutoService(Configurer.class)
@@ -18,8 +21,16 @@ public class ConscryptModeConfigurer
     super(
         ConscryptMode.class,
         ConscryptMode.Mode.class,
-        Mode.ON,
+        defaultValue(systemProperties),
         propertyFileLoader,
         systemProperties);
+  }
+
+  private static ConscryptMode.Mode defaultValue(Properties properties) {
+    String arch = properties.getProperty(OS_ARCH.key(), "").toLowerCase(Locale.ROOT);
+    if (OsUtil.isMac() && arch.equals("aarch64")) {
+      return Mode.OFF;
+    }
+    return Mode.ON;
   }
 }


### PR DESCRIPTION
The native libraries shipped in conscrypt-openjdk-uber 2.6.0 and later are built against a newer toolchain and require GLIBC_2.35:

  $ objdump -T libconscrypt_openjdk_jni-linux-x86_64.so | grep -o 'GLIBC_[0-9.]*' | sort -uV | tail -1
  2.5.2 -> GLIBC_2.16
  2.6.0 -> GLIBC_2.35
  2.6.1 -> GLIBC_2.35

RHEL 9, Rocky Linux 9 and other distributions in that family ship GLIBC 2.34, so loading the JNI library fails there during Robolectric initialization:

  java.lang.UnsatisfiedLinkError: /tmp/...libconscrypt_openjdk_jni.so:
  /lib64/libc.so.6: version `GLIBC_2.35' not found
  (required by libconscrypt_openjdk_jni.so)

Pin Conscrypt back to 2.5.2 and add it to Renovate's ignoreDeps so the bump is not reapplied automatically. Once upstream Conscrypt publishes libraries built against an older GLIBC (google/conscrypt is moving its release build to Ubuntu 20.04), this pin can be lifted.

Reverting the version bump also reverts commit 4395a552e9 ("Enable Conscrypt for Mac arm64 by default"): 2.5.2 does not contain a libconscrypt_openjdk_jni osx-aarch_64 prebuilt, so ConscryptModeConfigurer has to default to ConscryptMode.Mode.OFF on Mac arm64 again.

The XDH KeyPairGenerator removal added in d3df22513a is kept as-is. 2.5.2 does not register that service, so Provider.remove("KeyPairGenerator.XDH") is simply a no-op there and XDH generation keeps falling back to the JDK provider.

For #11362

### Overview

### Proposed Changes
