### PR TITLE
Use a single Renovate group for all AGP packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,11 +47,15 @@
     },
     {
       "groupName": "Android Gradle Plugin",
+      "matchDepNames": [
+        "com.android.application",
+        "com.android.legacy-kapt",
+        "com.android.library"
+      ],
       "matchManagers": "gradle",
       "matchPackageNames": [
-        "com.android.library",
         "com.android.tools:common",
-        "com.android.tools.build:gradle*"
+        "com.android.tools.build:gradle-api"
       ]
     },
     {


### PR DESCRIPTION
This PR fixes the duplicated Renovate PRs related to AGP (for example https://github.com/robolectric/robolectric/pull/11360 and https://github.com/robolectric/robolectric/pull/11361).
This properly use `matchDepNames` for dependencies, instead of `matchPackageNames`, which is for packages.

If this works, the two mentioned PRs should be merged into one by Renovate.