### PR TITLE
Update detekt to 2.0.0-alpha.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ kotlinx-coroutines = '1.11.0'
 spotless-gradle = "8.10.0"
 
 # https://detekt.dev/changelog
-detekt-gradle = "1.23.8"
+detekt-gradle = "2.0.0-alpha.6"
 
 # https://asm.ow2.io/versions.html
 asm = "9.10.1"
@@ -270,7 +270,7 @@ android-application = { id = "com.android.application", version.ref = "android-g
 android-library = { id = "com.android.library", version.ref = "android-gradle" }
 android-legacy-kapt = { id = "com.android.legacy-kapt", version.ref = "android-gradle" }
 application = { id = "application" }
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt-gradle" }
+detekt = { id = "dev.detekt", version.ref = "detekt-gradle" }
 error-prone = { id = "net.ltgt.errorprone", version.ref = "error-prone-gradle" }
 idea = { id = "idea" }
 gradle-plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "gradle-plugin-publish" }


### PR DESCRIPTION
detekt 1.23.8 bundles a Kotlin compiler that accepts no jvm-target above 22, so on a newer JDK every detekt task fails before analysing anything:

  Invalid value (26) passed to --jvm-target, must be one of
  [1.6, 1.8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]

That is not specific to any module -- :utils and :composeui fail the same way -- so `./gradlew detekt` is simply unusable for anyone developing on a JDK past 22, and CI only escapes it by pinning 21.

2.0.0-alpha.6 runs on all of them; this was checked on 21, 25 and 26.

The plugin id changes with it. 2.0 publishes under `dev.detekt`, and the old `io.gitlab.arturbosch.detekt` marker does not exist at this version, so the catalog entry moves too. No module needed changing: they all apply the plugin through the catalog alias, and nothing configures a detekt extension or names a detekt task directly.

Behaviour is unchanged where it matters: the same findings are reported, `@file:Suppress` is still honoured, and the xml and html reports are still written to build/reports/detekt.
