### PR TITLE
Use Spotless to format Java files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,10 +7,10 @@
       "depNameTemplate": "google/google-java-format",
       "extractVersionTemplate": "^v(?\u003cversion\u003e.*)$",
       "managerFilePatterns": [
-        "/^\\.github/workflows/check_code_style\\.yml$/"
+        "/^build-logic/convention/src/main/java/org/robolectric/gradle/SpotlessPlugin\\.kt$/"
       ],
       "matchStrings": [
-        "googleJavaFormatVersion\u003d\"(?\u003ccurrentValue\u003e.*)\""
+        "googleJavaFormat\\(\"(?\u003ccurrentValue\u003e.*)\"\\)"
       ]
     },
     {

--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -23,44 +23,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v7
 
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version-file: .github/.java-version
-      
+
       - name: Check Android Lint
-        run: |
-          ./gradlew lint --continue
+        run: ./gradlew lint --continue
 
-      - name: Download google-java-format
-        run: |
-          googleJavaFormatVersion="1.36.1"
-          curl -L -o $HOME/google-java-format.jar https://github.com/google/google-java-format/releases/download/v${googleJavaFormatVersion}/google-java-format-${googleJavaFormatVersion}-all-deps.jar
-          curl -L -o $HOME/google-java-format-diff.py https://raw.githubusercontent.com/google/google-java-format/v${googleJavaFormatVersion}/scripts/google-java-format-diff.py
-          chmod +x $HOME/google-java-format-diff.py
-
-      - name: Check Java formatting
-        run: |
-          base_branch="${{ github.event.pull_request.base.ref }}"
-          echo "Running google-java-format-diff against 'origin/$base_branch'"
-          git fetch origin "$base_branch" --depth 1
-          diff=$(git diff -U0 $(git merge-base HEAD origin/$base_branch) -- . \
-            ':(exclude)processor/src/test/resources/org/robolectric/Robolectric_*.java' \
-            ':(exclude)robolectric/src/test/java/org/robolectric/R.java' \
-            ':(exclude)robolectric/src/test/java/org/robolectric/Manifest.java' \
-            | $HOME/google-java-format-diff.py --google-java-format-jar=$HOME/google-java-format.jar -p1)
-          if [[ $diff ]]; then
-            echo "Please run google-java-format on the changes in this pull request"
-            git diff -U0 $(git merge-base HEAD origin/$base_branch) | $HOME/google-java-format-diff.py --google-java-format-jar=$HOME/google-java-format.jar -p1
-            exit 1
-          fi
-
-      - name: Check Kotlin formatting
+      - name: Check Java and Kotlin Formatting
         run: ./gradlew spotlessCheck
 
       - name: Check Kotlin Quality

--- a/build-logic/convention/src/main/java/org/robolectric/gradle/SpotlessPlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/SpotlessPlugin.kt
@@ -10,6 +10,17 @@ class SpotlessPlugin : Plugin<Project> {
     project.pluginManager.apply("com.diffplug.spotless")
 
     project.extensions.configure<SpotlessExtension> {
+      // Add configuration for Java files
+      java {
+        googleJavaFormat("1.36.1")
+        target("**/*.java")
+        targetExclude(
+          "processor/src/test/resources/org/robolectric/**/*.java",
+          "robolectric/src/test/java/org/robolectric/Manifest.java",
+          "robolectric/src/test/java/org/robolectric/R.java",
+        )
+      }
+
       // Add configurations for Kotlin files
       kotlin {
         target("**/*.kt")

--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowImsMmTelManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowImsMmTelManagerTest.java
@@ -645,4 +645,3 @@ public class ShadowImsMmTelManagerTest {
     assertThat(imsMmTelManager.isCrossSimCallingEnabled()).isTrue();
   }
 }
-


### PR DESCRIPTION
Instead of manually downloading `google-java-format` in the GitHub Action, we now use Spotless to validate Java code 
style.
The advantage is that we can now run the `spotlessCheck`/`spotlessApply` Gradle task for any Java or Kotlin change, not 
only Kotlin.
The main difference is that we now validate every Java source file (except for the defined exclusions), and not just the
 modified ones.

The dedicated `google-java-format` configuration for Renovate was update to work with this new setup.
