### PR TITLE
Reuse an already open jar filesystem when extracting fonts and hyphen data

### DIFF
--- a/nativeruntime/src/main/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoader.java
+++ b/nativeruntime/src/main/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoader.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -321,43 +322,14 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
    * graphics.
    */
   private void maybeCopyFonts(TempDirectory tempDirectory) throws IOException {
-    URI fontsUri;
-    try {
-      fontsUri = Resources.getResource("fonts/").toURI();
-    } catch (IllegalArgumentException | URISyntaxException e) {
+    Path fontsOutputPath = copyResourceDirectory("fonts", tempDirectory);
+    if (fontsOutputPath == null) {
       return;
-    }
-
-    FileSystem zipfs = null;
-
-    if ("jar".equals(fontsUri.getScheme())) {
-      zipfs = FileSystems.newFileSystem(fontsUri, ImmutableMap.of("create", "true"));
-    }
-
-    Path fontsInputPath = Paths.get(fontsUri);
-    Path fontsOutputPath = tempDirectory.create("fonts");
-
-    try (Stream<Path> pathStream = java.nio.file.Files.walk(fontsInputPath)) {
-      Iterator<Path> fileIterator = pathStream.iterator();
-      while (fileIterator.hasNext()) {
-        Path path = fileIterator.next();
-        // Avoid copying parent directory.
-        if ("fonts".equals(path.getFileName().toString())) {
-          continue;
-        }
-        String fontPath = "fonts/" + path.getFileName();
-        URL resource = Resources.getResource(fontPath);
-        Path outputPath = tempDirectory.getBasePath().resolve(fontPath);
-        Resources.asByteSource(resource).copyTo(Files.asByteSink(outputPath.toFile()));
-      }
     }
     System.setProperty(
         "robolectric.nativeruntime.fontdir",
         // Android's FontListParser expects a trailing slash for the base font directory.
         fontsOutputPath.toAbsolutePath() + File.separator);
-    if (zipfs != null) {
-      zipfs.close();
-    }
   }
 
   /**
@@ -365,39 +337,64 @@ public class DefaultNativeRuntimeLoader implements NativeRuntimeLoader {
    * graphics.
    */
   private void maybeCopyHyphenData(TempDirectory tempDirectory) throws IOException {
-    URI hyphenDataUri;
+    if (copyResourceDirectory(HYPHEN_DATA_DIR, tempDirectory) == null) {
+      Logger.info("Could not load hyphen data files: resource directory not found");
+    }
+  }
+
+  /**
+   * Copies every file of the classpath resource directory {@code directoryName} into a directory of
+   * the same name under {@code tempDirectory}.
+   *
+   * <p>When the resources are packaged in a jar, the directory is walked through a zip {@link
+   * FileSystem}. Such a filesystem may already be open for that jar in this JVM: another
+   * Robolectric sandbox (a test class running several SDK levels) or {@code org.robolectric.res.Fs}
+   * can hold one, and {@link FileSystems#newFileSystem} then throws {@link
+   * FileSystemAlreadyExistsException}. In that case the existing filesystem is reused and left to
+   * its owner. A filesystem opened here is always closed, even when the copy fails, so that it
+   * never leaks into the next sandbox.
+   *
+   * @return the output directory, or {@code null} when the resource directory does not exist
+   */
+  private static Path copyResourceDirectory(String directoryName, TempDirectory tempDirectory)
+      throws IOException {
+    URI directoryUri;
     try {
-      hyphenDataUri = Resources.getResource(HYPHEN_DATA_DIR + "/").toURI();
+      directoryUri = Resources.getResource(directoryName + "/").toURI();
     } catch (IllegalArgumentException | URISyntaxException e) {
-      Logger.info("Could not load hyphen data files: " + e.getMessage());
-      return;
+      return null;
     }
 
-    FileSystem zipfs = null;
-
-    if ("jar".equals(hyphenDataUri.getScheme())) {
-      zipfs = FileSystems.newFileSystem(hyphenDataUri, ImmutableMap.of("create", "true"));
-    }
-
-    Path hyphenDataInputPath = Paths.get(hyphenDataUri);
-    tempDirectory.create(HYPHEN_DATA_DIR);
-
-    try (Stream<Path> pathStream = java.nio.file.Files.walk(hyphenDataInputPath)) {
-      Iterator<Path> fileIterator = pathStream.iterator();
-      while (fileIterator.hasNext()) {
-        Path path = fileIterator.next();
-        // Avoid copying parent directory.
-        if (Objects.equals(path.getFileName().toString(), HYPHEN_DATA_DIR)) {
-          continue;
-        }
-        String hyphenDataPath = HYPHEN_DATA_DIR + "/" + path.getFileName();
-        URL resource = Resources.getResource(hyphenDataPath);
-        Path outputPath = tempDirectory.getBasePath().resolve(hyphenDataPath);
-        Resources.asByteSource(resource).copyTo(Files.asByteSink(outputPath.toFile()));
+    FileSystem ownedZipfs = null;
+    if ("jar".equals(directoryUri.getScheme())) {
+      try {
+        ownedZipfs = FileSystems.newFileSystem(directoryUri, ImmutableMap.of("create", "true"));
+      } catch (FileSystemAlreadyExistsException e) {
+        // Already open elsewhere in this JVM: reuse it, its owner is responsible for closing it.
       }
     }
-    if (zipfs != null) {
-      zipfs.close();
+
+    try {
+      Path outputPath = tempDirectory.create(directoryName);
+      try (Stream<Path> pathStream = java.nio.file.Files.walk(Paths.get(directoryUri))) {
+        Iterator<Path> fileIterator = pathStream.iterator();
+        while (fileIterator.hasNext()) {
+          Path path = fileIterator.next();
+          // Avoid copying parent directory.
+          if (directoryName.equals(path.getFileName().toString())) {
+            continue;
+          }
+          String resourcePath = directoryName + "/" + path.getFileName();
+          URL resource = Resources.getResource(resourcePath);
+          Path resourceOutputPath = tempDirectory.getBasePath().resolve(resourcePath);
+          Resources.asByteSource(resource).copyTo(Files.asByteSink(resourceOutputPath.toFile()));
+        }
+      }
+      return outputPath;
+    } finally {
+      if (ownedZipfs != null) {
+        ownedZipfs.close();
+      }
     }
   }
 

--- a/nativeruntime/src/test/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoaderTest.java
+++ b/nativeruntime/src/test/java/org/robolectric/nativeruntime/DefaultNativeRuntimeLoaderTest.java
@@ -6,6 +6,13 @@ import static com.google.common.truth.TruthJUnit.assume;
 
 import android.database.CursorWindow;
 import android.database.sqlite.SQLiteDatabase;
+import com.google.common.collect.ImmutableMap;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -14,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 public final class DefaultNativeRuntimeLoaderTest {
@@ -47,6 +55,59 @@ public final class DefaultNativeRuntimeLoaderTest {
   }
 
   @Test
+  @Config(minSdk = O)
+  public void extracts_fonts_whenFontsJarFileSystemIsAlreadyOpen() throws Exception {
+    // Issue #10116: another sandbox in the same JVM, or org.robolectric.res.Fs, may already
+    // hold a zip filesystem for the jar containing the fonts. Extraction must reuse it
+    // instead of failing with FileSystemAlreadyExistsException, and must leave it open.
+    assume().that(hasResource("fonts")).isTrue();
+    URI fontsUri = Thread.currentThread().getContextClassLoader().getResource("fonts/").toURI();
+    assume().that(fontsUri.getScheme()).isEqualTo("jar");
+
+    FileSystem alreadyOpen;
+    boolean ownsFileSystem;
+    try {
+      alreadyOpen = FileSystems.newFileSystem(fontsUri, ImmutableMap.of("create", "true"));
+      ownsFileSystem = true;
+    } catch (FileSystemAlreadyExistsException e) {
+      alreadyOpen = FileSystems.getFileSystem(fontsUri);
+      ownsFileSystem = false;
+    }
+    try {
+      DefaultNativeRuntimeLoader defaultNativeRuntimeLoader = new DefaultNativeRuntimeLoader();
+      defaultNativeRuntimeLoader.ensureLoaded();
+
+      Path root = defaultNativeRuntimeLoader.getDirectory();
+      assertThat(root.resolve("fonts/fonts.xml").toFile().exists()).isTrue();
+      assertThat(alreadyOpen.isOpen()).isTrue();
+    } finally {
+      if (ownsFileSystem) {
+        alreadyOpen.close();
+      }
+    }
+  }
+
+  @Test
+  @Config(minSdk = O)
+  public void closes_jarFileSystemItOpened_onceFontsAndHyphenDataAreExtracted() throws Exception {
+    // Issue #10116: a zip filesystem opened by the loader must not outlive the extraction,
+    // otherwise it leaks into the next sandbox of the same JVM.
+    assume().that(hasResource("fonts")).isTrue();
+    assume().that(hasResource("hyphen-data")).isTrue();
+    URI fontsUri = resourceUri("fonts/");
+    assume().that(fontsUri.getScheme()).isEqualTo("jar");
+    assume().that(isJarFileSystemOpen(fontsUri)).isFalse();
+
+    DefaultNativeRuntimeLoader defaultNativeRuntimeLoader = new DefaultNativeRuntimeLoader();
+    defaultNativeRuntimeLoader.ensureLoaded();
+
+    Path root = defaultNativeRuntimeLoader.getDirectory();
+    assertThat(Files.exists(root.resolve("fonts/fonts.xml"))).isTrue();
+    assertThat(Files.exists(root.resolve("hyphen-data/hyph-af.hyb"))).isTrue();
+    assertThat(isJarFileSystemOpen(fontsUri)).isFalse();
+  }
+
+  @Test
   public void tempDirectory() {
     DefaultNativeRuntimeLoader defaultNativeRuntimeLoader = new DefaultNativeRuntimeLoader();
     assertThat((Object) defaultNativeRuntimeLoader.getDirectory()).isNull();
@@ -56,5 +117,17 @@ public final class DefaultNativeRuntimeLoaderTest {
 
   private static boolean hasResource(String name) {
     return Thread.currentThread().getContextClassLoader().getResource(name) != null;
+  }
+
+  private static URI resourceUri(String name) throws Exception {
+    return Thread.currentThread().getContextClassLoader().getResource(name).toURI();
+  }
+
+  private static boolean isJarFileSystemOpen(URI jarUri) {
+    try {
+      return FileSystems.getFileSystem(jarUri).isOpen();
+    } catch (FileSystemNotFoundException e) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
### Overview

Fixes #10116.

`DefaultNativeRuntimeLoader` extracts `fonts/` and `hyphen-data/` from the jar that ships
them by opening a zip `FileSystem` with `FileSystems.newFileSystem(uri)`. The JDK keeps a
single zip filesystem per jar for the whole JVM, so if anything else already holds one for
that jar, the call throws `FileSystemAlreadyExistsException` and the sandbox fails to set up
its application state. This shows up intermittently when a test class runs several SDK levels
(two sandboxes in one JVM) under CPU load, for instance with Gradle `maxParallelForks`;
reporters on #10116 see it with `org.gradle.parallel=true` as well. The filesystem was also
only closed on the success path, so a failed copy leaked it into the next sandbox.

### Proposed Changes

- Extract the shared logic of `maybeCopyFonts` and `maybeCopyHyphenData` into
  `copyResourceDirectory`.
- When `newFileSystem` throws `FileSystemAlreadyExistsException`, reuse the filesystem that is
  already open (`Paths.get(uri)` resolves through it) and leave it to its owner.
- Close a filesystem opened by the loader in a `finally` block, so a failed copy can no longer
  leak it.
- Add `DefaultNativeRuntimeLoaderTest.extracts_fonts_whenFontsJarFileSystemIsAlreadyOpen`,
  which opens the fonts jar filesystem first, then loads the runtime and checks that the fonts
  were extracted and that the pre-existing filesystem is still open. It fails on `master` with
  the exception above and passes with this change.
