### PR TITLE
Run Android Lint last in `check_code_style.yml`

### DIFF
--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -32,11 +32,11 @@ jobs:
           distribution: 'temurin'
           java-version-file: .github/.java-version
 
-      - name: Check Android Lint
-        run: ./gradlew lint --continue
-
       - name: Check Java and Kotlin Formatting
         run: ./gradlew spotlessCheck
 
       - name: Check Kotlin Quality
         run: ./gradlew detekt
+
+      - name: Check Android Lint
+        run: ./gradlew lint --continue


### PR DESCRIPTION
The Android Lint step takes 4 or 5min to complete, while Spotless and Detekt need about 20seconds.
This moves Android Lint as the last step of the workflow, so formatting issues are reported faster.