### PR TITLE
Add torch strength and torch availability support to `ShadowCameraManager`

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraManagerTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowCameraManagerTest.java
@@ -43,6 +43,9 @@ public class ShadowCameraManagerTest {
 
   private static final boolean ENABLE = true;
 
+  private static final int MAXIMUM_STRENGTH_LEVEL = 5;
+  private static final int DEFAULT_STRENGTH_LEVEL = 2;
+
   private final CameraManager cameraManager =
       (CameraManager)
           ApplicationProvider.getApplicationContext().getSystemService(Context.CAMERA_SERVICE);
@@ -452,6 +455,294 @@ public class ShadowCameraManagerTest {
     }
 
     verify(mockCallback, never()).onTorchModeChanged(CAMERA_ID_0, torchEnabled);
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.P)
+  public void registerTorchCallbackWithExecutor() throws CameraAccessException {
+    CameraManager.TorchCallback mockCallback = mock(CameraManager.TorchCallback.class);
+    Executor executor = Runnable::run;
+
+    cameraManager.registerTorchCallback(executor, mockCallback);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    cameraManager.setTorchMode(CAMERA_ID_0, ENABLE);
+
+    verify(mockCallback).onTorchModeChanged(CAMERA_ID_0, ENABLE);
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.P)
+  public void unregisterTorchCallbackRegisteredWithExecutor() throws CameraAccessException {
+    CameraManager.TorchCallback mockCallback = mock(CameraManager.TorchCallback.class);
+    Executor executor = Runnable::run;
+
+    cameraManager.registerTorchCallback(executor, mockCallback);
+    cameraManager.unregisterTorchCallback(mockCallback);
+
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+    cameraManager.setTorchMode(CAMERA_ID_0, ENABLE);
+
+    verify(mockCallback, never()).onTorchModeChanged(CAMERA_ID_0, ENABLE);
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.TIRAMISU)
+  public void getTorchStrengthLevelReturnsDefaultLevel() throws CameraAccessException {
+    shadowOf(characteristics)
+        .set(CameraCharacteristics.FLASH_INFO_STRENGTH_MAXIMUM_LEVEL, MAXIMUM_STRENGTH_LEVEL);
+    shadowOf(characteristics)
+        .set(CameraCharacteristics.FLASH_INFO_STRENGTH_DEFAULT_LEVEL, DEFAULT_STRENGTH_LEVEL);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    assertThat(cameraManager.getTorchStrengthLevel(CAMERA_ID_0)).isEqualTo(DEFAULT_STRENGTH_LEVEL);
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.TIRAMISU)
+  public void getTorchStrengthLevelWithoutDefaultLevelCharacteristic()
+      throws CameraAccessException {
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    assertThat(cameraManager.getTorchStrengthLevel(CAMERA_ID_0)).isEqualTo(1);
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.TIRAMISU)
+  public void turnOnTorchWithStrengthLevelTurnsTorchOn() throws CameraAccessException {
+    shadowOf(characteristics)
+        .set(CameraCharacteristics.FLASH_INFO_STRENGTH_MAXIMUM_LEVEL, MAXIMUM_STRENGTH_LEVEL);
+    shadowOf(characteristics)
+        .set(CameraCharacteristics.FLASH_INFO_STRENGTH_DEFAULT_LEVEL, DEFAULT_STRENGTH_LEVEL);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    cameraManager.turnOnTorchWithStrengthLevel(CAMERA_ID_0, 3);
+
+    assertThat(shadowOf(cameraManager).getTorchMode(CAMERA_ID_0)).isTrue();
+    assertThat(cameraManager.getTorchStrengthLevel(CAMERA_ID_0)).isEqualTo(3);
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.TIRAMISU)
+  public void turnOnTorchWithStrengthLevelNotifiesTorchModeChanged() throws CameraAccessException {
+    CameraManager.TorchCallback mockCallback = mock(CameraManager.TorchCallback.class);
+    shadowOf(characteristics)
+        .set(CameraCharacteristics.FLASH_INFO_STRENGTH_MAXIMUM_LEVEL, MAXIMUM_STRENGTH_LEVEL);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    cameraManager.registerTorchCallback(mockCallback, /* handler= */ null);
+    cameraManager.turnOnTorchWithStrengthLevel(CAMERA_ID_0, 3);
+
+    verify(mockCallback).onTorchModeChanged(CAMERA_ID_0, true);
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.TIRAMISU)
+  public void turnOnTorchWithStrengthLevelWhileTorchOnNotifiesTorchStrengthLevelChanged()
+      throws CameraAccessException {
+    CameraManager.TorchCallback mockCallback = mock(CameraManager.TorchCallback.class);
+    shadowOf(characteristics)
+        .set(CameraCharacteristics.FLASH_INFO_STRENGTH_MAXIMUM_LEVEL, MAXIMUM_STRENGTH_LEVEL);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    cameraManager.registerTorchCallback(mockCallback, /* handler= */ null);
+    cameraManager.turnOnTorchWithStrengthLevel(CAMERA_ID_0, 3);
+    cameraManager.turnOnTorchWithStrengthLevel(CAMERA_ID_0, 4);
+
+    verify(mockCallback).onTorchStrengthLevelChanged(CAMERA_ID_0, 4);
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.TIRAMISU)
+  public void setTorchModeResetsTorchStrengthLevelToDefault() throws CameraAccessException {
+    shadowOf(characteristics)
+        .set(CameraCharacteristics.FLASH_INFO_STRENGTH_MAXIMUM_LEVEL, MAXIMUM_STRENGTH_LEVEL);
+    shadowOf(characteristics)
+        .set(CameraCharacteristics.FLASH_INFO_STRENGTH_DEFAULT_LEVEL, DEFAULT_STRENGTH_LEVEL);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    cameraManager.turnOnTorchWithStrengthLevel(CAMERA_ID_0, MAXIMUM_STRENGTH_LEVEL);
+    cameraManager.setTorchMode(CAMERA_ID_0, false);
+
+    assertThat(cameraManager.getTorchStrengthLevel(CAMERA_ID_0)).isEqualTo(DEFAULT_STRENGTH_LEVEL);
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.TIRAMISU)
+  public void turnOnTorchWithStrengthLevelStrengthOutOfRange() throws CameraAccessException {
+    shadowOf(characteristics)
+        .set(CameraCharacteristics.FLASH_INFO_STRENGTH_MAXIMUM_LEVEL, MAXIMUM_STRENGTH_LEVEL);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    try {
+      cameraManager.turnOnTorchWithStrengthLevel(CAMERA_ID_0, 0);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+
+    try {
+      cameraManager.turnOnTorchWithStrengthLevel(CAMERA_ID_0, MAXIMUM_STRENGTH_LEVEL + 1);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.TIRAMISU)
+  public void turnOnTorchWithStrengthLevelInvalidCameraId() throws CameraAccessException {
+    try {
+      cameraManager.turnOnTorchWithStrengthLevel(CAMERA_ID_0, 1);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.P)
+  public void registerTorchCallbackWithNullExecutor() {
+    CameraManager.TorchCallback mockCallback = mock(CameraManager.TorchCallback.class);
+
+    try {
+      cameraManager.registerTorchCallback((Executor) null, mockCallback);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.TIRAMISU)
+  public void turnOnTorchWithStrengthLevelWithoutFlashUnit() throws CameraAccessException {
+    shadowOf(characteristics).set(CameraCharacteristics.FLASH_INFO_AVAILABLE, false);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    try {
+      cameraManager.turnOnTorchWithStrengthLevel(CAMERA_ID_0, 1);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.TIRAMISU)
+  public void getTorchStrengthLevelWithoutFlashUnit() throws CameraAccessException {
+    shadowOf(characteristics).set(CameraCharacteristics.FLASH_INFO_AVAILABLE, false);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    try {
+      cameraManager.getTorchStrengthLevel(CAMERA_ID_0);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.TIRAMISU)
+  public void removeCameraResetsTorchStrengthLevel() throws CameraAccessException {
+    shadowOf(characteristics)
+        .set(CameraCharacteristics.FLASH_INFO_STRENGTH_MAXIMUM_LEVEL, MAXIMUM_STRENGTH_LEVEL);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+    cameraManager.turnOnTorchWithStrengthLevel(CAMERA_ID_0, MAXIMUM_STRENGTH_LEVEL);
+
+    shadowOf(cameraManager).removeCamera(CAMERA_ID_0);
+    shadowOf(cameraManager)
+        .addCamera(CAMERA_ID_0, ShadowCameraCharacteristics.newCameraCharacteristics());
+
+    assertThat(cameraManager.getTorchStrengthLevel(CAMERA_ID_0)).isEqualTo(1);
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.TIRAMISU)
+  public void removeCameraResetsTorchMode() throws CameraAccessException {
+    CameraManager.TorchCallback mockCallback = mock(CameraManager.TorchCallback.class);
+    shadowOf(characteristics)
+        .set(CameraCharacteristics.FLASH_INFO_STRENGTH_MAXIMUM_LEVEL, MAXIMUM_STRENGTH_LEVEL);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+    cameraManager.turnOnTorchWithStrengthLevel(CAMERA_ID_0, 3);
+
+    shadowOf(cameraManager).removeCamera(CAMERA_ID_0);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    // The torch is no longer considered on, so turning it on again reports a mode change rather
+    // than a strength level change.
+    cameraManager.registerTorchCallback(mockCallback, /* handler= */ null);
+    cameraManager.turnOnTorchWithStrengthLevel(CAMERA_ID_0, 2);
+
+    verify(mockCallback).onTorchModeChanged(CAMERA_ID_0, true);
+    verify(mockCallback, never()).onTorchStrengthLevelChanged(CAMERA_ID_0, 2);
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.M)
+  public void setTorchModeWhileCameraInUse() throws CameraAccessException {
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+    cameraManager.openCamera(CAMERA_ID_0, mock(CameraDevice.StateCallback.class), new Handler());
+    shadowOf(Looper.myLooper()).idle();
+
+    try {
+      cameraManager.setTorchMode(CAMERA_ID_0, ENABLE);
+      fail();
+    } catch (CameraAccessException e) {
+      assertThat(e.getReason()).isEqualTo(CameraAccessException.CAMERA_IN_USE);
+    }
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.M)
+  public void closeCameraDeviceNotifiesTorchModeChangedOff() throws CameraAccessException {
+    CameraManager.TorchCallback mockCallback = mock(CameraManager.TorchCallback.class);
+
+    cameraManager.registerTorchCallback(mockCallback, /* handler= */ null);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    CameraDevice.StateCallback stateCallback = mock(CameraDevice.StateCallback.class);
+    cameraManager.openCamera(CAMERA_ID_0, stateCallback, new Handler());
+    shadowOf(Looper.myLooper()).idle();
+    ArgumentCaptor<CameraDevice> deviceCaptor = ArgumentCaptor.forClass(CameraDevice.class);
+    verify(stateCallback).onOpened(deviceCaptor.capture());
+
+    deviceCaptor.getValue().close();
+    shadowOf(Looper.myLooper()).idle();
+
+    verify(mockCallback).onTorchModeChanged(CAMERA_ID_0, false);
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.M)
+  public void setTorchModeAfterCameraDeviceClosed() throws CameraAccessException {
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    CameraDevice.StateCallback stateCallback = mock(CameraDevice.StateCallback.class);
+    cameraManager.openCamera(CAMERA_ID_0, stateCallback, new Handler());
+    shadowOf(Looper.myLooper()).idle();
+    ArgumentCaptor<CameraDevice> deviceCaptor = ArgumentCaptor.forClass(CameraDevice.class);
+    verify(stateCallback).onOpened(deviceCaptor.capture());
+
+    deviceCaptor.getValue().close();
+    shadowOf(Looper.myLooper()).idle();
+
+    cameraManager.setTorchMode(CAMERA_ID_0, ENABLE);
+
+    assertThat(shadowOf(cameraManager).getTorchMode(CAMERA_ID_0)).isTrue();
+  }
+
+  @Test
+  @Config(minSdk = VERSION_CODES.M)
+  public void openCameraNotifiesTorchModeUnavailable() throws CameraAccessException {
+    CameraManager.TorchCallback mockCallback = mock(CameraManager.TorchCallback.class);
+
+    cameraManager.registerTorchCallback(mockCallback, /* handler= */ null);
+    shadowOf(cameraManager).addCamera(CAMERA_ID_0, characteristics);
+
+    cameraManager.openCamera(CAMERA_ID_0, mock(CameraDevice.StateCallback.class), new Handler());
+    shadowOf(Looper.myLooper()).idle();
+
+    verify(mockCallback).onTorchModeUnavailable(CAMERA_ID_0);
   }
 
   @Test

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCameraDeviceImpl.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCameraDeviceImpl.java
@@ -124,6 +124,8 @@ public class ShadowCameraDeviceImpl {
   @Implementation
   protected void close() {
     if (!closed) {
+      String cameraId = ReflectionHelpers.getField(realObject, "mCameraId");
+      ShadowCameraManager.notifyCameraDeviceClosed(cameraId);
       Runnable callOnClosed = ReflectionHelpers.getField(realObject, "mCallOnClosed");
       if (VERSION.SDK_INT >= VERSION_CODES.P) {
         Executor deviceExecutor = ReflectionHelpers.getField(realObject, "mDeviceExecutor");

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCameraManager.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowCameraManager.java
@@ -53,6 +53,9 @@ public class ShadowCameraManager {
   private static final Map<String, CameraCharacteristics> cameraIdToCharacteristics =
       new LinkedHashMap<>();
   private static final Map<String, Boolean> cameraTorches = new HashMap<>();
+  private static final Map<String, Integer> cameraTorchStrengths = new HashMap<>();
+  // Cameras with an open camera device, whose torches are unavailable while in use
+  private static final Set<String> camerasInUse = new HashSet<>();
   private static final Set<CameraManager.AvailabilityCallback> registeredCallbacks =
       new HashSet<>();
   // Cannot reference the torch callback in < Android M
@@ -76,6 +79,8 @@ public class ShadowCameraManager {
     createdCameras.clear();
     cameraIdToCharacteristics.clear();
     cameraTorches.clear();
+    cameraTorchStrengths.clear();
+    camerasInUse.clear();
     registeredCallbacks.clear();
     torchCallbacks.clear();
     if (lastDevice != null) {
@@ -110,13 +115,90 @@ public class ShadowCameraManager {
   }
 
   @Implementation(minSdk = VERSION_CODES.M)
-  protected void setTorchMode(@Nonnull String cameraId, boolean enabled) {
+  protected void setTorchMode(@Nonnull String cameraId, boolean enabled)
+      throws CameraAccessException {
     Objects.requireNonNull(cameraId);
     Preconditions.checkArgument(cameraIdToCharacteristics.keySet().contains(cameraId));
+    checkTorchAvailable(cameraId);
     cameraTorches.put(cameraId, enabled);
+    // Setting the torch mode resets the torch strength to its default level.
+    cameraTorchStrengths.remove(cameraId);
     for (Object callback : torchCallbacks) {
       ((CameraManager.TorchCallback) callback).onTorchModeChanged(cameraId, enabled);
     }
+  }
+
+  @Implementation(minSdk = VERSION_CODES.TIRAMISU)
+  protected void turnOnTorchWithStrengthLevel(@Nonnull String cameraId, int torchStrength)
+      throws CameraAccessException {
+    Objects.requireNonNull(cameraId);
+    Preconditions.checkArgument(cameraIdToCharacteristics.containsKey(cameraId));
+    checkFlashUnitAvailable(cameraId);
+    checkTorchAvailable(cameraId);
+    Preconditions.checkArgument(
+        torchStrength >= 1 && torchStrength <= getMaximumTorchStrengthLevel(cameraId));
+
+    boolean torchAlreadyOn = cameraTorches.getOrDefault(cameraId, false);
+    int previousStrength = getTorchStrengthLevelInternal(cameraId);
+    cameraTorches.put(cameraId, true);
+    cameraTorchStrengths.put(cameraId, torchStrength);
+
+    if (!torchAlreadyOn) {
+      for (Object callback : torchCallbacks) {
+        ((CameraManager.TorchCallback) callback).onTorchModeChanged(cameraId, true);
+      }
+    } else if (torchStrength != previousStrength) {
+      for (Object callback : torchCallbacks) {
+        ((CameraManager.TorchCallback) callback)
+            .onTorchStrengthLevelChanged(cameraId, torchStrength);
+      }
+    }
+  }
+
+  @Implementation(minSdk = VERSION_CODES.TIRAMISU)
+  protected int getTorchStrengthLevel(@Nonnull String cameraId) {
+    Objects.requireNonNull(cameraId);
+    Preconditions.checkArgument(cameraIdToCharacteristics.containsKey(cameraId));
+    checkFlashUnitAvailable(cameraId);
+    return getTorchStrengthLevelInternal(cameraId);
+  }
+
+  /**
+   * Throws if the camera's characteristics explicitly report that it has no flash unit. A missing
+   * {@link CameraCharacteristics#FLASH_INFO_AVAILABLE} key is tolerated so that cameras added with
+   * empty characteristics keep working with the torch APIs.
+   */
+  private static void checkFlashUnitAvailable(String cameraId) {
+    Boolean flashAvailable =
+        cameraIdToCharacteristics.get(cameraId).get(CameraCharacteristics.FLASH_INFO_AVAILABLE);
+    Preconditions.checkArgument(!Boolean.FALSE.equals(flashAvailable));
+  }
+
+  /** Throws if the camera's torch is unavailable because an open camera device is using it. */
+  private static void checkTorchAvailable(String cameraId) throws CameraAccessException {
+    if (camerasInUse.contains(cameraId)) {
+      throw new CameraAccessException(CameraAccessException.CAMERA_IN_USE);
+    }
+  }
+
+  private static int getTorchStrengthLevelInternal(String cameraId) {
+    Integer strength = cameraTorchStrengths.get(cameraId);
+    if (strength != null) {
+      return strength;
+    }
+    Integer defaultLevel =
+        cameraIdToCharacteristics
+            .get(cameraId)
+            .get(CameraCharacteristics.FLASH_INFO_STRENGTH_DEFAULT_LEVEL);
+    return defaultLevel == null ? 1 : defaultLevel;
+  }
+
+  private static int getMaximumTorchStrengthLevel(String cameraId) {
+    Integer maximumLevel =
+        cameraIdToCharacteristics
+            .get(cameraId)
+            .get(CameraCharacteristics.FLASH_INFO_STRENGTH_MAXIMUM_LEVEL);
+    return maximumLevel == null ? 1 : maximumLevel;
   }
 
   @Implementation(minSdk = UPSIDE_DOWN_CAKE, maxSdk = UPSIDE_DOWN_CAKE)
@@ -174,6 +256,7 @@ public class ShadowCameraManager {
       int unusedClientUid,
       int unusedOomScoreOffset) {
     CameraCharacteristics characteristics = getCameraCharacteristics(cameraId);
+    markCameraInUse(cameraId);
     Context context = RuntimeEnvironment.getApplication();
     CameraDeviceImpl deviceImpl =
         createCameraDeviceImpl(cameraId, callback, executor, characteristics, context);
@@ -188,6 +271,7 @@ public class ShadowCameraManager {
       String cameraId, CameraDevice.StateCallback callback, Executor executor, final int uid)
       throws CameraAccessException {
     CameraCharacteristics characteristics = getCameraCharacteristics(cameraId);
+    markCameraInUse(cameraId);
     Context context = reflector(ReflectorCameraManager.class, realObject).getContext();
 
     CameraDeviceImpl deviceImpl =
@@ -210,6 +294,7 @@ public class ShadowCameraManager {
       String cameraId, CameraDevice.StateCallback callback, Handler handler, final int uid)
       throws CameraAccessException {
     CameraCharacteristics characteristics = getCameraCharacteristics(cameraId);
+    markCameraInUse(cameraId);
     Context context = reflector(ReflectorCameraManager.class, realObject).getContext();
 
     CameraDeviceImpl deviceImpl;
@@ -254,6 +339,7 @@ public class ShadowCameraManager {
       String cameraId, CameraDevice.StateCallback callback, Handler handler)
       throws CameraAccessException {
     CameraCharacteristics characteristics = getCameraCharacteristics(cameraId);
+    markCameraInUse(cameraId);
 
     CameraDeviceImpl deviceImpl =
         ReflectionHelpers.callConstructor(
@@ -291,6 +377,15 @@ public class ShadowCameraManager {
 
   @Implementation(minSdk = VERSION_CODES.M)
   protected void registerTorchCallback(CameraManager.TorchCallback callback, Handler handler) {
+    Objects.requireNonNull(callback);
+    torchCallbacks.add(callback);
+  }
+
+  @Implementation(minSdk = VERSION_CODES.P)
+  protected void registerTorchCallback(Executor executor, CameraManager.TorchCallback callback) {
+    // Note: like the Handler-based overloads in this shadow, the executor is not used for
+    // dispatching; callbacks are invoked synchronously on the calling thread.
+    Preconditions.checkArgument(executor != null);
     Objects.requireNonNull(callback);
     torchCallbacks.add(callback);
   }
@@ -346,6 +441,35 @@ public class ShadowCameraManager {
   }
 
   /**
+   * Marks the camera's torch as unavailable while a camera device is open and calls all registered
+   * torch callbacks's onTorchModeUnavailable method.
+   */
+  private static void markCameraInUse(@Nonnull String cameraId) {
+    Objects.requireNonNull(cameraId);
+    camerasInUse.add(cameraId);
+    for (Object callback : torchCallbacks) {
+      ((CameraManager.TorchCallback) callback).onTorchModeUnavailable(cameraId);
+    }
+  }
+
+  /**
+   * Marks the camera's torch as available again after its camera device has been closed. The torch
+   * comes back turned off, and registered torch callbacks are notified with onTorchModeChanged.
+   * This is a no-op if the camera was not marked in use.
+   */
+  static void notifyCameraDeviceClosed(@Nonnull String cameraId) {
+    Objects.requireNonNull(cameraId);
+    if (!camerasInUse.remove(cameraId) || !cameraIdToCharacteristics.containsKey(cameraId)) {
+      return;
+    }
+    cameraTorches.put(cameraId, false);
+    cameraTorchStrengths.remove(cameraId);
+    for (Object callback : torchCallbacks) {
+      ((CameraManager.TorchCallback) callback).onTorchModeChanged(cameraId, false);
+    }
+  }
+
+  /**
    * Calls all registered callbacks's onCameraAvailable method. This is a no-op if no callbacks are
    * registered.
    */
@@ -393,6 +517,9 @@ public class ShadowCameraManager {
     Preconditions.checkArgument(cameraIdToCharacteristics.containsKey(cameraId));
 
     cameraIdToCharacteristics.remove(cameraId);
+    cameraTorches.remove(cameraId);
+    cameraTorchStrengths.remove(cameraId);
+    camerasInUse.remove(cameraId);
     triggerOnCameraUnavailable(cameraId);
   }
 


### PR DESCRIPTION
### Overview

`ShadowCameraManager` supports only a subset of the camera2 torch APIs: the
`Handler`-based `registerTorchCallback` overload and a simple on/off torch
state. This PR extends the torch support so tests can exercise the
`Executor`-based callback registration (API 28+), the torch strength APIs
(API 33+), and the torch availability transitions that occur when a camera
device is opened and closed.

### Proposed Changes

- Shadow the `registerTorchCallback(Executor, TorchCallback)` overload
  (API 28+) so callbacks registered with an executor receive torch events,
  matching the existing `Handler`-based overload. A null executor is
  rejected with `IllegalArgumentException`. As with the existing overloads,
  callbacks are dispatched synchronously on the calling thread.
- Implement `turnOnTorchWithStrengthLevel` and `getTorchStrengthLevel`
  (API 33+):
  - The strength level is validated against
    `FLASH_INFO_STRENGTH_MAXIMUM_LEVEL` and defaults to
    `FLASH_INFO_STRENGTH_DEFAULT_LEVEL` (both fall back to 1 when the key
    is absent, keeping cameras added with empty characteristics working).
  - `onTorchModeChanged` is dispatched when the torch turns on, and
    `onTorchStrengthLevelChanged` when the strength changes while the torch
    is already on. Calling `setTorchMode` resets the strength to its
    default level.
  - Cameras whose characteristics explicitly report
    `FLASH_INFO_AVAILABLE == false` are rejected with
    `IllegalArgumentException`.
- Model torch availability while a camera device is in use:
  - Opening a camera marks its torch unavailable and dispatches
    `TorchCallback#onTorchModeUnavailable`.
  - `setTorchMode` and `turnOnTorchWithStrengthLevel` throw
    `CameraAccessException(CAMERA_IN_USE)` while the camera is in use.
  - Closing the camera device makes the torch available again, turned off,
    and dispatches `onTorchModeChanged(cameraId, false)`.
- Clear per-camera torch state (mode, strength, in-use) in `removeCamera`
  so re-adding the same camera id starts from a clean state.