### PR TITLE
Run graphics tests on macOS 26 Intel

### DIFF
--- a/.github/workflows/graphics_tests.yml
+++ b/.github/workflows/graphics_tests.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         device: [
-          macos-15-intel, # Tests Mac x86_64
+          macos-26-intel, # Tests Mac x86_64
           macos-latest, # Tests Mac arm64
           ubuntu-latest, # Tests Linux x86_64
           windows-latest, # Tests Windows x86_64


### PR DESCRIPTION
Run the graphics tests on macOS 26 Intel (instead of macOS 15 Intel).

Here are the tools on macOS 15: https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
Here are the tools on macOS 26: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
