### PR TITLE
Enable strict plugins validation in `:build-logic:convention`

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -56,3 +56,8 @@ java {
 }
 
 kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_17 } }
+
+tasks.validatePlugins {
+  failOnWarning = true
+  enableStricterValidation = true
+}


### PR DESCRIPTION
This applies the same validation as for the `:simulator-gradle-plugin` plugin.
