### PR TITLE
Add a plugin to collect Error Prone issues across modules

### DIFF
--- a/build-logic/README.md
+++ b/build-logic/README.md
@@ -1,0 +1,75 @@
+# Robolectric build logic
+
+`build-logic` holds the convention plugins that configure Robolectric's modules — the Java and
+Kotlin module defaults, the shadow processor wiring, Spotless, the Gradle managed devices used for
+instrumentation tests, and publishing. Modules apply them by id, for example
+`org.robolectric.gradle.RoboJavaModulePlugin`.
+
+## Error Prone issue report
+
+Error Prone reports its findings as compilation errors, so a build stops at the first module that
+has any and never says what the remaining modules hold. That is why `SKIP_ERRORPRONE=true` is the
+usual way to work locally — but it hides the issues rather than counting them.
+
+`ErrorProneReportPlugin` collects them instead. It is applied automatically wherever Error Prone
+itself is (from `RoboJavaModulePlugin`) and does nothing unless `-PerrorproneReport` is set, so it
+has no effect on normal builds.
+
+### Usage
+
+```shell
+./gradlew -PerrorproneReport --continue compileTestJava
+```
+
+`collectErrorProneIssues` does not need naming: it finalizes every compile task, so it runs once
+they have. `--continue` does matter — Error Prone findings fail the compile task, and without it the
+build stops at the first module and the report only covers that one.
+
+Do not set `SKIP_ERRORPRONE=true` for this run — it disables Error Prone altogether, and the report
+comes back empty.
+
+### Output
+
+Each compile task tees the compiler's messages to
+`<module>/build/reports/errorprone/<task>.log`, and `collectErrorProneIssues` parses those into
+`build/reports/errorprone/`:
+
+| File | Contents |
+| --- | --- |
+| `summary.txt` | Totals, the errors listed first, a count per check, then every issue |
+| `issues.json` | One object per issue — `check`, `severity`, `file`, `line`, `message` |
+
+Paths are relative to the repository root. `summary.txt` opens with the shape of the problem:
+
+```
+1410 Error Prone issue(s): 30 error(s), 1380 warning(s)
+
+Errors (these fail the build):
+
+  robolectric/src/test/java/org/robolectric/android/XmlResourceParserImplTest.java:297
+    [NullArgumentForNonNullParameter] Null is not permitted for parameter 'arg0' of method 'isEqualTo'.
+...
+
+By check:
+
+  EffectivelyPrivate     346
+  MissingSummary         148
+  ReferenceEquality      110
+```
+
+Only the errors fail a build; the warnings are reported so they can be triaged, not because they
+need fixing now.
+
+### Notes
+
+Javac's own lint warnings (`[removal]`, `[deprecation]`) arrive on the same stream as Error Prone's.
+They are told apart by case — lowercase is javac, UpperCamelCase is an Error Prone check — and
+counted separately at the end of `summary.txt` so they do not inflate the totals.
+
+The per-module logs are written as the compiler emits them rather than when the task ends, because a
+compile that reports Error Prone errors fails and never reaches the end of the task.
+
+Do not read those per-module logs as a per-module breakdown. Gradle's task logging is process-global
+while tasks overlap, so a parallel build can capture one module's diagnostics into another module's
+log. Which module a diagnostic came from is recoverable from its path, so the aggregate simply
+discards duplicates; the log files are only a transport.

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -20,6 +20,10 @@ gradlePlugin {
       id = "org.robolectric.gradle.DeployedRoboKotlinModulePlugin"
       implementationClass = "org.robolectric.gradle.DeployedRoboKotlinModulePlugin"
     }
+    register("ErrorProneReportPlugin") {
+      id = "org.robolectric.gradle.ErrorProneReportPlugin"
+      implementationClass = "org.robolectric.gradle.ErrorProneReportPlugin"
+    }
     register("GradleManagedDevicePlugin") {
       id = "org.robolectric.gradle.GradleManagedDevicePlugin"
       implementationClass = "org.robolectric.gradle.GradleManagedDevicePlugin"

--- a/build-logic/convention/src/main/java/org/robolectric/gradle/CollectErrorProneIssuesTask.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/CollectErrorProneIssuesTask.kt
@@ -1,0 +1,112 @@
+package org.robolectric.gradle
+
+import java.io.File
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+/** Parses the per-module Error Prone logs into an aggregated report. */
+abstract class CollectErrorProneIssuesTask : DefaultTask() {
+
+  /** Per-module logs written by [ErrorProneReportPlugin]. */
+  @get:InputFiles
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val logs: ConfigurableFileCollection
+
+  /** Used only to report paths relative to the repository. */
+  @get:Internal abstract val projectRoot: DirectoryProperty
+
+  @get:OutputDirectory abstract val reportDir: DirectoryProperty
+
+  @TaskAction
+  fun collect() {
+    val logs = logs.files.filter { it.isFile }.sorted()
+    val root = projectRoot.get().asFile
+    // Gradle's per-task logging is process-global while tasks overlap, so a parallel build can
+    // capture one module's diagnostics into another module's log. Attribution does not matter for
+    // a repository-wide report, but the duplicates it produces do, hence a global distinct().
+    val all = logs.flatMap { parse(it, root) }.distinct().sortedWith(ORDER)
+    // javac's own lint categories are lowercase (removal, deprecation); Error Prone checks are
+    // UpperCamelCase. Both arrive on the same stream, so separate them here.
+    val (issues, lint) = all.partition { it.check.firstOrNull()?.isUpperCase() == true }
+    val dir = reportDir.get().asFile.apply { mkdirs() }
+
+    File(dir, "issues.json").writeText(toJson(issues))
+    File(dir, "summary.txt").writeText(toSummary(issues, lint))
+
+    val errors = issues.count { it.severity == "error" }
+    logger.lifecycle(
+      "Error Prone: ${issues.size} issue(s) ($errors error(s)) across " +
+        "${issues.map { it.check }.distinct().size} check(s); report in ${dir.absolutePath}"
+    )
+  }
+
+  private fun parse(log: File, root: File): List<Issue> =
+    DIAGNOSTIC.findAll(log.readText())
+      .map {
+        val (file, line, severity, check, message) = it.destructured
+        Issue(relativize(file, root), line.toInt(), severity, check, message.trim())
+      }
+      .toList()
+
+  private fun relativize(path: String, root: File): String = runCatching {
+    File(path).relativeTo(root).path
+  }
+    .getOrDefault(path)
+
+  private fun toSummary(issues: List<Issue>, lint: List<Issue>): String {
+    if (issues.isEmpty()) return "No Error Prone issues found.\n"
+    val errors = issues.filter { it.severity == "error" }
+    val counts = issues.groupingBy { it.check }.eachCount().entries.sortedWith(BY_COUNT)
+    val width = counts.maxOf { it.key.length }
+    return buildString {
+      append("${issues.size} Error Prone issue(s): ")
+      append("${errors.size} error(s), ${issues.size - errors.size} warning(s)\n")
+      if (errors.isNotEmpty()) {
+        append("\nErrors (these fail the build):\n\n")
+        errors.forEach { append("  ${it.file}:${it.line}\n    [${it.check}] ${it.message}\n") }
+      }
+      append("\nBy check:\n\n")
+      counts.forEach { append("  %-${width}s  %d%n".format(it.key, it.value)) }
+      append("\nAll issues:\n\n")
+      issues.forEach { append("  ${it.file}:${it.line}\n    [${it.check}] ${it.message}\n") }
+      if (lint.isNotEmpty()) {
+        val byCat = lint.groupingBy { it.check }.eachCount()
+        append("\n${lint.size} javac lint warning(s) also captured, not Error Prone: $byCat\n")
+      }
+    }
+  }
+
+  private fun toJson(issues: List<Issue>): String =
+    issues.joinToString(separator = ",\n", prefix = "[\n", postfix = "\n]\n") {
+      """  {"check": "${esc(it.check)}", "severity": "${esc(it.severity)}", """ +
+        """"file": "${esc(it.file)}", "line": ${it.line}, "message": "${esc(it.message)}"}"""
+    }
+
+  private fun esc(s: String) =
+    s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\t", "\\t")
+
+  private data class Issue(
+    val file: String,
+    val line: Int,
+    val severity: String,
+    val check: String,
+    val message: String,
+  )
+
+  private companion object {
+    /** e.g. `/path/Foo.java:42: warning: [UnusedVariable] the message` */
+    private val DIAGNOSTIC =
+      Regex("""^(\S+\.java):(\d+): (error|warning): \[(\w+)\] (.*)$""", RegexOption.MULTILINE)
+
+    private val ORDER = compareBy<Issue>({ it.check }, { it.file }, { it.line })
+    private val BY_COUNT =
+      compareByDescending<Map.Entry<String, Int>> { it.value }.thenBy { it.key }
+  }
+}

--- a/build-logic/convention/src/main/java/org/robolectric/gradle/ErrorProneReportPlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/ErrorProneReportPlugin.kt
@@ -1,0 +1,107 @@
+package org.robolectric.gradle
+
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.kotlin.dsl.withType
+
+/**
+ * Collects the Error Prone diagnostics emitted while compiling, so they can be reported together
+ * instead of only as far as the first module that fails.
+ *
+ * Enabled by `-PerrorproneReport`. Each [JavaCompile] tees the compiler's messages into
+ * `<module>/build/reports/errorprone/<task>.log`, and the root [CollectErrorProneIssuesTask] parses
+ * those into `build/reports/errorprone/issues.json` and a `summary.txt` counting each check.
+ */
+class ErrorProneReportPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    if (!project.providers.gradleProperty(ENABLE_PROPERTY).isPresent) return
+
+    if (project == project.rootProject) {
+      registerAggregateTask(project)
+      return
+    }
+
+    // Applying a plugin is idempotent, so each module can bootstrap the root task without racing
+    // another module to check whether it exists yet.
+    project.rootProject.pluginManager.apply(ErrorProneReportPlugin::class.java)
+
+    val collector =
+      project.gradle.sharedServices.registerIfAbsent(
+        "errorProneDiagnostics",
+        DiagnosticCollector::class.java,
+      ) {}
+    val aggregate = project.rootProject.tasks.named(TASK_NAME)
+    val reportDir = project.layout.buildDirectory.dir("reports/errorprone")
+
+    project.tasks.withType<JavaCompile>().configureEach {
+      val logFile = reportDir.map { it.file("$name.log").asFile }
+      val taskPath = path
+
+      // javac stops listing after 100 of each by default, which would truncate the report.
+      options.compilerArgs.addAll(listOf("-Xmaxerrs", "10000", "-Xmaxwarns", "10000"))
+
+      usesService(collector)
+      // The aggregate has no inputs Gradle can see, so without this it is free to run before the
+      // compilers have written anything and to report nothing at all.
+      finalizedBy(aggregate)
+
+      // The log is deliberately not declared as a task output. It is written by a logging
+      // listener rather than by the task's own action, so an up-to-date or cached compile would
+      // keep a stale one while never running the code that refreshes it -- and it would end up
+      // in the compile task's build cache entry.
+      //
+      // It is written as the compiler emits rather than in doLast, because Error Prone reports
+      // its findings as errors and a failing task never reaches doLast.
+      doFirst {
+        val log = logFile.get()
+        log.parentFile.mkdirs()
+        log.writeText("")
+        val service = collector.get()
+        service.register(taskPath, log)
+        logging.addStandardErrorListener { service.append(taskPath, it.toString()) }
+        logging.addStandardOutputListener { service.append(taskPath, it.toString()) }
+      }
+    }
+  }
+
+  private fun registerAggregateTask(root: Project) {
+    root.tasks.register<CollectErrorProneIssuesTask>(TASK_NAME) {
+      group = "verification"
+      description = "Aggregates Error Prone diagnostics from every module into one report."
+      logs.setFrom(
+        root.fileTree(root.layout.projectDirectory) {
+          include("**/build/reports/errorprone/*.log")
+        }
+      )
+      projectRoot.set(root.layout.projectDirectory)
+      reportDir.set(root.layout.buildDirectory.dir("reports/errorprone"))
+      // The logs come from listeners the build cannot track, so this must never be skipped.
+      outputs.upToDateWhen { false }
+    }
+  }
+
+  /** Appends compiler output to each task's log as it is produced. */
+  abstract class DiagnosticCollector : BuildService<BuildServiceParameters.None> {
+    private val logs = ConcurrentHashMap<String, File>()
+
+    fun register(taskPath: String, log: File) {
+      logs[taskPath] = log
+    }
+
+    fun append(taskPath: String, text: String) {
+      logs[taskPath]?.appendText(text)
+    }
+  }
+
+  private companion object {
+    const val ENABLE_PROPERTY = "errorproneReport"
+    const val TASK_NAME = "collectErrorProneIssues"
+  }
+}

--- a/build-logic/convention/src/main/java/org/robolectric/gradle/RoboJavaModulePlugin.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/RoboJavaModulePlugin.kt
@@ -23,6 +23,7 @@ class RoboJavaModulePlugin : Plugin<Project> {
     if (!skipErrorProne) {
       project.pluginManager.apply("net.ltgt.errorprone")
       project.dependencies.add("errorprone", project.libs.findLibrary("error-prone-core").get())
+      project.pluginManager.apply("org.robolectric.gradle.ErrorProneReportPlugin")
     }
 
     project.tasks.withType<JavaCompile>().configureEach {


### PR DESCRIPTION
Error Prone reports its findings as compilation errors, so a build stops at the first module that has any and never says what the remaining modules hold. That is why SKIP_ERRORPRONE=true is the usual way to work locally, which hides the issues rather than counting them.

`-PerrorproneReport` makes each JavaCompile tee the compiler's messages into <module>/build/reports/errorprone/<task>.log, and `collectErrorProneIssues` parses those into build/reports/errorprone. Run it as

  ./gradlew -PerrorproneReport --continue compileTestJava \
      collectErrorProneIssues

The file to open afterwards is build/reports/errorprone/summary.txt, which holds every issue and is arranged so it can be read at whichever level is wanted:

  header      the totals
  Errors      the ones that actually fail a build, in full
  By check    a count per check, most frequent first
  All issues  every one, as file:line then [Check] message
  footer      javac's own lint warnings, kept out of the totals

Beside it, issues.json carries the same data one object per issue -- check, severity, file, line, message -- for sorting or filtering. Paths in both are relative to the repository root. Neither is checked in; they live under build/ and appear when the task runs.

Two things the implementation has to work around. The logs are written as the compiler emits rather than when the task ends, because a compile that reports errors fails and never reaches the end of the task; --continue then carries the run across the remaining modules. And javac's own lint categories arrive on the same stream, so they are told apart by case -- lowercase `removal` is javac, UpperCamelCase `UnusedVariable` is Error Prone -- and counted separately rather than inflating the totals.

Without the property the plugin adds nothing to a build.

What it reports on this tree: 1705 issues across 68 checks in 11 modules, of which 30 are errors and the rest warnings. Every error is NullArgumentForNonNullParameter, which is what SKIP_ERRORPRONE has been hiding. The warnings are dominated by

  EffectivelyPrivate      394
  ReferenceEquality       168
  AssignmentExpression    162
  MissingSummary          148
  AssertThrowsMinimizer    84

and by module by shadows/framework (821), robolectric (394) and resources (380). Only the errors fail a build; the warnings are collected to be triaged, not because they need fixing now.
