### PR TITLE
Tell Renovate to update `google-java-format`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "google/google-java-format",
+      "managerFilePatterns": [
+        "^\\.github/workflows/check_code_style\\.yml$"
+      ],
+      "matchStrings": [
+        "googleJavaFormatVersion\u003d\"(?\u003ccurrentValue\u003e[^\\\"]+)\""
+      ]
+    }
+  ],
   "extends": [
     "config:recommended",
     ":disableDependencyDashboard",


### PR DESCRIPTION
This adds a custom manager to Renovate's configuration so it can update `google-java-format` in te `check_code_style.yml` workflow.

**Note:** I'd like to merge this before https://github.com/robolectric/robolectric/pull/11386, so I can check if it works or not.