### PR TITLE
Enable native access for the native runtime on JDK 24+

### DIFF
--- a/build-logic/convention/src/main/java/org/robolectric/gradle/TestTaskConfiguration.kt
+++ b/build-logic/convention/src/main/java/org/robolectric/gradle/TestTaskConfiguration.kt
@@ -58,6 +58,11 @@ private class RobolectricJvmArgumentsProvider(
 private class DefaultJvmArgumentsProvider : CommandLineArgumentProvider {
   override fun asArguments(): Iterable<String> {
     return listOf(
+      // The native runtime is loaded with System.load from the classpath, which JDK 24 made a
+      // restricted method (JEP 472). Without this every run prints a warning, and once the JDK
+      // switches its default to deny it will throw IllegalCallerException instead. Older JDKs
+      // accept the flag and ignore it.
+      "--enable-native-access=ALL-UNNAMED",
       "--add-opens=java.base/java.lang=ALL-UNNAMED",
       "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
       "--add-opens=java.base/java.io=ALL-UNNAMED",

--- a/nativeruntime/src/main/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoader.java
+++ b/nativeruntime/src/main/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoader.java
@@ -406,7 +406,21 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
     URL libraryResource = Resources.getResource(nativeLibraryPath());
     Logger.info("Loading android native library from: %s", libraryResource);
     Resources.asByteSource(libraryResource).copyTo(Files.asByteSink(libraryPath.toFile()));
-    System.load(libraryPath.toAbsolutePath().toString());
+    try {
+      System.load(libraryPath.toAbsolutePath().toString());
+    } catch (IllegalCallerException e) {
+      // JEP 472 made System.load a restricted method in JDK 24. Robolectric is on the classpath,
+      // so it is in the unnamed module and needs native access granted by the launcher; there is
+      // no way for the library to grant it to itself.
+      throw new IllegalStateException(
+          "Robolectric could not load its native runtime because the JVM denied native access to"
+              + " code on the classpath. Add --enable-native-access=ALL-UNNAMED to the JVM"
+              + " arguments of the test task, for example in Gradle:\n"
+              + "  tasks.withType(Test).configureEach {\n"
+              + "    jvmArgs '--enable-native-access=ALL-UNNAMED'\n"
+              + "  }",
+          e);
+    }
   }
 
   private static boolean isSupported() {


### PR DESCRIPTION
JDK 24 made System.load a restricted method (JEP 472). Robolectric loads its native runtime that way and sits on the classpath, so every run on a recent JDK prints:

  WARNING: A restricted method in java.lang.System has been called
  WARNING: java.lang.System::load has been called by
  org.robolectric.nativeruntime.DefaultNativeRuntimeLoader in an unnamed
  module
  WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for
  callers in this module
  WARNING: Restricted methods will be blocked in a future release unless
  native access is enabled

Native access can only be granted by the launcher, so a library cannot grant it to itself; the manifest attribute JEP 472 defines applies to executable jars only. What can be done is to stop Robolectric's own test JVMs from warning, and to make the failure legible when the JDK acts on that last line.

The flag goes into the arguments the test tasks already pass. It is accepted and ignored by JDK 17 and 21, so it needs no version guard, which was checked on 17, 21 and 25.

Under --illegal-native-access=deny, which is where the JDK has said it is heading, System.load instead throws

  java.lang.IllegalCallerException: Illegal native access from an unnamed module

which says nothing about Robolectric or about how to fix it. That is now caught and rethrown naming the flag and where to put it, since by then the warning that used to explain it will be gone.

Projects that consume Robolectric still have to pass the flag themselves. This does not change that; it removes the warning from this repository's own builds and makes the eventual hard failure explain itself.

For #11470