### PR TITLE
Assert between the steps of changeText_addNewline

### DIFF
--- a/integration_tests/androidx_test/src/sharedTest/java/org/robolectric/integrationtests/axt/EspressoTest.java
+++ b/integration_tests/androidx_test/src/sharedTest/java/org/robolectric/integrationtests/axt/EspressoTest.java
@@ -201,8 +201,11 @@ public final class EspressoTest {
 
   @Test
   public void changeText_addNewline() {
+    // Not replaceText: it leaves the cursor at the start, putting the newline before the text.
     onView(withId(R.id.edit_text)).perform(typeText("Some text."));
     onView(withId(R.id.edit_text)).perform(pressKey(KeyEvent.KEYCODE_ENTER));
+    // Wait for the newline, or the next keystrokes can land ahead of it.
+    onView(withId(R.id.edit_text)).check(matches(withText("Some text.\n")));
     onView(withId(R.id.edit_text)).perform(typeTextIntoFocusedView("Other text."));
 
     onView(withId(R.id.edit_text)).check(matches(withText("Some text.\nOther text.")));


### PR DESCRIPTION
The test typed a line, pressed enter, then typed another line, and on a slow device it read back:

  expected: "Some text.\nOther text."
  got:      "Some ttext.O\nther text."

Two separate faults. A character is repeated, because Espresso injects a typed string in chunks and re-injects any chunk it believes failed. And the O of the second line arrives ahead of the newline, because pressKey returned before the field had it and the next perform started typing into a field that had not caught up yet.

Checking the text between the two steps closes the second one: the assertion does not pass until the newline is there, so nothing can be typed ahead of it. The first stays possible, and is left alone -- typeText is what this test needs, since replaceText leaves the cursor at the start and would put the newline before the text rather than after it. That was tried; the test caught it.

The other typing tests are unchanged. typeText_espresso, typeText_phone and typeText_number are about typeText itself, so there is nothing to substitute, and typeText in onView_mainThread is only there to be rejected.