### PR TITLE
Rename the root project so it doesn't collide with the `:robolectric` subproject

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
   }
 }
 
-rootProject.name = "robolectric"
+rootProject.name = "robolectric-root"
 
 include(
   ":annotations",


### PR DESCRIPTION
Gradle generates a type-safe project accessor for a build's root project as well as for each of its subprojects, naming each after the project. The root project and the `:robolectric` subproject therefore both generate `getRobolectric()` in `RootProjectAccessor`, which then fails to compile:

  RootProjectAccessor.java: method getRobolectric() is already defined
  in class org.gradle.accessors.dm.RootProjectAccessor

This does not surface when building Robolectric on its own, because it does not enable the `TYPESAFE_PROJECT_ACCESSORS` feature preview. It does surface for any build that includes Robolectric with `includeBuild` and enables that feature, which makes Robolectric unusable as a composite build. Overriding the build name with `includeBuild(dir) { name = ... }` does not help, as accessor generation uses the included build's own `rootProject.name`.