### PR TITLE
Add `gradle/actions/setup-gradle` to `check_code_style`

### DIFF
--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -32,6 +32,9 @@ jobs:
           distribution: 'temurin'
           java-version-file: .github/.java-version
 
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
       - name: Check Java and Kotlin Formatting
         run: ./gradlew spotlessCheck
 


### PR DESCRIPTION
This PR adds the `gradle/actions/setup-gradle` step to the `check_code_style` workflow.
This allows Gradle cache to be stored and reused between workflow runs.
