### PR TITLE
Install HttpResponseCache as the default ResponseCache

### DIFF
--- a/robolectric/src/test/java/org/robolectric/shadows/ShadowHttpResponseCacheTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/ShadowHttpResponseCacheTest.java
@@ -5,37 +5,38 @@ import static com.google.common.truth.Truth.assertThat;
 import android.net.http.HttpResponseCache;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.io.File;
-import org.junit.After;
-import org.junit.Before;
+import java.net.ResponseCache;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class ShadowHttpResponseCacheTest {
-  @Before
-  public void setUp() {
-    // If someone else installed a cache, clear it.
-    ShadowHttpResponseCache.installed = null;
-  }
-
-  @After
-  public void tearDown() {
-    // Ensure we don't leak an installed cache from a test.
-    ShadowHttpResponseCache.installed = null;
-  }
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
   public void installedCacheIsReturned() throws Exception {
+    // Also checks that the previous test left no cache behind.
     assertThat(HttpResponseCache.getInstalled()).isNull();
-    HttpResponseCache cache = HttpResponseCache.install(File.createTempFile("foo", "bar"), 42);
+    HttpResponseCache cache = HttpResponseCache.install(temporaryFolder.newFolder(), 42);
     HttpResponseCache installed = HttpResponseCache.getInstalled();
     assertThat(installed).isSameInstanceAs(cache);
     assertThat(installed.maxSize()).isEqualTo(42);
   }
 
   @Test
+  public void installedCacheIsTheDefaultResponseCache() throws Exception {
+    assertThat(ResponseCache.getDefault()).isNull();
+
+    HttpResponseCache cache = HttpResponseCache.install(temporaryFolder.newFolder(), 42);
+
+    assertThat(HttpResponseCache.getDefault()).isSameInstanceAs(cache);
+  }
+
+  @Test
   public void countsStartAtZero() throws Exception {
-    HttpResponseCache cache = HttpResponseCache.install(File.createTempFile("foo", "bar"), 42);
+    HttpResponseCache cache = HttpResponseCache.install(temporaryFolder.newFolder(), 42);
     assertThat(cache.getHitCount()).isEqualTo(0);
     assertThat(cache.getNetworkCount()).isEqualTo(0);
     assertThat(cache.getRequestCount()).isEqualTo(0);
@@ -43,15 +44,57 @@ public class ShadowHttpResponseCacheTest {
 
   @Test
   public void deleteRemovesReference() throws Exception {
-    HttpResponseCache cache = HttpResponseCache.install(File.createTempFile("foo", "bar"), 42);
+    HttpResponseCache cache = HttpResponseCache.install(temporaryFolder.newFolder(), 42);
     cache.delete();
     assertThat(HttpResponseCache.getInstalled()).isNull();
+    assertThat(HttpResponseCache.getDefault()).isNull();
   }
 
   @Test
   public void closeRemovesReference() throws Exception {
-    HttpResponseCache cache = HttpResponseCache.install(File.createTempFile("foo", "bar"), 42);
+    HttpResponseCache cache = HttpResponseCache.install(temporaryFolder.newFolder(), 42);
     cache.close();
     assertThat(HttpResponseCache.getInstalled()).isNull();
+    assertThat(HttpResponseCache.getDefault()).isNull();
+  }
+
+  @Test
+  public void closeLeavesADifferentInstalledCacheAlone() throws Exception {
+    HttpResponseCache uninstalled = HttpResponseCache.install(temporaryFolder.newFolder(), 42);
+    HttpResponseCache installed = HttpResponseCache.install(temporaryFolder.newFolder(), 42);
+
+    uninstalled.close();
+
+    assertThat(HttpResponseCache.getInstalled()).isSameInstanceAs(installed);
+  }
+
+  @Test
+  public void installKeepsAnEquivalentCache() throws Exception {
+    File directory = temporaryFolder.newFolder();
+    HttpResponseCache cache = HttpResponseCache.install(directory, 42);
+
+    assertThat(HttpResponseCache.install(directory, 42)).isSameInstanceAs(cache);
+  }
+
+  @Test
+  public void installReplacesACacheWithADifferentMaxSize() throws Exception {
+    File directory = temporaryFolder.newFolder();
+    HttpResponseCache cache = HttpResponseCache.install(directory, 42);
+
+    HttpResponseCache replacement = HttpResponseCache.install(directory, 43);
+
+    assertThat(replacement).isNotSameInstanceAs(cache);
+    assertThat(HttpResponseCache.getInstalled()).isSameInstanceAs(replacement);
+    assertThat(replacement.maxSize()).isEqualTo(43);
+  }
+
+  @Test
+  public void installReplacesACacheWithADifferentDirectory() throws Exception {
+    HttpResponseCache cache = HttpResponseCache.install(temporaryFolder.newFolder(), 42);
+
+    HttpResponseCache replacement = HttpResponseCache.install(temporaryFolder.newFolder(), 42);
+
+    assertThat(replacement).isNotSameInstanceAs(cache);
+    assertThat(HttpResponseCache.getInstalled()).isSameInstanceAs(replacement);
   }
 }

--- a/shadows/framework/src/main/java/org/robolectric/shadows/ShadowHttpResponseCache.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/ShadowHttpResponseCache.java
@@ -6,12 +6,16 @@ import android.net.http.HttpResponseCache;
 import java.io.File;
 import java.net.CacheRequest;
 import java.net.CacheResponse;
+import java.net.ResponseCache;
 import java.net.URI;
 import java.net.URLConnection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.annotation.Resetter;
 import org.robolectric.shadow.api.Shadow;
 
 @SuppressWarnings({"UnusedDeclaration"})
@@ -19,9 +23,8 @@ import org.robolectric.shadow.api.Shadow;
 public class ShadowHttpResponseCache {
   private static final Object LOCK = new Object();
 
-  static ShadowHttpResponseCache installed = null;
+  @RealObject private HttpResponseCache realCache;
 
-  private HttpResponseCache originalObject;
   private File directory;
   private long maxSize;
   private int requestCount = 0;
@@ -31,24 +34,38 @@ public class ShadowHttpResponseCache {
 
   private int networkCount = 0;
 
+  /**
+   * Installs the cache the way the framework does, by making it the default {@link ResponseCache}.
+   *
+   * <p>Keeping it anywhere else would leave {@link ResponseCache#getDefault()} empty, which callers
+   * reach through the inherited {@code HttpResponseCache.getDefault()}.
+   */
   @Implementation
   protected static HttpResponseCache install(File directory, long maxSize) {
-    HttpResponseCache cache = newInstanceOf(HttpResponseCache.class);
-    ShadowHttpResponseCache shadowCache = Shadow.extract(cache);
-    shadowCache.originalObject = cache;
-    shadowCache.directory = directory;
-    shadowCache.maxSize = maxSize;
     synchronized (LOCK) {
-      installed = shadowCache;
+      HttpResponseCache installed = getInstalled();
+      if (installed != null) {
+        ShadowHttpResponseCache shadowInstalled = Shadow.extract(installed);
+        // An equivalent cache is already installed, so the framework keeps using it.
+        if (shadowInstalled.maxSize == maxSize
+            && Objects.equals(shadowInstalled.directory, directory)) {
+          return installed;
+        }
+      }
+
+      HttpResponseCache cache = newInstanceOf(HttpResponseCache.class);
+      ShadowHttpResponseCache shadowCache = Shadow.extract(cache);
+      shadowCache.directory = directory;
+      shadowCache.maxSize = maxSize;
+      ResponseCache.setDefault(cache);
       return cache;
     }
   }
 
   @Implementation
   protected static HttpResponseCache getInstalled() {
-    synchronized (LOCK) {
-      return (installed != null) ? installed.originalObject : null;
-    }
+    ResponseCache installed = ResponseCache.getDefault();
+    return installed instanceof HttpResponseCache ? (HttpResponseCache) installed : null;
   }
 
   @Implementation
@@ -63,8 +80,11 @@ public class ShadowHttpResponseCache {
 
   @Implementation
   protected void close() {
+    // Uninstalls only this cache, and only while it is the installed one.
     synchronized (LOCK) {
-      installed = null;
+      if (ResponseCache.getDefault() == realCache) {
+        ResponseCache.setDefault(null);
+      }
     }
   }
 
@@ -105,5 +125,18 @@ public class ShadowHttpResponseCache {
   @Implementation
   protected void flush() {
     // No-op as `mDelegate` is null.
+  }
+
+  /**
+   * The default {@link ResponseCache} is process-wide state that outlives the sandbox, so a cache a
+   * test installs has to be uninstalled again. Anything else installed there is left alone.
+   */
+  @Resetter
+  public static void reset() {
+    synchronized (LOCK) {
+      if (ResponseCache.getDefault() instanceof HttpResponseCache) {
+        ResponseCache.setDefault(null);
+      }
+    }
   }
 }


### PR DESCRIPTION
HttpResponseCache extends java.net.ResponseCache, and install() publishes the cache by calling ResponseCache.setDefault(). That is the only place it is kept: getInstalled() reads it straight back out, and so does the getDefault() callers inherit from ResponseCache.

The shadow kept the installed cache in a static field of its own and never touched ResponseCache, so getInstalled() worked while getDefault() returned null.

Store it where the framework stores it, and derive the rest from there. Three smaller divergences fall out of the same change:

  - install() returns the cache already installed when the directory and maxSize match, rather than replacing it with a new one.

  - close() and delete() uninstall the cache only while it is the installed one. They used to clear the reference whichever cache they were called on, so closing a stale cache uninstalled the live one.

  - A cache installed by a test no longer leaks into the next one. ResponseCache holds process-wide state that outlives the sandbox, so a @Resetter uninstalls it, and only if it is an HttpResponseCache -- a ResponseCache installed from outside is left alone. ShadowHttpResponseCacheTest had been clearing the old static field by hand in setUp and tearDown, which is what kept its first assertion honest; it can now check that it starts clean instead.

Fixes #2023
