### PR TITLE
Set the text directly in changeText_withCloseSoftKeyboard

### DIFF
--- a/integration_tests/androidx_test/src/sharedTest/java/org/robolectric/integrationtests/axt/EspressoTest.java
+++ b/integration_tests/androidx_test/src/sharedTest/java/org/robolectric/integrationtests/axt/EspressoTest.java
@@ -4,6 +4,7 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.pressKey;
+import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.action.ViewActions.typeTextIntoFocusedView;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -189,8 +190,10 @@ public final class EspressoTest {
 
   @Test
   public void changeText_withCloseSoftKeyboard() {
-    // Type text and then press the button.
-    onView(withId(R.id.edit_text)).perform(typeText("anything"), closeSoftKeyboard());
+    // Set text and then close the soft keyboard. This uses replaceText rather than typeText
+    // because injected keystrokes are occasionally replayed on a slow device, which duplicates
+    // a character; typeText itself is covered by the typeText_* tests above.
+    onView(withId(R.id.edit_text)).perform(replaceText("anything"), closeSoftKeyboard());
 
     // Check that the text was changed.
     onView(withId(R.id.edit_text)).check(matches(withText("anything")));


### PR DESCRIPTION
The test typed its text with typeText, and on API 37 the device saw a character twice:

  Expected: view.getText() ... is "anything"
  Got: view.getText() was "anythiing"

Espresso injects a typed string in chunks and re-injects a chunk it believes failed, so a device slow enough to make an injection look failed can replay part of it. The emulator these tests run on renders in software, which makes it slow enough.

The keystrokes are not what this test is for -- typeText is covered by typeText_espresso, typeText_findView, typeText_phone, typeText_number and changeText_addNewline, the first of those with a 43-character string. What is only covered here is closeSoftKeyboard, and replaceText still focuses the field and raises the keyboard for it to close.