### PR TITLE
Bound handler thread teardown waits

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowPausedLooperTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowPausedLooperTest.java
@@ -60,7 +60,8 @@ public class ShadowPausedLooperTest {
   @After
   public void quitHandlerThread() throws Exception {
     handlerThread.quit();
-    handlerThread.join();
+    handlerThread.join(SECONDS.toMillis(5));
+    assertThat(handlerThread.isAlive()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/20274776.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Bound the handler-thread join in ShadowPausedLooperTest and asserted that teardown completes.
