### PR TITLE
Create `ClassNameValidator` to ensure that the provided class name is not available

### DIFF
--- a/annotations/src/main/java/org/robolectric/annotation/ClassName.java
+++ b/annotations/src/main/java/org/robolectric/annotation/ClassName.java
@@ -29,7 +29,7 @@ import org.jspecify.annotations.NonNull;
  * }
  * </pre>
  */
-@Target({ElementType.TYPE_USE, ElementType.PARAMETER})
+@Target({ElementType.TYPE_USE, ElementType.PARAMETER, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ClassName {
 

--- a/processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/RobolectricProcessor.java
@@ -20,6 +20,7 @@ import org.robolectric.annotation.processing.generator.Generator;
 import org.robolectric.annotation.processing.generator.JavadocJsonGenerator;
 import org.robolectric.annotation.processing.generator.ServiceLoaderGenerator;
 import org.robolectric.annotation.processing.generator.ShadowProviderGenerator;
+import org.robolectric.annotation.processing.validator.ClassNameValidator;
 import org.robolectric.annotation.processing.validator.FilterValidator;
 import org.robolectric.annotation.processing.validator.ImplementationValidator;
 import org.robolectric.annotation.processing.validator.ImplementsValidator;
@@ -101,6 +102,7 @@ public class RobolectricProcessor extends AbstractProcessor {
     SdkStore sdkStore =
         new SdkStore(sdksFile, validateCompiledSdk, overrideSdkLocation, overrideSdkInfo);
 
+    addValidator(new ClassNameValidator(modelBuilder, environment, sdkStore));
     addValidator(new ImplementationValidator(modelBuilder, environment));
     addValidator(new FilterValidator(modelBuilder, environment));
     addValidator(

--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/ClassNameValidator.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/ClassNameValidator.java
@@ -1,0 +1,69 @@
+package org.robolectric.annotation.processing.validator;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.robolectric.annotation.processing.Helpers;
+import org.robolectric.annotation.processing.RobolectricModel;
+
+public class ClassNameValidator extends Validator {
+  private final SdkStore.@NonNull Sdk sdk;
+
+  public ClassNameValidator(
+      RobolectricModel.@NonNull Builder modelBuilder,
+      @NonNull ProcessingEnvironment env,
+      @NonNull SdkStore sdkStore) {
+    super(modelBuilder, env, "org.robolectric.annotation.ClassName");
+    sdk = sdkStore.minSdk();
+  }
+
+  @Override
+  public Void visitExecutable(ExecutableElement e, Element p) {
+    TypeMirror expectedAnnotationType = annotationType.asType();
+    for (AnnotationMirror annotationMirror : e.getReturnType().getAnnotationMirrors()) {
+      if (types.isSameType(annotationMirror.getAnnotationType(), expectedAnnotationType)) {
+        checkClassName(annotationMirror);
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public Void visitVariable(VariableElement e, Element p) {
+    checkClassName(getCurrentAnnotation());
+    return null;
+  }
+
+  private void checkClassName(@Nullable AnnotationMirror annotation) {
+    String className = getClassNameFromAnnotation(annotation);
+    if (className == null) {
+      return;
+    }
+    TypeElement typeElement = elements.getTypeElement(className.replace('$', '.'));
+    if (isClassAvailable(typeElement)) {
+      error("Use " + className + " directly, instead of @ClassName(\"" + className + "\")");
+    }
+  }
+
+  private @Nullable String getClassNameFromAnnotation(@Nullable AnnotationMirror annotation) {
+    if (annotation == null) {
+      return null;
+    }
+    AnnotationValue classNameValue = Helpers.getAnnotationTypeMirrorValue(annotation, "value");
+    if (classNameValue == null) {
+      return null;
+    }
+    return Helpers.getAnnotationStringValue(classNameValue);
+  }
+
+  private boolean isClassAvailable(Element element) {
+    return element != null && sdk.getClassInfo(element.toString()) != null;
+  }
+}

--- a/processor/src/main/java/org/robolectric/annotation/processing/validator/SdkStore.java
+++ b/processor/src/main/java/org/robolectric/annotation/processing/validator/SdkStore.java
@@ -40,6 +40,7 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
+import org.jspecify.annotations.NonNull;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -134,6 +135,17 @@ public class SdkStore {
       }
     }
     return matchingSdks;
+  }
+
+  @NonNull Sdk minSdk() {
+    loadSdksOnce();
+    Sdk minSdk = null;
+    for (Sdk sdk : sdks) {
+      if (minSdk == null || sdk.sdkInfo.apiLevel < minSdk.sdkInfo.apiLevel) {
+        minSdk = sdk;
+      }
+    }
+    return Objects.requireNonNull(minSdk);
   }
 
   private synchronized void loadSdksOnce() {

--- a/processor/src/test/java/com/example/objects/DummyClassName.java
+++ b/processor/src/test/java/com/example/objects/DummyClassName.java
@@ -1,0 +1,9 @@
+package com.example.objects;
+
+public class DummyClassName {
+  public void methodWithParameter(Object param) {}
+
+  public Dummy methodWithReturnType() {
+    return null;
+  }
+}

--- a/processor/src/test/java/org/robolectric/annotation/processing/validator/ClassNameValidatorTest.java
+++ b/processor/src/test/java/org/robolectric/annotation/processing/validator/ClassNameValidatorTest.java
@@ -1,0 +1,54 @@
+package org.robolectric.annotation.processing.validator;
+
+import static com.google.common.truth.Truth.assertAbout;
+import static org.robolectric.annotation.processing.validator.SingleClassSubject.singleClass;
+
+import com.example.objects.Dummy;
+import java.util.HashMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.robolectric.annotation.processing.Utils;
+import org.robolectric.versioning.VersionCalculator.SdkInfo;
+
+/** Tests for {@link ClassNameValidator} */
+@RunWith(JUnit4.class)
+public class ClassNameValidatorTest {
+
+  private static final SdkInfo sdkInfo = new SdkInfo(10000, false);
+  private static final HashMap<String, String> props = new HashMap<>();
+
+  static {
+    props.put("org.robolectric.annotation.processing.sdkCheckMode", "ERROR");
+    props.put("org.robolectric.annotation.processing.validateCompileSdk", "true");
+  }
+
+  @Test
+  public void classNameWithExistingParam_shouldNotCompile() {
+    final String testClass =
+        "org.robolectric.annotation.processing.shadows.ShadowClassNameParameterExisting";
+    assertAbout(singleClass(props, Utils.getClassRootDir(Dummy.class), sdkInfo))
+        .that(testClass)
+        .failsToCompile()
+        .withErrorContaining("Use com.example.objects.Dummy directly");
+  }
+
+  @Test
+  public void classNameWithNonExistingParam_shouldCompile() {
+    final String testClass =
+        "org.robolectric.annotation.processing.shadows.ShadowClassNameParameterNonExisting";
+    assertAbout(singleClass(props, Utils.getClassRootDir(Dummy.class), sdkInfo))
+        .that(testClass)
+        .compilesWithoutError();
+  }
+
+  @Test
+  public void classNameWithExistingReturnType_shouldNotCompile() {
+    final String testClass =
+        "org.robolectric.annotation.processing.shadows.ShadowClassNameReturnTypeExisting";
+    assertAbout(singleClass(props, Utils.getClassRootDir(Dummy.class), sdkInfo))
+        .that(testClass)
+        .failsToCompile()
+        .withErrorContaining("Use com.example.objects.Dummy directly");
+  }
+}

--- a/processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowClassNameParameterExisting.java
+++ b/processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowClassNameParameterExisting.java
@@ -1,0 +1,12 @@
+package org.robolectric.annotation.processing.shadows;
+
+import com.example.objects.DummyClassName;
+import org.robolectric.annotation.ClassName;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(value = DummyClassName.class)
+public class ShadowClassNameParameterExisting {
+  @Implementation
+  public void methodWithParameter(@ClassName("com.example.objects.Dummy") Object param) {}
+}

--- a/processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowClassNameParameterNonExisting.java
+++ b/processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowClassNameParameterNonExisting.java
@@ -1,0 +1,11 @@
+package org.robolectric.annotation.processing.shadows;
+
+import com.example.objects.DummyClassName;
+import org.robolectric.annotation.ClassName;
+import org.robolectric.annotation.Implements;
+
+@Implements(value = DummyClassName.class)
+public class ShadowClassNameParameterNonExisting {
+  public void methodWithParameter(
+      @ClassName("com.example.objects.NonExistingDummy") Object param) {}
+}

--- a/processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowClassNameReturnTypeExisting.java
+++ b/processor/src/test/resources/org/robolectric/annotation/processing/shadows/ShadowClassNameReturnTypeExisting.java
@@ -1,0 +1,14 @@
+package org.robolectric.annotation.processing.shadows;
+
+import com.example.objects.DummyClassName;
+import org.robolectric.annotation.ClassName;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(value = DummyClassName.class)
+public class ShadowClassNameReturnTypeExisting {
+  @Implementation
+  public @ClassName("com.example.objects.Dummy") Object methodWithReturnType() {
+    return null;
+  }
+}


### PR DESCRIPTION
The new validator looks for the provided class name into the SDK of the lowest supported Android version, and report any 
usage that can be inlined.

**Note:** this already triggers some errors. I'll address them in a dedicated PR:
- https://github.com/robolectric/robolectric/pull/11417

**Note 2:** this is an alternative to https://github.com/robolectric/robolectric/pull/10449.