### PR TITLE
Simplify shared test setup with Gradle's lazy API

### DIFF
--- a/integration_tests/androidx_test/build.gradle.kts
+++ b/integration_tests/androidx_test/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.api.dsl.AndroidLibrarySourceSet
+
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.robolectric.android.project)
@@ -26,20 +28,16 @@ android {
   }
 
   sourceSets {
-    val sharedTestDir = "src/sharedTest/"
-    val sharedTestSourceDir = sharedTestDir + "java"
-    val sharedTestResourceDir = sharedTestDir + "resources"
-    val sharedAndroidManifest = sharedTestDir + "AndroidManifest.xml"
+    val configurationAction: AndroidLibrarySourceSet.() -> Unit = {
+      val sharedTestDir = "src/sharedTest/"
 
-    val test = getByName("test")
-    test.resources.directories.add(sharedTestResourceDir)
-    test.java.directories.add(sharedTestSourceDir)
-    test.manifest.srcFile(sharedAndroidManifest)
+      resources.directories.add(sharedTestDir + "resources")
+      java.directories.add(sharedTestDir + "java")
+      manifest.srcFile(sharedTestDir + "AndroidManifest.xml")
+    }
 
-    val androidTest = getByName("androidTest")
-    androidTest.resources.directories.add(sharedTestResourceDir)
-    androidTest.java.directories.add(sharedTestSourceDir)
-    androidTest.manifest.srcFile(sharedAndroidManifest)
+    named("test", configurationAction)
+    named("androidTest", configurationAction)
   }
 }
 

--- a/integration_tests/ctesque/build.gradle.kts
+++ b/integration_tests/ctesque/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.api.dsl.AndroidLibrarySourceSet
+
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.robolectric.android.project)
@@ -29,17 +31,15 @@ android {
   androidResources { noCompress.add("txt") }
 
   sourceSets {
-    val sharedTestDir = "src/sharedTest/"
-    val sharedTestSourceDir = sharedTestDir + "java"
-    val sharedTestResourceDir = sharedTestDir + "resources"
+    val configurationAction: AndroidLibrarySourceSet.() -> Unit = {
+      val sharedTestDir = "src/sharedTest/"
 
-    val test = getByName("test")
-    test.resources.directories.add(sharedTestResourceDir)
-    test.java.directories.add(sharedTestSourceDir)
+      resources.directories.add(sharedTestDir + "resources")
+      java.directories.add(sharedTestDir + "java")
+    }
 
-    val androidTest = getByName("androidTest")
-    androidTest.resources.directories.add(sharedTestResourceDir)
-    androidTest.java.directories.add(sharedTestSourceDir)
+    named("test", configurationAction)
+    named("androidTest", configurationAction)
   }
 }
 


### PR DESCRIPTION
This PR simplifies the configuration of shared tests in the `:integration_tests` module for `:androidx_test` and `:ctesque`.

- Create a common `configurationAction` to apply to each test source set.
- Use Gradle's lazy APIs to access the test source sets.
