### PR TITLE
Share the native runtime's extracted data assets between loads

### DIFF
--- a/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/NativeRuntimeAssetsTest.java
+++ b/integration_tests/nativegraphics/src/test/java/org/robolectric/shadows/NativeRuntimeAssetsTest.java
@@ -1,0 +1,59 @@
+package org.robolectric.shadows;
+
+import static android.os.Build.VERSION_CODES.O;
+import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
+import static android.os.Build.VERSION_CODES.VANILLA_ICE_CREAM;
+import static com.google.common.truth.Truth.assertThat;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/**
+ * Loading the native runtime copies its data assets - the fonts, the hyphen data and the ICU data -
+ * out of the archives that supply them, and those assets are shared between loads. They do not all
+ * come from the same archive: the fonts come from the nativeruntime dist archive whatever the SDK
+ * under test, while from {@link VANILLA_ICE_CREAM} the ICU data and the hyphen data come from that
+ * SDK's android-all archive, and the ICU data file is named after its ICU version. Sharing all of
+ * them through one directory therefore left every load after the first pointing icu.data.path at a
+ * file that had never been copied, which fails the library load with U_ILLEGAL_ARGUMENT_ERROR.
+ *
+ * <p>Running at several SDK levels is what catches this: each gets its own sandbox, and so its own
+ * load, within the one JVM.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class NativeRuntimeAssetsTest {
+
+  @Test
+  @Config(sdk = {O, UPSIDE_DOWN_CAKE, VANILLA_ICE_CREAM, Config.NEWEST_SDK})
+  public void nativeRuntime_drawsText_atEverySdkLevel() {
+    Bitmap bitmap = Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888);
+    Canvas canvas = new Canvas(bitmap);
+    canvas.drawColor(Color.WHITE);
+
+    Paint paint = new Paint();
+    paint.setColor(Color.BLACK);
+    paint.setTextSize(30);
+    canvas.drawText("R", 10, 35, paint);
+
+    // Text rendering needs the fonts and the ICU data, so it only produces ink if both were made
+    // available at the paths the runtime was pointed at.
+    assertThat(hasNonWhitePixel(bitmap)).isTrue();
+  }
+
+  private static boolean hasNonWhitePixel(Bitmap bitmap) {
+    for (int x = 0; x < bitmap.getWidth(); x++) {
+      for (int y = 0; y < bitmap.getHeight(); y++) {
+        if (bitmap.getPixel(x, y) != Color.WHITE) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/nativeruntime/src/main/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoader.java
+++ b/nativeruntime/src/main/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoader.java
@@ -6,6 +6,7 @@ import static android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
 import static android.os.Build.VERSION_CODES.VANILLA_ICE_CREAM;
 import static com.google.common.base.StandardSystemProperty.OS_ARCH;
 import static com.google.common.base.StandardSystemProperty.OS_NAME;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 import android.database.CursorWindow;
 import android.graphics.Typeface;
@@ -18,13 +19,19 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.RandomAccessFile;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
@@ -63,8 +70,21 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
   private static final AtomicReference<NativeRuntimeLoader> nativeRuntimeLoader =
       new AtomicReference<>();
 
+  /**
+   * Set to {@code false} to extract the native runtime's data assets into a fresh temporary
+   * directory on every load, which is the behavior from before these assets were cached.
+   */
+  private static final String CACHE_ASSETS_PROPERTY = "robolectric.nativeruntime.cacheAssets";
+
+  private static final String ASSET_CACHE_DIR_NAME = "robolectric-nativeruntime-assets";
+
+  /** Written once a cache directory is fully populated, so partial extractions are never used. */
+  private static final String ASSET_CACHE_MARKER = ".complete";
+
   protected static final String METHOD_BINDING_FORMAT = "$$robo$$${method}$nativeBinding";
   private static final String HYPHEN_DATA_DIR = "hyphen-data";
+  private static final String FONTS_DIR = "fonts";
+  private static final String ICU_DIR = "icu";
 
   // These system properties are used to configure JNI registration for RNG (libandroid_runtime)
   // when it is being loaded. They are also used by Paparazzi, which loads a different version of
@@ -167,6 +187,12 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
 
   private TempDirectory extractDirectory;
 
+  /**
+   * Where the hyphen data was made available. This is a shared directory when it is shared, and
+   * {@link #extractDirectory}'s base path otherwise.
+   */
+  private Path hyphenDataDirectory;
+
   public static void injectAndLoad() {
     // Ensure a single instance.
     synchronized (nativeRuntimeLoader) {
@@ -220,13 +246,15 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
               "loadNativeRuntime",
               () -> {
                 extractDirectory = new TempDirectory("nativeruntime");
+                hyphenDataDirectory = extractDirectory.getBasePath();
+
                 if (VERSION.SDK_INT >= O) {
                   // Only copy fonts if graphics is supported, not just SQLite.
-                  maybeCopyFonts(extractDirectory);
-                  maybeCopyHyphenData(extractDirectory);
+                  maybeCopyFonts();
+                  maybeCopyHyphenData();
                 }
                 Map<String, String> originalProperties = new HashMap<>();
-                maybeCopyIcuData(extractDirectory);
+                maybeCopyIcuData();
                 maybeCopyExtraResources(extractDirectory);
                 if (isAndroidVOrGreater()) {
                   originalProperties = saveSystemProperties();
@@ -243,11 +271,7 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
                   restoreSystemProperties(originalProperties);
                 }
                 String hyphenDataDir =
-                    extractDirectory
-                        .getBasePath()
-                        .resolve(HYPHEN_DATA_DIR)
-                        .toFile()
-                        .getAbsolutePath();
+                    hyphenDataDirectory.resolve(HYPHEN_DATA_DIR).toFile().getAbsolutePath();
                 if (isAndroidVOrGreater()) {
                   invokeDeferredStaticInitializers();
                   setNativeSystemProperty("ro.hyphen.data.dir", hyphenDataDir);
@@ -264,87 +288,156 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
     }
   }
 
-  private static List<String> getResourcesInAndroidAll(String prefix) throws IOException {
+  /**
+   * A resource carried only by the android-all archive of the SDK under test, which from
+   * VANILLA_ICE_CREAM supplies the ICU data and the hyphen data.
+   */
+  private static URL androidAllResource() {
+    return Resources.getResource("build.prop");
+  }
+
+  private static File androidAllArchive() throws IOException {
     try {
       String jarPath =
-          Iterables.get(
-                  Splitter.on('!').split(Resources.getResource("build.prop").toURI().toString()), 0)
+          Iterables.get(Splitter.on('!').split(androidAllResource().toURI().toString()), 0)
               .substring("jar:file:".length());
-      List<String> resources = new ArrayList<>();
-      try (JarFile jarFile = new JarFile(jarPath)) {
-        Enumeration<JarEntry> entries = jarFile.entries();
-        while (entries.hasMoreElements()) {
-          JarEntry entry = entries.nextElement();
-          if (entry.getName().startsWith(prefix) && !entry.isDirectory()) {
-            resources.add(entry.getName());
-          }
-        }
-      }
-      return resources;
+      return new File(jarPath);
     } catch (URISyntaxException syntaxException) {
       throw new IOException(syntaxException);
     }
   }
 
-  /** Attempts to load the ICU dat file. This is only relevant for native graphics. */
-  private void maybeCopyIcuData(TempDirectory tempDirectory) throws IOException {
-    URL icuDatUrl;
-    try {
-      if (Build.VERSION.SDK_INT <= UPSIDE_DOWN_CAKE) {
-        icuDatUrl = Resources.getResource("icu/icudt68l.dat");
-      } else {
-        List<String> resources = getResourcesInAndroidAll("icu/icudt");
-        if (resources.size() != 1) {
-          throw new RuntimeException("More than one icudt file in android-all jar: " + resources);
-        } else {
-          icuDatUrl = Resources.getResource(resources.get(0));
-        }
+  /** The single ICU dat entry of the given android-all archive. */
+  private static JarEntry icuDatEntry(JarFile jarFile) {
+    List<JarEntry> found = new ArrayList<>();
+    Enumeration<JarEntry> entries = jarFile.entries();
+    while (entries.hasMoreElements()) {
+      JarEntry entry = entries.nextElement();
+      if (entry.getName().startsWith(ICU_DIR + "/icudt") && !entry.isDirectory()) {
+        found.add(entry);
       }
+    }
+    if (found.size() != 1) {
+      throw new RuntimeException("More than one icudt file in android-all jar: " + found);
+    }
+    return found.get(0);
+  }
+
+  /** Attempts to load the ICU dat file. This is only relevant for native graphics. */
+  private void maybeCopyIcuData() throws IOException {
+    Path baseDir =
+        assetDirectory(ICU_DIR, icuDataSource(), DefaultNativeRuntimeLoader::copyIcuData);
+    System.setProperty("icu.data.path", icuDatPath(baseDir).toAbsolutePath().toString());
+    System.setProperty("icu.locale.default", Locale.getDefault().toLanguageTag());
+  }
+
+  /**
+   * A resource of the archive that supplies the ICU data, which keys the copy of it.
+   *
+   * <p>Up to UPSIDE_DOWN_CAKE that is the dat file itself, whose name is fixed. From
+   * VANILLA_ICE_CREAM the dat file comes from the android-all archive under a name that varies with
+   * its ICU version, and the only way to learn that name is to enumerate the archive, so {@code
+   * build.prop} stands in for it. That keeps the enumeration off the path of a load which finds the
+   * data already copied, and {@link #copyIcuData} reads the dat file out of this same archive, so
+   * the copy always comes from the archive its directory is keyed by.
+   */
+  private static URL icuDataSource() {
+    try {
+      return Build.VERSION.SDK_INT <= UPSIDE_DOWN_CAKE
+          ? Resources.getResource(ICU_DIR + "/icudt68l.dat")
+          : androidAllResource();
     } catch (IllegalArgumentException e) {
       System.out.println("Could not load icu data file ");
       throw new RuntimeException(e);
     }
-    Path icuPath = tempDirectory.create("icu");
-    Path icuDatPath;
-    if (VERSION.SDK_INT <= UPSIDE_DOWN_CAKE) {
-      icuDatPath = icuPath.resolve("icudt68l.dat");
-    } else {
-      List<String> parts = Splitter.on('/').splitToList(icuDatUrl.toString());
-      icuDatPath = icuPath.resolve(Iterables.getLast(parts));
+  }
+
+  /** The ICU dat file under the given directory, which holds exactly the one. */
+  private static Path icuDatPath(Path baseDir) throws IOException {
+    try (Stream<Path> files = java.nio.file.Files.list(baseDir.resolve(ICU_DIR))) {
+      return Iterables.getOnlyElement(ImmutableList.copyOf(files.iterator()));
     }
-    Resources.asByteSource(icuDatUrl).copyTo(Files.asByteSink(icuDatPath.toFile()));
-    System.setProperty("icu.data.path", icuDatPath.toAbsolutePath().toString());
-    System.setProperty("icu.locale.default", Locale.getDefault().toLanguageTag());
+  }
+
+  private static void copyIcuData(Path baseDir) throws IOException {
+    Path icuPath = baseDir.resolve(ICU_DIR);
+    java.nio.file.Files.createDirectories(icuPath);
+    if (Build.VERSION.SDK_INT <= UPSIDE_DOWN_CAKE) {
+      URL icuDatUrl = Resources.getResource(ICU_DIR + "/icudt68l.dat");
+      Resources.asByteSource(icuDatUrl)
+          .copyTo(Files.asByteSink(icuPath.resolve("icudt68l.dat").toFile()));
+      return;
+    }
+    // Read the dat file straight out of the archive that keyed this directory rather than
+    // resolving it by name through the classpath. The instrumented and uninstrumented android-all
+    // archives both carry one, so which of them the classpath answers with depends on the load,
+    // and the copy has to come from the archive the key names.
+    try (JarFile jarFile = new JarFile(androidAllArchive())) {
+      JarEntry icuDatEntry = icuDatEntry(jarFile);
+      String fileName = Iterables.getLast(Splitter.on('/').splitToList(icuDatEntry.getName()));
+      // An archive entry can name anything, including a path that climbs out of the directory it
+      // is being written under, so resolve it and check it stayed put before writing.
+      Path icuDatPath = icuPath.resolve(fileName).normalize();
+      if (!icuDatPath.startsWith(icuPath)) {
+        throw new IOException("Unexpected ICU data entry name: " + icuDatEntry.getName());
+      }
+      try (InputStream input = jarFile.getInputStream(icuDatEntry)) {
+        java.nio.file.Files.copy(input, icuDatPath, REPLACE_EXISTING);
+      }
+    }
   }
 
   /**
    * Attempts to copy the system fonts to a temporary directory. This is only relevant for native
    * graphics.
    */
-  private void maybeCopyFonts(TempDirectory tempDirectory) throws IOException {
-    Path fontsOutputPath = copyResourceDirectory("fonts", tempDirectory);
-    if (fontsOutputPath == null) {
+  private void maybeCopyFonts() throws IOException {
+    URL fontsResource;
+    URI fontsUri;
+    try {
+      fontsResource = Resources.getResource(FONTS_DIR + "/");
+      fontsUri = fontsResource.toURI();
+    } catch (IllegalArgumentException | URISyntaxException e) {
       return;
     }
+
+    Path baseDir =
+        assetDirectory(
+            FONTS_DIR,
+            fontsResource,
+            directory -> copyResourceDirectory(FONTS_DIR, fontsUri, directory));
+
     System.setProperty(
         "robolectric.nativeruntime.fontdir",
         // Android's FontListParser expects a trailing slash for the base font directory.
-        fontsOutputPath.toAbsolutePath() + File.separator);
+        baseDir.resolve(FONTS_DIR).toAbsolutePath() + File.separator);
   }
 
   /**
    * Attempts to copy the hyphen data to a temporary directory. This is only relevant for native
    * graphics.
    */
-  private void maybeCopyHyphenData(TempDirectory tempDirectory) throws IOException {
-    if (copyResourceDirectory(HYPHEN_DATA_DIR, tempDirectory) == null) {
-      Logger.info("Could not load hyphen data files: resource directory not found");
+  private void maybeCopyHyphenData() throws IOException {
+    URL hyphenDataResource;
+    URI hyphenDataUri;
+    try {
+      hyphenDataResource = Resources.getResource(HYPHEN_DATA_DIR + "/");
+      hyphenDataUri = hyphenDataResource.toURI();
+    } catch (IllegalArgumentException | URISyntaxException e) {
+      Logger.info("Could not load hyphen data files: " + e.getMessage());
+      return;
     }
+
+    hyphenDataDirectory =
+        assetDirectory(
+            HYPHEN_DATA_DIR,
+            hyphenDataResource,
+            directory -> copyResourceDirectory(HYPHEN_DATA_DIR, hyphenDataUri, directory));
   }
 
   /**
    * Copies every file of the classpath resource directory {@code directoryName} into a directory of
-   * the same name under {@code tempDirectory}.
+   * the same name under {@code baseDir}.
    *
    * <p>When the resources are packaged in a jar, the directory is walked through a zip {@link
    * FileSystem}. Such a filesystem may already be open for that jar in this JVM: another
@@ -353,17 +446,9 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
    * FileSystemAlreadyExistsException}. In that case the existing filesystem is reused and left to
    * its owner. A filesystem opened here is always closed, even when the copy fails, so that it
    * never leaks into the next sandbox.
-   *
-   * @return the output directory, or {@code null} when the resource directory does not exist
    */
-  private static Path copyResourceDirectory(String directoryName, TempDirectory tempDirectory)
+  private static void copyResourceDirectory(String directoryName, URI directoryUri, Path baseDir)
       throws IOException {
-    URI directoryUri;
-    try {
-      directoryUri = Resources.getResource(directoryName + "/").toURI();
-    } catch (IllegalArgumentException | URISyntaxException e) {
-      return null;
-    }
 
     FileSystem ownedZipfs = null;
     if ("jar".equals(directoryUri.getScheme())) {
@@ -375,7 +460,7 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
     }
 
     try {
-      Path outputPath = tempDirectory.create(directoryName);
+      java.nio.file.Files.createDirectories(baseDir.resolve(directoryName));
       try (Stream<Path> pathStream = java.nio.file.Files.walk(Paths.get(directoryUri))) {
         Iterator<Path> fileIterator = pathStream.iterator();
         while (fileIterator.hasNext()) {
@@ -386,16 +471,126 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
           }
           String resourcePath = directoryName + "/" + path.getFileName();
           URL resource = Resources.getResource(resourcePath);
-          Path resourceOutputPath = tempDirectory.getBasePath().resolve(resourcePath);
-          Resources.asByteSource(resource).copyTo(Files.asByteSink(resourceOutputPath.toFile()));
+          Path outputPath = baseDir.resolve(resourcePath);
+          Resources.asByteSource(resource).copyTo(Files.asByteSink(outputPath.toFile()));
         }
       }
-      return outputPath;
     } finally {
       if (ownedZipfs != null) {
         ownedZipfs.close();
       }
     }
+  }
+
+  /** Copies a group of the native runtime's data assets into the given directory. */
+  private interface AssetCopier {
+    void copyTo(Path directory) throws IOException;
+  }
+
+  /**
+   * Makes the named group of data assets available and returns the directory holding it. The group
+   * is shared with other loads where possible, and copied into this instance's own temporary
+   * directory otherwise.
+   */
+  private Path assetDirectory(String group, URL source, AssetCopier copier) throws IOException {
+    Path shared = sharedAssetDirectory(group, source, copier);
+    if (shared != null) {
+      return shared;
+    }
+    Path own = extractDirectory.getBasePath();
+    copier.copyTo(own);
+    return own;
+  }
+
+  /**
+   * Returns a directory shared with other loads that holds the named group of data assets, copying
+   * them into it if they are not there yet, or {@code null} if the group has to be copied per
+   * instance instead.
+   *
+   * <p>Each group is keyed by the source that supplies it rather than by a single archive for all
+   * of them, because they do not all come from the same place: the fonts, and the ICU data up to
+   * UPSIDE_DOWN_CAKE, come from the nativeruntime dist archive, which is the same whatever the SDK
+   * under test, while from VANILLA_ICE_CREAM the ICU data and the hyphen data come from that SDK's
+   * android-all archive. Keying every group on one archive would hand a directory populated for one
+   * SDK to a load running at another, which then points icu.data.path at an ICU dat file that was
+   * never copied, since that file is named after its ICU version. Keying the groups separately also
+   * keeps the fonts, by far the largest group, to a single copy across every SDK.
+   *
+   * <p>A lock file is held across the copy so that concurrent test JVMs (a build tool will
+   * typically run several) cooperate rather than each writing the same files, and the marker file
+   * is only written once the copy has finished, so a partially populated directory is never used.
+   */
+  private Path sharedAssetDirectory(String group, URL source, AssetCopier copier) {
+    if (!Boolean.parseBoolean(System.getProperty(CACHE_ASSETS_PROPERTY, "true"))) {
+      return null;
+    }
+    Path directory;
+    try {
+      String identity = archiveIdentity(source);
+      if (identity == null) {
+        Logger.info(
+            "Not sharing native runtime %s: %s is not supplied by an archive", group, source);
+        return null;
+      }
+      String key =
+          Hashing.sha256().hashString(identity, StandardCharsets.UTF_8).toString().substring(0, 32);
+      directory =
+          Paths.get(System.getProperty("java.io.tmpdir"), ASSET_CACHE_DIR_NAME, group + "-" + key);
+    } catch (RuntimeException e) {
+      Logger.info("Unable to determine native runtime asset cache directory: " + e.getMessage());
+      return null;
+    }
+    Path marker = directory.resolve(ASSET_CACHE_MARKER);
+    if (java.nio.file.Files.exists(marker)) {
+      return directory;
+    }
+    Path lockFile = directory.resolveSibling(directory.getFileName() + ".lock");
+    try {
+      java.nio.file.Files.createDirectories(directory.getParent());
+      try (RandomAccessFile lockHandle = new RandomAccessFile(lockFile.toFile(), "rw");
+          FileChannel channel = lockHandle.getChannel();
+          FileLock lock = channel.lock()) {
+        // Another process may have finished while this one waited for the lock.
+        if (java.nio.file.Files.exists(marker)) {
+          return directory;
+        }
+        java.nio.file.Files.createDirectories(directory);
+        copier.copyTo(directory);
+        java.nio.file.Files.createFile(marker);
+        Logger.info("Copied native runtime %s to %s", group, directory);
+        return directory;
+      }
+    } catch (IOException | RuntimeException e) {
+      // Fall back to copying into this instance's temporary directory.
+      Logger.info("Unable to share native runtime " + group + ": " + e.getMessage());
+      return null;
+    }
+  }
+
+  /**
+   * Identifies the archive that supplies the given resource by its location plus its size and
+   * modification time, so that a rebuilt archive is not mistaken for a cached one. Returns {@code
+   * null} if no archive supplies it.
+   *
+   * <p>These assets only ever arrive in a jar: the fonts and the ICU data up to UPSIDE_DOWN_CAKE
+   * from the published nativeruntime dist archive, which ships prebuilt rather than being built
+   * from source, and from VANILLA_ICE_CREAM the ICU and hyphen data from an android-all archive. A
+   * resource sitting on the classpath unpacked could be edited in place without its location ever
+   * changing, and nothing as cheap identifies it, so rather than key a shared directory on
+   * something that stale it is not shared at all.
+   */
+  private static String archiveIdentity(URL resource) {
+    if ("jar".equals(resource.getProtocol())) {
+      String jarPath = Iterables.get(Splitter.on('!').split(resource.toString()), 0);
+      String filePrefix = "jar:file:";
+      if (jarPath.startsWith(filePrefix)) {
+        File jarFile = new File(jarPath.substring(filePrefix.length()));
+        if (jarFile.isFile()) {
+          return jarFile.getAbsolutePath() + ":" + jarFile.length() + ":" + jarFile.lastModified();
+        }
+      }
+    }
+    return null;
   }
 
   private void loadLibrary(TempDirectory tempDirectory) throws IOException {
@@ -468,6 +663,12 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
   @VisibleForTesting
   Path getDirectory() {
     return extractDirectory == null ? null : extractDirectory.getBasePath();
+  }
+
+  /** The directory the hyphen data was made available in. */
+  @VisibleForTesting
+  Path getHyphenDataDirectory() {
+    return hyphenDataDirectory;
   }
 
   @VisibleForTesting

--- a/nativeruntime/src/test/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoaderTest.java
+++ b/nativeruntime/src/test/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoaderTest.java
@@ -7,6 +7,7 @@ import static com.google.common.truth.TruthJUnit.assume;
 import android.database.CursorWindow;
 import android.database.sqlite.SQLiteDatabase;
 import com.google.common.collect.ImmutableMap;
+import java.io.File;
 import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemAlreadyExistsException;
@@ -17,15 +18,19 @@ import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+import org.robolectric.junit.rules.SetSystemPropertyRule;
 
 @RunWith(RobolectricTestRunner.class)
 public final class DefaultNativeRuntimeLoaderTest {
   ExecutorService executor = Executors.newSingleThreadExecutor();
+
+  @Rule public SetSystemPropertyRule setSystemPropertyRule = new SetSystemPropertyRule();
 
   @Before
   public void setUp() {
@@ -46,11 +51,19 @@ public final class DefaultNativeRuntimeLoaderTest {
     assume().that(hasResource("icu/icudt68l.dat")).isTrue();
     DefaultNativeRuntimeLoader defaultNativeRuntimeLoader = new DefaultNativeRuntimeLoader();
     defaultNativeRuntimeLoader.ensureLoaded();
-    // Check that extraction of some key files worked.
-    Path root = defaultNativeRuntimeLoader.getDirectory();
-    assertThat(root.resolve("icu/icudt68l.dat").toFile().exists()).isTrue();
+    // Check that extraction of some key files worked. Each group is checked through the property
+    // that the runtime reads it through, because a group being copied somewhere the property does
+    // not point at is exactly the failure worth catching.
+    assertThat(new File(System.getProperty("icu.data.path")).exists()).isTrue();
     if (RuntimeEnvironment.getApiLevel() >= O) {
-      assertThat(root.resolve("fonts/fonts.xml").toFile().exists()).isTrue();
+      assertThat(fontsXml().exists()).isTrue();
+      assertThat(
+              defaultNativeRuntimeLoader
+                  .getHyphenDataDirectory()
+                  .resolve("hyphen-data")
+                  .toFile()
+                  .isDirectory())
+          .isTrue();
     }
   }
 
@@ -61,8 +74,10 @@ public final class DefaultNativeRuntimeLoaderTest {
     // hold a zip filesystem for the jar containing the fonts. Extraction must reuse it
     // instead of failing with FileSystemAlreadyExistsException, and must leave it open.
     assume().that(hasResource("fonts")).isTrue();
-    URI fontsUri = Thread.currentThread().getContextClassLoader().getResource("fonts/").toURI();
+    URI fontsUri = resourceUri("fonts/");
     assume().that(fontsUri.getScheme()).isEqualTo("jar");
+    // Sharing would let a warm cache skip the copy, and with it the filesystem this covers.
+    setSystemPropertyRule.set("robolectric.nativeruntime.cacheAssets", "false");
 
     FileSystem alreadyOpen;
     boolean ownsFileSystem;
@@ -88,6 +103,25 @@ public final class DefaultNativeRuntimeLoaderTest {
   }
 
   @Test
+  public void extracts_fontsAndIcuData_whenAssetsAreNotShared() {
+    assume().that(hasResource("fonts")).isTrue();
+    assume().that(hasResource("icu/icudt68l.dat")).isTrue();
+    setSystemPropertyRule.set("robolectric.nativeruntime.cacheAssets", "false");
+
+    DefaultNativeRuntimeLoader loader = new DefaultNativeRuntimeLoader();
+    loader.ensureLoaded();
+
+    // Without sharing, the assets land in this instance's own temporary directory.
+    assertThat(new File(System.getProperty("icu.data.path")).exists()).isTrue();
+    assertThat(System.getProperty("icu.data.path"))
+        .startsWith(loader.getDirectory().toAbsolutePath().toString());
+    if (RuntimeEnvironment.getApiLevel() >= O) {
+      assertThat(fontsXml().exists()).isTrue();
+      assertThat((Object) loader.getHyphenDataDirectory()).isEqualTo(loader.getDirectory());
+    }
+  }
+
+  @Test
   @Config(minSdk = O)
   public void closes_jarFileSystemItOpened_onceFontsAndHyphenDataAreExtracted() throws Exception {
     // Issue #10116: a zip filesystem opened by the loader must not outlive the extraction,
@@ -97,6 +131,8 @@ public final class DefaultNativeRuntimeLoaderTest {
     URI fontsUri = resourceUri("fonts/");
     assume().that(fontsUri.getScheme()).isEqualTo("jar");
     assume().that(isJarFileSystemOpen(fontsUri)).isFalse();
+    // Sharing would let a warm cache skip the copy, and with it the filesystem this covers.
+    setSystemPropertyRule.set("robolectric.nativeruntime.cacheAssets", "false");
 
     DefaultNativeRuntimeLoader defaultNativeRuntimeLoader = new DefaultNativeRuntimeLoader();
     defaultNativeRuntimeLoader.ensureLoaded();
@@ -105,6 +141,53 @@ public final class DefaultNativeRuntimeLoaderTest {
     assertThat(Files.exists(root.resolve("fonts/fonts.xml"))).isTrue();
     assertThat(Files.exists(root.resolve("hyphen-data/hyph-af.hyb"))).isTrue();
     assertThat(isJarFileSystemOpen(fontsUri)).isFalse();
+  }
+
+  @Test
+  public void sharesAssetDirectory_acrossLoaders() {
+    assume().that(hasResource("fonts")).isTrue();
+    assume().that(RuntimeEnvironment.getApiLevel()).isAtLeast(O);
+    DefaultNativeRuntimeLoader first = new DefaultNativeRuntimeLoader();
+    first.ensureLoaded();
+    File firstFontsXml = fontsXml();
+    Path firstHyphenData = first.getHyphenDataDirectory();
+    assume().that(firstHyphenData).isNotEqualTo(first.getDirectory());
+
+    DefaultNativeRuntimeLoader.resetLoaded();
+    DefaultNativeRuntimeLoader second = new DefaultNativeRuntimeLoader();
+    second.ensureLoaded();
+
+    // The assets are reused rather than extracted again, while the native library stays per
+    // instance because System.load() rejects the same path from a second ClassLoader.
+    assertThat(fontsXml()).isEqualTo(firstFontsXml);
+    assertThat((Object) second.getHyphenDataDirectory()).isEqualTo(firstHyphenData);
+    assertThat((Object) second.getDirectory()).isNotEqualTo(first.getDirectory());
+    assertThat(firstHyphenData.resolve(".complete").toFile().exists()).isTrue();
+  }
+
+  /**
+   * The fonts come from the same archive whatever the SDK under test, while the ICU data does not,
+   * so they are shared through directories of their own rather than through one directory for every
+   * group.
+   */
+  @Test
+  public void sharesEachAssetGroup_inItsOwnDirectory() {
+    assume().that(hasResource("fonts")).isTrue();
+    assume().that(RuntimeEnvironment.getApiLevel()).isAtLeast(O);
+    DefaultNativeRuntimeLoader loader = new DefaultNativeRuntimeLoader();
+    loader.ensureLoaded();
+    Path hyphenData = loader.getHyphenDataDirectory();
+    assume().that(hyphenData).isNotEqualTo(loader.getDirectory());
+
+    Path fonts = fontsXml().toPath().getParent().getParent();
+    Path icu = new File(System.getProperty("icu.data.path")).toPath().getParent().getParent();
+    assertThat((Object) fonts).isNotEqualTo(icu);
+    assertThat((Object) fonts).isNotEqualTo(hyphenData);
+    assertThat((Object) icu).isNotEqualTo(hyphenData);
+  }
+
+  private static File fontsXml() {
+    return new File(System.getProperty("robolectric.nativeruntime.fontdir"), "fonts.xml");
   }
 
   @Test


### PR DESCRIPTION
Loading the native runtime extracts the fonts, hyphen data and ICU data out of the nativeruntime jar into a fresh temporary directory. That is over 180MB of files, and it is repeated for every ClassLoader that loads this class and for every test JVM, even though the contents are identical for a given jar.

Extract them once into a directory keyed by the archive that supplies them, and point the existing system properties at it. The assets are only ever read through absolute paths, so relocating them is transparent.

The native library itself is deliberately not shared: System.load() rejects the same path being loaded by a second ClassLoader, so it stays in the loader's own temporary directory.

An exclusive lock is held over the extraction and a marker file is written once it completes, so concurrent test JVMs cooperate instead of each writing the same files, and a partially written directory is never reused. The key includes the archive's size and modification time so a rebuilt jar is not mistaken for a cached one. Set -Drobolectric.nativeruntime.cacheAssets=false to restore the previous behavior of extracting per load.

Measured on an Android app module's Roborazzi suite of 65 screenshot tests, where the runtime is loaded twice (once in the app ClassLoader and once in the sandbox): loadNativeRuntime totalled 4123ms across the two loads, and extracting the 183MB of fonts and ICU data accounts for roughly 960ms of each.

```
Measured on an internal Roborazzi-heavy module (65 screenshot tests)

loadNativeRuntime total, 2 loads per run:

┌──────────────────────────────┬────────────────┐
│                              │     total      │
├──────────────────────────────┼────────────────┤
│ master (baseline)            │ 4123 ms        │
├──────────────────────────────┼────────────────┤
│ with fix, run 1 (cold cache) │ 1921 ms (−53%) │
├──────────────────────────────┼────────────────┤
│ with fix, run 2              │ 692 ms (−83%)  │
├──────────────────────────────┼────────────────┤
│ with fix, run 3              │ 684 ms (−83%)  │
└──────────────────────────────┴────────────────┘
```

