### PR TITLE
Keep HWUI frame timestamps monotonic across tests

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowNativeHardwareRendererFrameTimestampTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowNativeHardwareRendererFrameTimestampTest.java
@@ -1,0 +1,95 @@
+package org.robolectric.shadows;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.app.Activity;
+import android.graphics.Bitmap;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.PixelCopy;
+import android.view.View;
+import android.view.ViewGroup.LayoutParams;
+import android.view.Window;
+import android.widget.FrameLayout;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.GraphicsMode;
+import org.robolectric.annotation.GraphicsMode.Mode;
+
+/**
+ * Verifies that on SDK 37 (real draw traversals unconditionally enabled), PixelCopy captures draws
+ * performed after the initial traversal, in every test of a JVM process.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 37)
+@GraphicsMode(Mode.NATIVE)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ShadowNativeHardwareRendererFrameTimestampTest {
+
+  @Test
+  public void pixelCopy_afterContentChange_test1() throws Exception {
+    runContentChangeScenario();
+  }
+
+  @Test
+  public void pixelCopy_afterContentChange_test2() throws Exception {
+    runContentChangeScenario();
+  }
+
+  private static void runContentChangeScenario() throws Exception {
+    RedActivity activity = Robolectric.setupActivity(RedActivity.class);
+
+    // Sanity check: initial traversal should have produced a RED frame.
+    assertThat(captureWindowPixel(activity)).isEqualTo(Color.RED);
+
+    // Change content after the initial traversal, then let the scheduled traversal run.
+    activity.frameLayout.setBackgroundColor(Color.BLUE);
+    ShadowLooper.idleMainLooper();
+
+    assertThat(captureWindowPixel(activity)).isEqualTo(Color.BLUE);
+  }
+
+  private static int captureWindowPixel(Activity activity) throws Exception {
+    Window window = activity.getWindow();
+    View decorView = window.getDecorView();
+    Bitmap bitmap =
+        Bitmap.createBitmap(decorView.getWidth(), decorView.getHeight(), Bitmap.Config.ARGB_8888);
+    CountDownLatch latch = new CountDownLatch(1);
+    int[] result = new int[] {-1};
+    PixelCopy.request(
+        window,
+        bitmap,
+        copyResult -> {
+          result[0] = copyResult;
+          latch.countDown();
+        },
+        new Handler(Looper.getMainLooper()));
+    ShadowLooper.idleMainLooper();
+    latch.await(1, TimeUnit.SECONDS);
+    assertThat(result[0]).isEqualTo(PixelCopy.SUCCESS);
+    return bitmap.getPixel(100, 100);
+  }
+
+  static class RedActivity extends Activity {
+    FrameLayout frameLayout;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      frameLayout = new FrameLayout(this);
+      frameLayout.setLayoutParams(
+          new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+      frameLayout.setBackgroundColor(Color.RED);
+      setContentView(frameLayout);
+    }
+  }
+}

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeHardwareRenderer.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowNativeHardwareRenderer.java
@@ -45,6 +45,13 @@ import org.robolectric.util.reflector.ForType;
 public class ShadowNativeHardwareRenderer {
   @RealObject private HardwareRenderer realHardwareRenderer;
 
+  // HWUI's RenderThread outlives tests while Robolectric's simulated clock restarts per test.
+  // HWUI drops frames whose vsync is not newer than the last drawn one, which would leave stale
+  // window content from the second test on. These fields rebase the vsync passed to HWUI to keep
+  // it increasing; deliberately no @Resetter, matching the RenderThread's lifetime.
+  private static long vsyncRebaseOffsetNanos;
+  private static long lastRebasedVsyncNanos = Long.MIN_VALUE;
+
   @Implementation(maxSdk = UPSIDE_DOWN_CAKE)
   protected static void disableVsync() {
     HardwareRendererNatives.disableVsync();
@@ -221,6 +228,17 @@ public class ShadowNativeHardwareRenderer {
 
   @Implementation
   protected int syncAndDrawFrame(FrameInfo frameInfo) {
+    long[] timestamps = frameInfo.frameInfo;
+    long rawVsync = timestamps[FrameInfo.VSYNC];
+    if (rawVsync + vsyncRebaseOffsetNanos < lastRebasedVsyncNanos) {
+      // The simulated clock restarted because a new test began; adjust the offset so this frame
+      // continues one frame interval after the last frame.
+      vsyncRebaseOffsetNanos =
+          lastRebasedVsyncNanos + ShadowChoreographer.getFrameDelay().toNanos() - rawVsync;
+    }
+    long rebasedVsync = rawVsync + vsyncRebaseOffsetNanos;
+    lastRebasedVsyncNanos = rebasedVsync;
+    timestamps[FrameInfo.VSYNC] = rebasedVsync;
 
     // 'offset' represents the difference between the host's real monotonic clock
     // (System.nanoTime())
@@ -243,6 +261,9 @@ public class ShadowNativeHardwareRenderer {
     int result =
         reflector(HardwareRendererReflector.class, realHardwareRenderer)
             .syncAndDrawFrame(frameInfo);
+
+    // Restore the raw vsync for Java-side consumers such as FrameMetrics.
+    timestamps[FrameInfo.VSYNC] = rawVsync;
 
     if (offset != 0) {
       // After native completes:


### PR DESCRIPTION
On SDK 37, where real draw traversals are unconditionally enabled, PixelCopy returned stale frames in every test after the first one in a JVM process: only the initial traversal's frame ever reached the window surface, so screenshot tests captured the first frame's content.

The HWUI RenderThread and its TimeLord are created once per loaded native runtime and outlive individual tests, while Robolectric's simulated clock restarts for every test. TimeLord.latestVsync() never moves backwards, so after the first test it stays at the previous test's last vsync. The first frame of the next test still draws (its CanvasContext is new and has no swap history), but it records a swap at latestVsync. Every subsequent frame then hits the "already drawn for this vsync pulse" check in CanvasContext::prepareTree (|lastSwap.vsyncTime - latestVsync| < 2ms) and is dropped with SYNC_FRAME_DROPPED, leaving stale content in the surface.

Fix this by rebasing the FrameInfo timestamps passed to HardwareRenderer.syncAndDrawFrame whenever the vsync time moves backwards (i.e. a new test started), so the values seen by the native HWUI code remain monotonic for the lifetime of the render thread. The offset is zero until a clock reset is observed, so behavior within the first test is unchanged.

Fixes #11392